### PR TITLE
feat(core): subtitle-grade cue re-segmentation for all families

### DIFF
--- a/crates/openasr-core/src/api/backend/cue_segmentation.rs
+++ b/crates/openasr-core/src/api/backend/cue_segmentation.rs
@@ -1,0 +1,619 @@
+//! Family-agnostic re-segmentation of an assembled transcription into
+//! subtitle-grade cues.
+//!
+//! Model families differ wildly in how coarsely they segment: whisper emits
+//! sentence-ish segments, but X-ASR / qwen / cohere / moonshine each emit one
+//! monolithic segment per decode (per long-form slice), which renders as a
+//! single 30-60s subtitle cue. This pass runs after speaker attribution and
+//! rebalances every segment into short cues, splitting at sentence-final
+//! punctuation first, then clause punctuation, then word gaps, while honouring
+//! duration and line-length caps.
+//!
+//! Invariants:
+//! - It never reorders or rewrites words, so the joined transcript text is
+//!   unchanged (streaming==batch parity and `transcription.text` stay intact).
+//! - It splits *within* the segments it is given and never merges across them,
+//!   so speaker turns are preserved (a cue never spans two speakers).
+//! - Word timestamps drive the boundaries when present; otherwise a segment's
+//!   words are synthesised proportionally from its character span so the same
+//!   packer applies.
+
+use crate::{Segment, Transcription, WordTimestamp};
+
+/// Preferred cue duration. Cues are grown up to this bound before a cut is
+/// forced, so most cues land at or under it.
+const TARGET_CUE_SECONDS: f32 = 6.0;
+/// Hard ceiling used only when merging a dangling orphan tail back into its
+/// neighbour; a normal cue is already bounded by [`TARGET_CUE_SECONDS`].
+const MAX_CUE_SECONDS: f32 = 8.0;
+/// ~42 characters x 2 lines for Latin-script cues.
+const LATIN_MAX_CHARS: usize = 84;
+/// ~18 fullwidth characters x 2 lines for CJK-script cues.
+const CJK_MAX_CHARS: usize = 36;
+/// A trailing piece of this many words or fewer is treated as an orphan and
+/// merged back into the previous cue when it fits within the hard caps.
+const ORPHAN_MAX_WORDS: usize = 2;
+
+/// Re-segment every segment of `transcription` into subtitle-grade cues. The
+/// segment order, speaker attribution, and word sequence are preserved.
+pub(crate) fn resegment_transcription_cues(mut transcription: Transcription) -> Transcription {
+    if transcription.segments.is_empty() {
+        return transcription;
+    }
+    let mut cues = Vec::with_capacity(transcription.segments.len());
+    for segment in std::mem::take(&mut transcription.segments) {
+        cues.extend(segment_into_cues(segment));
+    }
+    transcription.segments = cues;
+    transcription
+}
+
+/// A word-sized unit the packer reasons over: its character span within the
+/// parent segment text plus its time span. Real word timestamps are used when
+/// they align to the segment text; otherwise units are synthesised from
+/// whitespace tokens with times interpolated proportionally.
+struct CueToken {
+    char_start: usize,
+    char_end: usize,
+    start: f32,
+    end: f32,
+}
+
+fn segment_into_cues(segment: Segment) -> Vec<Segment> {
+    let chars: Vec<char> = segment.text.chars().collect();
+    let (tokens, real_words) = build_tokens(&segment, &chars);
+    if tokens.len() < 2 {
+        return vec![segment];
+    }
+    let budget = char_budget(&chars);
+    let ranges = pack_tokens(&chars, &tokens, budget);
+    if ranges.len() <= 1 {
+        return vec![segment];
+    }
+    let mut cues = Vec::with_capacity(ranges.len());
+    for (first, last) in ranges {
+        let text: String = chars[tokens[first].char_start..tokens[last].char_end]
+            .iter()
+            .collect();
+        let text = text.trim().to_string();
+        if text.is_empty() {
+            continue;
+        }
+        let start = tokens[first].start.max(segment.start);
+        let end = tokens[last].end.max(start).min(segment.end.max(start));
+        let words: Vec<WordTimestamp> = if real_words {
+            segment.words[first..=last].to_vec()
+        } else {
+            Vec::new()
+        };
+        cues.push(Segment {
+            start,
+            end,
+            text,
+            speaker: segment.speaker.clone(),
+            speaker_label: segment.speaker_label.clone(),
+            speaker_profile_id: segment.speaker_profile_id.clone(),
+            words,
+        });
+    }
+    if cues.len() <= 1 {
+        return vec![segment];
+    }
+    cues
+}
+
+/// Build the token stream for a segment. Returns `(tokens, real_words)` where
+/// `real_words` is true when the tokens map 1:1 onto `segment.words` (so the
+/// caller can slice the original word timestamps into each cue).
+fn build_tokens(segment: &Segment, chars: &[char]) -> (Vec<CueToken>, bool) {
+    if segment.words.len() >= 2
+        && let Some(spans) = word_char_spans(chars, &segment.words)
+    {
+        let tokens = segment
+            .words
+            .iter()
+            .zip(spans)
+            .map(|(word, (char_start, char_end))| CueToken {
+                char_start,
+                char_end,
+                start: word.start,
+                end: word.end.max(word.start),
+            })
+            .collect();
+        return (tokens, true);
+    }
+    (synthesize_tokens(segment, chars), false)
+}
+
+/// Synthesise word-sized tokens from whitespace runs, interpolating times
+/// proportionally across `[segment.start, segment.end]` by character position.
+fn synthesize_tokens(segment: &Segment, chars: &[char]) -> Vec<CueToken> {
+    let total = chars.len();
+    if total == 0 {
+        return Vec::new();
+    }
+    let span_start = segment.start;
+    let span = (segment.end - segment.start).max(0.0);
+    let at = |char_index: usize| span_start + span * (char_index as f32 / total as f32);
+    let mut tokens = Vec::new();
+    let mut index = 0usize;
+    while index < total {
+        while index < total && chars[index].is_whitespace() {
+            index += 1;
+        }
+        if index >= total {
+            break;
+        }
+        let char_start = index;
+        while index < total && !chars[index].is_whitespace() {
+            index += 1;
+        }
+        tokens.push(CueToken {
+            char_start,
+            char_end: index,
+            start: at(char_start),
+            end: at(index),
+        });
+    }
+    tokens
+}
+
+/// Greedily pack tokens into cue ranges (inclusive `(first, last)` token
+/// indices). Cues grow up to the target caps and break at the first sentence
+/// boundary, preferring clause punctuation and then the widest word gap when a
+/// long sentence must be split.
+fn pack_tokens(chars: &[char], tokens: &[CueToken], budget: usize) -> Vec<(usize, usize)> {
+    let n = tokens.len();
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    while start < n {
+        let mut end = start;
+        // Grow the cue until it hits a content-bearing sentence boundary, runs
+        // out of tokens, or the next token would overflow the target caps.
+        while !(ends_sentence(chars, &tokens[end]) && range_has_content(chars, tokens, start, end))
+            && end + 1 < n
+            && fits(tokens, start, end + 1, budget, TARGET_CUE_SECONDS)
+        {
+            end += 1;
+        }
+        let cut = if (ends_sentence(chars, &tokens[end])
+            && range_has_content(chars, tokens, start, end))
+            || end == n - 1
+        {
+            end
+        } else {
+            choose_cut(chars, tokens, start, end)
+        };
+        ranges.push((start, cut));
+        start = cut + 1;
+    }
+    merge_orphan_tails(chars, tokens, ranges, budget)
+}
+
+/// Pick the split point within `[start, end]` for a sentence that is too long
+/// to keep whole: the latest clause boundary if any, else the token before the
+/// widest inter-word gap, else pack to `end`.
+fn choose_cut(chars: &[char], tokens: &[CueToken], start: usize, end: usize) -> usize {
+    for k in (start..=end).rev() {
+        if ends_clause(chars, &tokens[k]) && range_has_content(chars, tokens, start, k) {
+            return k;
+        }
+    }
+    let mut best_k = end;
+    let mut best_gap = 0.0f32;
+    for k in start..end {
+        let gap = tokens[k + 1].start - tokens[k].end;
+        if gap > best_gap {
+            best_gap = gap;
+            best_k = k;
+        }
+    }
+    best_k
+}
+
+/// Merge a trailing 1-2 word cue back into its predecessor when they belong to
+/// the same sentence (the predecessor did not end one) and the union still fits
+/// the hard caps -- avoids leaving a dangling orphan word on its own line.
+fn merge_orphan_tails(
+    chars: &[char],
+    tokens: &[CueToken],
+    ranges: Vec<(usize, usize)>,
+    budget: usize,
+) -> Vec<(usize, usize)> {
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+    for (first, last) in ranges {
+        if let Some(&(prev_first, prev_last)) = merged.last() {
+            let word_count = last - first + 1;
+            let prev_ends_sentence = ends_sentence(chars, &tokens[prev_last]);
+            if word_count <= ORPHAN_MAX_WORDS
+                && !prev_ends_sentence
+                && fits(tokens, prev_first, last, budget, MAX_CUE_SECONDS)
+            {
+                *merged.last_mut().unwrap() = (prev_first, last);
+                continue;
+            }
+        }
+        merged.push((first, last));
+    }
+    merged
+}
+
+/// Whether `tokens[start..=end]` fits both the character budget and `max_seconds`.
+fn fits(tokens: &[CueToken], start: usize, end: usize, budget: usize, max_seconds: f32) -> bool {
+    let chars = tokens[end]
+        .char_end
+        .saturating_sub(tokens[start].char_start);
+    if chars > budget {
+        return false;
+    }
+    let duration = tokens[end].end - tokens[start].start;
+    duration <= max_seconds
+}
+
+/// Character budget for the segment's dominant script: CJK cues carry far fewer
+/// (wider) characters per line than Latin cues.
+fn char_budget(chars: &[char]) -> usize {
+    let mut wide = 0usize;
+    let mut total = 0usize;
+    for &ch in chars {
+        if ch.is_whitespace() {
+            continue;
+        }
+        total += 1;
+        if is_wide_script(ch) {
+            wide += 1;
+        }
+    }
+    if total > 0 && wide * 2 >= total {
+        CJK_MAX_CHARS
+    } else {
+        LATIN_MAX_CHARS
+    }
+}
+
+fn is_wide_script(ch: char) -> bool {
+    matches!(
+        u32::from(ch),
+        0x1100..=0x115F      // Hangul Jamo
+        | 0x2E80..=0x2EFF    // CJK radicals
+        | 0x3000..=0x303F    // CJK symbols and punctuation
+        | 0x3040..=0x30FF    // Hiragana + Katakana
+        | 0x3400..=0x4DBF    // CJK Ext A
+        | 0x4E00..=0x9FFF    // CJK Unified
+        | 0xAC00..=0xD7A3    // Hangul syllables
+        | 0xF900..=0xFAFF    // CJK compatibility ideographs
+        | 0xFF00..=0xFF60    // Fullwidth forms
+        | 0x20000..=0x3134F  // CJK Ext B..H
+    )
+}
+
+/// Whether the token ends a sentence: its last non-closing character is
+/// sentence-final punctuation. The mark may be its own token (`" . "`) or glued
+/// to the last word (`"country."`).
+fn ends_sentence(chars: &[char], token: &CueToken) -> bool {
+    last_significant_char(chars, token).is_some_and(is_sentence_terminal_char)
+}
+
+/// Whether the token ends a clause: its last non-closing character is clause
+/// punctuation (comma / semicolon / colon, ASCII or fullwidth).
+fn ends_clause(chars: &[char], token: &CueToken) -> bool {
+    last_significant_char(chars, token).is_some_and(is_clause_punct)
+}
+
+/// The token's last character, skipping trailing closing punctuation and
+/// whitespace.
+fn last_significant_char(chars: &[char], token: &CueToken) -> Option<char> {
+    chars[token.char_start..token.char_end]
+        .iter()
+        .copied()
+        .rev()
+        .find(|c| !is_segment_closing_punct(*c) && !c.is_whitespace())
+}
+
+/// Whether `tokens[start..=end]` carries any non-punctuation content, so a cue
+/// never consists solely of a stray punctuation token.
+fn range_has_content(chars: &[char], tokens: &[CueToken], start: usize, end: usize) -> bool {
+    tokens[start..=end]
+        .iter()
+        .flat_map(|token| chars[token.char_start..token.char_end].iter().copied())
+        .any(char_has_content)
+}
+
+fn is_sentence_terminal_char(c: char) -> bool {
+    matches!(
+        c,
+        '.' | '!' | '?' | '\u{3002}' | '\u{ff01}' | '\u{ff1f}' | '\u{2026}'
+    )
+}
+
+fn is_clause_punct(c: char) -> bool {
+    matches!(
+        c,
+        ',' | ';' | ':' | '\u{ff0c}' | '\u{3001}' | '\u{ff1b}' | '\u{ff1a}'
+    )
+}
+
+fn is_segment_closing_punct(c: char) -> bool {
+    matches!(
+        c,
+        '"' | '\''
+            | ')'
+            | ']'
+            | '}'
+            | '\u{201d}'
+            | '\u{2019}'
+            | '\u{ff09}'
+            | '\u{3011}'
+            | '\u{300d}'
+            | '\u{300f}'
+    )
+}
+
+fn char_has_content(c: char) -> bool {
+    !is_sentence_terminal_char(c)
+        && !is_clause_punct(c)
+        && !is_segment_closing_punct(c)
+        && !c.is_whitespace()
+}
+
+/// Map each word token to its `[start, end)` char span in the segment `chars`
+/// by greedy forward matching (words are whitespace-separated tokens of the
+/// text). Returns `None` if a token does not align, so the caller falls back to
+/// synthesised tokens rather than mis-slicing text.
+fn word_char_spans(chars: &[char], words: &[WordTimestamp]) -> Option<Vec<(usize, usize)>> {
+    let mut spans = Vec::with_capacity(words.len());
+    let mut idx = 0usize;
+    for word in words {
+        while idx < chars.len() && chars[idx].is_whitespace() {
+            idx += 1;
+        }
+        let token: Vec<char> = word.word.trim().chars().collect();
+        if token.is_empty() {
+            spans.push((idx, idx));
+            continue;
+        }
+        if idx + token.len() > chars.len() {
+            return None;
+        }
+        if chars[idx..idx + token.len()] != token[..] {
+            return None;
+        }
+        spans.push((idx, idx + token.len()));
+        idx += token.len();
+    }
+    Some(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn word(text: &str, start: f32, end: f32) -> WordTimestamp {
+        WordTimestamp {
+            word: text.to_string(),
+            start,
+            end,
+            confidence: None,
+        }
+    }
+
+    fn segment(text: &str, words: Vec<WordTimestamp>) -> Segment {
+        let start = words.first().map_or(0.0, |w| w.start);
+        let end = words.last().map_or(0.0, |w| w.end);
+        Segment {
+            start,
+            end,
+            text: text.to_string(),
+            speaker: None,
+            speaker_label: None,
+            speaker_profile_id: None,
+            words,
+        }
+    }
+
+    fn transcription(segments: Vec<Segment>) -> Transcription {
+        Transcription {
+            text: segments
+                .iter()
+                .map(|s| s.text.trim())
+                .collect::<Vec<_>>()
+                .join(" "),
+            segments,
+            longform: None,
+            language: None,
+        }
+    }
+
+    #[test]
+    fn splits_latin_monolithic_segment_at_sentence_punctuation() {
+        // Real X-ASR jfk output (detok already glued `.` to the prior word).
+        let text = "And so my fellow americans ask not what your country can do for you. Ask what you can do for your country";
+        let words = vec![
+            word("And", 0.96, 1.00),
+            word("so", 1.43, 1.47),
+            word("my", 1.55, 1.59),
+            word("fellow", 1.71, 1.91),
+            word("americans", 2.19, 3.19),
+            word("ask", 4.11, 4.14),
+            word("not", 4.90, 4.94),
+            word("what", 5.74, 5.78),
+            word("your", 6.22, 6.26),
+            word("country", 6.50, 6.54),
+            word("can", 6.86, 6.89),
+            word("do", 7.13, 7.17),
+            word("for", 7.49, 7.53),
+            word("you.", 7.93, 7.97),
+            word("Ask", 8.77, 9.01),
+            word("what", 9.21, 9.25),
+            word("you", 9.41, 9.45),
+            word("can", 9.61, 9.64),
+            word("do", 9.84, 9.88),
+            word("for", 10.08, 10.12),
+            word("your", 10.28, 10.32),
+            word("country", 10.80, 10.84),
+        ];
+        let cues = segment_into_cues(segment(text, words));
+        // First sentence is >6s, so it splits at a clause/gap boundary too; the
+        // whole thing must be at least the two sentences, none over the caps.
+        assert!(cues.len() >= 2, "cues: {cues:?}");
+        // Every cue is <= the hard duration cap.
+        for cue in &cues {
+            assert!(
+                cue.end - cue.start <= MAX_CUE_SECONDS + 1e-3,
+                "cue too long: {cue:?}"
+            );
+            assert!(cue.text.chars().count() <= LATIN_MAX_CHARS);
+        }
+        // Words are preserved in order across all cues.
+        let joined: Vec<&str> = cues
+            .iter()
+            .flat_map(|c| c.words.iter().map(|w| w.word.as_str()))
+            .collect();
+        assert_eq!(joined.len(), 22);
+        assert_eq!(joined[0], "And");
+        assert_eq!(joined[21], "country");
+        // A cue boundary lands on the sentence end.
+        assert!(cues.iter().any(|c| c.text.ends_with("you.")));
+    }
+
+    #[test]
+    fn keeps_short_single_sentence_whole() {
+        let text = "hello world this is short";
+        let words = vec![
+            word("hello", 0.0, 0.3),
+            word("world", 0.4, 0.7),
+            word("this", 0.8, 1.0),
+            word("is", 1.1, 1.2),
+            word("short", 1.3, 1.6),
+        ];
+        let cues = segment_into_cues(segment(text, words));
+        assert_eq!(cues.len(), 1);
+        assert_eq!(cues[0].text, "hello world this is short");
+    }
+
+    #[test]
+    fn splits_cjk_segment_at_ideographic_period() {
+        // Unspaced CJK with a fullwidth period; each ideograph is its own word.
+        let text = "\u{4f60}\u{597d}\u{4e16}\u{754c}\u{3002}\u{4eca}\u{5929}\u{5929}\u{6c14}\u{5f88}\u{597d}";
+        let words = vec![
+            word("\u{4f60}", 0.0, 0.3),
+            word("\u{597d}", 0.3, 0.6),
+            word("\u{4e16}", 0.6, 0.9),
+            word("\u{754c}\u{3002}", 0.9, 1.2),
+            word("\u{4eca}", 1.3, 1.6),
+            word("\u{5929}", 1.6, 1.9),
+            word("\u{5929}", 1.9, 2.2),
+            word("\u{6c14}", 2.2, 2.5),
+            word("\u{5f88}", 2.5, 2.8),
+            word("\u{597d}", 2.8, 3.1),
+        ];
+        let cues = segment_into_cues(segment(text, words));
+        assert_eq!(cues.len(), 2, "cues: {cues:?}");
+        assert_eq!(cues[0].text, "\u{4f60}\u{597d}\u{4e16}\u{754c}\u{3002}");
+        assert_eq!(
+            cues[1].text,
+            "\u{4eca}\u{5929}\u{5929}\u{6c14}\u{5f88}\u{597d}"
+        );
+    }
+
+    #[test]
+    fn splits_long_unpunctuated_segment_by_duration() {
+        // Raw X-ASR zh-en without punctuation: a >6s run must still break by
+        // duration / word gap rather than render one long cue.
+        let words: Vec<WordTimestamp> = (0..10)
+            .map(|i| {
+                let start = i as f32 * 1.0;
+                word("word", start, start + 0.5)
+            })
+            .collect();
+        let text = "word word word word word word word word word word";
+        let cues = segment_into_cues(segment(text, words));
+        assert!(cues.len() >= 2, "a 9.5s run must split: {cues:?}");
+        for cue in &cues {
+            assert!(cue.end - cue.start <= MAX_CUE_SECONDS + 1e-3);
+        }
+    }
+
+    #[test]
+    fn never_crosses_speaker_turns() {
+        // Two segments, distinct speakers: re-segmentation stays within each and
+        // never merges across the turn boundary.
+        let mut a = segment(
+            "alpha bravo charlie. delta echo foxtrot.",
+            vec![
+                word("alpha", 0.0, 0.3),
+                word("bravo", 0.4, 0.7),
+                word("charlie.", 0.8, 1.1),
+                word("delta", 1.2, 1.5),
+                word("echo", 1.6, 1.9),
+                word("foxtrot.", 2.0, 2.3),
+            ],
+        );
+        a.speaker = Some("SPEAKER_00".to_string());
+        let mut b = segment(
+            "golf hotel.",
+            vec![word("golf", 2.5, 2.8), word("hotel.", 2.9, 3.2)],
+        );
+        b.speaker = Some("SPEAKER_01".to_string());
+        let out = resegment_transcription_cues(transcription(vec![a, b]));
+        // Each cue carries exactly one speaker; the SPEAKER_01 content is never
+        // fused with SPEAKER_00 content.
+        for cue in &out.segments {
+            let speaker = cue.speaker.as_deref().unwrap();
+            if cue.text.contains("golf") || cue.text.contains("hotel") {
+                assert_eq!(speaker, "SPEAKER_01");
+            } else {
+                assert_eq!(speaker, "SPEAKER_00");
+            }
+        }
+        assert!(
+            out.segments
+                .iter()
+                .any(|c| c.speaker.as_deref() == Some("SPEAKER_01"))
+        );
+    }
+
+    #[test]
+    fn merges_trailing_orphan_into_previous_cue() {
+        // A long clause followed by a dangling two-word tail of the same
+        // sentence: the tail must not become its own cue.
+        let words = vec![
+            word("the", 0.0, 0.3),
+            word("quick", 0.5, 0.9),
+            word("brown", 1.2, 1.6),
+            word("fox", 2.0, 2.4),
+            word("jumps,", 3.0, 3.4),
+            word("over", 5.6, 5.9),
+            word("it", 6.0, 6.2),
+        ];
+        let text = "the quick brown fox jumps, over it";
+        let cues = segment_into_cues(segment(text, words));
+        // "over it" (2 words) would orphan after the clause cut; it is merged
+        // back so no cue is a lone 1-2 word tail.
+        assert!(
+            cues.last().map(|c| c.words.len()).unwrap_or(0) > ORPHAN_MAX_WORDS || cues.len() == 1,
+            "orphan tail was not merged: {cues:?}"
+        );
+    }
+
+    #[test]
+    fn preserves_transcription_text_verbatim() {
+        let text = "one two three. four five six. seven eight nine.";
+        let words = vec![
+            word("one", 0.0, 0.3),
+            word("two", 0.4, 0.7),
+            word("three.", 0.8, 1.1),
+            word("four", 1.2, 1.5),
+            word("five", 1.6, 1.9),
+            word("six.", 2.0, 2.3),
+            word("seven", 2.4, 2.7),
+            word("eight", 2.8, 3.1),
+            word("nine.", 3.2, 3.5),
+        ];
+        let original = transcription(vec![segment(text, words)]);
+        let text_before = original.text.clone();
+        let out = resegment_transcription_cues(original);
+        assert_eq!(out.text, text_before, "joined text must be untouched");
+        assert!(out.segments.len() >= 3);
+    }
+}

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -32,6 +32,8 @@ use crate::{
     GgmlAsrExecutionOptions, GgmlAsrStreamingSessionRequest,
 };
 
+#[path = "cue_segmentation.rs"]
+mod cue_segmentation;
 #[path = "native_model_id.rs"]
 mod native_model_id;
 #[path = "native_path.rs"]

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -28,8 +28,8 @@ use crate::{
 };
 
 use super::{BackendError, Transcription, TranscriptionRequest};
+use crate::Segment;
 use crate::api::backend::TranscriptionLongFormMetadata;
-use crate::{Segment, WordTimestamp};
 
 const DEFAULT_NATIVE_LONGFORM_AUTO_TRIGGER_SECONDS: f32 = 30.0;
 const COHERE_LONGFORM_MAX_CHUNK_SECONDS: f32 = 10.0;
@@ -225,19 +225,17 @@ pub(super) fn run_native_transcription(
     // forced-for-diarization marker below tells whisper to keep the decode
     // path identical to a non-diarized run and derive word anchors post hoc
     // from the generated tokens instead.
-    // X-ASR batch emits one monolithic segment for the whole file (it has no
-    // internal segmentation), so a transcript renders as a single paragraph / one
-    // subtitle cue. Force its word timestamps -- free post-processing of emission
-    // frames -- so the single result can be split into sentence segments below at
-    // the model's own punctuation, then strip the anchors again if the caller did
-    // not request them. Gated to X-ASR: other families either already segment
-    // (whisper longform) or would pay a real decode cost for word timestamps.
-    let split_monolithic_segments = selected_family.adapter_id
-        == crate::arch::XASR_ZIPFORMER_GGML_ADAPTER_ID
-        && !run_longform
-        && !vad_diarization;
-    let force_word_timestamps_for_segmentation =
-        split_monolithic_segments && !request.word_timestamps;
+    // Every family's transcript is re-segmented into subtitle-grade cues after
+    // decode (see `cue_segmentation`); the splitter needs word anchors to place
+    // cue boundaries. For all families except whisper these are free -- pure
+    // post-processing of decode-time emission/token times already captured
+    // during decode -- so force them on and strip them again if the caller did
+    // not ask for them. Whisper is the exception: user-requested word timestamps
+    // switch its decode path to collect cross-attention (which can perturb the
+    // transcript), so it is left alone here and its cues fall back to
+    // proportional splitting when a segment exceeds the caps.
+    let is_whisper_family = selected_family.adapter_id == crate::arch::WHISPER_GGML_ADAPTER_ID;
+    let force_word_timestamps_for_segmentation = !is_whisper_family && !request.word_timestamps;
     request_options.word_timestamps =
         request.word_timestamps || vad_diarization || force_word_timestamps_for_segmentation;
     let strip_forced_word_timestamps =
@@ -479,14 +477,11 @@ pub(super) fn run_native_transcription(
         request_options,
         backend_preference,
     )?;
-    let mut normalized = normalize_transcription_segments(
+    let normalized = normalize_transcription_segments(
         transcription.into_transcription(),
         0.0,
         audio_duration_seconds,
     );
-    if split_monolithic_segments {
-        normalized = split_monolithic_segment_into_sentences(normalized);
-    }
     Ok(with_reported_language(
         apply_speaker_turns(
             with_longform_metadata(normalized, longform_metadata),
@@ -617,10 +612,13 @@ fn compute_speaker_attribution(
     }
 }
 
-/// Attribute speaker turns onto the transcription's segments (no-op if empty),
-/// splitting segments that span multiple speakers at word-snapped turn
-/// boundaries. `strip_forced_word_timestamps` removes the word anchors that
-/// were force-enabled for the split when the caller did not request them.
+/// Finalize a transcription for output: attribute speaker turns onto its
+/// segments (no-op if empty, splitting segments that span multiple speakers at
+/// word-snapped turn boundaries), then re-segment every (single-speaker) segment
+/// into subtitle-grade cues. Re-segmentation runs after attribution so cues
+/// never straddle a speaker turn, and before the strip so it can use the word
+/// anchors. `strip_forced_word_timestamps` removes the anchors that were
+/// force-enabled for the split when the caller did not request them.
 fn apply_speaker_turns(
     mut transcription: Transcription,
     attribution: &SpeakerAttribution,
@@ -633,145 +631,11 @@ fn apply_speaker_turns(
             &attribution.identities,
         );
     }
+    transcription = super::cue_segmentation::resegment_transcription_cues(transcription);
     if strip_forced_word_timestamps {
         for segment in &mut transcription.segments {
             segment.words.clear();
         }
-    }
-    transcription
-}
-
-/// Sentence-final punctuation for the zh-en (and common multilingual) output.
-fn is_sentence_terminal_char(c: char) -> bool {
-    matches!(
-        c,
-        '.' | '!' | '?' | '\u{3002}' | '\u{ff01}' | '\u{ff1f}' | '\u{2026}'
-    )
-}
-
-/// Closing punctuation that may trail a sentence mark (quotes, brackets).
-fn is_segment_closing_punct(c: char) -> bool {
-    matches!(
-        c,
-        '"' | '\''
-            | ')'
-            | ']'
-            | '}'
-            | '\u{201d}'
-            | '\u{2019}'
-            | '\u{ff09}'
-            | '\u{3011}'
-            | '\u{300d}'
-            | '\u{300f}'
-    )
-}
-
-/// Whether a token carries any non-punctuation content (so a lone punctuation
-/// token never starts its own sentence segment).
-fn word_has_content(word: &str) -> bool {
-    word.trim().chars().any(|c| {
-        !is_sentence_terminal_char(c) && !is_segment_closing_punct(c) && !c.is_whitespace()
-    })
-}
-
-/// Whether a token ends a sentence: its last non-closing character is terminal
-/// punctuation. X-ASR emits the mark either as its own token (" . ") or glued to
-/// the last word ("country.").
-fn word_ends_sentence(word: &str) -> bool {
-    word.trim_end()
-        .trim_end_matches(is_segment_closing_punct)
-        .chars()
-        .next_back()
-        .is_some_and(is_sentence_terminal_char)
-}
-
-/// Map each word token to its `[start, end)` char span in `text` by greedy
-/// forward matching (the words are tokens of `text`, separated by whitespace).
-/// Returns `None` if a token does not align, so the caller falls back to leaving
-/// the segment whole rather than emitting mis-sliced text.
-fn word_char_spans(text: &str, words: &[WordTimestamp]) -> Option<Vec<(usize, usize)>> {
-    let chars: Vec<char> = text.chars().collect();
-    let mut spans = Vec::with_capacity(words.len());
-    let mut idx = 0usize;
-    for word in words {
-        while idx < chars.len() && chars[idx].is_whitespace() {
-            idx += 1;
-        }
-        let token: Vec<char> = word.word.trim().chars().collect();
-        if token.is_empty() {
-            spans.push((idx, idx));
-            continue;
-        }
-        if idx + token.len() > chars.len() {
-            return None;
-        }
-        if chars[idx..idx + token.len()] != token[..] {
-            return None;
-        }
-        spans.push((idx, idx + token.len()));
-        idx += token.len();
-    }
-    Some(spans)
-}
-
-/// Split a single monolithic segment (e.g. X-ASR batch, which emits one segment
-/// for the whole file) into sentence segments at sentence-final punctuation,
-/// using word timestamps for exact boundaries and the original segment text for
-/// exact spacing. No-op unless there is exactly one segment carrying word
-/// timestamps and at least one interior sentence boundary. Pause gaps are
-/// deliberately NOT used: dramatic delivery pauses are not sentence boundaries.
-fn split_monolithic_segment_into_sentences(mut transcription: Transcription) -> Transcription {
-    if transcription.segments.len() != 1 {
-        return transcription;
-    }
-    let segment = transcription.segments[0].clone();
-    if segment.words.len() < 2 {
-        return transcription;
-    }
-    let Some(spans) = word_char_spans(&segment.text, &segment.words) else {
-        return transcription;
-    };
-    let n = segment.words.len();
-    // Word indices after which to cut: a sentence-final mark that has real
-    // content before it, never the final word (that cut just reproduces the
-    // whole segment).
-    let mut cut_after: Vec<usize> = Vec::new();
-    let mut group_has_content = false;
-    for (i, word) in segment.words.iter().enumerate() {
-        if word_has_content(&word.word) {
-            group_has_content = true;
-        }
-        if i + 1 < n && group_has_content && word_ends_sentence(&word.word) {
-            cut_after.push(i);
-            group_has_content = false;
-        }
-    }
-    if cut_after.is_empty() {
-        return transcription;
-    }
-    cut_after.push(n - 1);
-
-    let chars: Vec<char> = segment.text.chars().collect();
-    let mut out: Vec<Segment> = Vec::with_capacity(cut_after.len());
-    let mut first = 0usize;
-    for &last in &cut_after {
-        let text: String = chars[spans[first].0..spans[last].1].iter().collect();
-        let text = text.trim().to_string();
-        if !text.is_empty() {
-            out.push(Segment {
-                start: segment.words[first].start,
-                end: segment.words[last].end,
-                text,
-                speaker: segment.speaker.clone(),
-                speaker_label: segment.speaker_label.clone(),
-                speaker_profile_id: segment.speaker_profile_id.clone(),
-                words: segment.words[first..=last].to_vec(),
-            });
-        }
-        first = last + 1;
-    }
-    if out.len() > 1 {
-        transcription.segments = out;
     }
     transcription
 }
@@ -1314,137 +1178,6 @@ fn prefers_cpu_decoder_for_multichunk_metal(model_architecture: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn word(text: &str, start: f32, end: f32) -> WordTimestamp {
-        WordTimestamp {
-            word: text.to_string(),
-            start,
-            end,
-            confidence: None,
-        }
-    }
-
-    fn single_segment(text: &str, words: Vec<WordTimestamp>) -> Transcription {
-        let start = words.first().map_or(0.0, |w| w.start);
-        let end = words.last().map_or(0.0, |w| w.end);
-        Transcription {
-            text: text.to_string(),
-            segments: vec![Segment {
-                start,
-                end,
-                text: text.to_string(),
-                speaker: None,
-                speaker_label: None,
-                speaker_profile_id: None,
-                words,
-            }],
-            longform: None,
-            language: None,
-        }
-    }
-
-    #[test]
-    fn splits_monolithic_segment_at_sentence_punctuation() {
-        // Real X-ASR jfk output: one segment with a period token mid-stream. The
-        // dramatic pauses (ask/not/what) must NOT split; only the period does.
-        let text = "And so my fellow americans ask not what your country can do for you . Ask what you can do for your country";
-        let words = vec![
-            word("And", 0.96, 1.00),
-            word("so", 1.43, 1.47),
-            word("my", 1.55, 1.59),
-            word("fellow", 1.71, 1.91),
-            word("americans", 2.19, 3.19),
-            word("ask", 4.11, 4.14),
-            word("not", 4.90, 4.94),
-            word("what", 5.74, 5.78),
-            word("your", 6.22, 6.26),
-            word("country", 6.50, 6.54),
-            word("can", 6.86, 6.89),
-            word("do", 7.13, 7.17),
-            word("for", 7.49, 7.53),
-            word("you", 7.93, 7.97),
-            word(".", 8.61, 8.65),
-            word("Ask", 8.77, 9.01),
-            word("what", 9.21, 9.25),
-            word("you", 9.41, 9.45),
-            word("can", 9.61, 9.64),
-            word("do", 9.84, 9.88),
-            word("for", 10.08, 10.12),
-            word("your", 10.28, 10.32),
-            word("country", 10.80, 10.84),
-        ];
-        let split = split_monolithic_segment_into_sentences(single_segment(text, words));
-        assert_eq!(split.segments.len(), 2);
-        assert_eq!(
-            split.segments[0].text,
-            "And so my fellow americans ask not what your country can do for you ."
-        );
-        assert!((split.segments[0].start - 0.96).abs() < 1e-4);
-        assert!((split.segments[0].end - 8.65).abs() < 1e-4);
-        assert_eq!(
-            split.segments[1].text,
-            "Ask what you can do for your country"
-        );
-        assert!((split.segments[1].start - 8.77).abs() < 1e-4);
-        assert!((split.segments[1].end - 10.84).abs() < 1e-4);
-    }
-
-    #[test]
-    fn does_not_split_without_terminal_punctuation() {
-        let text = "hello world no punctuation at all here";
-        let words = vec![
-            word("hello", 0.0, 0.2),
-            word("world", 0.3, 0.5),
-            word("no", 0.6, 0.7),
-            word("punctuation", 0.8, 1.2),
-            word("at", 1.3, 1.4),
-            word("all", 1.5, 1.6),
-            word("here", 1.7, 1.9),
-        ];
-        let split = split_monolithic_segment_into_sentences(single_segment(text, words));
-        assert_eq!(split.segments.len(), 1);
-    }
-
-    #[test]
-    fn does_not_split_already_multi_segment_or_wordless() {
-        // Two segments -> untouched.
-        let mut two = single_segment("a. b.", vec![word("a.", 0.0, 0.1), word("b.", 0.2, 0.3)]);
-        two.segments.push(Segment {
-            start: 0.4,
-            end: 0.5,
-            text: "c.".to_string(),
-            speaker: None,
-            speaker_label: None,
-            speaker_profile_id: None,
-            words: vec![word("c.", 0.4, 0.5)],
-        });
-        assert_eq!(
-            split_monolithic_segment_into_sentences(two).segments.len(),
-            2
-        );
-
-        // Single segment with no word timestamps -> untouched (cannot anchor cuts).
-        let wordless = Transcription {
-            text: "One. Two.".to_string(),
-            segments: vec![Segment {
-                start: 0.0,
-                end: 1.0,
-                text: "One. Two.".to_string(),
-                speaker: None,
-                speaker_label: None,
-                speaker_profile_id: None,
-                words: Vec::new(),
-            }],
-            longform: None,
-            language: None,
-        };
-        assert_eq!(
-            split_monolithic_segment_into_sentences(wordless)
-                .segments
-                .len(),
-            1
-        );
-    }
 
     #[test]
     fn longform_progress_guard_publishes_and_clears() {

--- a/crates/openasr-core/src/format/renderers.rs
+++ b/crates/openasr-core/src/format/renderers.rs
@@ -145,13 +145,34 @@ fn render_segments(
         .join(separator)
 }
 
+/// Render segments as prose paragraphs, coalescing consecutive same-speaker
+/// cues into a single paragraph. The cue re-segmentation pass produces many
+/// short subtitle cues per speaker turn; timed formats (SRT/VTT/JSON) want that
+/// granularity, but markdown reads as one paragraph per turn.
 fn render_segments_body(transcription: &Transcription, separator: &str) -> String {
-    transcription
-        .segments
-        .iter()
-        .map(|segment| render_segment_text(&segment.text, segment.speaker.as_deref()))
-        .collect::<Vec<_>>()
-        .join(separator)
+    let mut paragraphs: Vec<String> = Vec::new();
+    let mut group_speaker: Option<Option<&str>> = None;
+    let mut group_text = String::new();
+    for segment in &transcription.segments {
+        let speaker = segment.speaker.as_deref();
+        let text = segment.text.trim();
+        if group_speaker == Some(speaker) {
+            if !group_text.is_empty() && !text.is_empty() {
+                group_text.push(' ');
+            }
+            group_text.push_str(text);
+        } else {
+            if let Some(previous) = group_speaker {
+                paragraphs.push(render_segment_text(&group_text, previous));
+            }
+            group_speaker = Some(speaker);
+            group_text = text.to_string();
+        }
+    }
+    if let Some(previous) = group_speaker {
+        paragraphs.push(render_segment_text(&group_text, previous));
+    }
+    paragraphs.join(separator)
 }
 
 fn render_segment_text(text: &str, speaker: Option<&str>) -> String {

--- a/crates/openasr-core/src/format/tests.rs
+++ b/crates/openasr-core/src/format/tests.rs
@@ -261,3 +261,48 @@ fn renders_markdown_speaker_prefix_only_when_present() {
         "# Transcript\n\nSPEAKER_00: hello world\n\nnext line\n"
     );
 }
+
+#[test]
+fn renders_markdown_coalesces_consecutive_same_speaker_cues() {
+    // The cue re-segmentation pass emits many short cues per speaker turn.
+    // Markdown groups consecutive same-speaker cues into one paragraph while a
+    // speaker change still starts a new one.
+    let transcription = Transcription {
+        text: "one two three four".to_string(),
+        segments: vec![
+            Segment {
+                start: 0.0,
+                end: 1.0,
+                text: "one two".to_string(),
+                speaker: Some("SPEAKER_00".to_string()),
+                speaker_label: None,
+                speaker_profile_id: None,
+                words: Vec::new(),
+            },
+            Segment {
+                start: 1.0,
+                end: 2.0,
+                text: "three".to_string(),
+                speaker: Some("SPEAKER_00".to_string()),
+                speaker_label: None,
+                speaker_profile_id: None,
+                words: Vec::new(),
+            },
+            Segment {
+                start: 2.0,
+                end: 3.0,
+                text: "four".to_string(),
+                speaker: Some("SPEAKER_01".to_string()),
+                speaker_label: None,
+                speaker_profile_id: None,
+                words: Vec::new(),
+            },
+        ],
+        longform: None,
+        language: None,
+    };
+    assert_eq!(
+        render_transcription(&transcription, ResponseFormat::Markdown).unwrap(),
+        "# Transcript\n\nSPEAKER_00: one two three\n\nSPEAKER_01: four\n"
+    );
+}

--- a/crates/openasr-core/src/longform/assembler.rs
+++ b/crates/openasr-core/src/longform/assembler.rs
@@ -69,7 +69,6 @@ impl TranscriptAssembler {
             self.stats.skipped_silent_chunks += 1;
             return;
         }
-        let synthesized_slice_fallback = transcript.segments.is_empty();
         if transcript.segments.is_empty() {
             let sample_rate = 16_000.0_f32;
             transcript.segments.push(Segment {
@@ -95,9 +94,11 @@ impl TranscriptAssembler {
                 self.stats.duplicate_merge_count += 1;
                 continue;
             }
-            if !synthesized_slice_fallback && self.try_merge_adjacent_segment(mapped.clone()) {
-                continue;
-            }
+            // Distinct segments are kept distinct: the post-ASR cue
+            // re-segmentation pass owns subtitle granularity, so the assembler
+            // no longer coalesces adjacent same-speaker segments into paragraph
+            // blobs. Only exact / high-overlap duplicates from slice overlap are
+            // dropped above.
             self.segments.push(mapped);
         }
     }
@@ -202,34 +203,6 @@ impl TranscriptAssembler {
         let min_len = previous_words.len().min(current_words.len());
         min_len >= self.merge_policy.redundant_min_words
             && overlap as f32 / min_len as f32 >= self.merge_policy.redundant_overlap_ratio
-    }
-
-    fn try_merge_adjacent_segment(&mut self, current: Segment) -> bool {
-        let Some(previous) = self.segments.last_mut() else {
-            return false;
-        };
-        if current.start < previous.end {
-            return false;
-        }
-        let gap = current.start - previous.end;
-        if gap > self.merge_policy.max_gap_seconds {
-            return false;
-        }
-        // Never merge across a speaker change — the merged segment would
-        // misattribute one speaker's words to the other.
-        if previous.speaker != current.speaker {
-            return false;
-        }
-        if !previous.text.ends_with(' ') {
-            previous.text.push(' ');
-        }
-        previous.text.push_str(current.text.trim());
-        previous.end = previous.end.max(current.end);
-        // The merged segment's words already carry original-timeline timestamps
-        // (mapped by map_segment_time before merge); append them so word-level
-        // timing spans the whole merged segment instead of only its first half.
-        previous.words.extend(current.words);
-        true
     }
 }
 
@@ -400,7 +373,11 @@ mod tests {
     }
 
     #[test]
-    fn assembler_merge_preserves_words_from_both_segments() {
+    fn assembler_keeps_adjacent_segments_distinct() {
+        // Adjacent, non-overlapping segments are no longer coalesced into a
+        // paragraph blob: the post-ASR cue re-segmentation pass owns subtitle
+        // granularity. Each segment survives with its own words and timing, and
+        // the joined transcript text still reads as one paragraph.
         let mut assembler =
             TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
         assembler.push_slice_result(SliceTranscript {
@@ -457,13 +434,12 @@ mod tests {
         let transcription = assembler.into_transcription();
         assert_eq!(
             transcription.segments.len(),
-            1,
-            "adjacent non-overlapping segments should merge into one"
+            2,
+            "adjacent segments must stay distinct"
         );
-        let merged = &transcription.segments[0];
-        assert_eq!(merged.text, "hello world from openasr");
-        let merged_words: Vec<&str> = merged.words.iter().map(|w| w.word.as_str()).collect();
-        assert_eq!(merged_words, ["hello", "world", "from", "openasr"]);
+        assert_eq!(transcription.segments[0].text, "hello world");
+        assert_eq!(transcription.segments[1].text, "from openasr");
+        assert_eq!(transcription.text, "hello world from openasr");
     }
 
     #[test]

--- a/crates/openasr-core/src/models/xasr_zipformer/tokenizer.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/tokenizer.rs
@@ -219,7 +219,30 @@ fn normalize_sentencepiece_spacing(text: &str) -> String {
 }
 
 fn should_suppress_sentencepiece_space(left: char, right: char) -> bool {
-    is_cjk_text_or_punctuation(left) && is_cjk_text_or_punctuation(right)
+    if is_cjk_text_or_punctuation(left) && is_cjk_text_or_punctuation(right) {
+        return true;
+    }
+    // Latin / shared punctuation detok: never a space before a closing mark,
+    // never a space after an opening bracket. The decision depends only on the
+    // nearest visible neighbours of each space, so the streaming detokenizer
+    // (which evaluates each pending space against `last_visible`) stays
+    // append-only and byte-for-byte identical to a full batch decode.
+    is_no_space_before_punctuation(right) || is_no_space_after_punctuation(left)
+}
+
+/// Punctuation that hugs the preceding token: a space in front of it is dropped
+/// (`hello ,` -> `hello,`, `word )` -> `word)`).
+fn is_no_space_before_punctuation(ch: char) -> bool {
+    matches!(
+        ch,
+        ',' | '.' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '\u{00bb}' | '\u{2026}'
+    )
+}
+
+/// Openers that hug the following token: a space after them is dropped
+/// (`( hello` -> `(hello`).
+fn is_no_space_after_punctuation(ch: char) -> bool {
+    matches!(ch, '(' | '[' | '{' | '\u{00ab}')
 }
 
 fn is_cjk_text_or_punctuation(ch: char) -> bool {
@@ -278,6 +301,94 @@ mod tests {
             tokenizer.decode(&[1, 2, 3, 4, 5, 6]).unwrap(),
             "二零年，美国 OpenASR"
         );
+    }
+
+    #[test]
+    fn drops_space_before_latin_closing_punctuation() {
+        // X-ASR emits Latin punctuation as its own `_,` / `_.` piece, which used
+        // to render as " , " / " . " (space on both sides). Only the space in
+        // front of a closing mark is suppressed; the following word keeps its
+        // space.
+        let tokenizer = XasrZipformerTokenizer::new(
+            vec![
+                "<blk>".to_string(),
+                "\u{2581}hello".to_string(),
+                "\u{2581},".to_string(),
+                "\u{2581}world".to_string(),
+                "\u{2581}.".to_string(),
+            ],
+            0,
+        )
+        .unwrap();
+        assert_eq!(tokenizer.decode(&[1, 2, 3, 4]).unwrap(), "hello, world.");
+    }
+
+    #[test]
+    fn hugs_brackets_to_their_contents() {
+        let tokenizer = XasrZipformerTokenizer::new(
+            vec![
+                "<blk>".to_string(),
+                "\u{2581}(".to_string(),
+                "\u{2581}inside".to_string(),
+                "\u{2581})".to_string(),
+                "\u{2581}next".to_string(),
+            ],
+            0,
+        )
+        .unwrap();
+        assert_eq!(tokenizer.decode(&[1, 2, 3, 4]).unwrap(), "(inside) next");
+    }
+
+    #[test]
+    fn keeps_space_between_cjk_and_latin_around_punctuation() {
+        // Latin punctuation rules must not disturb the CJK/Latin boundary space.
+        let tokenizer = XasrZipformerTokenizer::new(
+            vec![
+                "<blk>".to_string(),
+                "\u{2581}\u{7f8e}\u{56fd}".to_string(), // 美国
+                "\u{2581},".to_string(),
+                "\u{2581}OpenASR".to_string(),
+            ],
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            tokenizer.decode(&[1, 2, 3]).unwrap(),
+            "\u{7f8e}\u{56fd}, OpenASR"
+        );
+    }
+
+    #[test]
+    fn streaming_detokenizer_matches_batch_decode_with_latin_punctuation() {
+        // The Latin punctuation spacing rule must keep the streaming path
+        // byte-identical to batch decode at every prefix (append-only).
+        let tokenizer = XasrZipformerTokenizer::new(
+            vec![
+                "<blk>".to_string(),
+                "\u{2581}hello".to_string(),
+                "\u{2581},".to_string(),
+                "\u{2581}(".to_string(),
+                "\u{2581}world".to_string(),
+                "\u{2581})".to_string(),
+                "\u{2581}.".to_string(),
+            ],
+            0,
+        )
+        .unwrap();
+        let ids = [1u32, 2, 3, 4, 5, 6];
+        let mut streaming = XasrStreamingDetokenizer::default();
+        let mut previous = String::new();
+        for (count, &id) in ids.iter().enumerate() {
+            streaming.push_token(&tokenizer, id).unwrap();
+            let batch = tokenizer.decode(&ids[..=count]).unwrap();
+            assert_eq!(streaming.text(), batch, "prefix of {} tokens", count + 1);
+            assert!(
+                streaming.text().starts_with(&previous),
+                "streaming output must be append-only"
+            );
+            previous = streaming.text().to_string();
+        }
+        assert_eq!(streaming.text(), "hello, (world).");
     }
 
     #[test]


### PR DESCRIPTION
## What & why

File transcription produced subtitle files that were unusable as subtitles.

**Field defect.** For audio over 30s the native path auto-slices into ~30s
chunks; X-ASR / qwen / cohere / moonshine each emit **one monolithic segment
per slice**, and the long-form assembler then merged adjacent same-speaker
segments within a 1.2s gap. The result was 30-60s paragraph "cues" in SRT/VTT
(one cue spanning half a minute). Separately, the X-ASR detokenizer only
suppressed spaces between CJK characters, so Latin punctuation rendered as
`" , "` / `" . "` everywhere. An existing sentence splitter existed but was
gated to X-ASR, non-long-form, non-diarized runs, so it never ran for any of
the failing cases.

## Design

Three parts, one per commit:

1. **`fix(xasr)` detok spacing.** The shared SentencePiece spacing rule now also
   drops the space before a closing mark (`, . ; : ! ? ) ] } » …`) and after an
   opener (`( [ { «`). The rule still depends only on the nearest visible
   neighbours of each space, so the streaming detokenizer stays **append-only
   and byte-identical to batch decode** (streaming==batch parity holds — both
   paths call the same function).

2. **`feat(core)` family-agnostic cue re-segmentation** (`cue_segmentation.rs`).
   Runs after speaker attribution on the assembled transcription, for **all
   families including long-form**. Each single-speaker segment is split at
   sentence-final punctuation first, then clause punctuation, then the widest
   word gap, honouring a 6s target / 8s hard duration cap and per-script
   line-length budgets (84 Latin / 36 CJK chars), merging a dangling 1-2 word
   tail back into its clause. Word anchors drive the boundaries: forced on for
   every family except whisper (free post-processing; whisper keeps its decode
   path and falls back to proportional-by-character splitting) and stripped
   again when unrequested. **Words are never reordered or rewritten**, so
   `transcription.text` and streaming==batch parity are untouched, and a cue
   never straddles a speaker turn. Markdown coalesces consecutive same-speaker
   cues back into one paragraph; timed formats keep the fine cues.

3. **`refactor(longform)` assembler.** Drop the adjacent-segment coalescing so
   distinct segments stay distinct (the cue pass now owns granularity). The
   slice-overlap dedup is unchanged, so duplicated words across a slice overlap
   are still removed.

## Golden / test evolution

This repo's `golden_diff` suite is the whisper **decoder-graph numeric** test,
which these post-decode output-formatting changes do not touch — it still
passes unchanged. There are no committed rendered-output goldens in the open
core, so nothing to regenerate here; correctness is pinned by new fixture unit
tests (cue packer: Latin/CJK/no-punctuation/orphan/speaker-turn/text-preserved;
detok spacing incl. append-only streaming; assembler distinct-segments;
markdown coalescing) plus the real-file run below.

## Before / after (real file, 2-min LibriVox clip)

**X-ASR zh-en q8_0, SRT** — before: one 30s cue with `" . "` / `" , "` spacing:

```
1
00:00:00,230 --> 00:00:30,490
This is a libriVox recording all Librivox recordings are in the public domain . For more information and to find out how you can volunteer , please visit libriVox dot org . Recording by tom yates tom in bkk dot com the black cat by Igor Allan Poe . For the most wild yet most homely narrative which I am about to pan , I neither expect nor solicit beli
```

after:

```
1
00:00:00,790 --> 00:00:06,034
This is a libriVox recording all Librivox recordings are in the public domain.

2
00:00:05,994 --> 00:00:09,196
For more information and to find out how you can volunteer,

3
00:00:09,396 --> 00:00:12,798
please visit libriVox dot org.
```

**qwen3-asr-0.6b q4_k, SRT** — after:

```
1
00:00:00,230 --> 00:00:04,364
This is a LibriVox recording.

2
00:00:04,364 --> 00:00:08,587
All LibriVox recordings are in the public domain.

3
00:00:08,587 --> 00:00:12,809
For more information and to find out how you can volunteer,
```

Cues are sentence-level (<=6-8s), Latin punctuation hugs its word, and the
joined transcript text is unchanged.

## Known limitation -> PR2

The re-segmentation is a post-ASR pass, so a sentence split across a 30s slice
boundary still shows the truncation the slicer produced: X-ASR cue 8 ends
`"...nor solicit beli"` at 00:30.490 (a cut-off "belief"). Fixing
slice-boundary word damage (overlap-aware slicing / boundary stitching) is
**PR2** scope; it is not introduced here.

## Validation

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`,
`cargo nextest run --workspace` (1878 passed), `cargo test --workspace --doc`,
`cargo test -p openasr-core golden_diff`, and the bundled-catalog signature
test all pass, plus the real-file runs above.

## AI usage

Implemented with AI assistance (Claude); design, review, and validation owned
by the author.
