### PR TITLE
ci(release): windows hip + linux gpu variants + linux arm64 release artifacts (#24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install build dependencies
@@ -64,7 +64,7 @@ jobs:
   system-audio-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -81,7 +81,7 @@ jobs:
   dependency-policy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository == 'QuintinShaw/openasr'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Verify committed public catalog (consistent + public-only)
         run: |

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/family-regression.yml
+++ b/.github/workflows/family-regression.yml
@@ -28,11 +28,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # macos pinned (not macos-latest, which migrates to macOS 26 from
+        # 2026-06-15): the regression net's environment must not drift
+        # under the alias.
+        os: [ubuntu-latest, macos-15]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install build dependencies
@@ -50,7 +53,7 @@ jobs:
         env:
           OPENASR_GGML_NATIVE: "0"
         run: cargo build --release -p openasr-cli
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: openasr-cli-${{ matrix.os }}
           path: target/release/openasr
@@ -64,7 +67,10 @@ jobs:
       # rest of the net.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # macos pinned (not macos-latest, which migrates to macOS 26 from
+        # 2026-06-15): the regression net's environment must not drift
+        # under the alias.
+        os: [ubuntu-latest, macos-15]
         # Family registry: one entry per public model family, smallest
         # checkpoint x smallest quant. ONBOARDING A NEW FAMILY IS NOT DONE
         # until it is registered here with a committed golden under
@@ -96,14 +102,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: openasr-cli-${{ matrix.os }}
           path: bin
       - run: chmod +x bin/openasr
       - name: Restore model pack cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.openasr/models
           key: openasr-packs-${{ matrix.case.name }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('model-registry/catalog.json') }}
@@ -118,7 +124,7 @@ jobs:
             ${{ matrix.case.args || '' }}
       - name: Upload transcript
         if: always() && matrix.case.mode != 'verify'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: transcript-${{ matrix.case.name }}-${{ matrix.os }}
           path: tmp/family-regression/

--- a/.github/workflows/hip-compile.yml
+++ b/.github/workflows/hip-compile.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.repository_owner == 'QuintinShaw'
     runs-on: [self-hosted, Windows, X64, HIP]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/public-hf-e2e.yml
+++ b/.github/workflows/public-hf-e2e.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install build dependencies
@@ -60,7 +60,7 @@ jobs:
           tooling/public-hf-e2e/run.sh "${args[@]}"
       - name: Upload public-HF E2E evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: public-hf-e2e-evidence
           path: |

--- a/.github/workflows/qwen-gpu-parity.yml
+++ b/.github/workflows/qwen-gpu-parity.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository_owner == 'QuintinShaw'
     runs-on: [self-hosted, Windows, X64, HIP]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -85,6 +85,32 @@ jobs:
             features: hip
             timeout: 240
             experimental: true
+          # Linux GPU-feature variants, same rationale as the Windows ones
+          # above (no GPU on the hosted runner; build+package validated
+          # here, GPU inference validated on real hardware). Pinned to
+          # ubuntu-22.04 (not ubuntu-latest) so the LunarG/ROCm apt repos
+          # below target a codename known to exist in both.
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu-vulkan
+            binary_name: openasr
+            archive_ext: tar.gz
+            features: vulkan
+            timeout: 90
+            experimental: true
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu-cuda
+            binary_name: openasr
+            archive_ext: tar.gz
+            features: cuda
+            timeout: 120
+            experimental: true
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu-rocm
+            binary_name: openasr
+            archive_ext: tar.gz
+            features: hip
+            timeout: 240
+            experimental: true
 
     steps:
       - uses: actions/checkout@v4
@@ -109,8 +135,42 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
 
-      - name: Install Vulkan SDK
-        if: matrix.features == 'vulkan'
+      - name: Install Linux Vulkan SDK
+        if: runner.os == 'Linux' && matrix.features == 'vulkan'
+        # LunarG's apt recipe for jammy (matches llama.cpp's ubuntu-22.04
+        # Vulkan release job). vulkan-sdk gives cmake's FindVulkan the
+        # loader/headers/glslc it needs; mesa-vulkan-drivers gives the
+        # llvmpipe software ICD, so the produced binary can actually launch
+        # and run CPU-emulated Vulkan on this GPU-less runner.
+        run: |
+          set -euo pipefail
+          wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+          sudo apt-get update -y
+          sudo apt-get install -y vulkan-sdk mesa-vulkan-drivers
+
+      - name: Install Linux ROCm/HIP SDK
+        if: runner.os == 'Linux' && matrix.features == 'hip'
+        # AMD's official apt repo (the recipe llama.cpp's ubuntu-22-rocm
+        # release job uses). rocm-hip-sdk provides hipcc/the HIP clang
+        # toolchain, rocBLAS, and hipBLAS; ROCM_PATH lets both cmake's
+        # FindHIP language support and openasr-core's build.rs
+        # hip_toolkit_path() locate it.
+        run: |
+          set -euo pipefail
+          sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+          wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/rocm.gpg
+          echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.2.1 jammy main" \
+            | sudo tee /etc/apt/sources.list.d/rocm.list
+          printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600\n' \
+            | sudo tee /etc/apt/preferences.d/rocm-pin-600
+          sudo apt-get update -y
+          sudo apt-get install -y rocm-hip-sdk
+          echo "ROCM_PATH=/opt/rocm" >> "${GITHUB_ENV}"
+          echo "/opt/rocm/bin" >> "${GITHUB_PATH}"
+
+      - name: Install Windows Vulkan SDK
+        if: matrix.features == 'vulkan' && runner.os == 'Windows'
         shell: pwsh
         env:
           VULKAN_VERSION: 1.4.313.2
