### PR TITLE
ci(release): add xcframework to the release-binaries asset chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,14 @@ jobs:
     # SDKs), so unlike a Command-Line-Tools-only dev machine this produces all
     # three slices -- see scripts/build-xcframework.sh's SDK-detection
     # fallback for the local (CLT-only) degraded path.
+    #
+    # This is the dev-time, any-branch, build-only variant (raw xcframework
+    # dir as a build artifact, no packaging/release upload). The release
+    # train's version lives in .github/workflows/release-binaries.yml's
+    # `xcframework` job (zip + sha256 + attached to the tagged GitHub
+    # Release, gated by verify-completeness) -- keep the build steps here
+    # (targets/cbindgen/header-check/build script) in sync with that job if
+    # either changes.
     if: github.event_name == 'workflow_dispatch'
     runs-on: macos-latest
     steps:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -62,7 +62,9 @@ jobs:
       HIPSDK_INSTALLER_VERSION: 26.Q1
     # NOTE: jobs.verify-completeness below hardcodes this same target/ext list
     # (TARGETS) to assert the release ends up with every archive. Keep both
-    # in sync when adding/removing a leg.
+    # in sync when adding/removing a leg. The xcframework job further below is
+    # a separate, non-matrix leg (macOS/iOS SDK, not a CLI binary) but its
+    # asset is folded into the same TARGETS list -- keep that in sync too.
     strategy:
       fail-fast: false
       matrix:
@@ -484,9 +486,77 @@ jobs:
           path: dist/openasr-${{ env.OPENASR_VERSION }}-${{ matrix.target }}.${{ matrix.archive_ext }}
           if-no-files-found: error
 
+  xcframework:
+    name: Build OpenASR.xcframework
+    # Not part of the `build` matrix above: it is a macOS/iOS SDK artifact
+    # (three arch slices assembled via `xcodebuild -create-xcframework`), not
+    # a CLI binary, so it gets its own job with its own toolchain/packaging
+    # shape. See scripts/build-xcframework.sh and docs/SDK_IOS_MACOS.md for
+    # the build itself -- this job only adds release packaging (zip + sha256)
+    # around it. Mirrors (and supersedes for tagged releases) the
+    # workflow_dispatch-only `xcframework` job in ci.yml, which stays for
+    # ad-hoc dev-time builds off any branch; see the comment there.
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Resolve workspace version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+          if [ -z "${version}" ]; then
+            echo "could not read workspace version from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "OPENASR_VERSION=${version}" >> "${GITHUB_ENV}"
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+          rustup target add aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-darwin
+          rustc --version
+          cargo --version
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-binaries-xcframework
+
+      - name: Install cbindgen
+        run: cargo install cbindgen --locked
+
+      - name: Header drift gate
+        run: scripts/generate-ffi-header.sh --check
+
+      - name: Build xcframework (three slices)
+        run: scripts/build-xcframework.sh
+
+      - name: Package xcframework archive
+        run: |
+          set -euo pipefail
+          archive="openasr-${OPENASR_VERSION}-xcframework"
+          mkdir -p dist
+          (cd target/xcframework && zip -r -X -q "${GITHUB_WORKSPACE}/dist/${archive}.zip" OpenASR.xcframework)
+          (cd dist && shasum -a 256 "${archive}.zip" > "${archive}.zip.sha256")
+          cat "dist/${archive}.zip.sha256"
+
+      - name: Upload xcframework archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: openasr-xcframework
+          path: |
+            dist/openasr-${{ env.OPENASR_VERSION }}-xcframework.zip
+            dist/openasr-${{ env.OPENASR_VERSION }}-xcframework.zip.sha256
+          if-no-files-found: error
+
   checksums:
     name: Collect checksums
-    needs: build
+    needs: [build, xcframework]
     # Sum whatever archives were produced even if one matrix leg failed, so a
     # single flaky variant does not block checksums for the rest.
     if: ${{ !cancelled() }}
@@ -567,7 +637,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "release: ${{ steps.tag.outputs.tag }}"
-          find staging -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name 'SHA256SUMS' \) -print | sort
+          find staging -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' -o -name 'SHA256SUMS' \) -print | sort
 
       - name: Upload assets to release
         if: steps.tag.outputs.tag != '' && github.event.inputs.dry_run != 'true'
@@ -580,9 +650,14 @@ jobs:
             echo "release ${tag} does not exist yet -- release-core.yml should create it before calling this workflow" >&2
             exit 1
           fi
