### PR TITLE
fix(core): serialize daemon history-store WAL setup to stop flaky BUSY

### DIFF
--- a/crates/openasr-core/src/realtime/history_store.rs
+++ b/crates/openasr-core/src/realtime/history_store.rs
@@ -58,6 +58,11 @@ use thiserror::Error;
 
 use crate::ResponseFormat;
 
+/// Guards the one-time-per-database WAL switch and schema creation in
+/// [`DaemonHistoryStore::connection`]. See that method for why this can't
+/// rely on `busy_timeout` alone.
+static CONNECTION_SETUP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DaemonHistoryKind {
@@ -445,6 +450,10 @@ impl DaemonHistoryStore {
         })
     }
 
+    /// Serializes the one-time-per-`history.db` WAL switch and schema
+    /// creation performed in [`Self::connection`] across all connections
+    /// opened by this process. See the comment at the lock's call site for
+    /// why this needs its own guard instead of relying on `busy_timeout`.
     fn connection(&self) -> Result<Connection, DaemonHistoryStoreError> {
         std::fs::create_dir_all(&self.root).map_err(|source| {
             DaemonHistoryStoreError::CreateDir {
@@ -465,7 +474,25 @@ impl DaemonHistoryStore {
             })?;
         // WAL lets concurrent readers proceed alongside a writer; the daemon
         // opens a fresh connection per call, so file-level locking (not an
-        // in-process mutex) is what serializes writers across requests.
+        // in-process mutex) is what serializes writers across requests once
+        // the database is already in WAL mode.
+        //
+        // The *first* switch from the default rollback-journal into WAL mode
+        // needs a brief exclusive lock to rewrite the file header, and that
+        // specific lock acquisition does not go through the normal
+        // busy-handler retry loop `busy_timeout` installs (that loop covers
+        // ordinary step-time lock contention, not this one-time schema-level
+        // transition) -- so concurrent first-time callers can observe an
+        // immediate `SQLITE_BUSY` here instead of a patient wait. The schema
+        // DDL right below has the same shape (CREATE TABLE/VIRTUAL TABLE IF
+        // NOT EXISTS still touches the schema even when it is a no-op). Both
+        // only matter once, on first use of a given `history.db`; serialize
+        // them with an in-process mutex so at most one thread performs the
+        // WAL switch/schema creation at a time instead of racing SQLite's
+        // exclusive lock for it.
+        let _setup_guard = CONNECTION_SETUP_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         conn.pragma_update(None, "journal_mode", "WAL")
             .map_err(|source| DaemonHistoryStoreError::OpenDatabase {
                 path: path.clone(),
@@ -475,6 +502,7 @@ impl DaemonHistoryStore {
             path: path.clone(),
             source,
         })?;
+        drop(_setup_guard);
         Ok(conn)
     }
 


### PR DESCRIPTION
## Summary

Fixes issue #32 (`daemon_history_store_serializes_concurrent_writes_for_one_daemon` flakes with `DatabaseBusy`, ~1/5-1/6 reproduction rate locally, has flaked CI on two PRs today).

## Why

The test spawns 24 threads, each opening its own `Connection` via `DaemonHistoryStore::connection()`. Every fresh connection runs `busy_timeout(5s)`, then `PRAGMA journal_mode=WAL`, then schema DDL, before any transaction begins. Diagnosed the exact failing step with temporary logging: the failure is `DatabaseBusy` out of the `PRAGMA journal_mode=WAL` call, returned near-instantly (not after waiting close to the 5s timeout).

Root cause: the *first* switch from the default rollback journal into WAL mode needs a brief exclusive lock to rewrite the file header. That lock acquisition does not go through the busy-handler retry loop `busy_timeout` installs -- that loop covers ordinary step-time lock contention (e.g. waiting for a writer to commit), not this one-time schema-level transition. So concurrent first-time callers can observe an immediate `SQLITE_BUSY` here instead of a patient wait. `busy_timeout` itself was configured correctly; it just doesn't cover this particular lock.

## Changes

- Added a process-wide `CONNECTION_SETUP_LOCK: std::sync::Mutex<()>` in `crates/openasr-core/src/realtime/history_store.rs`.
- `DaemonHistoryStore::connection()` now holds that lock across the `PRAGMA journal_mode=WAL` call and the `ensure_schema` DDL (`CREATE TABLE/VIRTUAL TABLE IF NOT EXISTS`, which has the same one-time schema-touching shape), so at most one thread performs this one-time setup at a time instead of racing SQLite's exclusive lock for it.
- The regular read/write path (`record`/`list`/`get`/`delete`, each its own transaction after setup) is untouched -- it already relies correctly on WAL + `busy_timeout` for cross-process serialization, which was never implicated in the flakiness (all 20+ reproduction runs failed at the WAL-switch step, never at a later `tx.execute`/`tx.commit`).
- No retry/sleep loop added: this removes the race structurally (only one connection ever performs the exclusive-lock-requiring setup concurrently) rather than papering over transient busy errors.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (on `openasr-core`)
- [x] `cargo nextest run -p openasr-core` (1645 passed, 0 failed)
- [x] `cargo test -p openasr-core --doc` (no doctests in this crate)
- [x] 50 consecutive runs of `daemon_history_store_serializes_concurrent_writes_for_one_daemon` via `cargo nextest run -p openasr-core <test> --no-capture`: 0 failures (baseline before the fix: 3 failures in 20 runs, ~15%, consistent with the reported ~1/5 local repro rate)

## Manual smoke checks

N/A (unit-test-only fix, no behavior change to the history store's public API or on-disk format).

## Docs updated

- [x] No README/docs behavior change; added inline comments explaining the lock's purpose at both the `static` definition and the call site.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not change the on-disk schema, the public `DaemonHistoryStore` API, or the WAL/busy_timeout strategy for the actual read/write path -- only serializes the one-time-per-database setup that was racing.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- used an AI coding agent to reproduce the flake locally (looped `nextest run`), instrument temporary diagnostic logging to pinpoint the exact failing call, and implement/verify the fix (50 consecutive clean runs). I reviewed and understand the change.