@@ -126,15 +186,16 @@ jobs:
           Add-Content $env:GITHUB_PATH "C:\VulkanSDK\$env:VULKAN_VERSION\Bin"
 
       - name: Ensure Ninja
-        if: matrix.features == 'vulkan' || matrix.features == 'cuda' || matrix.features == 'hip'
+        if: runner.os == 'Windows' && (matrix.features == 'vulkan' || matrix.features == 'cuda' || matrix.features == 'hip')
         shell: pwsh
-        # build.rs configures the Windows Vulkan/CUDA/HIP ggml build with -G Ninja.
+        # build.rs only forces the Ninja generator for Windows GPU-feature
+        # builds (Linux keeps cmake's default Unix Makefiles generator).
         run: |
           if (-not (Get-Command ninja -ErrorAction SilentlyContinue)) { choco install ninja -y }
           ninja --version
 
       - name: Cache AMD HIP SDK install
-        if: matrix.features == 'hip'
+        if: runner.os == 'Windows' && matrix.features == 'hip'
         id: cache-hip-sdk
         uses: actions/cache@v4
         with:
@@ -142,7 +203,7 @@ jobs:
           key: hip-sdk-${{ env.HIPSDK_INSTALLER_VERSION }}-${{ runner.os }}
 
       - name: Install AMD HIP SDK
-        if: matrix.features == 'hip' && steps.cache-hip-sdk.outputs.cache-hit != 'true'
+        if: runner.os == 'Windows' && matrix.features == 'hip' && steps.cache-hip-sdk.outputs.cache-hit != 'true'
         shell: pwsh
         # Same recipe llama.cpp's Windows HIP release job uses (no self-hosted
         # runner needed): AMD publishes a silent installer for the consumer
@@ -164,7 +225,7 @@ jobs:
           }
 
       - name: Resolve HIP SDK path
-        if: matrix.features == 'hip'
+        if: runner.os == 'Windows' && matrix.features == 'hip'
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -213,8 +274,12 @@ jobs:
         shell: bash
         run: cargo build --release -p openasr-cli ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
 
+      # Same GPU-less-runner caveat as the Windows CUDA/HIP legs: those two
+      # exes dlopen the CUDA/ROCm runtime at launch, which needs a real
+      # driver this runner does not have. The Vulkan exe launches fine via
+      # the llvmpipe software ICD installed above.
       - name: Smoke release binary
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.features != 'cuda' && matrix.features != 'hip'
         run: |
           ./target/release/openasr --version
           ./target/release/openasr --help
@@ -265,6 +330,22 @@ jobs:
           dist_dir="dist/${archive}"
           mkdir -p "$dist_dir/docs"
           cp "target/release/${{ matrix.binary_name }}" "$dist_dir/"
