### PR TITLE
fix(core): fall back to macOS afconvert when ffmpeg is unavailable

### DIFF
--- a/crates/openasr-core/src/api/audio_io.rs
+++ b/crates/openasr-core/src/api/audio_io.rs
@@ -69,8 +69,18 @@ fn parse_wav_fmt(bytes: &[u8]) -> Result<WavFormat, NativeAsrError> {
     if bytes.len() < 16 {
         return Err(wav_error("fmt chunk is shorter than 16 bytes"));
     }
+    let mut audio_format = u16::from_le_bytes(bytes[0..2].try_into().unwrap());
+    // WAVE_FORMAT_EXTENSIBLE (0xFFFE) carries the real codec in the first two
+    // bytes of the trailing 16-byte SubFormat GUID, not in the top-level
+    // audio_format field. macOS `afconvert -f WAVE` always emits this extended
+    // (40-byte) fmt chunk, even for plain mono PCM16, so it must be unwrapped
+    // here or every afconvert-produced WAV would be rejected as an unsupported
+    // format below.
+    if audio_format == 0xFFFE && bytes.len() >= 26 {
+        audio_format = u16::from_le_bytes(bytes[24..26].try_into().unwrap());
+    }
     Ok(WavFormat {
-        audio_format: u16::from_le_bytes(bytes[0..2].try_into().unwrap()),
+        audio_format,
         channels: u16::from_le_bytes(bytes[2..4].try_into().unwrap()),
         sample_rate_hz: u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
         bits_per_sample: u16::from_le_bytes(bytes[14..16].try_into().unwrap()),
@@ -137,5 +147,55 @@ impl SampleEncoding {
 fn wav_error(message: impl Into<String>) -> NativeAsrError {
     NativeAsrError::SessionFailed {
         message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extensible_pcm16_mono_16k_wav(frames: u32) -> Vec<u8> {
+        // Mirrors the 40-byte WAVEFORMATEXTENSIBLE fmt chunk macOS
+        // `afconvert -f WAVE -d LEI16@16000` emits for mono PCM16, including
+        // the KSDATAFORMAT_SUBTYPE_PCM SubFormat GUID.
+        let data_size = frames * 2;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&(4 + 8 + 40 + 8 + data_size).to_le_bytes());
+        bytes.extend_from_slice(b"WAVE");
+        bytes.extend_from_slice(b"fmt ");
+        bytes.extend_from_slice(&40_u32.to_le_bytes());
+        bytes.extend_from_slice(&0xFFFE_u16.to_le_bytes()); // WAVE_FORMAT_EXTENSIBLE
+        bytes.extend_from_slice(&1_u16.to_le_bytes()); // channels
+        bytes.extend_from_slice(&16_000_u32.to_le_bytes()); // sample rate
+        bytes.extend_from_slice(&32_000_u32.to_le_bytes()); // byte rate
+        bytes.extend_from_slice(&2_u16.to_le_bytes()); // block align
+        bytes.extend_from_slice(&16_u16.to_le_bytes()); // bits per sample
+        bytes.extend_from_slice(&22_u16.to_le_bytes()); // cbSize
+        bytes.extend_from_slice(&16_u16.to_le_bytes()); // valid bits per sample
+        bytes.extend_from_slice(&4_u32.to_le_bytes()); // channel mask
+        // SubFormat GUID: 00000001-0000-0010-8000-00AA00389B71 (PCM)
+        bytes.extend_from_slice(&[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38,
+            0x9B, 0x71,
+        ]);
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&data_size.to_le_bytes());
+        for index in 0..frames {
+            bytes.extend_from_slice(&(index as i16).to_le_bytes());
+        }
+        bytes
+    }
+
+    #[test]
+    fn wave_format_extensible_pcm16_is_accepted() {
+        let bytes = extensible_pcm16_mono_16k_wav(4);
+
+        let samples = parse_wav_16khz_mono_f32(&bytes, "test").expect("extensible PCM16 WAV");
+
+        assert_eq!(
+            samples,
+            vec![0.0, 1.0 / 32768.0, 2.0 / 32768.0, 3.0 / 32768.0]
+        );
     }
 }

--- a/crates/openasr-core/src/audio/errors.rs
+++ b/crates/openasr-core/src/audio/errors.rs
@@ -31,9 +31,9 @@ pub enum AudioPreparationError {
         extensions: String,
     },
     #[error(
-        "Input requires audio conversion before the {backend} backend can read it, but ffmpeg was not found.\nInstall ffmpeg and add it to PATH, pass --ffmpeg-bin /path/to/ffmpeg, set OPENASR_FFMPEG_BIN, or run `openasr config set media.ffmpeg_bin /path/to/ffmpeg`."
+        "Input requires audio conversion before the {backend} backend can read it, but no audio converter was found.\n{hint}"
     )]
-    MissingFfmpeg { backend: BackendKind },
+    MissingFfmpeg { backend: BackendKind, hint: String },
     #[error(
         "Configured ffmpeg binary was not found or is not a regular file: {path}\nPass --ffmpeg-bin /path/to/ffmpeg, set OPENASR_FFMPEG_BIN, or run `openasr config set media.ffmpeg_bin /path/to/ffmpeg` with a valid ffmpeg executable."
     )]
