### PR TITLE
feat(qwen): add Qwen3-ForcedAligner-0.6B word-timestamp refinement

### DIFF
--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -25,7 +25,7 @@ pub(crate) struct TranscribeCommandOptions<'a> {
     pub(crate) runtime_paths: RuntimePathOverrides,
     pub(crate) diarize: bool,
     pub(crate) speakers: Option<u8>,
-    pub(crate) word_timestamps: bool,
+    pub(crate) word_timestamps_mode: Option<WordTimestampsMode>,
     pub(crate) model_pack: Option<&'a Path>,
     /// OADP Phase 0 `.oadp` adapter pack; plumbed through the transcription
     /// request (never the process environment — workers are already running).
@@ -143,6 +143,19 @@ pub(crate) struct PhraseBiasCliOptions {
     /// mid-phrase with matched depth; every applied value is capped at 20.0.
     #[arg(long = "hotword-boost", value_name = "BOOST")]
     pub(crate) hotword_boost: Option<f32>,
+}
+
+/// `--word-timestamps` tier: bare (or `=approximate`) keeps the model family's
+/// own decode-time word timestamps (free, every native family); `=aligned`
+/// additionally refines them by running the finished transcript and full
+/// audio back through the installed Qwen3-ForcedAligner-0.6B capability pack
+/// (native backend only; the pack is not auto-downloaded silently -- passing
+/// `=aligned` is itself the consent to install it, mirroring `--diarize`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub(crate) enum WordTimestampsMode {
+    Approximate,
+    Aligned,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Args)]
@@ -278,10 +291,13 @@ pub(crate) enum Command {
         /// Force an exact speaker count during diarization clustering.
         #[arg(long, requires = "diarize", value_parser = clap::value_parser!(u8).range(1..))]
         speakers: Option<u8>,
-        /// Request per-word timestamps from the model's own alignment
-        /// (rendered in json/verbose_json and word-timed VTT output).
-        #[arg(long)]
-        word_timestamps: bool,
+        /// Request per-word timestamps (rendered in json/verbose_json and
+        /// word-timed VTT output). Bare flag (or `=approximate`) uses the
+        /// model's own decode-time timestamps; `=aligned` refines them with
+        /// the Qwen3-ForcedAligner-0.6B capability pack (may install it if
+        /// missing; native backend only).
+        #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "approximate")]
+        word_timestamps: Option<WordTimestampsMode>,
         /// Local `.oasr` runtime pack file for native backend transcription.
         #[arg(long)]
         model_pack: Option<PathBuf>,

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -202,7 +202,7 @@ async fn run() -> Result<()> {
             runtime_paths: RuntimePathOverrides { ffmpeg_bin },
             diarize,
             speakers,
-            word_timestamps,
+            word_timestamps_mode: word_timestamps,
             model_pack: model_pack.as_deref(),
             adapter: adapter.as_deref(),
             output: output.as_deref(),
@@ -897,7 +897,7 @@ fn transcribe(options: TranscribeCommandOptions<'_>) -> Result<()> {
     // ignoring them (fail-closed). Checked before any pack install or network.
     if options.benchmark
         && (options.diarize
-            || options.word_timestamps
+            || options.word_timestamps_mode.is_some()
             || options.adapter.is_some()
             || options.language.is_some()
             || options.task.is_some()
@@ -954,6 +954,17 @@ fn transcribe(options: TranscribeCommandOptions<'_>) -> Result<()> {
         prepared_run.model_source.model_pack_path.as_deref(),
         options.diarize,
     )?;
+    // Passing --word-timestamps=aligned is itself the consent to install the
+    // Qwen3-ForcedAligner-0.6B capability pack, mirroring --diarize's WeSpeaker
+    // auto-install above; approximate (or omitted) never touches the network.
+    ensure_cli_word_timestamps_pack_installed(
+        prepared_run.backend_kind,
+        options.word_timestamps_mode,
+    )?;
+    ensure_word_timestamps_alignment_supported(
+        prepared_run.backend_kind,
+        options.word_timestamps_mode,
+    )?;
 
     // stdin: `transcribe -` reads a WAV stream from stdin into a temp file used
     // as the single input. Kept alive until the end of the run.
@@ -1003,7 +1014,10 @@ fn transcribe(options: TranscribeCommandOptions<'_>) -> Result<()> {
     )?;
 
     if per_file_output {
-        if options.word_timestamps || options.adapter.is_some() || phrase_bias.is_some() {
+        if options.word_timestamps_mode.is_some()
+            || options.adapter.is_some()
+            || phrase_bias.is_some()
+        {
             return Err(consent::CliExit::new(
                 consent::ExitCode::InputError,
                 "--word-timestamps, --adapter, and --phrase-bias apply to a single input only."
@@ -1056,7 +1070,11 @@ fn transcribe(options: TranscribeCommandOptions<'_>) -> Result<()> {
         .with_phrase_bias(phrase_bias)
         .with_diarization(options.diarize)
         .with_diarize_speakers(options.speakers)
-        .with_word_timestamps(options.word_timestamps);
+        .with_word_timestamps(options.word_timestamps_mode.is_some())
+        .with_word_timestamps_refine(matches!(
+            options.word_timestamps_mode,
+            Some(WordTimestampsMode::Aligned)
+        ));
     let transcription =
         transcribe_with_backend(prepared_run.backend_kind, request).map_err(|error| {
             consent::CliExit::new(consent::ExitCode::RuntimeFailed, error.to_string())

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -846,7 +846,7 @@ pub(super) fn ensure_cli_diarization_packs_installed(
             )
         })?;
 
-    install_cli_diarization_capability_pack_if_missing(
+    install_cli_capability_pack_if_missing(
         &installed_packs,
         &catalog,
         required_pack,
@@ -857,7 +857,61 @@ pub(super) fn ensure_cli_diarization_packs_installed(
     Ok(())
 }
 
-fn install_cli_diarization_capability_pack_if_missing(
+/// Whether `--word-timestamps=aligned` requires a backend it does not run on.
+/// The alignment refinement pass re-decodes the full file and the finished
+/// transcript through a second local pack, which only the native backend
+/// supports; approximate (or omitted) timestamps are unaffected.
+pub(super) fn ensure_word_timestamps_alignment_supported(
+    backend: BackendKind,
+    word_timestamps_mode: Option<WordTimestampsMode>,
+) -> Result<()> {
+    if !matches!(word_timestamps_mode, Some(WordTimestampsMode::Aligned)) {
+        return Ok(());
+    }
+    if backend != BackendKind::Native {
+        bail!("--word-timestamps=aligned requires the native backend.");
+    }
+    Ok(())
+}
+
+/// Passing `--word-timestamps=aligned` is itself the consent to install the
+/// Qwen3-ForcedAligner-0.6B capability pack, mirroring `--diarize`'s WeSpeaker
+/// auto-install above -- `approximate` (or an omitted flag) never touches the
+/// network.
+pub(super) fn ensure_cli_word_timestamps_pack_installed(
+    backend: BackendKind,
+    word_timestamps_mode: Option<WordTimestampsMode>,
+) -> Result<()> {
+    if !matches!(word_timestamps_mode, Some(WordTimestampsMode::Aligned))
+        || backend != BackendKind::Native
+    {
+        return Ok(());
+    }
+
+    let home = openasr_home()?;
+    let config = load_config(&home)?;
+    let catalog = match load_cli_model_catalog(&home)? {
+        Some(catalog) => catalog,
+        None => openasr_core::load_model_catalog(None, &home)?,
+    };
+    let installed_packs = openasr_core::list_installed_packs(&home)?;
+    let source_chain = openasr_core::resolve_chain(&config.download_source);
+    let required_pack = catalog.word_timestamps_forced_aligner_pack().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Public catalog does not contain a word-timestamps forced-alignment capability pack."
+        )
+    })?;
+
+    install_cli_capability_pack_if_missing(
+        &installed_packs,
+        &catalog,
+        required_pack,
+        &home,
+        &source_chain,
+    )
+}
+
+fn install_cli_capability_pack_if_missing(
     installed_packs: &[openasr_core::InstalledPack],
     catalog: &openasr_core::ModelCatalog,
     model: &openasr_core::CatalogModel,
@@ -881,10 +935,10 @@ fn install_cli_diarization_capability_pack_if_missing(
             size: None,
         },
     )?;
-    install_cli_diarization_capability_pack(&resolved, home, source_chain)
+    install_cli_capability_pack(&resolved, home, source_chain)
 }
 
-fn install_cli_diarization_capability_pack(
+fn install_cli_capability_pack(
     resolved: &openasr_core::ResolvedCatalogPull,
     home: &Path,
     source_chain: &[openasr_core::DownloadSource],
@@ -1479,6 +1533,57 @@ mod tests {
 
         ensure_diarization_supported(BackendKind::Native, Some(&declared_runtime_path), true)
             .expect("declared Cohere diarization pack should pass the CLI gate");
+    }
+
+    #[test]
+    fn word_timestamps_alignment_supported_only_when_aligned_requested() {
+        // Absent / approximate never gates on backend -- only `aligned` does.
+        ensure_word_timestamps_alignment_supported(BackendKind::Mock, None)
+            .expect("no word-timestamps request is always fine");
+        ensure_word_timestamps_alignment_supported(
+            BackendKind::Mock,
+            Some(WordTimestampsMode::Approximate),
+        )
+        .expect("approximate word timestamps do not require the native backend");
+    }
+
+    #[test]
+    fn word_timestamps_alignment_requires_native_backend() {
+        let error = ensure_word_timestamps_alignment_supported(
+            BackendKind::Mock,
+            Some(WordTimestampsMode::Aligned),
+        )
+        .expect_err("aligned refinement should reject the mock backend")
+        .to_string();
+        assert!(error.contains("--word-timestamps=aligned"));
+        assert!(error.contains("native"));
+
+        ensure_word_timestamps_alignment_supported(
+            BackendKind::Native,
+            Some(WordTimestampsMode::Aligned),
+        )
+        .expect("aligned refinement is allowed on the native backend");
+    }
+
+    #[test]
+    fn word_timestamps_pack_install_is_a_no_op_without_aligned_mode() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let _home = EnvVarRestore::set_os("OPENASR_HOME", temp.path());
+
+        // Neither absent nor approximate ever touches the catalog/network.
+        ensure_cli_word_timestamps_pack_installed(BackendKind::Native, None)
+            .expect("no word-timestamps request never installs a pack");
+        ensure_cli_word_timestamps_pack_installed(
+            BackendKind::Native,
+            Some(WordTimestampsMode::Approximate),
+        )
+        .expect("approximate word timestamps never install the forced-aligner pack");
+        ensure_cli_word_timestamps_pack_installed(
+            BackendKind::Mock,
+            Some(WordTimestampsMode::Aligned),
+        )
+        .expect("the mock backend never needs the native-only forced-aligner pack");
     }
 
     fn cohere_diarization_tokens() -> [&'static str; 31] {

--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -302,6 +302,15 @@ pub struct TranscriptionRequest {
     pub inference_threads: Option<u16>,
     pub execution_target: Option<ExecutionTarget>,
     pub word_timestamps: bool,
+    /// Opt-in refinement tier (`--word-timestamps=aligned` / API
+    /// `word_timestamps_mode=aligned`): after the family's own decode produces
+    /// the transcript and its approximate per-word timestamps, re-run the
+    /// installed Qwen3-ForcedAligner-0.6B capability pack over the finished
+    /// text and full audio and replace each segment's words with the
+    /// aligner-refined spans. Requires `word_timestamps` to also be `true`
+    /// (checked fail-closed, not silently implied) and the capability pack to
+    /// already be installed -- the native backend never downloads it.
+    pub word_timestamps_refine: bool,
     pub longform: Option<LongFormOptions>,
     pub display_file_name: Option<String>,
     pub diarize: bool,
@@ -324,6 +333,7 @@ impl TranscriptionRequest {
             inference_threads: None,
             execution_target: None,
             word_timestamps: false,
+            word_timestamps_refine: false,
             longform: None,
             display_file_name: None,
             diarize: false,
@@ -363,6 +373,11 @@ impl TranscriptionRequest {
 
     pub fn with_word_timestamps(mut self, word_timestamps: bool) -> Self {
         self.word_timestamps = word_timestamps;
+        self
+    }
+
+    pub fn with_word_timestamps_refine(mut self, word_timestamps_refine: bool) -> Self {
+        self.word_timestamps_refine = word_timestamps_refine;
         self
     }
 
@@ -685,6 +700,18 @@ pub enum BackendError {
         "Native ASR Core serve-batch decode is temporarily unavailable: {reason}\nThis is a transient condition; retry the request."
     )]
     ServeBatchUnavailable { reason: String, retryable: bool },
+    #[error(
+        "word_timestamps_refine=true (--word-timestamps=aligned) requires word_timestamps=true.\nThe request was rejected instead of silently aligning without emitting words."
+    )]
+    WordTimestampAlignmentRequiresWordTimestamps,
+    #[error(
+        "Word-timestamp alignment refinement (--word-timestamps=aligned) is not available for the {backend} backend: the Qwen3-ForcedAligner-0.6B capability pack is not installed.\nInstall it, or use --word-timestamps for the model's own approximate timestamps."
+    )]
+    WordTimestampAlignmentPackMissing { backend: &'static str },
+    #[error(
+        "Word-timestamp alignment refinement failed: {reason}\nThe request was rejected instead of returning approximate timestamps silently relabeled as aligned."
+    )]
+    WordTimestampAlignmentFailed { reason: String },
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -471,6 +471,7 @@ fn native_offline_request_to_transcription_request(
         .with_inference_threads(request.options.inference_threads)
         .with_execution_target(Some(execution_target))
         .with_word_timestamps(request.options.word_timestamps)
+        .with_word_timestamps_refine(request.options.word_timestamps_refine)
         .with_diarization(request.options.diarize)
         .with_longform(request.longform)
         .with_display_file_name(request.display_file_name)

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -29,7 +29,11 @@ use crate::{
 
 use super::{BackendError, Transcription, TranscriptionRequest};
 use crate::Segment;
+use crate::WordTimestamp;
 use crate::api::backend::TranscriptionLongFormMetadata;
+use crate::models::qwen::{
+    ForcedAlignItem, forced_aligner_pack, refine_word_timestamps_with_forced_aligner,
+};
 
 const DEFAULT_NATIVE_LONGFORM_AUTO_TRIGGER_SECONDS: f32 = 30.0;
 const COHERE_LONGFORM_MAX_CHUNK_SECONDS: f32 = 10.0;
@@ -96,7 +100,108 @@ struct NativeLongformPolicyResolution {
     provenance: Vec<String>,
 }
 
+/// Entry point for the native backend: runs the ordinary decode/longform/
+/// diarization pipeline unchanged (`run_native_transcription_impl`), then --
+/// only when the request opted into `--word-timestamps=aligned`
+/// (`word_timestamps_refine`) -- refines the finished transcript's per-word
+/// timestamps with the installed Qwen3-ForcedAligner-0.6B capability pack.
+/// Kept as a thin wrapper rather than threading the refinement into the
+/// (already long) decode/longform function: the aligner re-reads the whole
+/// file and the finished transcript text, so it has no dependency on any
+/// intermediate state that function computes.
 pub(super) fn run_native_transcription(
+    request: TranscriptionRequest,
+) -> Result<Transcription, BackendError> {
+    let refine = request.word_timestamps_refine;
+    if refine && !request.word_timestamps {
+        return Err(BackendError::WordTimestampAlignmentRequiresWordTimestamps);
+    }
+    let input_path = request.input_path.clone();
+    let language_hint = request.language.clone();
+    let transcription = run_native_transcription_impl(request)?;
+    if refine {
+        refine_transcription_word_timestamps_with_forced_aligner(
+            transcription,
+            &input_path,
+            language_hint.as_deref(),
+        )
+    } else {
+        Ok(transcription)
+    }
+}
+
+/// Re-decodes `input_path` and calls the installed Qwen3-ForcedAligner pack
+/// once over the whole finished transcript, then reassigns each segment's
+/// `words` from the aligner's own per-word spans (dropping the family's
+/// approximate per-word confidence -- the aligner does not produce one; never
+/// inventing a value is preferred to fabricating one). Segments/text/speaker
+/// attribution from the ordinary decode path are left untouched; only `words`
+/// changes.
+fn refine_transcription_word_timestamps_with_forced_aligner(
+    mut transcription: Transcription,
+    input_path: &Path,
+    language_hint: Option<&str>,
+) -> Result<Transcription, BackendError> {
+    let pack_path = forced_aligner_pack::resolve_forced_aligner_pack_path()
+        .ok_or(BackendError::WordTimestampAlignmentPackMissing { backend: "native" })?;
+    let prepared_audio = load_wav_16khz_mono_f32_v0(
+        input_path,
+        "Native ASR Core backend",
+        "Native ASR Core backend",
+    )
+    .map_err(|error| BackendError::NativeUnsupportedInputFormat {
+        reason: error.to_string(),
+    })?;
+    let language = transcription
+        .language
+        .clone()
+        .or_else(|| language_hint.map(str::to_string))
+        .unwrap_or_else(|| "en".to_string());
+    let items = refine_word_timestamps_with_forced_aligner(
+        &pack_path,
+        &prepared_audio,
+        &transcription.text,
+        &language,
+    )
+    .map_err(|error| BackendError::WordTimestampAlignmentFailed {
+        reason: error.to_string(),
+    })?;
+    assign_aligned_words_to_segments(&mut transcription.segments, &items);
+    Ok(transcription)
+}
+
+/// Distributes forced-aligner word spans onto the (time-ordered,
+/// non-overlapping) segments they fall into: each item's start time selects
+/// the last segment whose own start is `<=` it (segments are sorted and cover
+/// the whole file, so this always finds the enclosing segment for a
+/// well-formed decode). A segment with no aligned words keeps its prior
+/// (family-approximate) word list rather than being emptied -- most often
+/// because there is exactly one segment and the whole item list lands in it.
+fn assign_aligned_words_to_segments(segments: &mut [Segment], items: &[ForcedAlignItem]) {
+    if segments.is_empty() || items.is_empty() {
+        return;
+    }
+    let mut buckets: Vec<Vec<WordTimestamp>> = segments.iter().map(|_| Vec::new()).collect();
+    for item in items {
+        let segment_index = segments
+            .iter()
+            .rposition(|segment| f64::from(segment.start) <= item.start_time_s)
+            .unwrap_or(0);
+        buckets[segment_index].push(WordTimestamp {
+            word: item.text.clone(),
+            start: item.start_time_s as f32,
+            end: item.end_time_s as f32,
+            confidence: None,
+        });
+    }
+    for (segment, bucket) in segments.iter_mut().zip(buckets) {
+        if !bucket.is_empty() {
+            segment.words = bucket;
+        }
+    }
+}
+
+fn run_native_transcription_impl(
     request: TranscriptionRequest,
 ) -> Result<Transcription, BackendError> {
     let requested_model_id = normalize_and_validate_model_id(&request)?;
@@ -1721,5 +1826,69 @@ mod tests {
             LongFormVadEngine::FireRed,
             zh_wav_path(),
         );
+    }
+
+    fn segment(start: f32, end: f32, text: &str) -> Segment {
+        Segment {
+            start,
+            end,
+            text: text.to_string(),
+            speaker: None,
+            speaker_label: None,
+            speaker_profile_id: None,
+            words: vec![WordTimestamp {
+                word: text.to_string(),
+                start,
+                end,
+                confidence: Some(0.9),
+            }],
+        }
+    }
+
+    fn item(text: &str, start_time_s: f64, end_time_s: f64) -> ForcedAlignItem {
+        ForcedAlignItem {
+            text: text.to_string(),
+            start_time_s,
+            end_time_s,
+        }
+    }
+
+    #[test]
+    fn assign_aligned_words_replaces_words_within_one_segment() {
+        let mut segments = vec![segment(0.0, 2.0, "hello world")];
+        let items = vec![item("hello", 0.1, 0.4), item("world", 0.5, 0.9)];
+
+        assign_aligned_words_to_segments(&mut segments, &items);
+
+        let words = &segments[0].words;
+        assert_eq!(words.len(), 2);
+        assert_eq!(words[0].word, "hello");
+        assert_eq!(words[0].start, 0.1);
+        assert_eq!(words[0].end, 0.4);
+        assert_eq!(words[0].confidence, None);
+        assert_eq!(words[1].word, "world");
+    }
+
+    #[test]
+    fn assign_aligned_words_distributes_across_segments_by_start_time() {
+        let mut segments = vec![segment(0.0, 1.0, "hi"), segment(1.0, 2.0, "there")];
+        let items = vec![item("hi", 0.1, 0.5), item("there", 1.2, 1.6)];
+
+        assign_aligned_words_to_segments(&mut segments, &items);
+
+        assert_eq!(segments[0].words.len(), 1);
+        assert_eq!(segments[0].words[0].word, "hi");
+        assert_eq!(segments[1].words.len(), 1);
+        assert_eq!(segments[1].words[0].word, "there");
+    }
+
+    #[test]
+    fn assign_aligned_words_leaves_segments_untouched_when_items_empty() {
+        let mut segments = vec![segment(0.0, 1.0, "hi")];
+        let original_words = segments[0].words.clone();
+
+        assign_aligned_words_to_segments(&mut segments, &[]);
+
+        assert_eq!(segments[0].words, original_words);
     }
 }

--- a/crates/openasr-core/src/api/native/types.rs
+++ b/crates/openasr-core/src/api/native/types.rs
@@ -225,6 +225,10 @@ pub struct NativeAsrRequestOptions {
     pub diarize: bool,
     pub partial_results: bool,
     pub word_timestamps: bool,
+    /// Opt-in `--word-timestamps=aligned` / `word_aligned` refinement tier;
+    /// see `TranscriptionRequest::word_timestamps_refine`. Offline-only:
+    /// streaming sessions never consult this field.
+    pub word_timestamps_refine: bool,
 }
 
 impl NativeAsrRequestOptions {
@@ -269,6 +273,11 @@ impl NativeAsrRequestOptions {
 
     pub fn with_word_timestamps(mut self, word_timestamps: bool) -> Self {
         self.word_timestamps = word_timestamps;
+        self
+    }
+
+    pub fn with_word_timestamps_refine(mut self, word_timestamps_refine: bool) -> Self {
+        self.word_timestamps_refine = word_timestamps_refine;
         self
     }
 }

--- a/crates/openasr-core/src/capability_pack.rs
+++ b/crates/openasr-core/src/capability_pack.rs
@@ -1,0 +1,164 @@
+//! Generic resolution of an installed optional capability-pack file (a
+//! `.oasr`/`.safetensors` support model that augments a family's own decode
+//! path, e.g. the WeSpeaker speaker-embedder or the Qwen3-ForcedAligner
+//! word-timestamp refiner) from `openasr_home()/models/<dir>/`. Extracted from
+//! `diarize::pack` so a second capability-pack family (forced alignment) does
+//! not duplicate the same env-override + directory-scan logic -- infrastructure
+//! that decides where an installed pack lives stays model-agnostic; only the
+//! env var name and directory substring are per-feature.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve a pack path: the `env_var` override (if it points at a file), else the
+/// first `.oasr`/`.safetensors` under a `models/*` directory whose name contains
+/// `dir_substr`.
+pub(crate) fn resolve_installed_capability_pack(
+    env_var: &str,
+    dir_substr: &str,
+) -> Option<PathBuf> {
+    if let Ok(explicit) = std::env::var(env_var) {
+        let path = PathBuf::from(explicit);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let home = crate::openasr_home().ok()?;
+    find_pack(&home.join("models"), dir_substr)
+}
+
+/// Whether `path` is a GGUF (`.oasr`) pack, by sniffing the 4-byte magic rather
+/// than trusting the extension. A capability pack may be delivered as either a
+/// pulled GGUF `.oasr` or a raw `.safetensors` (the dev fast path), so loaders
+/// branch on this.
+pub(crate) fn is_gguf_capability_pack(path: &Path) -> bool {
+    use std::io::Read;
+    let mut magic = [0u8; 4];
+    std::fs::File::open(path)
+        .and_then(|mut file| file.read_exact(&mut magic))
+        .is_ok()
+        && &magic == b"GGUF"
+}
+
+fn find_pack(root: &Path, dir_substr: &str) -> Option<PathBuf> {
+    let mut model_dirs: Vec<PathBuf> = std::fs::read_dir(root)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_dir()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(|name| name.to_ascii_lowercase().contains(dir_substr))
+                    .unwrap_or(false)
+        })
+        .collect();
+    model_dirs.sort();
+    model_dirs.iter().find_map(|dir| first_pack_file(dir))
+}
+
+/// Find a pack file directly in `dir` or one quant subdirectory, preferring the
+/// `.oasr` catalog/pull format over a raw `.safetensors` (the dev fast path) when
+/// both are present -- so a pulled pack wins over a leftover dev safetensors.
+fn first_pack_file(dir: &Path) -> Option<PathBuf> {
+    if let Some(path) = best_pack_in_dir(dir) {
+        return Some(path);
+    }
+    let mut subdirs: Vec<PathBuf> = std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect();
+    subdirs.sort();
+    subdirs.iter().find_map(|sub| best_pack_in_dir(sub))
+}
+
+/// The highest-priority pack file directly in `dir`: `.oasr` (priority 0) beats
+/// `.safetensors` (priority 1); ties broken by name for determinism.
+fn best_pack_in_dir(dir: &Path) -> Option<PathBuf> {
+    let priority = |path: &Path| match path.extension().and_then(|ext| ext.to_str()) {
+        Some("oasr") => Some(0u8),
+        Some("safetensors") => Some(1u8),
+        _ => None,
+    };
+    let mut best: Option<(u8, PathBuf)> = None;
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(rank) = priority(&path) else {
+            continue;
+        };
+        let better = match &best {
+            None => true,
+            Some((best_rank, best_path)) => {
+                rank < *best_rank || (rank == *best_rank && path < *best_path)
+            }
+        };
+        if better {
+            best = Some((rank, path));
+        }
+    }
+    best.map(|(_, path)| path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{best_pack_in_dir, first_pack_file, is_gguf_capability_pack};
+    use std::fs;
+
+    #[test]
+    fn is_gguf_sniffs_magic_not_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let gguf = dir.path().join("pack.oasr");
+        fs::write(&gguf, b"GGUF\x00\x00\x00\x00rest").unwrap();
+        assert!(is_gguf_capability_pack(&gguf));
+
+        let safetensors = dir.path().join("pack.safetensors");
+        fs::write(&safetensors, b"\x10\x00\x00\x00\x00\x00\x00\x00{}").unwrap();
+        assert!(!is_gguf_capability_pack(&safetensors));
+
+        assert!(!is_gguf_capability_pack(&dir.path().join("missing")));
+    }
+
+    #[test]
+    fn first_pack_file_prefers_oasr_over_safetensors() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("model.safetensors"), b"st").unwrap();
+        fs::write(dir.path().join("model.oasr"), b"GGUF").unwrap();
+        let found = first_pack_file(dir.path()).unwrap();
+        assert_eq!(found.extension().unwrap(), "oasr");
+    }
+
+    #[test]
+    fn first_pack_file_falls_back_to_safetensors_and_subdirs() {
+        let only_st = tempfile::tempdir().unwrap();
+        fs::write(only_st.path().join("model.safetensors"), b"st").unwrap();
+        assert_eq!(
+            first_pack_file(only_st.path())
+                .unwrap()
+                .extension()
+                .unwrap(),
+            "safetensors"
+        );
+
+        let nested = tempfile::tempdir().unwrap();
+        let quant = nested.path().join("q8_0");
+        fs::create_dir(&quant).unwrap();
+        fs::write(quant.join("model.oasr"), b"GGUF").unwrap();
+        assert_eq!(
+            first_pack_file(nested.path()).unwrap().extension().unwrap(),
+            "oasr"
+        );
+    }
+
+    #[test]
+    fn best_pack_in_dir_ignores_non_pack_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("readme.txt"), b"x").unwrap();
+        fs::write(dir.path().join("config.json"), b"{}").unwrap();
+        assert!(best_pack_in_dir(dir.path()).is_none());
+    }
+}

--- a/crates/openasr-core/src/diarize/pack.rs
+++ b/crates/openasr-core/src/diarize/pack.rs
@@ -1,6 +1,9 @@
 //! Shared resolution of pulled diarization model-pack files. Support packs load
 //! tens-of-MB weights from files (not vendored), resolved from an env override
 //! or the standard installed location under `openasr_home()/models/<model>/`.
+//! Thin diarization-flavored wrappers over the model-agnostic resolver in
+//! `crate::capability_pack` (also used by the Qwen3-ForcedAligner
+//! word-timestamps capability pack).
 
 use std::path::{Path, PathBuf};
 
@@ -8,14 +11,7 @@ use std::path::{Path, PathBuf};
 /// first `.safetensors`/`.oasr` under a `models/*` directory whose name contains
 /// `dir_substr`.
 pub(super) fn resolve_pack(env_var: &str, dir_substr: &str) -> Option<PathBuf> {
-    if let Ok(explicit) = std::env::var(env_var) {
-        let path = PathBuf::from(explicit);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-    let home = crate::openasr_home().ok()?;
-    find_pack(&home.join("models"), dir_substr)
+    crate::capability_pack::resolve_installed_capability_pack(env_var, dir_substr)
 }
 
 /// Whether `path` is a GGUF (`.oasr`) pack, by sniffing the 4-byte magic rather
@@ -23,134 +19,5 @@ pub(super) fn resolve_pack(env_var: &str, dir_substr: &str) -> Option<PathBuf> {
 /// pulled GGUF `.oasr` or a raw `.safetensors` (the dev fast path), so the
 /// loaders branch on this.
 pub(super) fn is_gguf(path: &Path) -> bool {
-    use std::io::Read;
-    let mut magic = [0u8; 4];
-    std::fs::File::open(path)
-        .and_then(|mut file| file.read_exact(&mut magic))
-        .is_ok()
-        && &magic == b"GGUF"
-}
-
-fn find_pack(root: &Path, dir_substr: &str) -> Option<PathBuf> {
-    let mut model_dirs: Vec<PathBuf> = std::fs::read_dir(root)
-        .ok()?
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| {
-            path.is_dir()
-                && path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .map(|name| name.to_ascii_lowercase().contains(dir_substr))
-                    .unwrap_or(false)
-        })
-        .collect();
-    model_dirs.sort();
-    model_dirs.iter().find_map(|dir| first_pack_file(dir))
-}
-
-/// Find a pack file directly in `dir` or one quant subdirectory, preferring the
-/// `.oasr` catalog/pull format over a raw `.safetensors` (the dev fast path) when
-/// both are present — so a pulled pack wins over a leftover dev safetensors.
-fn first_pack_file(dir: &Path) -> Option<PathBuf> {
-    if let Some(path) = best_pack_in_dir(dir) {
-        return Some(path);
-    }
-    let mut subdirs: Vec<PathBuf> = std::fs::read_dir(dir)
-        .ok()?
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
-        .collect();
-    subdirs.sort();
-    subdirs.iter().find_map(|sub| best_pack_in_dir(sub))
-}
-
-/// The highest-priority pack file directly in `dir`: `.oasr` (priority 0) beats
-/// `.safetensors` (priority 1); ties broken by name for determinism.
-fn best_pack_in_dir(dir: &Path) -> Option<PathBuf> {
-    let priority = |path: &Path| match path.extension().and_then(|ext| ext.to_str()) {
-        Some("oasr") => Some(0u8),
-        Some("safetensors") => Some(1u8),
-        _ => None,
-    };
-    let mut best: Option<(u8, PathBuf)> = None;
-    for entry in std::fs::read_dir(dir).ok()?.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        let Some(rank) = priority(&path) else {
-            continue;
-        };
-        let better = match &best {
-            None => true,
-            Some((best_rank, best_path)) => {
-                rank < *best_rank || (rank == *best_rank && path < *best_path)
-            }
-        };
-        if better {
-            best = Some((rank, path));
-        }
-    }
-    best.map(|(_, path)| path)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{best_pack_in_dir, first_pack_file, is_gguf};
-    use std::fs;
-
-    #[test]
-    fn is_gguf_sniffs_magic_not_extension() {
-        let dir = tempfile::tempdir().unwrap();
-        let gguf = dir.path().join("pack.oasr");
-        fs::write(&gguf, b"GGUF\x00\x00\x00\x00rest").unwrap();
-        assert!(is_gguf(&gguf));
-
-        let safetensors = dir.path().join("pack.safetensors");
-        fs::write(&safetensors, b"\x10\x00\x00\x00\x00\x00\x00\x00{}").unwrap();
-        assert!(!is_gguf(&safetensors));
-
-        assert!(!is_gguf(&dir.path().join("missing")));
-    }
-
-    #[test]
-    fn first_pack_file_prefers_oasr_over_safetensors() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("model.safetensors"), b"st").unwrap();
-        fs::write(dir.path().join("model.oasr"), b"GGUF").unwrap();
-        let found = first_pack_file(dir.path()).unwrap();
-        assert_eq!(found.extension().unwrap(), "oasr");
-    }
-
-    #[test]
-    fn first_pack_file_falls_back_to_safetensors_and_subdirs() {
-        let only_st = tempfile::tempdir().unwrap();
-        fs::write(only_st.path().join("model.safetensors"), b"st").unwrap();
-        assert_eq!(
-            first_pack_file(only_st.path())
-                .unwrap()
-                .extension()
-                .unwrap(),
-            "safetensors"
-        );
-
-        let nested = tempfile::tempdir().unwrap();
-        let quant = nested.path().join("q8_0");
-        fs::create_dir(&quant).unwrap();
-        fs::write(quant.join("model.oasr"), b"GGUF").unwrap();
-        assert_eq!(
-            first_pack_file(nested.path()).unwrap().extension().unwrap(),
-            "oasr"
-        );
-    }
-
-    #[test]
-    fn best_pack_in_dir_ignores_non_pack_files() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("readme.txt"), b"x").unwrap();
-        fs::write(dir.path().join("config.json"), b"{}").unwrap();
-        assert!(best_pack_in_dir(dir.path()).is_none());
-    }
+    crate::capability_pack::is_gguf_capability_pack(path)
 }

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -18,6 +18,7 @@ mod arch;
 pub(crate) mod audio;
 pub(crate) mod batch;
 pub(crate) mod benchmark;