+          if [ "${{ matrix.features }}" = "cuda" ]; then
+            # The CUDA exe dlopens the CUDA runtime; ship NVIDIA's
+            # redistributable runtime .so files so end users only need a
+            # GPU driver, not a CUDA toolkit install.
+            find "${CUDA_PATH}/lib64" -maxdepth 1 \( -name 'libcudart.so*' -o -name 'libcublas.so*' -o -name 'libcublasLt.so*' \) \
+              -exec cp {} "$dist_dir/" \;
+          fi
+          if [ "${{ matrix.features }}" = "hip" ]; then
+            # The HIP exe dlopens the ROCm runtime + rocBLAS; ship them (and
+            # rocBLAS's per-arch Tensile "library" dir, loaded at first
+            # matmul, not at launch) so end users only need a GPU driver,
+            # not the full ROCm SDK.
+            cp "${ROCM_PATH}"/lib/libamdhip64.so* "${ROCM_PATH}"/lib/libhipblas.so* "${ROCM_PATH}"/lib/librocblas.so* "$dist_dir/"
+            mkdir -p "$dist_dir/rocblas/library"
+            cp "${ROCM_PATH}"/lib/rocblas/library/* "$dist_dir/rocblas/library/"
+          fi
           cp README.md LICENSE "$dist_dir/"
           cp -R model-registry "$dist_dir/model-registry"
           cp docs/FAQ.md docs/KNOWN_LIMITATIONS.md "$dist_dir/docs/"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -36,6 +36,13 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary_name: openasr
             archive_ext: tar.gz
+          # Native arm64 GitHub-hosted runner (no cross-compile toolchain
+          # needed). Both llama.cpp and competing ASR releases ship a Linux
+          # arm64 build; this was our most visible gap.
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            binary_name: openasr
+            archive_ext: tar.gz
           - os: macos-15-intel
             target: x86_64-apple-darwin
             binary_name: openasr
@@ -64,10 +71,10 @@ jobs:
             features: cuda
             timeout: 180
             experimental: true
-          # AMD HIP variant. Builds the same "radeon" fat code object
-          # (gfx1030/31/32, gfx1100/01/02, gfx1150/51, gfx1200/01) llama.cpp's
-          # own Windows HIP release job targets, covering RDNA2/3/3.5/4. HIP
-          # is statically linked (build.rs use_backend_dl is false for HIP),
+          # AMD HIP variant. Builds openasr-core's default consumer RDNA2/3/
+          # 3.5/4 fat code object (gfx1030/31/32/35, gfx1100/01/02, gfx1150/
+          # 51, gfx1200/01; see hip_gpu_targets() in build.rs for provenance).
+          # HIP is statically linked (build.rs use_backend_dl is false for HIP),
           # but still dynamically loads the ROCm runtime/BLAS DLLs staged
           # below, so it cannot launch on this GPU-less, driver-less runner
           # any more than the CUDA leg can; build + package only.

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -14,9 +14,10 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout || 60 }}
-    # Experimental legs (currently the Windows CUDA variant, whose hosted
-    # toolchain story is still settling) may fail without failing the run;
-    # their archives simply drop out of the artifact set until they stabilize.
+    # Escape hatch for future legs whose toolchain story is still settling:
+    # mark them `experimental: true` and they may fail without failing the
+    # run (their archives simply drop out of the artifact set) until they
+    # prove green. Every current leg has, so none carry the flag today.
     continue-on-error: ${{ matrix.experimental || false }}
     # Distributed binaries must be portable. build.rs auto-enables GGML_NATIVE
     # (-march=native) when host==target on x86, which is correct for local
@@ -70,7 +71,6 @@ jobs:
             archive_ext: zip
             features: cuda
             timeout: 180
-            experimental: true
           # AMD HIP variant. Builds openasr-core's default consumer RDNA2/3/
           # 3.5/4 fat code object (gfx1030/31/32/35, gfx1100/01/02, gfx1150/
           # 51, gfx1200/01; see hip_gpu_targets() in build.rs for provenance).
@@ -90,7 +90,6 @@ jobs:
             archive_ext: zip
             features: hip
             timeout: 240
-            experimental: true
           # Linux GPU-feature variants, same rationale as the Windows ones
           # above (no GPU on the hosted runner; build+package validated
           # here, GPU inference validated on real hardware). Pinned to
@@ -102,21 +101,18 @@ jobs:
             archive_ext: tar.gz
             features: vulkan
             timeout: 90
-            experimental: true
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu-cuda
             binary_name: openasr
             archive_ext: tar.gz
             features: cuda
             timeout: 120
-            experimental: true
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu-rocm
             binary_name: openasr
             archive_ext: tar.gz
             features: hip
             timeout: 240
-            experimental: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -78,7 +78,13 @@ jobs:
           # but still dynamically loads the ROCm runtime/BLAS DLLs staged
           # below, so it cannot launch on this GPU-less, driver-less runner
           # any more than the CUDA leg can; build + package only.
-          - os: windows-latest
+          # Pinned to windows-2022 like llama.cpp's HIP release job:
+          # windows-latest's VS 2026 STL declares the C99 floating
+          # comparison macros (isgreater & co.) in a way ROCm clang's HIP
+          # wrapper headers cannot overload ("__device__ function cannot
+          # overload __host__ __device__ function" in __clang_hip_cmath.h),
+          # so the device compile only works against the VS 2022 STL.
+          - os: windows-2022
             target: x86_64-pc-windows-msvc-hip
             binary_name: openasr.exe
             archive_ext: zip

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -25,6 +25,9 @@ jobs:
     # users tune locally via --features native or OPENASR_GGML_NATIVE=1.
     env:
       OPENASR_GGML_NATIVE: "0"
+      # AMD HIP SDK "PRO Edition" silent-installer release train, matched to
+      # llama.cpp's current Windows HIP release job.
+      HIPSDK_INSTALLER_VERSION: 26.Q1
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +63,20 @@ jobs:
             archive_ext: zip
             features: cuda
             timeout: 180
+            experimental: true
+          # AMD HIP variant. Builds the same "radeon" fat code object
+          # (gfx1030/31/32, gfx1100/01/02, gfx1150/51, gfx1200/01) llama.cpp's
+          # own Windows HIP release job targets, covering RDNA2/3/3.5/4. HIP
+          # is statically linked (build.rs use_backend_dl is false for HIP),
+          # but still dynamically loads the ROCm runtime/BLAS DLLs staged
+          # below, so it cannot launch on this GPU-less, driver-less runner
+          # any more than the CUDA leg can; build + package only.
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc-hip
+            binary_name: openasr.exe
+            archive_ext: zip
+            features: hip
+            timeout: 240
             experimental: true
 
     steps:
@@ -102,12 +119,54 @@ jobs:
           Add-Content $env:GITHUB_PATH "C:\VulkanSDK\$env:VULKAN_VERSION\Bin"
 
       - name: Ensure Ninja
-        if: matrix.features == 'vulkan' || matrix.features == 'cuda'
+        if: matrix.features == 'vulkan' || matrix.features == 'cuda' || matrix.features == 'hip'
         shell: pwsh
-        # build.rs configures the Windows Vulkan/CUDA ggml build with -G Ninja.
+        # build.rs configures the Windows Vulkan/CUDA/HIP ggml build with -G Ninja.
         run: |
           if (-not (Get-Command ninja -ErrorAction SilentlyContinue)) { choco install ninja -y }
           ninja --version
+
+      - name: Cache AMD HIP SDK install
+        if: matrix.features == 'hip'
+        id: cache-hip-sdk
+        uses: actions/cache@v4
+        with:
+          path: C:\Program Files\AMD\ROCm
+          key: hip-sdk-${{ env.HIPSDK_INSTALLER_VERSION }}-${{ runner.os }}
+
+      - name: Install AMD HIP SDK
+        if: matrix.features == 'hip' && steps.cache-hip-sdk.outputs.cache-hit != 'true'
+        shell: pwsh
+        # Same recipe llama.cpp's Windows HIP release job uses (no self-hosted
+        # runner needed): AMD publishes a silent installer for the consumer
+        # "PRO Edition" HIP SDK directly, so a GitHub-hosted windows-latest
+        # runner can provision it like any other toolchain.
+        run: |
+          $ErrorActionPreference = "Stop"
+          $url = "https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-$env:HIPSDK_INSTALLER_VERSION-Win11-For-HIP.exe"
+          Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\rocm-install.exe"
+          $proc = Start-Process "$env:RUNNER_TEMP\rocm-install.exe" -ArgumentList '-install' -NoNewWindow -PassThru
+          if (-not $proc.WaitForExit(600000)) {
+            Write-Error "AMD HIP SDK installation timed out after 10 minutes."
+            $proc.Kill()
+            exit 1
+          }
+          if ($proc.ExitCode -ne 0) {
+            Write-Error "AMD HIP SDK installation failed with exit code $($proc.ExitCode)"
+            exit 1
+          }
+
+      - name: Resolve HIP SDK path
+        if: matrix.features == 'hip'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $clang = Get-ChildItem 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | Select-Object -First 1
+          if (-not $clang) { Write-Error "AMD HIP SDK not found under C:\Program Files\AMD\ROCm"; exit 1 }
+          $hipRoot = $clang.Directory.Parent.FullName
+          & $clang.FullName --version
+          Add-Content $env:GITHUB_ENV "HIP_PATH=$hipRoot"
+          Add-Content $env:GITHUB_PATH "$hipRoot\bin"
 
       - name: Install CUDA toolkit
         if: matrix.features == 'cuda'
@@ -154,12 +213,13 @@ jobs:
           ./target/release/openasr --help
           ./target/release/openasr list
 
-      # The CUDA exe import-links nvcuda.dll, which only ships with an NVIDIA
-      # driver, so it cannot launch on this GPU-less runner: build + package
-      # only. The Vulkan exe resolves against the SDK loader installed above,
-      # so it launches and runs CPU paths here.
+      # The CUDA exe import-links nvcuda.dll (NVIDIA driver) and the HIP exe
+      # import-links amdhip64.dll (AMD driver), neither of which this GPU-less
+      # runner has, so those cannot launch here: build + package only. The
+      # Vulkan exe resolves against the SDK loader installed above, so it
+      # launches and runs CPU paths here.
       - name: Smoke release binary
-        if: runner.os == 'Windows' && matrix.features != 'cuda'
+        if: runner.os == 'Windows' && matrix.features != 'cuda' && matrix.features != 'hip'
         shell: pwsh
         run: |
           .\target\release\openasr.exe --version
@@ -230,14 +290,35 @@ jobs:
             if (-not $cudaDlls) { Write-Error "no CUDA runtime DLLs found under $env:CUDA_PATH\bin" }
             $cudaDlls | Copy-Item -Destination "$distDir\"
           }
+          if ("${{ matrix.features }}" -eq "hip") {
+            # The HIP exe dynamically links the ROCm runtime + BLAS; ship AMD's
+            # redistributable DLLs (and rocBLAS's per-arch Tensile "library"
+            # dir it loads at runtime -- omitting it fails at first matmul,
+            # not at launch) so end users only need a GPU driver, not the HIP
+            # SDK. hipBLASLt is optional (only some archs/tunings dispatch to
+            # it); copy it too when the SDK ships it.
+            $hipBin = Join-Path $env:HIP_PATH "bin"
+            $hipDlls = Get-ChildItem $hipBin -File |
+              Where-Object { $_.Name -match '^(amdhip64|libhipblas|rocblas|libhipblaslt)(_\d+)?\.dll$' }
+            if (-not $hipDlls) { Write-Error "no HIP runtime DLLs found under $hipBin" }
+            $hipDlls | Copy-Item -Destination "$distDir\"
+            New-Item -ItemType Directory -Force -Path "$distDir\rocblas\library" | Out-Null
+            Copy-Item (Join-Path $hipBin "rocblas\library\*") "$distDir\rocblas\library\"
+            $hipbltLibrary = Join-Path $hipBin "hipblaslt\library"
+            if (Test-Path $hipbltLibrary) {
+              New-Item -ItemType Directory -Force -Path "$distDir\hipblaslt\library" | Out-Null
+              Copy-Item (Join-Path $hipbltLibrary "*") "$distDir\hipblaslt\library\"
+            }
+          }
           Copy-Item README.md,LICENSE "$distDir\"
           Copy-Item model-registry "$distDir\model-registry" -Recurse
           Copy-Item docs\FAQ.md,docs\KNOWN_LIMITATIONS.md "$distDir\docs\"
           # Smoke the binary from the staged dist dir (NOT target/release,
           # whose build.rs-seeded DLLs would mask a packaging gap), so a broken
-          # archive fails here before it ships. The CUDA exe cannot launch
-          # without an NVIDIA driver, so it is exempt (validated on hardware).
-          if ("${{ matrix.features }}" -ne "cuda") {
+          # archive fails here before it ships. The CUDA/HIP exes cannot
+          # launch without a matching GPU driver, so they are exempt
+          # (validated on hardware).
+          if ("${{ matrix.features }}" -ne "cuda" -and "${{ matrix.features }}" -ne "hip") {
             & "$distDir\${{ matrix.binary_name }}" --version
             if ($LASTEXITCODE -ne 0) { exit 1 }
           }

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -236,6 +236,14 @@ jobs:
           Add-Content $env:GITHUB_ENV "HIP_PATH=$hipRoot"
           Add-Content $env:GITHUB_PATH "$hipRoot\bin"
 
+      # build.rs's Windows HIP import-lib shim shells out to `dumpbin` (to
+      # read libhipblas.dll/rocblas.dll's exports and synthesize .lib files
+      # the linker needs), which only resolves once the MSVC dev environment
+      # is loaded -- a plain windows-latest shell does not have it on PATH.
+      - name: Enable MSVC dev environment
+        if: runner.os == 'Windows' && matrix.features == 'hip'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Install CUDA toolkit
         if: matrix.features == 'cuda'
         uses: Jimver/cuda-toolkit@v0.2.35

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -48,7 +48,10 @@ jobs:
             target: x86_64-apple-darwin
             binary_name: openasr
             archive_ext: tar.gz
-          - os: macos-latest
+          # Pinned (not macos-latest, which migrates to macOS 26 from
+          # 2026-06-15): released binaries need a deterministic build
+          # environment that does not drift under the alias.
+          - os: macos-15
             target: aarch64-apple-darwin
             binary_name: openasr
             archive_ext: tar.gz
@@ -115,7 +118,7 @@ jobs:
             timeout: 240
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -199,7 +202,7 @@ jobs:
       - name: Cache AMD HIP SDK install
         if: runner.os == 'Windows' && matrix.features == 'hip'
         id: cache-hip-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: C:\Program Files\AMD\ROCm
           key: hip-sdk-${{ env.HIPSDK_INSTALLER_VERSION }}-${{ runner.os }}
@@ -317,7 +320,7 @@ jobs:
 
       - name: Restore model pack cache
         if: matrix.target == 'x86_64-pc-windows-msvc'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.openasr/models
           key: openasr-packs-whisper-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('model-registry/catalog.json') }}
@@ -430,7 +433,7 @@ jobs:
           Compress-Archive -Path "$distDir" -DestinationPath "dist\$archive.${{ matrix.archive_ext }}" -Force
 
       - name: Upload archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openasr-${{ matrix.target }}
           path: dist/openasr-${{ env.OPENASR_VERSION }}-${{ matrix.target }}.${{ matrix.archive_ext }}
@@ -445,7 +448,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: staging
           merge-multiple: true
@@ -458,7 +461,7 @@ jobs:
           sha256sum * > SHA256SUMS
           cat SHA256SUMS
       - name: Upload SHA256SUMS
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SHA256SUMS
           path: dist/SHA256SUMS

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -236,14 +236,6 @@ jobs:
           Add-Content $env:GITHUB_ENV "HIP_PATH=$hipRoot"
           Add-Content $env:GITHUB_PATH "$hipRoot\bin"
 
-      # build.rs's Windows HIP import-lib shim shells out to `dumpbin` (to
-      # read libhipblas.dll/rocblas.dll's exports and synthesize .lib files
-      # the linker needs), which only resolves once the MSVC dev environment
-      # is loaded -- a plain windows-latest shell does not have it on PATH.
-      - name: Enable MSVC dev environment
-        if: runner.os == 'Windows' && matrix.features == 'hip'
-        uses: ilammy/msvc-dev-cmd@v1
-
       - name: Install CUDA toolkit (Linux)
         if: runner.os == 'Linux' && matrix.features == 'cuda'
         uses: Jimver/cuda-toolkit@v0.2.35

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -244,8 +244,23 @@ jobs:
         if: runner.os == 'Windows' && matrix.features == 'hip'
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Install CUDA toolkit
-        if: matrix.features == 'cuda'
+      - name: Install CUDA toolkit (Linux)
+        if: runner.os == 'Linux' && matrix.features == 'cuda'
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: "13.2.0"
+          method: network
+          # The Linux apt repo splits CUDA 13 differently from the Windows
+          # silent installer: nvvm is folded into cuda-nvcc, the CUB/Thrust
+          # headers live in cuda-cccl, cuBLAS is a lib* package (installed
+          # via non-cuda-sub-packages below), and the libcuda.so driver stub
+          # ggml-cuda's VMM path links against comes from cuda-driver-dev.
+          sub-packages: '["nvcc", "crt", "cudart", "cudart-dev", "cccl", "driver-dev"]'
+          non-cuda-sub-packages: '["libcublas", "libcublas-dev"]'
+          use-github-cache: true
+
+      - name: Install CUDA toolkit (Windows)
+        if: runner.os == 'Windows' && matrix.features == 'cuda'
         uses: Jimver/cuda-toolkit@v0.2.35
         with:
           # 13.x is the first CUDA line whose host_config.h accepts the VS

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -154,6 +154,16 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y vulkan-sdk mesa-vulkan-drivers
 
+      # The ROCm SDK plus the fat multi-gfx build overflow the hosted
+      # runner's disk (observed "No space left on device"); drop the
+      # preinstalled toolchains this job never touches first. Same action
+      # llama.cpp's ubuntu-rocm release job uses.
+      - name: Free up disk space
+        if: runner.os == 'Linux' && matrix.features == 'hip'
+        uses: ggml-org/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+
       - name: Install Linux ROCm/HIP SDK
         if: runner.os == 'Linux' && matrix.features == 'hip'
         # AMD's official apt repo (the recipe llama.cpp's ubuntu-22-rocm

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -37,7 +37,7 @@ jobs:
       tag: ${{ steps.v.outputs.tag }}
       should_release: ${{ steps.v.outputs.should_release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - id: v
         name: Read workspace version and check for an existing tag
         run: |
@@ -83,7 +83,7 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install Linux build dependencies
@@ -111,7 +111,7 @@ jobs:
           cp README.md LICENSE "${stage}/"
           tar -czf "dist/openasr-${version}-${target}.tar.gz" -C dist "openasr-${version}-${target}"
       - name: Upload archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openasr-${{ matrix.target }}
           path: dist/openasr-${{ needs.resolve.outputs.version }}-${{ matrix.target }}.tar.gz
@@ -123,9 +123,9 @@ jobs:
     if: needs.resolve.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download build archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: staging
           merge-multiple: true

--- a/.github/workflows/serve-batch-parity.yml
+++ b/.github/workflows/serve-batch-parity.yml
@@ -31,7 +31,7 @@ jobs:
     name: moonshine CPU real-pack parity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Cache moonshine-tiny pack
         id: cache-pack
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: tmp/ci-packs/moonshine-tiny-q8_0.oasr
           key: moonshine-tiny-q8_0-${{ env.MOONSHINE_PACK_SHA256 }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -123,6 +123,7 @@ fn main() {
     let vulkan_sdk = feat_vulkan.then(vulkan_sdk_path).flatten();
     let windows_hip_shim = if feat_hip && is_windows {
         Some(prepare_windows_hip_sdk_shim(
+            &target,
             hip_path
                 .as_deref()
                 .expect("HIP_PATH, ROCM_PATH, or ROCM_HOME must point to AMD HIP SDK"),
@@ -1206,7 +1207,7 @@ fn normalize_cuda_gpu_targets(raw: &str) -> String {
         .join(";")
 }
 
-fn prepare_windows_hip_sdk_shim(hip_path: &Path, out_dir: &Path) -> PathBuf {
+fn prepare_windows_hip_sdk_shim(target: &str, hip_path: &Path, out_dir: &Path) -> PathBuf {
     let shim_dir = out_dir.join("openasr-windows-hip-sdk-shim");
     let import_lib_dir = shim_dir.join("lib");
     fs::create_dir_all(&import_lib_dir).expect("create Windows HIP import lib dir");
@@ -1214,10 +1215,12 @@ fn prepare_windows_hip_sdk_shim(hip_path: &Path, out_dir: &Path) -> PathBuf {
     let bin_dir = hip_path.join("bin");
     let sdk_include_dir = hip_path.join("include");
     prepare_windows_import_lib(
+        target,
         &bin_dir.join("libhipblas.dll"),
         &import_lib_dir.join("libhipblas.lib"),
     );
     prepare_windows_import_lib(
+        target,
         &bin_dir.join("rocblas.dll"),
         &import_lib_dir.join("rocblas.lib"),
     );
@@ -1240,7 +1243,29 @@ fn prepare_windows_hip_sdk_shim(hip_path: &Path, out_dir: &Path) -> PathBuf {
     shim_dir
 }
 
-fn prepare_windows_import_lib(dll_path: &Path, import_lib_path: &Path) {
+/// Build a Command for an MSVC binutils-style tool (dumpbin.exe, lib.exe).
+///
+/// These live next to cl.exe in the VC tools bin directory, which is NOT on
+/// PATH outside a Developer Command Prompt (CI runners invoke cargo from a
+/// plain shell). cc's windows_registry finds cl.exe through the VS installer
+/// metadata, so derive the sibling tool from there and inherit the tool env
+/// (PATH additions for the DLLs the tool itself needs). Falls back to plain
+/// PATH lookup for developer prompts / exotic setups.
+fn msvc_bin_tool(target: &str, tool: &str) -> Command {
+    if let Some(cl) = cc::windows_registry::find_tool(target, "cl.exe") {
+        let path = cl.path().with_file_name(tool);
+        if path.is_file() {
+            let mut command = Command::new(path);
+            for (key, value) in cl.env() {
+                command.env(key, value);
+            }
+            return command;
+        }
+    }
+    Command::new(tool)
+}
+
+fn prepare_windows_import_lib(target: &str, dll_path: &Path, import_lib_path: &Path) {
     if import_lib_path.is_file() {
         return;
     }
@@ -1251,7 +1276,7 @@ fn prepare_windows_import_lib(dll_path: &Path, import_lib_path: &Path) {
         );
     }
 
-    let output = Command::new("dumpbin")
+    let output = msvc_bin_tool(target, "dumpbin.exe")
         .arg("/exports")
         .arg(dll_path)
         .output()
@@ -1280,7 +1305,7 @@ fn prepare_windows_import_lib(dll_path: &Path, import_lib_path: &Path) {
     let def = format!("LIBRARY {library_name}\nEXPORTS\n{}\n", exports.join("\n"));
     fs::write(&def_path, def).expect("write Windows HIP import library definition");
 
-    let status = Command::new("lib")
+    let status = msvc_bin_tool(target, "lib.exe")
         .arg(format!("/def:{}", def_path.display()))
         .arg("/machine:x64")
         .arg(format!("/out:{}", import_lib_path.display()))

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -140,6 +140,13 @@ fn main() {
         .arg("-B")
         .arg(&build_dir)
         .arg("-DCMAKE_BUILD_TYPE=Release")
+        // ggml's static archives are linked into a Rust binary that is PIE by
+        // default on Linux. Host gcc/clang compile PIC anyway, but the ROCm
+        // and CUDA device-host compilers do not (amdclang++ emits non-PIC
+        // .eh_frame relocations that fail the final rust-lld link with
+        // "relocation R_X86_64_32 cannot be used against local symbol").
+        // Forcing PIC on is correct everywhere and required there.
+        .arg("-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
         .arg(cmake_flag("BUILD_SHARED_LIBS", use_backend_dl))
         .arg(cmake_flag("GGML_BACKEND_DL", use_backend_dl))
         .arg(cmake_flag("GGML_CPU_ALL_VARIANTS", use_backend_dl))

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -499,6 +499,20 @@ fn main() {
                 "cargo:rustc-link-search=native={}",
                 cuda_path.join("lib/x64").display()
             );
+            // libcuda.so is the DRIVER library: a real one only exists on a
+            // machine with an NVIDIA driver. Toolkit installs provide a link
+            // stub under lib64/stubs (cuda-driver-dev on Linux) precisely so
+            // driver-linking binaries can be built on driver-less hosts (CI).
+            // Listed last: a real driver library earlier on the search path
+            // still wins.
+            println!(
+                "cargo:rustc-link-search=native={}",
+                cuda_path.join("lib64/stubs").display()
+            );
+            println!(
+                "cargo:rustc-link-search=native={}",
+                cuda_path.join("lib/stubs").display()
+            );
         }
     }
 

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -1154,16 +1154,22 @@ fn hip_sdk_clang_path(hip_path: &Path) -> Option<PathBuf> {
 }
 
 fn hip_gpu_targets() -> String {
-    // The llama.cpp "radeon" consumer arch list (RDNA2/3/3.5/4): one fat code
-    // object covers every supported AMD card and the HIP runtime selects the ISA
-    // at load. Drops gfx906 (Vega20/CDNA1, not a consumer target) versus the old
-    // default. Override with OPENASR_HIP_GPU_TARGETS for a narrower/wider set.
+    // A consumer RDNA2/3/3.5/4 arch list: one fat code object covers every
+    // supported AMD card and the HIP runtime selects the ISA at load. Union
+    // of llama.cpp's current Windows HIP release list (gfx1030/31/32,
+    // gfx1100/01/02, gfx1150/51, gfx1200/01) and gfx1035 from a competing
+    // ASR product's HIP build, biased toward RDNA2/3/4 gaming/consumer cards.
+    // Deliberately excludes CDNA/datacenter compute cards (gfx906/908/90a):
+    // those are compute accelerators, not something an end user's desktop/
+    // laptop ships, and would meaningfully lengthen every HIP build for a
+    // target this product does not support. Override with
+    // OPENASR_HIP_GPU_TARGETS for a narrower/wider set.
     env::var("OPENASR_HIP_GPU_TARGETS")
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| {
-            "gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201"
+            "gfx1030;gfx1031;gfx1032;gfx1035;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201"
                 .to_string()
         })
 }


### PR DESCRIPTION
## Summary

Extends the release-binaries workflow from 6 to 11 legs: Windows HIP (AMD GPU), Linux Vulkan/CUDA/ROCm, and Linux arm64 CPU, all built and validated green on GitHub-hosted runners. Also bumps all GitHub actions to their Node 24 majors and pins release/regression macOS runners.

## Why

The v0.1.7 release shipped no AMD GPU artifact for Windows (the most requested hardware gap), no Linux GPU variants, and no Linux arm64 build. All are standard in comparable ASR/llama.cpp releases.

## Changes

- `x86_64-pc-windows-msvc-hip` leg: AMD HIP SDK (26.Q1 silent installer, llama.cpp's recipe), fat code object for gfx1030/31/32/35, gfx1100/01/02, gfx1150/51, gfx1200/01 (RDNA2/3/3.5/4); ships ROCm runtime DLLs + rocBLAS Tensile library dir. Pinned to windows-2022 (VS 2026 STL breaks ROCm clang's HIP cmath wrappers).
- Linux `-vulkan` (LunarG apt + llvmpipe ICD, exe launches on the runner), `-cuda` (CUDA 13.2 network sub-packages, Linux apt names), `-rocm` (AMD apt repo, same gfx list) legs; CUDA/HIP archives carry redistributable runtime .so files.
- `aarch64-unknown-linux-gnu` CPU leg on the native arm64 hosted runner.
- build.rs: `msvc_bin_tool()` resolves dumpbin/lib via cc's windows_registry (no dev-prompt dependency); `CMAKE_POSITION_INDEPENDENT_CODE=ON` (amdclang++ emits non-PIC objects that fail PIE links); CUDA `lib64/stubs` on the link path (driver-less CI links against the libcuda stub); gfx1035 added to default HIP targets.
- All legs promoted out of `experimental` after run 28840139900 (and 28828124314) built the full matrix green.
- actions/checkout v4->v7, upload-artifact v4->v7, download-artifact v4->v8, cache v4->v6 across all workflows (Node 20 deprecation); macos-latest pinned to macos-15 in release-binaries and family-regression.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2009 passed)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (advisories RUSTSEC-2026-0204 fails identically on main; unrelated to this PR)

## Manual smoke checks

- workflow_dispatch runs 28823920123 / 28825111410 / 28828124314 / 28840139900 on this branch: full 11-leg matrix green, checksums job green; Vulkan exes launch on the GPU-less runners (Windows SDK loader / Linux llvmpipe), CUDA/HIP legs are build+package (no driver on hosted runners), GPU inference to be validated on real hardware.

## Docs updated

- [x] No behavior/limitations docs affected (CI/build-infra only).
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No GPU inference validation on hosted runners (no GPU); real-hardware validation happens on maintainer machines.
- No Windows arm64, no macOS GPU variants beyond the default Metal build.
- ci.yml's macOS job intentionally stays on macos-latest (not a release/regression artifact producer).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - workflow/build.rs changes drafted and iterated with an AI agent under maintainer direction; all runs and failures reviewed by the maintainer.