@@ -43,17 +43,19 @@ pub enum AudioPreparationError {
     )]
     TempDir { source: std::io::Error },
     #[error(
-        "Could not convert input audio for the {backend} backend with ffmpeg (status {status}).\nOpenASR prepares recognized non-WAV inputs as temporary 16 kHz mono PCM WAV for non-mock backends. Check that your local ffmpeg can decode this container/codec, pass a different --ffmpeg-bin, or convert the file to WAV yourself.{stderr}"
+        "Could not convert input audio for the {backend} backend with {tool} (status {status}).\nOpenASR prepares recognized non-WAV inputs as temporary 16 kHz mono PCM WAV for non-mock backends. Check that your local {tool} can decode this container/codec, pass a different --ffmpeg-bin, or convert the file to WAV yourself.{stderr}"
     )]
-    FfmpegFailed {
+    ConversionFailed {
         backend: BackendKind,
+        tool: String,
         status: String,
         stderr: String,
     },
     #[error(
-        "Could not run ffmpeg: {path}\nPlease check that the file exists and is executable, or configure ffmpeg with --ffmpeg-bin, OPENASR_FFMPEG_BIN, or `openasr config set media.ffmpeg_bin`. Details: {source}"
+        "Could not run {tool}: {path}\nPlease check that the file exists and is executable, or configure ffmpeg with --ffmpeg-bin, OPENASR_FFMPEG_BIN, or `openasr config set media.ffmpeg_bin`. Details: {source}"
     )]
