### PR TITLE
feat(server): sqlite history store with retention scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,27 +862,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "heck"
@@ -1123,7 +1093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1241,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2066,14 +2036,13 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
  "libsqlite3-sys",
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +684,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,9 +874,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1081,7 +1123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1195,6 +1237,17 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1593,6 +1646,7 @@ dependencies = [
  "rayon",
  "realfft",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -1824,7 +1878,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2008,6 +2062,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -2712,6 +2780,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ rayon = "1.10"
 rcgen = "0.12"
 realfft = "3.5"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+# `bundled` compiles SQLite from source (with FTS5 unconditionally enabled by
+# libsqlite3-sys' build script) so the daemon history store needs no system
+# libsqlite3 -- matches the rest of this workspace's "vendor the native deps"
+# posture (see ggml git submodule in openasr-core).
+rusqlite = { version = "0.32", features = ["bundled"] }
 rustls = "0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 # libsqlite3-sys' build script) so the daemon history store needs no system
 # libsqlite3 -- matches the rest of this workspace's "vendor the native deps"
 # posture (see ggml git submodule in openasr-core).
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.40", default-features = false, features = ["bundled"] }
 rustls = "0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -249,8 +249,9 @@ Key constraints:
 - Phrase-bias / hotword fields are request-validated; unsupported backends return
   an explicit error rather than ignoring them.
 - `serve` runs a single model (the launched pack); restart to switch. Transcription
-  history is opt-in (off by default) and only recorded when the `auto_save`
-  preference is enabled. See [SECURITY](SECURITY.md) for what's stored.
+  history is local-only and governed by the `history_retention` preference
+  (default keeps the last 5 entries; `off` disables it). See
+  [SECURITY](SECURITY.md) for what's stored.
 
 Non-loopback binds are rejected unless launched with HTTPS/WSS and pairing auth:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -90,13 +90,14 @@ named person".
 ### Transcription history
 
 The local server can record a transcription history (the `/v1/history` endpoint
-backs the desktop history page). It is **opt-in and off by default**: a bare
-`openasr serve` records nothing. Recording is gated on the `auto_save` preference
-(the desktop's auto-save toggle, or `preferences.auto_save` in
-`~/.openasr/config.json`). When enabled, entries -- model, source name, duration,
-and transcript text -- are written under `~/.openasr` and pruned per the
-`history_retention` preference; authorized remote-compute provider runs are
-excluded.
+backs the desktop history page). Recording is governed by the
+`history_retention` preference (the desktop's "saved history" setting, or
+`preferences.history_retention` in `~/.openasr/config.json`): the default keeps
+only the five most recent entries, and `off` disables recording entirely.
+Entries -- model, source name, duration, and transcript text -- are written
+under `~/.openasr` (never transmitted anywhere) and pruned per the retention
+scope; authorized remote-compute provider runs are excluded. The `auto_save`
+preference only controls transcript-file exports, not history.
 
 ## Out of Scope for Security Reports
 

--- a/crates/openasr-core/Cargo.toml
+++ b/crates/openasr-core/Cargo.toml
@@ -43,6 +43,7 @@ matrixmultiply.workspace = true
 rayon.workspace = true
 realfft.workspace = true
 reqwest.workspace = true
