### PR TITLE
feat(dolphin): espnet frontend and rel-pos-v1 for multilingual checkpoints

### DIFF
--- a/crates/openasr-core/src/models/dolphin/encoder_graph.rs
+++ b/crates/openasr-core/src/models/dolphin/encoder_graph.rs
@@ -1123,3 +1123,61 @@ pub(crate) fn encode(
         encoder_out,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the centered Transformer-XL `RelPositionalEncodingV1` table's shape
+    /// and index direction (the multilingual dolphin encoder's only numeric
+    /// path with no weights-backed parity harness): `2*frames-1` rows running
+    /// from position `+(frames-1)` (row 0) down to `-(frames-1)` (last row),
+    /// the center row at `frames-1` being position 0, and rows symmetric about
+    /// that center differing only by `sin`'s sign (`cos` even). Catches an
+    /// off-by-one in the row/position mapping without loading a pack.
+    #[test]
+    fn relative_positional_table_is_centered_and_sign_symmetric() {
+        let d_model = 4usize;
+        let frames = 3usize;
+        let table = dolphin_relative_positional_table(d_model, frames).expect("table");
+        let n_positions = 2 * frames - 1; // 5
+        assert_eq!(table.len(), n_positions * d_model);
+
+        let row = |idx: usize| &table[idx * d_model..(idx + 1) * d_model];
+
+        // div_term for d_model=4: exp(0)=1 (pair 0), 10000^-0.5=0.01 (pair 1).
+        let expected_for_pos = |pos: f64| {
+            [
+                (pos * 1.0).sin() as f32,
+                (pos * 1.0).cos() as f32,
+                (pos * 0.01).sin() as f32,
+                (pos * 0.01).cos() as f32,
+            ]
+        };
+        // Row 0 is the most-positive position (frames-1 = 2), last row is -2.
+        for (bin, &expected) in expected_for_pos(2.0).iter().enumerate() {
+            assert!((row(0)[bin] - expected).abs() < 1.0e-6, "row0 bin{bin}");
+        }
+        // Center row (index frames-1 = 2) is position 0: sin=0, cos=1 per pair.
+        assert_eq!(row(frames - 1), &[0.0, 1.0, 0.0, 1.0]);
+        // Sign symmetry: row k and row (n_positions-1-k) hold opposite positions
+        // -- sin negated, cos preserved (off-by-one in the direction breaks this).
+        for k in 0..n_positions {
+            let mirror = n_positions - 1 - k;
+            let (a, b) = (row(k), row(mirror));
+            assert!((a[0] + b[0]).abs() < 1.0e-6, "sin pair0 antisymmetry k{k}");
+            assert!((a[1] - b[1]).abs() < 1.0e-6, "cos pair0 symmetry k{k}");
+            assert!((a[2] + b[2]).abs() < 1.0e-6, "sin pair1 antisymmetry k{k}");
+            assert!((a[3] - b[3]).abs() < 1.0e-6, "cos pair1 symmetry k{k}");
+        }
+    }
+
+    /// Odd `d_model` must still fill every row without indexing past the end
+    /// (the loop writes `row[i+1]` only when `i + 1 < d_model`).
+    #[test]
+    fn relative_positional_table_handles_odd_d_model() {
+        let table = dolphin_relative_positional_table(3, 2).expect("table");
+        assert_eq!(table.len(), (2 * 2 - 1) * 3);
+        assert!(table.iter().all(|v| v.is_finite()));
+    }
+}

--- a/crates/openasr-core/src/models/dolphin/encoder_graph.rs
+++ b/crates/openasr-core/src/models/dolphin/encoder_graph.rs
@@ -62,7 +62,22 @@ fn ggml_err(stage: &'static str) -> impl Fn(GgmlCpuGraphError) -> DolphinEncoder
     move |source| DolphinEncoderError::Ggml { stage, source }
 }
 
-/// Scalar/shape configuration for the Dolphin `small.cn` encoder.
+/// Scalar/shape configuration for the Dolphin encoder. `language_scheme`
+/// selects the encoder's relative-position-attention flavor, which differs
+/// between the two Dolphin training pipelines (confirmed by reading
+/// `DataoceanAI/Dolphin`'s own inference source, not assumed):
+///
+/// * [`DolphinLanguageScheme::CnDialect`] (`small.cn`/`cn-dialect-base`,
+///   WeNet-trained, `use_sdpa: true`): the simple non-centered
+///   `RelPositionalEncoding`, sliced `[0, frames)` from a baked/synthesized
+///   table, folded into the SDPA bias with **no `rel_shift`** (`pos_emb`
+///   length == `frames`) -- unchanged from before this scheme split existed.
+/// * [`DolphinLanguageScheme::Multilingual`] (`dolphin-small`/`dolphin-base`,
+///   ESPnet-trained, `use_sdpa: false`, `pos_enc_layer_type: rel_pos_v1`): the
+///   centered Transformer-XL `RelPositionalEncodingV1` (`2*frames-1` positions,
+///   `[frame-1 .. -(frame-1)]`), computed fresh per `frames` at graph-build
+///   time (see `dolphin_relative_positional_table`) and consumed through the
+///   real `rel_shift` (see `attention_branch`).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct DolphinEncoderConfig {
     pub d_model: usize,
@@ -75,9 +90,12 @@ pub(crate) struct DolphinEncoderConfig {
     pub num_blocks: usize,
     pub feature_dim: usize,
     /// Length of the sinusoidal position table baked into
-    /// `encoder.embed.pos_enc.pe` (`dolphin.encoder.max_ctx`).
+    /// `encoder.embed.pos_enc.pe` (`dolphin.encoder.max_ctx`). Only consulted
+    /// under [`DolphinLanguageScheme::CnDialect`]; the multilingual scheme
+    /// computes its rel-pos table fresh per request instead.
     pub max_positions: usize,
     pub layer_norm_epsilon: f32,
+    pub language_scheme: super::package_import::DolphinLanguageScheme,
 }
 
 impl DolphinEncoderConfig {
@@ -94,6 +112,7 @@ impl DolphinEncoderConfig {
             feature_dim: 80,
             max_positions: 5000,
             layer_norm_epsilon: 1e-5,
+            language_scheme: super::package_import::DolphinLanguageScheme::CnDialect,
         }
     }
 
