### PR TITLE
ci: version-bump-triggered core release workflow

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -1,0 +1,153 @@
+name: Release core
+
+# Version-bump-triggered release. When the workspace version in the root
+# Cargo.toml changes on main, this builds the `openasr` CLI for the platforms the
+# desktop app consumes and publishes a GitHub Release tagged `vX.Y.Z`. Editing
+# Cargo.toml without changing the version (deps, metadata) is a safe no-op because
+# the resolve job exits cleanly when tag `vX.Y.Z` already exists. `workflow_dispatch`
+# lets the maintainer cut the very first release (no bump) or re-run a failed one.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+  workflow_dispatch:
+
+# Only tag+release; no other write scope.
+permissions:
+  contents: write
+
+# Serialize releases; never cancel one mid-flight.
+concurrency:
+  group: release-core
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  resolve:
+    name: Resolve version
+    # Never let a fork attempt a release; only the canonical repo tags+publishes.
+    if: github.repository_owner == 'QuintinShaw'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+      should_release: ${{ steps.v.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        name: Read workspace version and check for an existing tag
+        run: |
+          set -euo pipefail
+          # Single source of truth: [workspace.package] version in the root
+          # Cargo.toml (all crates inherit via version.workspace = true). The
+          # anchored match hits only that line, not the ".. version = .." pins
+          # inside [workspace.dependencies] (those are indented after a name).
+          version="$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+          if [ -z "${version}" ]; then
+            echo "could not read workspace version from Cargo.toml" >&2
+            exit 1
+          fi
+          tag="v${version}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "tag ${tag} already exists -- nothing to release"
+            echo "should_release=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "tag ${tag} is new -- will build and release"
+            echo "should_release=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: resolve
+    if: needs.resolve.outputs.should_release == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    # Distributed binaries must be portable across end-user CPUs. build.rs
+    # auto-enables GGML_NATIVE (-march=native) when host==target on x86, which
+    # would tune the released Linux binary to the CI runner and SIGILL elsewhere.
+    # Force it off; power users tune locally.
+    env:
+      OPENASR_GGML_NATIVE: "0"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS arm64: what the OpenASR Desktop app consumes.
+          - os: macos-14
+            target: aarch64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        # ggml (build.rs -> CMake) plus ALSA headers for cpal.
+        run: sudo apt-get update && sudo apt-get install -y cmake libasound2-dev
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+      - name: Build release binary
+        run: cargo build --release -p openasr-cli
+      - name: Smoke release binary
+        run: |
+          ./target/release/openasr --version
+          ./target/release/openasr --help
+      - name: Package archive
+        run: |
+          set -euo pipefail
+          version="${{ needs.resolve.outputs.version }}"
+          target="${{ matrix.target }}"
+          stage="dist/openasr-${version}-${target}"
+          mkdir -p "${stage}"
+          cp target/release/openasr "${stage}/"
+          cp README.md LICENSE "${stage}/"
+          tar -czf "dist/openasr-${version}-${target}.tar.gz" -C dist "openasr-${version}-${target}"
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: openasr-${{ matrix.target }}
+          path: dist/openasr-${{ needs.resolve.outputs.version }}-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: [resolve, build]
+    if: needs.resolve.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build archives
+        uses: actions/download-artifact@v4
+        with:
+          path: staging
+          merge-multiple: true
+      - name: Collect archives and checksums
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          find staging -name '*.tar.gz' -exec cp {} dist/ \;
+          cd dist
+          sha256sum *.tar.gz > SHA256SUMS
+          cat SHA256SUMS
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.resolve.outputs.tag }}"
+          # gh creates the tag at this commit if it does not exist yet, then
+          # publishes the release with the archives + checksum file attached.
+          gh release create "${tag}" \
+            --target "${{ github.sha }}" \
+            --title "${tag}" \
+            --notes "Automated release of the \`openasr\` CLI for ${tag}. Prebuilt binaries for macOS arm64 and Linux x86_64; verify with SHA256SUMS." \
+            dist/*.tar.gz dist/SHA256SUMS

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -102,7 +102,15 @@ fn native_runtime_capabilities_from_metadata(
         && shared_native_ggml_streaming_execution_dispatch()
             .is_ok_and(|dispatch| dispatch.has_streaming_executor_for(descriptor))
     {
-        return NativeAsrCapabilities::native_true_streaming().with_partial_results(true);
+        // Partial granularity is a property of the registered streaming
+        // executor, not the pack: a pack cannot self-declare frame-sync
+        // partials, so already-published packs stay accurate as the
+        // registry gains (or loses) frame-sync executors.
+        let frame_sync = shared_native_ggml_streaming_execution_dispatch()
+            .is_ok_and(|dispatch| dispatch.is_frame_sync_for(descriptor));
+        return NativeAsrCapabilities::native_true_streaming()
+            .with_partial_results(true)
+            .with_frame_sync_partials(frame_sync);
     }
     NativeAsrCapabilities::native_offline()
 }

--- a/crates/openasr-core/src/api/native/types.rs
+++ b/crates/openasr-core/src/api/native/types.rs
@@ -52,6 +52,11 @@ pub struct NativeAsrCapabilities {
     pub class: NativeAsrCapabilityClass,
     pub supports_true_streaming: bool,
     pub supports_partials: bool,
+    /// True only when the true-streaming session uses the frame-sync
+    /// append-only partial driver (fixed low-latency chunks, never revises
+    /// already-emitted text). False for buffered/windowed re-decode
+    /// streaming, even though that also reports `supports_partials`.
+    pub supports_frame_sync_partials: bool,
     pub supports_timestamps: bool,
     pub supports_diarization: bool,
     pub supports_phrase_bias: bool,
@@ -70,6 +75,7 @@ impl NativeAsrCapabilities {
             class,
             supports_true_streaming,
             supports_partials: false,
+            supports_frame_sync_partials: false,
             supports_timestamps: false,
             supports_diarization: false,
             supports_phrase_bias: false,
@@ -113,6 +119,11 @@ impl NativeAsrCapabilities {
 
     pub const fn with_partial_results(mut self, supported: bool) -> Self {
         self.supports_partials = supported;
+        self
+    }
+
+    pub const fn with_frame_sync_partials(mut self, supported: bool) -> Self {
+        self.supports_frame_sync_partials = supported;
         self
     }
 

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -143,7 +143,7 @@ pub use models::{
         GgmlAsrBackendPreference, GgmlAsrExecutionDispatch, GgmlAsrExecutionError,
         GgmlAsrExecutionOptions, GgmlAsrExecutionRequest, GgmlAsrExecutionResult, GgmlAsrExecutor,
         GgmlAsrPreparedAudio, GgmlAsrRuntimeSourcePreflight, GgmlAsrStreamingExecutor,
-        GgmlAsrStreamingSessionConfig, GgmlAsrStreamingSessionRequest,
+        GgmlAsrStreamingSessionConfig, GgmlAsrStreamingSessionRequest, StreamingPartialGranularity,
     },
     ggml_family_adapter::{
         GGML_TOKENIZER_ID_KEY, GgmlAdapterMetadataSource, GgmlExecutionCapability,

--- a/crates/openasr-core/src/models/builtin_execution_dispatch.rs
+++ b/crates/openasr-core/src/models/builtin_execution_dispatch.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::GgmlAsrExecutionDispatch;
+use crate::StreamingPartialGranularity;
 use crate::arch::{OpenAsrArchitectureRegistry, OpenAsrArchitectureRegistryError};
 
 use super::cohere::CohereTranscribeGgmlExecutor;
@@ -92,34 +93,69 @@ pub(crate) fn build_builtin_ggml_streaming_execution_dispatch()
     // implementation. The offline executor registry is intentionally not reused
     // here, so metadata alone cannot turn an offline decoder into a claimed
     // realtime/partial runtime.
+    //
+    // Each adapter also declares its partial-result granularity here: the
+    // registration site is the only place that knows whether a family's
+    // streaming session is the frame-sync append-only driver (never revises
+    // emitted text) or a buffered/windowed re-decode driver (may revise).
+    // Only xasr-zipformer runs the frame-sync driver today; every other
+    // family re-decodes a growing or windowed buffer.
     Ok(GgmlAsrExecutionDispatch::default()
         .with_streaming_executor_for_adapter(
             crate::QWEN3_ASR_GGML_ADAPTER_ID,
             Arc::new(Qwen3AsrGgmlExecutor::default()),
         )
+        .with_streaming_partial_granularity_for_adapter(
+            crate::QWEN3_ASR_GGML_ADAPTER_ID,
+            StreamingPartialGranularity::Buffered,
+        )
         .with_streaming_executor_for_adapter(
             crate::WHISPER_GGML_ADAPTER_ID,
             Arc::new(WhisperGgmlExecutor::default()),
+        )
+        .with_streaming_partial_granularity_for_adapter(
+            crate::WHISPER_GGML_ADAPTER_ID,
+            StreamingPartialGranularity::Buffered,
         )
         .with_streaming_executor_for_adapter(
             crate::COHERE_TRANSCRIBE_GGML_ADAPTER_ID,
             Arc::new(CohereTranscribeGgmlExecutor::default()),
         )
+        .with_streaming_partial_granularity_for_adapter(
+            crate::COHERE_TRANSCRIBE_GGML_ADAPTER_ID,
+            StreamingPartialGranularity::Buffered,
+        )
         .with_streaming_executor_for_adapter(
             crate::MOONSHINE_GGML_ADAPTER_ID,
             Arc::new(MoonshineGgmlExecutor::default()),
+        )
+        .with_streaming_partial_granularity_for_adapter(
+            crate::MOONSHINE_GGML_ADAPTER_ID,
+            StreamingPartialGranularity::Buffered,
         )
         .with_streaming_executor_for_adapter(
             crate::PARAKEET_CTC_GGML_ADAPTER_ID,
             Arc::new(ParakeetCtcGgmlExecutor),
         )
+        .with_streaming_partial_granularity_for_adapter(
+            crate::PARAKEET_CTC_GGML_ADAPTER_ID,
+            StreamingPartialGranularity::Buffered,
+        )
         .with_streaming_executor_for_adapter(
             crate::WAV2VEC2_CTC_GGML_ADAPTER_ID,
             Arc::new(Wav2Vec2CtcGgmlExecutor),
         )
+        .with_streaming_partial_granularity_for_adapter(
+            crate::WAV2VEC2_CTC_GGML_ADAPTER_ID,
+            StreamingPartialGranularity::Buffered,
+        )
         .with_streaming_executor_for_adapter(
             crate::XASR_ZIPFORMER_GGML_ADAPTER_ID,
             Arc::new(XasrZipformerGgmlExecutor),
+        )
+        .with_streaming_partial_granularity_for_adapter(
+            crate::XASR_ZIPFORMER_GGML_ADAPTER_ID,
+            StreamingPartialGranularity::FrameSync,
         ))
 }
 
@@ -295,6 +331,28 @@ mod tests {
             message.contains(crate::arch::XASR_ZIPFORMER_STREAMING_EXECUTOR_COMPONENT_ID),
             "{message}"
         );
+    }
+
+    #[test]
+    fn builtin_streaming_dispatch_declares_xasr_as_the_only_frame_sync_family() {
+        let dispatch =
+            build_builtin_ggml_streaming_execution_dispatch().expect("builtin streaming dispatch");
+        let buffered_descriptors = [
+            qwen3_asr_runtime_descriptor_v1(),
+            whisper_runtime_descriptor_v1(),
+            crate::cohere_transcribe_runtime_descriptor_v1(),
+            crate::moonshine_runtime_descriptor_v1(),
+            parakeet_ctc_runtime_descriptor_v1(),
+            wav2vec2_ctc_runtime_descriptor_v1(),
+        ];
+        for descriptor in &buffered_descriptors {
+            assert!(
+                !dispatch.is_frame_sync_for(descriptor),
+                "{} should be buffered, not frame-sync",
+                descriptor.adapter_id
+            );
+        }
+        assert!(dispatch.is_frame_sync_for(&xasr_zipformer_runtime_descriptor_v1()));
     }
 
     #[test]

--- a/crates/openasr-core/src/models/ggml_asr_executor.rs
+++ b/crates/openasr-core/src/models/ggml_asr_executor.rs
@@ -335,12 +335,29 @@ pub trait GgmlAsrStreamingExecutor: Send + Sync {
     ) -> Result<Box<dyn NativeAsrSession>, GgmlAsrExecutionError>;
 }
 
+/// Partial-result granularity of a registered streaming executor. This is a
+/// generic infrastructure property (how partials are produced), not a
+/// per-model semantic: `FrameSync` executors append fixed low-latency chunks
+/// and never revise already-emitted text; `Buffered` executors re-decode a
+/// growing/windowed audio buffer and may revise prior partials. Only the
+/// registration site (`build_builtin_ggml_streaming_execution_dispatch`)
+/// knows which family is which.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamingPartialGranularity {
+    FrameSync,
+    Buffered,
+}
+
 #[derive(Default)]
 pub struct GgmlAsrExecutionDispatch {
     executors_by_adapter_id: BTreeMap<&'static str, Arc<dyn GgmlAsrExecutor>>,
     executors_by_capability: BTreeMap<&'static str, Arc<dyn GgmlAsrExecutor>>,
     streaming_executors_by_adapter_id: BTreeMap<&'static str, Arc<dyn GgmlAsrStreamingExecutor>>,
     streaming_executors_by_capability: BTreeMap<&'static str, Arc<dyn GgmlAsrStreamingExecutor>>,
+    streaming_partial_granularity_by_adapter_id:
+        BTreeMap<&'static str, StreamingPartialGranularity>,
+    streaming_partial_granularity_by_capability:
+        BTreeMap<&'static str, StreamingPartialGranularity>,
 }
 
 impl GgmlAsrExecutionDispatch {
@@ -380,6 +397,34 @@ impl GgmlAsrExecutionDispatch {
     ) -> Self {
         self.streaming_executors_by_capability
             .insert(capability_label(capability), executor);
+        self
+    }
+
+    /// Declares the partial-result granularity of the streaming executor
+    /// registered for `adapter_id`. This is orthogonal to (and does not
+    /// require) registering the executor itself here -- it only records the
+    /// granularity fact so capability derivation can answer
+    /// [`Self::is_frame_sync_for`] without touching model-family code.
+    pub fn with_streaming_partial_granularity_for_adapter(
+        mut self,
+        adapter_id: &'static str,
+        granularity: StreamingPartialGranularity,
+    ) -> Self {
+        self.streaming_partial_granularity_by_adapter_id
+            .insert(adapter_id, granularity);
+        self
+    }
+
+    /// Capability-keyed counterpart of
+    /// [`Self::with_streaming_partial_granularity_for_adapter`], mirroring the
+    /// adapter-id/capability duality used by the executor maps above.
+    pub fn with_streaming_partial_granularity_for_capability(
+        mut self,
+        capability: GgmlExecutionCapability,
+        granularity: StreamingPartialGranularity,
+    ) -> Self {
+        self.streaming_partial_granularity_by_capability
+            .insert(capability_label(capability), granularity);
         self
     }
 
@@ -462,6 +507,23 @@ impl GgmlAsrExecutionDispatch {
             || self
                 .streaming_executors_by_capability
                 .contains_key(capability_label(descriptor.execution_capability))
+    }
+
+    /// True only when the streaming executor registered for `descriptor` was
+    /// declared frame-sync at registration time. Unregistered granularity
+    /// (including families with no streaming executor at all) reads as
+    /// `false` -- fail closed to the buffered/no-partial-guarantee default
+    /// rather than assume low-latency partials.
+    pub fn is_frame_sync_for(&self, descriptor: &GgmlFamilyAdapterDescriptor) -> bool {
+        matches!(
+            self.streaming_partial_granularity_by_adapter_id
+                .get(descriptor.adapter_id),
+            Some(StreamingPartialGranularity::FrameSync)
+        ) || matches!(
+            self.streaming_partial_granularity_by_capability
+                .get(capability_label(descriptor.execution_capability)),
+            Some(StreamingPartialGranularity::FrameSync)
+        )
     }
 }
 
@@ -890,6 +952,37 @@ mod tests {
                 Arc::new(StubStreamingExecutor),
             );
         assert!(capability_dispatch.has_streaming_executor_for(&qwen));
+    }
+
+    #[test]
+    fn is_frame_sync_for_reports_registered_granularity_and_defaults_closed() {
+        let whisper = whisper_runtime_descriptor_v1();
+        let qwen = qwen3_asr_runtime_descriptor_v1();
+
+        // No granularity registered at all: fails closed to "not frame-sync",
+        // matching the treatment of an unregistered streaming executor.
+        let empty_dispatch = GgmlAsrExecutionDispatch::default();
+        assert!(!empty_dispatch.is_frame_sync_for(&whisper));
+        assert!(!empty_dispatch.is_frame_sync_for(&qwen));
+
+        let mixed_dispatch = GgmlAsrExecutionDispatch::default()
+            .with_streaming_partial_granularity_for_adapter(
+                whisper.adapter_id,
+                StreamingPartialGranularity::FrameSync,
+            )
+            .with_streaming_partial_granularity_for_adapter(
+                qwen.adapter_id,
+                StreamingPartialGranularity::Buffered,
+            );
+        assert!(mixed_dispatch.is_frame_sync_for(&whisper));
+        assert!(!mixed_dispatch.is_frame_sync_for(&qwen));
+
+        let capability_dispatch = GgmlAsrExecutionDispatch::default()
+            .with_streaming_partial_granularity_for_capability(
+                qwen.execution_capability,
+                StreamingPartialGranularity::FrameSync,
+            );
+        assert!(capability_dispatch.is_frame_sync_for(&qwen));
     }
 
     #[test]

--- a/crates/openasr-core/src/realtime/backend.rs
+++ b/crates/openasr-core/src/realtime/backend.rs
@@ -27,6 +27,13 @@ pub struct RealtimeBackendCapabilities {
     pub requires_vad_utterance_boundaries: bool,
     pub is_file_per_utterance_fallback: bool,
     pub is_true_streaming: bool,
+    /// True only for the frame-sync append-only streaming driver (fixed
+    /// low-latency chunks that are appended, never revised) -- the shape a
+    /// word-by-word dictation UX needs. False for buffered/windowed
+    /// re-decode streaming, CTC-windowed streaming, file-per-utterance
+    /// fallback, and unsupported modes, even when those report
+    /// `supports_partial_results = true`.
+    pub frame_sync_partials: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -88,6 +95,7 @@ impl RealtimeBackendCapabilities {
         requires_vad_utterance_boundaries: bool,
         phrase_bias: BackendFeatureCapability,
         word_timestamps: BackendFeatureCapability,
+        frame_sync_partials: bool,
     ) -> Self {
         Self {
             mode,
@@ -108,6 +116,7 @@ impl RealtimeBackendCapabilities {
                 RealtimeBackendMode::FilePerUtteranceFallback
             ),
             is_true_streaming: matches!(mode, RealtimeBackendMode::TrueStreaming),
+            frame_sync_partials,
         }
     }
 
@@ -119,6 +128,7 @@ impl RealtimeBackendCapabilities {
             false,
             realtime_phrase_bias_unsupported(),
             realtime_word_timestamps_unsupported(),
+            false,
         )
     }
 
@@ -130,6 +140,7 @@ impl RealtimeBackendCapabilities {
             true,
             realtime_phrase_bias_unsupported(),
             BackendFeatureCapability::supported(),
+            false,
         )
     }
 
@@ -141,9 +152,15 @@ impl RealtimeBackendCapabilities {
             true,
             BackendFeatureCapability::supported(),
             BackendFeatureCapability::supported(),
+            false,
         )
     }
 
+    /// Test/CLI-summary representative of a generic true-streaming backend.
+    /// It is conservatively buffered (`frame_sync_partials = false`): most
+    /// registered families re-decode a buffer, and production capabilities
+    /// for any given family are always derived from the streaming-executor
+    /// registry via [`Self::from_native_capabilities`], not from this stub.
     pub const fn true_streaming_local() -> Self {
         Self::build(
             RealtimeBackendMode::TrueStreaming,
@@ -152,6 +169,7 @@ impl RealtimeBackendCapabilities {
             false,
             realtime_phrase_bias_unsupported(),
             BackendFeatureCapability::supported(),
+            false,
         )
     }
 
@@ -191,6 +209,7 @@ impl RealtimeBackendCapabilities {
                     } else {
                         realtime_word_timestamps_unsupported()
                     },
+                    capabilities.supports_frame_sync_partials,
                 )
             }
             NativeAsrCapabilityClass::NativeModelAdapter => Self::build(
@@ -208,6 +227,7 @@ impl RealtimeBackendCapabilities {
                 } else {
                     realtime_word_timestamps_unsupported()
                 },
+                false,
             ),
             NativeAsrCapabilityClass::FilePerUtteranceFallback => {
                 Self::file_per_utterance_fallback()
@@ -288,6 +308,7 @@ mod tests {
             assert!(capabilities.requires_vad_utterance_boundaries);
             assert!(capabilities.is_file_per_utterance_fallback);
             assert!(!capabilities.is_true_streaming);
+            assert!(!capabilities.frame_sync_partials);
             assert!(!capabilities.effective_partial_results(true));
         }
     }
@@ -370,8 +391,65 @@ mod tests {
         assert!(!capabilities.requires_vad_utterance_boundaries);
         assert!(!capabilities.is_file_per_utterance_fallback);
         assert!(capabilities.is_true_streaming);
+        // A generic true-streaming stub is conservatively buffered; only a
+        // family whose registered executor is frame-sync claims this.
+        assert!(!capabilities.frame_sync_partials);
         assert!(capabilities.effective_partial_results(true));
         assert!(!capabilities.effective_partial_results(false));
+    }
+
+    #[test]
+    fn from_native_capabilities_derives_frame_sync_partials_from_the_registry_flag() {
+        let frame_sync = RealtimeBackendCapabilities::from_native_capabilities(
+            &NativeAsrCapabilities::native_true_streaming()
+                .with_partial_results(true)
+                .with_frame_sync_partials(true),
+        );
+        assert_eq!(frame_sync.mode, RealtimeBackendMode::TrueStreaming);
+        assert!(frame_sync.supports_partial_results);
+        assert!(frame_sync.frame_sync_partials);
+
+        let buffered = RealtimeBackendCapabilities::from_native_capabilities(
+            &NativeAsrCapabilities::native_true_streaming()
+                .with_partial_results(true)
+                .with_frame_sync_partials(false),
+        );
+        assert_eq!(buffered.mode, RealtimeBackendMode::TrueStreaming);
+        assert!(buffered.supports_partial_results);
+        assert!(!buffered.frame_sync_partials);
+
+        let offline = RealtimeBackendCapabilities::from_native_capabilities(
+            &NativeAsrCapabilities::native_offline(),
+        );
+        assert_eq!(offline.mode, RealtimeBackendMode::FilePerUtteranceFallback);
+        assert!(!offline.frame_sync_partials);
+
+        let fallback = RealtimeBackendCapabilities::from_native_capabilities(
+            &NativeAsrCapabilities::file_per_utterance_fallback(),
+        );
+        assert_eq!(fallback.mode, RealtimeBackendMode::FilePerUtteranceFallback);
+        assert!(!fallback.frame_sync_partials);
+
+        let unsupported = RealtimeBackendCapabilities::from_native_capabilities(
+            &NativeAsrCapabilities::unsupported(),
+        );
+        assert_eq!(unsupported.mode, RealtimeBackendMode::Unsupported);
+        assert!(!unsupported.frame_sync_partials);
+    }
+
+    #[test]
+    fn realtime_backend_capabilities_json_pins_frame_sync_partials_field_name() {
+        let frame_sync = RealtimeBackendCapabilities::from_native_capabilities(
+            &NativeAsrCapabilities::native_true_streaming()
+                .with_partial_results(true)
+                .with_frame_sync_partials(true),
+        );
+        let json = serde_json::to_value(frame_sync).expect("serialize capabilities");
+        assert_eq!(json["frame_sync_partials"], serde_json::json!(true));
+
+        let buffered = RealtimeBackendCapabilities::for_backend_kind(BackendKind::Native);
+        let json = serde_json::to_value(buffered).expect("serialize capabilities");
+        assert_eq!(json["frame_sync_partials"], serde_json::json!(false));
     }
 
     #[test]

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -2105,6 +2105,9 @@ async fn websocket_session_emits_capabilities_before_start_with_monotonic_sequen
             assert!(event.capabilities.supports_realtime_sessions);
             assert!(!event.capabilities.translation.supported);
             assert!(!event.capabilities.translation.installed);
+            // Default runtime (mock backend, no model pack) is
+            // file-per-utterance fallback, never frame-sync.
+            assert!(!event.capabilities.frame_sync_partials);
             assert_eq!(
                 event.capabilities.translation.reason,
                 Some("translation_pack_missing")
@@ -2112,6 +2115,49 @@ async fn websocket_session_emits_capabilities_before_start_with_monotonic_sequen
             assert_eq!(event.frame_duration_ms, DEFAULT_FRAME_DURATION_MS);
             assert_eq!(event.frame_byte_len, 640);
             assert_eq!(event.max_message_bytes, MAX_WS_MESSAGE_BYTES);
+        }
+        other => panic!("expected session.capabilities event, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn session_capabilities_event_reports_frame_sync_only_for_xasr_zipformer() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let xasr_path = temp.path().join("xasr-zipformer-capability-test.oasr");
+    write_xasr_streaming_fixture_pack(&xasr_path, "xasr-zipformer-capability-test");
+    let xasr_runtime = ServerRuntime {
+        backend: openasr_core::BackendKind::Native,
+        ffmpeg_bin: None,
+        model_pack_path: Some(xasr_path),
+    };
+    let (xasr_event_sender, mut xasr_event_receiver) = mpsc::channel(8);
+    let mut xasr_session = WsSession::new(xasr_runtime, test_distribution(), xasr_event_sender);
+    xasr_session.emit_capabilities().await.unwrap();
+    match xasr_event_receiver.recv().await.unwrap().event {
+        RealtimeEvent::Lifecycle(RealtimeLifecycleEvent::SessionCapabilities(event)) => {
+            assert!(event.capabilities.is_true_streaming);
+            assert!(event.capabilities.frame_sync_partials);
+        }
+        other => panic!("expected session.capabilities event, got {other:?}"),
+    }
+
+    let qwen_path = temp.path().join("qwen-capability-test.oasr");
+    write_qwen_streaming_fixture_pack(&qwen_path, "qwen-capability-test");
+    let qwen_runtime = ServerRuntime {
+        backend: openasr_core::BackendKind::Native,
+        ffmpeg_bin: None,
+        model_pack_path: Some(qwen_path),
+    };
+    let (qwen_event_sender, mut qwen_event_receiver) = mpsc::channel(8);
+    let mut qwen_session = WsSession::new(qwen_runtime, test_distribution(), qwen_event_sender);
+    qwen_session.emit_capabilities().await.unwrap();
+    match qwen_event_receiver.recv().await.unwrap().event {
+        RealtimeEvent::Lifecycle(RealtimeLifecycleEvent::SessionCapabilities(event)) => {
+            // Qwen also runs a native true-streaming session, but through the
+            // buffered re-decode driver -- it must not claim frame-sync partials.
+            assert!(event.capabilities.is_true_streaming);
+            assert!(!event.capabilities.frame_sync_partials);
         }
         other => panic!("expected session.capabilities event, got {other:?}"),
     }

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -925,6 +925,10 @@ async fn capabilities_endpoint_reflects_active_xasr_phrase_bias_capability() {
     assert_eq!(parsed["realtime"]["mode"], "true_streaming");
     assert_eq!(parsed["realtime"]["phrase_bias"]["supported"], false);
     assert_eq!(parsed["realtime"]["supports_partial_results"], true);
+    // xasr-zipformer is the only family running the frame-sync append-only
+    // streaming driver; every other true-streaming family re-decodes a
+    // buffer and must not claim this.
+    assert_eq!(parsed["realtime"]["frame_sync_partials"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Two commits on top of `origin/main`:

1. **`feat(realtime): expose frame-sync partial granularity in backend capabilities`** (f797385) - adds a capability field so callers can tell which backends emit frame-synchronous streaming partials vs. coarser chunk-level partials.
2. **`ci: version-bump-triggered core release workflow`** - new `.github/workflows/release-core.yml`.

## Release workflow

Publishes a GitHub Release automatically when the workspace version is bumped.

- **Versioning source of truth:** the single `[workspace.package] version` in the root `Cargo.toml` (all crates inherit via `version.workspace = true`). Currently `0.1.0`.
- **Triggers:** `push` to `main` filtered on `Cargo.toml`, plus `workflow_dispatch`.
- **Logic:** read `X.Y.Z` -> if tag `vX.Y.Z` already exists, exit as a clean no-op (so ordinary `Cargo.toml` edits and re-runs are safe) -> else build and publish.
- **Build matrix:** macOS arm64 (`macos-14`, what the desktop app consumes) and Linux x86_64 (`ubuntu-latest`, installs `cmake` + `libasound2-dev`), `submodules: recursive` for ggml, `Swatinem/rust-cache`. Builds `cargo build --release -p openasr-cli`.
- **Artifacts:** `openasr-{version}-{target}.tar.gz` (contains the `openasr` binary + README + LICENSE) plus an aggregate `SHA256SUMS`. `gh release create` cuts the tag at the pushed commit and attaches the assets.
- **Permissions/safety:** minimal `contents: write`; `github.repository_owner == 'QuintinShaw'` guard so forks never attempt a release; only `GITHUB_TOKEN`.

## Cutting the first release

Version already reads `0.1.0`, so the first release needs no bump: run the workflow manually (`workflow_dispatch`) to publish `v0.1.0`. Subsequent releases happen automatically on a version bump landing on `main`.

## Note on existing CI

Pushing tag `vX.Y.Z` also triggers the pre-existing `release-binaries.yml` (which builds a wider matrix but only uploads workflow-run artifacts, not Release assets). That is a redundant build, not a conflict; left untouched here.

AI involvement: workflow authored with Claude Code assistance; reviewed and owned by me.
