### PR TITLE
fix(server): start with zero models installed instead of failing closed at boot

### DIFF
--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -1247,6 +1247,50 @@ mod tests {
     }
 
     #[test]
+    fn resolve_serve_model_source_degrades_to_no_model_when_none_installed() {
+        // Root-cause regression: `serve` must not fail closed at startup just
+        // because a fresh install has zero pulled models -- that used to bail
+        // via `resolve_installed_native_pack`'s "is not installed" error before
+        // the HTTP listener ever bound, so the daemon process exited
+        // immediately and desktop's health poll just timed out on a process
+        // that was already dead.
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("OPENASR_HOME", temp.path()) };
+
+        let source = resolve_serve_model_source(
+            Some("qwen3-asr-0.6b"),
+            BackendKind::Native,
+            None,
+            &OpenAsrConfig::default(),
+        )
+        .expect("serve must resolve a model source even with zero packs installed");
+
+        assert_eq!(source.model_pack_path, None);
+        assert_eq!(source.model_id, "qwen3-asr-0.6b");
+    }
+
+    #[test]
+    fn resolve_serve_model_source_still_validates_explicit_model_pack_path() {
+        // The `--model-pack` escape hatch is explicit user input, so it must
+        // still fail closed (unlike the "nothing installed yet" case above)
+        // when the path itself does not validate.
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("OPENASR_HOME", temp.path()) };
+        let missing_pack = temp.path().join("does-not-exist.oasr");
+
+        let error = resolve_serve_model_source(
+            None,
+            BackendKind::Native,
+            Some(&missing_pack),
+            &OpenAsrConfig::default(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("Native model-pack path rejected"));
+    }
+
+    #[test]
     fn benchmark_flag_accepts_native_model_pack() {
         let cli = Cli::try_parse_from([
             "openasr",

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -321,14 +321,15 @@ pub(super) fn resolve_model_source_for_backend(
 }
 
 /// Resolves the installed `.oasr` pack for a model id (the resolved default when
-/// `model` is `None`). Never pulls: a missing model is a fail-closed error here.
-/// The CLI transcribe/live handlers ensure the pack is installed (consent-pull)
-/// before this runs; the server relies on this staying download-free.
-pub(super) fn resolve_installed_native_pack(
+/// `model` is `None`), or `Ok(None)` when no matching pack is installed yet (a
+/// normal state right after a fresh install, before the user has pulled any
+/// model). Genuine environment/registry errors (unreadable `OPENASR_HOME`,
+/// corrupt registry, ...) still return `Err`. Never pulls either way.
+fn resolve_installed_native_pack_opt(
     model: Option<&str>,
     config: &OpenAsrConfig,
     catalog: Option<&openasr_core::ModelCatalog>,
-) -> Result<PathBuf> {
+) -> Result<Option<PathBuf>> {
     let home = openasr_home()?;
     let model_ref = selected_model_ref(model, config, &[]);
     let packs = openasr_core::list_installed_packs(&home)?;
@@ -339,11 +340,26 @@ pub(super) fn resolve_installed_native_pack(
         host_profile: openasr_core::host_quant_recommendation_profile(),
     };
     match openasr_core::resolve_launch_pack(&packs, &request) {
-        Ok(selection) => Ok(selection.pack.path),
-        Err(_) => bail!(
-            "Model '{model_ref}' is not installed.\nRun: openasr pull {model_ref}\n(Or pass --model-pack <local.oasr> to run a specific local pack file.)"
-        ),
+        Ok(selection) => Ok(Some(selection.pack.path)),
+        Err(_) => Ok(None),
     }
+}
+
+/// Resolves the installed `.oasr` pack for a model id (the resolved default when
+/// `model` is `None`). Never pulls: a missing model is a fail-closed error here.
+/// The CLI transcribe/live handlers ensure the pack is installed (consent-pull)
+/// before this runs; the server relies on this staying download-free.
+pub(super) fn resolve_installed_native_pack(
+    model: Option<&str>,
+    config: &OpenAsrConfig,
+    catalog: Option<&openasr_core::ModelCatalog>,
+) -> Result<PathBuf> {
+    let model_ref = selected_model_ref(model, config, &[]);
+    resolve_installed_native_pack_opt(model, config, catalog)?.ok_or_else(|| {
+        anyhow!(
+            "Model '{model_ref}' is not installed.\nRun: openasr pull {model_ref}\n(Or pass --model-pack <local.oasr> to run a specific local pack file.)"
+        )
+    })
 }
 
 pub(super) fn prepare_backend_run(
@@ -366,6 +382,66 @@ pub(super) fn prepare_backend_run(
     })
 }
 
+/// Resolves the model source for `serve`. Unlike `resolve_model_source_for_backend`
+/// (used by `transcribe`/`live`, which run consent-pull first and so treat a
+/// missing pack as fatal), `serve` must come up with zero models installed --
+/// that is a normal post-install state, not a startup error. An explicit
+/// `--model-pack` escape hatch still fails closed if the path does not
+/// validate; only the "nothing installed yet" case degrades to no model bound,
+/// which `openasr-server` reports via `/health` and fails closed on a
+/// transcription request instead.
+pub(super) fn resolve_serve_model_source(
+    model: Option<&str>,
+    backend_kind: BackendKind,
+    model_pack: Option<&Path>,
+    config: &OpenAsrConfig,
+) -> Result<ResolvedModelSource> {
+    if backend_kind != BackendKind::Native {
+        return resolve_model_source_for_backend("serve", model, backend_kind, model_pack, config);
+    }
+    let catalog = load_cli_model_catalog(&openasr_home()?)?;
+    let model_pack_root = match model_pack {
+        Some(path) => Some(
+            validate_local_native_model_pack_path(path)
+                .map_err(|error| anyhow!("Native model-pack path rejected: {error}"))?,
+        ),
+        None => resolve_installed_native_pack_opt(model, config, catalog.as_ref())?,
+    };
+    let model_id = match &model_pack_root {
+        Some(_) => {
+            if let Some(model_ref) = model {
+                let normalized_model_ref = model_ref.trim();
+                parse_model_ref(normalized_model_ref).map_err(|error| {
+                    anyhow!(
+                        "Model '{model_ref}' is not a valid model id for native GGUF local-source serve: {error}"
+                    )
+                })?;
+                let cards = load_registry(default_registry_dir())
+                    .context("Could not load model registry")?;
+                match resolve_runtime_model_ref(&cards, catalog.as_ref(), normalized_model_ref) {
+                    Ok(resolved) => resolved.runtime_model_id,
+                    Err(error) if runtime_resolution_unknown_model(&error) => {
+                        normalized_model_ref.to_owned()
+                    }
+                    Err(error) => return Err(anyhow::anyhow!(error)),
+                }
+            } else {
+                NATIVE_RUNTIME_MODEL_ID_AUTO.to_string()
+            }
+        }
+        // No pack resolved: keep the requested model id (or the auto sentinel)
+        // around so the health/status payload can report which model, if any,
+        // was asked for.
+        None => model
+            .map(str::to_owned)
+            .unwrap_or_else(|| NATIVE_RUNTIME_MODEL_ID_AUTO.to_string()),
+    };
+    Ok(ResolvedModelSource {
+        model_id,
+        model_pack_path: model_pack_root,
+    })
+}
+
 pub(super) async fn serve(
     addr: SocketAddr,
     model: Option<&str>,
@@ -377,15 +453,11 @@ pub(super) async fn serve(
     let home = openasr_home()?;
     let config = load_config(&home)?;
     let backend = resolve_backend(backend_kind, &config)?;
-    let model_source =
-        resolve_model_source_for_backend("serve", model, backend, model_pack, &config)?;
-    if backend == BackendKind::Native {
-        let local_model_id = resolve_native_runtime_model_id_from_source(
-            model_source
-                .model_pack_path
-                .as_deref()
-                .expect("native source resolver checked above"),
-        )?;
+    let model_source = resolve_serve_model_source(model, backend, model_pack, &config)?;
+    if backend == BackendKind::Native
+        && let Some(model_pack_path) = model_source.model_pack_path.as_deref()
+    {
+        let local_model_id = resolve_native_runtime_model_id_from_source(model_pack_path)?;
         if let Some(model_ref) = model
             && model_source.model_id != local_model_id
         {
@@ -396,6 +468,10 @@ pub(super) async fn serve(
                 local_model_id
             );
         }
+    } else if backend == BackendKind::Native {
+        eprintln!(
+            "openasr-server: no installed native model pack found; starting with no model bound. Install one (openasr pull <model-id>) or install via the desktop model market; transcription requests will fail closed until then."
+        );
     }
     let ffmpeg_bin = resolve_ffmpeg_bin(runtime_paths.ffmpeg_bin.clone(), &config);
 

--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -826,18 +826,147 @@ fn serve_native_rejects_model_id_mismatch_with_local_runtime_source() {
         ));
 }
 
+/// Spawns the real `openasr serve` binary against `home` and blocks until it
+/// prints its "listening on http://<addr>" line, returning the bound address.
+/// Panics with the child's stderr if it exits before ever reporting ready --
+/// the exact old failure mode where a fresh, model-less install's daemon
+/// process died before the HTTP listener bound.
+// The happy path intentionally returns the still-running child to the
+// caller, which owns killing and waiting on it once its assertions are done
+// (every call site does); clippy's zombie-process heuristic can't see across
+// that boundary.
+#[allow(clippy::zombie_processes)]
+fn spawn_serve_and_wait_until_listening(home: &Path) -> (std::process::Child, String) {
+    // `serve` prints back the `--addr` it was given verbatim rather than the
+    // listener's actual bound address, so `--addr 127.0.0.1:0` would echo the
+    // unusable "port 0". Reserve a real ephemeral port ourselves, release it,
+    // and pass that through -- a race in principle, but a released loopback
+    // port is not reused within a single test's tiny window in practice.
+    let reserved = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port");
+    let addr = reserved
+        .local_addr()
+        .expect("reserved listener addr")
+        .to_string();
+    drop(reserved);
+
+    let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_openasr"));
+    command
+        .env("OPENASR_HOME", home)
+        .env_remove("OPENASR_MODEL")
+        .env_remove("OPENASR_ADDR")
+        .env_remove("OPENASR_ASSUME_YES")
+        .env_remove("OPENASR_OFFLINE")
+        .args(["serve", "--backend", "native", "--addr", &addr])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().expect("spawn openasr serve");
+    let stdout = child.stdout.take().expect("piped stdout");
+    let mut reader = std::io::BufReader::new(stdout);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        use std::io::BufRead;
+        let mut line = String::new();
+        let bytes_read = reader.read_line(&mut line).expect("read stdout line");
+        if bytes_read == 0 {
+            let status = child.wait().expect("child exit status");
+            let mut stderr = String::new();
+            if let Some(mut handle) = child.stderr.take() {
+                use std::io::Read;
+                let _ = handle.read_to_string(&mut stderr);
+            }
+            panic!(
+                "openasr serve exited before reporting it was listening (status: {status:?}, stderr: {stderr})"
+            );
+        }
+        if line
+            .trim_end()
+            .starts_with("OpenASR server listening on http://")
+        {
+            return (child, addr);
+        }
+        if std::time::Instant::now() > deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("openasr serve did not report listening within 10s");
+        }
+    }
+}
+
+fn raw_http_request(addr: &str, request: &[u8]) -> String {
+    use std::io::{Read, Write};
+    let stream = std::net::TcpStream::connect(addr).expect("connect to daemon");
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    (&stream).write_all(request).unwrap();
+    let mut response = Vec::new();
+    (&stream).read_to_end(&mut response).expect("read response");
+    String::from_utf8_lossy(&response).into_owned()
+}
+
 #[test]
-fn serve_native_without_installed_model_fails_closed() {
-    // With native as the default, `serve` resolves an installed pack by model id
-    // and never downloads. With nothing installed it fails closed (the server is
-    // never started) and points at the explicit pull command.
+fn serve_native_without_installed_model_starts_and_answers_health() {
+    // Root-cause regression, exercised through the real `openasr` binary: a
+    // fresh install with zero pulled models must still start the daemon and
+    // answer /health. Before the fix, `serve` bailed with "is not installed"
+    // before the HTTP listener ever bound, so the daemon process exited
+    // immediately -- and desktop's health poll just watched a process that
+    // was already dead until its 30s timeout gave up.
     let temp = tempfile::tempdir().unwrap();
-    openasr()
-        .env("OPENASR_HOME", temp.path())
-        .args(["serve", "--backend", "native", "--addr", "127.0.0.1:0"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("is not installed"));
+    let (mut child, addr) = spawn_serve_and_wait_until_listening(temp.path());
+
+    let response = raw_http_request(
+        &addr,
+        format!("GET /health HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n").as_bytes(),
+    );
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "expected a healthy 200 response, got: {response}"
+    );
+    assert!(
+        response.contains("\"model_installed\":false"),
+        "expected /health to honestly report no model installed, got: {response}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn transcriptions_via_daemon_with_no_installed_model_return_clear_400() {
+    // The other half of the same regression: once the daemon is up (see
+    // `serve_native_without_installed_model_starts_and_answers_health`), an
+    // actual transcription request with no model installed must fail closed
+    // with a clear, structured client error naming the model id -- not a
+    // connection error and not a 500.
+    let temp = tempfile::tempdir().unwrap();
+    let (mut child, addr) = spawn_serve_and_wait_until_listening(temp.path());
+
+    let boundary = "openasr-nomodel-test-boundary";
+    let mut body = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"sample.wav\"\r\nContent-Type: audio/wav\r\n\r\nnot a real wav\r\n--{boundary}\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nqwen3-asr-0.6b\r\n--{boundary}--\r\n"
+    )
+    .into_bytes();
+    let mut request = format!(
+        "POST /v1/audio/transcriptions HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\nContent-Type: multipart/form-data; boundary={boundary}\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    request.append(&mut body);
+
+    let response = raw_http_request(&addr, &request);
+    assert!(
+        response.starts_with("HTTP/1.1 400"),
+        "expected a fail-closed 400 for an uninstalled model, got: {response}"
+    );
+    assert!(
+        response.contains("qwen3-asr-0.6b") && response.contains("not installed"),
+        "expected a clear 'model not installed' message naming the model id, got: {response}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 #[test]

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -747,21 +747,36 @@ impl Default for ServerRuntime {
 }
 
 impl ServerRuntime {
+    /// Validates the runtime is *safe to serve with*, not that a model is
+    /// installed: no model bound at all (`model_pack_path: None`) is a normal
+    /// state for a fresh install with zero pulled models, and the daemon must
+    /// still start and answer `/health` in that state. Only a `model_pack_path`
+    /// that is actually set but fails to validate (bad path, corrupt/foreign
+    /// pack, ...) is a startup error -- that is a misconfiguration, not "no
+    /// model yet". Requests that need a model fail closed at request time
+    /// instead (see `validate_native_request_model`).
     pub fn validate(&self) -> Result<(), openasr_core::BackendError> {
         match self.backend {
             BackendKind::Mock => Ok(()),
             BackendKind::Native => {
                 let Some(model_pack_path) = self.model_pack_path.as_deref() else {
-                    return Err(openasr_core::BackendError::NativeModelPackPathRejected {
-                        reason: "native backend requires an explicit local .oasr runtime pack path"
-                            .to_string(),
-                    });
+                    return Ok(());
                 };
                 let pack_root =
                     openasr_core::validate_local_native_model_pack_path(model_pack_path)?;
                 let _ = validate_native_runtime_pack(&pack_root)?;
                 Ok(())
             }
+        }
+    }
+
+    /// Whether a native model pack is currently bound (surfaced by `/health` so
+    /// clients can distinguish "daemon not reachable" from "daemon ready, no
+    /// model installed" without racing a separate models-list call).
+    fn has_model_bound(&self) -> bool {
+        match self.backend {
+            BackendKind::Mock => true,
+            BackendKind::Native => self.model_pack_path.is_some(),
         }
     }
 }
@@ -1193,12 +1208,16 @@ fn load_persisted_pull_jobs(runtime: &DistributionRuntime) -> HashMap<String, Pu
     jobs
 }
 
-async fn health(Extension(identity): Extension<ServerHealthIdentity>) -> Json<HealthResponse> {
+async fn health(
+    State(runtime): State<ServerRuntime>,
+    Extension(identity): Extension<ServerHealthIdentity>,
+) -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "ok",
         server_version: identity.server_version,
         pid: identity.pid,
         instance_token: identity.instance_token.clone(),
+        model_installed: runtime.has_model_bound(),
     })
 }
 
@@ -1210,18 +1229,20 @@ async fn models(State(runtime): State<ServerRuntime>) -> Result<Json<ModelsRespo
             .map(|card| card.id)
             .collect(),
         BackendKind::Native => {
-            let Some(model_pack_path) = runtime.model_pack_path.as_deref() else {
-                return Err(ApiError::Backend(
-                    openasr_core::BackendError::NativeModelPackPathRejected {
-                        reason: "native backend requires an explicit local .oasr runtime pack path"
-                            .to_string(),
-                    },
-                ));
-            };
-            let pack_root = openasr_core::validate_local_native_model_pack_path(model_pack_path)
-                .map_err(ApiError::Backend)?;
-            let identity = validate_native_runtime_pack(&pack_root).map_err(ApiError::Backend)?;
-            vec![identity.model_id]
+            // No model bound is a normal fresh-install state, not an error:
+            // report an empty model list rather than fail-closed here (the
+            // transcription path is the fail-closed boundary for "no model").
+            match runtime.model_pack_path.as_deref() {
+                None => Vec::new(),
+                Some(model_pack_path) => {
+                    let pack_root =
+                        openasr_core::validate_local_native_model_pack_path(model_pack_path)
+                            .map_err(ApiError::Backend)?;
+                    let identity =
+                        validate_native_runtime_pack(&pack_root).map_err(ApiError::Backend)?;
+                    vec![identity.model_id]
+                }
+            }
         }
     };
     Ok(Json(ModelsResponse {
@@ -1323,6 +1344,12 @@ struct HealthResponse {
     server_version: &'static str,
     pid: u32,
     instance_token: Option<String>,
+    /// Whether a model is currently bound and ready to serve transcription
+    /// requests. `false` on a fresh install with zero pulled models -- the
+    /// daemon is still up and healthy, it just has nothing to transcribe with
+    /// yet. Clients should treat this as "go install a model", not "daemon
+    /// unreachable".
+    model_installed: bool,
 }
 
 #[derive(Serialize)]

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -639,9 +639,13 @@ pub(crate) fn validate_native_request_model(
     model: &str,
 ) -> Result<(), String> {
     let Some(model_pack_path) = runtime.model_pack_path.as_deref() else {
-        return Err(
-            "Native backend requires an explicit local .oasr runtime pack path.".to_string(),
-        );
+        // No model bound at all: a fresh install with zero pulled models is a
+        // normal daemon state (it starts and answers /health fine), but a
+        // transcription request needs a model, so this is where that need
+        // becomes a fail-closed, structured error.
+        return Err(format!(
+            "Model '{model}' is not installed. No models are installed on this server yet -- install one first (openasr pull {model}, or via the model market)."
+        ));
     };
     let pack_root = openasr_core::validate_local_native_model_pack_path(model_pack_path)
         .map_err(|error| error.to_string())?;

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -1017,19 +1017,76 @@ async fn native_transcription_without_installed_model_fails_closed_and_never_dow
         .await
         .unwrap();
 
-    assert_ne!(
+    // A missing model is a client error (400), not a crash and not a silent
+    // 500 -- the daemon is up, it just needs the caller to install a model
+    // first (see also `daemon_starts_and_reports_ready_with_zero_models_installed`,
+    // which locks in that the same empty-home startup itself never fails).
+    assert_eq!(
         response.status(),
-        StatusCode::OK,
-        "native serve must not transcribe an uninstalled model"
+        StatusCode::BAD_REQUEST,
+        "expected a fail-closed 400 for an uninstalled model"
     );
+    let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    let message = json["error"]["message"].as_str().unwrap();
     assert!(
-        response.status().is_client_error() || response.status().is_server_error(),
-        "expected a fail-closed error status, got {}",
-        response.status()
+        message.contains("qwen3-asr-0.6b") && message.contains("not installed"),
+        "expected a clear 'model not installed' message naming the model id, got: {message}"
     );
     assert!(
         !home.join("models").exists(),
         "the server must never download a model"
+    );
+}
+
+#[tokio::test]
+async fn daemon_starts_and_reports_ready_with_zero_models_installed() {
+    // The core regression this guards: a fresh install with zero pulled
+    // models must not prevent the daemon from starting at all. Previously
+    // `ServerRuntime::validate()` (run before the HTTP listener ever binds)
+    // hard-failed for the native backend whenever no model pack was resolved,
+    // so a brand-new install's daemon process exited immediately and the
+    // desktop app's health poll just timed out waiting for a process that was
+    // already dead. Starting the app (which runs the same validation the real
+    // `serve_with_launch_options` entrypoint runs) and hitting /health must
+    // succeed and honestly report that no model is installed yet.
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let runtime = openasr_server::ServerRuntime {
+        backend: openasr_core::BackendKind::Native,
+        ffmpeg_bin: None,
+        model_pack_path: None,
+    };
+    runtime
+        .validate()
+        .expect("serve must not fail closed at startup just because zero models are installed");
+
+    let app = openasr_server::app_with_runtime_and_distribution(
+        runtime,
+        openasr_server::DistributionRuntime {
+            openasr_home: Some(home),
+            catalog_url: None,
+        },
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    let parsed: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(parsed["status"], "ok");
+    assert_eq!(
+        parsed["model_installed"], false,
+        "health must honestly report no model bound instead of just being unreachable"
     );
 }
 
@@ -2092,17 +2149,18 @@ async fn speaker_reenroll_fails_closed_when_embedder_pack_is_missing() {
 }
 
 #[test]
-fn native_server_runtime_is_rejected_at_startup_validation() {
-    let error = openasr_server::ServerRuntime {
+fn native_server_runtime_with_no_model_pack_is_accepted_at_startup_validation() {
+    // A native backend with no model pack bound (a fresh install with zero
+    // models pulled) must still pass startup validation -- the daemon has to
+    // come up and answer /health; "no model" is a fail-closed error at
+    // transcription-request time, not a reason to refuse to serve at all.
+    openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
         ffmpeg_bin: None,
         model_pack_path: None,
     }
     .validate()
-    .unwrap_err()
-    .to_string();
-
-    assert!(error.contains("requires an explicit local .oasr runtime pack path"));
+    .expect("zero installed models must not block server startup");
 }
 
 #[test]
@@ -2269,7 +2327,7 @@ async fn health_returns_identity_json_without_instance_token() {
     );
     assert_eq!(parsed["pid"], serde_json::json!(std::process::id()));
     assert!(parsed["instance_token"].is_null());
-    assert_eq!(parsed.as_object().expect("health response object").len(), 4);
+    assert_eq!(parsed.as_object().expect("health response object").len(), 5);
 }
 
 #[tokio::test]
@@ -2301,7 +2359,7 @@ async fn health_echoes_launch_instance_token_without_env() {
         parsed["instance_token"],
         serde_json::json!("launch-health-token")
     );
-    assert_eq!(parsed.as_object().expect("health response object").len(), 4);
+    assert_eq!(parsed.as_object().expect("health response object").len(), 5);
 }
 
 #[tokio::test]
@@ -2335,7 +2393,7 @@ async fn health_prefers_env_instance_token_over_launch_option() {
         parsed["instance_token"],
         serde_json::json!("env-health-token")
     );
-    assert_eq!(parsed.as_object().expect("health response object").len(), 4);
+    assert_eq!(parsed.as_object().expect("health response object").len(), 5);
 }
 
 #[tokio::test]
@@ -4085,4 +4143,30 @@ async fn models_with_native_backend_lists_loaded_local_pack_id() {
     let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
     let parsed: Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(parsed["data"][0]["id"], "native-pack");
+}
+
+#[tokio::test]
+async fn models_with_native_backend_and_no_pack_lists_empty_instead_of_erroring() {
+    // Zero installed models is a normal listing result (an empty catalog of
+    // "currently loaded" models), not an error -- /v1/models must not fail
+    // closed the way an actual transcription request does.
+    let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
+        backend: openasr_core::BackendKind::Native,
+        ffmpeg_bin: None,
+        model_pack_path: None,
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/models")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    let parsed: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(parsed["data"].as_array().unwrap().len(), 0);
 }


### PR DESCRIPTION
## Summary

- `openasr serve` no longer fails to start when zero models are installed.
- The daemon binds its HTTP listener and answers `/health` normally on a
  fresh install; `/health` now reports `model_installed` so clients can tell
  "daemon up, no model yet" apart from "daemon unreachable".
- A transcription/translation request still fails closed with a clear 400
  naming the requested model id once the server actually needs to run one.

## Why

A friend's fresh install skipped model download during onboarding. The
desktop app then showed "daemon not ready after 30s / connection refused",
and separately, sending a transcription request produced a bare `Model
'qwen3-asr-0.6b' is not installed` error.

Root cause: two hard-fail points ran before the HTTP listener ever bound.
`crates/openasr-cli/src/native_segment_cli.rs`'s `serve()` resolved the
native model source up front and bailed via `resolve_installed_native_pack`'s
"is not installed" error whenever nothing was pulled yet. Even bypassing
that, `openasr_server::ServerRuntime::validate()` (called from
`serve_with_launch_options` before `TcpListener::bind`) also hard-rejected a
`Native` backend with `model_pack_path: None`. So a fresh install's daemon
process exited immediately with a non-zero status and never listened at all
-- the desktop app's 30s health poll was watching a process that was already
dead, not a slow one.

A missing model is a normal fresh-install state, not a startup error; it
should only become a fail-closed error when a request actually needs a
model.

## Changes

- `crates/openasr-cli/src/native_segment_cli.rs`: new
  `resolve_installed_native_pack_opt` (returns `Ok(None)` instead of bailing
  when nothing is installed, while still surfacing genuine environment
  errors) and `resolve_serve_model_source` (serve-only resolution that
  degrades to no model bound instead of failing closed; an explicit
  `--model-pack` escape hatch still fails closed on a bad path). `serve()`
  now uses this and only compares `--model` against the loaded pack's id
  when a pack is actually present.
- `crates/openasr-server/src/lib.rs`: `ServerRuntime::validate()` no longer
  rejects `model_pack_path: None` for the native backend; added
  `has_model_bound()`. `/health` gains a `model_installed: bool` field.
  `/v1/models` lists an empty array instead of erroring when no native pack
  is bound.
- `crates/openasr-server/src/routes/transcription.rs`:
  `validate_native_request_model` now returns a clear message naming the
  requested model id and explaining no models are installed yet (still maps
  to 400).
- Tests: CLI-level unit tests for the new resolution helper (including that
  an explicit bad `--model-pack` still fails closed); a real-binary
  spawn-and-poll test proving `openasr serve` starts and answers `/health`
  with zero models installed, and a companion test proving a transcription
  request against that same daemon returns a clear 400 naming the model id;
  server-side tests for `ServerRuntime::validate()` accepting `None`,
  `/health`'s new field, `/v1/models` listing empty, and a tightened
  assertion on the existing "transcription without installed model" test.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2051 passed, 0 failed, 116 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`
- [x] `cargo deny check` (advisories/bans/licenses/sources ok; pre-existing duplicate-version warnings only)

## Manual smoke checks

- Ran `openasr serve --backend native --addr 127.0.0.1:<port>` against an
  empty `OPENASR_HOME` directly: the daemon prints "listening on
  http://..." and stays up; `curl /health` returns 200 with
  `"model_installed":false`; a multipart `/v1/audio/transcriptions` request
  against it returns 400 with a message naming the model id and "not
  installed" (this is also locked in as an automated test, see above).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not change the CLI `transcribe`/`live` consent-pull flow (still the
  only place that installs a model, and only with visible consent).
- Does not add any new fail-open behavior: the server still never downloads
  a model on its own; a missing model still fails closed for any request
  that actually needs one.
- Desktop-side UX for guiding a user with zero models to the model market is
  a separate, closed-source change (openasr-app), not part of this PR.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- investigated and implemented with an AI coding agent (root-cause isolation of the two hard-fail points via targeted tracing through the CLI/server serve path, fix, and regression tests including a real-binary spawn test), reviewed and understood in full by the submitter.