@@ -102,9 +121,12 @@ impl DolphinEncoderConfig {
     /// through this same path). `layer_norm_epsilon` is not a per-checkpoint
     /// metadata key: every observed Dolphin/WeNet checkpoint uses the same
     /// `1e-5` LayerNorm epsilon, so it stays a fixed architecture constant
-    /// like `small_cn()`'s.
+    /// like `small_cn()`'s. `language_scheme` comes from the pack's
+    /// `dolphin.language.scheme` metadata (see `executor::run_dolphin_pipeline`),
+    /// same signal the decode-prefix builder and frontend already dispatch on.
     pub(crate) fn from_execution_metadata(
         metadata: &super::runtime_contract::DolphinExecutionMetadata,
+        language_scheme: super::package_import::DolphinLanguageScheme,
     ) -> Self {
         Self {
             d_model: metadata.encoder_d_model,
@@ -118,6 +140,7 @@ impl DolphinEncoderConfig {
             feature_dim: metadata.feature_dim,
             max_positions: metadata.encoder_max_ctx,
             layer_norm_epsilon: 1e-5,
+            language_scheme,
         }
     }
 }
@@ -190,8 +213,10 @@ struct EmbedWeights<'a> {
     conv1_b: GgmlCpuTensor<'a>,
     out_w: GgmlCpuTensor<'a>,
     out_b: GgmlCpuTensor<'a>,
-    /// `[d_model, frames]` slice of the shared sinusoidal position table.
-    pos_emb: GgmlCpuTensor<'a>,
+    // `pos_emb` moved out of `EmbedWeights`: its scheme-dependent shape/source
+    // (a baked-table slice for `CnDialect`, a graph-build-time-computed
+    // rel-pos-v1 table for `Multilingual`) is built directly in `encode()`
+    // instead, see `dolphin_relative_positional_table`.
 }
 
 struct BlockWeights<'a> {
@@ -370,7 +395,6 @@ fn build_embed_weights<'a, 'p>(
     graph: &GgmlCpuGraphBuilder<'a>,
     builder: &mut WeightBuilder<'a, 'p>,
     config: &DolphinEncoderConfig,
-    frames: usize,
 ) -> Result<EmbedWeights<'a>, DolphinEncoderError> {
     let d = config.d_model;
     let flat = d * subsample_width(config.feature_dim);
@@ -381,14 +405,36 @@ fn build_embed_weights<'a, 'p>(
         conv1_b: builder.w4(graph, "encoder.embed.conv.2.bias", 1, 1, d, 1)?,
         out_w: builder.w2(graph, "encoder.embed.out.0.weight", flat, d)?,
         out_b: builder.w1(graph, "encoder.embed.out.0.bias", d)?,
-        pos_emb: builder.pos_slice(
-            graph,
-            "encoder.embed.pos_enc.pe",
-            d,
-            frames,
-            config.max_positions,
-        )?,
     })
+}
+
+/// The centered Transformer-XL relative-position sinusoidal table ESPnet's
+/// `RelPositionalEncodingV1` computes fresh per forward call (never baked as a
+/// state-dict buffer): `2*frames-1` rows, position `frames-1` (row 0) down to
+/// `-(frames-1)` (last row) -- `pe_positive` (flipped) concatenated with
+/// `pe_negative[1:]` in the reference. Row-major `[position][d_model]`
+/// (d_model innermost), matching `pos_slice`'s baked-table layout so both
+/// schemes' `pos_emb` tensors share the same `[d_model, positions]` ggml
+/// binding convention downstream.
+fn dolphin_relative_positional_table(d_model: usize, frames: usize) -> Option<Vec<f32>> {
+    let n_positions = frames.checked_mul(2)?.checked_sub(1)?;
+    let total = n_positions.checked_mul(d_model)?;
+    let mut table = vec![0.0f32; total];
+    for position_idx in 0..n_positions {
+        let pos = (frames - 1) as f64 - position_idx as f64;
+        let row = &mut table[position_idx * d_model..(position_idx + 1) * d_model];
+        let mut i = 0;
+        while i < d_model {
+            let div_term = (-((i as f64) / (d_model as f64)) * 10000.0_f64.ln()).exp();
+            let angle = pos * div_term;
+            row[i] = angle.sin() as f32;
+            if i + 1 < d_model {
+                row[i + 1] = angle.cos() as f32;
+            }
+            i += 2;
+        }
+    }
+    Some(table)
 }
 
 fn build_block_weights<'a, 'p>(
@@ -540,10 +586,21 @@ fn feed_forward_half<'a>(
     )
 }
 
-/// The rel-pos global branch (WeNet `RelPositionMultiHeadedAttention` with
-/// `use_sdpa=true`): scores = `(q_u . k + q_v . p) / sqrt(head_dim)`, softmax,
-/// context. No `rel_shift` and `pos_emb` length == T because sdpa folds the bias
-/// straight into the scores; full-context single utterance so no mask term.
+/// The rel-pos global branch (`RelPositionMultiHeadedAttention`):
+/// scores = `(q_u . k + q_v . p) / sqrt(head_dim)`, softmax, context.
+///
+/// Two schemes, dispatched on `config.language_scheme` (see
+/// [`DolphinEncoderConfig`]'s doc comment):
+/// * `CnDialect` (`use_sdpa: true`): `pos_emb` length == `frames`, **no
+///   `rel_shift`** -- sdpa folds `matrix_bd` directly into the bias. Unchanged
+///   from the parity-verified small.cn path.
+/// * `Multilingual` (`use_sdpa: false`, `rel_pos_v1`): `pos_emb` length ==
+///   `2*frames-1` (centered), and `matrix_bd` goes through the real
+///   `rel_shift` (a strided `view_3d` reinterpretation, the same trick
+///   `nn::encoder::conformer_block` uses for cohere/parakeet's Transformer-XL
+///   rel-pos attention) before being added to `matrix_ac`.
+///
+/// Full-context single utterance either way, so no additive mask term.
 fn attention_branch<'a>(
     graph: &GgmlCpuGraphBuilder<'a>,
     normed: GgmlCpuTensor<'a>,
@@ -599,10 +656,22 @@ fn attention_branch<'a>(
         reshape_steps,
         map_err,
     )?;
