### PR TITLE
fix(server): 400 misdiagnosis on oversized uploads + qta input support

### DIFF
--- a/crates/openasr-core/src/audio/tests.rs
+++ b/crates/openasr-core/src/audio/tests.rs
@@ -34,6 +34,19 @@ fn unknown_extension_is_marked_but_does_not_error() {
 }
 
 #[test]
+fn qta_extension_is_recognized() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("voice memo.qta");
+    fs::write(&input, b"not a real mov").unwrap();
+
+    let info = probe_audio_input(&input).unwrap();
+
+    assert_eq!(info.extension.as_deref(), Some("qta"));
+    assert!(info.recognized_extension);
+    assert!(info.issues.is_empty());
+}
+
+#[test]
 fn missing_file_errors() {
     let temp = tempfile::tempdir().unwrap();
     let input = temp.path().join("missing.wav");
@@ -174,6 +187,29 @@ fn native_non_wav_conversion_mode_requires_ffmpeg_when_enabled() {
     )
     .unwrap_err();
 
+    assert!(matches!(
+        error,
+        AudioPreparationError::MissingFfmpeg {
+            backend: BackendKind::Native
+        }
+    ));
+}
+
+#[test]
+fn native_qta_input_is_recognized_and_reaches_ffmpeg_conversion() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("sample.qta");
+    fs::write(&input, b"mock bytes").unwrap();
+
+    let error = prepare_audio_input(
+        &input,
+        &AudioPreparationOptions::new(BackendKind::Native).with_native_non_wav_conversion(true),
+    )
+    .unwrap_err();
+
+    // A `.qta` file must reach the ffmpeg conversion step (and fail only
+    // because no ffmpeg binary is configured in this test), not get rejected
+    // upfront as an unrecognized extension.
     assert!(matches!(
         error,
         AudioPreparationError::MissingFfmpeg {

--- a/crates/openasr-core/src/audio/types.rs
+++ b/crates/openasr-core/src/audio/types.rs
@@ -2,8 +2,12 @@ use std::path::{Path, PathBuf};
 
 use crate::BackendKind;
 
+// `qta` is macOS QuickTime Player's audio recording extension -- a MOV
+// container (ffmpeg's `mov,mp4,m4a,3gp,3g2,mj2` demuxer probes and decodes it
+// like any other MOV/M4A file, no special handling needed beyond recognizing
+// the extension).
 pub(crate) const RECOGNIZED_EXTENSIONS: &[&str] =
-    &["wav", "mp3", "mp4", "m4a", "webm", "flac", "ogg"];
+    &["wav", "mp3", "mp4", "m4a", "webm", "flac", "ogg", "qta"];
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AudioInputInfo {

--- a/crates/openasr-core/src/batch_tests.rs
+++ b/crates/openasr-core/src/batch_tests.rs
@@ -103,7 +103,7 @@ fn no_supported_files_returns_friendly_error_with_supported_extensions() {
     let error = discover_batch_inputs(temp.path()).unwrap_err().to_string();
 
     assert!(error.contains("No supported audio or video files found in:"));
-    assert!(error.contains("Supported extensions: wav, mp3, mp4, m4a, webm, flac, ogg."));
+    assert!(error.contains("Supported extensions: wav, mp3, mp4, m4a, webm, flac, ogg, qta."));
 }
 
 #[test]

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1516,7 +1516,7 @@ impl std::fmt::Display for ApiError {
             Self::History(error) => write!(f, "Could not update transcription history: {error}"),
             Self::JobStore(message) => f.write_str(message),
             Self::MultipartRejection(error) => write!(f, "Could not read multipart form: {error}"),
-            Self::Multipart(error) => write!(f, "Could not read multipart form: {error}"),
+            Self::Multipart(error) => write!(f, "{}", multipart_error_message(error)),
             Self::AudioPreparation(error) => {
                 write!(
                     f,
@@ -1591,10 +1591,11 @@ impl IntoResponse for ApiError {
                 StatusCode::BAD_REQUEST,
                 format!("Could not read multipart form: {error}"),
             ),
-            Self::Multipart(error) => (
-                StatusCode::BAD_REQUEST,
-                format!("Could not read multipart form: {error}"),
-            ),
+            Self::Multipart(error) => {
+                let status = error.status();
+                let message = multipart_error_message(&error);
+                (status, message)
+            }
             Self::AudioPreparation(error) => (
                 StatusCode::BAD_REQUEST,
                 format!("Could not prepare uploaded audio for transcription: {error}"),
@@ -1694,6 +1695,26 @@ fn config_error_status(error: &openasr_core::ConfigError) -> StatusCode {
         | openasr_core::ConfigError::CreateHome { .. }
         | openasr_core::ConfigError::SerializeConfig(_)
         | openasr_core::ConfigError::WriteConfig { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+/// `axum::extract::multipart::MultipartError`'s `Display` always renders the
+/// generic "Error parsing `multipart/form-data` request", even when the
+/// underlying cause is the upload exceeding [`MAX_TRANSCRIPTION_UPLOAD_BYTES`]
+/// (`DefaultBodyLimit`). That generic text reads like a malformed-body/encoding
+/// bug when the real, actionable cause is "file too large". `MultipartError`'s
+/// `status`/`body_text` already classify the underlying `multer` error
+/// correctly, so use those instead of the raw `Display` for the client-facing
+/// message.
+fn multipart_error_message(error: &axum::extract::multipart::MultipartError) -> String {
+    if error.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        format!(
+            "Uploaded file is too large. The daemon accepts uploads up to {} MB; \
+             split the recording or use a smaller/compressed file.",
+            MAX_TRANSCRIPTION_UPLOAD_BYTES / (1024 * 1024)
+        )
+    } else {
+        format!("Could not read multipart form: {error}")
     }
 }
 

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1114,7 +1114,9 @@ fn safe_extension_suffix(file_name: &str) -> Option<String> {
         .and_then(std::ffi::OsStr::to_str)?
         .to_ascii_lowercase();
     match extension.as_str() {
-        "wav" | "mp3" | "m4a" | "mp4" | "webm" | "flac" | "ogg" => Some(format!(".{extension}")),
+        "wav" | "mp3" | "m4a" | "mp4" | "webm" | "flac" | "ogg" | "qta" => {
+            Some(format!(".{extension}"))
+        }
         _ => None,
     }
 }

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -2875,6 +2875,69 @@ async fn transcriptions_returns_mock_json_by_default() {
     );
 }
 
+/// A real-world upload filename containing CJK characters and a space must
+/// parse as multipart/form-data like any other filename -- this previously
+/// got misdiagnosed as a client encoding bug when the true cause was uploads
+/// exceeding the server's body-size limit (see the oversized-upload test
+/// below), not the filename itself.
+#[tokio::test]
+async fn transcriptions_accept_filename_with_cjk_characters_and_space() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = openasr_server::app_with_runtime_and_distribution(
+        openasr_server::ServerRuntime::default(),
+        openasr_server::DistributionRuntime {
+            openasr_home: Some(temp.path().join("home")),
+            catalog_url: None,
+        },
+    );
+    let request = multipart_request(
+        "whisper-large-v3-turbo",
+        "0511 博弘讨论配合问题.m4a",
+        b"not a real m4a",
+    );
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), 1024 * 256).await.unwrap();
+    let parsed: Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(
+        parsed["text"]
+            .as_str()
+            .unwrap()
+            .contains("OpenASR mock transcription")
+    );
+}
+
+/// An upload past the server's body-size ceiling must fail with a clear,
+/// actionable "file too large" message and 413, not the generic "Error
+/// parsing `multipart/form-data` request" text that `MultipartError`'s
+/// `Display` renders for every underlying `multer` failure (including this
+/// one) -- see `multipart_error_message` in `lib.rs`.
+#[tokio::test]
+async fn transcriptions_reject_upload_past_body_limit_with_clear_message() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = openasr_server::app_with_runtime_and_distribution(
+        openasr_server::ServerRuntime::default(),
+        openasr_server::DistributionRuntime {
+            openasr_home: Some(temp.path().join("home")),
+            catalog_url: None,
+        },
+    );
+    let oversized = vec![0u8; 65 * 1024 * 1024];
+    let request = multipart_request("whisper-large-v3-turbo", "huge.wav", &oversized);
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    let bytes = to_bytes(response.into_body(), 1024 * 256).await.unwrap();
+    let parsed: Value = serde_json::from_slice(&bytes).unwrap();
+    let message = parsed["error"]["message"].as_str().unwrap();
+    assert!(message.contains("too large"), "message was: {message}");
+    assert!(
+        !message.contains("Error parsing"),
+        "message regressed to the generic multipart error text: {message}"
+    );
+}
+
 #[tokio::test]
 async fn transcriptions_accept_word_timestamp_granularity_for_json() {
     let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Fix `/v1/audio/transcriptions` returning a generic, misleading 400
  ("Could not read multipart form: Error parsing `multipart/form-data`
  request") for uploads that exceed the 64 MB body-size ceiling. This
  is now a 413 with an actionable "file too large, max 64 MB" message.
- Add native support for `.qta` (macOS QuickTime Player's audio
  recording extension, a MOV container) as a recognized upload
  extension.

## Why

A user reported that transcribing a real recording named
"0511 博弘讨论配合问题.m4a" (CJK characters + a space) failed with a 400
"could not read multipart form" error, which looked like a client-side
filename-encoding bug.

Investigation (browser-engine multipart capture + raw byte replay,
Node's spec-compliant `FormData`/`Request`, and direct daemon testing)
showed the exact same filename and content parse correctly at any size
under the server's 64 MB `DefaultBodyLimit`, and the exact same
generic error reproduces for a *plain ASCII* filename once the payload
exceeds 64 MB. So the filename was never the cause: axum's
`MultipartError::Display` renders the same generic text for every
underlying `multer` failure, including the upload simply being too
large, and our error mapping was hardcoding `StatusCode::BAD_REQUEST`
with that generic text instead of using `MultipartError`'s own
`status()`/`body_text()`, which already classify body-limit errors
correctly.

Separately, `.qta` (QuickTime's audio-recording extension) was not in
the recognized-extension list, so it was rejected before ever reaching
ffmpeg. Verified by remuxing a real `.m4a` into a `.qta` and
transcribing it end-to-end through the native pipeline (ffmpeg's
`mov,mp4,m4a,3gp,3g2,mj2` demuxer already reads it by content probing,
no format hint needed for input).

## Changes

- `crates/openasr-server/src/lib.rs`: `ApiError::Multipart` now uses
  `MultipartError::status()`/`body_text()` via a new
  `multipart_error_message` helper instead of hardcoding 400 + generic
  text.
- `crates/openasr-server/tests/api.rs`: regression tests locking in (a)
  a real CJK-plus-space filename upload succeeding, and (b) an
  oversized upload returning 413 with the corrected message (and not
  regressing to the old generic "Error parsing" text).
- `crates/openasr-core/src/audio/types.rs`: add `"qta"` to
  `RECOGNIZED_EXTENSIONS`.
- `crates/openasr-server/src/routes/transcription.rs`: add `"qta"` to
  the upload temp-file suffix mapping ffmpeg conversion reads from.
- `crates/openasr-core/src/audio/tests.rs`,
  `crates/openasr-core/src/batch_tests.rs`: extension-recognition
  regression tests / updated hardcoded extension list.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2050 passed, 0 failed, 116 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources ok; pre-existing unrelated warnings only)

## Manual smoke checks

- Reproduced the exact reported error by replaying a real WebKit/undici
  `FormData`-serialized multipart body (with the reported CJK+space
  filename) through a locally built daemon once the payload exceeded
  64 MB; confirmed the same error with a plain-ASCII filename at the
  same size, and confirmed success for the same filename/content under
  the limit -- both before and after the fix, to isolate cause from
  effect.
- Remuxed a real `.m4a` into `.qta` via `ffmpeg -c copy -f mov` and
  transcribed it end-to-end through the native pipeline (200 OK, real
  transcription output) after the fix; confirmed it was rejected with
  "the file has no extension" before the fix.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not raise the 64 MB upload ceiling itself (that's an intentional,
  documented tradeoff pending streaming uploads to disk instead of
  in-memory buffering) -- only fixes the misleading error surfaced when
  it's hit.
- Does not add `.qta` as an ffmpeg *output* format (the server never
  writes `.qta`, only reads it as an upload).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- investigated and implemented with an AI coding agent (root-cause isolation via controlled repro across client encodings/sizes, fix, and regression tests), reviewed and understood in full by the submitter.