### PR TITLE
feat(server): stream file uploads to disk, raise the transcription upload ceiling

### DIFF
--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -232,10 +232,10 @@ pub use models::{
 pub use output::{OutputWriteError, atomic_write_text};
 pub use pull::{
     BackendFileFormat, DefaultPackPointer, InstalledBackend, InstalledPack, PullError,
-    PullModelPackRequest, PullProgress, default_pack_pointer_path, install_backend_pack,
-    install_catalog_model_pack_from_path, install_model_pack_from_path, list_installed_packs,
-    persist_default_pack_pointer, pull_model_pack, read_default_pack_pointer, remove_model_pack,
-    resolve_installed_pack_path, resolve_installed_pack_reference,
+    PullModelPackRequest, PullProgress, available_disk_space_bytes, default_pack_pointer_path,
+    install_backend_pack, install_catalog_model_pack_from_path, install_model_pack_from_path,
+    list_installed_packs, persist_default_pack_pointer, pull_model_pack, read_default_pack_pointer,
+    remove_model_pack, resolve_installed_pack_path, resolve_installed_pack_reference,
     resolve_installed_pack_reference_with_catalog,
 };
 pub use realtime::{

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -1377,6 +1377,16 @@ fn ensure_available_space(
     Ok(())
 }
 
+/// Best-effort free space (in bytes) on the filesystem containing `path`.
+/// `None` means the platform/probe could not determine it -- callers should
+/// treat that as "unknown" and stay permissive, matching how
+/// [`ensure_available_space`] treats a `None` probe for model-pack pulls.
+/// Exposed for other crates (e.g. `openasr-server`'s streaming upload path)
+/// that need the same disk-headroom check pulls already rely on.
+pub fn available_disk_space_bytes(path: &Path) -> Option<u64> {
+    available_space_bytes(path)
+}
+
 fn file_size_and_sha256(path: &Path) -> Result<(u64, String), PullError> {
     let mut file = File::open(path).map_err(|source| PullError::Io {
         path: path.to_path_buf(),

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -71,9 +71,23 @@ use tokio::{
 };
 use tokio_rustls::{TlsAcceptor, server::TlsStream};
 
-// The current upload path buffers multipart fields in memory via `field.bytes()`,
-// so keep the request ceiling conservative until uploads stream directly to disk.
-const MAX_TRANSCRIPTION_UPLOAD_BYTES: usize = 64 * 1024 * 1024;
+// The `file` field of `/v1/audio/transcriptions` (and `/v1/audio/translations`)
+// streams straight to a temp file in fixed-size chunks (see
+// `write_upload_temp_file_streaming` in routes/transcription.rs), so memory use
+// is O(chunk), not O(file); this ceiling is now just a finite abuse cap for a
+// single request, not a memory guard. 2 GiB comfortably covers multi-hour
+// uncompressed meeting recordings.
+const MAX_TRANSCRIPTION_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
+// Minimum free space the upload's temp volume must retain while an upload is
+// streaming to disk. Checked periodically (see `DISK_SPACE_CHECK_INTERVAL_BYTES`)
+// so a huge upload fails closed with a clear 507 instead of filling the disk;
+// mirrors the headroom check `pull.rs` already does before downloading a model
+// pack, via the shared `available_disk_space_bytes` probe.
+const MIN_FREE_DISK_HEADROOM_BYTES: u64 = 256 * 1024 * 1024;
+// How often (in bytes written) to re-check free disk space while streaming an
+// upload to its temp file: frequent enough to catch a disk filling up
+// mid-upload, infrequent enough that the statvfs probe doesn't dominate I/O.
+const DISK_SPACE_CHECK_INTERVAL_BYTES: u64 = 8 * 1024 * 1024;
 const SERVER_INSTANCE_TOKEN_ENV: &str = "OPENASR_SERVER_INSTANCE_TOKEN";
 const MAX_CONCURRENT_PULL_JOBS_PER_HOME: usize = 1;
 const PULL_JOB_PROGRESS_PERSIST_INTERVAL_BYTES: u64 = 8 * 1024 * 1024;
@@ -1552,6 +1566,10 @@ pub(crate) enum ApiError {
     Registry(openasr_core::RegistryError),
     Serialize(serde_json::Error),
     TempFile(std::io::Error),
+    /// The upload's temp volume ran (or was about to run) low on free space
+    /// mid-stream. The message is pre-built at the call site since it needs
+    /// the probed byte counts and temp-dir path.
+    InsufficientDiskSpace(String),
 }
 
 impl std::fmt::Display for ApiError {
@@ -1588,6 +1606,7 @@ impl std::fmt::Display for ApiError {
                     "Could not prepare uploaded audio for transcription: {error}"
                 )
             }
+            Self::InsufficientDiskSpace(message) => f.write_str(message),
         }
     }
 }
@@ -1706,6 +1725,7 @@ impl IntoResponse for ApiError {
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Could not prepare uploaded audio for transcription: {error}"),
             ),
+            Self::InsufficientDiskSpace(message) => (StatusCode::INSUFFICIENT_STORAGE, message),
         };
 
         // Log every failed request to stderr (captured in daemon.log by the
@@ -1726,6 +1746,7 @@ impl IntoResponse for ApiError {
                         StatusCode::NOT_FOUND => "not_found_error",
                         StatusCode::TOO_MANY_REQUESTS => "rate_limit_error",
                         StatusCode::SERVICE_UNAVAILABLE => "service_unavailable_error",
+                        StatusCode::INSUFFICIENT_STORAGE => "insufficient_storage_error",
                         _ => "openasr_error",
                     },
                 },