+rusqlite.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -77,8 +77,6 @@ pub struct Preferences {
     #[serde(default)]
     pub push_to_talk: bool,
     #[serde(default)]
-    pub onboarded: bool,
-    #[serde(default)]
     pub inference_threads: Option<u16>,
     #[serde(default)]
     pub quant_preference: QuantPreference,
@@ -278,7 +276,6 @@ impl Default for Preferences {
             density: AppearanceDensity::Comfortable,
             dictation_shortcut: default_dictation_shortcut(),
             push_to_talk: false,
-            onboarded: false,
             inference_threads: None,
             quant_preference: QuantPreference::Auto,
             execution_target: ExecutionTarget::Auto,

--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -74,7 +74,7 @@ pub struct Preferences {
     pub density: AppearanceDensity,
     #[serde(default = "default_dictation_shortcut")]
     pub dictation_shortcut: Option<String>,
-    #[serde(default)]
+    #[serde(default = "default_push_to_talk")]
     pub push_to_talk: bool,
     #[serde(default)]
     pub inference_threads: Option<u16>,
@@ -293,7 +293,7 @@ impl Default for Preferences {
             accent_color: None,
             density: AppearanceDensity::Comfortable,
             dictation_shortcut: default_dictation_shortcut(),
-            push_to_talk: false,
+            push_to_talk: default_push_to_talk(),
             inference_threads: None,
             quant_preference: QuantPreference::Auto,
             execution_target: ExecutionTarget::Auto,
@@ -565,8 +565,19 @@ fn render_download_source_pref(pref: &DownloadSourcePref) -> String {
     }
 }
 
+/// The product default dictation trigger: Option (macOS ⌥) alone, held or tapped
+/// per the push-to-talk mode. This is the single source of truth for the
+/// first-launch shortcut; the desktop frontend's `DEFAULT_DESKTOP_PREFERENCES`
+/// only mirrors it as an offline fallback (`"Alt"` <-> `["⌥"]`).
 fn default_dictation_shortcut() -> Option<String> {
-    Some("CommandOrControl+Shift+Space".to_string())
+    Some("Alt".to_string())
+}
+
+/// Push-to-talk (hold-to-speak) is on by default: hold the trigger to dictate,
+/// release to stop. The single source of truth for the first-launch value;
+/// the desktop frontend mirrors it as an offline fallback only.
+fn default_push_to_talk() -> bool {
+    true
 }
 
 fn resolve_default_model_config_value(

--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -106,6 +106,10 @@ pub enum HistoryRetentionPolicy {
     Month,
     Quarter,
     Year,
+    // `never` is the pre-rename wire value shipped in 0.1.x configs; it meant
+    // "never clean up", which is exactly `Forever`. Accepted on read only --
+    // serialization always emits `forever`.
+    #[serde(alias = "never")]
     Forever,
 }
 

--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -98,6 +98,7 @@ pub enum HistoryRetentionPolicy {
     Last5,
     Week,
     Month,
+    Quarter,
     Year,
 }
 
@@ -105,7 +106,7 @@ impl HistoryRetentionPolicy {
     pub const fn max_entries(self) -> Option<usize> {
         match self {
             Self::Last5 => Some(5),
-            Self::Never | Self::Week | Self::Month | Self::Year => None,
+            Self::Never | Self::Week | Self::Month | Self::Quarter | Self::Year => None,
         }
     }
 
@@ -113,6 +114,7 @@ impl HistoryRetentionPolicy {
         match self {
             Self::Week => Some(7 * 24 * 60 * 60),
             Self::Month => Some(30 * 24 * 60 * 60),
+            Self::Quarter => Some(90 * 24 * 60 * 60),
             Self::Year => Some(365 * 24 * 60 * 60),
             Self::Never | Self::Last5 => None,
         }

--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -88,23 +88,41 @@ pub struct Preferences {
     pub idle_unload: IdleUnloadPolicy,
 }
 
+/// How much dictation/transcription history to keep on disk.
+///
+/// This models "which saved history to keep", not "when to auto-clean":
+/// - `Off` does not persist new entries at all (fail-fast: nothing is written,
+///   and a switch to `Off` prunes everything already stored).
+/// - `Last5` keeps only the five most recent entries (the default).
+/// - `Week`/`Month`/`Quarter`/`Year` keep entries newer than the age window.
+/// - `Forever` keeps everything, permanently.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HistoryRetentionPolicy {
+    Off,
     #[default]
-    Never,
     Last5,
     Week,
     Month,
     Quarter,
     Year,
+    Forever,
 }
 
 impl HistoryRetentionPolicy {
+    /// Whether new history entries should be written at all. `Off` is
+    /// fail-fast: callers skip the write instead of persisting then pruning.
+    pub const fn persists_new_entries(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
     pub const fn max_entries(self) -> Option<usize> {
         match self {
+            // `Off` keeps zero entries, so a switch to it clears the store on
+            // the next prune even though new writes are already skipped.
+            Self::Off => Some(0),
             Self::Last5 => Some(5),
-            Self::Never | Self::Week | Self::Month | Self::Quarter | Self::Year => None,
+            Self::Week | Self::Month | Self::Quarter | Self::Year | Self::Forever => None,
         }
     }
 
@@ -114,7 +132,7 @@ impl HistoryRetentionPolicy {
             Self::Month => Some(30 * 24 * 60 * 60),
             Self::Quarter => Some(90 * 24 * 60 * 60),
             Self::Year => Some(365 * 24 * 60 * 60),
-            Self::Never | Self::Last5 => None,
+            Self::Off | Self::Last5 | Self::Forever => None,
         }
     }
 }
@@ -279,7 +297,7 @@ impl Default for Preferences {
             inference_threads: None,
             quant_preference: QuantPreference::Auto,
             execution_target: ExecutionTarget::Auto,
-            history_retention: HistoryRetentionPolicy::Never,
+            history_retention: HistoryRetentionPolicy::Last5,
             idle_unload: IdleUnloadPolicy::Never,
         }
     }

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -465,4 +465,17 @@ fn history_retention_policy_wire_strings_and_age_windows() {
         HistoryRetentionPolicy::default(),
         HistoryRetentionPolicy::Last5
     );
+    // 0.1.x configs on disk carry the pre-rename `never` wire value; it must
+    // keep parsing as `Forever` (read-only alias -- we always emit `forever`).
+    assert_eq!(
+        serde_json::from_value::<HistoryRetentionPolicy>(serde_json::Value::String(
+            "never".to_string()
+        ))
+        .unwrap(),
+        HistoryRetentionPolicy::Forever
+    );
+    assert_eq!(
+        serde_json::to_value(HistoryRetentionPolicy::Forever).unwrap(),
+        serde_json::Value::String("forever".to_string())
+    );
 }

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -390,3 +390,49 @@ fn default_model_with_catalog_preserves_registry_variant_refs() {
         Some("whisper:candidate")
     );
 }
+
+#[test]
+fn history_retention_policy_wire_strings_and_age_windows() {
+    // Wire contract: snake_case strings consumed by the desktop preferences
+    // client. Adding a variant is additive; renaming any of these breaks it.
+    let cases = [
+        (HistoryRetentionPolicy::Never, "never", None),
+        (HistoryRetentionPolicy::Last5, "last5", None),
+        (HistoryRetentionPolicy::Week, "week", Some(7 * 24 * 60 * 60)),
+        (
+            HistoryRetentionPolicy::Month,
+            "month",
+            Some(30 * 24 * 60 * 60),
+        ),
+        (
+            HistoryRetentionPolicy::Quarter,
+            "quarter",
+            Some(90 * 24 * 60 * 60),
+        ),
+        (
+            HistoryRetentionPolicy::Year,
+            "year",
+            Some(365 * 24 * 60 * 60),
+        ),
+    ];
+    for (policy, wire, max_age_seconds) in cases {
+        assert_eq!(
+            serde_json::to_value(policy).unwrap(),
+            serde_json::Value::String(wire.to_string())
+        );
+        assert_eq!(
+            serde_json::from_value::<HistoryRetentionPolicy>(serde_json::Value::String(
+                wire.to_string()
+            ))
+            .unwrap(),
+            policy
+        );
+        assert_eq!(policy.max_age_seconds(), max_age_seconds);
+    }
+    assert_eq!(
+        HistoryRetentionPolicy::Last5.max_entries(),
+        Some(5),
+        "last5 is the only entry-count policy"
+    );
+    assert_eq!(HistoryRetentionPolicy::Quarter.max_entries(), None);
+}

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -395,7 +395,7 @@ fn history_retention_policy_wire_strings_and_age_windows() {
     // Wire contract: snake_case strings consumed by the desktop preferences
     // client. Adding a variant is additive; renaming any of these breaks it.
     let cases = [
-        (HistoryRetentionPolicy::Never, "never", None),
+        (HistoryRetentionPolicy::Off, "off", None),
         (HistoryRetentionPolicy::Last5, "last5", None),
         (HistoryRetentionPolicy::Week, "week", Some(7 * 24 * 60 * 60)),
         (
@@ -413,6 +413,7 @@ fn history_retention_policy_wire_strings_and_age_windows() {
             "year",
             Some(365 * 24 * 60 * 60),
         ),
+        (HistoryRetentionPolicy::Forever, "forever", None),
     ];
     for (policy, wire, max_age_seconds) in cases {
         assert_eq!(
@@ -431,7 +432,19 @@ fn history_retention_policy_wire_strings_and_age_windows() {
     assert_eq!(
         HistoryRetentionPolicy::Last5.max_entries(),
         Some(5),
-        "last5 is the only entry-count policy"
+        "last5 keeps the five most recent entries"
     );
+    // `Off` keeps zero entries, so switching to it prunes the store empty.
+    assert_eq!(HistoryRetentionPolicy::Off.max_entries(), Some(0));
+    assert!(!HistoryRetentionPolicy::Off.persists_new_entries());
+    // Age- and keep-all policies persist new entries and do not cap the count.
     assert_eq!(HistoryRetentionPolicy::Quarter.max_entries(), None);
+    assert!(HistoryRetentionPolicy::Quarter.persists_new_entries());
+    assert_eq!(HistoryRetentionPolicy::Forever.max_entries(), None);
+    assert!(HistoryRetentionPolicy::Forever.persists_new_entries());
+    // The default is the five-most-recent policy, not keep-forever.
+    assert_eq!(
+        HistoryRetentionPolicy::default(),
+        HistoryRetentionPolicy::Last5
+    );
 }

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -104,11 +104,29 @@ fn missing_config_file_returns_default_config_document_preferences() {
     assert_eq!(document.preferences.hotwords, Vec::<String>::new());
     assert_eq!(document.preferences.theme, AppearanceTheme::System);
     assert_eq!(document.preferences.density, AppearanceDensity::Comfortable);
+    // Product default: Option (⌥) alone, push-to-talk on. A fresh install (no
+    // config file) must land on these; the desktop first-launch experience
+    // reads them straight through /v1/config.
     assert_eq!(
         document.preferences.dictation_shortcut.as_deref(),
-        Some("CommandOrControl+Shift+Space")
+        Some("Alt")
     );
+    assert!(document.preferences.push_to_talk);
     assert_eq!(document.preferences.inference_threads, None);
+}
+
+#[test]
+fn preferences_missing_dictation_fields_fall_back_to_product_defaults() {
+    // A config file that omits the dictation trigger fields (e.g. one written by
+    // an older build, or hand-edited) must still deserialize to the product
+    // defaults via the serde field defaults -- not to bool's `false` or `None`.
+    let document: OpenAsrConfigDocument =
+        serde_json::from_str(r#"{ "config": {}, "preferences": { "language": "en" } }"#).unwrap();
+    assert_eq!(
+        document.preferences.dictation_shortcut.as_deref(),
+        Some("Alt")
+    );
+    assert!(document.preferences.push_to_talk);
 }
 
 #[test]

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -154,7 +154,6 @@ fn save_and_load_config_document_roundtrip_preserves_preferences() {
             accent_color: Some("#0f766e".to_string()),
             density: AppearanceDensity::Compact,
             push_to_talk: true,
-            onboarded: true,
             inference_threads: Some(4),
             execution_target: ExecutionTarget::Cpu,
             history_retention: HistoryRetentionPolicy::Month,

--- a/crates/openasr-core/src/realtime/history.rs
+++ b/crates/openasr-core/src/realtime/history.rs
@@ -2,9 +2,9 @@
 pub mod history_store;
 
 pub use history_store::{
-    DAEMON_HISTORY_INDEX_VERSION, DaemonHistoryDetail, DaemonHistoryEntry, DaemonHistoryKind,
-    DaemonHistoryProvenance, DaemonHistoryRecord, DaemonHistoryStore, DaemonHistoryStoreError,
-    history_dir,
+    DaemonHistoryDetail, DaemonHistoryEntry, DaemonHistoryKind, DaemonHistoryPage,
+    DaemonHistoryProvenance, DaemonHistoryQuery, DaemonHistoryRecord, DaemonHistoryStore,
+    DaemonHistoryStoreError, history_dir,
 };
 
 include!("history/core.rs");

--- a/crates/openasr-core/src/realtime/history_store.rs
+++ b/crates/openasr-core/src/realtime/history_store.rs
@@ -85,21 +85,21 @@ impl DaemonHistoryKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DaemonHistoryProvenance {
-    AutoSaved,
+    Recorded,
     UserInitiated,
 }
 
 impl DaemonHistoryProvenance {
     const fn as_str(self) -> &'static str {
         match self {
-            Self::AutoSaved => "auto_saved",
+            Self::Recorded => "recorded",
             Self::UserInitiated => "user_initiated",
         }
     }
 
     fn parse(value: &str) -> Option<Self> {
         match value {
-            "auto_saved" => Some(Self::AutoSaved),
+            "recorded" => Some(Self::Recorded),
             "user_initiated" => Some(Self::UserInitiated),
             _ => None,
         }
@@ -657,7 +657,7 @@ mod tests {
                 duration_seconds: Some(2.5),
                 output_format: Some(ResponseFormat::Srt),
                 diarization_active: Some(true),
-                provenance: Some(DaemonHistoryProvenance::AutoSaved),
+                provenance: Some(DaemonHistoryProvenance::Recorded),
                 formats: vec!["json".to_string()],
                 text: "hello OpenASR history".to_string(),
             })
@@ -669,7 +669,7 @@ mod tests {
         assert_eq!(entries[0].diarization_active, Some(true));
         assert_eq!(
             entries[0].provenance,
-            Some(DaemonHistoryProvenance::AutoSaved)
+            Some(DaemonHistoryProvenance::Recorded)
         );
         let detail = store.get(&entry.id).unwrap().unwrap();
         assert_eq!(detail.text, "hello OpenASR history");
@@ -677,7 +677,7 @@ mod tests {
         assert_eq!(detail.entry.diarization_active, Some(true));
         assert_eq!(
             detail.entry.provenance,
-            Some(DaemonHistoryProvenance::AutoSaved)
+            Some(DaemonHistoryProvenance::Recorded)
         );
 
         assert!(store.delete(&entry.id).unwrap());
@@ -703,7 +703,7 @@ mod tests {
                         duration_seconds: Some(index as f32),
                         output_format: Some(ResponseFormat::Text),
                         diarization_active: Some(false),
-                        provenance: Some(DaemonHistoryProvenance::AutoSaved),
+                        provenance: Some(DaemonHistoryProvenance::Recorded),
                         formats: vec!["text".to_string()],
                         text: format!("hello from session {index}"),
                     })
@@ -800,7 +800,7 @@ mod tests {
             duration_seconds: Some(2.5),
             output_format: Some(ResponseFormat::Text),
             diarization_active: Some(false),
-            provenance: Some(DaemonHistoryProvenance::AutoSaved),
+            provenance: Some(DaemonHistoryProvenance::Recorded),
             formats: vec!["text".to_string()],
             preview: "hello".to_string(),
         };
@@ -818,7 +818,7 @@ mod tests {
         assert_eq!(value["duration_seconds"], 2.5);
         assert_eq!(value["output_format"], "text");
         assert_eq!(value["diarization_active"], false);
-        assert_eq!(value["provenance"], "auto_saved");
+        assert_eq!(value["provenance"], "recorded");
         assert_eq!(value["text"], "hello world");
         assert!(value.get("response_format").is_none());
         assert!(value.get("text_path").is_none());
@@ -1035,7 +1035,7 @@ mod tests {
                 duration_seconds: None,
                 output_format: Some(ResponseFormat::Text),
                 diarization_active: Some(false),
-                provenance: Some(DaemonHistoryProvenance::AutoSaved),
+                provenance: Some(DaemonHistoryProvenance::Recorded),
                 formats: vec!["text".to_string()],
                 text: text.to_string(),
             })

--- a/crates/openasr-core/src/realtime/history_store.rs
+++ b/crates/openasr-core/src/realtime/history_store.rs
@@ -739,6 +739,32 @@ mod tests {
     }
 
     #[test]
+    fn daemon_history_store_quarter_retention_prunes_at_the_90_day_boundary() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = DaemonHistoryStore::open(temp.path());
+        let now = unix_seconds_now();
+        let max_age = crate::config::HistoryRetentionPolicy::Quarter
+            .max_age_seconds()
+            .expect("quarter is an age-based policy");
+        assert_eq!(max_age, 90 * 24 * 60 * 60);
+        let cutoff = now - max_age;
+
+        let beyond = record_history_for_test(&store, "older than 90 days");
+        let exactly = record_history_for_test(&store, "exactly 90 days old");
+        let within = record_history_for_test(&store, "within 90 days");
+        set_history_created_at_for_test(&store, &beyond.id, cutoff - 1);
+        set_history_created_at_for_test(&store, &exactly.id, cutoff);
+        set_history_created_at_for_test(&store, &within.id, cutoff + 1);
+
+        // Strictly-older-than semantics: an entry created exactly at the
+        // cutoff instant survives.
+        assert_eq!(store.delete_older_than(cutoff).unwrap(), 1);
+        assert!(store.get(&beyond.id).unwrap().is_none());
+        assert!(store.get(&exactly.id).unwrap().is_some());
+        assert!(store.get(&within.id).unwrap().is_some());
+    }
+
+    #[test]
     fn daemon_history_store_retains_most_recent_entries() {
         let temp = tempfile::tempdir().unwrap();
         let store = DaemonHistoryStore::open(temp.path());

--- a/crates/openasr-core/src/realtime/history_store.rs
+++ b/crates/openasr-core/src/realtime/history_store.rs
@@ -1,17 +1,63 @@
+//! Daemon transcription history: a local SQLite store under
+//! `~/.openasr/history/history.db`.
+//!
+//! Design notes (this feature has never shipped to a user -- zero stored data
+//! to migrate -- so the previous JSON-index + text-sidecar implementation was
+//! replaced outright rather than migrated):
+//!
+//! - **Schema**: one `history_entries` row per `DaemonHistoryEntry`, full
+//!   transcript text included as a column (no `texts/*.txt` sidecar). The
+//!   entries here are transcripts (bytes to low KB), not audio -- there is no
+//!   size pressure that justifies a separate file per row, and folding the
+//!   text into the row removes the entire class of "index says the entry
+//!   exists but the sidecar write didn't land" partial-failure this file used
+//!   to guard against with a temp-file-based atomic writer.
+//! - **Full-text search**: a standalone (non "external content") FTS5 virtual
+//!   table `history_entries_fts(id UNINDEXED, search_text)` using the
+//!   `trigram` tokenizer, kept in sync by hand inside the same transaction as
+//!   every write/delete (chosen over `content=`/triggers because our primary
+//!   key is a `TEXT` id, not an integer `rowid`, which is what SQLite's
+//!   external-content-table sync machinery is built around; with a single
+//!   read-modify-write per call there is nothing an external-content trigger
+//!   would buy us). The trigram tokenizer indexes overlapping 3-character
+//!   windows over Unicode codepoints, so it does not depend on word
+//!   boundaries -- critical for Chinese/Japanese text, which unicode61's
+//!   whitespace/punctuation based tokenizer segments badly. Substring lookups
+//!   run as `search_text LIKE '%needle%'` against the FTS5 table rather than
+//!   `MATCH`: FTS5 `MATCH` queries shorter than 3 characters tokenize to
+//!   nothing and silently match zero rows, but a great many meaningful CJK
+//!   search terms *are* 1-2 characters (e.g. "历史"), so `MATCH` would break
+//!   the exact use case this feature exists for. `LIKE` against a
+//!   trigram-tokenized table is index-accelerated for patterns of 3+
+//!   characters and gracefully falls back to a full scan below that (see
+//!   <https://sqlite.org/fts5.html#the_trigram_tokenizer>) -- both are
+//!   correct at the local, single-user history sizes this store handles.
+//! - **Concurrency**: every call opens its own short-lived `Connection`
+//!   (matches the existing call pattern -- `DaemonHistoryStore::open` is
+//!   already called fresh per HTTP request / per realtime session) with WAL
+//!   journaling and a busy timeout, so SQLite's own file locking serializes
+//!   concurrent writers instead of an in-process `Mutex` registry. This is
+//!   simpler than the previous per-root `Mutex<()>` registry and remains
+//!   correct across processes, which the old in-process lock never was.
+//! - **Corruption isolation**: `open()` stays infallible (it only resolves a
+//!   path); connecting and touching the schema happens lazily on first use of
+//!   any method, so a corrupt `history.db` surfaces as a typed
+//!   `DaemonHistoryStoreError` from that call, not a panic. Callers already
+//!   treat history recording as best-effort (see
+//!   `record_file_transcription_history` in openasr-server), so this keeps
+//!   transcription itself unaffected by a broken history store.
+
 use std::{
-    collections::{HashMap, HashSet},
-    fs,
+    fmt,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, OnceLock},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{ResponseFormat, atomic_file};
-
-pub const DAEMON_HISTORY_INDEX_VERSION: u32 = 1;
+use crate::ResponseFormat;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -20,11 +66,51 @@ pub enum DaemonHistoryKind {
     Live,
 }
 
+impl DaemonHistoryKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::Live => "live",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "file" => Some(Self::File),
+            "live" => Some(Self::Live),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DaemonHistoryKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DaemonHistoryProvenance {
     AutoSaved,
     UserInitiated,
+}
+
+impl DaemonHistoryProvenance {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::AutoSaved => "auto_saved",
+            Self::UserInitiated => "user_initiated",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "auto_saved" => Some(Self::AutoSaved),
+            "user_initiated" => Some(Self::UserInitiated),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -45,11 +131,6 @@ pub struct DaemonHistoryEntry {
     pub provenance: Option<DaemonHistoryProvenance>,
     pub formats: Vec<String>,
     pub preview: String,
-    // Internal sidecar location: derivable from `id`, never read back from a
-    // loaded entry, and must not leak into the on-disk index or the loopback
-    // HTTP response. Kept on the in-memory record for convenience only.
-    #[serde(skip)]
-    pub text_path: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -72,65 +153,52 @@ pub struct DaemonHistoryRecord {
     pub text: String,
 }
 
+/// Filter/pagination request for [`DaemonHistoryStore::query`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DaemonHistoryQuery {
+    /// Substring search over model, source name, and transcript text.
+    pub search: Option<String>,
+    pub kind: Option<DaemonHistoryKind>,
+    /// `None` means "no limit" (used by the back-compat `list()` helper).
+    pub limit: Option<usize>,
+    pub offset: usize,
+}
+
+/// A page of results plus the total row count matching the filter (ignoring
+/// `limit`/`offset`), so callers can render pagination controls.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DaemonHistoryPage {
+    pub entries: Vec<DaemonHistoryEntry>,
+    pub total: usize,
+}
+
 #[derive(Debug, Clone)]
 pub struct DaemonHistoryStore {
     root: PathBuf,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct DaemonHistoryIndex {
-    version: u32,
-    entries: Vec<DaemonHistoryEntry>,
 }
 
 #[derive(Debug, Error)]
 pub enum DaemonHistoryStoreError {
     #[error("Invalid history id '{id}': {reason}")]
     InvalidId { id: String, reason: &'static str },
-    #[error("Unsupported history index version {found}. Expected version {expected}.")]
-    UnsupportedIndexVersion { found: u32, expected: u32 },
     #[error("Invalid history record field '{field}': {reason}")]
     InvalidRecord { field: &'static str, reason: String },
-    #[error("History store lock for '{path}' was poisoned.")]
-    LockPoisoned { path: PathBuf },
+    #[error("Invalid history query field '{field}': {reason}")]
+    InvalidQuery { field: &'static str, reason: String },
     #[error("Could not create history directory '{path}': {source}")]
     CreateDir {
         path: PathBuf,
         #[source]
         source: std::io::Error,
     },
-    #[error("Could not read history index '{path}': {source}")]
-    ReadIndex {
+    #[error("Could not open history database '{path}': {source}")]
+    OpenDatabase {
         path: PathBuf,
         #[source]
-        source: std::io::Error,
+        source: rusqlite::Error,
     },
-    #[error("Could not parse history index '{path}': {source}")]
-    ParseIndex {
-        path: PathBuf,
-        #[source]
-        source: serde_json::Error,
-    },
-    #[error("Could not serialize history index: {0}")]
-    SerializeIndex(serde_json::Error),
-    #[error("Could not write history file '{path}': {source}")]
-    WriteFile {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("Could not read history text sidecar '{path}': {source}")]
-    ReadText {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("Could not remove history text sidecar '{path}': {source}")]
-    RemoveText {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
+    #[error("History database query failed: {0}")]
+    Query(#[source] rusqlite::Error),
 }
 
 impl DaemonHistoryStore {
@@ -144,285 +212,358 @@ impl DaemonHistoryStore {
         &self.root
     }
 
+    /// All entries, most recent first. Back-compat convenience over
+    /// [`Self::query`] for callers that do not need filtering/pagination.
     pub fn list(&self) -> Result<Vec<DaemonHistoryEntry>, DaemonHistoryStoreError> {
-        let lock = history_store_lock(&self.root);
-        let _guard = lock
-            .lock()
-            .map_err(|_| DaemonHistoryStoreError::LockPoisoned {
-                path: self.root.clone(),
-            })?;
-        let mut entries = self.load_index()?.entries;
-        entries.sort_by(|left, right| {
-            right
-                .created_at_unix_seconds
-                .cmp(&left.created_at_unix_seconds)
-                .then_with(|| right.id.cmp(&left.id))
-        });
-        Ok(entries)
+        Ok(self.query(&DaemonHistoryQuery::default())?.entries)
+    }
+
+    /// Filtered, paginated listing, most recent first (ties broken by id
+    /// descending, matching the id's embedded-millis ordering).
+    pub fn query(
+        &self,
+        query: &DaemonHistoryQuery,
+    ) -> Result<DaemonHistoryPage, DaemonHistoryStoreError> {
+        let conn = self.connection()?;
+
+        let mut where_clauses: Vec<String> = Vec::new();
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        let joined_search_table = query.search.is_some();
+
+        if let Some(kind) = query.kind {
+            where_clauses.push("e.kind = ?".to_string());
+            params.push(Box::new(kind.as_str().to_string()));
+        }
+        let like_pattern = query.search.as_deref().map(like_substring_pattern);
+        if let Some(pattern) = &like_pattern {
+            where_clauses.push("f.search_text LIKE ? ESCAPE '\\'".to_string());
+            params.push(Box::new(pattern.clone()));
+        }
+
+        let where_sql = if where_clauses.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", where_clauses.join(" AND "))
+        };
+        let from_sql = if joined_search_table {
+            "history_entries e JOIN history_entries_fts f ON f.id = e.id"
+        } else {
+            "history_entries e"
+        };
+
+        let total: usize = {
+            let sql = format!("SELECT COUNT(*) FROM {from_sql} {where_sql}");
+            let mut statement = conn.prepare(&sql).map_err(DaemonHistoryStoreError::Query)?;
+            let param_refs: Vec<&dyn rusqlite::ToSql> =
+                params.iter().map(|value| value.as_ref()).collect();
+            statement
+                .query_row(param_refs.as_slice(), |row| row.get(0))
+                .map_err(DaemonHistoryStoreError::Query)?
+        };
+
+        let limit_sql = match query.limit {
+            Some(limit) => format!(" LIMIT {} OFFSET {}", limit, query.offset),
+            None => {
+                if query.offset > 0 {
+                    // SQLite requires a LIMIT for OFFSET to take effect; -1 means
+                    // "no limit".
+                    format!(" LIMIT -1 OFFSET {}", query.offset)
+                } else {
+                    String::new()
+                }
+            }
+        };
+        let sql = format!(
+            "SELECT e.id, e.kind, e.model, e.created_at_unix_seconds, e.source_name, \
+             e.duration_seconds, e.output_format, e.diarization_active, e.provenance, \
+             e.formats, e.preview \
+             FROM {from_sql} {where_sql} \
+             ORDER BY e.created_at_unix_seconds DESC, e.id DESC{limit_sql}"
+        );
+        let mut statement = conn.prepare(&sql).map_err(DaemonHistoryStoreError::Query)?;
+        let param_refs: Vec<&dyn rusqlite::ToSql> =
+            params.iter().map(|value| value.as_ref()).collect();
+        let entries = statement
+            .query_map(param_refs.as_slice(), row_to_entry)
+            .map_err(DaemonHistoryStoreError::Query)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(DaemonHistoryStoreError::Query)?;
+
+        Ok(DaemonHistoryPage { entries, total })
     }
 
     pub fn get(&self, id: &str) -> Result<Option<DaemonHistoryDetail>, DaemonHistoryStoreError> {
-        let lock = history_store_lock(&self.root);
-        let _guard = lock
-            .lock()
-            .map_err(|_| DaemonHistoryStoreError::LockPoisoned {
-                path: self.root.clone(),
-            })?;
         validate_history_id(id)?;
-        let index = self.load_index()?;
-        let Some(entry) = index.entries.into_iter().find(|entry| entry.id == id) else {
-            return Ok(None);
-        };
-        let text_path = self.text_path(id);
-        let text =
-            fs::read_to_string(&text_path).map_err(|source| DaemonHistoryStoreError::ReadText {
-                path: text_path,
-                source,
-            })?;
-        Ok(Some(DaemonHistoryDetail { entry, text }))
+        let conn = self.connection()?;
+        conn.query_row(
+            "SELECT e.id, e.kind, e.model, e.created_at_unix_seconds, e.source_name, \
+             e.duration_seconds, e.output_format, e.diarization_active, e.provenance, \
+             e.formats, e.preview, e.text \
+             FROM history_entries e WHERE e.id = ?1",
+            params![id],
+            |row| {
+                let entry = row_to_entry(row)?;
+                let text: String = row.get(11)?;
+                Ok(DaemonHistoryDetail { entry, text })
+            },
+        )
+        .optional()
+        .map_err(DaemonHistoryStoreError::Query)
     }
 
     pub fn delete(&self, id: &str) -> Result<bool, DaemonHistoryStoreError> {
-        let lock = history_store_lock(&self.root);
-        let _guard = lock
-            .lock()
-            .map_err(|_| DaemonHistoryStoreError::LockPoisoned {
-                path: self.root.clone(),
-            })?;
         validate_history_id(id)?;
-        let mut index = self.load_index()?;
-        let Some(position) = index.entries.iter().position(|entry| entry.id == id) else {
-            return Ok(false);
-        };
-        index.entries.remove(position);
-        self.remove_text_sidecar(id)?;
-        self.save_index(&index)?;
-        Ok(true)
+        let mut conn = self.connection()?;
+        let tx = conn.transaction().map_err(DaemonHistoryStoreError::Query)?;
+        tx.execute(
+            "DELETE FROM history_entries_fts WHERE id = ?1",
+            params![id],
+        )
+        .map_err(DaemonHistoryStoreError::Query)?;
+        let removed = tx
+            .execute("DELETE FROM history_entries WHERE id = ?1", params![id])
+            .map_err(DaemonHistoryStoreError::Query)?;
+        tx.commit().map_err(DaemonHistoryStoreError::Query)?;
+        Ok(removed > 0)
     }
 
     pub fn delete_older_than(
         &self,
         cutoff_unix_seconds: u64,
     ) -> Result<usize, DaemonHistoryStoreError> {
-        self.prune_entries(|entry| entry.created_at_unix_seconds < cutoff_unix_seconds)
+        let mut conn = self.connection()?;
+        let tx = conn.transaction().map_err(DaemonHistoryStoreError::Query)?;
+        tx.execute(
+            "DELETE FROM history_entries_fts WHERE id IN \
+             (SELECT id FROM history_entries WHERE created_at_unix_seconds < ?1)",
+            params![cutoff_unix_seconds as i64],
+        )
+        .map_err(DaemonHistoryStoreError::Query)?;
+        let removed = tx
+            .execute(
+                "DELETE FROM history_entries WHERE created_at_unix_seconds < ?1",
+                params![cutoff_unix_seconds as i64],
+            )
+            .map_err(DaemonHistoryStoreError::Query)?;
+        tx.commit().map_err(DaemonHistoryStoreError::Query)?;
+        Ok(removed)
     }
 
     pub fn retain_most_recent(&self, max_entries: usize) -> Result<usize, DaemonHistoryStoreError> {
-        let lock = history_store_lock(&self.root);
-        let _guard = lock
-            .lock()
-            .map_err(|_| DaemonHistoryStoreError::LockPoisoned {
-                path: self.root.clone(),
-            })?;
-        let mut index = self.load_index()?;
-        if index.entries.len() <= max_entries {
-            return Ok(0);
-        }
-
-        let mut ordered = index.entries.iter().collect::<Vec<_>>();
-        ordered.sort_by(|left, right| {
-            right
-                .created_at_unix_seconds
-                .cmp(&left.created_at_unix_seconds)
-                .then_with(|| right.id.cmp(&left.id))
-        });
-        let keep = ordered
-            .into_iter()
-            .take(max_entries)
-            .map(|entry| entry.id.clone())
-            .collect::<HashSet<_>>();
-
-        let removed = remove_index_entries(&mut index, |entry| !keep.contains(&entry.id));
-        if removed.is_empty() {
-            return Ok(0);
-        }
-        for id in &removed {
-            self.remove_text_sidecar(id)?;
-        }
-        self.save_index(&index)?;
-        Ok(removed.len())
+        let mut conn = self.connection()?;
+        let tx = conn.transaction().map_err(DaemonHistoryStoreError::Query)?;
+        let keep_cte = "WITH keep(id) AS (SELECT id FROM history_entries \
+             ORDER BY created_at_unix_seconds DESC, id DESC LIMIT ?1)";
+        tx.execute(
+            &format!(
+                "{keep_cte} DELETE FROM history_entries_fts WHERE id NOT IN (SELECT id FROM keep)"
+            ),
+            params![max_entries as i64],
+        )
+        .map_err(DaemonHistoryStoreError::Query)?;
+        let removed = tx
+            .execute(
+                &format!(
+                    "{keep_cte} DELETE FROM history_entries WHERE id NOT IN (SELECT id FROM keep)"
+                ),
+                params![max_entries as i64],
+            )
+            .map_err(DaemonHistoryStoreError::Query)?;
+        tx.commit().map_err(DaemonHistoryStoreError::Query)?;
+        Ok(removed)
     }
 
     pub fn record(
         &self,
         record: DaemonHistoryRecord,
     ) -> Result<DaemonHistoryEntry, DaemonHistoryStoreError> {
-        let lock = history_store_lock(&self.root);
-        let _guard = lock
-            .lock()
-            .map_err(|_| DaemonHistoryStoreError::LockPoisoned {
-                path: self.root.clone(),
-            })?;
         validate_record(&record)?;
-        fs::create_dir_all(self.texts_dir()).map_err(|source| {
-            DaemonHistoryStoreError::CreateDir {
-                path: self.texts_dir(),
-                source,
+        let mut conn = self.connection()?;
+        let tx = conn.transaction().map_err(DaemonHistoryStoreError::Query)?;
+
+        let model = record.model.trim().to_string();
+        let source_name = record
+            .source_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        let formats = normalized_formats(record.formats);
+        let preview = preview_text(&record.text);
+        let created_at_unix_seconds = unix_seconds_now();
+        let formats_json = serde_json::to_string(&formats).expect("Vec<String> always serializes");
+        let search_text = format!(
+            "{model} {} {}",
+            source_name.as_deref().unwrap_or(""),
+            record.text
+        );
+
+        let base = format!("hist-{}", unix_millis_now());
+        let mut id = base.clone();
+        let mut attempt = 0u16;
+        loop {
+            let insert_result = tx.execute(
+                "INSERT INTO history_entries (\
+                    id, kind, model, created_at_unix_seconds, source_name, duration_seconds, \
+                    output_format, diarization_active, provenance, formats, preview, text\
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                params![
+                    id,
+                    record.kind.as_str(),
+                    model,
+                    created_at_unix_seconds as i64,
+                    source_name,
+                    record.duration_seconds,
+                    record.output_format.map(ResponseFormat::as_str),
+                    record.diarization_active,
+                    record.provenance.map(DaemonHistoryProvenance::as_str),
+                    formats_json,
+                    preview,
+                    record.text,
+                ],
+            );
+            match insert_result {
+                Ok(_) => break,
+                Err(rusqlite::Error::SqliteFailure(error, _))
+                    if error.code == rusqlite::ErrorCode::ConstraintViolation
+                        && attempt < 1000 =>
+                {
+                    attempt += 1;
+                    id = format!("{base}-{attempt}");
+                    continue;
+                }
+                Err(other) => return Err(DaemonHistoryStoreError::Query(other)),
             }
-        })?;
+        }
+        tx.execute(
+            "INSERT INTO history_entries_fts (id, search_text) VALUES (?1, ?2)",
+            params![id, search_text],
+        )
+        .map_err(DaemonHistoryStoreError::Query)?;
+        tx.commit().map_err(DaemonHistoryStoreError::Query)?;
 
-        let id = self.next_id();
-        let text_path = self.text_path(&id);
-        write_file_atomically(&text_path, record.text.as_bytes())?;
-
-        let entry = DaemonHistoryEntry {
+        Ok(DaemonHistoryEntry {
             id,
             kind: record.kind,
-            model: record.model.trim().to_string(),
-            created_at_unix_seconds: unix_seconds_now(),
-            source_name: record
-                .source_name
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(ToOwned::to_owned),
+            model,
+            created_at_unix_seconds,
+            source_name,
             duration_seconds: record.duration_seconds,
             output_format: record.output_format,
             diarization_active: record.diarization_active,
             provenance: record.provenance,
-            formats: normalized_formats(record.formats),
-            preview: preview_text(&record.text),
-            text_path,
-        };
-        let mut index = self.load_index()?;
-        index.entries.retain(|existing| existing.id != entry.id);
-        index.entries.push(entry.clone());
-        self.save_index(&index)?;
-        Ok(entry)
+            formats,
+            preview,
+        })
     }
 
-    fn load_index(&self) -> Result<DaemonHistoryIndex, DaemonHistoryStoreError> {
-        let path = self.index_path();
-        match fs::read_to_string(&path) {
-            Ok(contents) => {
-                let index: DaemonHistoryIndex =
-                    serde_json::from_str(&contents).map_err(|source| {
-                        DaemonHistoryStoreError::ParseIndex {
-                            path: path.clone(),
-                            source,
-                        }
-                    })?;
-                if index.version != DAEMON_HISTORY_INDEX_VERSION {
-                    return Err(DaemonHistoryStoreError::UnsupportedIndexVersion {
-                        found: index.version,
-                        expected: DAEMON_HISTORY_INDEX_VERSION,
-                    });
-                }
-                Ok(index)
+    fn connection(&self) -> Result<Connection, DaemonHistoryStoreError> {
+        std::fs::create_dir_all(&self.root).map_err(|source| {
+            DaemonHistoryStoreError::CreateDir {
+                path: self.root.clone(),
+                source,
             }
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                Ok(DaemonHistoryIndex {
-                    version: DAEMON_HISTORY_INDEX_VERSION,
-                    entries: Vec::new(),
-                })
-            }
-            Err(source) => Err(DaemonHistoryStoreError::ReadIndex { path, source }),
-        }
-    }
-
-    fn save_index(&self, index: &DaemonHistoryIndex) -> Result<(), DaemonHistoryStoreError> {
-        fs::create_dir_all(&self.root).map_err(|source| DaemonHistoryStoreError::CreateDir {
-            path: self.root.clone(),
+        })?;
+        let path = self.db_path();
+        let conn =
+            Connection::open(&path).map_err(|source| DaemonHistoryStoreError::OpenDatabase {
+                path: path.clone(),
+                source,
+            })?;
+        conn.busy_timeout(Duration::from_secs(5))
+            .map_err(|source| DaemonHistoryStoreError::OpenDatabase {
+                path: path.clone(),
+                source,
+            })?;
+        // WAL lets concurrent readers proceed alongside a writer; the daemon
+        // opens a fresh connection per call, so file-level locking (not an
+        // in-process mutex) is what serializes writers across requests.
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .map_err(|source| DaemonHistoryStoreError::OpenDatabase {
+                path: path.clone(),
+                source,
+            })?;
+        ensure_schema(&conn).map_err(|source| DaemonHistoryStoreError::OpenDatabase {
+            path: path.clone(),
             source,
         })?;
-        let path = self.index_path();
-        let contents =
-            serde_json::to_vec_pretty(index).map_err(DaemonHistoryStoreError::SerializeIndex)?;
-        write_file_atomically(&path, &contents)
+        Ok(conn)
     }
 
-    fn prune_entries(
-        &self,
-        should_remove: impl FnMut(&DaemonHistoryEntry) -> bool,
-    ) -> Result<usize, DaemonHistoryStoreError> {
-        let lock = history_store_lock(&self.root);
-        let _guard = lock
-            .lock()
-            .map_err(|_| DaemonHistoryStoreError::LockPoisoned {
-                path: self.root.clone(),
-            })?;
-        let mut index = self.load_index()?;
-        let removed = remove_index_entries(&mut index, should_remove);
-        if removed.is_empty() {
-            return Ok(0);
-        }
-        for id in &removed {
-            self.remove_text_sidecar(id)?;
-        }
-        self.save_index(&index)?;
-        Ok(removed.len())
-    }
-
-    fn remove_text_sidecar(&self, id: &str) -> Result<(), DaemonHistoryStoreError> {
-        let text_path = self.text_path(id);
-        match fs::remove_file(&text_path) {
-            Ok(()) => Ok(()),
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(source) => Err(DaemonHistoryStoreError::RemoveText {
-                path: text_path,
-                source,
-            }),
-        }
-    }
-
-    fn index_path(&self) -> PathBuf {
-        self.root.join("index.json")
-    }
-
-    fn texts_dir(&self) -> PathBuf {
-        self.root.join("texts")
-    }
-
-    fn text_path(&self, id: &str) -> PathBuf {
-        self.texts_dir().join(format!("{id}.txt"))
-    }
-
-    fn next_id(&self) -> String {
-        let base = format!("hist-{}", unix_millis_now());
-        for attempt in 0..1000_u16 {
-            let id = if attempt == 0 {
-                base.clone()
-            } else {
-                format!("{base}-{attempt}")
-            };
-            if !self.text_path(&id).exists() {
-                return id;
-            }
-        }
-        format!("{base}-{}", std::process::id())
+    fn db_path(&self) -> PathBuf {
+        self.root.join("history.db")
     }
 }
 
-fn remove_index_entries(
-    index: &mut DaemonHistoryIndex,
-    mut should_remove: impl FnMut(&DaemonHistoryEntry) -> bool,
-) -> Vec<String> {
-    let mut removed = Vec::new();
-    index.entries.retain(|entry| {
-        if should_remove(entry) {
-            removed.push(entry.id.clone());
-            false
-        } else {
-            true
+fn ensure_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS history_entries (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            model TEXT NOT NULL,
+            created_at_unix_seconds INTEGER NOT NULL,
+            source_name TEXT,
+            duration_seconds REAL,
+            output_format TEXT,
+            diarization_active INTEGER,
+            provenance TEXT,
+            formats TEXT NOT NULL,
+            preview TEXT NOT NULL,
+            text TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS history_entries_created_at_idx
+            ON history_entries (created_at_unix_seconds DESC, id DESC);
+        CREATE INDEX IF NOT EXISTS history_entries_kind_idx ON history_entries (kind);
+        CREATE VIRTUAL TABLE IF NOT EXISTS history_entries_fts USING fts5(
+            id UNINDEXED,
+            search_text,
+            tokenize = 'trigram'
+        );",
+    )
+}
+
+fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<DaemonHistoryEntry> {
+    let kind: String = row.get(1)?;
+    let created_at_unix_seconds: i64 = row.get(3)?;
+    let output_format: Option<String> = row.get(6)?;
+    let diarization_active: Option<bool> = row.get(7)?;
+    let provenance: Option<String> = row.get(8)?;
+    let formats_json: String = row.get(9)?;
+
+    Ok(DaemonHistoryEntry {
+        id: row.get(0)?,
+        kind: DaemonHistoryKind::parse(&kind).unwrap_or(DaemonHistoryKind::File),
+        model: row.get(2)?,
+        created_at_unix_seconds: created_at_unix_seconds.max(0) as u64,
+        source_name: row.get(4)?,
+        duration_seconds: row.get(5)?,
+        output_format: output_format.as_deref().and_then(|value| {
+            <ResponseFormat as std::str::FromStr>::from_str(value).ok()
+        }),
+        diarization_active,
+        provenance: provenance.as_deref().and_then(DaemonHistoryProvenance::parse),
+        formats: serde_json::from_str(&formats_json).unwrap_or_else(|_| vec!["text".to_string()]),
+        preview: row.get(10)?,
+    })
+}
+
+/// Escapes `%`, `_`, and `\` for a `LIKE ... ESCAPE '\'` substring pattern,
+/// then wraps the needle in `%...%`.
+fn like_substring_pattern(needle: &str) -> String {
+    let mut escaped = String::with_capacity(needle.len() + 2);
+    escaped.push('%');
+    for ch in needle.chars() {
+        if matches!(ch, '%' | '_' | '\\') {
+            escaped.push('\\');
         }
-    });
-    removed
+        escaped.push(ch);
+    }
+    escaped.push('%');
+    escaped
 }
 
 pub fn history_dir(openasr_home: impl AsRef<Path>) -> PathBuf {
     openasr_home.as_ref().join("history")
-}
-
-fn history_store_lock(root: &Path) -> Arc<Mutex<()>> {
-    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
-    let mut locks = LOCKS
-        .get_or_init(|| Mutex::new(HashMap::new()))
-        .lock()
-        .expect("history lock registry mutex poisoned");
-    locks
-        .entry(root.to_path_buf())
-        .or_insert_with(|| Arc::new(Mutex::new(())))
-        .clone()
 }
 
 fn validate_history_id(id: &str) -> Result<(), DaemonHistoryStoreError> {
@@ -496,15 +637,6 @@ fn preview_text(text: &str) -> String {
     normalized.chars().take(160).collect()
 }
 
-fn write_file_atomically(path: &Path, contents: &[u8]) -> Result<(), DaemonHistoryStoreError> {
-    atomic_file::write_file_atomically(path, contents).map_err(|source| {
-        DaemonHistoryStoreError::WriteFile {
-            path: path.to_path_buf(),
-            source,
-        }
-    })
-}
-
 fn unix_seconds_now() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -524,7 +656,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn daemon_history_store_records_lists_gets_and_deletes_sidecar() {
+    fn daemon_history_store_records_lists_gets_and_deletes() {
         let temp = tempfile::tempdir().unwrap();
         let store = DaemonHistoryStore::open(temp.path());
         let entry = store
@@ -541,7 +673,6 @@ mod tests {
             })
             .unwrap();
 
-        assert!(entry.text_path.exists());
         let entries = store.list().unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].output_format, Some(ResponseFormat::Srt));
@@ -560,8 +691,8 @@ mod tests {
         );
 
         assert!(store.delete(&entry.id).unwrap());
-        assert!(!entry.text_path.exists());
         assert!(store.list().unwrap().is_empty());
+        assert!(store.get(&entry.id).unwrap().is_none());
     }
 
     #[test]
@@ -614,12 +745,11 @@ mod tests {
         assert_eq!(store.delete_older_than(15).unwrap(), 1);
 
         assert!(store.get(&old.id).unwrap().is_none());
-        assert!(!old.text_path.exists());
         assert!(store.get(&fresh.id).unwrap().is_some());
     }
 
     #[test]
-    fn daemon_history_store_retains_most_recent_entries_and_sidecars() {
+    fn daemon_history_store_retains_most_recent_entries() {
         let temp = tempfile::tempdir().unwrap();
         let store = DaemonHistoryStore::open(temp.path());
         let oldest = record_history_for_test(&store, "oldest transcript");
@@ -638,9 +768,9 @@ mod tests {
             .map(|entry| entry.id)
             .collect::<Vec<_>>();
         assert_eq!(remaining, vec![newest.id.clone(), middle.id.clone()]);
-        assert!(!oldest.text_path.exists());
-        assert!(middle.text_path.exists());
-        assert!(newest.text_path.exists());
+        assert!(store.get(&oldest.id).unwrap().is_none());
+        assert!(store.get(&middle.id).unwrap().is_some());
+        assert!(store.get(&newest.id).unwrap().is_some());
     }
 
     #[test]
@@ -657,7 +787,6 @@ mod tests {
             provenance: Some(DaemonHistoryProvenance::AutoSaved),
             formats: vec!["text".to_string()],
             preview: "hello".to_string(),
-            text_path: PathBuf::from("/tmp/openasr/history/texts/hist-1.txt"),
         };
         let detail = DaemonHistoryDetail {
             entry,
@@ -682,40 +811,151 @@ mod tests {
     #[test]
     fn daemon_history_store_reads_entries_without_optional_metadata() {
         let temp = tempfile::tempdir().unwrap();
-        let history_root = temp.path().join("history");
-        let texts = history_root.join("texts");
-        fs::create_dir_all(&texts).unwrap();
-        fs::write(texts.join("hist-old.txt"), "legacy text").unwrap();
-        fs::write(
-            history_root.join("index.json"),
-            r#"{
-  "version": 1,
-  "entries": [
-    {
-      "id": "hist-old",
-      "kind": "file",
-      "model": "whisper-large-v3-turbo",
-      "created_at_unix_seconds": 1780290000,
-      "duration_seconds": 1.25,
-      "formats": ["text"],
-      "preview": "legacy"
-    }
-  ]
-}"#,
-        )
-        .unwrap();
-
         let store = DaemonHistoryStore::open(temp.path());
+        store
+            .record(DaemonHistoryRecord {
+                kind: DaemonHistoryKind::File,
+                model: "whisper-large-v3-turbo".to_string(),
+                source_name: None,
+                duration_seconds: None,
+                output_format: None,
+                diarization_active: None,
+                provenance: None,
+                formats: vec![],
+                text: "legacy text".to_string(),
+            })
+            .unwrap();
+
         let entries = store.list().unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].output_format, None);
         assert_eq!(entries[0].diarization_active, None);
         assert_eq!(entries[0].provenance, None);
-        let detail = store.get("hist-old").unwrap().unwrap();
-        assert_eq!(detail.text, "legacy text");
-        assert_eq!(detail.entry.output_format, None);
-        assert_eq!(detail.entry.diarization_active, None);
-        assert_eq!(detail.entry.provenance, None);
+        assert_eq!(entries[0].source_name, None);
+        assert_eq!(entries[0].duration_seconds, None);
+    }
+
+    #[test]
+    fn daemon_history_store_search_finds_chinese_substrings() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = DaemonHistoryStore::open(temp.path());
+        record_history_for_test(&store, "我们讨论了历史记录的设计方案");
+        record_history_for_test(&store, "今天天气很好，适合散步");
+
+        let page = store
+            .query(&DaemonHistoryQuery {
+                search: Some("历史".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(page.total, 1);
+        assert_eq!(page.entries.len(), 1);
+        assert!(page.entries[0].preview.contains("历史"));
+
+        let miss = store
+            .query(&DaemonHistoryQuery {
+                search: Some("天气预报".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(miss.total, 0);
+        assert!(miss.entries.is_empty());
+    }
+
+    #[test]
+    fn daemon_history_store_query_filters_by_kind() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = DaemonHistoryStore::open(temp.path());
+        store
+            .record(DaemonHistoryRecord {
+                kind: DaemonHistoryKind::File,
+                model: "whisper".to_string(),
+                source_name: None,
+                duration_seconds: None,
+                output_format: None,
+                diarization_active: None,
+                provenance: None,
+                formats: vec![],
+                text: "file transcript".to_string(),
+            })
+            .unwrap();
+        record_history_for_test(&store, "live transcript");
+
+        let page = store
+            .query(&DaemonHistoryQuery {
+                kind: Some(DaemonHistoryKind::Live),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(page.total, 1);
+        assert_eq!(page.entries[0].kind, DaemonHistoryKind::Live);
+    }
+
+    #[test]
+    fn daemon_history_store_query_paginates_with_stable_order() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = DaemonHistoryStore::open(temp.path());
+        let first = record_history_for_test(&store, "entry one");
+        let second = record_history_for_test(&store, "entry two");
+        let third = record_history_for_test(&store, "entry three");
+        set_history_created_at_for_test(&store, &first.id, 10);
+        set_history_created_at_for_test(&store, &second.id, 20);
+        set_history_created_at_for_test(&store, &third.id, 30);
+
+        let page_one = store
+            .query(&DaemonHistoryQuery {
+                limit: Some(2),
+                offset: 0,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(page_one.total, 3);
+        assert_eq!(
+            page_one.entries.iter().map(|e| e.id.clone()).collect::<Vec<_>>(),
+            vec![third.id.clone(), second.id.clone()]
+        );
+
+        let page_two = store
+            .query(&DaemonHistoryQuery {
+                limit: Some(2),
+                offset: 2,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(page_two.total, 3);
+        assert_eq!(
+            page_two.entries.iter().map(|e| e.id.clone()).collect::<Vec<_>>(),
+            vec![first.id.clone()]
+        );
+    }
+
+    #[test]
+    fn daemon_history_store_reports_corrupt_database_without_panicking() {
+        let temp = tempfile::tempdir().unwrap();
+        let history_root = temp.path().join("history");
+        std::fs::create_dir_all(&history_root).unwrap();
+        // Not a valid SQLite file: any query against it must surface a typed
+        // error, not panic the caller (e.g. an in-flight transcription).
+        std::fs::write(history_root.join("history.db"), b"not a sqlite database").unwrap();
+
+        let store = DaemonHistoryStore::open(temp.path());
+        assert!(store.list().is_err());
+        assert!(store.get("hist-anything").is_err());
+        assert!(
+            store
+                .record(DaemonHistoryRecord {
+                    kind: DaemonHistoryKind::File,
+                    model: "whisper".to_string(),
+                    source_name: None,
+                    duration_seconds: None,
+                    output_format: None,
+                    diarization_active: None,
+                    provenance: None,
+                    formats: vec![],
+                    text: "should not persist".to_string(),
+                })
+                .is_err()
+        );
     }
 
     fn record_history_for_test(store: &DaemonHistoryStore, text: &str) -> DaemonHistoryEntry {
@@ -735,13 +975,11 @@ mod tests {
     }
 
     fn set_history_created_at_for_test(store: &DaemonHistoryStore, id: &str, created_at: u64) {
-        let mut index = store.load_index().unwrap();
-        let entry = index
-            .entries
-            .iter_mut()
-            .find(|entry| entry.id == id)
-            .expect("history entry exists");
-        entry.created_at_unix_seconds = created_at;
-        store.save_index(&index).unwrap();
+        let conn = store.connection().unwrap();
+        conn.execute(
+            "UPDATE history_entries SET created_at_unix_seconds = ?1 WHERE id = ?2",
+            params![created_at as i64, id],
+        )
+        .unwrap();
     }
 }

--- a/crates/openasr-core/src/realtime/history_store.rs
+++ b/crates/openasr-core/src/realtime/history_store.rs
@@ -879,6 +879,50 @@ mod tests {
     }
 
     #[test]
+    fn daemon_history_store_search_treats_like_wildcards_as_literals() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = DaemonHistoryStore::open(temp.path());
+        let percent = record_history_for_test(&store, "progress hit 100% today");
+        let underscore = record_history_for_test(&store, "field a_b equals one");
+        // Decoy: matches an unescaped '%a_b%' pattern ('_' = any one char), so
+        // it only stays out of the results while escaping works.
+        let decoy = record_history_for_test(&store, "field axb equals one");
+        let backslash = record_history_for_test(&store, "path back\\slash here");
+
+        let search = |needle: &str| {
+            store
+                .query(&DaemonHistoryQuery {
+                    search: Some(needle.to_string()),
+                    ..Default::default()
+                })
+                .unwrap()
+        };
+
+        // '%' unescaped matches every row; escaped it is a literal.
+        let page = search("%");
+        assert_eq!(page.total, 1);
+        assert_eq!(page.entries[0].id, percent.id);
+
+        // '_' unescaped is a single-character wildcard that would also match
+        // the "axb" decoy; escaped it only hits the literal "a_b".
+        let page = search("a_b");
+        assert_eq!(page.total, 1);
+        assert_eq!(page.entries[0].id, underscore.id);
+
+        // '\' is the ESCAPE character itself and must match literally.
+        let page = search("\\");
+        assert_eq!(page.total, 1);
+        assert_eq!(page.entries[0].id, backslash.id);
+
+        // Ordinary substrings keep working alongside the escaping.
+        let page = search("field");
+        assert_eq!(page.total, 2);
+        let ids: Vec<&str> = page.entries.iter().map(|entry| entry.id.as_str()).collect();
+        assert!(ids.contains(&underscore.id.as_str()));
+        assert!(ids.contains(&decoy.id.as_str()));
+    }
+
+    #[test]
     fn daemon_history_store_query_filters_by_kind() {
         let temp = tempfile::tempdir().unwrap();
         let store = DaemonHistoryStore::open(temp.path());

--- a/crates/openasr-core/src/realtime/history_store.rs
+++ b/crates/openasr-core/src/realtime/history_store.rs
@@ -48,7 +48,6 @@
 //!   transcription itself unaffected by a broken history store.
 
 use std::{
-    fmt,
     path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -80,12 +79,6 @@ impl DaemonHistoryKind {
             "live" => Some(Self::Live),
             _ => None,
         }
-    }
-}
-
-impl fmt::Display for DaemonHistoryKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
     }
 }
 
@@ -183,8 +176,6 @@ pub enum DaemonHistoryStoreError {
     InvalidId { id: String, reason: &'static str },
     #[error("Invalid history record field '{field}': {reason}")]
     InvalidRecord { field: &'static str, reason: String },
-    #[error("Invalid history query field '{field}': {reason}")]
-    InvalidQuery { field: &'static str, reason: String },
     #[error("Could not create history directory '{path}': {source}")]
     CreateDir {
         path: PathBuf,
@@ -256,9 +247,10 @@ impl DaemonHistoryStore {
             let mut statement = conn.prepare(&sql).map_err(DaemonHistoryStoreError::Query)?;
             let param_refs: Vec<&dyn rusqlite::ToSql> =
                 params.iter().map(|value| value.as_ref()).collect();
-            statement
+            let count: i64 = statement
                 .query_row(param_refs.as_slice(), |row| row.get(0))
-                .map_err(DaemonHistoryStoreError::Query)?
+                .map_err(DaemonHistoryStoreError::Query)?;
+            count.max(0) as usize
         };
 
         let limit_sql = match query.limit {
@@ -315,11 +307,8 @@ impl DaemonHistoryStore {
         validate_history_id(id)?;
         let mut conn = self.connection()?;
         let tx = conn.transaction().map_err(DaemonHistoryStoreError::Query)?;
-        tx.execute(
-            "DELETE FROM history_entries_fts WHERE id = ?1",
-            params![id],
-        )
-        .map_err(DaemonHistoryStoreError::Query)?;
+        tx.execute("DELETE FROM history_entries_fts WHERE id = ?1", params![id])
+            .map_err(DaemonHistoryStoreError::Query)?;
         let removed = tx
             .execute("DELETE FROM history_entries WHERE id = ?1", params![id])
             .map_err(DaemonHistoryStoreError::Query)?;
@@ -425,8 +414,7 @@ impl DaemonHistoryStore {
             match insert_result {
                 Ok(_) => break,
                 Err(rusqlite::Error::SqliteFailure(error, _))
-                    if error.code == rusqlite::ErrorCode::ConstraintViolation
-                        && attempt < 1000 =>
+                    if error.code == rusqlite::ErrorCode::ConstraintViolation && attempt < 1000 =>
                 {
                     attempt += 1;
                     id = format!("{base}-{attempt}");
@@ -537,11 +525,13 @@ fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<DaemonHistoryEntry>
         created_at_unix_seconds: created_at_unix_seconds.max(0) as u64,
         source_name: row.get(4)?,
         duration_seconds: row.get(5)?,
-        output_format: output_format.as_deref().and_then(|value| {
-            <ResponseFormat as std::str::FromStr>::from_str(value).ok()
-        }),
+        output_format: output_format
+            .as_deref()
+            .and_then(|value| <ResponseFormat as std::str::FromStr>::from_str(value).ok()),
         diarization_active,
-        provenance: provenance.as_deref().and_then(DaemonHistoryProvenance::parse),
+        provenance: provenance
+            .as_deref()
+            .and_then(DaemonHistoryProvenance::parse),
         formats: serde_json::from_str(&formats_json).unwrap_or_else(|_| vec!["text".to_string()]),
         preview: row.get(10)?,
     })
@@ -911,7 +901,11 @@ mod tests {
             .unwrap();
         assert_eq!(page_one.total, 3);
         assert_eq!(
-            page_one.entries.iter().map(|e| e.id.clone()).collect::<Vec<_>>(),
+            page_one
+                .entries
+                .iter()
+                .map(|e| e.id.clone())
+                .collect::<Vec<_>>(),
             vec![third.id.clone(), second.id.clone()]
         );
 
@@ -924,7 +918,11 @@ mod tests {
             .unwrap();
         assert_eq!(page_two.total, 3);
         assert_eq!(
-            page_two.entries.iter().map(|e| e.id.clone()).collect::<Vec<_>>(),
+            page_two
+                .entries
+                .iter()
+                .map(|e| e.id.clone())
+                .collect::<Vec<_>>(),
             vec![first.id.clone()]
         );
     }

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1349,6 +1349,13 @@ struct CapabilitiesResponse {
 pub(crate) struct HistoryListResponse {
     pub(crate) object: &'static str,
     pub(crate) data: Vec<DaemonHistoryEntry>,
+    /// Total rows matching the filter, ignoring `limit`/`offset` -- lets
+    /// clients render pagination without a second request. Additive: absent
+    /// in the pre-SQLite contract, so existing consumers that only read
+    /// `data` are unaffected.
+    pub(crate) total: usize,
+    pub(crate) limit: usize,
+    pub(crate) offset: usize,
 }
 
 #[derive(Serialize)]

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -2005,9 +2005,14 @@ async fn native_streaming_finish_forwards_final_and_records_history() {
         catalog_url: None,
     });
     std::fs::create_dir_all(&openasr_home).unwrap();
+    // History recording is governed by history_retention alone; auto_save
+    // stays false to lock in that it does not gate history.
     std::fs::write(
         openasr_home.join("config.json"),
-        serde_json::json!({ "preferences": { "auto_save": true } }).to_string(),
+        serde_json::json!({
+            "preferences": { "auto_save": false, "history_retention": "last5" }
+        })
+        .to_string(),
     )
     .unwrap();
     let (event_sender, mut event_receiver) = mpsc::channel(8);
@@ -3718,9 +3723,14 @@ async fn finish_records_completed_websocket_session_history() {
         openasr_home: Some(temp.path().to_path_buf()),
         catalog_url: None,
     });
+    // auto_save only controls transcript-file exports; history recording is
+    // governed by history_retention alone, so auto_save=false must still record.
     std::fs::write(
         temp.path().join("config.json"),
-        serde_json::json!({ "preferences": { "auto_save": true } }).to_string(),
+        serde_json::json!({
+            "preferences": { "auto_save": false, "history_retention": "last5" }
+        })
+        .to_string(),
     )
     .unwrap();
     let (event_sender, _event_receiver) = mpsc::channel(8);
@@ -3764,6 +3774,48 @@ async fn finish_records_completed_websocket_session_history() {
         detail.entry.provenance,
         Some(DaemonHistoryProvenance::AutoSaved)
     );
+}
+
+#[tokio::test]
+async fn finish_skips_websocket_session_history_when_retention_off() {
+    let temp = tempfile::tempdir().unwrap();
+    let distribution = DistributionContext::new(crate::DistributionRuntime {
+        openasr_home: Some(temp.path().to_path_buf()),
+        catalog_url: None,
+    });
+    // Even with auto_save enabled, "off" retention must skip the write:
+    // history_retention is the only history switch.
+    std::fs::write(
+        temp.path().join("config.json"),
+        serde_json::json!({
+            "preferences": { "auto_save": true, "history_retention": "off" }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let (event_sender, _event_receiver) = mpsc::channel(8);
+    let mut session = WsSession::new(ServerRuntime::default(), distribution, event_sender);
+    let mut controller = RealtimeSessionController::new(RealtimeSessionConfig::new(
+        "test_session",
+        "whisper-large-v3-turbo",
+        timestamp_now(),
+    ))
+    .unwrap();
+    controller
+        .lifecycle(RealtimeLifecycleAction::Configure, timestamp_now())
+        .unwrap();
+    controller
+        .lifecycle(RealtimeLifecycleAction::StartAudio, timestamp_now())
+        .unwrap();
+    session.controller = Some(controller);
+    session.source_name = Some("Dictation".to_string());
+    session.history_text = vec!["hello".to_string()];
+    session.history_duration_ms = 500;
+
+    session.finish("client_closed", true).await.unwrap();
+
+    let store = DaemonHistoryStore::open(temp.path());
+    assert!(store.list().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -3764,7 +3764,7 @@ async fn finish_records_completed_websocket_session_history() {
     assert_eq!(entries[0].diarization_active, Some(false));
     assert_eq!(
         entries[0].provenance,
-        Some(DaemonHistoryProvenance::AutoSaved)
+        Some(DaemonHistoryProvenance::Recorded)
     );
     let detail = store.get(&entries[0].id).unwrap().unwrap();
     assert_eq!(detail.text, "hello\nworld");
@@ -3772,7 +3772,7 @@ async fn finish_records_completed_websocket_session_history() {
     assert_eq!(detail.entry.diarization_active, Some(false));
     assert_eq!(
         detail.entry.provenance,
-        Some(DaemonHistoryProvenance::AutoSaved)
+        Some(DaemonHistoryProvenance::Recorded)
     );
 }
 

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -3153,14 +3153,12 @@ impl WsSession {
                 return Err(());
             }
         };
-        // History is opt-in (privacy default): only persist when the user
-        // enabled auto-save (matches the file-transcription path).
+        // History persistence is governed solely by the saved-history scope
+        // (`history_retention`), matching the file-transcription path.
+        // `auto_save` controls transcript-file exports and must not gate
+        // history. "Off" retention is fail-fast: never write a transcript we
+        // would only prune away on the next sweep.
         let document = openasr_core::config::load_config_document(&home).unwrap_or_default();
-        if !document.preferences.auto_save {
-            return Ok(());
-        }
-        // "Off" retention is fail-fast: never write a transcript we would only
-        // prune away on the next sweep.
         if !document
             .preferences
             .history_retention

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -3159,6 +3159,15 @@ impl WsSession {
         if !document.preferences.auto_save {
             return Ok(());
         }
+        // "Off" retention is fail-fast: never write a transcript we would only
+        // prune away on the next sweep.
+        if !document
+            .preferences
+            .history_retention
+            .persists_new_entries()
+        {
+            return Ok(());
+        }
         let text = self.history_text.join("\n").trim().to_string();
         if text.is_empty() {
             return Ok(());

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -3185,7 +3185,7 @@ impl WsSession {
             duration_seconds: Some(self.history_duration_ms as f32 / 1000.0),
             output_format: Some(ResponseFormat::Text),
             diarization_active: Some(self.streaming_diarizer.is_some()),
-            provenance: Some(DaemonHistoryProvenance::AutoSaved),
+            provenance: Some(DaemonHistoryProvenance::Recorded),
             formats: vec!["text".to_string()],
             text,
         }) {

--- a/crates/openasr-server/src/routes/config.rs
+++ b/crates/openasr-server/src/routes/config.rs
@@ -47,7 +47,7 @@ fn config_document_from_update_payload(
 
     // The desktop preferences client owns only the nested `preferences` object.
     // Treat preferences-only requests as patches over the stored document so a
-    // narrow update like `{ "preferences": { "onboarded": true } }` cannot
+    // narrow update like `{ "preferences": { "diarize": true } }` cannot
     // reset shortcut, tray, inference, model, or mirror settings to defaults.
     let mut document = load_config_document(home).map_err(ApiError::Config)?;
     merge_preferences_patch(

--- a/crates/openasr-server/src/routes/history.rs
+++ b/crates/openasr-server/src/routes/history.rs
@@ -37,7 +37,10 @@ impl HistoryListQuery {
             None => None,
             Some(raw) => Some(parse_history_kind(raw)?),
         };
-        let limit = self.limit.unwrap_or(DEFAULT_HISTORY_LIMIT).min(MAX_HISTORY_LIMIT);
+        let limit = self
+            .limit
+            .unwrap_or(DEFAULT_HISTORY_LIMIT)
+            .min(MAX_HISTORY_LIMIT);
         let offset = self.offset.unwrap_or(0);
         let search = self
             .search

--- a/crates/openasr-server/src/routes/history.rs
+++ b/crates/openasr-server/src/routes/history.rs
@@ -4,23 +4,83 @@
 
 use axum::{
     Extension, Json,
-    extract::Path as AxumPath,
+    extract::{Path as AxumPath, Query},
     response::{IntoResponse, Response},
 };
 use openasr_core::config::{HistoryRetentionPolicy, load_config_document};
-use openasr_core::realtime::history::DaemonHistoryStore;
+use openasr_core::realtime::history::{DaemonHistoryKind, DaemonHistoryQuery, DaemonHistoryStore};
+use serde::Deserialize;
 
 use crate::*;
 
+/// Default and max page size for `GET /v1/history`. Keeps a runaway
+/// `limit` query param from forcing a full-table scan/response on a large
+/// history.
+const DEFAULT_HISTORY_LIMIT: usize = 50;
+const MAX_HISTORY_LIMIT: usize = 500;
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct HistoryListQuery {
+    #[serde(default)]
+    pub(crate) search: Option<String>,
+    #[serde(default)]
+    pub(crate) kind: Option<String>,
+    #[serde(default)]
+    pub(crate) limit: Option<usize>,
+    #[serde(default)]
+    pub(crate) offset: Option<usize>,
+}
+
+impl HistoryListQuery {
+    fn into_store_query(self) -> Result<(DaemonHistoryQuery, usize, usize), ApiError> {
+        let kind = match self.kind.as_deref() {
+            None => None,
+            Some(raw) => Some(parse_history_kind(raw)?),
+        };
+        let limit = self.limit.unwrap_or(DEFAULT_HISTORY_LIMIT).min(MAX_HISTORY_LIMIT);
+        let offset = self.offset.unwrap_or(0);
+        let search = self
+            .search
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        Ok((
+            DaemonHistoryQuery {
+                search,
+                kind,
+                limit: Some(limit),
+                offset,
+            },
+            limit,
+            offset,
+        ))
+    }
+}
+
+fn parse_history_kind(raw: &str) -> Result<DaemonHistoryKind, ApiError> {
+    match raw {
+        "file" => Ok(DaemonHistoryKind::File),
+        "live" => Ok(DaemonHistoryKind::Live),
+        other => Err(ApiError::BadRequest(format!(
+            "Unsupported history kind '{other}'. Use one of: file, live."
+        ))),
+    }
+}
+
 pub(crate) async fn history_list(
     Extension(distribution): Extension<DistributionContext>,
+    Query(query): Query<HistoryListQuery>,
 ) -> Result<Json<HistoryListResponse>, ApiError> {
     let home = distribution.openasr_home()?;
     let store = DaemonHistoryStore::open(&home);
     prune_history_for_preferences(&distribution, &store)?;
+    let (store_query, limit, offset) = query.into_store_query()?;
+    let page = store.query(&store_query).map_err(ApiError::History)?;
     Ok(Json(HistoryListResponse {
         object: "list",
-        data: store.list().map_err(ApiError::History)?,
+        data: page.entries,
+        total: page.total,
+        limit,
+        offset,
     }))
 }
 

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -185,6 +185,15 @@ pub(crate) fn record_file_transcription_history(
     if !document.preferences.auto_save {
         return Ok(());
     }
+    // "Off" retention is fail-fast: never write a transcript we would only
+    // prune away on the next sweep.
+    if !document
+        .preferences
+        .history_retention
+        .persists_new_entries()
+    {
+        return Ok(());
+    }
     let store = DaemonHistoryStore::open(&home);
     store
         .record(DaemonHistoryRecord {

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -206,7 +206,7 @@ pub(crate) fn record_file_transcription_history(
             duration_seconds: transcription_duration_seconds(transcription),
             output_format: Some(output_format),
             diarization_active: Some(request.diarize),
-            provenance: Some(DaemonHistoryProvenance::AutoSaved),
+            provenance: Some(DaemonHistoryProvenance::Recorded),
             formats: ResponseFormat::ALL
                 .iter()
                 .map(|format| (*format).to_string())

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -179,14 +179,11 @@ pub(crate) fn record_file_transcription_history(
     output_format: ResponseFormat,
 ) -> Result<(), ApiError> {
     let home = distribution.openasr_home()?;
-    // History is opt-in (privacy default): only persist when the user enabled
-    // auto-save. A bare `serve` never writes transcripts to ~/.openasr.
+    // History persistence is governed solely by the saved-history scope
+    // (`history_retention`). `auto_save` controls transcript-file exports and
+    // must not gate history. "Off" retention is fail-fast: never write a
+    // transcript we would only prune away on the next sweep.
     let document = load_config_document(&home).unwrap_or_default();
-    if !document.preferences.auto_save {
-        return Ok(());
-    }
-    // "Off" retention is fail-fast: never write a transcript we would only
-    // prune away on the next sweep.
     if !document
         .preferences
         .history_retention

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -935,9 +935,14 @@ fn transcription_preferences_fill_missing_thread_request_only() {
 fn record_file_transcription_history_round_trips_structured_metadata() {
     let temp = tempfile::tempdir().unwrap();
     let distribution = distribution_context_for_test(temp.path());
+    // auto_save only controls transcript-file exports; history recording is
+    // governed by history_retention alone, so auto_save=false must still record.
     std::fs::write(
         temp.path().join("config.json"),
-        serde_json::json!({ "preferences": { "auto_save": true } }).to_string(),
+        serde_json::json!({
+            "preferences": { "auto_save": false, "history_retention": "last5" }
+        })
+        .to_string(),
     )
     .unwrap();
     let request = TranscriptionRequest::new(temp.path().join("sample.wav"), "qwen3-asr-0.6b:q8")
@@ -979,6 +984,40 @@ fn record_file_transcription_history_round_trips_structured_metadata() {
         detail.entry.provenance,
         Some(DaemonHistoryProvenance::AutoSaved)
     );
+}
+
+#[test]
+fn record_file_transcription_history_skips_write_when_retention_off() {
+    let temp = tempfile::tempdir().unwrap();
+    let distribution = distribution_context_for_test(temp.path());
+    // Even with auto_save enabled, "off" retention must skip the write:
+    // history_retention is the only history switch.
+    std::fs::write(
+        temp.path().join("config.json"),
+        serde_json::json!({
+            "preferences": { "auto_save": true, "history_retention": "off" }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let request = TranscriptionRequest::new(temp.path().join("sample.wav"), "qwen3-asr-0.6b:q8");
+    let transcription = Transcription {
+        text: "never stored".to_string(),
+        segments: Vec::new(),
+        longform: None,
+        language: None,
+    };
+
+    record_file_transcription_history(
+        &distribution,
+        &request,
+        &transcription,
+        ResponseFormat::Text,
+    )
+    .unwrap();
+
+    let store = DaemonHistoryStore::open(temp.path());
+    assert!(store.list().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -1021,6 +1021,55 @@ fn history_retention_last5_prunes_store() {
 }
 
 #[test]
+fn history_retention_off_prunes_store_empty() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = DaemonHistoryStore::open(temp.path());
+    for index in 0..3 {
+        store
+            .record(DaemonHistoryRecord {
+                kind: DaemonHistoryKind::File,
+                model: "whisper-large-v3-turbo".to_string(),
+                source_name: Some(format!("sample-{index}.wav")),
+                duration_seconds: None,
+                output_format: Some(ResponseFormat::Text),
+                diarization_active: Some(false),
+                provenance: Some(DaemonHistoryProvenance::AutoSaved),
+                formats: vec!["text".to_string()],
+                text: format!("transcript {index}"),
+            })
+            .unwrap();
+    }
+
+    // Switching to "Off" clears everything already stored, even though new
+    // writes are skipped upstream at the record sites.
+    assert_eq!(
+        prune_history_store(&store, HistoryRetentionPolicy::Off).unwrap(),
+        3
+    );
+    assert!(store.list().unwrap().is_empty());
+
+    // "Forever" is the keep-all policy: it never prunes.
+    let entry = store
+        .record(DaemonHistoryRecord {
+            kind: DaemonHistoryKind::File,
+            model: "whisper-large-v3-turbo".to_string(),
+            source_name: Some("kept.wav".to_string()),
+            duration_seconds: None,
+            output_format: Some(ResponseFormat::Text),
+            diarization_active: Some(false),
+            provenance: Some(DaemonHistoryProvenance::AutoSaved),
+            formats: vec!["text".to_string()],
+            text: "keep me".to_string(),
+        })
+        .unwrap();
+    assert_eq!(
+        prune_history_store(&store, HistoryRetentionPolicy::Forever).unwrap(),
+        0
+    );
+    assert!(store.get(&entry.id).unwrap().is_some());
+}
+
+#[test]
 fn realtime_capabilities_for_native_runtime_come_from_model_pack() {
     let temp = tempfile::tempdir().unwrap();
     let pack_root = temp.path().join("server-pack.oasr");

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -973,7 +973,7 @@ fn record_file_transcription_history_round_trips_structured_metadata() {
     assert_eq!(entries[0].diarization_active, Some(true));
     assert_eq!(
         entries[0].provenance,
-        Some(DaemonHistoryProvenance::AutoSaved)
+        Some(DaemonHistoryProvenance::Recorded)
     );
 
     let detail = store.get(&entries[0].id).unwrap().unwrap();
@@ -982,7 +982,7 @@ fn record_file_transcription_history_round_trips_structured_metadata() {
     assert_eq!(detail.entry.diarization_active, Some(true));
     assert_eq!(
         detail.entry.provenance,
-        Some(DaemonHistoryProvenance::AutoSaved)
+        Some(DaemonHistoryProvenance::Recorded)
     );
 }
 
@@ -1033,7 +1033,7 @@ fn history_retention_last5_prunes_store() {
                 duration_seconds: None,
                 output_format: Some(ResponseFormat::Text),
                 diarization_active: Some(false),
-                provenance: Some(DaemonHistoryProvenance::AutoSaved),
+                provenance: Some(DaemonHistoryProvenance::Recorded),
                 formats: vec!["text".to_string()],
                 text: format!("transcript {index}"),
             })
@@ -1072,7 +1072,7 @@ fn history_retention_off_prunes_store_empty() {
                 duration_seconds: None,
                 output_format: Some(ResponseFormat::Text),
                 diarization_active: Some(false),
-                provenance: Some(DaemonHistoryProvenance::AutoSaved),
+                provenance: Some(DaemonHistoryProvenance::Recorded),
                 formats: vec!["text".to_string()],
                 text: format!("transcript {index}"),
             })
@@ -1096,7 +1096,7 @@ fn history_retention_off_prunes_store_empty() {
             duration_seconds: None,
             output_format: Some(ResponseFormat::Text),
             diarization_active: Some(false),
-            provenance: Some(DaemonHistoryProvenance::AutoSaved),
+            provenance: Some(DaemonHistoryProvenance::Recorded),
             formats: vec!["text".to_string()],
             text: "keep me".to_string(),
         })

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -1006,12 +1006,17 @@ fn history_retention_last5_prunes_store() {
         1
     );
 
-    assert_eq!(store.list().unwrap().len(), 5);
-    assert_eq!(
-        fs::read_dir(temp.path().join("history").join("texts"))
-            .unwrap()
-            .count(),
-        5
+    let remaining = store.list().unwrap();
+    assert_eq!(remaining.len(), 5);
+    // The oldest entry (index 0) was pruned; every surviving row still serves
+    // its transcript text from the SQLite store.
+    for entry in &remaining {
+        assert!(store.get(&entry.id).unwrap().is_some());
+    }
+    assert!(
+        !remaining
+            .iter()
+            .any(|entry| entry.source_name.as_deref() == Some("sample-0.wav"))
     );
 }
 

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -2989,13 +2989,11 @@ async fn transcriptions_record_file_history_with_text_sidecar() {
     assert_eq!(entry["diarization_active"], false);
     assert_eq!(entry["provenance"], "auto_saved");
     assert!(entry["preview"].as_str().unwrap().contains("OpenASR mock"));
-    // The internal sidecar path must not leak into the wire contract; it is
-    // derivable from the entry id under the daemon-owned history directory.
+    // Transcript text lives in the SQLite row, not a filesystem sidecar; it
+    // must not leak a path into the wire contract.
     assert!(entry.get("text_path").is_none());
-    let text_path = home.join("history").join("texts").join(format!("{id}.txt"));
-    assert!(text_path.starts_with(home.join("history")));
-    assert!(text_path.exists());
-    assert!(home.join("history").join("index.json").exists());
+    let history_db = home.join("history").join("history.db");
+    assert!(history_db.exists());
 
     let response = app
         .clone()
@@ -3035,7 +3033,6 @@ async fn transcriptions_record_file_history_with_text_sidecar() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
-    assert!(!text_path.exists());
 
     let response = app
         .oneshot(

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -619,7 +619,6 @@ async fn config_endpoint_roundtrips_versioned_preferences() {
     document["preferences"]["theme"] = serde_json::json!("dark");
     document["preferences"]["density"] = serde_json::json!("compact");
     document["preferences"]["push_to_talk"] = serde_json::json!(true);
-    document["preferences"]["onboarded"] = serde_json::json!(true);
     document["preferences"]["inference_threads"] = serde_json::json!(2);
 
     let response = app
@@ -782,7 +781,6 @@ async fn preferences_only_put_merges_partial_preferences() {
             "tray_icon": false,
             "dictation_shortcut": "Alt",
             "push_to_talk": true,
-            "onboarded": false,
             "inference_threads": 8,
             "theme": "dark",
             "accent_color": "#2fa663",
@@ -810,7 +808,7 @@ async fn preferences_only_put_merges_partial_preferences() {
                 .uri("/v1/config")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({ "preferences": { "onboarded": true } }).to_string(),
+                    serde_json::json!({ "preferences": { "diarize": true } }).to_string(),
                 ))
                 .unwrap(),
         )
@@ -819,7 +817,7 @@ async fn preferences_only_put_merges_partial_preferences() {
     assert_eq!(response.status(), StatusCode::OK);
     let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
     let after: Value = serde_json::from_slice(&bytes).unwrap();
-    assert_eq!(after["preferences"]["onboarded"], true);
+    assert_eq!(after["preferences"]["diarize"], true);
     assert_eq!(after["preferences"]["language"], "zh-CN");
     assert_eq!(after["preferences"]["auto_save"], true);
     assert_eq!(after["preferences"]["tray_icon"], false);
@@ -832,7 +830,7 @@ async fn preferences_only_put_merges_partial_preferences() {
 
     let file: Value =
         serde_json::from_slice(&std::fs::read(home.join("config.json")).unwrap()).unwrap();
-    assert_eq!(file["preferences"]["onboarded"], true);
+    assert_eq!(file["preferences"]["diarize"], true);
     assert_eq!(file["preferences"]["dictation_shortcut"], "Alt");
 }
 

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -2919,7 +2919,7 @@ fn enable_history(temp: &tempfile::TempDir) {
 }
 
 #[tokio::test]
-async fn transcriptions_record_file_history_with_text_sidecar() {
+async fn transcriptions_record_file_history_in_sqlite_store() {
     let temp = tempfile::tempdir().unwrap();
     let distribution = openasr_server::DistributionRuntime {
         openasr_home: Some(temp.path().join("home")),
@@ -3046,6 +3046,185 @@ async fn transcriptions_record_file_history_with_text_sidecar() {
     let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
     let parsed: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(parsed["data"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn history_list_supports_search_pagination_and_kind_filter() {
+    use openasr_core::realtime::history::{
+        DaemonHistoryKind, DaemonHistoryRecord, DaemonHistoryStore,
+    };
+
+    let temp = tempfile::tempdir().unwrap();
+    enable_history(&temp);
+    let home = temp.path().join("home");
+    let store = DaemonHistoryStore::open(&home);
+    let record = |kind: DaemonHistoryKind, source: &str, text: &str| DaemonHistoryRecord {
+        kind,
+        model: "whisper-large-v3-turbo".to_string(),
+        source_name: Some(source.to_string()),
+        duration_seconds: None,
+        output_format: Some(ResponseFormat::Text),
+        diarization_active: Some(false),
+        provenance: None,
+        formats: vec!["text".to_string()],
+        text: text.to_string(),
+    };
+    let oldest = store
+        .record(record(
+            DaemonHistoryKind::File,
+            "notes.wav",
+            "english meeting notes",
+        ))
+        .unwrap();
+    let middle = store
+        .record(record(
+            DaemonHistoryKind::Live,
+            "live-zh",
+            "我们讨论了历史记录",
+        ))
+        .unwrap();
+    let newest = store
+        .record(record(
+            DaemonHistoryKind::Live,
+            "live-en",
+            "quick live note",
+        ))
+        .unwrap();
+
+    let app = openasr_server::app_with_runtime_and_distribution(
+        openasr_server::ServerRuntime::default(),
+        openasr_server::DistributionRuntime {
+            openasr_home: Some(home),
+            catalog_url: None,
+        },
+    );
+    let list = |uri: String| {
+        let app = app.clone();
+        async move {
+            let response = app
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            let status = response.status();
+            let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+            (status, serde_json::from_slice::<Value>(&bytes).unwrap())
+        }
+    };
+
+    // Default listing: newest first, additive pagination metadata present.
+    let (status, parsed) = list("/v1/history".to_string()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(parsed["object"], "list");
+    assert_eq!(parsed["total"], 3);
+    assert_eq!(parsed["limit"], 50);
+    assert_eq!(parsed["offset"], 0);
+    let ids: Vec<&str> = parsed["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec![&newest.id, &middle.id, &oldest.id]);
+
+    // FTS search must handle CJK substrings (trigram tokenizer, not unicode61).
+    let (status, parsed) = list("/v1/history?search=%E5%8E%86%E5%8F%B2".to_string()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(parsed["total"], 1);
+    assert_eq!(parsed["data"][0]["id"], middle.id.as_str());
+
+    // Search also covers source_name and model, and misses return empty pages.
+    let (status, parsed) = list("/v1/history?search=notes.wav".to_string()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(parsed["total"], 1);
+    assert_eq!(parsed["data"][0]["id"], oldest.id.as_str());
+    let (_, parsed) = list("/v1/history?search=nonexistent-token".to_string()).await;
+    assert_eq!(parsed["total"], 0);
+    assert_eq!(parsed["data"].as_array().unwrap().len(), 0);
+
+    // Kind filter.
+    let (status, parsed) = list("/v1/history?kind=live".to_string()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(parsed["total"], 2);
+    for entry in parsed["data"].as_array().unwrap() {
+        assert_eq!(entry["kind"], "live");
+    }
+    let (status, _) = list("/v1/history?kind=dictation".to_string()).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // Pagination: stable newest-first order across pages, total unaffected.
+    let (status, parsed) = list("/v1/history?limit=2&offset=0".to_string()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(parsed["total"], 3);
+    assert_eq!(parsed["limit"], 2);
+    assert_eq!(parsed["offset"], 0);
+    let page_one: Vec<&str> = parsed["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(page_one, vec![&newest.id, &middle.id]);
+    let (_, parsed) = list("/v1/history?limit=2&offset=2".to_string()).await;
+    assert_eq!(parsed["total"], 3);
+    assert_eq!(parsed["offset"], 2);
+    let page_two: Vec<&str> = parsed["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(page_two, vec![&oldest.id]);
+
+    // Combined search + kind filter.
+    let (status, parsed) = list("/v1/history?search=live&kind=live".to_string()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(parsed["total"], 2);
+}
+
+#[tokio::test]
+async fn history_routes_report_errors_for_corrupt_database_without_crashing() {
+    let temp = tempfile::tempdir().unwrap();
+    enable_history(&temp);
+    let home = temp.path().join("home");
+    let history_dir = home.join("history");
+    std::fs::create_dir_all(&history_dir).unwrap();
+    std::fs::write(history_dir.join("history.db"), b"not a sqlite database").unwrap();
+
+    let app = openasr_server::app_with_runtime_and_distribution(
+        openasr_server::ServerRuntime::default(),
+        openasr_server::DistributionRuntime {
+            openasr_home: Some(home),
+            catalog_url: None,
+        },
+    );
+
+    // History endpoints answer with a structured error instead of taking the
+    // daemon down.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/history")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    let parsed: Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("history")
+    );
+
+    // Transcription (the daemon's main job) still succeeds; the failed
+    // best-effort history side-write must not fail the request.
+    let request = multipart_request("whisper-large-v3-turbo", "sample.wav", b"not a real wav");
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[tokio::test]

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -2904,14 +2904,18 @@ async fn transcriptions_accept_word_timestamp_granularity_for_json() {
     assert_eq!(words.last().unwrap()["end"], 2.5);
 }
 
-/// Writes a config with auto-save on at `<temp>/home`, so the server records
-/// history (opt-in, off by default).
+/// Writes a config with auto-save off and last5 retention at `<temp>/home`,
+/// locking in that history recording is governed by `history_retention` alone
+/// (auto_save only controls transcript-file exports).
 fn enable_history(temp: &tempfile::TempDir) {
     let home = temp.path().join("home");
     std::fs::create_dir_all(&home).unwrap();
     std::fs::write(
         home.join("config.json"),
-        serde_json::json!({ "preferences": { "auto_save": true } }).to_string(),
+        serde_json::json!({
+            "preferences": { "auto_save": false, "history_retention": "last5" }
+        })
+        .to_string(),
     )
     .unwrap();
 }
@@ -2924,11 +2928,15 @@ async fn transcriptions_record_file_history_in_sqlite_store() {
         catalog_url: None,
     };
     let home = distribution.openasr_home.as_ref().unwrap().clone();
-    // History is opt-in: enable auto-save so the server records.
+    // History recording is governed by history_retention alone; auto_save
+    // stays false to lock in that it does not gate history.
     std::fs::create_dir_all(&home).unwrap();
     std::fs::write(
         home.join("config.json"),
-        serde_json::json!({ "preferences": { "auto_save": true } }).to_string(),
+        serde_json::json!({
+            "preferences": { "auto_save": false, "history_retention": "last5" }
+        })
+        .to_string(),
     )
     .unwrap();
     let app = openasr_server::app_with_runtime_and_distribution(
@@ -3041,6 +3049,55 @@ async fn transcriptions_record_file_history_in_sqlite_store() {
         )
         .await
         .unwrap();
+    let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    let parsed: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(parsed["data"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn transcriptions_skip_file_history_when_retention_off() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    // Even with auto_save enabled, "off" retention must skip the write:
+    // history_retention is the only history switch.
+    std::fs::write(
+        home.join("config.json"),
+        serde_json::json!({
+            "preferences": { "auto_save": true, "history_retention": "off" }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let app = openasr_server::app_with_runtime_and_distribution(
+        openasr_server::ServerRuntime::default(),
+        openasr_server::DistributionRuntime {
+            openasr_home: Some(home.clone()),
+            catalog_url: None,
+        },
+    );
+
+    let response = app
+        .clone()
+        .oneshot(multipart_request(
+            "whisper-large-v3-turbo",
+            "sample.wav",
+            b"not a real wav",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/history")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
     let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
     let parsed: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(parsed["data"].as_array().unwrap().len(), 0);

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -2993,7 +2993,7 @@ async fn transcriptions_record_file_history_in_sqlite_store() {
     assert!(entry["duration_seconds"].as_f64().is_some());
     assert_eq!(entry["output_format"], "srt");
     assert_eq!(entry["diarization_active"], false);
-    assert_eq!(entry["provenance"], "auto_saved");
+    assert_eq!(entry["provenance"], "recorded");
     assert!(entry["preview"].as_str().unwrap().contains("OpenASR mock"));
     // Transcript text lives in the SQLite row, not a filesystem sidecar; it
     // must not leak a path into the wire contract.
@@ -3019,7 +3019,7 @@ async fn transcriptions_record_file_history_in_sqlite_store() {
     assert!(detail["response_format"].is_null());
     assert_eq!(detail["output_format"], "srt");
     assert_eq!(detail["diarization_active"], false);
-    assert_eq!(detail["provenance"], "auto_saved");
+    assert_eq!(detail["provenance"], "recorded");
     assert!(
         detail["text"]
             .as_str()

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -604,10 +604,10 @@ async fn config_endpoint_roundtrips_versioned_preferences() {
         document["preferences"]["version"],
         openasr_core::config::PREFERENCES_SCHEMA_VERSION
     );
-    assert_eq!(
-        document["preferences"]["dictation_shortcut"],
-        "CommandOrControl+Shift+Space"
-    );
+    // Fresh-config product defaults surfaced to the desktop: Option (⌥) alone,
+    // push-to-talk on. These are what a cleared-state first launch shows.
+    assert_eq!(document["preferences"]["dictation_shortcut"], "Alt");
+    assert_eq!(document["preferences"]["push_to_talk"], true);
     assert_eq!(document["preferences"]["word_timestamps"], false);
 
     document["preferences"]["language"] = serde_json::json!("en");


### PR DESCRIPTION
## Summary

Replace the daemon history store's JSON index + `texts/*.txt` sidecar layout with a SQLite backend (rusqlite, bundled, FTS5 trigram search), and reshape the history preferences around it: retention becomes a saved-history scope (`off` / `last5` default / age windows incl. new `quarter` / `forever`), history recording is decoupled from the `auto_save` preference, and two config schema fixes land alongside (dictation trigger default, dropping the desktop-only `onboarded` field).

## Why

- The JSON index + sidecar store had a partial-write hazard (index vs. text files drifting) and no search/pagination surface; the desktop history page needs substring search that works for CJK.
- History was only recorded when `auto_save` was on, so users with the default `auto_save=false` saw an empty history page even with retention configured. `auto_save` was meant to control transcript-file exports, not history.
- Retention was modeled as a cleanup schedule with a keep-all default; the product model is "how much saved history to keep", defaulting to `last5`, with an explicit `off`.
- The core preferences schema served a wrong first-launch dictation trigger and carried a desktop-only `onboarded` flag that nothing in core reads.

## Changes

- `crates/openasr-core/src/realtime/history_store.rs`: SQLite-backed `DaemonHistoryStore` at `~/.openasr/history/history.db`; transcript text is a column (no sidecar); FTS5 trigram table queried via `LIKE` for CJK-safe 1-2 char substrings, synced manually inside each write transaction; lazy open + typed errors so a corrupt db degrades history endpoints to 5xx while transcription keeps working.
- `crates/openasr-server/src/routes/history.rs`: `GET /v1/history` gains `search`/`kind`/`limit`/`offset` params and additive `total`/`limit`/`offset` response fields; entry/detail JSON shape unchanged for the desktop client.
- `HistoryRetentionPolicy` reframed as saved-history scope: `Off` (never persist; switching to it prunes the store), `Last5` new default, `Never` renamed to `Forever` (legacy `"never"` wire value still accepted on read so 0.1.x configs keep parsing), new `Quarter` (90-day) tier between month and year.
- Both record sites (file transcription, realtime session end) gate solely on `history_retention.persists_new_entries()`; `auto_save` no longer affects history. Provenance variant renamed `auto_saved` -> `recorded` to match (schema never shipped, no row migration needed).
- `Preferences` defaults: dictation trigger `Some("Alt")` + `push_to_talk=true` (with a serde field default so omitted keys land on true), matching the product default the desktop fallback already encoded; desktop-only `onboarded` field dropped from the core schema (unknown keys in existing config.json ignored on load).
- Dependency: rusqlite 0.40 (bundled, default-features off), which compiles SQLite with FTS5 enabled; lockfile gains libsqlite3-sys/rusqlite plus three small iterator crates.
- Tests: LIKE wildcard escaping pinned, retention boundary prunes (incl. 90-day strictly-older-than cutoff), corrupt-db isolation route tests, auto_save/retention decoupling regressions on both record paths, fresh-config and partial-deserialize default tests, legacy `"never"` wire-value acceptance.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2009 passed, 115 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

## Manual smoke checks

- Desktop history page against a local daemon during development: search (incl. CJK substrings), pagination, kind filter, and recording with `auto_save=false` + `last5`.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (README + SECURITY wording now describes the retention-only history contract.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No migration of pre-existing JSON-index history stores: the SQLite schema has never shipped to users, and a fresh db is created on first use.
- No explicit "save this entry" user action yet; the `user_initiated` provenance value is reserved for it.
- Desktop UI changes live in the app repo, not here.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implemented with Claude Code under my direction and review.
