### PR TITLE
feat(server): add agent skill and loopback API keys (#29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,7 @@ version = "0.1.8"
 dependencies = [
  "cc",
  "ed25519-dalek",
+ "getrandom 0.3.4",
  "libc",
  "matrixmultiply",
  "memmap2",

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ network-free output for CI.
 | `transcribe <inputs>...` | Transcribe files or directories. `--benchmark` prints run timing instead of the transcript; aliased as `t`. |
 | `live` | Microphone / system-audio capture; emits frame-synchronous streaming partials for packs that declare streaming, else final-per-utterance. |
 | `serve` | Local OpenAI-compatible HTTP API; secured remote serving via TLS + pairing. |
+| `apikey create/list/revoke` | Manage local API keys for `serve`; once one exists, loopback callers must send it too (see [Agent Integration](docs/AGENT_INTEGRATION.md)). |
 | `search [query]` / `pull <id>` | Browse the model catalog / download and install a pack. |
 | `list` / `show <id-or-pack>` / `rm <id>` | List installed packs / show catalog or pack details / remove a pack. |
 | `verify <pack.oasr>` | Probe a local pack's ggml integrity (no inference, no download). |
@@ -255,8 +256,13 @@ Key constraints:
   history is local-only and governed by the `history_retention` preference
   (default keeps the last 5 entries; `off` disables it). See
   [SECURITY](SECURITY.md) for what's stored.
+- The default `--addr` (`127.0.0.1:8080`) is a fixed, predictable port so
+  scripts and coding agents can rely on it. Loopback callers are trusted by
+  default (no key required); `openasr apikey create` opts into requiring a
+  bearer key even on loopback -- see [Agent Integration](docs/AGENT_INTEGRATION.md).
 
-Non-loopback binds are rejected unless launched with HTTPS/WSS and pairing auth:
+Non-loopback binds are rejected unless launched with HTTPS/WSS and pairing auth
+(an API key never substitutes for this -- it is a loopback-only escape hatch):
 
 ```bash
 export OPENASR_PAIRING_ADMIN_TOKEN="$(openssl rand -hex 32)"

--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -469,8 +469,12 @@ pub(crate) enum Command {
     },
     /// Start the OpenAI-compatible API server.
     ///
-    /// Defaults to local HTTP on 127.0.0.1. Non-loopback remote serving must
-    /// use HTTPS/WSS and pairing auth.
+    /// Defaults to local HTTP on 127.0.0.1:8080 (a fixed, predictable port so
+    /// scripts and coding agents can rely on it). Loopback callers are trusted
+    /// by default (no key required); once an API key exists (`openasr apikey
+    /// create`) loopback requests must send it too. Non-loopback remote
+    /// serving must always use HTTPS/WSS and pairing auth, regardless of API
+    /// keys.
     Serve {
         /// Address to bind.
         #[arg(long, default_value = "127.0.0.1:8080", env = "OPENASR_ADDR")]
@@ -496,6 +500,34 @@ pub(crate) enum Command {
         /// Local `.oasr` runtime pack file for native backend transcription.
         #[arg(long)]
         model_pack: Option<PathBuf>,
+    },
+    /// Manage local API keys for `openasr serve` (`Authorization: Bearer
+    /// <key>`). Loopback callers need no key by default; creating one forces
+    /// every loopback request to present it too. Only a key's hash is
+    /// persisted -- the plaintext is shown once, at creation.
+    Apikey {
+        #[command(subcommand)]
+        command: ApiKeyCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ApiKeyCommand {
+    /// Create a new API key. Prints the plaintext key exactly once -- it is
+    /// not recoverable afterward; only its hash is persisted.
+    Create {
+        /// Optional label to tell keys apart in `apikey list` (for example the
+        /// agent or host it is issued to).
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// List issued API keys (id, name, creation time, key preview). Never
+    /// prints a full key.
+    List,
+    /// Revoke (delete) an API key by id.
+    Revoke {
+        /// Key id, as printed by `apikey list` (e.g. key_1a2b3c4d5e6f7a8b).
+        id: String,
     },
 }
 

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -215,6 +215,7 @@ async fn run() -> Result<()> {
             consent: consent::PullConsent::resolve(yes, offline),
         }),
         Command::Speaker { command } => speaker_command(command),
+        Command::Apikey { command } => apikey_command(command),
         Command::BenchSuite {
             config,
             baseline,
@@ -675,6 +676,81 @@ fn enroll_speaker(input: &Path, name: &str, match_similarity: Option<f32>) -> Re
         input.display(),
         path.display()
     );
+    Ok(())
+}
+
+fn apikey_command(command: ApiKeyCommand) -> Result<()> {
+    match command {
+        ApiKeyCommand::Create { name } => apikey_create(name),
+        ApiKeyCommand::List => apikey_list(),
+        ApiKeyCommand::Revoke { id } => apikey_revoke(&id),
+    }
+}
+
+fn api_key_store_path() -> Result<PathBuf> {
+    openasr_core::apikeys::api_key_store_path()
+        .context("Could not determine the OpenASR home directory for the API key store.")
+}
+
+fn apikey_create(name: Option<String>) -> Result<()> {
+    let path = api_key_store_path()?;
+    let mut store = openasr_core::apikeys::ApiKeyStore::load(&path)
+        .map_err(|reason| anyhow!("Could not read API key store: {reason}."))?;
+    let (token, record) = store
+        .create(name)
+        .map_err(|reason| anyhow!("Could not create API key: {reason}."))?;
+    store
+        .save(&path)
+        .map_err(|reason| anyhow!("Could not save API key store: {reason}."))?;
+    println!(
+        "Created API key {} ({}).\nThis is the ONLY time the full key is shown -- store it now:\n\n  {token}\n\nOnce any key exists, `openasr serve` requires it (Authorization: Bearer <key>) even on 127.0.0.1. Run `openasr apikey revoke {}` to remove it.",
+        record.id,
+        record.name.as_deref().unwrap_or("unnamed"),
+        record.id
+    );
+    Ok(())
+}
+
+fn apikey_list() -> Result<()> {
+    let path = api_key_store_path()?;
+    let store = openasr_core::apikeys::ApiKeyStore::load(&path)
+        .map_err(|reason| anyhow!("Could not read API key store: {reason}."))?;
+    if store.keys.is_empty() {
+        println!(
+            "No API keys configured; `openasr serve` trusts every loopback (127.0.0.1) caller. Run `openasr apikey create` to require one."
+        );
+        return Ok(());
+    }
+    println!("{:<22} {:<20} {:<26} PREVIEW", "ID", "NAME", "CREATED AT");
+    for key in &store.keys {
+        println!(
+            "{:<22} {:<20} {:<26} {}",
+            key.id,
+            key.name.as_deref().unwrap_or("-"),
+            key.created_at,
+            key.token_preview
+        );
+    }
+    Ok(())
+}
+
+fn apikey_revoke(id: &str) -> Result<()> {
+    let path = api_key_store_path()?;
+    let mut store = openasr_core::apikeys::ApiKeyStore::load(&path)
+        .map_err(|reason| anyhow!("Could not read API key store: {reason}."))?;
+    if !store.revoke(id) {
+        bail!("No API key with id '{id}'. Run `openasr apikey list` to see current keys.");
+    }
+    store
+        .save(&path)
+        .map_err(|reason| anyhow!("Could not save API key store: {reason}."))?;
+    if store.keys.is_empty() {
+        println!(
+            "Revoked API key {id}. No keys remain; `openasr serve` now trusts every loopback caller again."
+        );
+    } else {
+        println!("Revoked API key {id}.");
+    }
     Ok(())
 }
 

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -474,8 +474,9 @@ pub(super) async fn serve(
         );
     }
     let ffmpeg_bin = resolve_ffmpeg_bin(runtime_paths.ffmpeg_bin.clone(), &config);
+    let api_key_hashes = load_active_api_key_hashes()?;
 
-    let mut launch_options = serve_launch_options(addr, security)?;
+    let mut launch_options = serve_launch_options(addr, security, api_key_hashes)?;
     // Persist pairing credentials/revocations under OPENASR_HOME so a paired
     // remote server keeps its devices across the restarts the desktop performs on
     // every daemon start (no-op for the local non-pairing UI daemon).
@@ -494,6 +495,19 @@ pub(super) async fn serve(
     .await
 }
 
+/// Reads currently-active API key hashes from the local `apikeys.json` store
+/// (see `openasr apikey create/list/revoke`). An unreadable store fails
+/// closed (serve refuses to start) rather than silently opening loopback
+/// access; a missing store is just "no keys yet" and returns empty.
+fn load_active_api_key_hashes() -> Result<Vec<String>> {
+    let Some(path) = openasr_core::apikeys::api_key_store_path() else {
+        return Ok(Vec::new());
+    };
+    let store = openasr_core::apikeys::ApiKeyStore::load(&path)
+        .with_context(|| format!("Could not load API key store at {}", path.display()))?;
+    Ok(store.active_token_hashes())
+}
+
 #[derive(Debug, Clone, Default)]
 pub(super) struct ServeSecurityOptions {
     pub tls_self_signed: bool,
@@ -504,6 +518,7 @@ pub(super) struct ServeSecurityOptions {
 fn serve_launch_options(
     addr: SocketAddr,
     security: ServeSecurityOptions,
+    api_key_hashes: Vec<String>,
 ) -> Result<openasr_server::ServerLaunchOptions> {
     let tls = if security.tls_self_signed {
         openasr_server::ServerTlsConfig::self_signed(default_tls_subject_alt_names(
@@ -528,6 +543,15 @@ fn serve_launch_options(
                 bail!("Pairing administrator token in ${env_name} must not be empty.");
             }
             openasr_server::ServerAuth::pairing(token)
+        }
+        // Local API keys (`openasr apikey create`) are a loopback-only escape
+        // hatch: they let a trusted-but-explicit caller (a coding agent, a
+        // script) require a bearer credential even from 127.0.0.1, where the
+        // server otherwise trusts every caller by default. They must never
+        // relax the non-loopback path, which stays fail-closed on TLS +
+        // device pairing regardless of any configured key.
+        None if addr.ip().is_loopback() => {
+            openasr_server::ServerAuth::from_token_hashes(api_key_hashes)
         }
         None => openasr_server::ServerAuth::disabled(),
     };
@@ -1476,6 +1500,7 @@ mod tests {
                     pairing_admin_token_env: Some("OPENASR_TEST_PAIRING_TOKEN".to_string()),
                     ..Default::default()
                 },
+                Vec::new(),
             )
             .expect_err("missing env must fail")
             .to_string();
@@ -1488,6 +1513,7 @@ mod tests {
                     pairing_admin_token_env: Some("OPENASR_TEST_PAIRING_TOKEN".to_string()),
                     ..Default::default()
                 },
+                Vec::new(),
             )
             .expect_err("empty env must fail")
             .to_string();
@@ -1508,6 +1534,7 @@ mod tests {
                     pairing_admin_token_env: Some("OPENASR_TEST_PAIRING_TOKEN_OK".to_string()),
                     ..Default::default()
                 },
+                Vec::new(),
             )
             .expect("serve launch options")
         };
@@ -1568,5 +1595,91 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(approved.status(), StatusCode::OK);
+    }
+
+    async fn models_status(app: axum::Router, bearer: Option<&str>) -> StatusCode {
+        let mut request = Request::builder().method("GET").uri("/v1/models");
+        if let Some(bearer) = bearer {
+            request = request.header(header::AUTHORIZATION, format!("Bearer {bearer}"));
+        }
+        app.oneshot(request.body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+            .status()
+    }
+
+    #[tokio::test]
+    async fn serve_loopback_without_configured_keys_leaves_auth_disabled() {
+        let launch_options = serve_launch_options(
+            "127.0.0.1:8080".parse().unwrap(),
+            ServeSecurityOptions::default(),
+            Vec::new(),
+        )
+        .expect("serve launch options");
+        let app = openasr_server::app_with_runtime_and_distribution_and_launch_options(
+            openasr_server::ServerRuntime::default(),
+            openasr_server::DistributionRuntime::default(),
+            launch_options,
+        );
+
+        assert_eq!(models_status(app, None).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn serve_loopback_with_configured_key_requires_matching_bearer() {
+        let key_hash = openasr_core::apikeys::hash_api_key_token("oasr_sk_test-agent-key");
+        let launch_options = serve_launch_options(
+            "127.0.0.1:8080".parse().unwrap(),
+            ServeSecurityOptions::default(),
+            vec![key_hash],
+        )
+        .expect("serve launch options");
+        let build_app = || {
+            openasr_server::app_with_runtime_and_distribution_and_launch_options(
+                openasr_server::ServerRuntime::default(),
+                openasr_server::DistributionRuntime::default(),
+                launch_options.clone(),
+            )
+        };
+
+        assert_eq!(
+            models_status(build_app(), None).await,
+            StatusCode::UNAUTHORIZED,
+            "loopback must require the key once one is configured"
+        );
+        assert_eq!(
+            models_status(build_app(), Some("wrong-key")).await,
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            models_status(build_app(), Some("oasr_sk_test-agent-key")).await,
+            StatusCode::OK
+        );
+    }
+
+    #[tokio::test]
+    async fn serve_non_loopback_ignores_configured_keys_without_pairing() {
+        let key_hash = openasr_core::apikeys::hash_api_key_token("oasr_sk_test-agent-key");
+        let launch_options = serve_launch_options(
+            "0.0.0.0:8080".parse().unwrap(),
+            ServeSecurityOptions::default(),
+            vec![key_hash],
+        )
+        .expect("serve launch options");
+        let app = openasr_server::app_with_runtime_and_distribution_and_launch_options(
+            openasr_server::ServerRuntime::default(),
+            openasr_server::DistributionRuntime::default(),
+            launch_options,
+        );
+
+        // A locally-created API key must never substitute for device pairing
+        // on a non-loopback bind: `validate_listen_security` is what actually
+        // fail-closes this bind (no TLS/auth), but at the auth-construction
+        // level the key must not have been wired in either.
+        assert_eq!(
+            models_status(app, Some("oasr_sk_test-agent-key")).await,
+            StatusCode::OK,
+            "non-loopback must not honor a loopback-only API key"
+        );
     }
 }

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -474,7 +474,17 @@ pub(super) async fn serve(
         );
     }
     let ffmpeg_bin = resolve_ffmpeg_bin(runtime_paths.ffmpeg_bin.clone(), &config);
-    let api_key_hashes = load_active_api_key_hashes()?;
+    let api_key_hashes = if supervised_daemon_launch() {
+        // The desktop supervisor's managed daemon (marked by the instance-token
+        // env it always sets) has its own trust model: the UI talks to its
+        // daemon over loopback without bearer headers, and remote access goes
+        // through TLS + pairing. Enforcing user-created API keys here would
+        // lock the desktop app out of its own daemon, so keys apply only to
+        // manually-launched `openasr serve`.
+        Vec::new()
+    } else {
+        load_active_api_key_hashes()?
+    };
 
     let mut launch_options = serve_launch_options(addr, security, api_key_hashes)?;
     // Persist pairing credentials/revocations under OPENASR_HOME so a paired
@@ -493,6 +503,15 @@ pub(super) async fn serve(
         launch_options,
     )
     .await
+}
+
+/// True when this `serve` process was launched by the desktop supervisor,
+/// which always sets the server instance-token env for its managed daemon
+/// (`OPENASR_SERVER_INSTANCE_TOKEN`, consumed by `openasr-server` for
+/// same-port restart identity).
+fn supervised_daemon_launch() -> bool {
+    env::var_os("OPENASR_SERVER_INSTANCE_TOKEN")
+        .is_some_and(|value| !value.to_string_lossy().trim().is_empty())
 }
 
 /// Reads currently-active API key hashes from the local `apikeys.json` store
@@ -1595,6 +1614,18 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(approved.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn supervised_daemon_launch_detects_instance_token_env() {
+        with_env_lock(|| {
+            let _removed = EnvVarRestore::remove("OPENASR_SERVER_INSTANCE_TOKEN");
+            assert!(!supervised_daemon_launch());
+            let _blank = EnvVarRestore::set("OPENASR_SERVER_INSTANCE_TOKEN", "  ");
+            assert!(!supervised_daemon_launch());
+            let _set = EnvVarRestore::set("OPENASR_SERVER_INSTANCE_TOKEN", "desktop-token");
+            assert!(supervised_daemon_launch());
+        });
     }
 
     async fn models_status(app: axum::Router, bearer: Option<&str>) -> StatusCode {

--- a/crates/openasr-core/Cargo.toml
+++ b/crates/openasr-core/Cargo.toml
@@ -34,6 +34,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-cli
 
 [dependencies]
 ed25519-dalek.workspace = true
+getrandom.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/openasr-core/src/apikeys.rs
+++ b/crates/openasr-core/src/apikeys.rs
@@ -1,0 +1,325 @@
+//! Local server API-key store.
+//!
+//! `openasr serve` trusts loopback (127.0.0.1) callers by default (no key
+//! required) -- this store backs the *opt-in* escape hatch for callers (coding
+//! agents, scripts) that want an explicit bearer credential even on loopback.
+//! Only a SHA-256 hash of each key is ever persisted; the plaintext token is
+//! generated once by `ApiKeyStore::create` and must be shown to the caller
+//! immediately -- it cannot be recovered from the store afterward.
+//!
+//! The hash algorithm here (SHA-256 over the raw token bytes, lowercase hex)
+//! must match `openasr_server::ServerAuth`'s bearer-token hashing, since the
+//! server compares an incoming `Authorization: Bearer <token>` header against
+//! the hashes persisted here. `openasr-server`'s test suite asserts the two
+//! stay in lockstep.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::realtime::events::realtime_timestamp_now;
+
+/// Version of the on-disk API-key store.
+pub const API_KEY_STORE_VERSION: u32 = 1;
+/// Plaintext token prefix, so a leaked/pasted key is recognizable at a glance.
+pub const API_KEY_TOKEN_PREFIX: &str = "oasr_sk_";
+/// Public key-record id prefix (distinct from the secret token itself).
+pub const API_KEY_ID_PREFIX: &str = "key_";
+/// Random key material length in bytes (before hex-encoding).
+const API_KEY_TOKEN_RANDOM_BYTES: usize = 32;
+/// Env var override for the store path, mirroring
+/// `diarize::enrollment::VOICEPRINT_STORE_ENV`, so tests do not touch a real
+/// `OPENASR_HOME`.
+pub const API_KEY_STORE_ENV: &str = "OPENASR_API_KEYS_PATH";
+
+static API_KEY_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Error)]
+pub enum ApiKeyError {
+    #[error("unsupported API key store version {found}; expected {expected}")]
+    UnsupportedVersion { found: u32, expected: u32 },
+    #[error("could not read API key store {path}: {source}")]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("could not parse API key store {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    #[error("could not create API key store directory {path}: {source}")]
+    CreateDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("could not write API key store {path}: {source}")]
+    Write {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("could not serialize API key store: {0}")]
+    Serialize(serde_json::Error),
+    #[error("could not generate random key material: {0}")]
+    Random(getrandom::Error),
+    #[error("API key not found: {0}")]
+    NotFound(String),
+}
+
+/// One issued API key. Only the hash is load-bearing for auth; `token_preview`
+/// is a display-only fragment (prefix + first 4 hex chars) so a user can tell
+/// keys apart in `openasr apikey list` without re-displaying the secret.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApiKeyRecord {
+    pub id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    pub created_at: String,
+    pub token_hash: String,
+    pub token_preview: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApiKeyStore {
+    pub version: u32,
+    #[serde(default)]
+    pub keys: Vec<ApiKeyRecord>,
+}
+
+impl Default for ApiKeyStore {
+    fn default() -> Self {
+        Self {
+            version: API_KEY_STORE_VERSION,
+            keys: Vec::new(),
+        }
+    }
+}
+
+/// Canonical store location: `OPENASR_API_KEYS_PATH` when set, otherwise
+/// `openasr_home()/apikeys.json`.
+pub fn api_key_store_path() -> Option<PathBuf> {
+    std::env::var(API_KEY_STORE_ENV)
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| {
+            crate::openasr_home()
+                .ok()
+                .map(|home| home.join("apikeys.json"))
+        })
+}
+
+/// SHA-256 hex digest of a raw token. Must match
+/// `openasr_server`'s internal `bearer_token_hash`.
+pub fn hash_api_key_token(token: &str) -> String {
+    let digest = Sha256::digest(token.trim().as_bytes());
+    hex_encode(&digest)
+}
+
+impl ApiKeyStore {
+    pub fn load(path: &Path) -> Result<Self, ApiKeyError> {
+        if !path.is_file() {
+            return Ok(Self::default());
+        }
+        let bytes = fs::read(path).map_err(|source| ApiKeyError::Read {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let store: Self = serde_json::from_slice(&bytes).map_err(|source| ApiKeyError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        store.validate_version()?;
+        Ok(store)
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), ApiKeyError> {
+        self.validate_version()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| ApiKeyError::CreateDir {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+            set_owner_only_dir_permissions(parent);
+        }
+        let json = serde_json::to_vec_pretty(self).map_err(ApiKeyError::Serialize)?;
+        crate::atomic_file::write_owner_only_file_atomically(path, &json).map_err(|source| {
+            ApiKeyError::Write {
+                path: path.to_path_buf(),
+                source,
+            }
+        })
+    }
+
+    /// Generates a new key, appends it (hash-only) to the store, and returns
+    /// the plaintext token alongside its record. Callers must persist the
+    /// store (`save`) and display the plaintext exactly once -- it is not
+    /// recoverable afterward.
+    pub fn create(&mut self, name: Option<String>) -> Result<(String, ApiKeyRecord), ApiKeyError> {
+        let token = format!(
+            "{API_KEY_TOKEN_PREFIX}{}",
+            random_hex(API_KEY_TOKEN_RANDOM_BYTES).map_err(ApiKeyError::Random)?
+        );
+        let preview_len = API_KEY_TOKEN_PREFIX.len() + 4;
+        let token_preview = token.chars().take(preview_len).collect::<String>() + "...";
+        let record = ApiKeyRecord {
+            id: generate_key_id(),
+            name: name
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+            created_at: realtime_timestamp_now(),
+            token_hash: hash_api_key_token(&token),
+            token_preview,
+        };
+        self.keys.push(record.clone());
+        Ok((token, record))
+    }
+
+    /// Removes a key by id. Returns `true` if a key was found and removed.
+    pub fn revoke(&mut self, id: &str) -> bool {
+        let before = self.keys.len();
+        self.keys.retain(|key| key.id != id);
+        self.keys.len() != before
+    }
+
+    /// Hashes of all currently-active keys, for wiring into
+    /// `openasr_server::ServerAuth::from_token_hashes`.
+    pub fn active_token_hashes(&self) -> Vec<String> {
+        self.keys.iter().map(|key| key.token_hash.clone()).collect()
+    }
+
+    fn validate_version(&self) -> Result<(), ApiKeyError> {
+        if self.version == API_KEY_STORE_VERSION {
+            Ok(())
+        } else {
+            Err(ApiKeyError::UnsupportedVersion {
+                found: self.version,
+                expected: API_KEY_STORE_VERSION,
+            })
+        }
+    }
+}
+
+fn generate_key_id() -> String {
+    let counter = API_KEY_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut hasher = Sha256::new();
+    hasher.update(realtime_timestamp_now().as_bytes());
+    hasher.update(counter.to_le_bytes());
+    hasher.update(std::process::id().to_le_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("{API_KEY_ID_PREFIX}{}", &digest[..16])
+}
+
+fn random_hex(byte_count: usize) -> Result<String, getrandom::Error> {
+    let mut bytes = vec![0u8; byte_count];
+    getrandom::fill(&mut bytes)?;
+    Ok(hex_encode(&bytes))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn set_owner_only_dir_permissions(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_returns_prefixed_token_and_stores_only_hash() {
+        let mut store = ApiKeyStore::default();
+        let (token, record) = store.create(Some("agent-laptop".to_string())).unwrap();
+        assert!(token.starts_with(API_KEY_TOKEN_PREFIX));
+        assert_eq!(token.len(), API_KEY_TOKEN_PREFIX.len() + 64);
+        assert_eq!(record.token_hash, hash_api_key_token(&token));
+        assert_ne!(record.token_hash, token, "must never store the plaintext");
+        assert_eq!(record.name.as_deref(), Some("agent-laptop"));
+        assert_eq!(store.keys.len(), 1);
+        assert_eq!(store.active_token_hashes(), vec![record.token_hash]);
+    }
+
+    #[test]
+    fn create_trims_and_drops_empty_name() {
+        let mut store = ApiKeyStore::default();
+        let (_, record) = store.create(Some("  ".to_string())).unwrap();
+        assert_eq!(record.name, None);
+    }
+
+    #[test]
+    fn revoke_removes_matching_key_only() {
+        let mut store = ApiKeyStore::default();
+        let (_, first) = store.create(None).unwrap();
+        let (_, second) = store.create(None).unwrap();
+
+        assert!(store.revoke(&first.id));
+        assert_eq!(store.keys.len(), 1);
+        assert_eq!(store.keys[0].id, second.id);
+        assert!(!store.revoke("key_doesnotexist"));
+    }
+
+    #[test]
+    fn round_trips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("apikeys.json");
+        let mut store = ApiKeyStore::default();
+        store.create(Some("ci".to_string())).unwrap();
+        store.save(&path).unwrap();
+
+        let loaded = ApiKeyStore::load(&path).unwrap();
+        assert_eq!(loaded, store);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+    }
+
+    #[test]
+    fn missing_store_loads_as_empty_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        let store = ApiKeyStore::load(&path).unwrap();
+        assert_eq!(store, ApiKeyStore::default());
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("apikeys.json");
+        fs::write(&path, br#"{"version":99,"keys":[]}"#).unwrap();
+        let error = ApiKeyStore::load(&path).unwrap_err();
+        assert!(matches!(error, ApiKeyError::UnsupportedVersion { .. }));
+    }
+
+    #[test]
+    fn two_created_keys_have_distinct_ids_and_hashes() {
+        let mut store = ApiKeyStore::default();
+        let (token_a, record_a) = store.create(None).unwrap();
+        let (token_b, record_b) = store.create(None).unwrap();
+        assert_ne!(token_a, token_b);
+        assert_ne!(record_a.id, record_b.id);
+        assert_ne!(record_a.token_hash, record_b.token_hash);
+    }
+}

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -13,6 +13,7 @@ mod http;
 // (workspace consumers enable the `testing` feature).
 pub mod adapter_pack;
 pub mod api;
+pub mod apikeys;
 mod arch;
 pub(crate) mod audio;
 pub(crate) mod batch;

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -11,7 +11,7 @@ pub(crate) use routes::transcription::*;
 pub(crate) use routes::translation::*;
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     convert::Infallible,
     env,
     ffi::OsStr,
@@ -385,7 +385,7 @@ pub struct ServerAuth {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ServerAuthMode {
     Disabled,
-    StaticBearer { token_hash: String },
+    StaticBearer { token_hashes: HashSet<String> },
     Pairing { admin_token_hash: String },
 }
 
@@ -409,10 +409,26 @@ impl ServerAuth {
         if token.is_empty() {
             return Self::disabled();
         }
+        Self::from_token_hashes([bearer_token_hash(&token)])
+    }
+
+    /// Enforces one of a set of pre-hashed bearer tokens (SHA-256 hex, matching
+    /// `bearer_token_hash`). Used to wire the CLI's persisted API-key store
+    /// (`openasr apikey create/list/revoke`, see `openasr_core::apikeys`) --
+    /// only hashes ever cross the store/serve boundary, never plaintext keys.
+    /// An empty set of hashes disables auth (loopback stays key-free by
+    /// default until at least one key exists).
+    pub fn from_token_hashes(token_hashes: impl IntoIterator<Item = String>) -> Self {
+        let token_hashes: HashSet<String> = token_hashes
+            .into_iter()
+            .map(|hash| hash.trim().to_ascii_lowercase())
+            .filter(|hash| !hash.is_empty())
+            .collect();
+        if token_hashes.is_empty() {
+            return Self::disabled();
+        }
         Self {
-            mode: ServerAuthMode::StaticBearer {
-                token_hash: bearer_token_hash(&token),
-            },
+            mode: ServerAuthMode::StaticBearer { token_hashes },
             pairing: Arc::new(Mutex::new(PairingRegistry::default())),
             pairing_safety_code: None,
         }
@@ -520,8 +536,8 @@ impl ServerAuth {
     fn authorizes(&self, headers: &axum::http::HeaderMap) -> bool {
         match &self.mode {
             ServerAuthMode::Disabled => true,
-            ServerAuthMode::StaticBearer { token_hash } => header_bearer_token(headers)
-                .is_some_and(|token| bearer_token_hash(token) == *token_hash),
+            ServerAuthMode::StaticBearer { token_hashes } => header_bearer_token(headers)
+                .is_some_and(|token| token_hashes.contains(&bearer_token_hash(token))),
             ServerAuthMode::Pairing { admin_token_hash } => header_bearer_token(headers)
                 .is_some_and(|token| {
                     let token_hash = bearer_token_hash(token);

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -42,6 +42,53 @@ fn serve_batch_unavailable_non_retryable_maps_to_503() {
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 }
 
+fn header_map_with_bearer(token: &str) -> axum::http::HeaderMap {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        header::AUTHORIZATION,
+        format!("Bearer {token}").parse().unwrap(),
+    );
+    headers
+}
+
+#[test]
+fn from_token_hashes_authorizes_only_the_matching_token() {
+    let auth = ServerAuth::from_token_hashes([bearer_token_hash("agent-secret")]);
+    assert!(auth.authorizes(&header_map_with_bearer("agent-secret")));
+    assert!(!auth.authorizes(&header_map_with_bearer("wrong-token")));
+    assert!(!auth.authorizes(&axum::http::HeaderMap::new()));
+}
+
+#[test]
+fn from_token_hashes_with_no_hashes_disables_auth() {
+    let auth = ServerAuth::from_token_hashes(Vec::<String>::new());
+    assert!(!auth.is_enabled());
+    // Disabled auth authorizes everyone -- this is the loopback-default-free
+    // state before any `openasr apikey create`.
+    assert!(auth.authorizes(&axum::http::HeaderMap::new()));
+}
+
+#[test]
+fn from_token_hashes_supports_multiple_concurrently_valid_keys() {
+    let auth =
+        ServerAuth::from_token_hashes([bearer_token_hash("key-a"), bearer_token_hash("key-b")]);
+    assert!(auth.authorizes(&header_map_with_bearer("key-a")));
+    assert!(auth.authorizes(&header_map_with_bearer("key-b")));
+    assert!(!auth.authorizes(&header_map_with_bearer("key-c")));
+}
+
+#[test]
+fn core_api_key_hash_matches_server_bearer_hash() {
+    // `openasr-cli` persists `openasr_core::apikeys::ApiKeyStore` hashes and
+    // hands them to `ServerAuth::from_token_hashes`; the two hash functions
+    // must stay identical (SHA-256 hex) or every configured key would
+    // silently stop authorizing at the API boundary.
+    let token = "oasr_sk_test-drift-check-token";
+    let core_hash = openasr_core::apikeys::hash_api_key_token(token);
+    let auth = ServerAuth::from_token_hashes([core_hash]);
+    assert!(auth.authorizes(&header_map_with_bearer(token)));
+}
+
 fn resolved_pull_fixture() -> ResolvedCatalogPull {
     ResolvedCatalogPull {
         requested: "moonshine-tiny:q8".to_string(),

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -94,6 +94,13 @@ openasr apikey revoke key_1a2b3c4d5e6f7a8b
 Revoking the last remaining key returns loopback `serve` to its key-free
 default.
 
+API keys apply to **manually-launched** `openasr serve` only. The desktop
+app's supervisor-managed daemon (identified by the instance-token environment
+variable the supervisor sets when spawning it) is exempt: its UI talks to it
+over loopback without bearer headers, and its remote access is secured by
+TLS + pairing instead -- so creating a key never locks the desktop app out
+of its own daemon.
+
 ### What API keys do not change
 
 A locally-created API key is a **loopback-only** convenience. Binding `serve`

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -1,0 +1,116 @@
+# Agent Integration
+
+How to point a coding agent (Claude Code, Codex, or any other agent that can
+run a shell / call a local HTTP API) at OpenASR. Two independent paths:
+
+1. **Skill + CLI** -- the agent shells out to the `openasr` binary directly.
+   This is the primary, recommended path: no server process, no network
+   surface, works offline.
+2. **Local OpenAI-compatible HTTP API** -- for agents/tools that only speak
+   HTTP (or want a long-lived local daemon instead of spawning a process per
+   request).
+
+Both paths run entirely on-device: no telemetry, no cloud fallback, no
+implicit model download (see [SECURITY](../SECURITY.md) and the repo-root
+"Product principles").
+
+## 1. Skill (CLI) path
+
+The published Skill lives at [`skills/openasr/SKILL.md`](../skills/openasr/SKILL.md)
+and follows the [`vercel-labs/skills`](https://github.com/vercel-labs/skills)
+convention: any file host on GitHub is a valid registry entry, no separate
+publishing step. Install it into a project with:
+
+```bash
+npx skills add QuintinShaw/openasr --skill openasr --agent claude-code
+# or interactively: npx skills add QuintinShaw/openasr
+```
+
+This copies `SKILL.md` into the agent's local skills directory (for example
+`.claude/skills/openasr/SKILL.md` for Claude Code). Verified locally with
+`npx skills add <path-to-checkout> --skill openasr --agent claude-code`, which
+installs to `./.claude/skills/openasr/SKILL.md`. The Skill teaches the
+agent the `openasr` CLI surface: `transcribe`, `live`, `search`/`pull`/`list`,
+`serve`, and `apikey`, including expected output shapes and common failure
+modes (missing model, `--offline` fail-closed, non-WAV without `ffmpeg`).
+
+Prerequisite: the `openasr` binary must be on `PATH` (`cargo install
+--path crates/openasr-cli` from a source checkout, or a released binary).
+The Skill itself does not install OpenASR.
+
+## 2. Local HTTP API path
+
+```bash
+openasr serve --addr 127.0.0.1:8080 --backend native \
+  --model-pack /path/to/model.oasr --model your-runtime-model-id
+```
+
+`--addr` defaults to `127.0.0.1:8080` -- a fixed, predictable port on purpose,
+so an agent (or a script) can hardcode the base URL instead of discovering it.
+This is independent of the desktop app's sidecar, which negotiates its own
+port via a local handshake file and is unaffected by this default.
+
+### Loopback trust and API keys
+
+Loopback (`127.0.0.1`) callers are trusted by default: no `Authorization`
+header is required. That is deliberate for the common case (an agent running
+on the same machine). If you want an explicit credential anyway -- for
+example a shared dev box, or just to be strict about who can call the daemon
+-- create a key:
+
+```bash
+openasr apikey create --name "claude-code-laptop"
+# Created API key key_1a2b3c4d5e6f7a8b (claude-code-laptop).
+# This is the ONLY time the full key is shown -- store it now:
+#
+#   oasr_sk_<64 hex chars>
+#
+# Once any key exists, `openasr serve` requires it (Authorization: Bearer <key>)
+# even on 127.0.0.1. Run `openasr apikey revoke key_1a2b3c4d5e6f7a8b` to remove it.
+```
+
+Only a SHA-256 hash of the key is ever written to disk
+(`~/.openasr/apikeys.json`, permissions `0600`); the plaintext is shown
+exactly once, at creation, and cannot be recovered afterward. From that point
+on, every loopback request to `serve` -- including `/v1/audio/transcriptions`
+-- must carry `Authorization: Bearer <key>`, or it gets `401`. `GET /health`
+stays unauthenticated (used for liveness probes).
+
+```bash
+curl -s http://127.0.0.1:8080/v1/audio/transcriptions \
+  -H "Authorization: Bearer oasr_sk_<...>" \
+  -F file=@audio.wav \
+  -F model=your-runtime-model-id \
+  -F response_format=verbose_json
+```
+
+Manage keys with:
+
+```bash
+openasr apikey list      # id, name, created-at, key preview (never the full key)
+openasr apikey revoke key_1a2b3c4d5e6f7a8b
+```
+
+Revoking the last remaining key returns loopback `serve` to its key-free
+default.
+
+### What API keys do not change
+
+A locally-created API key is a **loopback-only** convenience. Binding `serve`
+to a non-loopback address (remote/network access) still requires HTTPS/WSS
+and device pairing exactly as before (`--tls-self-signed
+--pairing-admin-token-env ...`); an API key never substitutes for that, and
+non-loopback binds ignore any configured keys entirely. See the "Non-loopback
+binds" section of the root [README](../README.md#local-http-api) for the
+remote-serving flow.
+
+### Endpoints an agent typically needs
+
+- `GET /health` -- liveness + server identity, unauthenticated.
+- `GET /v1/models` -- installed packs.
+- `POST /v1/audio/transcriptions` -- OpenAI-compatible transcription
+  (multipart `file` + `model`; `response_format` of `json`, `text`, `srt`,
+  `vtt`, `verbose_json`, or `markdown`).
+
+See the root [README](../README.md#local-http-api) for the full request-field
+reference (longform/segment options, phrase-bias/hotword fields, streaming).

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -18,6 +18,7 @@ contributors -- crate relationships, the audio-to-transcript pipeline, and the
 | [Known Limitations](KNOWN_LIMITATIONS.md) | Current user-visible limits: no public binary release yet, `.oasr`-only native packs, gated streaming/diarization (declared/capability packs only), generic accelerator selection, and internal-only benchmarks. |
 | [FAQ](FAQ.md) | Current-behavior questions: what OpenASR is, which families run, which backends are active, and the conservative offline transcription lane. |
 | [Releasing](../RELEASING.md) | The commit-driven release process: the single workspace version, `scripts/bump-version.sh`, and the version-triggered `Release core` workflow. |
+| [Agent Integration](AGENT_INTEGRATION.md) | How a coding agent uses OpenASR: the `skills/openasr` Skill (CLI path) and the local OpenAI-compatible HTTP API, including `openasr apikey` for opt-in loopback authentication. |
 
 ## Format contracts (`docs/format/`)
 

--- a/skills/openasr/SKILL.md
+++ b/skills/openasr/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: openasr
+description: Transcribe audio, dictate, and manage local speech-to-text models with the OpenASR CLI (`openasr`) -- local-first, no cloud calls, no telemetry. Use this whenever the user asks to transcribe an audio/video file, capture a microphone/system-audio dictation, list or install ASR models, or run a local OpenAI-compatible transcription API.
+license: Apache-2.0
+---
+
+# OpenASR
+
+OpenASR is a local-first speech-to-text CLI (`openasr`) and local HTTP server.
+Everything below runs on-device: no network calls unless you explicitly
+`pull` a model, no telemetry, no cloud fallback.
+
+Prerequisite: the `openasr` binary must be on `PATH`. Check with `openasr
+--version`; if missing, tell the user to install it (`cargo install --path
+crates/openasr-cli` from a source checkout, or a released binary) rather than
+guessing a path.
+
+## Quick decision guide
+
+- One-off file/batch transcription -> `openasr transcribe`.
+- Live microphone or system-audio capture -> `openasr live`.
+- "What models do I have / can I get" -> `openasr list` / `openasr search`.
+- Need a long-lived local HTTP endpoint (e.g. another tool wants to POST
+  audio) -> `openasr serve`, see "Local HTTP API" below.
+
+## Transcribing files
+
+```bash
+openasr transcribe audio.wav --model whisper-small --format json
+```
+
+- Multiple inputs or a directory: pass several paths or a directory; use
+  `-o/--output <dir>` to write one file per input instead of stdout.
+- `--format` (short `-f`) accepts `text`, `json`, `srt`, `vtt`,
+  `verbose_json`, `markdown`; repeat `-f` to write several formats at once as
+  sidecar files.
+- `--model <id>` selects a model id from the registry (see `openasr search`);
+  omit it to use the configured default. If the model is not installed yet,
+  the CLI prompts to download it interactively -- pass `-y/--yes` to accept
+  non-interactively, or `--offline` to fail closed instead of prompting/
+  downloading (use `--offline` in any non-interactive/CI context).
+- `--diarize` labels speakers (`SPEAKER_00`, ...); `--word-timestamps` asks
+  for per-word timing where the model supports it.
+- `--benchmark` prints timing (elapsed, audio duration, real-time factor)
+  instead of the transcript, for a single input.
+- Non-WAV input (mp3, mp4, ...) needs `ffmpeg` on `PATH`, or pass
+  `--ffmpeg-bin <path>`.
+
+Common failure modes:
+
+- "model not installed" + a non-interactive shell: add `-y` (install) or
+  `--offline` (explicitly skip and fail) depending on intent -- do not assume.
+- Unsupported audio container without `ffmpeg`: install `ffmpeg` or convert
+  first (`ffmpeg -i in.mp4 -ac 1 -ar 16000 -c:a pcm_s16le out.wav`).
+- A partially-supported model/format combination returns an explicit error
+  naming the unsupported field rather than silently ignoring it -- surface
+  that error text to the user, do not retry blindly.
+
+## Live dictation / capture
+
+```bash
+openasr live --model whisper-small
+```
+
+Streams from the default input device and prints frame-synchronous partial
+results for packs that declare streaming support, otherwise final text per
+utterance. Run `openasr live --help` for device selection and output flags;
+behavior mirrors `transcribe`'s model-resolution and consent-pull rules.
+
+## Managing models
+
+```bash
+openasr search              # browse the full catalog
+openasr search whisper      # filter by name/family
+openasr list                # installed packs only
+openasr show <id>           # catalog card or a local .oasr pack's details
+openasr pull <id>[:<quant>] # download + install (e.g. `pull moonshine-tiny:q8`)
+openasr rm <id>             # remove an installed pack
+```
+
+Models are distributed as `.oasr` packs (GGUF-backed internally); bare
+`.gguf` files are not accepted directly as run input.
+
+## Local HTTP API
+
+`openasr serve` exposes a local OpenAI-compatible HTTP API -- use this when a
+tool needs to POST audio over HTTP instead of shelling out per file.
+
+```bash
+openasr serve --addr 127.0.0.1:8080 --backend native \
+  --model-pack /path/to/model.oasr --model your-runtime-model-id
+```
+
+`--addr` defaults to `127.0.0.1:8080` (fixed, not random) so you can hardcode
+the base URL. Loopback (`127.0.0.1`) requests are trusted by default -- no
+`Authorization` header needed:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/audio/transcriptions \
+  -F file=@audio.wav \
+  -F model=your-runtime-model-id \
+  -F response_format=verbose_json
+```
+
+Key endpoints: `GET /health` (liveness, unauthenticated), `GET /v1/models`
+(installed packs), `POST /v1/audio/transcriptions` (the transcription call
+above). `response_format` accepts `json`, `text`, `srt`, `vtt`,
+`verbose_json`, `markdown`.
+
+### Optional: requiring an API key even on loopback
+
+If the deployment wants an explicit credential even for local callers, create
+one first:
+
+```bash
+openasr apikey create --name "my-agent"
+# prints the plaintext key exactly once -- save it, it cannot be re-shown
+```
+
+Once any key exists, every `serve` request (except `/health`) must carry
+`Authorization: Bearer <key>`, including from `127.0.0.1`:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/audio/transcriptions \
+  -H "Authorization: Bearer oasr_sk_<...>" \
+  -F file=@audio.wav -F model=your-runtime-model-id
+```
+
+Manage keys with `openasr apikey list` / `openasr apikey revoke <id>`.
+Revoking the last key returns loopback `serve` to its key-free default.
+
+An API key is a **loopback-only** convenience -- binding `serve` to a
+non-loopback address for real remote/network access always requires
+HTTPS/WSS plus device pairing (`--tls-self-signed
+--pairing-admin-token-env ...`), regardless of any configured key.
+
+Full reference (longform/segment fields, phrase-bias/hotword fields,
+streaming, pairing flow): see `docs/AGENT_INTEGRATION.md` and the "Local HTTP
+API" section of the repo README at
+https://github.com/QuintinShaw/openasr.
+
+## Guardrails
+
+- Never suggest or attempt to send audio to a cloud service; OpenASR is
+  local-only by design.
+- Do not fabricate a transcript or model id -- if a command fails, surface
+  the actual error and, if it is a missing-model/consent case, ask the user
+  how to proceed rather than guessing `-y` vs `--offline`.
+- `.oasr` is the only accepted user-facing pack format.


### PR DESCRIPTION
## Summary

First-phase coding-agent integration: an official agent Skill (`skills/openasr/SKILL.md`) plus opt-in local API keys for `openasr serve` (`openasr apikey create/list/revoke`), with loopback staying key-free by default and non-loopback remote serving unchanged (TLS + pairing, fail-closed).

## Why

Coding agents (Claude Code, Codex, etc.) need a documented, predictable way to use OpenASR: a Skill file they can install via the `npx skills` ecosystem for the CLI path, and an explicit bearer credential option for the local OpenAI-compatible API when an operator wants loopback callers authenticated too.

## Changes

- `skills/openasr/SKILL.md`: agent Skill (frontmatter + instructions) covering `transcribe`, `live`, model management, `serve`, `apikey`, common failure modes, and guardrails. Follows the vercel-labs/skills convention (GitHub repo is the registry; no separate publishing step).
- `openasr_core::apikeys`: hash-only API key store (`~/.openasr/apikeys.json`, `0600`, atomic owner-only writes). Tokens are `oasr_sk_` + 32 random bytes hex; plaintext is shown once at creation and never persisted.
- `openasr apikey create/list/revoke` CLI subcommands.
- `ServerAuth::from_token_hashes`: static-bearer auth over a set of pre-hashed tokens; `StaticBearer` mode generalized from one hash to a set. `openasr serve` wires the persisted key hashes in for loopback binds only; an unreadable store fails closed at serve startup.
- Loopback binds: key-free by default (unchanged); once a key exists, every loopback request except `/health` requires `Authorization: Bearer <key>`.
- Non-loopback binds: completely unaffected by API keys; still require TLS + pairing (fail-closed).
- Desktop-supervisor-managed daemon (marked by the `OPENASR_SERVER_INSTANCE_TOKEN` env the supervisor always sets) is exempt from API keys, so creating a key never locks the desktop app out of its own daemon.
- `serve` default `--addr` was already fixed at `127.0.0.1:8080`; documented that as a stable contract (no behavior change, desktop sidecar port discovery untouched).
- Docs: `docs/AGENT_INTEGRATION.md` (skill install, API key flow, curl examples), README CLI table + Local HTTP API section, `docs/DOCS_INDEX.md` entry.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2071 passed, 116 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

## Manual smoke checks

- `openasr apikey create/list/revoke` end-to-end against a temp `OPENASR_HOME`; `apikeys.json` verified `0600`, hash-only, preview truncated.
- Live `openasr serve --addr 127.0.0.1:18099 --backend mock` matrix: no header -> 401, wrong key -> 401, correct key -> 200, `/health` without auth -> 200; after revoking the last key, no header -> 200 again.
- Skill installed for real with `npx skills add <checkout> --skill openasr --agent claude-code -y` -> lands at `./.claude/skills/openasr/SKILL.md`; `npx skills add -l` lists the skill with its frontmatter description.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No MCP server (explicitly out of scope).
- No change to the desktop sidecar port negotiation or the pairing/TLS remote path.
- API keys are loopback-only; they intentionally do not grant remote access.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — implemented with AI assistance (Claude Code) under maintainer direction and review.