@@ -1765,9 +1786,9 @@ fn config_error_status(error: &openasr_core::ConfigError) -> StatusCode {
 fn multipart_error_message(error: &axum::extract::multipart::MultipartError) -> String {
     if error.status() == StatusCode::PAYLOAD_TOO_LARGE {
         format!(
-            "Uploaded file is too large. The daemon accepts uploads up to {} MB; \
+            "Uploaded file is too large. The daemon accepts uploads up to {} GB; \
              split the recording or use a smaller/compressed file.",
-            MAX_TRANSCRIPTION_UPLOAD_BYTES / (1024 * 1024)
+            MAX_TRANSCRIPTION_UPLOAD_BYTES / (1024 * 1024 * 1024)
         )
     } else {
         format!("Could not read multipart form: {error}")

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -312,8 +312,7 @@ impl TranscriptionRequestBuilder {
                     .as_deref()
                     .and_then(safe_extension_suffix)
                     .unwrap_or_default();
-                let bytes = field.bytes().await.map_err(ApiError::Multipart)?;
-                self.uploaded_file = Some(write_upload_temp_file(&bytes, &suffix)?);
+                self.uploaded_file = Some(write_upload_temp_file_streaming(field, &suffix).await?);
             }
             "model" => {
                 self.model = Some(field.text().await.map_err(ApiError::Multipart)?);
@@ -1111,6 +1110,69 @@ pub(crate) fn write_upload_temp_file(
     Ok(file.into_temp_path())
 }
 
+/// Streams a multipart `file` field straight to a temp file, one chunk at a
+/// time, instead of buffering the whole upload in memory first. This is what
+/// lets `/v1/audio/transcriptions` accept multi-gigabyte recordings under
+/// `MAX_TRANSCRIPTION_UPLOAD_BYTES` with O(chunk) memory instead of O(file):
+/// the previous `field.bytes()` path held the entire upload in a `Bytes`
+/// buffer before ever touching disk.
+pub(crate) async fn write_upload_temp_file_streaming(
+    mut field: Field<'_>,
+    suffix: &str,
+) -> Result<tempfile::TempPath, ApiError> {
+    let mut file = tempfile::Builder::new()
+        .prefix("openasr-upload-")
+        .suffix(suffix)
+        .tempfile()
+        .map_err(ApiError::TempFile)?;
+    let temp_dir = file.path().parent().map(Path::to_path_buf);
+
+    // Preflight: fail closed before writing a single byte if the temp
+    // volume is already below the headroom floor.
+    check_temp_dir_headroom(temp_dir.as_deref())?;
+
+    let mut since_last_check: u64 = 0;
+    while let Some(chunk) = field.chunk().await.map_err(ApiError::Multipart)? {
+        since_last_check = since_last_check.saturating_add(chunk.len() as u64);
+        if since_last_check >= DISK_SPACE_CHECK_INTERVAL_BYTES {
+            since_last_check = 0;
+            check_temp_dir_headroom(temp_dir.as_deref())?;
+        }
+        file.write_all(&chunk).map_err(ApiError::TempFile)?;
+    }
+    file.flush().map_err(ApiError::TempFile)?;
+    Ok(file.into_temp_path())
+}
+
+/// Fails closed with a 507 if the temp directory's volume has dropped below
+/// [`MIN_FREE_DISK_HEADROOM_BYTES`] free. `None` (probe unsupported on this
+/// platform, or no temp dir to check) stays permissive, matching how
+/// `pull.rs`'s `ensure_available_space` treats an unknown probe.
+fn check_temp_dir_headroom(temp_dir: Option<&Path>) -> Result<(), ApiError> {
+    let Some(dir) = temp_dir else {
+        return Ok(());
+    };
+    check_disk_headroom_bytes(openasr_core::available_disk_space_bytes(dir), dir)
+}
+
+/// Pure decision function split out from `check_temp_dir_headroom` so the
+/// insufficient-space branch can be unit tested by injecting an `available_bytes`
+/// value directly, without needing to actually fill a disk.
+fn check_disk_headroom_bytes(available_bytes: Option<u64>, dir: &Path) -> Result<(), ApiError> {
+    match available_bytes {
+        Some(available) if available < MIN_FREE_DISK_HEADROOM_BYTES => {
+            Err(ApiError::InsufficientDiskSpace(format!(
+                "Not enough free disk space to receive this upload: {} MB free in '{}', \
+                 need at least {} MB headroom. Free up space on that volume and retry.",
+                available / (1024 * 1024),
+                dir.display(),
+                MIN_FREE_DISK_HEADROOM_BYTES / (1024 * 1024),
+            )))
+        }
+        _ => Ok(()),
+    }
+}
+
 fn safe_extension_suffix(file_name: &str) -> Option<String> {
     let extension = std::path::Path::new(file_name)
         .file_name()
@@ -1131,8 +1193,8 @@ mod native_runtime_tests {
     use std::fs;
 
     use super::{
-        native_asr_error_to_backend, parse_bool_field, safe_extension_suffix,
-        write_upload_temp_file,
+        check_disk_headroom_bytes, native_asr_error_to_backend, parse_bool_field,
+        safe_extension_suffix, write_upload_temp_file,
     };
 
     #[test]
@@ -1223,6 +1285,37 @@ mod native_runtime_tests {
             }
             other => panic!("expected BadRequest, got {other:?}"),
         }
+    }
+
+    // Disk-headroom checks below inject `available_bytes` directly (rather
+    // than filling a real disk) per `check_disk_headroom_bytes`'s doc comment.
+
+    #[test]
+    fn disk_headroom_check_fails_closed_when_available_space_is_below_the_floor() {
+        let dir = std::path::Path::new("/tmp/openasr-upload-test");
+        let error = check_disk_headroom_bytes(Some(1024), dir).unwrap_err();
+
+        match error {
+            super::ApiError::InsufficientDiskSpace(message) => {
+                assert!(message.contains("Not enough free disk space"), "{message}");
+                assert!(message.contains("/tmp/openasr-upload-test"), "{message}");
+            }
+            other => panic!("expected InsufficientDiskSpace, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disk_headroom_check_passes_when_available_space_is_ample() {
+        let dir = std::path::Path::new("/tmp/openasr-upload-test");
+        assert!(check_disk_headroom_bytes(Some(64 * 1024 * 1024 * 1024), dir).is_ok());
+    }
+
+    #[test]
+    fn disk_headroom_check_stays_permissive_when_probe_is_unsupported() {
+        // `None` means the platform/probe couldn't tell -- must not block
+        // uploads on that basis, matching pull.rs's `ensure_available_space`.
+        let dir = std::path::Path::new("/tmp/openasr-upload-test");
+        assert!(check_disk_headroom_bytes(None, dir).is_ok());
     }
 }
 

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -2973,11 +2973,46 @@ async fn transcriptions_accept_filename_with_cjk_characters_and_space() {
     );
 }
 
-/// An upload past the server's body-size ceiling must fail with a clear,
-/// actionable "file too large" message and 413, not the generic "Error
-/// parsing `multipart/form-data` request" text that `MultipartError`'s
-/// `Display` renders for every underlying `multer` failure (including this
-/// one) -- see `multipart_error_message` in `lib.rs`.
+/// Regression guard for the real-world report this change fixes: a meeting
+/// recording just over the *old* 64 MB ceiling used to fail with 413 even
+/// though the daemon could transcribe it fine. The `file` field now streams
+/// straight to disk (see `write_upload_temp_file_streaming` in
+/// `routes/transcription.rs`), so a 65 MB upload must succeed end to end.
+#[tokio::test]
+async fn transcriptions_accept_upload_past_old_64mb_limit() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = openasr_server::app_with_runtime_and_distribution(
+        openasr_server::ServerRuntime::default(),
+        openasr_server::DistributionRuntime {
+            openasr_home: Some(temp.path().join("home")),
+            catalog_url: None,
+        },
+    );
+    let past_old_limit = vec![0u8; 65 * 1024 * 1024];
+    let request = multipart_request("whisper-large-v3-turbo", "meeting.wav", &past_old_limit);
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), 1024 * 256).await.unwrap();
+    let parsed: Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(
+        parsed["text"]
+            .as_str()
+            .unwrap()
+            .contains("OpenASR mock transcription"),
+        "expected a successful mock transcription, got: {parsed}"
+    );
+}
+
+/// An upload past the server's (now multi-gigabyte) body-size ceiling must
+/// still fail closed with a clear, actionable "file too large" message and
+/// 413, not the generic "Error parsing `multipart/form-data` request" text
+/// that `MultipartError`'s `Display` renders for every underlying `multer`
+/// failure (including this one) -- see `multipart_error_message` in
+/// `lib.rs`. The request body below is built from a handful of cheap
+/// `Bytes` clones (refcount bumps, not copies) streamed past the ceiling, so
+/// exercising the real multi-gigabyte limit doesn't require the test itself
+/// to hold multiple gigabytes in memory.
 #[tokio::test]
 async fn transcriptions_reject_upload_past_body_limit_with_clear_message() {
     let temp = tempfile::tempdir().unwrap();
@@ -2988,8 +3023,11 @@ async fn transcriptions_reject_upload_past_body_limit_with_clear_message() {
             catalog_url: None,
         },
     );
-    let oversized = vec![0u8; 65 * 1024 * 1024];
-    let request = multipart_request("whisper-large-v3-turbo", "huge.wav", &oversized);
+    // Mirrors `MAX_TRANSCRIPTION_UPLOAD_BYTES` in `lib.rs`; kept in sync by
+    // hand since it's a private constant of the crate under test (same
+    // convention the old 64 MB-scaled test above used).
+    const CEILING_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+    let request = oversized_streaming_multipart_request(CEILING_BYTES + 8 * 1024 * 1024);
     let response = app.oneshot(request).await.unwrap();
 
     assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
@@ -2998,9 +3036,184 @@ async fn transcriptions_reject_upload_past_body_limit_with_clear_message() {
     let message = parsed["error"]["message"].as_str().unwrap();
     assert!(message.contains("too large"), "message was: {message}");
     assert!(
+        message.contains("GB"),
+        "message should cite the new GB-scale ceiling, not the old MB one: {message}"
+    );
+    assert!(
         !message.contains("Error parsing"),
         "message regressed to the generic multipart error text: {message}"
     );
+}
+
+/// Builds a `/v1/audio/transcriptions` request whose `file` field streams
+/// `total_file_bytes` of zeroed content without ever materializing that much
+/// memory in the test process: the chunk is a single `Bytes` allocation,
+/// cloned (cheap, `Arc`-backed) for every repetition.
+fn oversized_streaming_multipart_request(total_file_bytes: u64) -> Request<Body> {
+    let boundary = "openasr-oversize-boundary";
+    let preamble = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nwhisper-large-v3-turbo\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"huge.wav\"\r\nContent-Type: audio/wav\r\n\r\n"
+    );
+
+    const CHUNK_BYTES: usize = 4 * 1024 * 1024;
+    let chunk = axum::body::Bytes::from(vec![0u8; CHUNK_BYTES]);
+    let chunk_count = (total_file_bytes / CHUNK_BYTES as u64) as usize + 1;
+
+    let head = futures_util::stream::once(async move {
+        Ok::<_, std::io::Error>(axum::body::Bytes::from(preamble.into_bytes()))
+    });
+    let tail = futures_util::stream::iter(std::iter::repeat_n(chunk, chunk_count))
+        .map(Ok::<_, std::io::Error>)
+        .then(yield_between_chunks);
+    let body = Body::from_stream(head.chain(tail));
+
+    Request::builder()
+        .method("POST")
+        .uri("/v1/audio/transcriptions")
+        .header(
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(body)
+        .unwrap()
+}
+
+/// Real-world evidence that the upload path no longer buffers the whole
+/// file in memory: a 200 MB upload's resident-set growth must stay far
+/// below the file size, at roughly the same order of magnitude as a 1 MB
+/// upload's. Before this change, `field.bytes()` held the entire multipart
+/// field in memory, so this delta tracked file size almost 1:1.
+///
+/// This drives the *actual* running process (via `oneshot`, same process as
+/// the test) with a body streamed from cheap `Bytes` clones -- so the input
+/// construction itself doesn't add O(file) memory that would muddy the
+/// measurement -- and samples RSS with `ps`, which is available in this
+/// project's macOS and Linux CI targets.
+#[tokio::test]
+async fn transcriptions_large_upload_memory_stays_bounded() {
+    let temp = tempfile::tempdir().unwrap();
+    let build_app = || {
+        openasr_server::app_with_runtime_and_distribution(
+            openasr_server::ServerRuntime::default(),
+            openasr_server::DistributionRuntime {
+                openasr_home: Some(temp.path().join("home")),
+                catalog_url: None,
+            },
+        )
+    };
+    const SMALL_FILE_BYTES: u64 = 1024 * 1024;
+    const LARGE_FILE_BYTES: u64 = 200 * 1024 * 1024;
+
+    // Warm up allocator/paging so the first request's one-time setup costs
+    // don't get counted as part of either delta below.
+    let warmup = multipart_request(
+        "whisper-large-v3-turbo",
+        "warm.wav",
+        &vec![0u8; SMALL_FILE_BYTES as usize],
+    );
+    let response = build_app().oneshot(warmup).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let baseline_rss_kb = process_rss_kb();
+    let small = multipart_request(
+        "whisper-large-v3-turbo",
+        "small.wav",
+        &vec![0u8; SMALL_FILE_BYTES as usize],
+    );
+    let response = build_app().oneshot(small).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let after_small_rss_kb = process_rss_kb();
+
+    let large = streamed_zero_multipart_request(LARGE_FILE_BYTES);
+    let response = build_app().oneshot(large).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let after_large_rss_kb = process_rss_kb();
+
+    let small_delta_kb = after_small_rss_kb.saturating_sub(baseline_rss_kb);
+    let large_delta_kb = after_large_rss_kb.saturating_sub(after_small_rss_kb);
+    let large_file_kb = LARGE_FILE_BYTES / 1024;
+
+    // Generous ceiling (half the file size) to avoid flakiness from
+    // allocator/page-cache noise, while still failing hard if the upload
+    // path regresses back to buffering the whole file: full buffering would
+    // put `large_delta_kb` within shouting distance of `large_file_kb`.
+    assert!(
+        large_delta_kb < large_file_kb / 2,
+        "RSS grew by {large_delta_kb} KB for a {large_file_kb} KB upload \
+         (small-file baseline delta was {small_delta_kb} KB) -- looks like \
+         the upload is being buffered in memory again"
+    );
+}
+
+fn process_rss_kb() -> u64 {
+    let pid = std::process::id().to_string();
+    let output = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid])
+        .output()
+        .expect("`ps` should be available to sample this test process's RSS");
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .unwrap_or_else(|error| panic!("could not parse `ps -o rss=` output: {error}"))
+}
+
+/// Builds a request that streams `total_file_bytes` of zeroed content as a
+/// well-formed, successfully-parseable multipart body (unlike
+/// `oversized_streaming_multipart_request`, which is truncated because the
+/// server is expected to reject it before the body ends).
+fn streamed_zero_multipart_request(total_file_bytes: u64) -> Request<Body> {
+    let boundary = "openasr-stream-boundary";
+    let preamble = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"large.wav\"\r\nContent-Type: audio/wav\r\n\r\n"
+    );
+    let trailer = format!(
+        "\r\n--{boundary}\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nwhisper-large-v3-turbo\r\n--{boundary}--\r\n"
+    );
+
+    const CHUNK_BYTES: usize = 64 * 1024;
+    let chunk = axum::body::Bytes::from(vec![0u8; CHUNK_BYTES]);
+    let full_chunks = (total_file_bytes / CHUNK_BYTES as u64) as usize;
+
+    let head = futures_util::stream::once(async move {
+        Ok::<_, std::io::Error>(axum::body::Bytes::from(preamble.into_bytes()))
+    });
+    let body_chunks = futures_util::stream::iter(std::iter::repeat_n(chunk, full_chunks))
+        .map(Ok::<_, std::io::Error>)
+        .then(yield_between_chunks);
+    let tail = futures_util::stream::once(async move {
+        Ok::<_, std::io::Error>(axum::body::Bytes::from(trailer.into_bytes()))
+    });
+    let body = Body::from_stream(head.chain(body_chunks).chain(tail));
+
+    Request::builder()
+        .method("POST")
+        .uri("/v1/audio/transcriptions")
+        .header(
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(body)
+        .unwrap()
+}
+
+/// Inserts a real async yield point between streamed body chunks.
+///
+/// Without this, `futures_util::stream::iter` resolves every poll
+/// immediately (`Poll::Ready`, never `Poll::Pending`), which is *not* how a
+/// real network body behaves -- a real client's bytes arrive as separate
+/// TCP reads with actual `Pending` gaps in between, and that backpressure is
+/// exactly what makes `multer`'s field-parsing loop hand back a chunk as
+/// soon as one is available instead of draining the whole stream in one
+/// synchronous sweep. Skipping this made an earlier version of the
+/// large-upload memory test below spuriously "prove" the upload was fully
+/// buffered (`field.chunk()` returned the *entire* file as a single chunk)
+/// even though the real server, driven by a real socket, streams correctly.
+async fn yield_between_chunks(
+    item: Result<axum::body::Bytes, std::io::Error>,
+) -> Result<axum::body::Bytes, std::io::Error> {
+    tokio::task::yield_now().await;
+    item
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `/v1/audio/transcriptions` (and `/v1/audio/translations`) now streams the
  `file` multipart field straight to a temp file in fixed-size chunks
  instead of buffering the whole upload via `field.bytes()`, so memory use
  is O(chunk) rather than O(file).
- Raises the request body ceiling from 64 MB to 2 GiB now that memory no
  longer scales with file size, updating the 413 message accordingly.
- Adds a free-disk-space check on the upload's temp volume (reusing
  `pull.rs`'s existing `available_disk_space_bytes` probe), checked before
  streaming starts and periodically while it runs; fails closed with 507
  and a readable message if the volume is low.

## Why

A real user's meeting recording (m4a) over 64 MB was rejected with a clear
413 (a prior PR turned a misleading 400 into a clear 413, but the real ask
was to make the upload work, not just fail more legibly).

## Changes

- `crates/openasr-server/src/routes/transcription.rs`: streaming
  `write_upload_temp_file_streaming` (replaces `field.bytes()` for the
  `file` field), `check_disk_headroom_bytes` / `check_temp_dir_headroom`
  disk-space guard.
- `crates/openasr-server/src/lib.rs`: `MAX_TRANSCRIPTION_UPLOAD_BYTES` raised
  to 2 GiB, new `MIN_FREE_DISK_HEADROOM_BYTES` / `DISK_SPACE_CHECK_INTERVAL_BYTES`
  constants, new `ApiError::InsufficientDiskSpace` (507), updated 413 message.
- `crates/openasr-core/src/pull.rs` + `lib.rs`: exposes the existing disk-space
  probe as public `available_disk_space_bytes` so the server can reuse it.
- `crates/openasr-server/tests/api.rs`: regression test that a 65 MB upload
  (past the old ceiling) now transcribes successfully; a ceiling test that
  still rejects an upload past the new 2 GiB limit (built from cheap `Bytes`
  clones so the test itself doesn't need multiple gigabytes of memory); a
  real-process RSS test showing a 200 MB upload's memory growth stays far
  below the file size.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2087 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources ok; pre-existing warnings only)

## Manual smoke checks

- Built a real 67.1 MB WAV (200x concatenated `fixtures/jfk.wav`, ~36m40s)
  and POSTed it to a locally running `openasr serve --model-pack
  whisper-tiny.en-q8_0.oasr`: HTTP 200 in ~193s, transcript correctly
  contains the real JFK speech content repeated throughout ("ask not what
  your country can do for you...").

## Docs updated

- N/A (no user-facing docs describe the old 64 MB ceiling).

## Scope / non-goals

- Does not change the ASR pipeline's own audio-decode memory profile
  (loading/slicing a long waveform for longform transcription) -- only the
  HTTP upload-to-disk path.
- Did not touch `models/firered*` or `crates/openasr-ffi` per in-flight
  work on those.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with Claude Code (streaming upload rewrite, disk-headroom check, tests).