### PR TITLE
chore(release): v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openasr-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "openasr-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "openasr-core",
  "rustls",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "openasr-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc",
  "ed25519-dalek",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "openasr-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "openasr-system-audio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libloading",
  "objc2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/QuintinShaw/openasr"
@@ -20,9 +20,9 @@ authors = ["OpenASR contributors"]
 # Inter-crate deps are version-locked in lockstep with [workspace.package].
 # A release bumps the version there and these three pins together; pushing
 # that bump to main publishes the release (see RELEASING.md).
-openasr-core = { path = "crates/openasr-core", version = "0.1.0" }
-openasr-server = { path = "crates/openasr-server", version = "0.1.0" }
-openasr-system-audio = { path = "crates/openasr-system-audio", version = "0.1.0" }
+openasr-core = { path = "crates/openasr-core", version = "0.1.1" }
+openasr-server = { path = "crates/openasr-server", version = "0.1.1" }
+openasr-system-audio = { path = "crates/openasr-system-audio", version = "0.1.1" }
 anyhow = "1.0"
 assert_cmd = "2.0"
 axum = { version = "0.8", features = ["multipart", "ws"] }


### PR DESCRIPTION
Cuts the **v0.1.1** release. Bumps the workspace version and the three
inter-crate pins (`openasr-core`, `openasr-server`, `openasr-system-audio`)
from `0.1.0` to `0.1.1`, with `Cargo.lock` regenerated in lockstep.

Per `RELEASING.md`, merging this to `main` is the release: the version
bump lands on `main`, the `Release core` workflow reads the new workspace
version, tags `v0.1.1`, and publishes the GitHub Release artifacts.

### What v0.1.1 ships (landed on main since v0.1.0)

- `fix(core): cap consecutive n-gram repeats in seq2seq greedy decode` (#2)
- `feat(core): subtitle-grade cue re-segmentation for all families` (#3)
- `fix(core): silence-aware longform VAD/packed force-cuts` (#4)
- `fix(core): time-domain overlap trim in longform assembler` (#5)

### Scope

Version/lockfile only — no source changes in this PR.

Assisted-by: Claude