### PR TITLE
ci(release): fix tag-triggered binaries dispatch, add completeness gate and 3-part notes (#29)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,13 +1,44 @@
 name: Release binaries
 
+# Three ways in:
+#   1. push: tags v* -- a maintainer pushes an annotated release tag directly
+#      (e.g. `git push --follow-tags` from scripts/bump-version.sh). Real tag
+#      pushes fire this natively.
+#   2. workflow_call -- release-core.yml calls this workflow directly (as a
+#      job, not a webhook) right after it creates the vX.Y.Z tag + GitHub
+#      Release. This is required because a tag created through the GITHUB_TOKEN
+#      API does *not* fire the `push: tags` event (GitHub does not cascade
+#      Actions-token-authored pushes into further workflow runs), so without
+#      this explicit call the full release matrix silently never builds.
+#   3. workflow_dispatch -- manual re-run/dry-run, with the same `ref` input
+#      as workflow_call so a maintainer can target an existing tag (e.g. to
+#      retry a failed platform leg, or dry-run the upload/completeness logic
+#      against an already-released tag without touching its assets).
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag) to build; empty = default branch"
+        required: false
+        default: ""
+      dry_run:
+        description: "Evaluate upload/completeness logic but do not upload or edit the release"
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (tag) to build"
+        required: false
+        type: string
+        default: ""
   push:
     tags:
       - "v*"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -29,6 +60,9 @@ jobs:
       # AMD HIP SDK "PRO Edition" silent-installer release train, matched to
       # llama.cpp's current Windows HIP release job.
       HIPSDK_INSTALLER_VERSION: 26.Q1
+    # NOTE: jobs.verify-completeness below hardcodes this same target/ext list
+    # (TARGETS) to assert the release ends up with every archive. Keep both
+    # in sync when adding/removing a leg.
     strategy:
       fail-fast: false
       matrix:
@@ -121,6 +155,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Resolve workspace version
         shell: bash
@@ -476,3 +511,149 @@ jobs:
           name: SHA256SUMS
           path: dist/SHA256SUMS
           if-no-files-found: error