+pub(crate) mod capability_pack;
 pub mod config;
 pub mod device;
 pub mod diarize;
@@ -265,12 +266,12 @@ pub use realtime::{
     VadStateMachine,
 };
 pub use registry::{
-    BackendResolutionError, CATALOG_FEATURE_SPEAKER_DIARIZATION, CatalogBackend,
-    CatalogBackendFile, CatalogBackendFileRole, CatalogBackendVendor, CatalogCapability,
-    CatalogCapabilityRole, CatalogError, CatalogLanguageMode, CatalogMirror, CatalogModel,
-    CatalogModelKind, CatalogProse, CatalogPullRequest, CatalogQuant, CatalogQuantPerf,
-    CatalogQuantRecommendationProfile, LicenseClass, ModelAvailability, ModelCard, ModelCatalog,
-    ModelRef, ModelResolutionError, ModelVariantMetadata, RegistryError,
+    BackendResolutionError, CATALOG_FEATURE_SPEAKER_DIARIZATION, CATALOG_FEATURE_WORD_TIMESTAMPS,
+    CatalogBackend, CatalogBackendFile, CatalogBackendFileRole, CatalogBackendVendor,
+    CatalogCapability, CatalogCapabilityRole, CatalogError, CatalogLanguageMode, CatalogMirror,
+    CatalogModel, CatalogModelKind, CatalogProse, CatalogPullRequest, CatalogQuant,
+    CatalogQuantPerf, CatalogQuantRecommendationProfile, LicenseClass, ModelAvailability,
+    ModelCard, ModelCatalog, ModelRef, ModelResolutionError, ModelVariantMetadata, RegistryError,
     ResolvedCatalogBackendPull, ResolvedCatalogPull, ResolvedModel, ResolvedRuntimeModelRef,
     RuntimeModelRefSource, RuntimeModelResolutionError, canonical_quant_tag, current_cli_version,
     default_catalog_cache_path, default_catalog_url, default_registry_dir,

--- a/crates/openasr-core/src/models/qwen/audio_encoder.rs
+++ b/crates/openasr-core/src/models/qwen/audio_encoder.rs
@@ -1344,4 +1344,140 @@ mod tests {
         assert_eq!(values[0], 0.0);
         assert_eq!(values[4], 1.0);
     }
+
+    /// Stage 2 bisection gate: run the ggml audio encoder (24 layers/1024/16
+    /// heads, reused unmodified from qwen3-asr -- everything here is
+    /// metadata-driven) against the Qwen3-ForcedAligner-0.6B checkpoint's real
+    /// weights, fed the exact mel input the Python reference
+    /// (`thinker.get_audio_features`) consumed for `fixtures/jfk.wav`, and
+    /// compare row-for-row against the Python reference's `last_hidden_state`.
+    /// Dev-machine only (needs the Stage 0 HF download + Stage 0 reference
+    /// dump); skips cleanly elsewhere.
+    #[test]
+    fn forced_aligner_audio_encoder_matches_python_reference_for_jfk() {
+        use std::path::PathBuf;
+
+        use super::super::forced_aligner_import::{
+            Qwen3ForcedAlignerLocalSourceImportRequest,
+            convert_local_qwen_forced_aligner_source_to_runtime_pack,
+        };
+        use super::super::package_import::Qwen3AsrRuntimeQuantizationMode as ForcedAlignerQuantMode;
+        use crate::ggml_runtime::GgufTensorDataReader;
+        use crate::models::qwen::runtime_contract::Qwen3AsrExecutionMetadata;
+
+        let source_root =
+            PathBuf::from("/Volumes/QuintinDocument/hf-cache/qwen3-forced-aligner-0.6b");
+        let ref_dir =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp/forced-aligner-ref/fixtures");
+        let mel_path = ref_dir.join("audio_mel_input.f32le");
+        let output_path = ref_dir.join("audio_encoder_output.f32le");
+        if !source_root.exists() || !mel_path.exists() || !output_path.exists() {
+            eprintln!(
+                "skipping: {} / {} not present (Stage 0/2 dev-machine reference artifacts)",
+                source_root.display(),
+                mel_path.display()
+            );
+            return;
+        }
+
+        let pack_dir = std::env::temp_dir().join("openasr-forced-aligner-stage2-test");
+        let _ = std::fs::create_dir_all(&pack_dir);
+        let pack_path = pack_dir.join("qwen3-forced-aligner-0.6b-fp16.oasr");
+        let _ = std::fs::remove_file(&pack_path);
+        let request = Qwen3ForcedAlignerLocalSourceImportRequest {
+            source_root,
+            output_root: pack_path.clone(),
+            package_id: "qwen3-forced-aligner-0.6b".to_string(),
+            package_variant: Some("fp16".to_string()),
+            source_name: "Qwen/Qwen3-ForcedAligner-0.6B".to_string(),
+            source_revision: "test".to_string(),
+            license_name: "Apache-2.0".to_string(),
+            license_source: "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B".to_string(),
+            quantization: ForcedAlignerQuantMode::Fp16,
+        };
+        convert_local_qwen_forced_aligner_source_to_runtime_pack(&request)
+            .expect("forced-aligner conversion must succeed");
+
+        let metadata = Qwen3AsrExecutionMetadata {
+            sample_rate_hz: 16_000,
+            n_mels: 128,
+            n_fft: 400,
+            win_length: 400,
+            hop_length: 160,
+            audio_layers: 24,
+            audio_d_model: 1024,
+            audio_heads: 16,
+            llm_layers: 28,
+            llm_d_model: 1024,
+            llm_heads: 16,
+            llm_kv_heads: 8,
+            llm_head_dim: 128,
+            vocab_size: 152_064,
+            llm_max_positions: 8_192,
+            audio_start_token_id: 151_669,
+            audio_end_token_id: 151_670,
+            audio_pad_token_id: 151_676,
+            eos_token_id: 151_645,
+            pad_token_id: 151_643,
+        };
+
+        let reader = GgufTensorDataReader::from_path(&pack_path).expect("gguf reader");
+        let weights = load_qwen3_audio_encoder_weights_from_reader(&reader, metadata)
+            .expect("audio encoder weights");
+        assert_eq!(weights.layer_count(), 24);
+
+        let mel_bytes = std::fs::read(&mel_path).expect("read reference mel");
+        let mel_values: Vec<f32> = mel_bytes
+            .chunks_exact(4)
+            .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
+            .collect();
+        assert_eq!(mel_values.len(), 128 * 1100);
+        let mel_features = Qwen3AsrMelFeatures {
+            n_mels: 128,
+            n_frames: 1100,
+            data: mel_values,
+        };
+
+        let mut runtime = Qwen3AsrAudioEncoderRuntime::new(Some(&pack_path)).expect("runtime");
+        let output = runtime
+            .encode(&weights, metadata, &mel_features)
+            .expect("encode");
+
+        let ref_bytes = std::fs::read(&output_path).expect("read reference output");
+        let ref_values: Vec<f32> = ref_bytes
+            .chunks_exact(4)
+            .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
+            .collect();
+        assert_eq!(ref_values.len(), 143 * 1024);
+        assert_eq!(
+            output.row_count, 143,
+            "ggml chunked row count must match the Python reference's audio-feature row count"
+        );
+        assert_eq!(output.rows.len(), ref_values.len());
+
+        let mut max_abs_diff = 0.0_f32;
+        let mut sum_abs_diff = 0.0_f64;
+        for (a, b) in output.rows.iter().zip(ref_values.iter()) {
+            let diff = (a - b).abs();
+            max_abs_diff = max_abs_diff.max(diff);
+            sum_abs_diff += diff as f64;
+        }
+        let mean_abs_diff = sum_abs_diff / output.rows.len() as f64;
+        eprintln!(
+            "forced_aligner_audio_encoder_matches_python_reference_for_jfk: max_abs_diff={max_abs_diff} mean_abs_diff={mean_abs_diff}"
+        );
+        // fp16-quantized 2D weights (Python ran fp32) accumulated over 24
+        // encoder layers. Observed parity is fp16-rounding-level tight
+        // (max_abs_diff ~0.006, mean_abs_diff ~0.0002); bound with headroom so
+        // the test still catches wiring bugs (wrong shapes/permutes/layer
+        // count/head count) without being brittle to harmless rounding drift.
+        assert!(
+            max_abs_diff < 0.1,
+            "audio encoder output diverges from Python reference: max_abs_diff={max_abs_diff}"
+        );
+        assert!(
+            mean_abs_diff < 0.01,
+            "audio encoder output diverges from Python reference on average: mean_abs_diff={mean_abs_diff}"
+        );
+    }
 }