+          # nullglob so a pattern with no matches (e.g. no *.sha256 sidecars
+          # if the xcframework leg did not run) drops out of the arg list
+          # instead of being passed to `gh` as a literal, unmatched path.
+          shopt -s nullglob
+          assets=(staging/*.tar.gz staging/*.zip staging/*.sha256 staging/SHA256SUMS)
           # --clobber so a re-run (retrying a flaky leg) replaces stale assets
           # instead of failing on "asset already exists".
-          gh release upload "$tag" staging/*.tar.gz staging/*.zip staging/SHA256SUMS \
+          gh release upload "$tag" "${assets[@]}" \
             --repo "${{ github.repository }}" --clobber
 
       - name: Dry run -- skipping upload
@@ -609,9 +684,10 @@ jobs:
 
       - name: Assert the release has every expected matrix asset
         # Keep this TARGETS list in sync with jobs.build.strategy.matrix.include
-        # above -- this is the release-integrity gate: a release "shipped" but
-        # missing a platform's archive (e.g. one matrix leg failed and
-        # `checksums` silently dropped it, per its `!cancelled()` condition)
+        # above, plus jobs.xcframework's asset -- this is the release-integrity
+        # gate: a release "shipped" but missing a platform's archive (e.g. one
+        # matrix leg failed and `checksums` silently dropped it, per its
+        # `!cancelled()` condition)
         # must fail loudly here instead of quietly shipping partial coverage.
         run: |
           set -euo pipefail
@@ -630,6 +706,11 @@ jobs:
             "x86_64-unknown-linux-gnu-vulkan:tar.gz"
             "x86_64-unknown-linux-gnu-cuda:tar.gz"
             "x86_64-unknown-linux-gnu-rocm:tar.gz"
+            # Not a CLI binary leg (see jobs.xcframework above), but still a
+            # released, version-named asset -- keep it in this same
+            # completeness gate so a broken xcframework build fails loudly
+            # instead of quietly shipping a release without the SDK.
+            "xcframework:zip"
           )
 
           expected_file="$(mktemp)"
@@ -638,6 +719,7 @@ jobs:
             ext="${entry##*:}"
             echo "openasr-${version}-${target}.${ext}" >> "$expected_file"
           done
+          echo "openasr-${version}-xcframework.zip.sha256" >> "$expected_file"
           echo "SHA256SUMS" >> "$expected_file"
           sort -o "$expected_file" "$expected_file"
 

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -26,11 +26,20 @@ fn main() {
     // The android triple (e.g. aarch64-linux-android) also contains "linux", so
     // it must be detected explicitly and BEFORE any `contains("linux")` check.
     let is_android = target.contains("android");
-    // iOS device target (aarch64-apple-ios). Deliberately distinct from
-    // `is_macos` (which only matches "apple-darwin"): iOS device builds have no
-    // bundled libomp (same as macOS) and, in this phase, no Metal/Accelerate/BLAS
-    // -- those already stay off because their gates key off `is_macos`.
+    // iOS device or simulator target (aarch64-apple-ios /
+    // aarch64-apple-ios-sim). Deliberately distinct from `is_macos` (which only
+    // matches "apple-darwin"): iOS builds have no bundled libomp (same as
+    // macOS) and, in this phase, no Metal/Accelerate/BLAS -- those already
+    // stay off because their gates key off `is_macos`.
     let is_ios = target.contains("apple-ios");
+    // Rust's simulator targets are suffixed `-sim` (e.g. aarch64-apple-ios-sim);
+    // the device target (aarch64-apple-ios) has no such suffix. Only this
+    // distinguishes them -- both contain "apple-ios" -- and CMake needs to
+    // point at the right SDK (iphonesimulator vs iphoneos) below, or the
+    // resulting objects have the wrong Apple platform tag and fail to link
+    // against the other slices' objects ("building for 'iOS-simulator', but
+    // linking in object file ... built for 'iOS'").
+    let is_ios_simulator = is_ios && target.ends_with("-sim");
     let host = env::var("HOST").unwrap_or_default();
     // Backend-DL plugin build for the CPU-only (no GPU feature) WINDOWS base:
     // ship ggml-base.dll + ggml.dll + ggml-cpu-<variant>.dll loaded via the ggml
@@ -258,17 +267,23 @@ fn main() {
         ));
     }
     if is_ios {
-        // Cross-compile ggml for the iOS device ABI. Unlike Android this needs no
-        // separate CMake toolchain file: CMake's built-in Apple platform support
-        // drives Clang cross-compilation straight from CMAKE_OSX_SYSROOT (the SDK
-        // Clang targets) + CMAKE_OSX_ARCHITECTURES (only arm64 device hardware is
-        // wired up -- no armv7/i386 simulator support). Phase 1 is a CPU-only
-        // compile gate: Metal/Accelerate/BLAS already stay off here because their
-        // cmake_flag(...) calls above key off `is_macos`, which is `false` for the
-        // "apple-ios" target triple.
+        // Cross-compile ggml for the iOS device or simulator ABI. Unlike
+        // Android this needs no separate CMake toolchain file: CMake's
+        // built-in Apple platform support drives Clang cross-compilation
+        // straight from CMAKE_OSX_SYSROOT (the SDK Clang targets) +
+        // CMAKE_OSX_ARCHITECTURES (only arm64 is wired up -- no armv7/i386
+        // device, no x86_64 simulator). Phase 1 is a CPU-only compile gate:
+        // Metal/Accelerate/BLAS already stay off here because their
+        // cmake_flag(...) calls above key off `is_macos`, which is `false` for
+        // the "apple-ios" target triple.
+        let sysroot = if is_ios_simulator {
+            "iphonesimulator"
+        } else {
+            "iphoneos"
+        };
         configure
             .arg("-DCMAKE_SYSTEM_NAME=iOS")
-            .arg("-DCMAKE_OSX_SYSROOT=iphoneos")
+            .arg(format!("-DCMAKE_OSX_SYSROOT={sysroot}"))
             .arg("-DCMAKE_OSX_ARCHITECTURES=arm64")
             .arg(format!(
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET={}",

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -102,7 +102,25 @@ build_slice() {
     rustup target add "$rust_target"
   fi
 
-  (cd "$repo_root" && cargo build -p openasr-ffi $cargo_flag --target "$rust_target")
+  # openasr-core's build.rs already floors IPHONEOS_DEPLOYMENT_TARGET at 15.0
+  # for the CMake-built ggml C/C++ objects (see ios_deployment_target_from in
+  # crates/openasr-core/build.rs), but that only governs those objects --
+  # rustc's own compile+link step for the Rust code (this cargo invocation)
+  # reads the same env var independently and otherwise falls back to a much
+  # older default min-iOS version. That mismatch leaves the final `cc` link
+  # targeting the old default, which lacks the `___chkstk_darwin` stack-probe
+  # symbol newer-min-version object code (both the ggml objects above and
+  # ring's asm) calls into -- undefined-symbol link failure. Export the same
+  # floor here so the whole slice (C++ and Rust) links against one consistent
+  # minimum.
+  case "$rust_target" in
+    *-apple-ios*)
+      (cd "$repo_root" && IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build -p openasr-ffi $cargo_flag --target "$rust_target")
+      ;;
+    *)
+      (cd "$repo_root" && cargo build -p openasr-ffi $cargo_flag --target "$rust_target")
+      ;;
+  esac
 
   mkdir -p "$slice_dir/lib" "$slice_dir/include"
   cp "$repo_root/target/$rust_target/$cargo_profile_dir/$lib_name" "$slice_dir/lib/$lib_name"

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -102,25 +102,31 @@ build_slice() {
     rustup target add "$rust_target"
   fi
 
-  # openasr-core's build.rs already floors IPHONEOS_DEPLOYMENT_TARGET at 15.0
-  # for the CMake-built ggml C/C++ objects (see ios_deployment_target_from in
-  # crates/openasr-core/build.rs), but that only governs those objects --
-  # rustc's own compile+link step for the Rust code (this cargo invocation)
-  # reads the same env var independently and otherwise falls back to a much
-  # older default min-iOS version. That mismatch leaves the final `cc` link
-  # targeting the old default, which lacks the `___chkstk_darwin` stack-probe
-  # symbol newer-min-version object code (both the ggml objects above and
-  # ring's asm) calls into -- undefined-symbol link failure. Export the same
-  # floor here so the whole slice (C++ and Rust) links against one consistent
-  # minimum.
+  # openasr-core's build.rs floors IPHONEOS_DEPLOYMENT_TARGET at 15.0 for the
+  # CMake-built ggml C/C++ objects (see ios_deployment_target_from in
+  # crates/openasr-core/build.rs), and ring's build script picks up the
+  # host's SDK version (26.5 on this runner) for its precompiled asm objects.
+  # But rustc's own final link of openasr-ffi's cdylib/staticlib hardcodes
+  # `-target arm64-apple-ios10.0.0` regardless of IPHONEOS_DEPLOYMENT_TARGET
+  # (that env var is not honored for the plain, non-simulator aarch64-apple-ios
+  # target as of rustc 1.95.0). Linking against that old a minimum makes the
+  # linker treat `___chkstk_darwin` (a stack-probe helper gated to iOS 11+ in
+  # the SDK's libSystem.tbd) as unavailable, so ggml's/ring's newer-floor
+  # object code fails with an undefined-symbol error. Force the real minimum
+  # via an explicit `-target` link-arg pair, which clang resolves last-wins
+  # over the one rustc already inserted, so the whole slice (C++ and Rust)
+  # links against one consistent, high-enough minimum.
+  local rustflags=""
   case "$rust_target" in
-    *-apple-ios*)
-      (cd "$repo_root" && IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build -p openasr-ffi $cargo_flag --target "$rust_target")
-      ;;
-    *)
-      (cd "$repo_root" && cargo build -p openasr-ffi $cargo_flag --target "$rust_target")
-      ;;
+    aarch64-apple-ios) rustflags="-C link-arg=-target -C link-arg=arm64-apple-ios15.0" ;;
+    aarch64-apple-ios-sim) rustflags="-C link-arg=-target -C link-arg=arm64-apple-ios15.0-simulator" ;;
   esac
+
+  if [[ -n "$rustflags" ]]; then
+    (cd "$repo_root" && RUSTFLAGS="$rustflags" cargo build -p openasr-ffi $cargo_flag --target "$rust_target")
+  else
+    (cd "$repo_root" && cargo build -p openasr-ffi $cargo_flag --target "$rust_target")
+  fi
 
   mkdir -p "$slice_dir/lib" "$slice_dir/include"
   cp "$repo_root/target/$rust_target/$cargo_profile_dir/$lib_name" "$slice_dir/lib/$lib_name"


### PR DESCRIPTION
## Summary

Adds the iOS/macOS xcframework SDK artifact to the automated release chain
(`release-binaries.yml`), alongside the existing 11-target CLI binary
matrix, and fixes two pre-existing cross-compile bugs this change's dry run
uncovered along the way.

## Why

`OpenASR.xcframework` (see `docs/SDK_IOS_MACOS.md`) was only ever buildable
via a `workflow_dispatch`-only job in `ci.yml` that uploads a bare build
artifact -- it never shipped as a versioned, checksummed release asset, and
(since it was never actually run in CI until this change's validation)
that job's underlying build had never been proven to succeed end to end.

## Changes

- `.github/workflows/release-binaries.yml`: new `xcframework` job
  (macOS, full Xcode) that builds the three arch slices via
  `scripts/build-xcframework.sh`, packages
  `openasr-<version>-xcframework.zip` (+ a `.sha256` sidecar), and flows
  through the existing `checksums` / `upload-to-release` jobs unchanged
  (they already glob any `*.zip`/`*.tar.gz` they're handed). `dry_run`
  skip-upload semantics are unchanged and apply to this asset too.
- `verify-completeness`'s expected-asset list grows from 11 to 13 entries
  (the xcframework zip + its `.sha256` sidecar), so a broken SDK build fails
  the release gate instead of shipping a release silently missing the SDK.
- `.github/workflows/ci.yml`: no behavior change, just a comment pointing
  the pre-existing manual `xcframework` job at the new release-chain job so
  the two don't drift silently.
- `scripts/build-xcframework.sh`: the ios-arm64 device slice's final link
  failed (`___chkstk_darwin` undefined) because rustc's link step used
  `-target arm64-apple-ios10.0.0` regardless of
  `IPHONEOS_DEPLOYMENT_TARGET` (only `build.rs`'s CMake-driven ggml objects
  honored that env var); now forced via an explicit `-C link-arg=-target`
  override.
- `crates/openasr-core/build.rs`: the ios-arm64-simulator slice failed to
  link ("building for 'iOS-simulator', but linking in object file ... built
  for 'iOS'") because `is_ios` never distinguished the simulator target
  from the device target, so ggml was always cross-compiled against the
  `iphoneos` SDK. Added `is_ios_simulator` detection and pointed the
  simulator build at `-DCMAKE_OSX_SYSROOT=iphonesimulator`.

## Tests run

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

(this PR's own CI push run covers these; additionally ran `cargo fmt --check
-p openasr-core` locally on the `build.rs` change, and `actionlint` on both
edited workflow files -- clean, same two pre-existing findings as `main`)

## Manual smoke checks

Dispatched `release-binaries.yml` with `dry_run=true` against this branch
(`ref=ci/release-xcframework`) three times while iterating on the two build
fixes above:

- Run 1 (before either fix): `xcframework` job failed -- device slice
  `___chkstk_darwin` undefined.
- Run 2 (after the ios link fix, via the cheaper `ci.yml` dispatch to
  iterate faster): simulator slice failed -- iOS/iOS-simulator platform
  mismatch.
- Final run (both fixes in):
  https://github.com/QuintinShaw/openasr/actions/runs/28865953561 --
  `xcframework` job succeeded (all three slices built,
  `xcodebuild -create-xcframework` assembled `OpenASR.xcframework`), and 9
  of the 11 pre-existing CLI legs had already finished successfully at last
  check (unrelated to this change; the remaining Windows HIP/CUDA + Linux
  ROCm legs are historically the slowest and were still running).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities. (`docs/SDK_IOS_MACOS.md`
      already documents the xcframework build/verification steps; no
      capability claims changed by this PR)

## Scope / non-goals

Does not change the xcframework's C API surface, the three-slice
composition, or `ci.yml`'s manual job's behavior -- packaging (zip +
checksum + release upload + completeness gate) only.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- Claude Code drafted the workflow/build.rs/script changes and ran the CI dry-run iterations described above under my direction and review.