+
+  upload-to-release:
+    name: Upload assets to release
+    needs: checksums
+    if: ${{ !cancelled() && needs.checksums.result == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Resolve the release tag for this ref
+        id: tag
+        shell: bash
+        # Only a ref that is (or resolves to) a `v*` tag has a GitHub Release
+        # to attach assets to. A `workflow_dispatch` run against a branch, or
+        # any other ref shape, has nothing to upload to -- that is not an
+        # error, just a no-op (lets this workflow still be dispatched for
+        # ad-hoc build-only smoke runs).
+        run: |
+          set -euo pipefail
+          ref="${{ inputs.ref }}"
+          if [ -z "$ref" ]; then
+            ref="${{ github.ref }}"
+          fi
+          case "$ref" in
+            refs/tags/*) tag="${ref#refs/tags/}" ;;
+            v[0-9]*.*) tag="$ref" ;;
+            *) tag="" ;;
+          esac
+          if [ -z "$tag" ]; then
+            echo "ref '$ref' does not resolve to a release tag -- nothing to upload" >&2
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "tag ${tag} does not exist on origin -- nothing to upload" >&2
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Download archives + SHA256SUMS
+        if: steps.tag.outputs.tag != ''
+        uses: actions/download-artifact@v8
+        with:
+          path: staging
+          merge-multiple: true
+
+      - name: List what would be uploaded
+        if: steps.tag.outputs.tag != ''
+        run: |
+          set -euo pipefail
+          echo "release: ${{ steps.tag.outputs.tag }}"
+          find staging -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name 'SHA256SUMS' \) -print | sort
+
+      - name: Upload assets to release
+        if: steps.tag.outputs.tag != '' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          if ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "release ${tag} does not exist yet -- release-core.yml should create it before calling this workflow" >&2
+            exit 1
+          fi
+          # --clobber so a re-run (retrying a flaky leg) replaces stale assets
+          # instead of failing on "asset already exists".
+          gh release upload "$tag" staging/*.tar.gz staging/*.zip staging/SHA256SUMS \
+            --repo "${{ github.repository }}" --clobber
+
+      - name: Dry run -- skipping upload
+        if: steps.tag.outputs.tag != '' && github.event.inputs.dry_run == 'true'
+        run: echo "dry_run=true -- not uploading to ${{ steps.tag.outputs.tag }} (evaluated condition/logic only)"
+
+  verify-completeness:
+    name: Verify release completeness
+    needs: upload-to-release
+    if: needs.upload-to-release.outputs.tag != ''
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Resolve workspace version
+        run: |
+          set -euo pipefail
+          version="$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+          echo "OPENASR_VERSION=${version}" >> "${GITHUB_ENV}"
+
+      - name: Assert the release has every expected matrix asset
+        # Keep this TARGETS list in sync with jobs.build.strategy.matrix.include
+        # above -- this is the release-integrity gate: a release "shipped" but
+        # missing a platform's archive (e.g. one matrix leg failed and
+        # `checksums` silently dropped it, per its `!cancelled()` condition)
+        # must fail loudly here instead of quietly shipping partial coverage.
+        run: |
+          set -euo pipefail
+          tag="${{ needs.upload-to-release.outputs.tag }}"
+          version="${OPENASR_VERSION}"
+
+          TARGETS=(
+            "x86_64-unknown-linux-gnu:tar.gz"
+            "aarch64-unknown-linux-gnu:tar.gz"
+            "x86_64-apple-darwin:tar.gz"
+            "aarch64-apple-darwin:tar.gz"
+            "x86_64-pc-windows-msvc:zip"
+            "x86_64-pc-windows-msvc-vulkan:zip"
+            "x86_64-pc-windows-msvc-cuda:zip"
+            "x86_64-pc-windows-msvc-hip:zip"
+            "x86_64-unknown-linux-gnu-vulkan:tar.gz"
+            "x86_64-unknown-linux-gnu-cuda:tar.gz"
+            "x86_64-unknown-linux-gnu-rocm:tar.gz"
+          )
+
+          expected_file="$(mktemp)"
+          for entry in "${TARGETS[@]}"; do
+            target="${entry%%:*}"
+            ext="${entry##*:}"
+            echo "openasr-${version}-${target}.${ext}" >> "$expected_file"
+          done
+          echo "SHA256SUMS" >> "$expected_file"
+          sort -o "$expected_file" "$expected_file"
+
+          actual_file="$(mktemp)"
+          gh release view "$tag" --repo "${{ github.repository }}" --json assets \
+            --jq '.assets[].name' | sort > "$actual_file"
+
+          echo "== expected =="
+          cat "$expected_file"
+          echo "== actual =="
+          cat "$actual_file"
+
+          missing="$(comm -23 "$expected_file" "$actual_file")"
+          if [ -n "$missing" ]; then
+            echo "::error::release ${tag} is missing expected asset(s):"
+            echo "$missing"
+            exit 1
+          fi
+          echo "release ${tag} has all $(wc -l < "$expected_file" | tr -d ' ') expected assets."

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -4,8 +4,17 @@ name: Release core
 # Cargo.toml changes on main, this builds the `openasr` CLI for the platforms the
 # desktop app consumes and publishes a GitHub Release tagged `vX.Y.Z`. Editing
 # Cargo.toml without changing the version (deps, metadata) is a safe no-op because
-# the resolve job exits cleanly when tag `vX.Y.Z` already exists. `workflow_dispatch`
-# lets the maintainer cut the very first release (no bump) or re-run a failed one.
+# the resolve job exits cleanly when a Release for `vX.Y.Z` already exists.
+# `workflow_dispatch` lets the maintainer cut the very first release (no bump)
+# or re-run a failed one.
+#
+# The `vX.Y.Z` tag itself is created locally by `scripts/bump-version.sh
+# --notes "..."` (an *annotated* tag whose message is the release notes) and
+# shipped to origin by `git push --follow-tags` alongside the version-bump
+# commit -- see RELEASING.md. This workflow does not create the tag; it reads
+# the tag's annotation for the release's Highlights section and fails loudly
+# if the tag is missing (a maintainer who forgot `--follow-tags` should see
+# that immediately, not get a release with an empty Highlights block).
 
 on:
   push:
@@ -14,7 +23,8 @@ on:
       - "Cargo.toml"
   workflow_dispatch:
 
-# Only tag+release; no other write scope.
+# tag annotation is read-only (git fetch); write scope is for creating the
+# release and calling release-binaries.yml (contents: write).
 permissions:
   contents: write
 
@@ -36,10 +46,11 @@ jobs:
       version: ${{ steps.v.outputs.version }}
       tag: ${{ steps.v.outputs.tag }}
       should_release: ${{ steps.v.outputs.should_release }}
+      highlights: ${{ steps.highlights.outputs.highlights }}
     steps:
       - uses: actions/checkout@v7
       - id: v
-        name: Read workspace version and check for an existing tag
+        name: Read workspace version and check whether it is already released
         run: |
           set -euo pipefail
           # Single source of truth: [workspace.package] version in the root
@@ -53,18 +64,55 @@ jobs:
           tag="v${version}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
-          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-            echo "tag ${tag} already exists -- nothing to release"
+
+          # The tag must already exist on origin -- scripts/bump-version.sh
+          # --notes creates it locally and `git push --follow-tags` ships it
+          # together with this Cargo.toml commit. If it's missing, fail
+          # loudly instead of silently skipping (a push without the tag is a
+          # maintainer mistake, not a legitimate "already released" no-op).
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            {
+              echo "::error::tag ${tag} not found on origin."
+              echo "Did you run scripts/bump-version.sh ${version} --notes \"...\" and git push --follow-tags? See RELEASING.md."
+            } >&2
+            exit 1
+          fi
+
+          if gh release view "${tag}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "release ${tag} already exists -- nothing to do"
             echo "should_release=false" >> "${GITHUB_OUTPUT}"
           else
-            echo "tag ${tag} is new -- will build and release"
+            echo "release ${tag} does not exist yet -- will build and release"
             echo "should_release=true" >> "${GITHUB_OUTPUT}"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - id: highlights
+        name: Read the annotated tag's message as release Highlights
+        if: steps.v.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          tag="${{ steps.v.outputs.tag }}"
+          git fetch --no-tags origin "refs/tags/${tag}:refs/tags/${tag}"
+          # Strip the trailing PGP signature block (present if the tagger's
+          # git config auto-signs tags) -- only the annotation text itself is
+          # the Highlights content.
+          body="$(git for-each-ref "refs/tags/${tag}" --format='%(contents)' \
+            | sed '/-----BEGIN PGP SIGNATURE-----/,$d')"
+          if [ -z "${body// /}" ]; then
+            echo "::error::tag ${tag} has an empty annotation -- was it created with \`git tag -a\` (not \`git tag\`)? See RELEASING.md." >&2
+            exit 1
+          fi
+          {
+            echo "highlights<<RELEASE_HIGHLIGHTS_EOF"
+            echo "$body"
+            echo "RELEASE_HIGHLIGHTS_EOF"
+          } >> "${GITHUB_OUTPUT}"
 
   build:
     name: Build ${{ matrix.target }}
     needs: resolve
-    if: needs.resolve.outputs.should_release == 'true'
+    if: needs.resolve.outputs.should_release == 'true' && success()
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     # Distributed binaries must be portable across end-user CPUs. build.rs
@@ -120,8 +168,10 @@ jobs:
   release:
     name: Publish release
     needs: [resolve, build]
-    if: needs.resolve.outputs.should_release == 'true'
+    if: needs.resolve.outputs.should_release == 'true' && success()
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
       - name: Download build archives
@@ -137,16 +187,82 @@ jobs:
           cd dist
           sha256sum *.tar.gz > SHA256SUMS
           cat SHA256SUMS
-      - name: Create GitHub Release
+
+      - name: Assemble release notes (Highlights / What's Changed / Install & Verify)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HIGHLIGHTS: ${{ needs.resolve.outputs.highlights }}
         run: |
           set -euo pipefail
           tag="${{ needs.resolve.outputs.tag }}"
-          # gh creates the tag at this commit if it does not exist yet, then
-          # publishes the release with the archives + checksum file attached.
+
+          {
+            echo "## Highlights"
+            echo
+            printf '%s\n' "$HIGHLIGHTS"
+          } > highlights.md
+
+          # "What's Changed": GitHub's generated-notes body already includes
+          # its own "## What's Changed" heading, PR bullet list, and a
+          # trailing "Full Changelog" compare link -- reuse it verbatim
+          # instead of reimplementing PR-diffing.
+          gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f "tag_name=${tag}" -f "target_commitish=${{ github.sha }}" \
+            --jq .body > whats-changed.md
+
+          # Install & Verify: stub for now (this job's own build only covers
+          # macOS arm64 + Linux x86_64; the full multi-platform matrix hasn't
+          # built yet). The `finalize-notes` job below replaces this section
+          # with the real asset list once `binaries` (release-binaries.yml)
+          # finishes uploading everything.
+          printf '' | scripts/render-install-verify.sh \
+            "${{ needs.resolve.outputs.version }}" "${{ github.repository }}" "${tag}" \
+            > install-verify.md
+
+          cat highlights.md whats-changed.md install-verify.md > body.md
+
+      - name: Create GitHub Release
+        run: |
+          set -euo pipefail
+          tag="${{ needs.resolve.outputs.tag }}"
+          # The tag already exists (scripts/bump-version.sh --notes created
+          # it locally; `git push --follow-tags` shipped it), so `gh release
+          # create` publishes against that existing tag rather than minting
+          # a fresh one.
           gh release create "${tag}" \
-            --target "${{ github.sha }}" \
             --title "${tag}" \
-            --notes "Automated release of the \`openasr\` CLI for ${tag}. Prebuilt binaries for macOS arm64 and Linux x86_64; verify with SHA256SUMS." \
+            --notes-file body.md \
             dist/*.tar.gz dist/SHA256SUMS
+
+  binaries:
+    name: Build full release matrix
+    needs: [resolve, release]
+    if: needs.resolve.outputs.should_release == 'true' && success()
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-binaries.yml
+    with:
+      ref: ${{ needs.resolve.outputs.tag }}
+
+  finalize-notes:
+    name: Finalize Install & Verify with real assets
+    needs: [resolve, release, binaries]
+    if: needs.resolve.outputs.should_release == 'true' && success()
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Rebuild Install & Verify from the release's actual assets
+        run: |
+          set -euo pipefail
+          tag="${{ needs.resolve.outputs.tag }}"
+          version="${{ needs.resolve.outputs.version }}"
+
+          gh release view "$tag" --json assets --jq '.assets[].name' > asset-names.txt
+          scripts/render-install-verify.sh "$version" "${{ github.repository }}" "$tag" \
+            < asset-names.txt > install-verify.md
+          gh release view "$tag" --json body --jq .body > current-body.md
+
+          python3 scripts/splice-install-verify.py current-body.md install-verify.md > new-body.md
+
+          gh release edit "$tag" --notes-file new-body.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,9 +5,9 @@ version bump pushed to `main` IS the release.
 
 Feature, fix, and any other content changes go through pull requests as usual.
 The release bump itself is the exception: a maintainer pushes it directly to
-`main` as a single `chore(release)` commit. Routing the bump through a PR adds
-nothing (the release fires on the merge commit anyway) and CI runs on `main`
-push regardless.
+`main` as a single `chore(release)` commit plus its annotated `vX.Y.Z` tag.
+Routing the bump through a PR adds nothing (the release fires on the merge
+commit anyway) and CI runs on `main` push regardless.
 
 ## Versioning
 
@@ -29,27 +29,67 @@ bump, or CI's `--locked` builds fail:
 1. On `main`, run:
 
    ```bash
-   scripts/bump-version.sh X.Y.Z
+   scripts/bump-version.sh X.Y.Z --notes "Release highlights go here."
    ```
 
-   This bumps the version, regenerates both lockfiles, and self-checks the
-   result with `cargo metadata --locked`. It is idempotent -- rerunning it
-   with the version already at `X.Y.Z` is a no-op diff.
-2. Commit and push to `main`:
+   `--notes` is **required** (the script fails closed without it, or with a
+   blank/whitespace-only value): it becomes the message of an *annotated*
+   `vX.Y.Z` git tag, which `release-core.yml` reads verbatim as the
+   release's **Highlights** section. Write it like the top of a changelog
+   entry -- one or a few lines of plain markdown, no need to restate the
+   version number.
+
+   The script bumps the version, regenerates both lockfiles, self-checks the
+   result with `cargo metadata --locked`, commits `chore(release): vX.Y.Z`,
+   and creates the annotated `vX.Y.Z` tag on that commit. It is idempotent:
+   rerunning with the same version and no pending file changes skips the
+   commit, and if the tag already exists locally it is left alone (delete it
+   first with `git tag -d vX.Y.Z` to redo the notes).
+
+2. Push the commit **and** the tag together:
 
    ```bash
-   git add Cargo.toml Cargo.lock tooling/system-audio-check/Cargo.lock
-   git commit -m "chore(release): vX.Y.Z"
-   git push
+   git push --follow-tags
    ```
+
+   Pushing just the commit without the tag (plain `git push`) is a mistake
+   `release-core.yml` catches and fails loudly on -- it needs the tag's
+   annotation for Highlights and refuses to guess.
+
 3. The `Release core` workflow (`.github/workflows/release-core.yml`)
    triggers on `Cargo.toml` changes:
-   - reads the workspace version;
-   - exits cleanly if the tag `vX.Y.Z` already exists (so unrelated
-     `Cargo.toml` edits and re-runs are no-ops);
-   - otherwise builds release binaries for macOS arm64 and Linux x86_64,
-     creates the `vX.Y.Z` tag, and publishes a GitHub Release with
-     `openasr-<version>-<target>.tar.gz` artifacts plus `SHA256SUMS`.
+   - reads the workspace version and confirms the `vX.Y.Z` tag exists on
+     origin (failing loudly if it's missing -- see step 2);
+   - exits cleanly if a GitHub Release for `vX.Y.Z` already exists (so
+     unrelated `Cargo.toml` edits and re-runs are no-ops);
+   - otherwise builds its own macOS-arm64 + Linux-x86_64 binaries, reads the
+     tag annotation for Highlights, and creates the GitHub Release with a
+     three-part body (see below);
+   - then calls `.github/workflows/release-binaries.yml` directly (as a
+     `workflow_call`, not a webhook -- tags created through the
+     `GITHUB_TOKEN` API do not cascade into further Actions triggers, so a
+     real `push: tags` event alone would never fire for a tag this workflow
+     created) to build the full release matrix (Linux x86_64/arm64, macOS
+     x86_64/arm64, Windows, plus Vulkan/CUDA/HIP feature variants) and
+     upload every archive to the same release;
+   - `release-binaries.yml`'s own completeness gate then asserts the release
+     ends up with every expected platform archive, failing the run if one is
+     missing instead of silently shipping a partial release;
+   - finally, `release-core.yml` rewrites the release's Install & Verify
+     section from the now-complete, real asset list.
+
+### Release notes structure
+
+Every release body has three sections:
+
+- **Highlights** -- the `--notes` text from the annotated tag, verbatim.
+- **What's Changed** -- GitHub's auto-generated PR list between this tag and
+  the previous one, plus a "Full Changelog" compare link.
+- **Install & Verify** -- one bullet per shipped platform archive (label +
+  direct download link) plus a `sha256sum -c` snippet, generated from the
+  release's actual asset list. Never hand-written, so it can't drift the way
+  a fixed "macOS arm64 and Linux x86_64" sentence would once more platforms
+  ship.
 
 No pre-release channels: the core releases plain `X.Y.Z` versions only.
 
@@ -57,4 +97,12 @@ No pre-release channels: the core releases plain `X.Y.Z` versions only.
 
 `workflow_dispatch` on the `Release core` workflow performs the same
 resolve-and-release for the version currently on `main` (useful for retries;
-it is idempotent thanks to the existing-tag check).
+it is idempotent thanks to the existing-release check).
+
+`workflow_dispatch` on `Release binaries` (`.github/workflows/release-binaries.yml`)
+independently rebuilds/re-uploads the full matrix for an existing tag: pass
+`ref: vX.Y.Z` to target it, or `dry_run: true` to exercise the tag-resolution,
+upload, and completeness-gate logic without mutating the release's assets
+(the completeness check still runs and will fail loudly if that release is
+genuinely incomplete -- that failure is expected and informative, not a bug
+in the dry run).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,7 +12,16 @@ Local engineering scripts for validation and iteration.
 ## Current scripts
 
 - `bump-version.sh`
-  - Bump the workspace release version in one command (see `RELEASING.md`).
+  - Bump the workspace release version, commit, and tag it (`--notes`
+    required; see `RELEASING.md`).
+- `render-install-verify.sh`
+  - Render a release's "Install & Verify" section from its actual asset list
+    (used by `.github/workflows/release-core.yml`, both for the initial stub
+    and the final finalize-notes pass).
+- `splice-install-verify.py`
+  - Replace the `<!-- install-verify:start/end -->` section of a release
+    body in place (used by `.github/workflows/release-core.yml`'s
+    `finalize-notes` job).
 - `generate_longform_pause_probe.py`
   - Generate a deterministic longform pause probe from a local speech WAV — a
     test-data generator for longform planner validation.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,35 +1,80 @@
 #!/usr/bin/env bash
-# Bump the workspace release version in one command.
+# Bump the workspace release version, commit it, and tag the release --
+# in one command.
 #
 # Single source of truth: [workspace.package] version in the root Cargo.toml
 # (every member crate inherits it via `version.workspace = true`; the
 # workspace.dependencies path pins carry no version to keep in sync). This
-# script updates that one field, then regenerates both lockfiles that pin the
-# resolved workspace version, and self-checks the result with
-# `cargo metadata --locked` so a stale lockfile fails loud instead of at CI.
+# script updates that one field, regenerates both lockfiles that pin the
+# resolved workspace version, self-checks the result with
+# `cargo metadata --locked` so a stale lockfile fails loud instead of at CI,
+# commits the result, and creates an *annotated* `vX.Y.Z` tag whose message
+# is the release notes.
 #
 # Usage:
-#   scripts/bump-version.sh X.Y.Z
+#   scripts/bump-version.sh X.Y.Z --notes "Release highlights go here."
 #
-# Idempotent: running it again with the same version is a no-op (no diff).
+# --notes is required and fail-closed: without it there is nothing to put in
+# the tag annotation, and `release-core.yml` reads that annotation verbatim
+# as the release's "Highlights" section, so a release cut without notes would
+# silently ship with an empty/stale Highlights block. Multi-line notes work
+# (quote the whole argument); each line becomes a line of the tag message.
+#
+# Idempotent: rerunning with the same version and no working-tree changes
+# skips the commit; if the `vX.Y.Z` tag already exists locally, tag creation
+# is skipped too (with a warning) rather than failing -- to change the notes
+# of an already-tagged version, delete the local tag first
+# (`git tag -d vX.Y.Z`) and rerun.
 #
 # After it succeeds:
-#   git add -A
-#   git commit -m "chore(release): vX.Y.Z"
-#   git push
-# Pushing to main triggers `.github/workflows/release-core.yml`, which tags
-# and publishes the release (see RELEASING.md).
+#   git push --follow-tags
+# Pushing the commit + annotated tag together to main triggers
+# `.github/workflows/release-core.yml`, which reads the tag annotation for
+# Highlights and publishes the release (see RELEASING.md).
 
 set -euo pipefail
 
 usage() {
-  echo "usage: $(basename "$0") X.Y.Z" >&2
+  echo "usage: $(basename "$0") X.Y.Z --notes \"release highlights\"" >&2
   exit 1
 }
 
-[ $# -eq 1 ] || usage
+version=""
+notes=""
 
-version="$1"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --notes=*)
+      notes="${1#--notes=}"
+      shift
+      ;;
+    --notes)
+      [ $# -ge 2 ] || usage
+      notes="$2"
+      shift 2
+      ;;
+    -*)
+      usage
+      ;;
+    *)
+      if [ -n "$version" ]; then
+        usage
+      fi
+      version="$1"
+      shift
+      ;;
+  esac
+done
+
+[ -n "$version" ] || usage
+
+# Fail-closed: no notes, no release. This is the one thing the tag
+# annotation exists to carry, so an empty/whitespace-only value is rejected
+# the same as a missing flag.
+if [ -z "${notes// /}" ]; then
+  echo "error: --notes is required (it becomes the release's Highlights section)" >&2
+  usage
+fi
 
 # SemVer 0.y.z (and future X.Y.Z once past 1.0); no pre-release/build suffix,
 # matching what release-core.yml expects to tag as vX.Y.Z.
@@ -43,6 +88,7 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 cd "$REPO_ROOT"
 
 CARGO_TOML="Cargo.toml"
+tag="v${version}"
 
 if [ ! -f "$CARGO_TOML" ]; then
   echo "error: expected to find ${CARGO_TOML} at repo root (${REPO_ROOT})" >&2
@@ -82,13 +128,27 @@ cargo metadata --locked --format-version 1 >/dev/null
 echo "==> self-check: cargo metadata --locked (tooling/system-audio-check)"
 (cd tooling/system-audio-check && cargo metadata --locked --format-version 1 >/dev/null)
 
-echo "==> done. changed files:"
+echo "==> changed files:"
 git status --porcelain -- Cargo.toml Cargo.lock tooling/system-audio-check/Cargo.lock
+
+if [ -n "$(git status --porcelain -- Cargo.toml Cargo.lock tooling/system-audio-check/Cargo.lock)" ]; then
+  echo "==> committing chore(release): ${tag}"
+  git add Cargo.toml Cargo.lock tooling/system-audio-check/Cargo.lock
+  git commit -m "chore(release): ${tag}"
+else
+  echo "==> no file changes to commit (already at ${version})"
+fi
+
+if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+  echo "==> tag ${tag} already exists locally -- skipping (delete it with \`git tag -d ${tag}\` to redo the notes)"
+else
+  echo "==> creating annotated tag ${tag}"
+  git tag -a "$tag" -m "$notes"
+fi
 
 cat <<EOF
 
-Next steps:
-  git add Cargo.toml Cargo.lock tooling/system-audio-check/Cargo.lock
-  git commit -m "chore(release): v${version}"
-  git push   # triggers .github/workflows/release-core.yml on main
+Next step:
+  git push --follow-tags   # ships the commit + ${tag}; triggers
+                           # .github/workflows/release-core.yml on main
 EOF

--- a/scripts/render-install-verify.sh
+++ b/scripts/render-install-verify.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Render the "Install & Verify" section of a GitHub Release body from the
+# release's *actual* asset list, so it never drifts from what really shipped
+# (the old hardcoded "macOS arm64 and Linux x86_64" sentence was exactly this
+# kind of drift once release-binaries.yml started shipping 11 targets).
+#
+# Usage:
+#   scripts/render-install-verify.sh <version> <repo-slug> <tag> < asset-names.txt
+#
+# asset-names.txt: one release asset filename per line (as returned by
+# `gh release view <tag> --json assets --jq '.assets[].name'`), e.g.:
+#   openasr-0.1.8-aarch64-apple-darwin.tar.gz
+#   openasr-0.1.8-x86_64-pc-windows-msvc.zip
+#   SHA256SUMS
+#
+# Prints a self-delimited markdown section (including its start/end HTML
+# comment markers) on stdout, so a caller can splice it into an existing
+# release body by replacing everything between the markers.
+
+set -euo pipefail
+
+if [ $# -ne 3 ]; then
+  echo "usage: $(basename "$0") <version> <repo-slug> <tag> < asset-names.txt" >&2
+  exit 1
+fi
+
+version="$1"
+repo="$2"
+tag="$3"
+
+# Human label for each known target substring. Order matters: more specific
+# substrings (with a GPU-feature suffix) must be matched before their base
+# target, since e.g. "x86_64-pc-windows-msvc-vulkan" also contains
+# "x86_64-pc-windows-msvc".
+label_for_target() {
+  case "$1" in
+    x86_64-pc-windows-msvc-vulkan) echo "Windows x86_64 (Vulkan)" ;;
+    x86_64-pc-windows-msvc-cuda) echo "Windows x86_64 (CUDA)" ;;
+    x86_64-pc-windows-msvc-hip) echo "Windows x86_64 (AMD HIP/ROCm)" ;;
+    x86_64-pc-windows-msvc) echo "Windows x86_64" ;;
+    x86_64-unknown-linux-gnu-vulkan) echo "Linux x86_64 (Vulkan)" ;;
+    x86_64-unknown-linux-gnu-cuda) echo "Linux x86_64 (CUDA)" ;;
+    x86_64-unknown-linux-gnu-rocm) echo "Linux x86_64 (AMD HIP/ROCm)" ;;
+    x86_64-unknown-linux-gnu) echo "Linux x86_64" ;;
+    aarch64-unknown-linux-gnu) echo "Linux arm64" ;;
+    x86_64-apple-darwin) echo "macOS x86_64 (Intel)" ;;
+    aarch64-apple-darwin) echo "macOS arm64 (Apple Silicon)" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+echo "<!-- install-verify:start -->"
+echo "## Install & Verify"
+echo
+echo "Download the archive for your platform from the assets below, extract it,"
+echo "and run the \`openasr\` binary directly (no installer)."
+echo
+
+any_asset=0
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  [ "$name" != "SHA256SUMS" ] || continue
+  case "$name" in
+    "openasr-${version}-"*.tar.gz) target="${name#openasr-"${version}"-}"; target="${target%.tar.gz}" ;;
+    "openasr-${version}-"*.zip) target="${name#openasr-"${version}"-}"; target="${target%.zip}" ;;
+    *) continue ;;
+  esac
+  label="$(label_for_target "$target")"
+  echo "- **${label}**: [\`${name}\`](https://github.com/${repo}/releases/download/${tag}/${name})"
+  any_asset=1
+done
+
+if [ "$any_asset" -eq 0 ]; then
+  echo "_(no platform archives found for this release yet)_"
+fi
+
+cat <<EOF
+
+### Verify
+
+Every archive is listed in \`SHA256SUMS\`, published alongside them on this
+release:
+
+\`\`\`bash
+curl -LO https://github.com/${repo}/releases/download/${tag}/SHA256SUMS
+curl -LO https://github.com/${repo}/releases/download/${tag}/<the archive you downloaded>
+sha256sum -c SHA256SUMS --ignore-missing
+\`\`\`
+EOF
+echo "<!-- install-verify:end -->"

--- a/scripts/splice-install-verify.py
+++ b/scripts/splice-install-verify.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Replace the Install & Verify section of a release body in place.
+
+Usage:
+  splice-install-verify.py <body-file> <new-section-file>
+
+Prints the spliced body to stdout. <new-section-file> must contain the
+`<!-- install-verify:start -->` ... `<!-- install-verify:end -->` markers
+(scripts/render-install-verify.sh emits them); everything between the same
+markers in <body-file> is replaced with it.
+"""
+import sys
+
+START_MARKER = "<!-- install-verify:start -->"
+END_MARKER = "<!-- install-verify:end -->"
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 1
+    body_path, new_section_path = sys.argv[1], sys.argv[2]
+    body = open(body_path, encoding="utf-8").read()
+    new_section = open(new_section_path, encoding="utf-8").read().rstrip("\n")
+
+    try:
+        start = body.index(START_MARKER)
+        end = body.index(END_MARKER) + len(END_MARKER)
+    except ValueError:
+        print(
+            f"error: {body_path} does not contain both {START_MARKER!r} and "
+            f"{END_MARKER!r} markers -- was it created by the release job's "
+            "render-install-verify.sh stub?",
+            file=sys.stderr,
+        )
+        return 1
+
+    sys.stdout.write(body[:start] + new_section + body[end:])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- `release-core.yml` now calls `release-binaries.yml` directly via `workflow_call` right after creating the GitHub Release, instead of relying on the `push: tags` webhook -- tags minted through the `GITHUB_TOKEN` API never fired that event, so the full release matrix silently never built (only release-core's own 2 archives shipped; see v0.1.8).
- `release-binaries.yml` gains an `upload-to-release` job (it previously only produced Actions-run artifacts, never attached anything to the release) and a `verify-completeness` job that fails the run if any expected platform archive is missing from the final release.
- `scripts/bump-version.sh` now requires `--notes` (fail-closed) and writes it into an annotated `vX.Y.Z` git tag; the script also now creates the release commit + tag itself so the tag points at the right commit.
- `release-core.yml` composes the release body as Highlights (tag annotation) / What's Changed (GitHub generated-notes) / Install & Verify (rendered from the release's actual asset list via `scripts/render-install-verify.sh`, finalized again once the full binaries matrix uploads via `scripts/splice-install-verify.py`).
- `RELEASING.md` updated for the new one-command cut-and-tag flow.

## Why

Task #29: the release chain shipped incomplete releases (v0.1.8 had to be patched twice) with no integrity check, and release notes were a hardcoded one-liner ("macOS arm64 and Linux x86_64") that had already drifted from the real 11-target matrix.

## Changes

- `.github/workflows/release-binaries.yml`: `workflow_call`/`workflow_dispatch` `ref` + `dry_run` inputs, `upload-to-release` job, `verify-completeness` job, `permissions: contents: write`.
- `.github/workflows/release-core.yml`: `resolve` now checks release existence (not tag existence) and reads the tag annotation for Highlights; new `binaries` job (workflow_call) and `finalize-notes` job.
- `scripts/bump-version.sh`: `--notes` required; now commits + creates the annotated tag.
- `scripts/render-install-verify.sh`, `scripts/splice-install-verify.py`: new, unit-tested manually (see PR description below).
- `RELEASING.md`, `scripts/README.md`: updated for the new flow.

## Tests run

- [x] `cargo fmt --check` (no Rust changed)
- [x] `cargo clippy --all-targets -- -D warnings` (no Rust changed)
- [ ] `cargo nextest run --workspace` (no Rust changed, CI covers)
- [ ] `cargo test --workspace --doc` (no Rust changed, CI covers)
- [ ] `cargo deny check` (no Rust changed)

## Manual smoke checks

- `actionlint` clean on both modified workflows (pre-existing unrelated findings only).
- `shellcheck` clean on both new/modified scripts.
- `scripts/bump-version.sh`: exercised in a scratch clone -- missing/blank `--notes` rejected (exit 1), full run creates the commit + annotated tag, idempotent rerun no-ops both.
- `scripts/render-install-verify.sh` / `scripts/splice-install-verify.py`: exercised against synthetic asset lists and a sample release body; correctly renders per-platform links and replaces the marked section in place.
- `workflow_dispatch` dry run of `release-binaries.yml` against the existing `v0.1.8` tag (`ref=v0.1.8 dry_run=true`) from this branch, to exercise the real tag-resolution/upload-skip/completeness-gate logic without mutating `v0.1.8`'s assets.

## Docs updated

- [x] `RELEASING.md` rewritten for the new `--notes` + tag-then-push flow and the 3-part notes structure.

## Scope / non-goals

- Does not touch the Rust CLI/core; workflow + release-tooling only.
- Does not change the release-core job's own duplicate macOS-arm64/Linux-x86_64 build (pre-existing overlap with release-binaries.yml's matrix); out of scope for #29.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- this PR (workflow YAML, bump-version.sh, and the two new notes-rendering scripts) was written by an AI coding agent under explicit maintainer direction (task #29); reviewed and owned by the maintainer.