+    let is_multilingual = matches!(
+        config.language_scheme,
+        super::package_import::DolphinLanguageScheme::Multilingual
+    );
+    let pos_layout = if is_multilingual {
+        AttentionHeadLayout {
+            sequence_len: 2 * frames - 1,
+            ..layout
+        }
+    } else {
+        layout
+    };
     let p = reshape_projection_to_attention_heads(
         graph,
         p,
-        layout,
+        pos_layout,
         STANDARD_HEAD_PERMUTE_AXES,
         false,
         reshape_steps,
@@ -612,9 +681,47 @@ fn attention_branch<'a>(
     let ac = graph
         .mul_mat(graph.cont(k).map_err(map)?, q_u)
         .map_err(map)?;
-    let bd = graph
+    let bd_raw = graph
         .mul_mat(graph.cont(p).map_err(map)?, q_v)
         .map_err(map)?;
+    let bd = if is_multilingual {
+        // rel_shift: reinterpret `bd_raw` (`[2*frames-1, frames, heads]`) as
+        // `[frames, frames, heads]` via the classic pad+reshape+slice trick,
+        // done directly as a strided view (no extra copy) -- byte-identical
+        // stride formula to `nn::encoder::conformer_block`'s `bd` view.
+        let element = std::mem::size_of::<f32>();
+        let nb1 =
+            (2 * frames - 2)
+                .checked_mul(element)
+                .ok_or_else(|| DolphinEncoderError::Shape {
+                    reason: "rel_shift nb1 overflow".to_string(),
+                })?;
+        let nb2 = (2 * frames - 1)
+            .checked_mul(frames)
+            .and_then(|value| value.checked_mul(element))
+            .ok_or_else(|| DolphinEncoderError::Shape {
+                reason: "rel_shift nb2 overflow".to_string(),
+            })?;
+        let offset =
+            (frames - 1)
+                .checked_mul(element)
+                .ok_or_else(|| DolphinEncoderError::Shape {
+                    reason: "rel_shift offset overflow".to_string(),
+                })?;
+        graph
+            .view_3d(
+                bd_raw,
+                frames,
+                frames,
+                config.attention_heads,
+                nb1,
+                nb2,
+                offset,
+            )
+            .map_err(map)?
+    } else {
+        bd_raw
+    };
     let scores = graph.add(ac, bd).map_err(map)?;
     let scores = graph
         .scale(scores, 1.0 / (config.head_dim as f32).sqrt())
@@ -895,7 +1002,7 @@ pub(crate) fn encode(
 
     // Phase A: create every weight tensor (must precede the first buffer alloc).
     let mut builder = WeightBuilder::new(provider);
-    let embed = build_embed_weights(&graph, &mut builder, config, frames)?;
+    let embed = build_embed_weights(&graph, &mut builder, config)?;
     let mut blocks = Vec::with_capacity(config.num_blocks);
     for index in 0..config.num_blocks {
         blocks.push(build_block_weights(&graph, &mut builder, config, index)?);
@@ -907,6 +1014,39 @@ pub(crate) fn encode(
         blocks,
         after_norm_w,
         after_norm_b,
+    };
+
+    // The encoder's relative-position table: a baked-table slice for
+    // `CnDialect` (via the provider, like every other weight), or a table
+    // computed fresh for this request's `frames` for `Multilingual` (never
+    // baked -- see `dolphin_relative_positional_table`). The latter is
+    // uploaded like `input` below (an owned buffer kept alive for the whole
+    // call), not through `WeightBuilder` (which only holds provider-borrowed
+    // slices).
+    let is_multilingual = matches!(
+        config.language_scheme,
+        super::package_import::DolphinLanguageScheme::Multilingual
+    );
+    let mut computed_pos_table: Option<Vec<f32>> = None;
+    let pos_emb = if is_multilingual {
+        let table = dolphin_relative_positional_table(config.d_model, frames).ok_or_else(|| {
+            DolphinEncoderError::Shape {
+                reason: "relative position table size overflow".to_string(),
+            }
+        })?;
+        let tensor = graph
+            .new_tensor_2d_f32(config.d_model, 2 * frames - 1, "dolphin_rel_pos")
+            .map_err(ggml_err("weight_alloc_relpos"))?;
+        computed_pos_table = Some(table);
+        tensor
+    } else {
+        builder.pos_slice(
+            &graph,
+            "encoder.embed.pos_enc.pe",
+            config.d_model,
+            frames,
+            config.max_positions,
+        )?
     };
 
     let input = graph
@@ -925,14 +1065,7 @@ pub(crate) fn encode(
     taps.push(after_subsample);
     let mut hidden = after_subsample;
     for block in &weights.blocks {
-        hidden = encoder_block(
-            &mut graph,
-            hidden,
-            weights.embed.pos_emb,
-            block,
-            config,
-            frames,
-        )?;
+        hidden = encoder_block(&mut graph, hidden, pos_emb, block, config, frames)?;
         taps.push(hidden);
     }
     let encoder_out = affine_ln(
@@ -955,6 +1088,11 @@ pub(crate) fn encode(
     graph
         .set_f32_slice(input, features, "dolphin_features")
         .map_err(ggml_err("upload_features"))?;
+    if let Some(table) = &computed_pos_table {
+        graph
+            .set_f32_slice(pos_emb, table, "dolphin_rel_pos")
+            .map_err(ggml_err("upload_rel_pos"))?;
+    }
     for (tensor, data, name) in &builder.uploads {
         graph
             .set_f32_slice(*tensor, data, name)

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -38,23 +38,25 @@ use super::decoder_graph::DolphinDecoderConfig;
 use super::encoder_graph::{
     DolphinEncoderConfig, DolphinEncoderOutput, DolphinNativeWeight, DolphinWeightProvider, encode,
 };
-use super::frontend::{DolphinFbankFrontend, NUM_MEL_BINS, apply_global_cmvn};
+use super::frontend::{DolphinEspnetFrontend, DolphinFbankFrontend, apply_global_cmvn};
 use super::hotword_context::{
     apply_hotword_deep_biasing, encode_hotword_context_embeddings, tokenize_hotword_phrase,
 };
 use super::joint_decode::{DolphinJointDecodeConfig, detokenize_char_tokens, joint_decode};
 use super::language::{build_dolphin_decode_prefix, build_dolphin_multilingual_decode_prefix};
+use super::package_import::DolphinLanguageScheme;
 use super::runtime_contract::parse_dolphin_execution_metadata;
 
 /// Encoder weight namespace baked into the pack under exact WeNet names.
 const ENCODER_TENSOR_PREFIX: &str = "encoder.";
 /// Sentinels proving the pack baked the encoder + CTC head namespaces (cheap
-/// index probe, no dequantization).
-const ENCODER_SENTINEL_TENSORS: [&str; 3] = [
-    "encoder.embed.pos_enc.pe",
-    "encoder.after_norm.weight",
-    "ctc.ctc_lo.weight",
-];
+/// index probe, no dequantization), common to both language schemes.
+const ENCODER_SENTINEL_TENSORS: [&str; 2] = ["encoder.after_norm.weight", "ctc.ctc_lo.weight"];
+/// CnDialect-only sentinel: the multilingual scheme's encoder attention never
+/// bakes this table (its `rel_pos_v1` table is computed fresh per request
+/// instead -- see `encoder_graph::dolphin_relative_positional_table`), so
+/// requiring it there would fail closed on every valid multilingual pack.
+const ENCODER_CN_DIALECT_SENTINEL_TENSOR: &str = "encoder.embed.pos_enc.pe";
 
 /// Global CMVN vectors baked in the pack (checkpoint's own `encoder.global_cmvn`).
 const CMVN_MEAN_TENSOR: &str = "encoder.global_cmvn.mean";
@@ -343,16 +345,27 @@ pub(crate) fn run_dolphin_pipeline(
     let tokens = metadata
         .get_string_array(TOKENIZER_TOKENS_KEY)
         .ok_or_else(|| format!("dolphin pack is missing the '{TOKENIZER_TOKENS_KEY}' vocab"))?;
+    // The pack's own `dolphin.language.scheme` (absent on every pack predating
+    // this key, which defaults to the cn-dialect family -- both originally
+    // published dolphin packs are cn-dialect). This single signal now
+    // dispatches three things that all trace back to which of the two
+    // DataoceanAI training pipelines produced the checkpoint: the decode
+    // prefix builder (below), the audio frontend, and the encoder's
+    // relative-position-attention scheme (`DolphinEncoderConfig`).
+    let language_scheme = match metadata.get_string(LANGUAGE_SCHEME_KEY) {
+        Some("multilingual") => DolphinLanguageScheme::Multilingual,
+        _ => DolphinLanguageScheme::CnDialect,
+    };
     // Build the `<sos> <lang> <region> <asr> <notimestamp>` prefix per request
     // from the pack vocab; fail closed (typed) on an unknown code or a missing
-    // language/region token. Dispatches on the pack's own
-    // `dolphin.language.scheme` (absent on every pack predating this key,
-    // which defaults to the cn-dialect family's fixed-`<zh>` builder -- both
-    // currently-published dolphin packs are cn-dialect).
-    let prefix = match metadata.get_string(LANGUAGE_SCHEME_KEY) {
-        Some("multilingual") => build_dolphin_multilingual_decode_prefix(tokens, language)
-            .map_err(|error| format!("dolphin multilingual decode prefix build failed: {error}"))?,
-        _ => build_dolphin_decode_prefix(tokens, language)
+    // language/region token.
+    let prefix = match language_scheme {
+        DolphinLanguageScheme::Multilingual => {
+            build_dolphin_multilingual_decode_prefix(tokens, language).map_err(|error| {
+                format!("dolphin multilingual decode prefix build failed: {error}")
+            })?
+        }
+        DolphinLanguageScheme::CnDialect => build_dolphin_decode_prefix(tokens, language)
             .map_err(|error| format!("dolphin decode prefix build failed: {error}"))?,
     };
     let eos_token_id = metadata
@@ -372,21 +385,29 @@ pub(crate) fn run_dolphin_pipeline(
     let execution_metadata = parse_dolphin_execution_metadata(metadata, weights)
         .map_err(|error| format!("dolphin runtime metadata contract failed: {error}"))?;
 
-    // Frontend: kaldi fbank -> global CMVN (the exact tensor the encoder consumes).
-    let mut features = DolphinFbankFrontend::new()
-        .compute(samples)
-        .map_err(|error| format!("dolphin fbank frontend failed: {error}"))?;
+    // Frontend: kaldi fbank (cn-dialect) or the ESPnet DefaultFrontend
+    // (multilingual) -> global CMVN (the exact tensor the encoder consumes).
+    // See `frontend::DolphinEspnetFrontend`'s doc comment for why these two
+    // checkpoints need materially different feature pipelines.
+    let mut features = match language_scheme {
+        DolphinLanguageScheme::CnDialect => DolphinFbankFrontend::new().compute(samples),
+        DolphinLanguageScheme::Multilingual => DolphinEspnetFrontend::new().compute(samples),
+    }
+    .map_err(|error| format!("dolphin frontend failed: {error}"))?;
     let cmvn_mean = weights
         .tensor(CMVN_MEAN_TENSOR)
         .ok_or_else(|| format!("dolphin pack is missing '{CMVN_MEAN_TENSOR}'"))?;
     let cmvn_istd = weights
         .tensor(CMVN_ISTD_TENSOR)
         .ok_or_else(|| format!("dolphin pack is missing '{CMVN_ISTD_TENSOR}'"))?;
-    apply_global_cmvn(&mut features.data, NUM_MEL_BINS, cmvn_mean, cmvn_istd)
+    apply_global_cmvn(&mut features.data, features.n_mels, cmvn_mean, cmvn_istd)
         .map_err(|error| format!("dolphin global CMVN failed: {error}"))?;
 
-    // Encoder (parity-verified for small.cn; shape-derived for every size).
-    let encoder_config = DolphinEncoderConfig::from_execution_metadata(&execution_metadata);
+    // Encoder (parity-verified for small.cn; shape-derived for every size;
+    // `language_scheme` picks the rel-pos-attention flavor -- see
+    // `DolphinEncoderConfig`'s doc comment).
+    let encoder_config =
+        DolphinEncoderConfig::from_execution_metadata(&execution_metadata, language_scheme);
     let encoder = encode(
         &encoder_config,
         weights,
@@ -501,7 +522,11 @@ impl GgmlAsrExecutor for DolphinGgmlExecutor {
         parse_dolphin_execution_metadata(&preflight.metadata, preflight.tensor_index.as_ref())
             .map_err(|error| fail(format!("dolphin runtime metadata contract failed: {error}")))?;
         // Confirm the encoder + CTC namespaces are actually baked before decoding.
-        for sentinel in ENCODER_SENTINEL_TENSORS {
+        let mut sentinels = ENCODER_SENTINEL_TENSORS.to_vec();
+        if preflight.metadata.get_string(LANGUAGE_SCHEME_KEY) != Some("multilingual") {
+            sentinels.push(ENCODER_CN_DIALECT_SENTINEL_TENSOR);
+        }
+        for sentinel in sentinels {
             if preflight.tensor_index.get(sentinel).is_none() {
                 return Err(fail(format!(
                     "dolphin pack is missing required tensor '{sentinel}'"

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -330,6 +330,38 @@ pub(crate) fn transcribe_dolphin_pcm(
     )
 }
 
+/// Parse the pack's `dolphin.language.scheme` metadata (see [`LANGUAGE_SCHEME_KEY`])
+/// into the typed [`DolphinLanguageScheme`] that dispatches the decode-prefix
+/// builder, audio frontend, and encoder rel-pos-attention scheme. A **missing**
+/// key is an intentional backward-compat default to `CnDialect` -- every pack
+/// baked before this key existed (both originally published dolphin packs) is
+/// cn-dialect. A key that IS **present** but holds anything other than the two
+/// recognized values fails closed with a typed error instead of silently
+/// falling back: a corrupt or future-versioned pack must never be silently
+/// misdispatched to the wrong frontend/attention scheme.
+fn parse_dolphin_language_scheme(metadata: &GgufMetadata) -> Result<DolphinLanguageScheme, String> {
+    parse_dolphin_language_scheme_value(metadata.get_string(LANGUAGE_SCHEME_KEY))
+}
+
+/// The string-level half of [`parse_dolphin_language_scheme`], split out so a
+/// test can pin it against [`DolphinLanguageScheme::label`] (the importer's
+/// writer) without needing to construct a [`GgufMetadata`] -- the two literal
+/// sets (writer labels here, reader match arms in `package_import.rs`) must
+/// never drift out of sync.
+fn parse_dolphin_language_scheme_value(
+    value: Option<&str>,
+) -> Result<DolphinLanguageScheme, String> {
+    match value {
+        None => Ok(DolphinLanguageScheme::CnDialect),
+        Some("cn_dialect") => Ok(DolphinLanguageScheme::CnDialect),
+        Some("multilingual") => Ok(DolphinLanguageScheme::Multilingual),
+        Some(other) => Err(format!(
+            "dolphin pack has unrecognized '{LANGUAGE_SCHEME_KEY}' value {other:?} \
+             (expected 'cn_dialect' or 'multilingual')"
+        )),
+    }
+}
+
 /// Run the fbank+CMVN -> encoder -> joint-decode -> detokenize pipeline over
 /// already-loaded `weights`. Split out from [`transcribe_dolphin_pcm`] so the
 /// executor can reuse pooled weights across requests without re-dequantizing.
@@ -351,11 +383,10 @@ pub(crate) fn run_dolphin_pipeline(
     // dispatches three things that all trace back to which of the two
     // DataoceanAI training pipelines produced the checkpoint: the decode
     // prefix builder (below), the audio frontend, and the encoder's
-    // relative-position-attention scheme (`DolphinEncoderConfig`).
-    let language_scheme = match metadata.get_string(LANGUAGE_SCHEME_KEY) {
-        Some("multilingual") => DolphinLanguageScheme::Multilingual,
-        _ => DolphinLanguageScheme::CnDialect,
-    };
+    // relative-position-attention scheme (`DolphinEncoderConfig`). See
+    // `parse_dolphin_language_scheme` for the fail-closed handling of a
+    // present-but-unrecognized value.
+    let language_scheme = parse_dolphin_language_scheme(metadata)?;
     // Build the `<sos> <lang> <region> <asr> <notimestamp>` prefix per request
     // from the pack vocab; fail closed (typed) on an unknown code or a missing
     // language/region token.
@@ -521,9 +552,14 @@ impl GgmlAsrExecutor for DolphinGgmlExecutor {
         // Fail closed on an incomplete pack (missing runtime scalar keys).
         parse_dolphin_execution_metadata(&preflight.metadata, preflight.tensor_index.as_ref())
             .map_err(|error| fail(format!("dolphin runtime metadata contract failed: {error}")))?;
+        // Resolve the language scheme once here (fail closed on an unrecognized
+        // value at Gate-0, before any decode work); `run_dolphin_pipeline` below
+        // re-derives the same result from the same metadata key rather than
+        // threading it through, per its own doc comment.
+        let language_scheme = parse_dolphin_language_scheme(&preflight.metadata).map_err(fail)?;
         // Confirm the encoder + CTC namespaces are actually baked before decoding.
         let mut sentinels = ENCODER_SENTINEL_TENSORS.to_vec();
-        if preflight.metadata.get_string(LANGUAGE_SCHEME_KEY) != Some("multilingual") {
+        if language_scheme == DolphinLanguageScheme::CnDialect {
             sentinels.push(ENCODER_CN_DIALECT_SENTINEL_TENSOR);
         }
         for sentinel in sentinels {
@@ -626,6 +662,38 @@ mod tests {
 
     const FIXTURE_ROOT: &str =
         "/Volumes/QuintinDocument/openasr-dev/openasr/tmp/publish/dolphin-cn-dialect-small";
+
+    /// Pin the importer's `DolphinLanguageScheme::label()` writer against this
+    /// module's `parse_dolphin_language_scheme_value` reader: every scheme must
+    /// round-trip label -> parse -> the same scheme, so the two literal sets
+    /// (write side here, read side in `package_import.rs`) cannot silently drift
+    /// apart. Also pins the backward-compat default (missing key -> CnDialect)
+    /// and the fail-closed rejection of an unrecognized value.
+    #[test]
+    fn language_scheme_label_round_trips_through_the_executor_parser() {
+        for scheme in [
+            DolphinLanguageScheme::CnDialect,
+            DolphinLanguageScheme::Multilingual,
+        ] {
+            assert_eq!(
+                parse_dolphin_language_scheme_value(Some(scheme.label())),
+                Ok(scheme),
+                "label {:?} must parse back to {scheme:?}",
+                scheme.label()
+            );
+        }
+        assert_eq!(
+            parse_dolphin_language_scheme_value(None),
+            Ok(DolphinLanguageScheme::CnDialect),
+            "a missing scheme key must keep defaulting to cn-dialect for pre-existing packs"
+        );
+        assert!(
+            parse_dolphin_language_scheme_value(Some("bogus"))
+                .unwrap_err()
+                .contains("bogus"),
+            "an unrecognized scheme value must fail closed rather than silently default"
+        );
+    }
 
     /// Golden `attention_rescoring` transcript (manifest `text_nospecial`): the
     /// model's own joint-decode output for the Sichuan clip. This is the parity

--- a/crates/openasr-core/src/models/dolphin/frontend.rs
+++ b/crates/openasr-core/src/models/dolphin/frontend.rs
@@ -1,10 +1,12 @@
-//! Dolphin `small.cn` kaldi-fbank frontend + global CMVN (WeNet format).
+//! Dolphin frontends: kaldi-fbank (cn-dialect, WeNet format) and ESPnet
+//! `DefaultFrontend` (multilingual) + global CMVN.
 //!
-//! Reproduces the reference feature pipeline used to fit `small.cn`:
-//! `torchaudio.compliance.kaldi.fbank` with the `train.yaml` `fbank_conf`
-//! (25 ms window, 10 ms shift, 80 mel bins, `dither=0`) over the waveform scaled
-//! by `1 << 15` (float `[-1, 1]` back to the int16 magnitude kaldi expects),
-//! followed by the checkpoint's `global_cmvn` `(x - mean) * istd`.
+//! [`DolphinFbankFrontend`] reproduces the reference feature pipeline used to fit
+//! `small.cn`/`cn-dialect-base`: `torchaudio.compliance.kaldi.fbank` with the
+//! `train.yaml` `fbank_conf` (25 ms window, 10 ms shift, 80 mel bins, `dither=0`)
+//! over the waveform scaled by `1 << 15` (float `[-1, 1]` back to the int16
+//! magnitude kaldi expects), followed by the checkpoint's `global_cmvn`
+//! `(x - mean) * istd`.
 //!
 //! Fixed to the kaldi defaults the reference uses: Povey window, `remove_dc_offset`,
 //! pre-emphasis 0.97, HTK mel scale over 20-8000 Hz, `snip_edges=true`, and the
@@ -15,6 +17,19 @@
 //! max abs diff ~1e-4 (f32 FFT/mel noise), and `(x - mean) * istd` reproduces
 //! `logmel_feats_cmvn` (the exact tensor fed to the encoder). Both are exercised
 //! by the executor's end-to-end harness against the committed golden.
+//!
+//! [`DolphinEspnetFrontend`] is the multilingual (dolphin-small/dolphin-base)
+//! counterpart: those checkpoints' `train.yaml` carries a `dataset_conf`
+//! with *both* a `fbank_conf` and a `frontend_conf` key, and DataoceanAI's
+//! own `dolphin/processor.py::extract_feats` picks the ESPnet `DefaultFrontend`
+//! (`frontend_conf`) whenever it is present, ignoring `fbank_conf` entirely --
+//! confirmed by reading `DataoceanAI/Dolphin`'s inference source directly
+//! (`dolphin/model.py::Stft`/`LogMel`/`DefaultFrontend`), not assumed. That
+//! frontend is a materially different pipeline from the kaldi one above: a
+//! periodic Hann window (not Povey), `torch.stft`-style reflect-centered
+//! framing (not kaldi `snip_edges`), no pre-emphasis/DC-removal/int16 scaling,
+//! and a **Slaney**-normalized librosa mel scale/filterbank (not HTK
+//! peak-normalized) -- see `build_slaney_mel_filters`.
 
 #![allow(dead_code)]
 
@@ -260,6 +275,235 @@ fn build_mel_filters() -> Vec<MelFilter> {
     filters
 }
 
+// --- ESPnet DefaultFrontend (multilingual dolphin-small/dolphin-base) -------
+
+/// `frontend_conf` shared by dolphin-small and dolphin-base `train.yaml`:
+/// `n_fft: 512, win_length: 400, hop_length: 160, fs: 16000`. `LogMel`'s own
+/// defaults fill in the rest (unset in `frontend_conf`): `n_mels=80`,
+/// `fmin=0`, `fmax=fs/2`, `htk=False` (librosa Slaney mel).
+const ESPNET_N_FFT: usize = 512;
+const ESPNET_WIN_LENGTH: usize = 400;
+const ESPNET_HOP_LENGTH: usize = 160;
+pub(crate) const ESPNET_NUM_MEL_BINS: usize = 80;
+const ESPNET_FMIN_HZ: f64 = 0.0;
+/// `LogMel.__init__`'s `fmax = fs / 2` default (16 kHz Nyquist).
+const ESPNET_FMAX_HZ: f64 = 8_000.0;
+/// `torch.clamp(mel_feat, min=1e-10)` before `.log()` in `LogMel.forward`.
+const ESPNET_LOG_ENERGY_FLOOR: f32 = 1.0e-10;
+
+/// One triangular Slaney mel filter over the full `0..=n_fft/2` power-bin
+/// range (unlike [`MelFilter`], not gated to a contiguous nonzero run: the
+/// area-normalized Slaney weights are small enough near the band edges that
+/// hand-rolling a first/last-bin search buys little, and dense storage keeps
+/// the librosa reference formula ported verbatim below).
+struct EspnetMelFilter {
+    weights: Vec<f32>,
+}
+
+pub(crate) struct DolphinEspnetFrontend {
+    /// Periodic Hann window (`torch.hann_window(win_length)` default,
+    /// `periodic=True`), zero-padded/centered into the `n_fft`-length FFT
+    /// input buffer (`left = (n_fft - win_length) / 2`), mirroring
+    /// `torch.stft`'s own window centering when `win_length < n_fft`.
+    windowed_zero_pad: [f32; ESPNET_N_FFT],
+    filters: Vec<EspnetMelFilter>,
+    fft: Arc<dyn RealToComplex<f32>>,
+}
+
+impl std::fmt::Debug for DolphinEspnetFrontend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DolphinEspnetFrontend")
+            .field("n_mels", &self.filters.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for DolphinEspnetFrontend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DolphinEspnetFrontend {
+    pub(crate) fn new() -> Self {
+        let mut windowed_zero_pad = [0.0f32; ESPNET_N_FFT];
+        let left = (ESPNET_N_FFT - ESPNET_WIN_LENGTH) / 2;
+        for (n, slot) in windowed_zero_pad[left..left + ESPNET_WIN_LENGTH]
+            .iter_mut()
+            .enumerate()
+        {
+            // Periodic Hann: `0.5 - 0.5*cos(2*pi*n/N)` (N = win_length in the
+            // denominator, not N-1 -- `torch.hann_window`'s default).
+            *slot = 0.5
+                - 0.5 * (2.0 * std::f32::consts::PI * n as f32 / ESPNET_WIN_LENGTH as f32).cos();
+        }
+        Self {
+            windowed_zero_pad,
+            filters: build_slaney_mel_filters(
+                SAMPLE_RATE_HZ,
+                ESPNET_N_FFT,
+                ESPNET_NUM_MEL_BINS,
+                ESPNET_FMIN_HZ,
+                ESPNET_FMAX_HZ,
+            ),
+            fft: RealFftPlanner::<f32>::new().plan_fft_forward(ESPNET_N_FFT),
+        }
+    }
+
+    /// Compute pre-CMVN ESPnet log-mel features for 16 kHz mono `samples`
+    /// (float in `[-1, 1]`). `torch.stft(..., center=True, pad_mode="reflect")`
+    /// framing: the signal is conceptually reflect-padded by `n_fft/2` on each
+    /// side (exactly `win_length`'s slack either side of `hop_length`), giving
+    /// `n_frames = 1 + samples.len() / hop_length` (the padding cancels the
+    /// `n_fft` term because `2 * (n_fft/2) == n_fft`). No pre-emphasis, DC
+    /// removal, or dither: this frontend runs directly on the float PCM the
+    /// caller already decoded (no int16 rescale, unlike the kaldi frontend).
+    pub(crate) fn compute(
+        &self,
+        samples: &[f32],
+    ) -> Result<DolphinFbankFeatures, DolphinFrontendError> {
+        if samples.is_empty() || samples.iter().any(|v| !v.is_finite()) {
+            return Err(DolphinFrontendError::UnsupportedAudio);
+        }
+        let pad = ESPNET_N_FFT / 2;
+        let n_frames = 1 + samples.len() / ESPNET_HOP_LENGTH;
+        let r2c = &self.fft;
+        let mut fft_in = r2c.make_input_vec();
+        let mut fft_out = r2c.make_output_vec();
+        let mut scratch = r2c.make_scratch_vec();
+        let mut power = vec![0.0f32; ESPNET_N_FFT / 2 + 1];
+
+        let n_mels = self.filters.len();
+        let mut feats = vec![0.0f32; n_frames * n_mels];
+        for fr in 0..n_frames {
+            let frame_start = (fr * ESPNET_HOP_LENGTH) as i64 - pad as i64;
+            for (j, slot) in fft_in.iter_mut().enumerate() {
+                let sample = reflect_sample(samples, frame_start + j as i64);
+                *slot = sample * self.windowed_zero_pad[j];
+            }
+            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
+                .expect("dolphin espnet fbank rfft");
+            for (bin, value) in fft_out.iter().enumerate() {
+                power[bin] = value.re * value.re + value.im * value.im;
+            }
+            for (bin, filter) in self.filters.iter().enumerate() {
+                let mut energy = 0.0f32;
+                for (weight, p) in filter.weights.iter().zip(power.iter()) {
+                    energy += weight * p;
+                }
+                feats[fr * n_mels + bin] = energy.max(ESPNET_LOG_ENERGY_FLOOR).ln();
+            }
+        }
+        Ok(DolphinFbankFeatures {
+            data: feats,
+            n_frames,
+            n_mels,
+        })
+    }
+}
+
+/// `numpy`/`torch` `mode="reflect"` boundary sample at signal index `k`
+/// (may be negative or `>= samples.len()`): mirrors the signal about each
+/// edge without repeating the edge sample itself, matching `torch.stft`'s
+/// `pad_mode="reflect"` centering. Single-sample signals fold to that sample.
+fn reflect_sample(samples: &[f32], k: i64) -> f32 {
+    let len = samples.len();
+    if len <= 1 {
+        return samples.first().copied().unwrap_or(0.0);
+    }
+    let period = 2 * (len as i64 - 1);
+    let mut m = k % period;
+    if m < 0 {
+        m += period;
+    }
+    let m = if m < len as i64 { m } else { period - m };
+    samples[m as usize]
+}
+
+/// librosa's Slaney (non-HTK) mel scale: linear below 1 kHz, logarithmic
+/// above. `htk=False` is `librosa.filters.mel`'s default and what
+/// `DefaultFrontend`'s `LogMel` uses when `htk` is left unset (as
+/// dolphin-small/dolphin-base's `frontend_conf` does).
+fn hz_to_mel_slaney(freq: f64) -> f64 {
+    const F_SP: f64 = 200.0 / 3.0;
+    const MIN_LOG_HZ: f64 = 1000.0;
+    const MIN_LOG_MEL: f64 = MIN_LOG_HZ / F_SP; // 15.0
+    let logstep = 6.4f64.ln() / 27.0;
+    if freq >= MIN_LOG_HZ {
+        MIN_LOG_MEL + (freq / MIN_LOG_HZ).ln() / logstep
+    } else {
+        freq / F_SP
+    }
+}
+
+fn mel_to_hz_slaney(mel: f64) -> f64 {
+    const F_SP: f64 = 200.0 / 3.0;
+    const MIN_LOG_HZ: f64 = 1000.0;
+    const MIN_LOG_MEL: f64 = MIN_LOG_HZ / F_SP; // 15.0
+    let logstep = 6.4f64.ln() / 27.0;
+    if mel >= MIN_LOG_MEL {
+        MIN_LOG_HZ * (logstep * (mel - MIN_LOG_MEL)).exp()
+    } else {
+        F_SP * mel
+    }
+}
+
+/// `librosa.filters.mel(sr, n_fft, n_mels, fmin, fmax, htk=False)` (default
+/// `norm="slaney"`): `n_mels` overlapping triangles over `n_fft/2+1` linear FFT
+/// bins, with edges chosen evenly spaced in Slaney-mel space and each row
+/// scaled by `2 / (mel_edge[i+2] - mel_edge[i])` (area, not peak, normalized --
+/// the opposite convention from the kaldi/HTK filters above).
+fn build_slaney_mel_filters(
+    sample_rate_hz: u32,
+    n_fft: usize,
+    n_mels: usize,
+    fmin_hz: f64,
+    fmax_hz: f64,
+) -> Vec<EspnetMelFilter> {
+    let n_fft_bins = n_fft / 2 + 1;
+    let sr = f64::from(sample_rate_hz);
+
+    // `fft_frequencies`: linear bins `k * sr / n_fft`.
+    let fft_freqs: Vec<f64> = (0..n_fft_bins)
+        .map(|k| k as f64 * sr / n_fft as f64)
+        .collect();
+
+    // `mel_frequencies(n_mels + 2, fmin, fmax)`: `n_mels+2` Hz edges, evenly
+    // spaced in mel space then mapped back to Hz.
+    let min_mel = hz_to_mel_slaney(fmin_hz);
+    let max_mel = hz_to_mel_slaney(fmax_hz);
+    let n_edges = n_mels + 2;
+    // `mel_frequencies`: Hz values of `n_edges` mel-evenly-spaced points.
+    // NOTE: librosa's `mel()` keeps `mel_f`/`fdiff`/`ramps` in **Hz** space
+    // from here on (only the edge placement itself uses the mel scale) --
+    // it never round-trips back through `hz_to_mel`.
+    let mel_edges_hz: Vec<f64> = (0..n_edges)
+        .map(|i| {
+            let mel = if n_edges == 1 {
+                min_mel
+            } else {
+                min_mel + (max_mel - min_mel) * i as f64 / (n_edges - 1) as f64
+            };
+            mel_to_hz_slaney(mel)
+        })
+        .collect();
+    let fdiff: Vec<f64> = mel_edges_hz.windows(2).map(|w| w[1] - w[0]).collect();
+
+    let mut filters = Vec::with_capacity(n_mels);
+    for m in 0..n_mels {
+        let enorm = 2.0 / (mel_edges_hz[m + 2] - mel_edges_hz[m]);
+        let mut weights = vec![0.0f32; n_fft_bins];
+        for (k, &freq) in fft_freqs.iter().enumerate() {
+            let lower = -(mel_edges_hz[m] - freq) / fdiff[m];
+            let upper = (mel_edges_hz[m + 2] - freq) / fdiff[m + 1];
+            let weight = lower.min(upper).max(0.0) * enorm;
+            weights[k] = weight as f32;
+        }
+        filters.push(EspnetMelFilter { weights });
+    }
+    filters
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -299,5 +543,165 @@ mod tests {
     fn global_cmvn_rejects_mismatched_vector() {
         let mut feats = vec![0.0; 4];
         assert!(apply_global_cmvn(&mut feats, 2, &[0.0], &[1.0, 1.0]).is_err());
+    }
+
+    // --- ESPnet DefaultFrontend parity (dolphin-small/dolphin-base) --------
+    //
+    // Golden values below are from a direct port of
+    // `dolphin/model.py::Stft`+`LogMel` (the exact classes DataoceanAI's own
+    // inference code runs for these checkpoints), computed with
+    // `torch.stft(n_fft=512, win_length=400, hop_length=160, window=hann_window(400),
+    // center=True, pad_mode="reflect")` -> power -> `librosa.filters.mel(sr=16000,
+    // n_fft=512, n_mels=80, fmin=0, fmax=8000, htk=False) @ power` -> `clamp(1e-10).log()`,
+    // over `fixtures/jfk.wav` (16 kHz mono, 176000 samples).
+
+    fn jfk_samples() -> Vec<f32> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/jfk.wav");
+        crate::api::audio_io::load_wav_16khz_mono_f32_v0(
+            &path,
+            "dolphin_espnet_frontend_test",
+            "jfk.wav",
+        )
+        .expect("load jfk.wav")
+    }
+
+    #[test]
+    fn slaney_mel_filterbank_matches_librosa_reference() {
+        let filters = build_slaney_mel_filters(
+            SAMPLE_RATE_HZ,
+            ESPNET_N_FFT,
+            ESPNET_NUM_MEL_BINS,
+            0.0,
+            8_000.0,
+        );
+        assert_eq!(filters.len(), 80);
+
+        // librosa.filters.mel(...)[0][:10]
+        let expected_row0: [f32; 10] = [
+            0.0,
+            2.253_456e-2,
+            8.637_710_5e-3,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ];
+        for (bin, &expected) in expected_row0.iter().enumerate() {
+            let actual = filters[0].weights[bin];
+            assert!(
+                (actual - expected).abs() < 1.0e-6,
+                "mel row0 bin{bin}: actual {actual} expected {expected}"
+            );
+        }
+
+        // librosa.filters.mel(...)[79][240:257]
+        let expected_row79_tail: [f32; 17] = [
+            1.066_234_2e-3,
+            1.430_553_3e-3,
+            1.794_872_1e-3,
+            2.159_191_3e-3,
+            2.523_510_3e-3,
+            2.887_829_2e-3,
+            3.252_148_4e-3,
+            3.155_337e-3,
+            2.804_744e-3,
+            2.454_151e-3,
+            2.103_558e-3,
+            1.752_965e-3,
+            1.402_372e-3,
+            1.051_779e-3,
+            7.011_86e-4,
+            3.505_93e-4,
+            0.0,
+        ];
+        for (offset, &expected) in expected_row79_tail.iter().enumerate() {
+            let actual = filters[79].weights[240 + offset];
+            assert!(
+                (actual - expected).abs() < 1.0e-6,
+                "mel row79 bin{}: actual {actual} expected {expected}",
+                240 + offset
+            );
+        }
+    }
+
+    #[test]
+    fn espnet_frontend_matches_reference_logmel_frame_count() {
+        let samples = jfk_samples();
+        assert_eq!(samples.len(), 176_000);
+        let features = DolphinEspnetFrontend::new()
+            .compute(&samples)
+            .expect("espnet fbank");
+        // 1 + 176000 / 160 = 1101 (torch.stft center=True reflect framing).
+        assert_eq!(features.n_frames, 1_101);
+        assert_eq!(features.n_mels, 80);
+        assert!(features.data.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn espnet_frontend_matches_reference_logmel_values() {
+        let samples = jfk_samples();
+        let features = DolphinEspnetFrontend::new()
+            .compute(&samples)
+            .expect("espnet fbank");
+
+        let frame_at = |frame: usize| &features.data[frame * 80..frame * 80 + 8];
+
+        // frame 0 is fully inside the reflect-padded silence lead-in -> the
+        // 1e-10 clamp floor, ln(1e-10) = -23.02585.
+        for &value in frame_at(0) {
+            assert!(
+                (value - (-23.025_85)).abs() < 1.0e-3,
+                "frame0 expected clamp floor, got {value}"
+            );
+        }
+
+        // frame 500 first 8 mel bins (torch/librosa reference).
+        let expected_frame500: [f32; 8] = [
+            -6.403_16,
+            -5.750_341_4,
+            -5.296_384_3,
+            -4.686_787,
+            -4.055_321,
+            -4.389_283,
+            -3.961_102_7,
+            -3.866_433_4,
+        ];
+        for (bin, &expected) in expected_frame500.iter().enumerate() {
+            let actual = frame_at(500)[bin];
+            assert!(
+                (actual - expected).abs() < 1.0e-2,
+                "frame500 bin{bin}: actual {actual} expected {expected}"
+            );
+        }
+
+        // last frame (1100) first 8 mel bins.
+        let expected_frame_last: [f32; 8] = [
+            -9.255_437,
+            -8.575_424,
+            -7.676_475,
+            -6.291_418,
+            -3.404_137_6,
+            -3.624_057_8,
+            -3.642_896_4,
+            -2.373_729_7,
+        ];
+        for (bin, &expected) in expected_frame_last.iter().enumerate() {
+            let actual = frame_at(1_100)[bin];
+            assert!(
+                (actual - expected).abs() < 1.0e-2,
+                "frame1100 bin{bin}: actual {actual} expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn espnet_frontend_rejects_empty_audio() {
+        assert!(matches!(
+            DolphinEspnetFrontend::new().compute(&[]),
+            Err(DolphinFrontendError::UnsupportedAudio)
+        ));
     }
 }

--- a/crates/openasr-core/src/models/dolphin/package_import.rs
+++ b/crates/openasr-core/src/models/dolphin/package_import.rs
@@ -201,9 +201,23 @@ pub fn convert_local_dolphin_wenet_source_to_runtime_pack(
     let mut tensors = build_runtime_tensors(&safetensors, request.quantization)?;
     tensors.push(build_mel_filterbank_tensor());
     // Synthesize the sinusoidal position table(s) the checkpoint itself did
-    // not bake as a state-dict buffer (the multilingual export computes them
-    // on the fly instead of storing them; see `sinusoidal_pos_table_max_ctx`).
-    if safetensors.tensor("encoder.embed.pos_enc.pe").is_none() {
+    // not bake as a state-dict buffer (see `sinusoidal_pos_table_max_ctx`).
+    // The encoder table is CnDialect-only: that family's WeNet-trained
+    // encoder attention consumes the simple non-centered `RelPositionalEncoding`
+    // sliced from this table (`encoder_graph::attention_branch`'s "sdpa fold, no
+    // rel_shift" path). The multilingual family's ESPnet-trained encoder uses
+    // `RelPositionalEncodingV1` instead -- a centered table ESPnet itself never
+    // bakes (computed fresh per forward call) -- so the runtime computes that
+    // one at graph-build time from the request's own frame count instead
+    // (`encoder_graph::dolphin_relative_positional_table`); baking a
+    // fixed-`max_ctx`-sized version of it here would be both wrong-shaped (this
+    // table's layout depends on the runtime frame count, not a fixed ceiling)
+    // and dead weight. The decoder's table is unaffected either way: both
+    // families' Transformer decoder uses the same plain absolute
+    // `PositionalEncoding`.
+    if request.language_scheme == DolphinLanguageScheme::CnDialect
+        && safetensors.tensor("encoder.embed.pos_enc.pe").is_none()
+    {
         tensors.push(synthesized_position_table_tensor(
             "encoder.embed.pos_enc.pe",
             architecture.encoder_d_model,


### PR DESCRIPTION
## Summary

Add multilingual Dolphin (dolphin-small/dolphin-base, ESPnet-trained) support: the ESPnet DefaultFrontend audio path and the rel-pos-v1 (centered Transformer-XL) encoder attention scheme, dispatched by the pack's `dolphin.language.scheme` metadata. Includes two review-hardening follow-ups: fail-closed rejection of an unrecognized scheme value, and a round-trip test pinning the importer's scheme labels against the executor's parser.

## Why

dolphin-small/dolphin-base transcribed as degenerate output ("啊。") because the runtime unconditionally reused the cn-dialect family's kaldi-fbank frontend and simple absolute position table, which were only ever verified against small.cn. DataoceanAI's two training pipelines diverge on both the frontend (ESPnet DefaultFrontend: hann window, reflect-centered STFT framing, no pre-emphasis/dither, Slaney mel) and the encoder relative-position scheme (centered rel-pos-v1 table computed per forward, never baked).

## Changes

- `models/dolphin/frontend.rs`: ESPnet DefaultFrontend implementation (`DolphinEspnetFrontend`) alongside the existing kaldi fbank, with reference-logmel parity tests.
- `models/dolphin/encoder_graph.rs`: rel-pos-v1 centered relative positional table computed at graph-build time from the request frame count; unit tests pin the 2*frames-1 shape, center row, and sin/cos sign symmetry.
- `models/dolphin/package_import.rs`: `DolphinLanguageScheme` (cn_dialect/multilingual) baked as `dolphin.language.scheme`; multilingual import guard asserting every advertised catalog language code resolves against the shipped vocab.
- `models/dolphin/executor.rs`: scheme-dispatched frontend/attention/prefix-builder selection; hardening — a present-but-unrecognized `dolphin.language.scheme` now fails closed with a typed error (missing key still defaults to cn_dialect for pre-existing packs), the Gate-0 sentinel check reuses the parsed enum instead of a duplicate string literal, and a new test round-trips every scheme label through the parser.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

## Manual smoke checks

- Real-audio review verification passed: multilingual dolphin checkpoints produce correct transcripts on real human speech clips (English/Chinese) through the full pack pipeline; cn-dialect small.cn/base golden parity unchanged (Sichuan clip joint-decode transcript byte-identical to the reference `attention_rescoring` output).
- Reviewed by a second-pass code review; the two findings (unknown-scheme silent fallback, duplicated scheme literal) are fixed in the final commit.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (Module docs updated in-place; no user-facing doc changes needed until the multilingual packs publish.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not publish or flip public the dolphin-small/dolphin-base packs (separate release pipeline step).
- Japanese real-speech re-verification and the region-default "heuristic, unconfirmed" annotation for the model cards are follow-ups tracked for the publish step.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — implementation and tests written with Claude assistance under my direction and review.