-    FfmpegSpawn {
+    ConversionSpawn {
+        tool: String,
         path: PathBuf,
         #[source]
         source: std::io::Error,

--- a/crates/openasr-core/src/audio/prepare.rs
+++ b/crates/openasr-core/src/audio/prepare.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-const FFMPEG_STDERR_LIMIT: usize = 800;
+const CONVERSION_STDERR_LIMIT: usize = 800;
 
 pub(crate) fn prepare_external_input(
     info: AudioInputInfo,
@@ -45,41 +45,30 @@ pub(crate) fn prepare_external_input(
         });
     }
 
-    let ffmpeg = resolve_ffmpeg_for_conversion(options)?;
+    let tool = resolve_conversion_tool(options)?;
     let temp_dir = tempfile::Builder::new()
         .prefix("openasr-audio-")
         .tempdir()
         .map_err(|source| AudioPreparationError::TempDir { source })?;
     let prepared_path = temp_dir.path().join("prepared.wav");
-    let output = Command::new(&ffmpeg)
-        .arg("-hide_banner")
-        .arg("-loglevel")
-        .arg("error")
-        .arg("-y")
-        .arg("-i")
-        .arg(&info.path)
-        .arg("-vn")
-        .arg("-ac")
-        .arg("1")
-        .arg("-ar")
-        .arg("16000")
-        .arg("-c:a")
-        .arg("pcm_s16le")
-        .arg(&prepared_path)
+    let output = tool
+        .build_command(&info.path, &prepared_path)
         .output()
-        .map_err(|source| AudioPreparationError::FfmpegSpawn {
-            path: ffmpeg.clone(),
+        .map_err(|source| AudioPreparationError::ConversionSpawn {
+            tool: tool.label().to_string(),
+            path: tool.path().clone(),
             source,
         })?;
 
     if !output.status.success() {
-        return Err(AudioPreparationError::FfmpegFailed {
+        return Err(AudioPreparationError::ConversionFailed {
             backend: options.backend,
+            tool: tool.label().to_string(),
             status: output.status.code().map_or_else(
                 || "terminated by signal".to_string(),
                 |code| code.to_string(),
             ),
-            stderr: format_stderr_suffix(&String::from_utf8_lossy(&output.stderr)),
+            stderr: format_stderr_suffix(tool.label(), &String::from_utf8_lossy(&output.stderr)),
         });
     }
 
@@ -95,44 +84,141 @@ pub(crate) fn prepare_external_input(
     }
 }
 
-fn resolve_ffmpeg_for_conversion(
-    options: &AudioPreparationOptions,
-) -> Result<PathBuf, AudioPreparationError> {
-    let Some(path) = options.ffmpeg_bin.clone() else {
-        return Err(AudioPreparationError::MissingFfmpeg {
-            backend: options.backend,
-        });
-    };
+/// An external tool used to convert a non-WAV input into a 16 kHz mono PCM16
+/// WAV. macOS ships `/usr/bin/afconvert` on every install (no Homebrew
+/// required), so it is used as a fallback conversion path when ffmpeg is not
+/// configured and cannot be found on PATH.
+enum ConversionTool {
+    Ffmpeg(PathBuf),
+    #[cfg(target_os = "macos")]
+    Afconvert(PathBuf),
+}
 
-    if path.components().count() == 1 {
-        return Ok(path);
+impl ConversionTool {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Ffmpeg(_) => "ffmpeg",
+            #[cfg(target_os = "macos")]
+            Self::Afconvert(_) => "afconvert",
+        }
     }
 
-    match fs::metadata(&path) {
-        Ok(metadata) if metadata.is_file() => Ok(path),
-        _ => Err(AudioPreparationError::InvalidConfiguredFfmpeg { path }),
+    fn path(&self) -> &PathBuf {
+        match self {
+            Self::Ffmpeg(path) => path,
+            #[cfg(target_os = "macos")]
+            Self::Afconvert(path) => path,
+        }
+    }
+
+    fn build_command(&self, input: &std::path::Path, output: &std::path::Path) -> Command {
+        match self {
+            Self::Ffmpeg(path) => {
+                let mut command = Command::new(path);
+                command
+                    .arg("-hide_banner")
+                    .arg("-loglevel")
+                    .arg("error")
+                    .arg("-y")
+                    .arg("-i")
+                    .arg(input)
+                    .arg("-vn")
+                    .arg("-ac")
+                    .arg("1")
+                    .arg("-ar")
+                    .arg("16000")
+                    .arg("-c:a")
+                    .arg("pcm_s16le")
+                    .arg(output);
+                command
+            }
+            #[cfg(target_os = "macos")]
+            Self::Afconvert(path) => {
+                let mut command = Command::new(path);
+                // -f WAVE -d LEI16@16000 -c 1: canonical 16 kHz mono PCM16 WAV,
+                // matching the ffmpeg path above (afconvert always writes the
+                // fmt chunk as WAVE_FORMAT_EXTENSIBLE; the WAV reader in
+                // `api::audio_io` unwraps that to the underlying PCM/float
+                // subformat).
+                command
+                    .arg("-f")
+                    .arg("WAVE")
+                    .arg("-d")
+                    .arg("LEI16@16000")
+                    .arg("-c")
+                    .arg("1")
+                    .arg(input)
+                    .arg(output);
+                command
+            }
+        }
     }
 }
 
-fn format_stderr_suffix(stderr: &str) -> String {
+/// macOS system path for `afconvert`, present on every macOS install
+/// (Core Audio command-line tool, no Homebrew/ffmpeg required).
+#[cfg(target_os = "macos")]
+const MACOS_AFCONVERT_PATH: &str = "/usr/bin/afconvert";
+
+fn resolve_conversion_tool(
+    options: &AudioPreparationOptions,
+) -> Result<ConversionTool, AudioPreparationError> {
+    if let Some(path) = options.ffmpeg_bin.clone() {
+        if path.components().count() == 1 {
+            return Ok(ConversionTool::Ffmpeg(path));
+        }
+        return match fs::metadata(&path) {
+            Ok(metadata) if metadata.is_file() => Ok(ConversionTool::Ffmpeg(path)),
+            _ => Err(AudioPreparationError::InvalidConfiguredFfmpeg { path }),
+        };
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let afconvert = PathBuf::from(MACOS_AFCONVERT_PATH);
+        if matches!(fs::metadata(&afconvert), Ok(metadata) if metadata.is_file()) {
+            return Ok(ConversionTool::Afconvert(afconvert));
+        }
+    }
+
+    Err(AudioPreparationError::MissingFfmpeg {
+        backend: options.backend,
+        hint: missing_converter_hint(),
+    })
+}
+
+fn missing_converter_hint() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        format!(
+            "Install ffmpeg and add it to PATH, pass --ffmpeg-bin /path/to/ffmpeg, set OPENASR_FFMPEG_BIN, run `openasr config set media.ffmpeg_bin /path/to/ffmpeg`, or restore {MACOS_AFCONVERT_PATH} (OpenASR falls back to it automatically when ffmpeg is not configured, but it cannot decode every codec, e.g. Opus/WebM or Ogg Vorbis -- install ffmpeg for full format support)."
+        )
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "Install ffmpeg and add it to PATH, pass --ffmpeg-bin /path/to/ffmpeg, set OPENASR_FFMPEG_BIN, or run `openasr config set media.ffmpeg_bin /path/to/ffmpeg`.".to_string()
+    }
+}
+
+fn format_stderr_suffix(tool: &str, stderr: &str) -> String {
     let summary = summarize_stderr(stderr);
     if summary.is_empty() {
         String::new()
     } else {
-        format!("\nffmpeg stderr: {summary}")
+        format!("\n{tool} stderr: {summary}")
     }
 }
 
 fn summarize_stderr(stderr: &str) -> String {
     let summary = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
-    if summary.chars().count() <= FFMPEG_STDERR_LIMIT {
+    if summary.chars().count() <= CONVERSION_STDERR_LIMIT {
         summary
     } else {
         format!(
             "{}...",
             summary
                 .chars()
-                .take(FFMPEG_STDERR_LIMIT)
+                .take(CONVERSION_STDERR_LIMIT)
                 .collect::<String>()
         )
     }

--- a/crates/openasr-core/src/audio/tests.rs
+++ b/crates/openasr-core/src/audio/tests.rs
@@ -176,6 +176,7 @@ fn native_float_wav_passthrough_without_ffmpeg() {
 }
 
 #[test]
+#[cfg(not(target_os = "macos"))]
 fn native_non_wav_conversion_mode_requires_ffmpeg_when_enabled() {
     let temp = tempfile::tempdir().unwrap();
     let input = temp.path().join("sample.mp3");
@@ -190,12 +191,14 @@ fn native_non_wav_conversion_mode_requires_ffmpeg_when_enabled() {
     assert!(matches!(
         error,
         AudioPreparationError::MissingFfmpeg {
-            backend: BackendKind::Native
+            backend: BackendKind::Native,
+            ..
         }
     ));
 }
 
 #[test]
+#[cfg(not(target_os = "macos"))]
 fn native_qta_input_is_recognized_and_reaches_ffmpeg_conversion() {
     let temp = tempfile::tempdir().unwrap();
     let input = temp.path().join("sample.qta");
@@ -213,9 +216,88 @@ fn native_qta_input_is_recognized_and_reaches_ffmpeg_conversion() {
     assert!(matches!(
         error,
         AudioPreparationError::MissingFfmpeg {
-            backend: BackendKind::Native
+            backend: BackendKind::Native,
+            ..
         }
     ));
+}
+
+// On macOS these same inputs reach the afconvert fallback instead of erroring
+// with MissingFfmpeg -- see the macos-only tests below (`native_non_wav_*` /
+// `native_qta_*` counterparts) that assert the conversion actually happens.
+#[test]
+#[cfg(target_os = "macos")]
+fn native_non_wav_conversion_falls_back_to_afconvert_when_ffmpeg_absent() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("sample.mp3");
+    fs::write(&input, b"mock bytes, not a real mp3").unwrap();
+
+    let error = prepare_audio_input(
+        &input,
+        &AudioPreparationOptions::new(BackendKind::Native).with_native_non_wav_conversion(true),
+    )
+    .unwrap_err();
+
+    // Reaches afconvert (present at /usr/bin/afconvert on every macOS
+    // install) and fails there because the fixture bytes are not a real MP3
+    // stream -- proof the fallback is wired up rather than short-circuiting
+    // to MissingFfmpeg.
+    assert!(matches!(
+        error,
+        AudioPreparationError::ConversionFailed { tool, .. } if tool == "afconvert"
+    ));
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn native_qta_input_reaches_afconvert_conversion() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("sample.qta");
+    fs::write(&input, b"mock bytes, not a real mov").unwrap();
+
+    let error = prepare_audio_input(
+        &input,
+        &AudioPreparationOptions::new(BackendKind::Native).with_native_non_wav_conversion(true),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        AudioPreparationError::ConversionFailed { tool, .. } if tool == "afconvert"
+    ));
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn native_m4a_input_converts_via_afconvert_without_ffmpeg() {
+    let fixture_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .unwrap()
+        .join("fixtures");
+    let temp = tempfile::tempdir().unwrap();
+    let m4a = temp.path().join("jfk.m4a");
+    let status = std::process::Command::new("/usr/bin/afconvert")
+        .arg("-f")
+        .arg("m4af")
+        .arg("-d")
+        .arg("aac")
+        .arg(fixture_dir.join("jfk.wav"))
+        .arg(&m4a)
+        .status()
+        .expect("afconvert must be available to build the m4a fixture");
+    assert!(status.success());
+
+    let prepared = prepare_audio_input(
+        &m4a,
+        &AudioPreparationOptions::new(BackendKind::Native).with_native_non_wav_conversion(true),
+    )
+    .expect("afconvert fallback should decode a real m4a without ffmpeg configured");
+
+    assert!(prepared.is_converted());
+    let bytes = fs::read(prepared.path()).unwrap();
+    assert_eq!(&bytes[0..4], b"RIFF");
+    assert_eq!(&bytes[8..12], b"WAVE");
 }
 
 fn write_test_wav(path: &Path, sample_rate: u32, channels: u16, bits_per_sample: u16, frames: u32) {

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1659,6 +1659,13 @@ impl IntoResponse for ApiError {
             ),
         };
 
+        // Log every failed request to stderr (captured in daemon.log by the
+        // desktop sidecar) with the status and message that also went out in
+        // the HTTP response body. Before this, a failing request left no
+        // trace in the daemon log at all -- only the one-line startup banner
+        // -- making field reports impossible to diagnose from logs alone.
+        eprintln!("openasr-server: request failed status={status} message={message}");
+
         (
             status,
             Json(ErrorResponse {


### PR DESCRIPTION
## Summary

- Fall back to the macOS system `/usr/bin/afconvert` for non-WAV audio conversion when ffmpeg is not configured and not found on PATH, instead of failing the transcription request outright.
- Fix the production WAV reader (`api::audio_io`) to accept `WAVE_FORMAT_EXTENSIBLE` fmt chunks (unwrapping the SubFormat GUID) -- afconvert always emits this extended chunk even for plain mono PCM16, so without this fix the afconvert fallback would still produce a WAV the backend rejected.
- Log every failed transcription request's status and message to stderr so `daemon.log` captures the failure, instead of only the one-line startup banner.

## Why

A fresh macOS install with no Homebrew/ffmpeg cannot transcribe non-WAV uploads (e.g. `.m4a` from Voice Memos): the request fails with `MissingFfmpeg`, and the daemon log has zero trace of what happened. macOS ships `afconvert` (Core Audio CLI) on every install, so it can serve as a no-install-required fallback for the common formats (m4a/mp4, mp3, mov/qta).

## Changes

- `crates/openasr-core/src/audio/prepare.rs`: generalize the ffmpeg-only conversion path into a `ConversionTool` enum (`Ffmpeg` / macOS-only `Afconvert`); resolve afconvert as a fallback only when `ffmpeg_bin` is unresolved (explicit config / `OPENASR_FFMPEG_BIN` / PATH ffmpeg still take priority, unchanged); update error messages to no longer claim ffmpeg is the only fix on macOS.
- `crates/openasr-core/src/audio/errors.rs`: generalize `FfmpegFailed`/`FfmpegSpawn` into tool-attributed `ConversionFailed`/`ConversionSpawn`; `MissingFfmpeg` now carries a platform-aware hint.
- `crates/openasr-core/src/api/audio_io.rs`: unwrap `WAVE_FORMAT_EXTENSIBLE` fmt chunks to the underlying PCM/float subformat so afconvert-produced (and any other extensible-format) WAVs are accepted.
- `crates/openasr-core/src/audio/tests.rs`: macOS-only tests exercising the afconvert fallback (reaches conversion for mp3/qta, and an end-to-end real m4a decode); non-macOS tests keep asserting `MissingFfmpeg`.
- `crates/openasr-server/src/lib.rs`: log `status` + `message` for every failed API response to stderr.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2052 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources ok; pre-existing duplicate-version warnings only)

## Manual smoke checks

Reproduced the field report end to end with `PATH=/usr/bin:/bin` (no ffmpeg) and a real `whisper-small` `.oasr` pack:
- Before this change: uploading a real `.m4a` returns `400` with `MissingFfmpeg`, daemon.log has only the startup line.
- After this change: the same `.m4a` upload transcribes correctly via afconvert; `.mov`/`.qta`/`.mp3` also convert successfully. `.webm` (Opus, which afconvert cannot decode) fails with a clear `ConversionFailed` naming `afconvert` and its stderr, and the failure is now logged to daemon.log with status+message.

## Docs updated

- [x] Error message text updated in place (no separate README/docs claims to update for this format-fallback path).
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not add ffmpeg back as a bundled dependency; afconvert is a fallback, not a replacement (it cannot decode Opus/WebM/Ogg Vorbis).
- Does not touch non-macOS platforms; behavior there is unchanged (`cfg(target_os = "macos")` gated).
- Desktop-side error surfacing and daemon.log rotation are handled in a separate, closed-source app-repo change.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- root-cause investigation, implementation, and test authoring were done with Claude Code assistance; I reviewed and verified all of it, including empirically confirming the afconvert format matrix and the WAVE_FORMAT_EXTENSIBLE parsing bug.