--- a/crates/openasr-core/src/models/qwen/forced_aligner_align_text.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_align_text.rs
@@ -112,8 +112,12 @@ pub(crate) fn word_list_for_language(
     text: &str,
     language: &str,
 ) -> Result<Vec<String>, Qwen3ForcedAlignerTextError> {
+    // Accepts both the reference's full language names and the ISO 639-1
+    // codes callers thread through from `Transcription::language` /
+    // `--language` (e.g. "ja"/"ko"), so a real caller's short codes trigger
+    // the same fail-closed guard as the reference's own "japanese"/"korean".
     let normalized = language.to_ascii_lowercase();
-    if normalized == "japanese" || normalized == "korean" {
+    if matches!(normalized.as_str(), "japanese" | "ja" | "korean" | "ko") {
         return Err(Qwen3ForcedAlignerTextError::UnsupportedLanguage {
             language: language.to_string(),
         });

--- a/crates/openasr-core/src/models/qwen/forced_aligner_align_text.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_align_text.rs
@@ -1,0 +1,384 @@
+//! Text-side algorithms for the Qwen3-ForcedAligner NAR pipeline: the
+//! deterministic word tokenizer that turns the input transcript into the
+//! per-word unit list fed to the `<timestamp>` prompt, and the `fix_timestamp`
+//! longest-increasing-subsequence (LIS) monotonicity repair applied to the raw
+//! per-`<timestamp>`-position classify-head outputs.
+//!
+//! Both are ports of `Qwen3ForceAlignProcessor` in the reference
+//! `qwen_asr.inference.qwen3_forced_aligner` package (`tokenize_space_lang`,
+//! `split_segment_with_chinese`, `is_cjk_char`, `clean_token`, `fix_timestamp`).
+//! Only the "space language" path (used for every language except Japanese and
+//! Korean, which the reference routes through external morphological
+//! segmenters -- `nagisa` / `soynlp` -- not yet ported) is implemented here;
+//! Chinese text has no ASCII whitespace, so `tokenize_space_lang`'s per-segment
+//! CJK character split already produces the correct one-token-per-character
+//! output for it, matching the reference's *non*-special-cased Chinese path
+//! (Chinese is not one of the two languages `encode_timestamp` special-cases).
+
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub(crate) enum Qwen3ForcedAlignerTextError {
+    #[error(
+        "qwen3-forced-aligner word tokenizer does not yet support language '{language}' (only the space/CJK-character path used for non-Japanese/Korean languages is ported)"
+    )]
+    UnsupportedLanguage { language: String },
+    #[error("qwen3-forced-aligner fix_timestamp requires a non-empty timestamp sequence")]
+    EmptyTimestampSequence,
+}
+
+/// Unicode-category test mirroring `Qwen3ForceAlignProcessor.is_kept_char`:
+/// letters, numbers, and the ASCII apostrophe (kept for contractions such as
+/// "don't") survive punctuation stripping; everything else is discarded.
+fn is_kept_char(ch: char) -> bool {
+    if ch == '\'' {
+        return true;
+    }
+    // Python's unicodedata category groups: "L*" (letters) and "N*" (numbers).
+    // Rust's char::is_alphanumeric() covers exactly the Unicode "Letter" and
+    // "Number" major categories, matching `cat.startswith("L")` / `("N")`.
+    ch.is_alphanumeric()
+}
+
+fn clean_token(token: &str) -> String {
+    token.chars().filter(|&ch| is_kept_char(ch)).collect()
+}
+
+/// CJK Unified Ideograph ranges, ported verbatim from
+/// `Qwen3ForceAlignProcessor.is_cjk_char`.
+fn is_cjk_char(ch: char) -> bool {
+    let code = ch as u32;
+    (0x4E00..=0x9FFF).contains(&code)
+        || (0x3400..=0x4DBF).contains(&code)
+        || (0x20000..=0x2A6DF).contains(&code)
+        || (0x2A700..=0x2B73F).contains(&code)
+        || (0x2B740..=0x2B81F).contains(&code)
+        || (0x2B820..=0x2CEAF).contains(&code)
+        || (0xF900..=0xFAFF).contains(&code)
+}
+
+/// Port of `split_segment_with_chinese`: within one whitespace-delimited
+/// segment, every CJK character becomes its own token and runs of non-CJK
+/// characters are kept together as one token (cleaned later by the caller).
+fn split_segment_with_chinese(segment: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut buf = String::new();
+    for ch in segment.chars() {
+        if is_cjk_char(ch) {
+            if !buf.is_empty() {
+                tokens.push(std::mem::take(&mut buf));
+            }
+            tokens.push(ch.to_string());
+        } else {
+            buf.push(ch);
+        }
+    }
+    if !buf.is_empty() {
+        tokens.push(buf);
+    }
+    tokens
+}
+
+/// Port of `tokenize_space_lang`: split on ASCII whitespace, strip punctuation
+/// from each whitespace-delimited segment, then further split any CJK
+/// characters out of that segment into their own tokens. Used for every
+/// language the reference does not special-case with an external
+/// morphological tokenizer (i.e. every language except Japanese/Korean),
+/// which includes both English and Chinese in our supported scope.
+fn tokenize_space_lang(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    for segment in text.split_ascii_whitespace() {
+        let cleaned = clean_token(segment);
+        if cleaned.is_empty() {
+            continue;
+        }
+        for piece in split_segment_with_chinese(&cleaned) {
+            if !piece.is_empty() {
+                tokens.push(piece);
+            }
+        }
+    }
+    tokens
+}
+
+/// Port of `Qwen3ForceAlignProcessor.encode_timestamp`'s word-list step only
+/// (the prompt-string assembly is done by the caller against the runtime
+/// tokenizer, not by literal string concatenation -- see
+/// `forced_aligner_runtime::build_forced_aligner_decode_prompt`). Japanese and
+/// Korean are not yet supported: the reference routes them through `nagisa`
+/// and `soynlp`, which have not been ported, so failing closed here is safer
+/// than silently mis-tokenizing.
+pub(crate) fn word_list_for_language(
+    text: &str,
+    language: &str,
+) -> Result<Vec<String>, Qwen3ForcedAlignerTextError> {
+    let normalized = language.to_ascii_lowercase();
+    if normalized == "japanese" || normalized == "korean" {
+        return Err(Qwen3ForcedAlignerTextError::UnsupportedLanguage {
+            language: language.to_string(),
+        });
+    }
+    Ok(tokenize_space_lang(text))
+}
+
+/// Port of `Qwen3ForceAlignProcessor.fix_timestamp`: repairs local
+/// non-monotonicity in the raw per-position classify-head timestamps (in
+/// segment-count units, i.e. before multiplying by `timestamp_segment_time`)
+/// by finding the longest non-decreasing subsequence (LIS with `<=`) and
+/// interpolating/clamping the "anomaly" runs between LIS anchors:
+///   - anomaly runs of length <= 2: nearest LIS neighbor wins (ties break
+///     toward the left neighbor, matching the reference's `<=` comparison).
+///   - anomaly runs of length > 2: linear interpolation between the
+///     surrounding LIS anchors (or a flat clamp if only one side has an
+///     anchor -- i.e. the anomaly touches a sequence boundary).
+///
+/// Ported field-for-field from the Python `dp`/`parent` LIS reconstruction so
+/// tie-breaking and integer truncation (`int(res)`, i.e. truncation toward
+/// zero) match exactly; see the bit-exact fixtures in the test module below,
+/// captured by running the reference implementation directly.
+//
+// The interpolation loops below are deliberately index-based (`for k in
+// i..j`), not iterator-chained, to stay a transcription of the Python
+// reference's index arithmetic that a reviewer can diff line-for-line.
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn fix_timestamp(data: &[i64]) -> Result<Vec<i64>, Qwen3ForcedAlignerTextError> {
+    let n = data.len();
+    if n == 0 {
+        return Err(Qwen3ForcedAlignerTextError::EmptyTimestampSequence);
+    }
+
+    let mut dp = vec![1_i64; n];
+    let mut parent = vec![-1_i64; n];
+    for i in 1..n {
+        for j in 0..i {
+            if data[j] <= data[i] && dp[j] + 1 > dp[i] {
+                dp[i] = dp[j] + 1;
+                parent[i] = j as i64;
+            }
+        }
+    }
+
+    let max_length = *dp.iter().max().expect("n > 0 checked above");
+    let max_idx = dp
+        .iter()
+        .position(|&len| len == max_length)
+        .expect("max exists");
+
+    let mut lis_indices = Vec::new();
+    let mut idx = max_idx as i64;
+    while idx != -1 {
+        lis_indices.push(idx as usize);
+        idx = parent[idx as usize];
+    }
+    lis_indices.reverse();
+
+    let mut is_normal = vec![false; n];
+    for &idx in &lis_indices {
+        is_normal[idx] = true;
+    }
+
+    // Python operates on an f64-typed `result` copy (the reference casts to
+    // int only in the final return); mirror that so the interpolation step's
+    // arithmetic matches bit-for-bit.
+    let mut result: Vec<f64> = data.iter().map(|&value| value as f64).collect();
+
+    let mut i = 0_usize;
+    while i < n {
+        if !is_normal[i] {
+            let mut j = i;
+            while j < n && !is_normal[j] {
+                j += 1;
+            }
+            let anomaly_count = j - i;
+
+            let left_val = (0..i).rev().find(|&k| is_normal[k]).map(|k| result[k]);
+            let right_val = (j..n).find(|&k| is_normal[k]).map(|k| result[k]);
+
+            if anomaly_count <= 2 {
+                for k in i..j {
+                    result[k] = match (left_val, right_val) {
+                        (None, Some(right)) => right,
+                        (Some(left), None) => left,
+                        (Some(left), Some(right)) => {
+                            // Python: `left_val if (k - (i - 1)) <= (j - k) else right_val`.
+                            // `i` is always > 0 here when `left_val` is Some
+                            // (there is a normal index before it), so `i - 1`
+                            // cannot underflow.
+                            if (k as i64 - (i as i64 - 1)) <= (j as i64 - k as i64) {
+                                left
+                            } else {
+                                right
+                            }
+                        }
+                        (None, None) => result[k],
+                    };
+                }
+            } else {
+                match (left_val, right_val) {
+                    (Some(left), Some(right)) => {
+                        let step = (right - left) / (anomaly_count as f64 + 1.0);
+                        for k in i..j {
+                            result[k] = left + step * ((k - i + 1) as f64);
+                        }
+                    }
+                    (Some(left), None) => {
+                        for k in i..j {
+                            result[k] = left;
+                        }
+                    }
+                    (None, Some(right)) => {
+                        for k in i..j {
+                            result[k] = right;
+                        }
+                    }
+                    (None, None) => {}
+                }
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+
+    // Python's `int(res)` truncates toward zero; timestamps here are always
+    // non-negative in practice, but truncate (not round) to match exactly.
+    Ok(result
+        .into_iter()
+        .map(|value| value.trunc() as i64)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn word_list_tokenizes_english_like_space_lang_reference() {
+        let words = word_list_for_language(
+            "And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.",
+            "English",
+        )
+        .expect("word list");
+        assert_eq!(
+            words,
+            vec![
+                "And",
+                "so",
+                "my",
+                "fellow",
+                "Americans",
+                "ask",
+                "not",
+                "what",
+                "your",
+                "country",
+                "can",
+                "do",
+                "for",
+                "you",
+                "ask",
+                "what",
+                "you",
+                "can",
+                "do",
+                "for",
+                "your",
+                "country"
+            ]
+        );
+    }
+
+    #[test]
+    fn word_list_splits_chinese_text_into_individual_characters() {
+        let words = word_list_for_language("今天天气非常好我打算和朋友们一起去公园散步", "Chinese")
+            .expect("word list");
+        assert_eq!(
+            words,
+            vec![
+                "今", "天", "天", "气", "非", "常", "好", "我", "打", "算", "和", "朋", "友", "们",
+                "一", "起", "去", "公", "园", "散", "步"
+            ]
+        );
+    }
+
+    #[test]
+    fn word_list_rejects_unsupported_languages() {
+        let error = word_list_for_language("hello", "Japanese").expect_err("must fail");
+        assert!(matches!(
+            error,
+            Qwen3ForcedAlignerTextError::UnsupportedLanguage { .. }
+        ));
+    }
+
+    // Bit-exact fixtures captured by running the reference
+    // `Qwen3ForceAlignProcessor.fix_timestamp` directly (see
+    // tmp/forced-aligner-ref/fix_timestamp_fixture.py, dev-machine only /
+    // gitignored -- values transcribed here so the test has no runtime
+    // dependency on the Python venv).
+
+    #[test]
+    fn fix_timestamp_is_a_noop_for_already_monotonic_input() {
+        let input = [0, 80, 160, 240, 320];
+        assert_eq!(fix_timestamp(&input).unwrap(), vec![0, 80, 160, 240, 320]);
+    }
+
+    #[test]
+    fn fix_timestamp_repairs_a_single_dip_anomaly() {
+        let input = [0, 80, 40, 240, 320];
+        assert_eq!(fix_timestamp(&input).unwrap(), vec![0, 80, 80, 240, 320]);
+    }
+
+    #[test]
+    fn fix_timestamp_repairs_a_two_element_anomaly_run() {
+        let input = [0, 80, 200, 30, 40, 320, 400];
+        assert_eq!(
+            fix_timestamp(&input).unwrap(),
+            vec![0, 80, 200, 200, 320, 320, 400]
+        );
+    }
+
+    #[test]
+    fn fix_timestamp_interpolates_a_longer_anomaly_run() {
+        let input = [0, 500, 10, 20, 30, 40, 600, 700];
+        assert_eq!(
+            fix_timestamp(&input).unwrap(),
+            vec![0, 0, 10, 20, 30, 40, 600, 700]
+        );
+    }
+
+    #[test]
+    fn fix_timestamp_clamps_a_leading_anomaly_with_no_left_anchor() {
+        let input = [500, 10, 100, 200, 300];
+        assert_eq!(fix_timestamp(&input).unwrap(), vec![10, 10, 100, 200, 300]);
+    }
+
+    #[test]
+    fn fix_timestamp_clamps_a_trailing_anomaly_with_no_right_anchor() {
+        let input = [0, 100, 200, 300, 10];
+        assert_eq!(fix_timestamp(&input).unwrap(), vec![0, 100, 200, 300, 300]);
+    }
+
+    #[test]
+    fn fix_timestamp_is_a_noop_for_the_real_jfk_word_boundary_sequence() {
+        // Ports of the real (already-monotonic) jfk.wav per-word start/end
+        // timestamps from tmp/forced-aligner-ref/reference_output.json --
+        // confirms fix_timestamp does not perturb a real, already-consistent
+        // trace (the common case).
+        let input = [
+            320, 560, 640, 960, 960, 1280, 1360, 1680, 1680, 2160, 3280, 3680, 4000, 4320, 5360,
+            5600, 5600, 5920, 5920, 6400, 6400, 6640, 6640, 6880, 6960, 7040, 7040, 7520, 8160,
+            8480, 8640, 8800, 8800, 9200, 9200, 9440, 9440, 9600, 9680, 9760, 9760, 10000, 10000,
+            10480,
+        ];
+        assert_eq!(fix_timestamp(&input).unwrap(), input.to_vec());
+    }
+
+    #[test]
+    fn fix_timestamp_rejects_empty_input() {
+        let error = fix_timestamp(&[]).expect_err("must fail");
+        assert!(matches!(
+            error,
+            Qwen3ForcedAlignerTextError::EmptyTimestampSequence
+        ));
+    }
+}

--- a/crates/openasr-core/src/models/qwen/forced_aligner_import.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_import.rs
@@ -1,0 +1,579 @@
+//! Local-source (safetensors) -> `.oasr` (GGUF) conversion for
+//! Qwen3-ForcedAligner-0.6B.
+//!
+//! Qwen3-ForcedAligner shares its `thinker` (audio encoder + LM) tensor layout
+//! byte-for-byte with Qwen3-ASR (same `Qwen3ASRForConditionalGeneration`
+//! class in the reference `qwen_asr` package; see
+//! `qwen_asr.core.transformers_backend.modeling_qwen3_asr`). The only
+//! structural difference is the final head: when `model_type` contains
+//! `"forced_aligner"`, the reference replaces the tied `lm_head` with an
+//! independent `Linear(hidden_size, classify_num)` (5000 x 80ms timestamp
+//! bins) instead of `Linear(hidden_size, vocab_size)`. Both live at the same
+//! source tensor name `thinker.lm_head.weight`, so the generic tensor-name
+//! remap/quantization pipeline in `package_import` is reused unmodified; this
+//! module only differs in config parsing (top-level `timestamp_token_id`/
+//! `timestamp_segment_time`, and `thinker_config.classify_num`) and in the
+//! GGUF metadata it emits.
+//!
+//! Deliberately NOT wired into `ggml_family_registry`: this produces a valid
+//! GGUF/.oasr pack for numeric-parity verification and Stage 2 ggml
+//! execution, but the forced-aligner's NAR (single forward pass, argmax at
+//! `<timestamp>` positions) decode policy is not the qwen3-asr autoregressive
+//! greedy decoder, so it must not be dispatchable through the existing
+//! qwen3-asr runtime path. Family registration + CLI wiring is out of scope
+//! for this stage.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::ggml_runtime::{
+    GgufWriteValue, read_gguf_metadata_from_runtime_source, read_gguf_tensor_index,
+    read_gguf_tensor_index_from_runtime_source, validate_ggml_runtime_source_path,
+    write_gguf_file_v0,
+};
+use crate::models::local_source_import::{
+    LocalSourceImportError, SafetensorsFile, read_source_json_file, validate_error,
+    validate_output_pack_extension,
+};
+
+use super::package_import::{
+    Qwen3AsrRuntimeQuantizationMode, build_qwen_runtime_tensors, compose_model_id, insert_metadata,
+    insert_metadata_string_array, insert_metadata_u32, load_merges, load_vocab_tokens,
+    patch_added_tokens,
+};
+
+const SOURCE_CONFIG_JSON: &str = "config.json";
+const TOKENIZER_GGML_MODEL_KEY: &str = "tokenizer.ggml.model";
+const TOKENIZER_GGML_MODEL_VALUE_GPT2: &str = "gpt2";
+const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
+const TOKENIZER_GGML_MERGES_KEY: &str = "tokenizer.ggml.merges";
+const OPENASR_MODEL_ID_KEY: &str = "openasr.model.id";
+const GENERAL_ARCHITECTURE_KEY: &str = "general.architecture";
+
+/// GGUF `general.architecture` / `openasr.model.family` value for this
+/// converter's output. Deliberately distinct from `qwen3-asr` so a bundled
+/// pack can never be mistaken for (or dispatched through) the qwen3-asr
+/// autoregressive runtime -- the decode policy is materially different (one
+/// NAR forward pass + argmax at `<timestamp>` positions, not incremental
+/// greedy generation).
+pub const QWEN3_FORCED_ALIGNER_MODEL_FAMILY: &str = "qwen3-forced-aligner";
+pub const QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID: &str = "qwen3-forced-aligner";
+
+pub type Qwen3ForcedAlignerLocalSourceError = LocalSourceImportError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Qwen3ForcedAlignerLocalSourceImportRequest {
+    pub source_root: PathBuf,
+    pub output_root: PathBuf,
+    pub package_id: String,
+    pub package_variant: Option<String>,
+    pub source_name: String,
+    pub source_revision: String,
+    pub license_name: String,
+    pub license_source: String,
+    pub quantization: Qwen3AsrRuntimeQuantizationMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Qwen3ForcedAlignerLocalSourceImportRuntimeResult {
+    pub output_path: PathBuf,
+    pub model_id: String,
+    pub tensor_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForcedAlignerConfigJson {
+    #[serde(default)]
+    timestamp_token_id: Option<u32>,
+    #[serde(default)]
+    timestamp_segment_time: Option<u32>,
+    thinker_config: ForcedAlignerThinkerConfigJson,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForcedAlignerThinkerConfigJson {
+    audio_config: ForcedAlignerAudioConfigJson,
+    text_config: ForcedAlignerTextConfigJson,
+    #[serde(default)]
+    classify_num: Option<usize>,
+    #[serde(default)]
+    audio_token_id: Option<u32>,
+    #[serde(default)]
+    audio_start_token_id: Option<u32>,
+    #[serde(default)]
+    audio_end_token_id: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForcedAlignerAudioConfigJson {
+    #[serde(default)]
+    num_mel_bins: Option<usize>,
+    #[serde(default)]
+    encoder_layers: Option<usize>,
+    #[serde(default)]
+    d_model: Option<usize>,
+    #[serde(default)]
+    encoder_attention_heads: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForcedAlignerTextConfigJson {
+    #[serde(default)]
+    num_hidden_layers: Option<usize>,
+    #[serde(default)]
+    hidden_size: Option<usize>,
+    #[serde(default)]
+    num_attention_heads: Option<usize>,
+    #[serde(default)]
+    num_key_value_heads: Option<usize>,
+    #[serde(default)]
+    head_dim: Option<usize>,
+    #[serde(default)]
+    vocab_size: Option<usize>,
+    #[serde(default)]
+    max_position_embeddings: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+struct ForcedAlignerMetadataFields {
+    sample_rate_hz: u32,
+    n_mels: usize,
+    n_fft: usize,
+    win_length: usize,
+    hop_length: usize,
+    audio_layers: usize,
+    audio_d_model: usize,
+    audio_heads: usize,
+    llm_layers: usize,
+    llm_d_model: usize,
+    llm_heads: usize,
+    llm_kv_heads: usize,
+    llm_head_dim: usize,
+    /// Token-embedding table size (`thinker.model.embed_tokens.weight` rows),
+    /// distinct from `classify_num` -- unlike qwen3-asr, the forced aligner's
+    /// output head is NOT tied to the embedding table.
+    embed_vocab_size: usize,
+    /// Classification head width (`thinker.lm_head.weight` rows): 5000
+    /// 80ms-wide timestamp bins, independent of `embed_vocab_size`.
+    classify_num: usize,
+    llm_max_positions: usize,
+    audio_start_token_id: u32,
+    audio_end_token_id: u32,
+    audio_pad_token_id: u32,
+    timestamp_token_id: u32,
+    timestamp_segment_time_ms: u32,
+}
+
+pub fn convert_local_qwen_forced_aligner_source_to_runtime_pack(
+    request: &Qwen3ForcedAlignerLocalSourceImportRequest,
+) -> Result<Qwen3ForcedAlignerLocalSourceImportRuntimeResult, Qwen3ForcedAlignerLocalSourceError> {
+    validate_request(request)?;
+    let config: ForcedAlignerConfigJson =
+        read_source_json_file(&request.source_root, SOURCE_CONFIG_JSON)?;
+    let mut tokens = load_vocab_tokens(&request.source_root)?;
+    let merges = load_merges(&request.source_root)?;
+    let fields = forced_aligner_metadata_fields(&config);
+    if tokens.len() < fields.embed_vocab_size {
+        tokens.resize_with(fields.embed_vocab_size, String::new);
+    }
+    patch_added_tokens(&request.source_root, &mut tokens)?;
+    for (index, token) in tokens.iter_mut().enumerate() {
+        if token.is_empty() {
+            *token = format!("<unused_{index}>");
+        }
+    }
+
+    let safetensor_files = discover_safetensor_files(&request.source_root)?;
+    let mut tensors = build_qwen_runtime_tensors(
+        &safetensor_files,
+        request.quantization,
+        fields.n_mels,
+        fields.n_fft,
+        fields.sample_rate_hz,
+        fields.win_length,
+    )?;
+
+    let model_id = compose_model_id(&request.package_id, request.package_variant.as_deref());
+    let metadata = forced_aligner_gguf_metadata(request, &fields, &model_id, &tokens, &merges);
+
+    write_gguf_file_v0(&request.output_root, &metadata, &tensors).map_err(|error| {
+        validate_error(format!(
+            "Qwen3-ForcedAligner local-source GGUF writer failed for '{}': {error}",
+            request.output_root.display()
+        ))
+    })?;
+
+    // Mechanical round-trip check only (tensor count / readability). This
+    // converter is not registered with `ggml_family_registry`, so there is no
+    // builtin runtime tensor contract to validate against yet -- that lands
+    // with family registration in a later stage.
+    let runtime_source =
+        validate_ggml_runtime_source_path(&request.output_root).map_err(|error| {
+            validate_error(format!(
+                "Qwen3-ForcedAligner local-source import produced invalid runtime path '{}': {error}",
+                request.output_root.display()
+            ))
+        })?;
+    let _metadata_read =
+        read_gguf_metadata_from_runtime_source(&runtime_source).map_err(|error| {
+            validate_error(format!(
+                "Qwen3-ForcedAligner import produced unreadable GGUF metadata: {error}"
+            ))
+        })?;
+    let _tensor_index_read =
+        read_gguf_tensor_index_from_runtime_source(&runtime_source).map_err(|error| {
+            validate_error(format!(
+                "Qwen3-ForcedAligner import produced unreadable GGUF tensor index: {error}"
+            ))
+        })?;
+
+    let index = read_gguf_tensor_index(&request.output_root).map_err(|error| {
+        validate_error(format!(
+            "Qwen3-ForcedAligner local-source GGUF writer produced unreadable tensor index: {error}"
+        ))
+    })?;
+    tensors.clear();
+    Ok(Qwen3ForcedAlignerLocalSourceImportRuntimeResult {
+        output_path: request.output_root.clone(),
+        model_id,
+        tensor_count: index.tensors().len(),
+    })
+}
+
+fn forced_aligner_metadata_fields(config: &ForcedAlignerConfigJson) -> ForcedAlignerMetadataFields {
+    let audio = &config.thinker_config.audio_config;
+    let text = &config.thinker_config.text_config;
+    let llm_d_model = text.hidden_size.unwrap_or(1024);
+    let llm_heads = text.num_attention_heads.unwrap_or(16);
+    let llm_head_dim = text.head_dim.unwrap_or(llm_d_model / llm_heads.max(1));
+    let embed_vocab_size = text.vocab_size.unwrap_or(152_064);
+    ForcedAlignerMetadataFields {
+        sample_rate_hz: 16_000,
+        n_mels: audio.num_mel_bins.unwrap_or(128),
+        n_fft: 400,
+        win_length: 400,
+        hop_length: 160,
+        audio_layers: audio.encoder_layers.unwrap_or(24),
+        audio_d_model: audio.d_model.unwrap_or(1024),
+        audio_heads: audio.encoder_attention_heads.unwrap_or(16),
+        llm_layers: text.num_hidden_layers.unwrap_or(28),
+        llm_d_model,
+        llm_heads,
+        llm_kv_heads: text.num_key_value_heads.unwrap_or(8),
+        llm_head_dim,
+        embed_vocab_size,
+        classify_num: config.thinker_config.classify_num.unwrap_or(5_000),
+        llm_max_positions: text.max_position_embeddings.unwrap_or(8_192),
+        audio_start_token_id: config
+            .thinker_config
+            .audio_start_token_id
+            .unwrap_or(151_669),
+        audio_end_token_id: config.thinker_config.audio_end_token_id.unwrap_or(151_670),
+        audio_pad_token_id: config.thinker_config.audio_token_id.unwrap_or(151_676),
+        timestamp_token_id: config.timestamp_token_id.unwrap_or(151_705),
+        timestamp_segment_time_ms: config.timestamp_segment_time.unwrap_or(80),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn forced_aligner_gguf_metadata(
+    request: &Qwen3ForcedAlignerLocalSourceImportRequest,
+    fields: &ForcedAlignerMetadataFields,
+    model_id: &str,
+    tokens: &[String],
+    merges: &[String],
+) -> BTreeMap<String, GgufWriteValue> {
+    let mut metadata = BTreeMap::new();
+    insert_metadata(
+        &mut metadata,
+        crate::models::oasr_metadata::OASR_METADATA_KEY_PACKAGE_VERSION,
+        crate::models::oasr_metadata::OASR_PACKAGE_VERSION_V1,
+    );
+    insert_metadata(
+        &mut metadata,
+        crate::models::oasr_metadata::OASR_METADATA_KEY_MODEL_FAMILY,
+        QWEN3_FORCED_ALIGNER_MODEL_FAMILY,
+    );
+    insert_metadata(
+        &mut metadata,
+        crate::models::oasr_metadata::OASR_METADATA_KEY_MODEL_ARCHITECTURE,
+        QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
+    );
+    insert_metadata(&mut metadata, OPENASR_MODEL_ID_KEY, model_id);
+    insert_metadata(
+        &mut metadata,
+        GENERAL_ARCHITECTURE_KEY,
+        QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
+    );
+
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio.sample_rate_hz",
+        fields.sample_rate_hz,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio.n_mels",
+        fields.n_mels as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio.n_fft",
+        fields.n_fft as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio.win_length",
+        fields.win_length as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio.hop_length",
+        fields.hop_length as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio.n_layers",
+        fields.audio_layers as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio.d_model",
+        fields.audio_d_model as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio.n_heads",
+        fields.audio_heads as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.llm.n_layers",
+        fields.llm_layers as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.llm.d_model",
+        fields.llm_d_model as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.llm.n_heads",
+        fields.llm_heads as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.llm.n_kv_heads",
+        fields.llm_kv_heads as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.llm.head_dim",
+        fields.llm_head_dim as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.llm.embed_vocab_size",
+        fields.embed_vocab_size as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.llm.classify_num",
+        fields.classify_num as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.llm.max_positions",
+        fields.llm_max_positions as u32,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio_start_token_id",
+        fields.audio_start_token_id,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio_end_token_id",
+        fields.audio_end_token_id,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.audio_pad_token_id",
+        fields.audio_pad_token_id,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.timestamp_token_id",
+        fields.timestamp_token_id,
+    );
+    insert_metadata_u32(
+        &mut metadata,
+        "qwen3_forced_aligner.timestamp_segment_time_ms",
+        fields.timestamp_segment_time_ms,
+    );
+
+    insert_metadata(
+        &mut metadata,
+        TOKENIZER_GGML_MODEL_KEY,
+        TOKENIZER_GGML_MODEL_VALUE_GPT2,
+    );
+    insert_metadata_string_array(&mut metadata, TOKENIZER_GGML_TOKENS_KEY, tokens);
+    insert_metadata_string_array(&mut metadata, TOKENIZER_GGML_MERGES_KEY, merges);
+
+    insert_metadata(&mut metadata, "openasr.source.name", &request.source_name);
+    insert_metadata(
+        &mut metadata,
+        "openasr.source.revision",
+        &request.source_revision,
+    );
+    insert_metadata(&mut metadata, "openasr.license.name", &request.license_name);
+    insert_metadata(
+        &mut metadata,
+        "openasr.license.source",
+        &request.license_source,
+    );
+    metadata
+}
+
+fn discover_safetensor_files(
+    source_root: &Path,
+) -> Result<Vec<SafetensorsFile>, LocalSourceImportError> {
+    let mut paths = Vec::new();
+    for entry in std::fs::read_dir(source_root).map_err(|source| LocalSourceImportError::Read {
+        path: source_root.to_path_buf(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| LocalSourceImportError::Read {
+            path: source_root.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("safetensors"))
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    if paths.is_empty() {
+        return Err(validate_error(format!(
+            "Qwen3-ForcedAligner local-source converter could not find any *.safetensors in '{}'",
+            source_root.display()
+        )));
+    }
+    let mut files = Vec::with_capacity(paths.len());
+    for path in paths {
+        files.push(SafetensorsFile::open(path)?);
+    }
+    Ok(files)
+}
+
+fn validate_request(
+    request: &Qwen3ForcedAlignerLocalSourceImportRequest,
+) -> Result<(), LocalSourceImportError> {
+    if request.package_id.trim().is_empty() {
+        return Err(validate_error(
+            "Qwen3-ForcedAligner local-source converter requires non-empty package_id",
+        ));
+    }
+    if request.source_name.trim().is_empty() {
+        return Err(validate_error(
+            "Qwen3-ForcedAligner local-source converter requires non-empty source_name",
+        ));
+    }
+    if request.source_revision.trim().is_empty() {
+        return Err(validate_error(
+            "Qwen3-ForcedAligner local-source converter requires non-empty source_revision",
+        ));
+    }
+    if request.license_name.trim().is_empty() {
+        return Err(validate_error(
+            "Qwen3-ForcedAligner local-source converter requires non-empty license_name",
+        ));
+    }
+    if request.license_source.trim().is_empty() {
+        return Err(validate_error(
+            "Qwen3-ForcedAligner local-source converter requires non-empty license_source",
+        ));
+    }
+    validate_output_pack_extension(&request.output_root)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    /// Stage 1 gate: convert the real downloaded Qwen3-ForcedAligner-0.6B
+    /// checkpoint (if present on disk -- this test is opt-in / dev-machine
+    /// only, mirroring the firered `tmp/firered-out` precedent) and assert
+    /// every mapped destination tensor's element count matches the source
+    /// safetensors tensor 1:1, plus the two synthesized frontend tensors.
+    #[test]
+    fn forced_aligner_conversion_produces_tensor_parity_with_source_checkpoint() {
+        let source_root =
+            PathBuf::from("/Volumes/QuintinDocument/hf-cache/qwen3-forced-aligner-0.6b");
+        if !source_root.exists() {
+            eprintln!(
+                "skipping: {} not present (Stage 0 reference download is dev-machine only)",
+                source_root.display()
+            );
+            return;
+        }
+        let output_dir = std::env::temp_dir().join("openasr-forced-aligner-stage1-test");
+        let _ = std::fs::create_dir_all(&output_dir);
+        let output_root = output_dir.join("qwen3-forced-aligner-0.6b-fp16.oasr");
+
+        let request = Qwen3ForcedAlignerLocalSourceImportRequest {
+            source_root: source_root.clone(),
+            output_root: output_root.clone(),
+            package_id: "qwen3-forced-aligner-0.6b".to_string(),
+            package_variant: Some("fp16".to_string()),
+            source_name: "Qwen/Qwen3-ForcedAligner-0.6B".to_string(),
+            source_revision: "test".to_string(),
+            license_name: "Apache-2.0".to_string(),
+            license_source: "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B".to_string(),
+            quantization: Qwen3AsrRuntimeQuantizationMode::Fp16,
+        };
+
+        let result = convert_local_qwen_forced_aligner_source_to_runtime_pack(&request)
+            .expect("forced-aligner conversion must succeed against the real checkpoint");
+
+        // Cross-check against the raw safetensors header: every source tensor
+        // must have a mapped destination (name known to `remap_qwen_tensor_name`
+        // via the shared qwen3-asr tensor-name convention), and the two
+        // synthesized frontend tensors (mel filters/window) are additional.
+        let safetensor_files = discover_safetensor_files(&source_root).expect("safetensors");
+        let mut source_tensor_names = BTreeSet::new();
+        for file in &safetensor_files {
+            for tensor in &file.header().tensors {
+                source_tensor_names.insert(tensor.name.clone());
+            }
+        }
+        // 2 synthesized frontend tensors (audio.mel_filters / audio.mel_window)
+        // are not present in the source safetensors.
+        assert_eq!(
+            result.tensor_count,
+            source_tensor_names.len() + 2,
+            "expected every source tensor to map 1:1 to a destination tensor, plus 2 synthesized frontend tensors"
+        );
+
+        let index = read_gguf_tensor_index(&output_root).expect("tensor index");
+        // Spot-check the classify head landed with its real (non-tied) shape:
+        // [1024 (hidden), 5000 (classify_num)] after the qwen dim-reversal
+        // convention (source safetensors shape is [5000, 1024]).
+        let output_weight = index.get("output.weight").expect("output.weight present");
+        assert_eq!(output_weight.dims, vec![1024, 5000]);
+
+        let token_embd = index
+            .get("token_embd.weight")
+            .expect("token_embd.weight present");
+        assert_eq!(token_embd.dims, vec![1024, 152_064]);
+
+        let _ = std::fs::remove_file(&output_root);
+    }
+}

--- a/crates/openasr-core/src/models/qwen/forced_aligner_pack.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_pack.rs
@@ -1,0 +1,21 @@
+//! Runtime resolution of the Qwen3-ForcedAligner-0.6B capability-pack file
+//! (the `word-timestamps` feature's `ForcedAligner` role, `catalog::
+//! word_timestamps_forced_aligner_pack`). Resolved from
+//! `OPENASR_FORCED_ALIGNER_PACK` or the standard
+//! `openasr_home()/models/*forced-aligner*/` location, mirroring
+//! `diarize::embed::pack`'s WeSpeaker resolution but built on the shared
+//! `crate::capability_pack` resolver directly (this pack is not diarization).
+
+use std::path::PathBuf;
+
+const FORCED_ALIGNER_PACK_ENV: &str = "OPENASR_FORCED_ALIGNER_PACK";
+const FORCED_ALIGNER_INSTALLED_DIR_HINT: &str = "forced-aligner";
+
+/// The resolved path to the installed Qwen3-ForcedAligner pack, or `None` if
+/// no pack is installed.
+pub(crate) fn resolve_forced_aligner_pack_path() -> Option<PathBuf> {
+    crate::capability_pack::resolve_installed_capability_pack(
+        FORCED_ALIGNER_PACK_ENV,
+        FORCED_ALIGNER_INSTALLED_DIR_HINT,
+    )
+}

--- a/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
@@ -1,25 +1,16 @@
-//! Stage 3-5 NAR (non-autoregressive) execution pipeline for
+//! Stage 3-6 NAR (non-autoregressive) execution pipeline for
 //! Qwen3-ForcedAligner-0.6B: metadata parsing, prompt/token assembly, and the
 //! end-to-end "mel -> audio encoder -> LLM prefill -> classify head at
 //! `<timestamp>` positions -> fix_timestamp -> per-word spans" path.
 //!
-//! Deliberately NOT wired into `ggml_family_registry` or the CLI/server (same
-//! posture as Stage 1/2): this is a dev-machine-gated numeric-parity harness
-//! only. Product surface (capability-pack registration, `--word-timestamps`
-//! opt-in wiring, catalog publication) is tracked as follow-up work, not part
-//! of this stage.
-//!
-//! `#![allow(dead_code)]`: every entry point here is exercised only by the
-//! `#[cfg(test)]` Stage 5 gate below (mirroring the Stage 1/2 precedent in
-//! `forced_aligner_import.rs` / `audio_encoder.rs`'s dev-machine-only tests).
-//! Those precedents dodge `dead_code` by being `pub fn` re-exported from the
-//! crate's public surface; deliberately not doing that here, since it would
-//! force widening several execution-graph internals (audio encoder weights,
-//! logits head, layer projections, per-stage error enums) from `pub(crate)`
-//! to fully `pub` just to satisfy the lint, which is a real API-surface
-//! change this stage does not intend to make. Remove this allow once Stage 6
-//! (capability-pack registration / CLI wiring) adds a real caller.
-#![allow(dead_code)]
+//! Stage 6 adds the real caller: [`refine_word_timestamps_with_forced_aligner`]
+//! is invoked from `api::backend::native_transcribe` when a request opts into
+//! `--word-timestamps=aligned` and the capability pack
+//! (`models::qwen::forced_aligner_pack`) is installed. `align_forced` and
+//! `load_forced_aligner_prepared_assets` stay `pub(crate)` (not `pub`): the
+//! one in-crate caller does not need a wider surface, and every
+//! execution-graph internal they touch (audio encoder weights, logits head,
+//! layer projections, per-stage error enums) stays `pub(crate)` too.
 
 use thiserror::Error;
 
@@ -483,6 +474,23 @@ pub(crate) fn align_forced(
 /// rounding ambiguity to reproduce).
 fn round_to_millis(value: f64) -> f64 {
     (value * 1000.0).round() / 1000.0
+}
+
+/// One-shot entry point for the `--word-timestamps=aligned` opt-in refinement
+/// tier: loads the pack fresh (no process-wide cache -- this runs at most once
+/// per `transcribe` call, the same cost profile as loading the primary ASR
+/// pack) and runs the full NAR pipeline. `language` accepts either an ISO
+/// 639-1 code or a full name; unsupported languages (Japanese, Korean --
+/// see `forced_aligner_align_text`) fail closed with
+/// [`Qwen3ForcedAlignerRuntimeError::TextFailed`] rather than mis-tokenizing.
+pub(crate) fn refine_word_timestamps_with_forced_aligner(
+    pack_path: &std::path::Path,
+    audio_samples_16khz_mono: &[f32],
+    text: &str,
+    language: &str,
+) -> Result<Vec<ForcedAlignItem>, Qwen3ForcedAlignerRuntimeError> {
+    let assets = load_forced_aligner_prepared_assets(pack_path)?;
+    align_forced(pack_path, &assets, audio_samples_16khz_mono, text, language)
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
@@ -1,0 +1,638 @@
+//! Stage 3-5 NAR (non-autoregressive) execution pipeline for
+//! Qwen3-ForcedAligner-0.6B: metadata parsing, prompt/token assembly, and the
+//! end-to-end "mel -> audio encoder -> LLM prefill -> classify head at
+//! `<timestamp>` positions -> fix_timestamp -> per-word spans" path.
+//!
+//! Deliberately NOT wired into `ggml_family_registry` or the CLI/server (same
+//! posture as Stage 1/2): this is a dev-machine-gated numeric-parity harness
+//! only. Product surface (capability-pack registration, `--word-timestamps`
+//! opt-in wiring, catalog publication) is tracked as follow-up work, not part
+//! of this stage.
+//!
+//! `#![allow(dead_code)]`: every entry point here is exercised only by the
+//! `#[cfg(test)]` Stage 5 gate below (mirroring the Stage 1/2 precedent in
+//! `forced_aligner_import.rs` / `audio_encoder.rs`'s dev-machine-only tests).
+//! Those precedents dodge `dead_code` by being `pub fn` re-exported from the
+//! crate's public surface; deliberately not doing that here, since it would
+//! force widening several execution-graph internals (audio encoder weights,
+//! logits head, layer projections, per-stage error enums) from `pub(crate)`
+//! to fully `pub` just to satisfy the lint, which is a real API-surface
+//! change this stage does not intend to make. Remove this allow once Stage 6
+//! (capability-pack registration / CLI wiring) adds a real caller.
+#![allow(dead_code)]
+
+use thiserror::Error;
+
+use crate::ggml_runtime::{GgufMetadata, GgufTensorDataReadError, GgufTensorDataReader};
+use crate::models::gpt2_bpe::{build_merge_rank, build_token_to_id, encode_prompt_text};
+
+use super::audio_encoder::{
+    Qwen3AsrAudioEncoderError, Qwen3AsrAudioEncoderRuntime, Qwen3AsrAudioEncoderWeights,
+    load_qwen3_audio_encoder_weights_from_reader,
+};
+use super::decode_prompt::Qwen3AsrDecodePrompt;
+use super::forced_aligner_align_text::{
+    Qwen3ForcedAlignerTextError, fix_timestamp, word_list_for_language,
+};
+use super::frontend::{
+    Qwen3AsrMelFrontendError, load_qwen3_mel_frontend_plan_from_reader,
+    qwen3_mel_features_from_prepared_audio,
+};
+use super::llm_prefill::{Qwen3AsrLlmPrefillInputError, build_qwen3_llm_prefill_input};
+use super::llm_transformer::{
+    Qwen3AsrLlmLayerAttentionProjection, Qwen3AsrLlmWholeDecoderGraphExecutor,
+    load_qwen3_llm_attention_projections_from_reader,
+};
+use super::logits_head::{
+    Qwen3AsrLlmLogitsHead, Qwen3AsrLlmLogitsHeadError,
+    load_qwen3_llm_logits_head_from_reader_with_output_tensor,
+};
+use super::prompt_embedding::{
+    Qwen3AsrPromptEmbeddingError, build_qwen3_prompt_embeddings_with_audio_splice,
+};
+use super::runtime_contract::Qwen3AsrExecutionMetadata;
+use super::tensor_names::OUTPUT_WEIGHT;
+use super::token_embedding::{
+    Qwen3AsrTokenEmbeddingError, Qwen3AsrTokenEmbeddingTable,
+    load_qwen3_token_embedding_table_from_reader,
+};
+use crate::models::ggml_asr_executor::GgmlAsrPreparedAudio;
+
+/// Same rope theta as the shared qwen3-asr LLM stack (`QWEN_ROPE_THETA` in
+/// `batched_decode.rs`); the forced aligner's LM shares that architecture
+/// byte-for-byte (see `forced_aligner_import.rs`), so it uses the same value.
+const FORCED_ALIGNER_ROPE_THETA: f32 = 1_000_000.0;
+const DEFAULT_RMS_NORM_EPSILON: f32 = 1.0e-6;
+
+const KEY_SAMPLE_RATE: &str = "qwen3_forced_aligner.audio.sample_rate_hz";
+const KEY_N_MELS: &str = "qwen3_forced_aligner.audio.n_mels";
+const KEY_N_FFT: &str = "qwen3_forced_aligner.audio.n_fft";
+const KEY_WIN_LENGTH: &str = "qwen3_forced_aligner.audio.win_length";
+const KEY_HOP_LENGTH: &str = "qwen3_forced_aligner.audio.hop_length";
+const KEY_AUDIO_LAYERS: &str = "qwen3_forced_aligner.audio.n_layers";
+const KEY_AUDIO_D_MODEL: &str = "qwen3_forced_aligner.audio.d_model";
+const KEY_AUDIO_HEADS: &str = "qwen3_forced_aligner.audio.n_heads";
+const KEY_LLM_LAYERS: &str = "qwen3_forced_aligner.llm.n_layers";
+const KEY_LLM_D_MODEL: &str = "qwen3_forced_aligner.llm.d_model";
+const KEY_LLM_HEADS: &str = "qwen3_forced_aligner.llm.n_heads";
+const KEY_LLM_KV_HEADS: &str = "qwen3_forced_aligner.llm.n_kv_heads";
+const KEY_LLM_HEAD_DIM: &str = "qwen3_forced_aligner.llm.head_dim";
+const KEY_EMBED_VOCAB_SIZE: &str = "qwen3_forced_aligner.llm.embed_vocab_size";
+const KEY_CLASSIFY_NUM: &str = "qwen3_forced_aligner.llm.classify_num";
+const KEY_LLM_MAX_POSITIONS: &str = "qwen3_forced_aligner.llm.max_positions";
+const KEY_AUDIO_START_TOKEN_ID: &str = "qwen3_forced_aligner.audio_start_token_id";
+const KEY_AUDIO_END_TOKEN_ID: &str = "qwen3_forced_aligner.audio_end_token_id";
+const KEY_AUDIO_PAD_TOKEN_ID: &str = "qwen3_forced_aligner.audio_pad_token_id";
+const KEY_TIMESTAMP_TOKEN_ID: &str = "qwen3_forced_aligner.timestamp_token_id";
+const KEY_TIMESTAMP_SEGMENT_TIME_MS: &str = "qwen3_forced_aligner.timestamp_segment_time_ms";
+const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
+const TOKENIZER_GGML_MERGES_KEY: &str = "tokenizer.ggml.merges";
+
+#[derive(Debug, Error)]
+pub(crate) enum Qwen3ForcedAlignerRuntimeError {
+    #[error("qwen3-forced-aligner runtime is missing required GGUF metadata key '{key}'")]
+    MissingMetadata { key: &'static str },
+    #[error("qwen3-forced-aligner runtime GGUF metadata '{key}' is invalid: {reason}")]
+    InvalidMetadata { key: &'static str, reason: String },
+    #[error("qwen3-forced-aligner tokenizer construction failed: {0}")]
+    TokenizerFailed(#[from] crate::NativeAsrError),
+    #[error("qwen3-forced-aligner text processing failed: {0}")]
+    TextFailed(#[from] Qwen3ForcedAlignerTextError),
+    #[error("qwen3-forced-aligner mel frontend failed: {0}")]
+    MelFrontendFailed(#[from] Qwen3AsrMelFrontendError),
+    #[error("qwen3-forced-aligner audio encoder failed: {0}")]
+    AudioEncoderFailed(#[from] Qwen3AsrAudioEncoderError),
+    #[error("qwen3-forced-aligner token embedding failed: {0}")]
+    TokenEmbeddingFailed(#[from] Qwen3AsrTokenEmbeddingError),
+    #[error("qwen3-forced-aligner prompt embedding failed: {0}")]
+    PromptEmbeddingFailed(#[from] Qwen3AsrPromptEmbeddingError),
+    #[error("qwen3-forced-aligner llm prefill input failed: {0}")]
+    LlmPrefillInputFailed(#[from] Qwen3AsrLlmPrefillInputError),
+    #[error("qwen3-forced-aligner llm graph failed: {reason}")]
+    LlmGraphFailed { reason: String },
+    #[error("qwen3-forced-aligner logits head failed: {0}")]
+    LogitsHeadFailed(#[from] Qwen3AsrLlmLogitsHeadError),
+    #[error(
+        "qwen3-forced-aligner expected {expected} <timestamp> positions (2 per word x {word_count} words), found {found}"
+    )]
+    TimestampPositionCountMismatch {
+        expected: usize,
+        found: usize,
+        word_count: usize,
+    },
+    #[error("qwen3-forced-aligner GGUF tensor read failed: {0}")]
+    TensorRead(#[from] GgufTensorDataReadError),
+    #[error("qwen3-forced-aligner llm layer projection load failed: {0}")]
+    LlmTransformerFailed(#[from] super::llm_transformer::Qwen3AsrLlmTransformerError),
+}
+
+/// Parsed `qwen3_forced_aligner.*` GGUF metadata, with the embedding-table
+/// vocab size and the classify-head width kept as two independent fields (see
+/// the Stage 1 importer's `embed_vocab_size` / `classify_num` split -- the
+/// forced aligner's output head is not tied to the token embedding table, so
+/// a single `Qwen3AsrExecutionMetadata.vocab_size` cannot represent both).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Qwen3ForcedAlignerRuntimeMetadata {
+    pub sample_rate_hz: u32,
+    pub n_mels: usize,
+    pub n_fft: usize,
+    pub win_length: usize,
+    pub hop_length: usize,
+    pub audio_layers: usize,
+    pub audio_d_model: usize,
+    pub audio_heads: usize,
+    pub llm_layers: usize,
+    pub llm_d_model: usize,
+    pub llm_heads: usize,
+    pub llm_kv_heads: usize,
+    pub llm_head_dim: usize,
+    pub embed_vocab_size: usize,
+    pub classify_num: usize,
+    pub llm_max_positions: usize,
+    pub audio_start_token_id: u32,
+    pub audio_end_token_id: u32,
+    pub audio_pad_token_id: u32,
+    pub timestamp_token_id: u32,
+    pub timestamp_segment_time_ms: u32,
+}
+
+impl Qwen3ForcedAlignerRuntimeMetadata {
+    /// A `Qwen3AsrExecutionMetadata` view sized for the shared token-embedding
+    /// table / audio-encoder / LLM-layer loaders, which are architecture
+    /// (layers/d_model/heads) driven and generic over `vocab_size` -- they
+    /// never special-case the qwen3-asr tied head, so reusing them here with
+    /// `vocab_size = embed_vocab_size` is exact, not an approximation.
+    /// `eos_token_id`/`pad_token_id` are unused by every loader this view
+    /// feeds (audio encoder, mel frontend, token embedding, LLM layer
+    /// projections); the aligner's actual EOS-equivalent-free NAR decode
+    /// never consults them, so any placeholder value is harmless.
+    pub(crate) fn as_embedding_execution_metadata(&self) -> Qwen3AsrExecutionMetadata {
+        Qwen3AsrExecutionMetadata {
+            sample_rate_hz: self.sample_rate_hz,
+            n_mels: self.n_mels,
+            n_fft: self.n_fft,
+            win_length: self.win_length,
+            hop_length: self.hop_length,
+            audio_layers: self.audio_layers,
+            audio_d_model: self.audio_d_model,
+            audio_heads: self.audio_heads,
+            llm_layers: self.llm_layers,
+            llm_d_model: self.llm_d_model,
+            llm_heads: self.llm_heads,
+            llm_kv_heads: self.llm_kv_heads,
+            llm_head_dim: self.llm_head_dim,
+            vocab_size: self.embed_vocab_size,
+            llm_max_positions: self.llm_max_positions,
+            audio_start_token_id: self.audio_start_token_id,
+            audio_end_token_id: self.audio_end_token_id,
+            audio_pad_token_id: self.audio_pad_token_id,
+            eos_token_id: self.audio_end_token_id,
+            pad_token_id: self.audio_pad_token_id,
+        }
+    }
+
+    /// A `Qwen3AsrExecutionMetadata` view sized for the shared logits-head
+    /// loader, with `vocab_size = classify_num` so it reads/matmuls against
+    /// the 5000-wide `output.weight` classification head instead of a real
+    /// vocabulary.
+    pub(crate) fn as_classify_execution_metadata(&self) -> Qwen3AsrExecutionMetadata {
+        let mut metadata = self.as_embedding_execution_metadata();
+        metadata.vocab_size = self.classify_num;
+        metadata
+    }
+}
+
+pub(crate) fn parse_forced_aligner_runtime_metadata(
+    metadata: &GgufMetadata,
+) -> Result<Qwen3ForcedAlignerRuntimeMetadata, Qwen3ForcedAlignerRuntimeError> {
+    Ok(Qwen3ForcedAlignerRuntimeMetadata {
+        sample_rate_hz: required_u32(metadata, KEY_SAMPLE_RATE)?,
+        n_mels: required_u32(metadata, KEY_N_MELS)? as usize,
+        n_fft: required_u32(metadata, KEY_N_FFT)? as usize,
+        win_length: required_u32(metadata, KEY_WIN_LENGTH)? as usize,
+        hop_length: required_u32(metadata, KEY_HOP_LENGTH)? as usize,
+        audio_layers: required_u32(metadata, KEY_AUDIO_LAYERS)? as usize,
+        audio_d_model: required_u32(metadata, KEY_AUDIO_D_MODEL)? as usize,
+        audio_heads: required_u32(metadata, KEY_AUDIO_HEADS)? as usize,
+        llm_layers: required_u32(metadata, KEY_LLM_LAYERS)? as usize,
+        llm_d_model: required_u32(metadata, KEY_LLM_D_MODEL)? as usize,
+        llm_heads: required_u32(metadata, KEY_LLM_HEADS)? as usize,
+        llm_kv_heads: required_u32(metadata, KEY_LLM_KV_HEADS)? as usize,
+        llm_head_dim: required_u32(metadata, KEY_LLM_HEAD_DIM)? as usize,
+        embed_vocab_size: required_u32(metadata, KEY_EMBED_VOCAB_SIZE)? as usize,
+        classify_num: required_u32(metadata, KEY_CLASSIFY_NUM)? as usize,
+        llm_max_positions: required_u32(metadata, KEY_LLM_MAX_POSITIONS)? as usize,
+        audio_start_token_id: required_u32(metadata, KEY_AUDIO_START_TOKEN_ID)?,
+        audio_end_token_id: required_u32(metadata, KEY_AUDIO_END_TOKEN_ID)?,
+        audio_pad_token_id: required_u32(metadata, KEY_AUDIO_PAD_TOKEN_ID)?,
+        timestamp_token_id: required_u32(metadata, KEY_TIMESTAMP_TOKEN_ID)?,
+        timestamp_segment_time_ms: required_u32(metadata, KEY_TIMESTAMP_SEGMENT_TIME_MS)?,
+    })
+}
+
+fn required_u32(
+    metadata: &GgufMetadata,
+    key: &'static str,
+) -> Result<u32, Qwen3ForcedAlignerRuntimeError> {
+    metadata
+        .get_u32(key)
+        .ok_or(Qwen3ForcedAlignerRuntimeError::MissingMetadata { key })
+}
+
+/// One item of forced-alignment output: a word (or CJK character) span in
+/// seconds. Mirrors the reference's `ForcedAlignItem`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ForcedAlignItem {
+    pub text: String,
+    pub start_time_s: f64,
+    pub end_time_s: f64,
+}
+
+/// Assembles the aligner's decode prompt directly from BPE-encoded pieces
+/// (rather than literally concatenating a Python-style string and
+/// re-tokenizing it): the shared `encode_prompt_text` special-token matcher
+/// only recognizes `<|...|>`-shaped tokens, not the bare `<timestamp>`
+/// marker, so `<timestamp>` positions are injected as already-known token ids
+/// instead of being round-tripped through text matching. This produces the
+/// same token sequence as the reference for prose without embedded special
+/// markers: the reference's literal string join places each word directly
+/// adjacent to `<timestamp>` with no separating whitespace, so tokenizing
+/// each word independently (as done here) reproduces the same "no leading
+/// space" byte-level-BPE segmentation the reference gets from splitting on
+/// added-token boundaries before re-tokenizing.
+///
+/// Returns the assembled `Qwen3AsrDecodePrompt` (for the shared audio-splice
+/// prompt-embedding builder) plus the ordered list of `<timestamp>` token
+/// positions (two per word: start, end).
+pub(crate) fn build_forced_aligner_decode_prompt(
+    metadata: &Qwen3ForcedAlignerRuntimeMetadata,
+    token_to_id: &std::collections::BTreeMap<String, u32>,
+    merge_rank: &std::collections::BTreeMap<String, usize>,
+    word_list: &[String],
+    audio_frame_count: usize,
+) -> Result<(Qwen3AsrDecodePrompt, Vec<usize>), Qwen3ForcedAlignerRuntimeError> {
+    let encode = |text: &str| -> Result<Vec<u32>, Qwen3ForcedAlignerRuntimeError> {
+        encode_prompt_text(text, token_to_id, merge_rank, "Qwen3-ForcedAligner")
+            .map_err(Qwen3ForcedAlignerRuntimeError::TokenizerFailed)
+    };
+
+    let mut token_ids = encode("<|audio_start|>")?;
+    let audio_pad_start_index = token_ids.len();
+    token_ids.extend(std::iter::repeat_n(
+        metadata.audio_pad_token_id,
+        audio_frame_count,
+    ));
+    token_ids.extend(encode("<|audio_end|>")?);
+
+    let mut timestamp_positions = Vec::with_capacity(word_list.len() * 2);
+    for word in word_list {
+        token_ids.extend(encode(word)?);
+        timestamp_positions.push(token_ids.len());
+        token_ids.push(metadata.timestamp_token_id);
+        timestamp_positions.push(token_ids.len());
+        token_ids.push(metadata.timestamp_token_id);
+    }
+
+    Ok((
+        Qwen3AsrDecodePrompt {
+            token_ids,
+            audio_pad_start_index,
+            audio_pad_count: audio_frame_count,
+        },
+        timestamp_positions,
+    ))
+}
+
+/// Everything read once from the `.oasr` pack, reusable across multiple
+/// `align()` calls against the same pack (mirrors the qwen3-asr prepared
+/// runtime's shape, but intentionally not merged with it -- the forced
+/// aligner's asset set differs by exactly the classify head vs tied lm_head).
+pub(crate) struct Qwen3ForcedAlignerPreparedAssets {
+    pub metadata: Qwen3ForcedAlignerRuntimeMetadata,
+    pub token_to_id: std::collections::BTreeMap<String, u32>,
+    pub merge_rank: std::collections::BTreeMap<String, usize>,
+    pub audio_encoder_weights: Qwen3AsrAudioEncoderWeights,
+    pub token_embedding_table: Qwen3AsrTokenEmbeddingTable,
+    pub logits_head: Qwen3AsrLlmLogitsHead,
+    pub layer_attention_projections: Vec<Qwen3AsrLlmLayerAttentionProjection>,
+}
+
+pub(crate) fn load_forced_aligner_prepared_assets(
+    pack_path: &std::path::Path,
+) -> Result<Qwen3ForcedAlignerPreparedAssets, Qwen3ForcedAlignerRuntimeError> {
+    let gguf_metadata = crate::ggml_runtime::read_gguf_metadata(pack_path).map_err(|error| {
+        Qwen3ForcedAlignerRuntimeError::InvalidMetadata {
+            key: "<gguf>",
+            reason: error.to_string(),
+        }
+    })?;
+    let metadata = parse_forced_aligner_runtime_metadata(&gguf_metadata)?;
+
+    let tokens = gguf_metadata
+        .get_string_array(TOKENIZER_GGML_TOKENS_KEY)
+        .ok_or(Qwen3ForcedAlignerRuntimeError::MissingMetadata {
+            key: TOKENIZER_GGML_TOKENS_KEY,
+        })?;
+    let merges = gguf_metadata
+        .get_string_array(TOKENIZER_GGML_MERGES_KEY)
+        .ok_or(Qwen3ForcedAlignerRuntimeError::MissingMetadata {
+            key: TOKENIZER_GGML_MERGES_KEY,
+        })?;
+    let token_to_id = build_token_to_id(tokens, "Qwen3-ForcedAligner")?;
+    let merge_rank = build_merge_rank(merges);
+
+    let reader = GgufTensorDataReader::from_path(pack_path)?;
+    let embedding_metadata = metadata.as_embedding_execution_metadata();
+    let classify_metadata = metadata.as_classify_execution_metadata();
+
+    let audio_encoder_weights =
+        load_qwen3_audio_encoder_weights_from_reader(&reader, embedding_metadata)?;
+    let token_embedding_table =
+        load_qwen3_token_embedding_table_from_reader(&reader, embedding_metadata)?;
+    let logits_head = load_qwen3_llm_logits_head_from_reader_with_output_tensor(
+        &reader,
+        classify_metadata,
+        OUTPUT_WEIGHT,
+        DEFAULT_RMS_NORM_EPSILON,
+    )?;
+    let layer_attention_projections =
+        load_qwen3_llm_attention_projections_from_reader(&reader, embedding_metadata)?;
+
+    Ok(Qwen3ForcedAlignerPreparedAssets {
+        metadata,
+        token_to_id,
+        merge_rank,
+        audio_encoder_weights,
+        token_embedding_table,
+        logits_head,
+        layer_attention_projections,
+    })
+}
+
+/// Runs the full NAR forced-alignment pipeline for one (audio, text,
+/// language) sample against an already-loaded pack: mel -> audio encoder ->
+/// prompt assembly -> token embedding + audio splice -> LLM prefill (single
+/// forward pass, one row per prompt token) -> classify-head argmax at every
+/// `<timestamp>` position -> `fix_timestamp` LIS repair -> per-word spans.
+pub(crate) fn align_forced(
+    pack_path: &std::path::Path,
+    assets: &Qwen3ForcedAlignerPreparedAssets,
+    audio_samples_16khz_mono: &[f32],
+    text: &str,
+    language: &str,
+) -> Result<Vec<ForcedAlignItem>, Qwen3ForcedAlignerRuntimeError> {
+    let word_list = word_list_for_language(text, language)?;
+
+    let reader = GgufTensorDataReader::from_path(pack_path)?;
+    let embedding_metadata = assets.metadata.as_embedding_execution_metadata();
+    let mel_plan = load_qwen3_mel_frontend_plan_from_reader(&reader, embedding_metadata)?;
+    let prepared_audio = GgmlAsrPreparedAudio::mono_16khz(audio_samples_16khz_mono.to_vec());
+    let mel_features = qwen3_mel_features_from_prepared_audio(&prepared_audio, &mel_plan)?;
+
+    let mut audio_runtime = Qwen3AsrAudioEncoderRuntime::new(Some(pack_path)).map_err(|error| {
+        Qwen3ForcedAlignerRuntimeError::LlmGraphFailed {
+            reason: format!("audio encoder runtime init failed: {error}"),
+        }
+    })?;
+    let audio_embeddings = audio_runtime
+        .encode(
+            &assets.audio_encoder_weights,
+            embedding_metadata,
+            &mel_features,
+        )
+        .map_err(Qwen3ForcedAlignerRuntimeError::AudioEncoderFailed)?;
+
+    let (decode_prompt, timestamp_positions) = build_forced_aligner_decode_prompt(
+        &assets.metadata,
+        &assets.token_to_id,
+        &assets.merge_rank,
+        &word_list,
+        audio_embeddings.row_count,
+    )?;
+
+    let token_rows = assets
+        .token_embedding_table
+        .gather_rows(&decode_prompt.token_ids)?;
+    let prompt_embeddings = build_qwen3_prompt_embeddings_with_audio_splice(
+        &decode_prompt,
+        assets.token_embedding_table.d_model(),
+        &token_rows,
+        &audio_embeddings.rows,
+    )?;
+    let prefill_input = build_qwen3_llm_prefill_input(&prompt_embeddings)?;
+
+    let mut whole_decoder = Qwen3AsrLlmWholeDecoderGraphExecutor::new(
+        &assets.layer_attention_projections,
+        Some(pack_path),
+    )
+    .map_err(|error| Qwen3ForcedAlignerRuntimeError::LlmGraphFailed {
+        reason: error.to_string(),
+    })?;
+    let prefill_output = whole_decoder
+        .run_prefill(
+            &prefill_input.token_major_embeddings,
+            prefill_input.token_count,
+            FORCED_ALIGNER_ROPE_THETA,
+        )
+        .map_err(|error| Qwen3ForcedAlignerRuntimeError::LlmGraphFailed {
+            reason: error.to_string(),
+        })?;
+
+    let hidden_size = prompt_embeddings.hidden_size;
+    let expected_timestamp_positions = word_list.len() * 2;
+    if timestamp_positions.len() != expected_timestamp_positions {
+        return Err(
+            Qwen3ForcedAlignerRuntimeError::TimestampPositionCountMismatch {
+                expected: expected_timestamp_positions,
+                found: timestamp_positions.len(),
+                word_count: word_list.len(),
+            },
+        );
+    }
+
+    let mut raw_timestamps_ms = Vec::with_capacity(timestamp_positions.len());
+    for &position in &timestamp_positions {
+        let start = position * hidden_size;
+        let end = start + hidden_size;
+        let hidden_row = &prefill_output.hidden[start..end];
+        let bin = assets
+            .logits_head
+            .compute_top1_token_for_last_hidden(hidden_row)?;
+        raw_timestamps_ms
+            .push(i64::from(bin) * i64::from(assets.metadata.timestamp_segment_time_ms));
+    }
+
+    let fixed_ms = fix_timestamp(&raw_timestamps_ms)?;
+
+    let mut items = Vec::with_capacity(word_list.len());
+    for (index, word) in word_list.into_iter().enumerate() {
+        let start_ms = fixed_ms[index * 2];
+        let end_ms = fixed_ms[index * 2 + 1];
+        items.push(ForcedAlignItem {
+            text: word,
+            start_time_s: round_to_millis(start_ms as f64 / 1000.0),
+            end_time_s: round_to_millis(end_ms as f64 / 1000.0),
+        });
+    }
+    Ok(items)
+}
+
+/// Matches Python's `round(x, 3)` (round-half-to-even on the underlying f64
+/// representation is close enough here: timestamps are integer milliseconds
+/// divided by 1000, i.e. always an exact multiple of 0.001, so there is no
+/// rounding ambiguity to reproduce).
+fn round_to_millis(value: f64) -> f64 {
+    (value * 1000.0).round() / 1000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stage 5 gate: run the full NAR pipeline end-to-end against the real
+    /// Qwen3-ForcedAligner-0.6B checkpoint for both fixtures (`jfk.wav`
+    /// English, `zh_sample.wav` Chinese) and compare every word's start/end
+    /// against the reference `qwen_asr.inference.qwen3_forced_aligner`
+    /// output captured in `tmp/forced-aligner-ref/reference_output.json`
+    /// (dev-machine only / gitignored -- see
+    /// `tmp/forced-aligner-ref/run_reference.py`). Skips cleanly when the
+    /// Stage 0 reference artifacts are absent (e.g. in ordinary CI).
+    #[test]
+    fn forced_aligner_end_to_end_matches_python_reference_for_jfk_and_zh_sample() {
+        use std::path::PathBuf;
+
+        use super::super::forced_aligner_import::{
+            Qwen3ForcedAlignerLocalSourceImportRequest,
+            convert_local_qwen_forced_aligner_source_to_runtime_pack,
+        };
+        use super::super::package_import::Qwen3AsrRuntimeQuantizationMode as ForcedAlignerQuantMode;
+        use crate::api::audio_io::load_wav_16khz_mono_f32_v0;
+
+        let source_root =
+            PathBuf::from("/Volumes/QuintinDocument/hf-cache/qwen3-forced-aligner-0.6b");
+        let ref_dir =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp/forced-aligner-ref");
+        let reference_output_path = ref_dir.join("reference_output.json");
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        if !source_root.exists() || !reference_output_path.exists() {
+            eprintln!(
+                "skipping: {} / {} not present (Stage 0 dev-machine reference artifacts)",
+                source_root.display(),
+                reference_output_path.display()
+            );
+            return;
+        }
+
+        let pack_dir = std::env::temp_dir().join("openasr-forced-aligner-stage5-test");
+        let _ = std::fs::create_dir_all(&pack_dir);
+        let pack_path = pack_dir.join("qwen3-forced-aligner-0.6b-fp16.oasr");
+        let _ = std::fs::remove_file(&pack_path);
+        let request = Qwen3ForcedAlignerLocalSourceImportRequest {
+            source_root,
+            output_root: pack_path.clone(),
+            package_id: "qwen3-forced-aligner-0.6b".to_string(),
+            package_variant: Some("fp16".to_string()),
+            source_name: "Qwen/Qwen3-ForcedAligner-0.6B".to_string(),
+            source_revision: "test".to_string(),
+            license_name: "Apache-2.0".to_string(),
+            license_source: "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B".to_string(),
+            quantization: ForcedAlignerQuantMode::Fp16,
+        };
+        convert_local_qwen_forced_aligner_source_to_runtime_pack(&request)
+            .expect("forced-aligner conversion must succeed");
+
+        let assets = load_forced_aligner_prepared_assets(&pack_path).expect("prepared assets");
+
+        let reference_json: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(&reference_output_path).expect("read reference_output.json"),
+        )
+        .expect("parse reference_output.json");
+
+        struct Case<'a> {
+            key: &'a str,
+            audio_relpath: &'a str,
+            text: &'a str,
+            language: &'a str,
+        }
+        let cases = [
+            Case {
+                key: "jfk",
+                audio_relpath: "fixtures/jfk.wav",
+                text: "And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.",
+                language: "English",
+            },
+            Case {
+                key: "zh_sample",
+                audio_relpath: "fixtures/zh_sample.wav",
+                text: "今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我通常会读书或者看一部电影放松一下",
+                language: "Chinese",
+            },
+        ];
+
+        for case in cases {
+            let audio_path = repo_root.join(case.audio_relpath);
+            let samples = load_wav_16khz_mono_f32_v0(
+                &audio_path,
+                "forced-aligner-stage5-test",
+                "forced-aligner-stage5-test",
+            )
+            .expect("load wav");
+
+            let items = align_forced(&pack_path, &assets, &samples, case.text, case.language)
+                .expect("align_forced");
+
+            let reference_items = reference_json[case.key]["items"]
+                .as_array()
+                .unwrap_or_else(|| panic!("reference items array for '{}'", case.key));
+            assert_eq!(
+                items.len(),
+                reference_items.len(),
+                "word count mismatch for '{}'",
+                case.key
+            );
+
+            let mut diffs_ms = Vec::with_capacity(items.len() * 2);
+            for (index, (item, reference_item)) in
+                items.iter().zip(reference_items.iter()).enumerate()
+            {
+                let reference_text = reference_item["text"].as_str().unwrap_or_default();
+                assert_eq!(
+                    item.text, reference_text,
+                    "word text mismatch at index {index} for '{}'",
+                    case.key
+                );
+                let reference_start = reference_item["start_time"].as_f64().unwrap_or_default();
+                let reference_end = reference_item["end_time"].as_f64().unwrap_or_default();
+                diffs_ms.push(((item.start_time_s - reference_start) * 1000.0).abs());
+                diffs_ms.push(((item.end_time_s - reference_end) * 1000.0).abs());
+                eprintln!(
+                    "{} word[{index}] {:?}: ours=({:.3},{:.3}) ref=({:.3},{:.3})",
+                    case.key,
+                    item.text,
+                    item.start_time_s,
+                    item.end_time_s,
+                    reference_start,
+                    reference_end
+                );
+            }
+            diffs_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let median_diff_ms = diffs_ms[diffs_ms.len() / 2];
+            eprintln!(
+                "forced_aligner_end_to_end '{}': median start/end diff = {median_diff_ms:.3}ms (n={})",
+                case.key,
+                diffs_ms.len()
+            );
+            // Threshold: median per-word start/end diff under one 80ms
+            // timestamp-segment bin (the classify head's own resolution), so
+            // this catches wiring regressions without being brittle to
+            // single-bin rounding differences from fp16 quantization.
+            assert!(
+                median_diff_ms < 80.0,
+                "'{}' diverges from Python reference: median diff {median_diff_ms:.3}ms >= 80ms",
+                case.key
+            );
+        }
+
+        let _ = std::fs::remove_file(&pack_path);
+    }
+}

--- a/crates/openasr-core/src/models/qwen/mod.rs
+++ b/crates/openasr-core/src/models/qwen/mod.rs
@@ -1,7 +1,9 @@
 mod audio_encoder;
 mod batched_decode;
 mod decode_prompt;
+mod forced_aligner_align_text;
 mod forced_aligner_import;
+mod forced_aligner_runtime;
 mod frontend;
 mod ggml_executor;
 mod graph_config;

--- a/crates/openasr-core/src/models/qwen/mod.rs
+++ b/crates/openasr-core/src/models/qwen/mod.rs
@@ -1,6 +1,7 @@
 mod audio_encoder;
 mod batched_decode;
 mod decode_prompt;
+mod forced_aligner_import;
 mod frontend;
 mod ggml_executor;
 mod graph_config;
@@ -20,6 +21,12 @@ mod tokenizer;
 
 pub(crate) use audio_encoder::{
     Qwen3AsrAudioEncoderWeights, load_qwen3_audio_encoder_weights_from_reader,
+};
+pub use forced_aligner_import::{
+    QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID, QWEN3_FORCED_ALIGNER_MODEL_FAMILY,
+    Qwen3ForcedAlignerLocalSourceError, Qwen3ForcedAlignerLocalSourceImportRequest,
+    Qwen3ForcedAlignerLocalSourceImportRuntimeResult,
+    convert_local_qwen_forced_aligner_source_to_runtime_pack,
 };
 pub(crate) use frontend::{Qwen3AsrMelFrontendPlan, load_qwen3_mel_frontend_plan_from_reader};
 pub(crate) use ggml_executor::Qwen3AsrGgmlExecutor;

--- a/crates/openasr-core/src/models/qwen/mod.rs
+++ b/crates/openasr-core/src/models/qwen/mod.rs
@@ -3,6 +3,7 @@ mod batched_decode;
 mod decode_prompt;
 mod forced_aligner_align_text;
 mod forced_aligner_import;
+pub(crate) mod forced_aligner_pack;
 mod forced_aligner_runtime;
 mod frontend;
 mod ggml_executor;
@@ -29,6 +30,9 @@ pub use forced_aligner_import::{
     Qwen3ForcedAlignerLocalSourceError, Qwen3ForcedAlignerLocalSourceImportRequest,
     Qwen3ForcedAlignerLocalSourceImportRuntimeResult,
     convert_local_qwen_forced_aligner_source_to_runtime_pack,
+};
+pub(crate) use forced_aligner_runtime::{
+    ForcedAlignItem, refine_word_timestamps_with_forced_aligner,
 };
 pub(crate) use frontend::{Qwen3AsrMelFrontendPlan, load_qwen3_mel_frontend_plan_from_reader};
 pub(crate) use ggml_executor::Qwen3AsrGgmlExecutor;

--- a/crates/openasr-core/src/models/qwen/package_import.rs
+++ b/crates/openasr-core/src/models/qwen/package_import.rs
@@ -216,7 +216,7 @@ pub fn convert_local_qwen_source_to_runtime_pack(
     })
 }
 
-fn build_qwen_runtime_tensors(
+pub(super) fn build_qwen_runtime_tensors(
     safetensor_files: &[SafetensorsFile],
     quantization: Qwen3AsrRuntimeQuantizationMode,
     n_mels: usize,
@@ -627,7 +627,7 @@ fn qwen_runtime_gguf_metadata(
     metadata
 }
 
-fn patch_added_tokens(
+pub(super) fn patch_added_tokens(
     source_root: &Path,
     tokens: &mut [String],
 ) -> Result<(), LocalSourceImportError> {
@@ -652,7 +652,7 @@ fn patch_added_tokens(
     Ok(())
 }
 
-fn load_vocab_tokens(source_root: &Path) -> Result<Vec<String>, LocalSourceImportError> {
+pub(super) fn load_vocab_tokens(source_root: &Path) -> Result<Vec<String>, LocalSourceImportError> {
     let vocab: BTreeMap<String, usize> = read_source_json_file(source_root, SOURCE_VOCAB_JSON)?;
     if vocab.is_empty() {
         return Err(validate_error("Qwen vocab.json cannot be empty"));
@@ -670,7 +670,7 @@ fn load_vocab_tokens(source_root: &Path) -> Result<Vec<String>, LocalSourceImpor
     Ok(tokens)
 }
 
-fn load_merges(source_root: &Path) -> Result<Vec<String>, LocalSourceImportError> {
+pub(super) fn load_merges(source_root: &Path) -> Result<Vec<String>, LocalSourceImportError> {
     let path = source_root.join(SOURCE_MERGES_TXT);
     if !path.exists() {
         return Ok(Vec::new());
@@ -690,7 +690,7 @@ fn load_merges(source_root: &Path) -> Result<Vec<String>, LocalSourceImportError
         .collect())
 }
 
-fn discover_safetensor_files(
+pub(super) fn discover_safetensor_files(
     request: &Qwen3AsrLocalSourceImportRequest,
 ) -> Result<Vec<SafetensorsFile>, LocalSourceImportError> {
     let mut paths = Vec::new();
@@ -799,7 +799,7 @@ fn f32_tensor(name: &str, dims: Vec<u64>, values: Vec<f32>) -> GgufWriteTensor {
     }
 }
 
-fn compose_model_id(package_id: &str, package_variant: Option<&str>) -> String {
+pub(super) fn compose_model_id(package_id: &str, package_variant: Option<&str>) -> String {
     match package_variant
         .map(str::trim)
         .filter(|variant| !variant.is_empty())
@@ -841,7 +841,7 @@ fn validate_request(
     Ok(())
 }
 
-fn insert_metadata(
+pub(super) fn insert_metadata(
     metadata: &mut BTreeMap<String, GgufWriteValue>,
     key: &str,
     value: impl ToString,
@@ -849,11 +849,15 @@ fn insert_metadata(
     metadata.insert(key.to_string(), GgufWriteValue::String(value.to_string()));
 }
 
-fn insert_metadata_u32(metadata: &mut BTreeMap<String, GgufWriteValue>, key: &str, value: u32) {
+pub(super) fn insert_metadata_u32(
+    metadata: &mut BTreeMap<String, GgufWriteValue>,
+    key: &str,
+    value: u32,
+) {
     metadata.insert(key.to_string(), GgufWriteValue::U32(value));
 }
 
-fn insert_metadata_string_array(
+pub(super) fn insert_metadata_string_array(
     metadata: &mut BTreeMap<String, GgufWriteValue>,
     key: &str,
     values: &[String],

--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -30,6 +30,11 @@ const CATALOG_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const CATALOG_HTTP_TIMEOUT: Duration = Duration::from_secs(60);
 pub const CATALOG_FEATURE_SPEAKER_DIARIZATION: &str = "speaker-diarization";
 const CATALOG_SPEAKER_EMBEDDER_WESPEAKER_ID: &str = "wespeaker-voxceleb-resnet34-lm";
+/// Capability-pack feature key for the optional forced-alignment word-timestamp
+/// refinement tier (`--word-timestamps=aligned`). Mirrors
+/// `CATALOG_FEATURE_SPEAKER_DIARIZATION`'s role as the shared vocabulary
+/// between the catalog and the CLI/server opt-in wiring.
+pub const CATALOG_FEATURE_WORD_TIMESTAMPS: &str = "word-timestamps";
 // Soft-disabled for the initial public release lane. The ModelScope URL
 // validation block below stays in place so re-enabling is a one-switch decision.
 const MODELSCOPE_CATALOG_MIRRORS_ENABLED: bool = false;
@@ -337,6 +342,12 @@ pub struct CatalogCapability {
 pub enum CatalogCapabilityRole {
     SpeakerEmbedder,
     SpeakerSegmenter,
+    /// A forced-alignment refinement model for the `word-timestamps` feature
+    /// (e.g. Qwen3-ForcedAligner-0.6B): consumes a finished transcript's text
+    /// plus the source audio and replaces the model family's own approximate
+    /// per-word timestamps with aligner-refined spans. Opt-in only; the
+    /// family's own approximate timestamps remain the default.
+    ForcedAligner,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -456,6 +467,21 @@ impl ModelCatalog {
                     && model.capability.as_ref().is_some_and(|capability| {
                         capability.role == CatalogCapabilityRole::SpeakerEmbedder
                     })
+            })
+    }
+
+    /// The forced-alignment capability pack for the `word-timestamps` feature
+    /// (`--word-timestamps=aligned`), when the catalog carries one. Unlike
+    /// diarization's single pinned embedder id, any public pack advertising
+    /// `(word-timestamps, ForcedAligner)` qualifies -- there is exactly one
+    /// today (Qwen3-ForcedAligner-0.6B) but callers should not hardcode its id.
+    pub fn word_timestamps_forced_aligner_pack(&self) -> Option<&CatalogModel> {
+        self.capability_packs_for_feature(CATALOG_FEATURE_WORD_TIMESTAMPS)
+            .into_iter()
+            .find(|model| {
+                model.capability.as_ref().is_some_and(|capability| {
+                    capability.role == CatalogCapabilityRole::ForcedAligner
+                })
             })
     }
 }

--- a/crates/openasr-core/src/registry/tests/catalog.rs
+++ b/crates/openasr-core/src/registry/tests/catalog.rs
@@ -256,11 +256,19 @@ fn runtime_variant_card(id: &str, quantization: &str) -> ModelCard {
 }
 
 fn capability_pack_model(id: &str, role: CatalogCapabilityRole) -> CatalogModel {
+    capability_pack_model_with_feature(id, CATALOG_FEATURE_SPEAKER_DIARIZATION, role)
+}
+
+fn capability_pack_model_with_feature(
+    id: &str,
+    feature: &str,
+    role: CatalogCapabilityRole,
+) -> CatalogModel {
     let revision = "0123456789abcdef0123456789abcdef01234567";
     let mut model = alias_contract_model(id, id, id, &[], None, "embedder", true);
     model.kind = CatalogModelKind::CapabilityPack;
     model.capability = Some(CatalogCapability {
-        feature: CATALOG_FEATURE_SPEAKER_DIARIZATION.to_string(),
+        feature: feature.to_string(),
         role,
     });
     model.recommended_quant = "f32".to_string();
@@ -440,6 +448,50 @@ fn speaker_diarization_required_pack_selects_wespeaker_embedder() {
         .speaker_diarization_required_embedder_pack()
         .expect("WeSpeaker required pack");
     assert_eq!(default_required.id, "wespeaker-voxceleb-resnet34-lm");
+}
+
+#[test]
+fn word_timestamps_forced_aligner_pack_selects_the_aligner_capability_pack() {
+    let mut catalog = alias_contract_catalog();
+    catalog.models.push(capability_pack_model(
+        "wespeaker-voxceleb-resnet34-lm",
+        CatalogCapabilityRole::SpeakerEmbedder,
+    ));
+    catalog.models.push(capability_pack_model_with_feature(
+        "qwen3-forced-aligner-0.6b",
+        CATALOG_FEATURE_WORD_TIMESTAMPS,
+        CatalogCapabilityRole::ForcedAligner,
+    ));
+
+    let aligner = catalog
+        .word_timestamps_forced_aligner_pack()
+        .expect("forced-aligner capability pack");
+    assert_eq!(aligner.id, "qwen3-forced-aligner-0.6b");
+}
+
+#[test]
+fn word_timestamps_forced_aligner_pack_is_none_when_absent() {
+    let mut catalog = alias_contract_catalog();
+    catalog.models.push(capability_pack_model(
+        "wespeaker-voxceleb-resnet34-lm",
+        CatalogCapabilityRole::SpeakerEmbedder,
+    ));
+
+    assert!(catalog.word_timestamps_forced_aligner_pack().is_none());
+}
+
+#[test]
+fn word_timestamps_forced_aligner_pack_ignores_staged_non_public_entries() {
+    let mut catalog = alias_contract_catalog();
+    let mut staged = capability_pack_model_with_feature(
+        "qwen3-forced-aligner-0.6b",
+        CATALOG_FEATURE_WORD_TIMESTAMPS,
+        CatalogCapabilityRole::ForcedAligner,
+    );
+    staged.public = false;
+    catalog.models.push(staged);
+
+    assert!(catalog.word_timestamps_forced_aligner_pack().is_none());
 }
 
 #[test]

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1680,6 +1680,9 @@ impl IntoResponse for ApiError {
                     | openasr_core::BackendError::NativeModelSelectionMismatch { .. }
                     | openasr_core::BackendError::NativeModelPackPathRequired
                     | openasr_core::BackendError::NativeModelPackPathRejected { .. }
+                    | openasr_core::BackendError::WordTimestampAlignmentRequiresWordTimestamps
+                    | openasr_core::BackendError::WordTimestampAlignmentPackMissing { .. }
+                    | openasr_core::BackendError::WordTimestampAlignmentFailed { .. }
                     | openasr_core::BackendError::NativeFailClosed { .. } => {
                         // Native backend "fail-closed" is a deliberate, client-facing
                         // refusal (unexecutable/unsupported request or unusable pack),

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -504,9 +504,18 @@ impl TranscriptionRequestBuilder {
         };
         let phrase_bias =
             build_phrase_bias_config(&phrase_bias_phrases, hotword_boost, phrase_bias_boost)?;
-        let word_timestamps = timestamp_granularities
+        // `word_aligned` opts into the Qwen3-ForcedAligner-0.6B refinement tier
+        // (see `--word-timestamps=aligned`); it also implies `word` so callers
+        // do not have to pass both. The server never auto-installs the pack --
+        // a missing pack fails the request closed (BackendError mapped to 400)
+        // rather than silently falling back to approximate timestamps.
+        let word_timestamps_refine = timestamp_granularities
             .iter()
-            .any(|value| value.as_str() == "word");
+            .any(|value| value.as_str() == "word_aligned");
+        let word_timestamps = word_timestamps_refine
+            || timestamp_granularities
+                .iter()
+                .any(|value| value.as_str() == "word");
         let uploaded_path: &Path = uploaded_file.as_ref();
         let request = TranscriptionRequest::new(uploaded_path.to_path_buf(), model_id)
             .with_language(language)
@@ -517,6 +526,7 @@ impl TranscriptionRequestBuilder {
             .with_inference_threads(inference_threads)
             .with_execution_target(execution_target)
             .with_word_timestamps(word_timestamps)
+            .with_word_timestamps_refine(word_timestamps_refine)
             .with_display_file_name(file_name)
             .with_diarization(diarize)
             .with_diarize_speakers(speakers);
@@ -963,10 +973,10 @@ fn build_phrase_bias_config(
 fn validate_timestamp_granularities(values: &[String]) -> Result<(), ApiError> {
     for value in values {
         match value.as_str() {
-            "segment" | "word" => {}
+            "segment" | "word" | "word_aligned" => {}
             other => {
                 return Err(ApiError::BadRequest(format!(
-                    "Unsupported timestamp granularity '{other}'. Use one of: segment, word."
+                    "Unsupported timestamp granularity '{other}'. Use one of: segment, word, word_aligned."
                 )));
             }
         }
@@ -1043,7 +1053,8 @@ pub(crate) async fn transcribe_with_runtime(
                         .with_phrase_bias(request.phrase_bias.clone())
                         .with_inference_threads(request.inference_threads)
                         .with_diarization(request.diarize)
-                        .with_word_timestamps(request.word_timestamps),
+                        .with_word_timestamps(request.word_timestamps)
+                        .with_word_timestamps_refine(request.word_timestamps_refine),
                 )
                 .with_longform(request.longform.clone())
                 .with_display_file_name(request.display_file_name.clone());

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -59,6 +59,22 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   returns an empty word list -- its attention-based encoder-decoder has no
   alignment head exposed yet, so `--word-timestamps` requests yield a
   segment-level span rather than fabricated per-word times.
+- Word-timestamp refinement (`--word-timestamps=aligned` / API
+  `timestamp_granularities=word_aligned`) is an opt-in tier on top of the
+  approximate timestamps above: it re-runs the finished transcript and the full
+  source audio through the Qwen3-ForcedAligner-0.6B capability pack and
+  replaces each segment's word spans with the aligner's own output. Passing
+  `=aligned` is the consent to install the pack (mirroring `--diarize`'s
+  WeSpeaker auto-install); the native backend never installs it silently
+  otherwise, and the server never auto-installs it at all (operator-gated pull
+  only). It is native-backend-only, requires `--word-timestamps` semantics
+  implicitly (word timestamps are always emitted for `aligned`), and does not
+  yet support Japanese or Korean transcripts -- the reference routes those
+  through external morphological segmenters (`nagisa`/`soynlp`) that have not
+  been ported, so an `aligned` request against ja/ko text fails closed with a
+  typed error rather than mis-tokenizing. Every other family keeps its
+  approximate timestamps unchanged; `aligned` only affects the words replaced
+  by the aligner's output, never segment text or speaker attribution.
 - Hardware execution target selection is generic: Desktop/server requests support
   `auto`, `cpu`, and `accelerated` when the native runtime reports an accelerated
   device. There is no per-provider/per-device pinning surface such as `gpu0`,


### PR DESCRIPTION
## Summary

- Onboards Qwen3-ForcedAligner-0.6B as an optional word-timestamp refinement
  capability pack: `--word-timestamps=aligned` (CLI) / `timestamp_granularities=word_aligned`
  (API) re-run the finished transcript and full source audio through the
  installed pack and replace each segment's word spans with the aligner's own
  output. `--word-timestamps` / `=approximate` keep every family's existing
  decode-time timestamps unchanged.
- Adds the capability-pack data model: `CatalogCapabilityRole::ForcedAligner`
  and the `word-timestamps` feature key (registry.rs), mirroring the existing
  `speaker-diarization` / WeSpeaker precedent.
- Extracts the diarization pack-file resolver (env override + installed-dir
  scan) into a model-agnostic `crate::capability_pack` module, now shared by
  the WeSpeaker/pyannote diarization packs and the new forced-aligner pack.
- Fixes a real caller for the Stage 3-5 forced-alignment NAR pipeline
  (previously `#[allow(dead_code)]`, exercised only by the dev-machine-gated
  parity harness).

## Why

Stages 1-5 (already merged to this branch) built and numerically validated the
Qwen3-ForcedAligner-0.6B engine end to end (per-word parity vs. the Python
reference at 0.000ms median difference). Stage 6 is the product surface:
capability-pack registration and the CLI/API opt-in wiring that give the
engine a real caller.

## Changes

- `crates/openasr-core/src/registry.rs`: `CATALOG_FEATURE_WORD_TIMESTAMPS`,
  `CatalogCapabilityRole::ForcedAligner`, `ModelCatalog::word_timestamps_forced_aligner_pack()`.
- `crates/openasr-core/src/capability_pack.rs` (new): generic installed-pack
  resolver extracted from `diarize::pack` (which now delegates to it).
- `crates/openasr-core/src/models/qwen/forced_aligner_pack.rs` (new): resolves
  the installed Qwen3-ForcedAligner pack (`OPENASR_FORCED_ALIGNER_PACK` env
  override or `openasr_home()/models/*forced-aligner*/`).
- `crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs`: adds
  `refine_word_timestamps_with_forced_aligner`, the one-shot load+align entry
  point that removes the Stage 5 `#[allow(dead_code)]`.
- `crates/openasr-core/src/models/qwen/forced_aligner_align_text.rs`: the
  Japanese/Korean fail-closed language gate now also recognizes the ISO
  639-1 codes (`ja`/`ko`), not just the reference's full names, since a real
  caller threads ISO codes through (`Transcription::language` / `--language`).
- `crates/openasr-core/src/api/backend/{mod.rs,native.rs,native_transcribe.rs}`:
  `TranscriptionRequest::word_timestamps_refine`, three new `BackendError`
  variants, and the actual refinement pass -- a thin wrapper around the
  existing decode/longform/diarization pipeline that re-decodes the file,
  calls the aligner once, and reassigns each segment's `words` by time-range.
- `crates/openasr-core/src/api/native/types.rs`: matching
  `NativeAsrRequestOptions::word_timestamps_refine` (offline-only).
- `crates/openasr-cli/src/{cli_args.rs,main.rs,native_segment_cli.rs}`:
  `--word-timestamps` becomes an optional-value flag (`WordTimestampsMode::
  {Approximate,Aligned}`); `=aligned` is the consent to auto-install the pack
  (mirrors `--diarize`'s WeSpeaker auto-install) and requires the native
  backend.
- `crates/openasr-server/src/{lib.rs,routes/transcription.rs}`: new
  `word_aligned` timestamp granularity; server never auto-installs the pack
  (operator-gated pull only, matching existing diarization behavior).
- `docs/KNOWN_LIMITATIONS.md`: documents the new opt-in tier and its ja/ko gap.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2159 passed, 120 skipped -- unchanged skip set; includes the dev-machine-gated Stage 5 golden parity tests, still green)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`
- [x] `tooling/publish-model/scripts/regenerate_all.sh --check`
- [x] `python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'` (155 passed)

New unit tests added: catalog capability-pack lookup (found/absent/staged-non-public-excluded), CLI `aligned`-mode backend/consent gating, and the segment word-reassignment remap function.

## Manual smoke checks

Not run against real weights in this PR (no catalog entry ships yet -- see
Scope below); the Stage 5 dev-machine-gated parity harness (`cargo nextest run
--workspace`, included above) already exercises the full pipeline against the
real checkpoint and passed.

## Docs updated

- [x] `docs/KNOWN_LIMITATIONS.md` updated for the new opt-in tier and its scope.
- [x] No docs overclaim current capabilities (the catalog entry gap below is called out).

## Scope / non-goals

- **No `catalog.json`/manifest entry yet.** Wiring the model into the catalog
  needs it hosted on Hugging Face so the entry's URL/sha256 are real, not
  fabricated -- that upload is an explicit, separate, irreversible step (see
  `tooling/publish-model/PUBLISHING.md`) intentionally not taken in this PR.
  Until that lands, `word_timestamps_forced_aligner_pack()` returns `None` and
  `--word-timestamps=aligned` fails closed with a clear "not in the public
  catalog" error -- the code path is real and tested, just inert without a
  published pack.
- Does not add Japanese/Korean word tokenization for the aligner (unchanged
  from Stage 1-5; fails closed, documented in `KNOWN_LIMITATIONS.md`).
- Realtime/streaming sessions do not consult `word_timestamps_refine` (offline
  `transcribe` only).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance (Claude); reviewed and understood in full before submission.