### PR TITLE
feat(firered-punc): Chinese punctuation model engine (tokenizer, stage, BERT forward, pull contract)

### DIFF
--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -618,6 +618,15 @@ pub fn validate_native_runtime_model_pack_contract(path: &Path) -> Result<(), St
     {
         return result.map_err(|error| format!("translation pack validation failed: {error}"));
     }
+    // Punctuation packs (FireRedPunc) are a text-in/labels-out post-processor,
+    // not an ASR runtime adapter; their contract is "the punctuation metadata
+    // geometry validates" -- checked here so `openasr pull` stays fail-closed
+    // for them too.
+    if let Some(result) =
+        crate::models::firered_punc::validate_punctuation_runtime_pack_contract(path, &metadata)
+    {
+        return result.map_err(|error| format!("punctuation pack validation failed: {error}"));
+    }
     let selection_metadata = selection_metadata_from_gguf(&metadata);
     let registry = GgmlFamilyRegistry::with_builtin_adapters();
     let descriptor = registry

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod models;
 mod nn;
 pub(crate) mod output;
 pub(crate) mod pull;
+pub(crate) mod punctuation;
 pub mod realtime;
 pub(crate) mod registry;
 pub(crate) mod remote_compute;

--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -9,6 +9,7 @@ pub(crate) mod diarize_pack_import;
 pub(crate) mod dolphin;
 pub(crate) mod executor_component_registry;
 pub(crate) mod firered_aed;
+pub(crate) mod firered_punc;
 pub(crate) mod frame_sync_streaming_driver;
 pub(crate) mod frontend_component_registry;
 pub mod ggml_asr_executor;

--- a/crates/openasr-core/src/models/firered_punc/config.rs
+++ b/crates/openasr-core/src/models/firered_punc/config.rs
@@ -25,6 +25,7 @@ pub(crate) const FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY: &str = "firered-punc.att
 pub(crate) const FIRERED_PUNC_ATTENTION_LAYER_NORM_EPSILON_KEY: &str =
     "firered-punc.attention.layer_norm_epsilon";
 pub(crate) const FIRERED_PUNC_CONTEXT_LENGTH_KEY: &str = "firered-punc.context_length";
+pub(crate) const FIRERED_PUNC_VOCAB_SIZE_KEY: &str = "firered-punc.vocab_size";
 pub(crate) const FIRERED_PUNC_LABEL_COUNT_KEY: &str = "firered-punc.label_count";
 pub(crate) const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
 

--- a/crates/openasr-core/src/models/firered_punc/config.rs
+++ b/crates/openasr-core/src/models/firered_punc/config.rs
@@ -1,0 +1,125 @@
+//! FireRedPunc (`FireRedTeam/FireRedPunc`) architecture constants and the
+//! pack-metadata contract.
+//!
+//! FireRedPunc is a BERT-style bidirectional encoder (initialised from
+//! `chinese-lert-base`) with a token-level classification head: for each input
+//! subword it predicts which punctuation mark, if any, follows that token. It
+//! is a text-in / labels-out post-processor, not an ASR model -- no audio
+//! frontend, no autoregressive decode. Apache-2.0.
+//!
+//! The released label space is exactly five Chinese full-width classes (see
+//! [`PUNC_LABELS`]); the model architecturally cannot emit English half-width
+//! marks, so the OpenASR integration is Chinese-only by construction.
+
+use thiserror::Error;
+
+/// `general.architecture` value stamped into the FireRedPunc `.oasr` pack. The
+/// pull-time contract dispatches on this string, so ASR/translation packs fall
+/// through to their own family adapters.
+pub(crate) const FIRERED_PUNC_ARCHITECTURE_VALUE: &str = "firered-punc";
+
+pub(crate) const FIRERED_PUNC_BLOCK_COUNT_KEY: &str = "firered-punc.block_count";
+pub(crate) const FIRERED_PUNC_EMBEDDING_LENGTH_KEY: &str = "firered-punc.embedding_length";
+pub(crate) const FIRERED_PUNC_FEED_FORWARD_LENGTH_KEY: &str = "firered-punc.feed_forward_length";
+pub(crate) const FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY: &str = "firered-punc.attention.head_count";
+pub(crate) const FIRERED_PUNC_ATTENTION_LAYER_NORM_EPSILON_KEY: &str =
+    "firered-punc.attention.layer_norm_epsilon";
+pub(crate) const FIRERED_PUNC_CONTEXT_LENGTH_KEY: &str = "firered-punc.context_length";
+pub(crate) const FIRERED_PUNC_LABEL_COUNT_KEY: &str = "firered-punc.label_count";
+pub(crate) const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
+
+/// chinese-lert-base hyper-parameters (`config.json`): 12-layer BERT-base,
+/// hidden 768, 12 heads, intermediate 3072, GELU, LayerNorm eps 1e-12, learned
+/// absolute positions up to 512, two token-type segments.
+pub(crate) const FIRERED_PUNC_EXPECTED_LAYERS: usize = 12;
+pub(crate) const FIRERED_PUNC_EXPECTED_D_MODEL: usize = 768;
+pub(crate) const FIRERED_PUNC_EXPECTED_FFN_DIM: usize = 3072;
+pub(crate) const FIRERED_PUNC_EXPECTED_HEADS: usize = 12;
+pub(crate) const FIRERED_PUNC_EXPECTED_VOCAB_SIZE: usize = 21_128;
+pub(crate) const FIRERED_PUNC_EXPECTED_MAX_POSITIONS: usize = 512;
+pub(crate) const FIRERED_PUNC_TYPE_VOCAB_SIZE: usize = 2;
+pub(crate) const FIRERED_PUNC_LAYER_NORM_EPSILON: f32 = 1.0e-12;
+
+/// The five punctuation classes from upstream `out_dict`, in label-id order.
+/// Index 0 is "no punctuation after this token" (`<space>` in `out_dict`); the
+/// remaining four are the Chinese full-width comma, period, question mark, and
+/// exclamation mark. This ordering is the contract with the trained classifier
+/// head and must not be reordered.
+pub(crate) const PUNC_LABELS: [Option<char>; 5] =
+    [None, Some('，'), Some('。'), Some('？'), Some('！')];
+
+/// Number of punctuation classes (`PUNC_LABELS.len()`), i.e. the classifier
+/// head output width.
+pub(crate) const FIRERED_PUNC_LABEL_COUNT: usize = PUNC_LABELS.len();
+
+/// Returns the punctuation mark for a predicted label id, or `None` for the
+/// "no punctuation" class (label 0) and any id outside the trained label space.
+pub(crate) fn punctuation_for_label(label_id: usize) -> Option<char> {
+    PUNC_LABELS.get(label_id).copied().flatten()
+}
+
+/// Validated FireRedPunc pack geometry, read from the GGUF metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FireRedPuncExecutionMetadata {
+    pub layers: usize,
+    pub d_model: usize,
+    pub ffn_dim: usize,
+    pub heads: usize,
+    pub head_dim: usize,
+    pub vocab_size: usize,
+    pub max_positions: usize,
+    pub label_count: usize,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum FireRedPuncConfigError {
+    #[error("firered-punc pack is missing required metadata key '{0}'")]
+    MissingMetadata(String),
+    #[error("firered-punc metadata key '{key}' has an unexpected type")]
+    MetadataType { key: String },
+    #[error(
+        "firered-punc geometry mismatch: {field} is {got}, expected {expected} for chinese-lert-base"
+    )]
+    UnexpectedGeometry {
+        field: &'static str,
+        got: usize,
+        expected: usize,
+    },
+    #[error("firered-punc embedding_length {d_model} is not divisible by head_count {heads}")]
+    HeadDimNotDivisible { d_model: usize, heads: usize },
+}
+
+impl FireRedPuncExecutionMetadata {
+    /// Asserts the pack geometry matches the chinese-lert-base checkpoint the
+    /// runtime graph is written against. FireRedPunc ships a single published
+    /// checkpoint, so an off-geometry pack is a conversion bug, not a variant.
+    pub(crate) fn assert_expected_chinese_lert_base(self) -> Result<(), FireRedPuncConfigError> {
+        let checks = [
+            ("layers", self.layers, FIRERED_PUNC_EXPECTED_LAYERS),
+            ("d_model", self.d_model, FIRERED_PUNC_EXPECTED_D_MODEL),
+            ("ffn_dim", self.ffn_dim, FIRERED_PUNC_EXPECTED_FFN_DIM),
+            ("heads", self.heads, FIRERED_PUNC_EXPECTED_HEADS),
+            (
+                "vocab_size",
+                self.vocab_size,
+                FIRERED_PUNC_EXPECTED_VOCAB_SIZE,
+            ),
+            (
+                "max_positions",
+                self.max_positions,
+                FIRERED_PUNC_EXPECTED_MAX_POSITIONS,
+            ),
+            ("label_count", self.label_count, FIRERED_PUNC_LABEL_COUNT),
+        ];
+        for (field, got, expected) in checks {
+            if got != expected {
+                return Err(FireRedPuncConfigError::UnexpectedGeometry {
+                    field,
+                    got,
+                    expected,
+                });
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/openasr-core/src/models/firered_punc/graph.rs
+++ b/crates/openasr-core/src/models/firered_punc/graph.rs
@@ -1,0 +1,717 @@
+//! FireRedPunc BERT forward graph: token/position/segment embeddings ->
+//! post-embedding LayerNorm -> N post-norm transformer blocks (bidirectional
+//! self-attention, no causal mask; erf-GELU FFN) -> token-classification head
+//! -> `[label_count, seq]` logits.
+//!
+//! Composed from the shared `nn::{attn, ffn, norm}` building blocks (the same
+//! `apply_affine_layer_norm` / `apply_feed_forward_residual` /
+//! `reshape_projection_to_attention_heads` used by the ASR encoders). All
+//! weights are host f32 uploaded to the graph arena; the forward is driven with
+//! `GgmlCpuGraphRunner` + `compute_output_f32`.
+
+use crate::ggml_runtime::{
+    GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor,
+    GgmlStaticTensor, GgmlStaticTensorArena,
+};
+use crate::nn::attn::{
+    AttentionHeadLayout, AttentionReshapeSteps, AttentionValueMergeSteps,
+    STANDARD_HEAD_PERMUTE_AXES, attention_context_from_probs,
+    reshape_projection_to_attention_heads,
+};
+use crate::nn::ffn::{
+    FeedForwardActivation, FeedForwardResidualSteps, apply_feed_forward_residual,
+};
+use crate::nn::norm::{AffineLayerNormSteps, apply_affine_layer_norm};
+
+use super::config::{FIRERED_PUNC_LAYER_NORM_EPSILON, FireRedPuncExecutionMetadata};
+use super::weights::{FireRedPuncLayerWeights, FireRedPuncWeights, NamedTensor};
+
+const FIRERED_PUNC_GRAPH_CONTEXT_BYTES: usize = 256 * 1024 * 1024;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FireRedPuncGraphError {
+    #[error("firered-punc graph build failed at '{step}': {source}")]
+    Build {
+        step: &'static str,
+        source: GgmlCpuGraphError,
+    },
+    #[error("firered-punc graph execution failed: {reason}")]
+    Execution { reason: String },
+    #[error("firered-punc input length {got} exceeds max positions {max}")]
+    SequenceTooLong { got: usize, max: usize },
+    #[error("firered-punc input is empty")]
+    EmptyInput,
+}
+
+fn bf(step: &'static str) -> impl Fn(GgmlCpuGraphError) -> FireRedPuncGraphError {
+    move |source| FireRedPuncGraphError::Build { step, source }
+}
+
+fn bf2(step: &'static str, source: GgmlCpuGraphError) -> FireRedPuncGraphError {
+    FireRedPuncGraphError::Build { step, source }
+}
+
+struct LayerArena {
+    attn_q_weight: GgmlStaticTensor,
+    attn_q_bias: GgmlStaticTensor,
+    attn_k_weight: GgmlStaticTensor,
+    attn_k_bias: GgmlStaticTensor,
+    attn_v_weight: GgmlStaticTensor,
+    attn_v_bias: GgmlStaticTensor,
+    attn_output_weight: GgmlStaticTensor,
+    attn_output_bias: GgmlStaticTensor,
+    attn_norm_weight: GgmlStaticTensor,
+    attn_norm_bias: GgmlStaticTensor,
+    ffn_up_weight: GgmlStaticTensor,
+    ffn_up_bias: GgmlStaticTensor,
+    ffn_down_weight: GgmlStaticTensor,
+    ffn_down_bias: GgmlStaticTensor,
+    ffn_norm_weight: GgmlStaticTensor,
+    ffn_norm_bias: GgmlStaticTensor,
+}
+
+pub(crate) struct FireRedPuncGraph {
+    metadata: FireRedPuncExecutionMetadata,
+    runner: GgmlCpuGraphRunner,
+    arena: GgmlStaticTensorArena,
+    token_embd: GgmlStaticTensor,
+    token_type_embd: GgmlStaticTensor,
+    position_embd: GgmlStaticTensor,
+    embd_norm_weight: GgmlStaticTensor,
+    embd_norm_bias: GgmlStaticTensor,
+    layers: Vec<LayerArena>,
+    punc_head_weight: GgmlStaticTensor,
+    punc_head_bias: GgmlStaticTensor,
+}
+
+fn alloc_2d(
+    arena: &GgmlStaticTensorArena,
+    weight: &NamedTensor,
+    ne0: usize,
+    ne1: usize,
+    step: &'static str,
+) -> Result<GgmlStaticTensor, FireRedPuncGraphError> {
+    debug_assert_eq!(weight.values.len(), ne0 * ne1, "{step} shape");
+    arena.new_tensor_2d_f32(ne0, ne1, step).map_err(bf(step))
+}
+
+fn alloc_1d(
+    arena: &GgmlStaticTensorArena,
+    weight: &NamedTensor,
+    step: &'static str,
+) -> Result<GgmlStaticTensor, FireRedPuncGraphError> {
+    arena
+        .new_tensor_1d_f32(weight.values.len(), step)
+        .map_err(bf(step))
+}
+
+fn upload(
+    arena: &mut GgmlStaticTensorArena,
+    handle: GgmlStaticTensor,
+    weight: &NamedTensor,
+    step: &'static str,
+) -> Result<(), FireRedPuncGraphError> {
+    arena
+        .set_f32_slice(handle, &weight.values, step)
+        .map_err(bf(step))
+}
+
+impl FireRedPuncGraph {
+    pub(crate) fn new(
+        weights: &FireRedPuncWeights,
+        metadata: FireRedPuncExecutionMetadata,
+    ) -> Result<Self, FireRedPuncGraphError> {
+        let mut config = GgmlCpuGraphConfig::default();
+        config.context_bytes = FIRERED_PUNC_GRAPH_CONTEXT_BYTES;
+        config.graph_size = config.graph_size.max(metadata.layers * 64 + 512);
+        let runner = GgmlCpuGraphRunner::new(config).map_err(bf("runner_init"))?;
+        let mut arena = runner
+            .start_static_tensor_arena(FIRERED_PUNC_GRAPH_CONTEXT_BYTES)
+            .map_err(bf("arena_init"))?;
+
+        let d = metadata.d_model;
+        let ffn = metadata.ffn_dim;
+
+        // ----- declare arena tensors (first upload freezes allocation) -----
+        let token_embd = alloc_2d(
+            &arena,
+            &weights.token_embd,
+            d,
+            metadata.vocab_size,
+            "token_embd",
+        )?;
+        let token_type_embd = alloc_2d(
+            &arena,
+            &weights.token_type_embd,
+            d,
+            weights.token_type_embd.values.len() / d,
+            "token_type_embd",
+        )?;
+        let position_embd = alloc_2d(
+            &arena,
+            &weights.position_embd,
+            d,
+            metadata.max_positions,
+            "position_embd",
+        )?;
+        let embd_norm_weight = alloc_1d(&arena, &weights.embd_norm_weight, "embd_norm_w")?;
+        let embd_norm_bias = alloc_1d(&arena, &weights.embd_norm_bias, "embd_norm_b")?;
+        let mut layers = Vec::with_capacity(weights.layers.len());
+        for layer in &weights.layers {
+            layers.push(alloc_layer(&arena, layer, d, ffn)?);
+        }
+        let punc_head_weight = alloc_2d(
+            &arena,
+            &weights.punc_head_weight,
+            d,
+            metadata.label_count,
+            "punc_head_w",
+        )?;
+        let punc_head_bias = alloc_1d(&arena, &weights.punc_head_bias, "punc_head_b")?;
+
+        // ----- upload arena values -----
+        upload(&mut arena, token_embd, &weights.token_embd, "token_embd")?;
+        upload(
+            &mut arena,
+            token_type_embd,
+            &weights.token_type_embd,
+            "token_type_embd",
+        )?;
+        upload(
+            &mut arena,
+            position_embd,
+            &weights.position_embd,
+            "position_embd",
+        )?;
+        upload(
+            &mut arena,
+            embd_norm_weight,
+            &weights.embd_norm_weight,
+            "embd_norm_w",
+        )?;
+        upload(
+            &mut arena,
+            embd_norm_bias,
+            &weights.embd_norm_bias,
+            "embd_norm_b",
+        )?;
+        for (layer, handles) in weights.layers.iter().zip(&layers) {
+            upload_layer(&mut arena, layer, handles)?;
+        }
+        upload(
+            &mut arena,
+            punc_head_weight,
+            &weights.punc_head_weight,
+            "punc_head_w",
+        )?;
+        upload(
+            &mut arena,
+            punc_head_bias,
+            &weights.punc_head_bias,
+            "punc_head_b",
+        )?;
+
+        Ok(Self {
+            metadata,
+            runner,
+            arena,
+            token_embd,
+            token_type_embd,
+            position_embd,
+            embd_norm_weight,
+            embd_norm_bias,
+            layers,
+            punc_head_weight,
+            punc_head_bias,
+        })
+    }
+
+    /// Run the BERT forward over `token_ids` (the full sequence, including the
+    /// caller's `[CLS]`/`[SEP]` wrapping) and return `[label_count, seq]` logits
+    /// laid out label-fastest: `logits[pos * label_count + label]`.
+    pub(crate) fn forward(&mut self, token_ids: &[u32]) -> Result<Vec<f32>, FireRedPuncGraphError> {
+        let seq = token_ids.len();
+        if seq == 0 {
+            return Err(FireRedPuncGraphError::EmptyInput);
+        }
+        if seq > self.metadata.max_positions {
+            return Err(FireRedPuncGraphError::SequenceTooLong {
+                got: seq,
+                max: self.metadata.max_positions,
+            });
+        }
+        let heads = self.metadata.heads;
+        let head_dim = self.metadata.head_dim;
+        let eps = FIRERED_PUNC_LAYER_NORM_EPSILON;
+        let label_count = self.metadata.label_count;
+
+        let ids_i32: Vec<i32> = token_ids.iter().map(|&id| id as i32).collect();
+        let pos_i32: Vec<i32> = (0..seq as i32).collect();
+        let type_i32: Vec<i32> = vec![0; seq];
+
+        let mut graph = self.runner.start_graph();
+        let ids_t = graph.new_tensor_1d_i32(seq, "ids").map_err(bf("new_ids"))?;
+        graph.set_input(ids_t).map_err(bf("set_ids"))?;
+        let pos_t = graph
+            .new_tensor_1d_i32(seq, "posids")
+            .map_err(bf("new_pos"))?;
+        graph.set_input(pos_t).map_err(bf("set_pos"))?;
+        let type_t = graph
+            .new_tensor_1d_i32(seq, "typeids")
+            .map_err(bf("new_type"))?;
+        graph.set_input(type_t).map_err(bf("set_type"))?;
+
+        // ----- embeddings: token + position + segment, then LayerNorm -----
+        let tok = graph
+            .get_rows(self.arena.graph_tensor(self.token_embd), ids_t)
+            .map_err(bf("embd_token"))?;
+        let pos = graph
+            .get_rows(self.arena.graph_tensor(self.position_embd), pos_t)
+            .map_err(bf("embd_pos"))?;
+        let seg = graph
+            .get_rows(self.arena.graph_tensor(self.token_type_embd), type_t)
+            .map_err(bf("embd_seg"))?;
+        let mut state = graph.add(tok, pos).map_err(bf("embd_add_pos"))?;
+        state = graph.add(state, seg).map_err(bf("embd_add_seg"))?;
+        state = apply_affine_layer_norm(
+            &graph,
+            state,
+            eps,
+            self.arena.graph_tensor(self.embd_norm_weight),
+            self.arena.graph_tensor(self.embd_norm_bias),
+            AffineLayerNormSteps {
+                norm: "embd_norm",
+                scale: "embd_norm_scale",
+                bias: "embd_norm_bias",
+            },
+            bf2,
+        )?;
+
+        let layout = AttentionHeadLayout {
+            head_dim,
+            attention_heads: heads,
+            sequence_len: seq,
+        };
+        for handles in &self.layers {
+            state = bert_block(&mut graph, &self.arena, state, handles, layout, eps)?;
+        }
+
+        // ----- classification head: [d_model, label] x [d_model, seq] -----
+        let mut logits = graph
+            .mul_mat(self.arena.graph_tensor(self.punc_head_weight), state)
+            .map_err(bf("head_matmul"))?;
+        logits = graph
+            .add(logits, self.arena.graph_tensor(self.punc_head_bias))
+            .map_err(bf("head_bias"))?;
+        graph.set_output(logits).map_err(bf("set_output"))?;
+        graph
+            .prepare_outputs_for_upload(&[logits])
+            .map_err(bf("prepare_outputs"))?;
+
+        graph
+            .set_i32_slice(ids_t, &ids_i32, "upload_ids")
+            .map_err(bf("upload_ids"))?;
+        graph
+            .set_i32_slice(pos_t, &pos_i32, "upload_pos")
+            .map_err(bf("upload_pos"))?;
+        graph
+            .set_i32_slice(type_t, &type_i32, "upload_type")
+            .map_err(bf("upload_type"))?;
+
+        let want = label_count * seq;
+        graph
+            .compute_output_f32(logits, want)
+            .map_err(|error| FireRedPuncGraphError::Execution {
+                reason: error.to_string(),
+            })
+    }
+}
+
+fn bert_block<'a>(
+    graph: &mut GgmlCpuGraphBuilder<'a>,
+    arena: &GgmlStaticTensorArena,
+    input: GgmlCpuTensor<'a>,
+    h: &LayerArena,
+    layout: AttentionHeadLayout,
+    eps: f32,
+) -> Result<GgmlCpuTensor<'a>, FireRedPuncGraphError> {
+    // ----- bidirectional self-attention (no causal mask) -----
+    let q = linear(
+        graph,
+        arena,
+        h.attn_q_weight,
+        h.attn_q_bias,
+        input,
+        "attn_q",
+    )?;
+    let k = linear(
+        graph,
+        arena,
+        h.attn_k_weight,
+        h.attn_k_bias,
+        input,
+        "attn_k",
+    )?;
+    let v = linear(
+        graph,
+        arena,
+        h.attn_v_weight,
+        h.attn_v_bias,
+        input,
+        "attn_v",
+    )?;
+
+    let q_heads = reshape_projection_to_attention_heads(
+        graph,
+        q,
+        layout,
+        STANDARD_HEAD_PERMUTE_AXES,
+        false,
+        AttentionReshapeSteps {
+            reshape: "attn_q_reshape",
+            permute: "attn_q_permute",
+            cont: "attn_q_cont",
+        },
+        bf2,
+    )?;
+    let k_heads = reshape_projection_to_attention_heads(
+        graph,
+        k,
+        layout,
+        STANDARD_HEAD_PERMUTE_AXES,
+        false,
+        AttentionReshapeSteps {
+            reshape: "attn_k_reshape",
+            permute: "attn_k_permute",
+            cont: "attn_k_cont",
+        },
+        bf2,
+    )?;
+    let v_heads = reshape_projection_to_attention_heads(
+        graph,
+        v,
+        layout,
+        STANDARD_HEAD_PERMUTE_AXES,
+        true,
+        AttentionReshapeSteps {
+            reshape: "attn_v_reshape",
+            permute: "attn_v_permute",
+            cont: "attn_v_cont",
+        },
+        bf2,
+    )?;
+    let k_cont = graph.cont(k_heads).map_err(bf("attn_k_cont2"))?;
+    let mut scores = graph.mul_mat(k_cont, q_heads).map_err(bf("attn_scores"))?;
+    scores = graph
+        .scale(scores, 1.0 / (layout.head_dim as f32).sqrt())
+        .map_err(bf("attn_scale"))?;
+    scores = graph.soft_max(scores).map_err(bf("attn_softmax"))?;
+    let context = attention_context_from_probs(
+        graph,
+        v_heads,
+        scores,
+        layout,
+        AttentionValueMergeSteps {
+            value_permute: "attn_v_t_permute",
+            value_cont: "attn_v_t_cont",
+            context_mul: "attn_ctx_mul",
+            context_merge_permute: "attn_ctx_permute",
+            context_merge_cont: "attn_ctx_cont",
+            context_merge_reshape: "attn_ctx_reshape",
+        },
+        bf2,
+    )?;
+    let attn_out = linear(
+        graph,
+        arena,
+        h.attn_output_weight,
+        h.attn_output_bias,
+        context,
+        "attn_out",
+    )?;
+    let attn_residual = graph.add(input, attn_out).map_err(bf("attn_residual"))?;
+    let state = apply_affine_layer_norm(
+        graph,
+        attn_residual,
+        eps,
+        arena.graph_tensor(h.attn_norm_weight),
+        arena.graph_tensor(h.attn_norm_bias),
+        AffineLayerNormSteps {
+            norm: "attn_norm",
+            scale: "attn_norm_scale",
+            bias: "attn_norm_bias",
+        },
+        bf2,
+    )?;
+
+    // ----- feed-forward (erf-GELU) + post-norm -----
+    let up_w = arena.graph_tensor(h.ffn_up_weight);
+    let up_b = arena.graph_tensor(h.ffn_up_bias);
+    let down_w = arena.graph_tensor(h.ffn_down_weight);
+    let down_b = arena.graph_tensor(h.ffn_down_bias);
+    let ffn_out = apply_feed_forward_residual(
+        graph,
+        state,
+        state,
+        FeedForwardActivation::GeluErf,
+        None,
+        FeedForwardResidualSteps {
+            activation: "ffn_gelu",
+            scale: None,
+            residual: "ffn_residual",
+        },
+        |g, x| {
+            let up = g.mul_mat(up_w, x).map_err(bf("ffn_up"))?;
+            g.add(up, up_b).map_err(bf("ffn_up_bias"))
+        },
+        |g, x| {
+            let down = g.mul_mat(down_w, x).map_err(bf("ffn_down"))?;
+            g.add(down, down_b).map_err(bf("ffn_down_bias"))
+        },
+        bf2,
+    )?;
+    apply_affine_layer_norm(
+        graph,
+        ffn_out,
+        eps,
+        arena.graph_tensor(h.ffn_norm_weight),
+        arena.graph_tensor(h.ffn_norm_bias),
+        AffineLayerNormSteps {
+            norm: "ffn_norm",
+            scale: "ffn_norm_scale",
+            bias: "ffn_norm_bias",
+        },
+        bf2,
+    )
+}
+
+/// `mul_mat(weight, x) + bias` -- a biased linear over `[in, seq]`.
+fn linear<'a>(
+    graph: &mut GgmlCpuGraphBuilder<'a>,
+    arena: &GgmlStaticTensorArena,
+    weight: GgmlStaticTensor,
+    bias: GgmlStaticTensor,
+    x: GgmlCpuTensor<'a>,
+    step: &'static str,
+) -> Result<GgmlCpuTensor<'a>, FireRedPuncGraphError> {
+    let projected = graph
+        .mul_mat(arena.graph_tensor(weight), x)
+        .map_err(bf(step))?;
+    graph
+        .add(projected, arena.graph_tensor(bias))
+        .map_err(bf(step))
+}
+
+fn alloc_layer(
+    arena: &GgmlStaticTensorArena,
+    layer: &FireRedPuncLayerWeights,
+    d: usize,
+    ffn: usize,
+) -> Result<LayerArena, FireRedPuncGraphError> {
+    Ok(LayerArena {
+        attn_q_weight: alloc_2d(arena, &layer.attn_q_weight, d, d, "attn_q_w")?,
+        attn_q_bias: alloc_1d(arena, &layer.attn_q_bias, "attn_q_b")?,
+        attn_k_weight: alloc_2d(arena, &layer.attn_k_weight, d, d, "attn_k_w")?,
+        attn_k_bias: alloc_1d(arena, &layer.attn_k_bias, "attn_k_b")?,
+        attn_v_weight: alloc_2d(arena, &layer.attn_v_weight, d, d, "attn_v_w")?,
+        attn_v_bias: alloc_1d(arena, &layer.attn_v_bias, "attn_v_b")?,
+        attn_output_weight: alloc_2d(arena, &layer.attn_output_weight, d, d, "attn_out_w")?,
+        attn_output_bias: alloc_1d(arena, &layer.attn_output_bias, "attn_out_b")?,
+        attn_norm_weight: alloc_1d(arena, &layer.attn_norm_weight, "attn_norm_w")?,
+        attn_norm_bias: alloc_1d(arena, &layer.attn_norm_bias, "attn_norm_b")?,
+        ffn_up_weight: alloc_2d(arena, &layer.ffn_up_weight, d, ffn, "ffn_up_w")?,
+        ffn_up_bias: alloc_1d(arena, &layer.ffn_up_bias, "ffn_up_b")?,
+        ffn_down_weight: alloc_2d(arena, &layer.ffn_down_weight, ffn, d, "ffn_down_w")?,
+        ffn_down_bias: alloc_1d(arena, &layer.ffn_down_bias, "ffn_down_b")?,
+        ffn_norm_weight: alloc_1d(arena, &layer.ffn_norm_weight, "ffn_norm_w")?,
+        ffn_norm_bias: alloc_1d(arena, &layer.ffn_norm_bias, "ffn_norm_b")?,
+    })
+}
+
+/// Argmax label id per position over label-fastest `[label_count, seq]` logits.
+pub(crate) fn argmax_labels_per_position(
+    logits: &[f32],
+    label_count: usize,
+    seq: usize,
+) -> Vec<usize> {
+    (0..seq)
+        .map(|pos| {
+            let row = &logits[pos * label_count..(pos + 1) * label_count];
+            row.iter()
+                .enumerate()
+                .max_by(|(_, a), (_, b)| a.total_cmp(b))
+                .map(|(idx, _)| idx)
+                .unwrap_or(0)
+        })
+        .collect()
+}
+
+fn upload_layer(
+    arena: &mut GgmlStaticTensorArena,
+    layer: &FireRedPuncLayerWeights,
+    h: &LayerArena,
+) -> Result<(), FireRedPuncGraphError> {
+    upload(arena, h.attn_q_weight, &layer.attn_q_weight, "attn_q_w")?;
+    upload(arena, h.attn_q_bias, &layer.attn_q_bias, "attn_q_b")?;
+    upload(arena, h.attn_k_weight, &layer.attn_k_weight, "attn_k_w")?;
+    upload(arena, h.attn_k_bias, &layer.attn_k_bias, "attn_k_b")?;
+    upload(arena, h.attn_v_weight, &layer.attn_v_weight, "attn_v_w")?;
+    upload(arena, h.attn_v_bias, &layer.attn_v_bias, "attn_v_b")?;
+    upload(
+        arena,
+        h.attn_output_weight,
+        &layer.attn_output_weight,
+        "attn_out_w",
+    )?;
+    upload(
+        arena,
+        h.attn_output_bias,
+        &layer.attn_output_bias,
+        "attn_out_b",
+    )?;
+    upload(
+        arena,
+        h.attn_norm_weight,
+        &layer.attn_norm_weight,
+        "attn_norm_w",
+    )?;
+    upload(
+        arena,
+        h.attn_norm_bias,
+        &layer.attn_norm_bias,
+        "attn_norm_b",
+    )?;
+    upload(arena, h.ffn_up_weight, &layer.ffn_up_weight, "ffn_up_w")?;
+    upload(arena, h.ffn_up_bias, &layer.ffn_up_bias, "ffn_up_b")?;
+    upload(
+        arena,
+        h.ffn_down_weight,
+        &layer.ffn_down_weight,
+        "ffn_down_w",
+    )?;
+    upload(arena, h.ffn_down_bias, &layer.ffn_down_bias, "ffn_down_b")?;
+    upload(
+        arena,
+        h.ffn_norm_weight,
+        &layer.ffn_norm_weight,
+        "ffn_norm_w",
+    )?;
+    upload(arena, h.ffn_norm_bias, &layer.ffn_norm_bias, "ffn_norm_b")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nt(name: &str, dims: Vec<usize>, values: Vec<f32>) -> NamedTensor {
+        NamedTensor {
+            name: name.to_string(),
+            dims,
+            values,
+        }
+    }
+
+    /// A tiny 1-layer BERT (d_model=4, 1 head, ffn=4, vocab=6, 5 labels) whose
+    /// attention and FFN projections are zeroed, so each block reduces to a
+    /// LayerNorm and the forward computes `logits = head . LayerNorm(embed)`.
+    /// The classifier head is one-hot on dim 0 for label 1 with a +5 baseline
+    /// on label 2, making per-token argmax hand-verifiable: a token embedded at
+    /// [4,0,0,0] normalises to a positive dim-0 and wins label 1; the zero
+    /// embedding normalises to all-zero and falls back to the label-2 baseline.
+    fn tiny_metadata() -> FireRedPuncExecutionMetadata {
+        FireRedPuncExecutionMetadata {
+            layers: 1,
+            d_model: 4,
+            ffn_dim: 4,
+            heads: 1,
+            head_dim: 4,
+            vocab_size: 6,
+            max_positions: 8,
+            label_count: 5,
+        }
+    }
+
+    fn tiny_weights() -> FireRedPuncWeights {
+        let zeros = |n: usize| vec![0.0f32; n];
+        let ones = |n: usize| vec![1.0f32; n];
+        let layer = FireRedPuncLayerWeights {
+            attn_q_weight: nt("blk.0.attn_q.weight", vec![4, 4], zeros(16)),
+            attn_q_bias: nt("blk.0.attn_q.bias", vec![4], zeros(4)),
+            attn_k_weight: nt("blk.0.attn_k.weight", vec![4, 4], zeros(16)),
+            attn_k_bias: nt("blk.0.attn_k.bias", vec![4], zeros(4)),
+            attn_v_weight: nt("blk.0.attn_v.weight", vec![4, 4], zeros(16)),
+            attn_v_bias: nt("blk.0.attn_v.bias", vec![4], zeros(4)),
+            attn_output_weight: nt("blk.0.attn_output.weight", vec![4, 4], zeros(16)),
+            attn_output_bias: nt("blk.0.attn_output.bias", vec![4], zeros(4)),
+            attn_norm_weight: nt("blk.0.attn_norm.weight", vec![4], ones(4)),
+            attn_norm_bias: nt("blk.0.attn_norm.bias", vec![4], zeros(4)),
+            ffn_up_weight: nt("blk.0.ffn_up.weight", vec![4, 4], zeros(16)),
+            ffn_up_bias: nt("blk.0.ffn_up.bias", vec![4], zeros(4)),
+            ffn_down_weight: nt("blk.0.ffn_down.weight", vec![4, 4], zeros(16)),
+            ffn_down_bias: nt("blk.0.ffn_down.bias", vec![4], zeros(4)),
+            ffn_norm_weight: nt("blk.0.ffn_norm.weight", vec![4], ones(4)),
+            ffn_norm_bias: nt("blk.0.ffn_norm.bias", vec![4], zeros(4)),
+        };
+        // token_embd [d=4, vocab=6], column-major per token: token 1 = [4,0,0,0].
+        let mut token_embd = zeros(4 * 6);
+        token_embd[4] = 4.0;
+        // head [d=4, label=5]: label 1 column = [10,0,0,0], others 0.
+        let mut head = zeros(4 * 5);
+        head[4] = 10.0;
+        FireRedPuncWeights {
+            token_embd: nt("token_embd.weight", vec![4, 6], token_embd),
+            token_type_embd: nt("token_type_embd.weight", vec![4, 2], zeros(8)),
+            position_embd: nt("position_embd.weight", vec![4, 8], zeros(32)),
+            embd_norm_weight: nt("embd_norm.weight", vec![4], ones(4)),
+            embd_norm_bias: nt("embd_norm.bias", vec![4], zeros(4)),
+            layers: vec![layer],
+            punc_head_weight: nt("punc_head.weight", vec![4, 5], head),
+            punc_head_bias: nt("punc_head.bias", vec![5], vec![0.0, 0.0, 5.0, 0.0, 0.0]),
+        }
+    }
+
+    #[test]
+    fn synthetic_forward_matches_hand_computed_argmax() {
+        let metadata = tiny_metadata();
+        let weights = tiny_weights();
+        let mut graph = FireRedPuncGraph::new(&weights, metadata).expect("build graph");
+        // Token 1 embeds to a positive dim-0 (-> label 1); token 0 to zero
+        // (-> label-2 baseline).
+        let logits = graph.forward(&[1, 0]).expect("forward");
+        assert_eq!(logits.len(), metadata.label_count * 2);
+        assert!(logits.iter().all(|v| v.is_finite()), "no NaN/Inf");
+        let labels = argmax_labels_per_position(&logits, metadata.label_count, 2);
+        assert_eq!(
+            labels,
+            vec![1, 2],
+            "per-token argmax matches hand computation"
+        );
+    }
+
+    #[test]
+    fn synthetic_forward_is_deterministic() {
+        let metadata = tiny_metadata();
+        let weights = tiny_weights();
+        let mut graph = FireRedPuncGraph::new(&weights, metadata).expect("build graph");
+        let a = graph.forward(&[1, 0, 2]).expect("forward a");
+        let b = graph.forward(&[1, 0, 2]).expect("forward b");
+        assert_eq!(a, b, "same input -> same logits");
+    }
+
+    #[test]
+    fn empty_and_overlong_inputs_fail_closed() {
+        let metadata = tiny_metadata();
+        let weights = tiny_weights();
+        let mut graph = FireRedPuncGraph::new(&weights, metadata).expect("build graph");
+        assert!(matches!(
+            graph.forward(&[]),
+            Err(FireRedPuncGraphError::EmptyInput)
+        ));
+        let too_long: Vec<u32> = vec![0; metadata.max_positions + 1];
+        assert!(matches!(
+            graph.forward(&too_long),
+            Err(FireRedPuncGraphError::SequenceTooLong { .. })
+        ));
+    }
+}

--- a/crates/openasr-core/src/models/firered_punc/mod.rs
+++ b/crates/openasr-core/src/models/firered_punc/mod.rs
@@ -22,6 +22,9 @@
 #![allow(dead_code)]
 
 pub(crate) mod config;
+pub(crate) mod graph;
+pub(crate) mod runtime;
 pub(crate) mod runtime_contract;
 pub(crate) mod tensor_names;
 pub(crate) mod tokenizer;
+pub(crate) mod weights;

--- a/crates/openasr-core/src/models/firered_punc/mod.rs
+++ b/crates/openasr-core/src/models/firered_punc/mod.rs
@@ -1,0 +1,26 @@
+//! FireRedPunc (`FireRedTeam/FireRedPunc`) punctuation-restoration model family.
+//!
+//! A BERT-style bidirectional encoder (initialised from `chinese-lert-base`)
+//! with a token-classification head that predicts, for each subword, which of
+//! five Chinese punctuation classes follows it (`<none>`, `，`, `。`, `？`,
+//! `！`). It is a **text-in / labels-out post-processor**, not an ASR model:
+//! no audio frontend, no autoregressive decode. It exists to punctuate the
+//! output of unpunctuated ASR families (e.g. dolphin), gated by the catalog
+//! `emits_punctuation` capability. Apache-2.0.
+//!
+//! The released label space is Chinese-only, so the integration is Chinese-only
+//! by construction; the architecture cannot emit English half-width marks.
+//!
+//! Stage status:
+//! - [`config`] / [`tensor_names`] / [`tokenizer`] define the pack geometry,
+//!   GGUF tensor layout, and the offset-preserving WordPiece encoder.
+
+// Later integration stages (runtime, package import, pull-contract dispatch,
+// and the punctuation post-processing stage) consume the geometry, tensor
+// names, label table, and tokenizer defined here; allow the not-yet-wired
+// surface until those stages land.
+#![allow(dead_code)]
+
+pub(crate) mod config;
+pub(crate) mod tensor_names;
+pub(crate) mod tokenizer;

--- a/crates/openasr-core/src/models/firered_punc/mod.rs
+++ b/crates/openasr-core/src/models/firered_punc/mod.rs
@@ -22,5 +22,6 @@
 #![allow(dead_code)]
 
 pub(crate) mod config;
+pub(crate) mod runtime_contract;
 pub(crate) mod tensor_names;
 pub(crate) mod tokenizer;

--- a/crates/openasr-core/src/models/firered_punc/mod.rs
+++ b/crates/openasr-core/src/models/firered_punc/mod.rs
@@ -28,3 +28,24 @@ pub(crate) mod runtime_contract;
 pub(crate) mod tensor_names;
 pub(crate) mod tokenizer;
 pub(crate) mod weights;
+
+/// Pull-time contract for FireRedPunc punctuation packs.
+///
+/// Returns `Some` only when the pack declares the `firered-punc` GGUF
+/// architecture; ASR/translation packs fall through to their own adapters. The
+/// check is the cheap metadata-only geometry validation (no weight load), so
+/// `openasr pull` stays fail-closed for punctuation packs without paying a full
+/// model build.
+pub(crate) fn validate_punctuation_runtime_pack_contract(
+    _path: &std::path::Path,
+    metadata: &crate::GgufMetadata,
+) -> Option<Result<(), String>> {
+    if !runtime_contract::metadata_declares_firered_punc(metadata) {
+        return None;
+    }
+    Some(
+        runtime_contract::parse_and_validate_firered_punc_metadata(metadata)
+            .map(|_| ())
+            .map_err(|error| error.to_string()),
+    )
+}

--- a/crates/openasr-core/src/models/firered_punc/runtime.rs
+++ b/crates/openasr-core/src/models/firered_punc/runtime.rs
@@ -1,0 +1,123 @@
+//! FireRedPunc runtime: load an `.oasr` pack and punctuate text.
+//!
+//! Ties the pack contract, WordPiece tokenizer, and BERT graph together and
+//! implements [`crate::punctuation::PunctuationClassifier`], so the punctuation
+//! post-processing stage can drive it exactly like the unit-test mock. The
+//! graph needs `&mut` for a forward, so it sits behind a `RefCell` to keep the
+//! classifier trait's `&self`.
+
+use std::cell::RefCell;
+use std::path::Path;
+
+use crate::ggml_runtime::{GgufTensorDataReader, read_gguf_metadata};
+use crate::punctuation::{
+    PunctuationClassifier, PunctuationError, PunctuationRestoreConfig, restore_punctuation,
+};
+
+use super::config::{FireRedPuncExecutionMetadata, TOKENIZER_GGML_TOKENS_KEY};
+use super::graph::{FireRedPuncGraph, FireRedPuncGraphError, argmax_labels_per_position};
+use super::runtime_contract::parse_and_validate_firered_punc_metadata;
+use super::tokenizer::FireRedPuncTokenizer;
+use super::weights::load_firered_punc_weights;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FireRedPuncRuntimeError {
+    #[error("firered-punc pack read failed: {0}")]
+    Read(String),
+    #[error("firered-punc pack metadata invalid: {0}")]
+    Metadata(String),
+    #[error("firered-punc pack is missing '{0}'")]
+    MissingMetadata(&'static str),
+    #[error("firered-punc tokenizer build failed: {0}")]
+    Tokenizer(String),
+    #[error("firered-punc weight load failed: {0}")]
+    Weights(String),
+    #[error("firered-punc graph build failed: {0}")]
+    Graph(#[from] FireRedPuncGraphError),
+}
+
+pub(crate) struct FireRedPuncRuntime {
+    metadata: FireRedPuncExecutionMetadata,
+    tokenizer: FireRedPuncTokenizer,
+    graph: RefCell<FireRedPuncGraph>,
+}
+
+impl FireRedPuncRuntime {
+    pub(crate) fn from_pack(path: &Path) -> Result<Self, FireRedPuncRuntimeError> {
+        let reader = GgufTensorDataReader::from_path(path)
+            .map_err(|error| FireRedPuncRuntimeError::Read(error.to_string()))?;
+        let gguf = read_gguf_metadata(path)
+            .map_err(|error| FireRedPuncRuntimeError::Read(error.to_string()))?;
+        let metadata = parse_and_validate_firered_punc_metadata(&gguf)
+            .map_err(|error| FireRedPuncRuntimeError::Metadata(error.to_string()))?;
+        let tokens = gguf.get_string_array(TOKENIZER_GGML_TOKENS_KEY).ok_or(
+            FireRedPuncRuntimeError::MissingMetadata(TOKENIZER_GGML_TOKENS_KEY),
+        )?;
+        let tokenizer = FireRedPuncTokenizer::new(tokens.to_vec())
+            .map_err(|error| FireRedPuncRuntimeError::Tokenizer(error.to_string()))?;
+        let weights = load_firered_punc_weights(&reader, &metadata)
+            .map_err(|error| FireRedPuncRuntimeError::Weights(error.to_string()))?;
+        let graph = FireRedPuncGraph::new(&weights, metadata)?;
+        Ok(Self {
+            metadata,
+            tokenizer,
+            graph: RefCell::new(graph),
+        })
+    }
+
+    /// Restore punctuation on `text` (finalize-only, Chinese full-width marks).
+    pub(crate) fn punctuate(&self, text: &str) -> Result<String, PunctuationError> {
+        restore_punctuation(
+            text,
+            &self.tokenizer,
+            self,
+            PunctuationRestoreConfig::default(),
+        )
+    }
+}
+
+impl PunctuationClassifier for FireRedPuncRuntime {
+    fn predict_window_labels(
+        &self,
+        content_token_ids: &[u32],
+    ) -> Result<Vec<usize>, PunctuationError> {
+        if content_token_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Wrap the content window in [CLS] ... [SEP] for the encoder.
+        let mut ids = Vec::with_capacity(content_token_ids.len() + 2);
+        ids.push(self.tokenizer.cls_id());
+        ids.extend_from_slice(content_token_ids);
+        ids.push(self.tokenizer.sep_id());
+
+        let logits = self
+            .graph
+            .borrow_mut()
+            .forward(&ids)
+            .map_err(|error| PunctuationError::Classifier(error.to_string()))?;
+        let per_position =
+            argmax_labels_per_position(&logits, self.metadata.label_count, ids.len());
+        // Drop the [CLS] (index 0) and [SEP] (last) predictions; return the
+        // labels aligned to the content tokens.
+        Ok(per_position[1..=content_token_ids.len()].to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real-weights parity: only runs when `OPENASR_FIRERED_PUNC_REAL_PACK`
+    /// points at a converted FireRedPunc `.oasr` pack. Left env-gated (like the
+    /// hymt2 / qwen real-pack tests) so the default suite stays weight-free; the
+    /// true upstream parity is exercised at publish time.
+    #[test]
+    fn real_pack_punctuates_readme_example() {
+        let Some(path) = std::env::var_os("OPENASR_FIRERED_PUNC_REAL_PACK") else {
+            return;
+        };
+        let runtime = FireRedPuncRuntime::from_pack(Path::new(&path)).expect("load real pack");
+        let out = runtime.punctuate("你好世界").expect("punctuate");
+        assert_eq!(out, "你好世界。", "upstream README golden");
+    }
+}

--- a/crates/openasr-core/src/models/firered_punc/runtime_contract.rs
+++ b/crates/openasr-core/src/models/firered_punc/runtime_contract.rs
@@ -1,0 +1,202 @@
+//! FireRedPunc execution metadata parsed from the `.oasr` GGUF header.
+//!
+//! The pull-time contract and the runtime both read the pack geometry through
+//! [`parse_firered_punc_execution_metadata`]; it validates the architecture tag
+//! and the chinese-lert-base geometry before any weights are materialised, so a
+//! malformed or mis-converted pack fails closed.
+
+use crate::models::runtime_contract::{
+    MetadataContractError, ScalarMetadataView, required_string_scalar, required_u64_scalar,
+    u64_to_usize, validate_positive_usize,
+};
+
+use super::config::{
+    FIRERED_PUNC_ARCHITECTURE_VALUE, FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY,
+    FIRERED_PUNC_BLOCK_COUNT_KEY, FIRERED_PUNC_CONTEXT_LENGTH_KEY,
+    FIRERED_PUNC_EMBEDDING_LENGTH_KEY, FIRERED_PUNC_FEED_FORWARD_LENGTH_KEY,
+    FIRERED_PUNC_LABEL_COUNT_KEY, FIRERED_PUNC_VOCAB_SIZE_KEY, FireRedPuncConfigError,
+    FireRedPuncExecutionMetadata,
+};
+use crate::arch::GENERAL_ARCHITECTURE_KEY;
+
+/// Returns `true` when the pack declares the FireRedPunc architecture. Used by
+/// the pull-time dispatch to route punctuation packs to this family instead of
+/// the ASR/translation adapters.
+pub(crate) fn metadata_declares_firered_punc<M: ScalarMetadataView>(metadata: &M) -> bool {
+    metadata
+        .get_string_scalar(GENERAL_ARCHITECTURE_KEY)
+        .map(|arch| arch.trim() == FIRERED_PUNC_ARCHITECTURE_VALUE)
+        .unwrap_or(false)
+}
+
+pub(crate) fn parse_firered_punc_execution_metadata<M: ScalarMetadataView>(
+    metadata: &M,
+) -> Result<FireRedPuncExecutionMetadata, MetadataContractError> {
+    let architecture = required_string_scalar(metadata, GENERAL_ARCHITECTURE_KEY)?;
+    if architecture != FIRERED_PUNC_ARCHITECTURE_VALUE {
+        return Err(MetadataContractError::InvalidValue {
+            key: GENERAL_ARCHITECTURE_KEY,
+            reason: format!("expected '{FIRERED_PUNC_ARCHITECTURE_VALUE}', got '{architecture}'"),
+        });
+    }
+
+    let usize_key = |key: &'static str| -> Result<usize, MetadataContractError> {
+        u64_to_usize(required_u64_scalar(metadata, key)?, key)
+    };
+    let layers = usize_key(FIRERED_PUNC_BLOCK_COUNT_KEY)?;
+    let d_model = usize_key(FIRERED_PUNC_EMBEDDING_LENGTH_KEY)?;
+    let ffn_dim = usize_key(FIRERED_PUNC_FEED_FORWARD_LENGTH_KEY)?;
+    let heads = usize_key(FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY)?;
+    let max_positions = usize_key(FIRERED_PUNC_CONTEXT_LENGTH_KEY)?;
+    let vocab_size = usize_key(FIRERED_PUNC_VOCAB_SIZE_KEY)?;
+    let label_count = usize_key(FIRERED_PUNC_LABEL_COUNT_KEY)?;
+
+    for (key, value) in [
+        (FIRERED_PUNC_BLOCK_COUNT_KEY, layers),
+        (FIRERED_PUNC_EMBEDDING_LENGTH_KEY, d_model),
+        (FIRERED_PUNC_FEED_FORWARD_LENGTH_KEY, ffn_dim),
+        (FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY, heads),
+        (FIRERED_PUNC_CONTEXT_LENGTH_KEY, max_positions),
+        (FIRERED_PUNC_VOCAB_SIZE_KEY, vocab_size),
+        (FIRERED_PUNC_LABEL_COUNT_KEY, label_count),
+    ] {
+        validate_positive_usize(value, key)?;
+    }
+    if !d_model.is_multiple_of(heads) {
+        return Err(MetadataContractError::InvalidValue {
+            key: FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY,
+            reason: format!("head_count {heads} does not divide embedding_length {d_model}"),
+        });
+    }
+
+    Ok(FireRedPuncExecutionMetadata {
+        layers,
+        d_model,
+        ffn_dim,
+        heads,
+        head_dim: d_model / heads,
+        vocab_size,
+        max_positions,
+        label_count,
+    })
+}
+
+/// Parse and additionally assert the single published chinese-lert-base
+/// geometry (see [`FireRedPuncExecutionMetadata::assert_expected_chinese_lert_base`]).
+pub(crate) fn parse_and_validate_firered_punc_metadata<M: ScalarMetadataView>(
+    metadata: &M,
+) -> Result<FireRedPuncExecutionMetadata, FireRedPuncConfigError> {
+    let parsed = parse_firered_punc_execution_metadata(metadata).map_err(|error| match error {
+        MetadataContractError::MissingRequiredKey { key } => {
+            FireRedPuncConfigError::MissingMetadata(key.to_string())
+        }
+        MetadataContractError::InvalidValue { key, .. } => FireRedPuncConfigError::MetadataType {
+            key: key.to_string(),
+        },
+    })?;
+    parsed.assert_expected_chinese_lert_base()?;
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::firered_punc::config::{
+        FIRERED_PUNC_EXPECTED_D_MODEL, FIRERED_PUNC_EXPECTED_FFN_DIM, FIRERED_PUNC_EXPECTED_HEADS,
+        FIRERED_PUNC_EXPECTED_LAYERS, FIRERED_PUNC_EXPECTED_MAX_POSITIONS,
+        FIRERED_PUNC_EXPECTED_VOCAB_SIZE, FIRERED_PUNC_LABEL_COUNT,
+    };
+    use std::collections::BTreeMap;
+
+    fn base_metadata() -> BTreeMap<String, String> {
+        let mut m = BTreeMap::new();
+        m.insert(
+            GENERAL_ARCHITECTURE_KEY.to_string(),
+            FIRERED_PUNC_ARCHITECTURE_VALUE.to_string(),
+        );
+        m.insert(
+            FIRERED_PUNC_BLOCK_COUNT_KEY.to_string(),
+            FIRERED_PUNC_EXPECTED_LAYERS.to_string(),
+        );
+        m.insert(
+            FIRERED_PUNC_EMBEDDING_LENGTH_KEY.to_string(),
+            FIRERED_PUNC_EXPECTED_D_MODEL.to_string(),
+        );
+        m.insert(
+            FIRERED_PUNC_FEED_FORWARD_LENGTH_KEY.to_string(),
+            FIRERED_PUNC_EXPECTED_FFN_DIM.to_string(),
+        );
+        m.insert(
+            FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY.to_string(),
+            FIRERED_PUNC_EXPECTED_HEADS.to_string(),
+        );
+        m.insert(
+            FIRERED_PUNC_CONTEXT_LENGTH_KEY.to_string(),
+            FIRERED_PUNC_EXPECTED_MAX_POSITIONS.to_string(),
+        );
+        m.insert(
+            FIRERED_PUNC_VOCAB_SIZE_KEY.to_string(),
+            FIRERED_PUNC_EXPECTED_VOCAB_SIZE.to_string(),
+        );
+        m.insert(
+            FIRERED_PUNC_LABEL_COUNT_KEY.to_string(),
+            FIRERED_PUNC_LABEL_COUNT.to_string(),
+        );
+        m
+    }
+
+    #[test]
+    fn parses_chinese_lert_base_geometry() {
+        let meta = base_metadata();
+        assert!(metadata_declares_firered_punc(&meta));
+        let parsed = parse_and_validate_firered_punc_metadata(&meta).expect("valid metadata");
+        assert_eq!(parsed.layers, FIRERED_PUNC_EXPECTED_LAYERS);
+        assert_eq!(parsed.d_model, FIRERED_PUNC_EXPECTED_D_MODEL);
+        assert_eq!(
+            parsed.head_dim,
+            FIRERED_PUNC_EXPECTED_D_MODEL / FIRERED_PUNC_EXPECTED_HEADS
+        );
+        assert_eq!(parsed.label_count, FIRERED_PUNC_LABEL_COUNT);
+    }
+
+    #[test]
+    fn wrong_architecture_is_rejected() {
+        let mut meta = base_metadata();
+        meta.insert(GENERAL_ARCHITECTURE_KEY.to_string(), "bert".to_string());
+        assert!(!metadata_declares_firered_punc(&meta));
+        assert!(parse_firered_punc_execution_metadata(&meta).is_err());
+    }
+
+    #[test]
+    fn missing_key_fails_closed() {
+        let mut meta = base_metadata();
+        meta.remove(FIRERED_PUNC_BLOCK_COUNT_KEY);
+        let err = parse_firered_punc_execution_metadata(&meta).unwrap_err();
+        assert_eq!(
+            err,
+            MetadataContractError::MissingRequiredKey {
+                key: FIRERED_PUNC_BLOCK_COUNT_KEY
+            }
+        );
+    }
+
+    #[test]
+    fn off_geometry_pack_is_rejected() {
+        let mut meta = base_metadata();
+        meta.insert(FIRERED_PUNC_BLOCK_COUNT_KEY.to_string(), "6".to_string());
+        // Parse succeeds structurally, but the expected-geometry assert rejects
+        // a non chinese-lert-base layer count.
+        assert!(parse_firered_punc_execution_metadata(&meta).is_ok());
+        assert!(parse_and_validate_firered_punc_metadata(&meta).is_err());
+    }
+
+    #[test]
+    fn indivisible_head_count_is_rejected() {
+        let mut meta = base_metadata();
+        meta.insert(
+            FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY.to_string(),
+            "5".to_string(),
+        );
+        assert!(parse_firered_punc_execution_metadata(&meta).is_err());
+    }
+}

--- a/crates/openasr-core/src/models/firered_punc/tensor_names.rs
+++ b/crates/openasr-core/src/models/firered_punc/tensor_names.rs
@@ -1,0 +1,60 @@
+//! GGUF tensor names for the FireRedPunc BERT encoder + classification head.
+//!
+//! BERT uses biased projections and full (weight + bias) LayerNorms throughout,
+//! unlike the RMS-norm, bias-free LLM families. The conversion recipe in
+//! `tooling/publish-model` maps the upstream `chinese-lert-base` / classifier
+//! state dict onto these names; the runtime binds them back by the same names.
+
+use crate::models::tensor_schema::layer_tensor_names;
+
+/// Word embedding table `[d_model, vocab_size]`.
+pub(crate) const TOKEN_EMBD_WEIGHT: &str = "token_embd.weight";
+/// Segment (token-type) embedding table `[d_model, 2]`. Punctuation inference
+/// is single-segment, so only row 0 is ever gathered, but the tensor is kept
+/// for a faithful checkpoint round-trip.
+pub(crate) const TOKEN_TYPE_EMBD_WEIGHT: &str = "token_type_embd.weight";
+/// Learned absolute position table `[d_model, max_positions]`.
+pub(crate) const POSITION_EMBD_WEIGHT: &str = "position_embd.weight";
+/// Post-embedding LayerNorm (BERT `embeddings.LayerNorm`).
+pub(crate) const EMBD_NORM_WEIGHT: &str = "embd_norm.weight";
+pub(crate) const EMBD_NORM_BIAS: &str = "embd_norm.bias";
+/// Token-classification head `[d_model, label_count]` + bias `[label_count]`.
+pub(crate) const PUNC_HEAD_WEIGHT: &str = "punc_head.weight";
+pub(crate) const PUNC_HEAD_BIAS: &str = "punc_head.bias";
+
+layer_tensor_names! {
+    pub(crate) struct FireRedPuncLayerTensorNames;
+    pub(crate) fn firered_punc_layer_tensor_names @ "blk";
+    {
+        attn_q_weight => "attn_q.weight",
+        attn_q_bias => "attn_q.bias",
+        attn_k_weight => "attn_k.weight",
+        attn_k_bias => "attn_k.bias",
+        attn_v_weight => "attn_v.weight",
+        attn_v_bias => "attn_v.bias",
+        attn_output_weight => "attn_output.weight",
+        attn_output_bias => "attn_output.bias",
+        attn_norm_weight => "attn_norm.weight",
+        attn_norm_bias => "attn_norm.bias",
+        ffn_up_weight => "ffn_up.weight",
+        ffn_up_bias => "ffn_up.bias",
+        ffn_down_weight => "ffn_down.weight",
+        ffn_down_bias => "ffn_down.bias",
+        ffn_norm_weight => "ffn_norm.weight",
+        ffn_norm_bias => "ffn_norm.bias",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn firered_punc_layer_tensor_names_are_block_scoped() {
+        let names = firered_punc_layer_tensor_names(7);
+        assert_eq!(names.attn_q_weight, "blk.7.attn_q.weight");
+        assert_eq!(names.attn_norm_bias, "blk.7.attn_norm.bias");
+        assert_eq!(names.ffn_down_weight, "blk.7.ffn_down.weight");
+        assert_eq!(names.ffn_norm_weight, "blk.7.ffn_norm.weight");
+    }
+}

--- a/crates/openasr-core/src/models/firered_punc/tokenizer.rs
+++ b/crates/openasr-core/src/models/firered_punc/tokenizer.rs
@@ -1,0 +1,369 @@
+//! Offset-preserving BERT WordPiece tokenizer for FireRedPunc.
+//!
+//! Unlike the ASR families (which only ever *detokenize*), punctuation
+//! restoration must *encode* transcript text into subword ids to feed the BERT
+//! classifier, then map each predicted label back onto the original characters.
+//! So this tokenizer tracks, for every content subword, the char span it came
+//! from in the *original* (un-normalised) text -- the classifier stage inserts
+//! punctuation at those offsets and never re-emits normalised text, preserving
+//! the transcript's exact casing and characters.
+//!
+//! Normalisation matches BERT uncased basic tokenisation minus accent
+//! stripping: control chars dropped, whitespace splits words, each CJK char and
+//! each punctuation char is its own word, ASCII letters lowercased. Accent
+//! stripping is intentionally omitted (ASR transcript text is Chinese/English
+//! with rare combining marks; those fall back to `[UNK]`), keeping this free of
+//! a unicode-normalisation dependency.
+
+const CLS_TOKEN: &str = "[CLS]";
+const SEP_TOKEN: &str = "[SEP]";
+const UNK_TOKEN: &str = "[UNK]";
+const PAD_TOKEN: &str = "[PAD]";
+const WORDPIECE_CONTINUATION: &str = "##";
+/// BERT's `max_input_chars_per_word`: longer words map straight to `[UNK]`.
+const MAX_INPUT_CHARS_PER_WORD: usize = 100;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub(crate) enum FireRedPuncTokenizerError {
+    #[error("firered-punc vocab is missing required special token '{0}'")]
+    MissingSpecialToken(&'static str),
+    #[error("firered-punc vocab is empty")]
+    EmptyVocab,
+}
+
+/// One content subword and the char span it occupies in the original text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WordPiecePiece {
+    pub token_id: u32,
+    /// Char index (into the original string) of the first source char.
+    pub char_start: usize,
+    /// Char index one past the last source char (exclusive).
+    pub char_end: usize,
+    /// True when this is the last subword of its word, i.e. a legal place to
+    /// attach a following punctuation mark. Mid-word continuation pieces
+    /// (`##...`) are never word-final, so punctuation can never land inside a
+    /// word.
+    pub word_final: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FireRedPuncTokenizer {
+    vocab: Vec<String>,
+    token_to_id: std::collections::HashMap<String, u32>,
+    cls_id: u32,
+    sep_id: u32,
+    unk_id: u32,
+    pad_id: u32,
+}
+
+impl FireRedPuncTokenizer {
+    pub(crate) fn new(vocab: Vec<String>) -> Result<Self, FireRedPuncTokenizerError> {
+        if vocab.is_empty() {
+            return Err(FireRedPuncTokenizerError::EmptyVocab);
+        }
+        let mut token_to_id = std::collections::HashMap::with_capacity(vocab.len());
+        for (idx, token) in vocab.iter().enumerate() {
+            token_to_id.entry(token.clone()).or_insert(idx as u32);
+        }
+        let lookup = |tok: &'static str| {
+            token_to_id
+                .get(tok)
+                .copied()
+                .ok_or(FireRedPuncTokenizerError::MissingSpecialToken(tok))
+        };
+        let cls_id = lookup(CLS_TOKEN)?;
+        let sep_id = lookup(SEP_TOKEN)?;
+        let unk_id = lookup(UNK_TOKEN)?;
+        let pad_id = lookup(PAD_TOKEN)?;
+        Ok(Self {
+            vocab,
+            token_to_id,
+            cls_id,
+            sep_id,
+            unk_id,
+            pad_id,
+        })
+    }
+
+    pub(crate) fn vocab_size(&self) -> usize {
+        self.vocab.len()
+    }
+
+    pub(crate) fn cls_id(&self) -> u32 {
+        self.cls_id
+    }
+
+    pub(crate) fn sep_id(&self) -> u32 {
+        self.sep_id
+    }
+
+    pub(crate) fn pad_id(&self) -> u32 {
+        self.pad_id
+    }
+
+    /// Tokenise `text` into content subwords with original-text char spans.
+    /// The result excludes `[CLS]`/`[SEP]`; call [`Self::window_input_ids`] to
+    /// wrap a slice of pieces into model input ids.
+    pub(crate) fn encode(&self, text: &str) -> Vec<WordPiecePiece> {
+        let chars: Vec<char> = text.chars().collect();
+        let mut pieces = Vec::new();
+        let mut idx = 0usize;
+        while idx < chars.len() {
+            let c = chars[idx];
+            if is_whitespace(c) || is_control(c) {
+                idx += 1;
+                continue;
+            }
+            if is_cjk_char(c) || is_split_punctuation(c) {
+                // CJK chars and punctuation each form a standalone word.
+                self.push_word(&chars[idx..idx + 1], idx, &mut pieces);
+                idx += 1;
+                continue;
+            }
+            // Accumulate a maximal run of non-whitespace, non-CJK,
+            // non-standalone-punctuation chars into one word.
+            let start = idx;
+            while idx < chars.len() {
+                let cc = chars[idx];
+                if is_whitespace(cc)
+                    || is_control(cc)
+                    || is_cjk_char(cc)
+                    || is_split_punctuation(cc)
+                {
+                    break;
+                }
+                idx += 1;
+            }
+            self.push_word(&chars[start..idx], start, &mut pieces);
+        }
+        pieces
+    }
+
+    /// WordPiece-tokenise a single word (`word_chars`, whose first char is at
+    /// original char index `word_start`) and append the resulting pieces.
+    fn push_word(&self, word_chars: &[char], word_start: usize, out: &mut Vec<WordPiecePiece>) {
+        // Normalised (lowercased) form used only for vocab lookup; spans are
+        // always expressed against the original indices.
+        let normalised: String = word_chars.iter().flat_map(|c| c.to_lowercase()).collect();
+        let norm_chars: Vec<char> = normalised.chars().collect();
+
+        // Lowercasing is 1:1 for the scripts ASR emits; when it is not (rare),
+        // fall back to whole-word [UNK] so spans stay trustworthy.
+        let spans_aligned = norm_chars.len() == word_chars.len();
+        if !spans_aligned || norm_chars.len() > MAX_INPUT_CHARS_PER_WORD {
+            out.push(WordPiecePiece {
+                token_id: self.unk_id,
+                char_start: word_start,
+                char_end: word_start + word_chars.len(),
+                word_final: true,
+            });
+            return;
+        }
+
+        // Greedy longest-match-first WordPiece over the normalised chars.
+        let mut sub_pieces: Vec<WordPiecePiece> = Vec::new();
+        let mut cursor = 0usize;
+        let mut is_bad = false;
+        while cursor < norm_chars.len() {
+            let mut end = norm_chars.len();
+            let mut matched: Option<u32> = None;
+            let mut matched_end = cursor;
+            while end > cursor {
+                let mut candidate: String = norm_chars[cursor..end].iter().collect();
+                if cursor > 0 {
+                    candidate.insert_str(0, WORDPIECE_CONTINUATION);
+                }
+                if let Some(&id) = self.token_to_id.get(&candidate) {
+                    matched = Some(id);
+                    matched_end = end;
+                    break;
+                }
+                end -= 1;
+            }
+            match matched {
+                Some(id) => {
+                    sub_pieces.push(WordPiecePiece {
+                        token_id: id,
+                        char_start: word_start + cursor,
+                        char_end: word_start + matched_end,
+                        word_final: false,
+                    });
+                    cursor = matched_end;
+                }
+                None => {
+                    is_bad = true;
+                    break;
+                }
+            }
+        }
+
+        if is_bad || sub_pieces.is_empty() {
+            out.push(WordPiecePiece {
+                token_id: self.unk_id,
+                char_start: word_start,
+                char_end: word_start + word_chars.len(),
+                word_final: true,
+            });
+            return;
+        }
+
+        if let Some(last) = sub_pieces.last_mut() {
+            last.word_final = true;
+        }
+        out.extend(sub_pieces);
+    }
+
+    /// Wrap a window of content pieces into `[CLS] ... [SEP]` model input ids.
+    pub(crate) fn window_input_ids(&self, window: &[WordPiecePiece]) -> Vec<u32> {
+        let mut ids = Vec::with_capacity(window.len() + 2);
+        ids.push(self.cls_id);
+        ids.extend(window.iter().map(|piece| piece.token_id));
+        ids.push(self.sep_id);
+        ids
+    }
+}
+
+fn is_whitespace(c: char) -> bool {
+    c == ' ' || c == '\t' || c == '\n' || c == '\r' || c.is_whitespace()
+}
+
+fn is_control(c: char) -> bool {
+    if c == '\t' || c == '\n' || c == '\r' {
+        return false;
+    }
+    c.is_control()
+}
+
+/// Punctuation that BERT basic tokenisation splits into its own token: all
+/// ASCII punctuation plus any Unicode punctuation category char. Splitting them
+/// out means transcript punctuation the model *does* see stays isolated.
+fn is_split_punctuation(c: char) -> bool {
+    let cp = c as u32;
+    let ascii_punct = (0x21..=0x2F).contains(&cp)
+        || (0x3A..=0x40).contains(&cp)
+        || (0x5B..=0x60).contains(&cp)
+        || (0x7B..=0x7E).contains(&cp);
+    ascii_punct || c.is_ascii_punctuation() || is_unicode_punctuation(c)
+}
+
+fn is_unicode_punctuation(c: char) -> bool {
+    matches!(
+        c,
+        '\u{3001}'..='\u{3003}'
+            | '\u{3008}'..='\u{3011}'
+            | '\u{FF01}'..='\u{FF0F}'
+            | '\u{FF1A}'..='\u{FF20}'
+            | '\u{FF3B}'..='\u{FF40}'
+            | '\u{FF5B}'..='\u{FF65}'
+            | '\u{2018}'..='\u{201F}'
+    )
+}
+
+/// BERT `_is_chinese_char`: the CJK Unified Ideograph blocks. Note this is the
+/// upstream definition -- it deliberately excludes CJK punctuation/kana, which
+/// are handled as punctuation/other words.
+fn is_cjk_char(c: char) -> bool {
+    let cp = c as u32;
+    (0x4E00..=0x9FFF).contains(&cp)
+        || (0x3400..=0x4DBF).contains(&cp)
+        || (0x20000..=0x2A6DF).contains(&cp)
+        || (0x2A700..=0x2B73F).contains(&cp)
+        || (0x2B740..=0x2B81F).contains(&cp)
+        || (0x2B820..=0x2CEAF).contains(&cp)
+        || (0xF900..=0xFAFF).contains(&cp)
+        || (0x2F800..=0x2FA1F).contains(&cp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal synthetic WordPiece vocab: the special tokens, a few CJK chars,
+    /// and English pieces for "hello"/"world" exercising `##` continuation.
+    fn test_tokenizer() -> FireRedPuncTokenizer {
+        let vocab = [
+            "[PAD]", "[UNK]", "[CLS]", "[SEP]", "你", "好", "世", "界", "hello", "wor", "##ld",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        FireRedPuncTokenizer::new(vocab).expect("vocab has special tokens")
+    }
+
+    #[test]
+    fn missing_special_token_is_rejected() {
+        let err = FireRedPuncTokenizer::new(vec!["你".to_string()]).unwrap_err();
+        assert_eq!(err, FireRedPuncTokenizerError::MissingSpecialToken("[CLS]"));
+    }
+
+    #[test]
+    fn cjk_is_one_piece_per_char_with_char_spans() {
+        let tok = test_tokenizer();
+        let pieces = tok.encode("你好世界");
+        assert_eq!(pieces.len(), 4);
+        for (i, piece) in pieces.iter().enumerate() {
+            assert_eq!(piece.char_start, i);
+            assert_eq!(piece.char_end, i + 1);
+            assert!(piece.word_final, "every CJK char is its own word");
+        }
+        let ids: Vec<u32> = pieces.iter().map(|p| p.token_id).collect();
+        assert_eq!(ids, vec![4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn window_ids_wrap_with_cls_and_sep() {
+        let tok = test_tokenizer();
+        let pieces = tok.encode("你好");
+        let ids = tok.window_input_ids(&pieces);
+        assert_eq!(ids, vec![tok.cls_id(), 4, 5, tok.sep_id()]);
+    }
+
+    #[test]
+    fn english_word_splits_into_wordpieces_only_last_is_word_final() {
+        let tok = test_tokenizer();
+        let pieces = tok.encode("world");
+        assert_eq!(pieces.len(), 2, "wor + ##ld");
+        assert_eq!(pieces[0].token_id, 9);
+        assert!(!pieces[0].word_final);
+        assert_eq!(pieces[0].char_start, 0);
+        assert_eq!(pieces[0].char_end, 3);
+        assert_eq!(pieces[1].token_id, 10);
+        assert!(pieces[1].word_final);
+        assert_eq!(pieces[1].char_start, 3);
+        assert_eq!(pieces[1].char_end, 5);
+    }
+
+    #[test]
+    fn lowercasing_preserves_original_spans() {
+        let tok = test_tokenizer();
+        let pieces = tok.encode("HELLO");
+        assert_eq!(pieces.len(), 1);
+        assert_eq!(pieces[0].token_id, 8, "lowercased to the 'hello' piece");
+        assert_eq!(pieces[0].char_start, 0);
+        assert_eq!(pieces[0].char_end, 5, "span is against the original text");
+        assert!(pieces[0].word_final);
+    }
+
+    #[test]
+    fn unknown_word_falls_back_to_unk_spanning_the_word() {
+        let tok = test_tokenizer();
+        let pieces = tok.encode("zzz");
+        assert_eq!(pieces.len(), 1);
+        assert_eq!(pieces[0].token_id, tok.unk_id);
+        assert_eq!(pieces[0].char_start, 0);
+        assert_eq!(pieces[0].char_end, 3);
+        assert!(pieces[0].word_final);
+    }
+
+    #[test]
+    fn whitespace_between_words_is_skipped_but_offsets_track_original() {
+        let tok = test_tokenizer();
+        let pieces = tok.encode("你 好");
+        assert_eq!(pieces.len(), 2);
+        assert_eq!(pieces[0].char_start, 0);
+        assert_eq!(pieces[0].char_end, 1);
+        // The second CJK char sits at original index 2 (after the space).
+        assert_eq!(pieces[1].char_start, 2);
+        assert_eq!(pieces[1].char_end, 3);
+    }
+}

--- a/crates/openasr-core/src/models/firered_punc/weights.rs
+++ b/crates/openasr-core/src/models/firered_punc/weights.rs
@@ -1,0 +1,155 @@
+//! Load a FireRedPunc `.oasr` pack into host f32 weights.
+//!
+//! FireRedPunc is BERT-base (~110M params) and runs as an occasional
+//! finalize-only pass, so -- unlike the ASR encoders that keep the dominant
+//! linears quantized and zero-copy -- every tensor is simply dequantized to f32
+//! and uploaded to the graph arena. That keeps the graph and its synthetic-
+//! weight numeric test straightforward; the conversion recipe may still store
+//! the pack quantized (the loader dequantizes on read).
+
+use crate::ggml_runtime::{GgufTensorDataReadError, GgufTensorDataReader};
+
+use super::config::FireRedPuncExecutionMetadata;
+use super::tensor_names::{
+    EMBD_NORM_BIAS, EMBD_NORM_WEIGHT, POSITION_EMBD_WEIGHT, PUNC_HEAD_BIAS, PUNC_HEAD_WEIGHT,
+    TOKEN_EMBD_WEIGHT, TOKEN_TYPE_EMBD_WEIGHT, firered_punc_layer_tensor_names,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FireRedPuncWeightsError {
+    #[error("firered-punc weight read failed: {0}")]
+    Read(#[from] GgufTensorDataReadError),
+    #[error("firered-punc tensor '{name}' has {got} elements, expected {expected}")]
+    ElementCount {
+        name: String,
+        got: usize,
+        expected: usize,
+    },
+}
+
+/// A host weight: stored dims (from the GGUF index) + dequantized f32 values.
+#[derive(Debug, Clone)]
+pub(crate) struct NamedTensor {
+    pub name: String,
+    pub dims: Vec<usize>,
+    pub values: Vec<f32>,
+}
+
+/// One BERT block's weights (`blk.{i}.*`). Linear weights are stored `[in, out]`
+/// (ne0 = in_features) so the graph's `mul_mat(weight, x)` yields `[out, seq]`.
+#[derive(Debug, Clone)]
+pub(crate) struct FireRedPuncLayerWeights {
+    pub attn_q_weight: NamedTensor,
+    pub attn_q_bias: NamedTensor,
+    pub attn_k_weight: NamedTensor,
+    pub attn_k_bias: NamedTensor,
+    pub attn_v_weight: NamedTensor,
+    pub attn_v_bias: NamedTensor,
+    pub attn_output_weight: NamedTensor,
+    pub attn_output_bias: NamedTensor,
+    pub attn_norm_weight: NamedTensor,
+    pub attn_norm_bias: NamedTensor,
+    pub ffn_up_weight: NamedTensor,
+    pub ffn_up_bias: NamedTensor,
+    pub ffn_down_weight: NamedTensor,
+    pub ffn_down_bias: NamedTensor,
+    pub ffn_norm_weight: NamedTensor,
+    pub ffn_norm_bias: NamedTensor,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FireRedPuncWeights {
+    pub token_embd: NamedTensor,
+    pub token_type_embd: NamedTensor,
+    pub position_embd: NamedTensor,
+    pub embd_norm_weight: NamedTensor,
+    pub embd_norm_bias: NamedTensor,
+    pub layers: Vec<FireRedPuncLayerWeights>,
+    pub punc_head_weight: NamedTensor,
+    pub punc_head_bias: NamedTensor,
+}
+
+fn load_named(
+    reader: &GgufTensorDataReader,
+    name: &str,
+) -> Result<NamedTensor, FireRedPuncWeightsError> {
+    let tensor = reader.tensor_index().get(name).ok_or_else(|| {
+        FireRedPuncWeightsError::Read(GgufTensorDataReadError::TensorNotFound {
+            path: reader.tensor_index().path().to_path_buf(),
+            tensor_name: name.to_string(),
+        })
+    })?;
+    let dims: Vec<usize> = tensor.dims.iter().map(|&d| d as usize).collect();
+    let shape_u64: Vec<u64> = tensor.dims.clone();
+    let values = reader.host_tensor_f32_copy_dequantized_by_name(name, &shape_u64)?;
+    Ok(NamedTensor {
+        name: name.to_string(),
+        dims,
+        values,
+    })
+}
+
+fn load_expected(
+    reader: &GgufTensorDataReader,
+    name: &str,
+    expected: usize,
+) -> Result<NamedTensor, FireRedPuncWeightsError> {
+    let tensor = load_named(reader, name)?;
+    if tensor.values.len() != expected {
+        return Err(FireRedPuncWeightsError::ElementCount {
+            name: name.to_string(),
+            got: tensor.values.len(),
+            expected,
+        });
+    }
+    Ok(tensor)
+}
+
+fn load_layer(
+    reader: &GgufTensorDataReader,
+    layer: usize,
+    metadata: &FireRedPuncExecutionMetadata,
+) -> Result<FireRedPuncLayerWeights, FireRedPuncWeightsError> {
+    let names = firered_punc_layer_tensor_names(layer);
+    let d = metadata.d_model;
+    let ffn = metadata.ffn_dim;
+    Ok(FireRedPuncLayerWeights {
+        attn_q_weight: load_expected(reader, &names.attn_q_weight, d * d)?,
+        attn_q_bias: load_expected(reader, &names.attn_q_bias, d)?,
+        attn_k_weight: load_expected(reader, &names.attn_k_weight, d * d)?,
+        attn_k_bias: load_expected(reader, &names.attn_k_bias, d)?,
+        attn_v_weight: load_expected(reader, &names.attn_v_weight, d * d)?,
+        attn_v_bias: load_expected(reader, &names.attn_v_bias, d)?,
+        attn_output_weight: load_expected(reader, &names.attn_output_weight, d * d)?,
+        attn_output_bias: load_expected(reader, &names.attn_output_bias, d)?,
+        attn_norm_weight: load_expected(reader, &names.attn_norm_weight, d)?,
+        attn_norm_bias: load_expected(reader, &names.attn_norm_bias, d)?,
+        ffn_up_weight: load_expected(reader, &names.ffn_up_weight, d * ffn)?,
+        ffn_up_bias: load_expected(reader, &names.ffn_up_bias, ffn)?,
+        ffn_down_weight: load_expected(reader, &names.ffn_down_weight, ffn * d)?,
+        ffn_down_bias: load_expected(reader, &names.ffn_down_bias, d)?,
+        ffn_norm_weight: load_expected(reader, &names.ffn_norm_weight, d)?,
+        ffn_norm_bias: load_expected(reader, &names.ffn_norm_bias, d)?,
+    })
+}
+
+pub(crate) fn load_firered_punc_weights(
+    reader: &GgufTensorDataReader,
+    metadata: &FireRedPuncExecutionMetadata,
+) -> Result<FireRedPuncWeights, FireRedPuncWeightsError> {
+    let d = metadata.d_model;
+    let mut layers = Vec::with_capacity(metadata.layers);
+    for layer in 0..metadata.layers {
+        layers.push(load_layer(reader, layer, metadata)?);
+    }
+    Ok(FireRedPuncWeights {
+        token_embd: load_expected(reader, TOKEN_EMBD_WEIGHT, d * metadata.vocab_size)?,
+        token_type_embd: load_named(reader, TOKEN_TYPE_EMBD_WEIGHT)?,
+        position_embd: load_expected(reader, POSITION_EMBD_WEIGHT, d * metadata.max_positions)?,
+        embd_norm_weight: load_expected(reader, EMBD_NORM_WEIGHT, d)?,
+        embd_norm_bias: load_expected(reader, EMBD_NORM_BIAS, d)?,
+        layers,
+        punc_head_weight: load_expected(reader, PUNC_HEAD_WEIGHT, d * metadata.label_count)?,
+        punc_head_bias: load_expected(reader, PUNC_HEAD_BIAS, metadata.label_count)?,
+    })
+}

--- a/crates/openasr-core/src/punctuation/mod.rs
+++ b/crates/openasr-core/src/punctuation/mod.rs
@@ -1,0 +1,341 @@
+//! Optional punctuation-restoration post-processing stage.
+//!
+//! FireRedPunc (see `models::firered_punc`) is a BERT token classifier that
+//! predicts, for each subword of an unpunctuated transcript, which Chinese
+//! punctuation mark (if any) follows it. This stage turns those per-token
+//! labels into a punctuated string, and decides *when* the stage runs.
+//!
+//! Design (kept decoupled from ASR, high-cohesion / low-coupling):
+//!
+//! - **Opt-in and auto-gated.** The stage runs only for models whose transcript
+//!   is unpunctuated, keyed off the catalog `emits_punctuation` capability
+//!   (`Some(false)` -> run; `Some(true)`/`None` -> leave the text untouched, so
+//!   punctuating families like whisper/qwen are never double-punctuated). See
+//!   [`should_apply_punctuation`].
+//! - **Finalize-only.** It is meant to run once on a finalized segment, not per
+//!   streaming partial -- re-punctuating every partial with a bidirectional
+//!   encoder is expensive and reintroduces caption flicker.
+//! - **Offset-preserving.** Labels attach to the original text via the
+//!   tokenizer's char spans; the stage inserts marks into the original
+//!   characters and never re-emits normalised (lowercased) text.
+//!
+//! The classifier itself is abstracted behind [`PunctuationClassifier`] so this
+//! orchestration is fully unit-testable without model weights; the ggml
+//! FireRedPunc runtime implements the trait.
+
+// The runtime trait impl and the finalize-path caller land in following stages;
+// allow the not-yet-wired surface until then.
+#![allow(dead_code)]
+
+use crate::models::firered_punc::config::punctuation_for_label;
+use crate::models::firered_punc::tokenizer::{FireRedPuncTokenizer, WordPiecePiece};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PunctuationError {
+    // Constructed by the ggml FireRedPunc runtime (lands with the runtime
+    // stage) when a forward pass fails; the stage orchestration only forwards
+    // it.
+    #[error("punctuation classifier failed: {0}")]
+    Classifier(String),
+    #[error(
+        "punctuation classifier returned {got} labels for a {expected}-token window (must match)"
+    )]
+    LabelCountMismatch { got: usize, expected: usize },
+}
+
+/// A model that scores punctuation for one window of content tokens.
+///
+/// Implementations receive the content token ids for a single window (the
+/// tokenizer's `[CLS]`/`[SEP]` wrapping is the implementation's concern) and
+/// return the argmax label id per content token, in the same order and length.
+/// Label ids index [`crate::models::firered_punc::config::PUNC_LABELS`].
+pub(crate) trait PunctuationClassifier {
+    fn predict_window_labels(
+        &self,
+        content_token_ids: &[u32],
+    ) -> Result<Vec<usize>, PunctuationError>;
+}
+
+/// Runtime knobs for the restoration walk.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PunctuationRestoreConfig {
+    /// Maximum content tokens per classifier window (BERT max positions minus
+    /// the `[CLS]`/`[SEP]` wrapping). Windows are cut only at word boundaries so
+    /// a word's subwords never span two windows.
+    pub max_content_tokens: usize,
+}
+
+impl Default for PunctuationRestoreConfig {
+    fn default() -> Self {
+        // chinese-lert-base max_position_embeddings (512) - [CLS] - [SEP].
+        Self {
+            max_content_tokens: 510,
+        }
+    }
+}
+
+/// Whether the punctuation stage should run for a model with the given
+/// `emits_punctuation` capability. Only unpunctuated families (`Some(false)`)
+/// opt in; `None` ("unknown", treated as already punctuated) and `Some(true)`
+/// are left untouched.
+pub(crate) fn should_apply_punctuation(emits_punctuation: Option<bool>) -> bool {
+    emits_punctuation == Some(false)
+}
+
+/// Restore punctuation on `text` using `classifier`, returning the punctuated
+/// string. Insertion points come from the tokenizer's char spans, so the
+/// original characters (casing included) are preserved verbatim; only
+/// punctuation marks are added.
+pub(crate) fn restore_punctuation(
+    text: &str,
+    tokenizer: &FireRedPuncTokenizer,
+    classifier: &dyn PunctuationClassifier,
+    config: PunctuationRestoreConfig,
+) -> Result<String, PunctuationError> {
+    let pieces = tokenizer.encode(text);
+    if pieces.is_empty() {
+        return Ok(text.to_string());
+    }
+
+    // (char_end offset in the original text, punctuation mark) insertions.
+    let mut insertions: Vec<(usize, char)> = Vec::new();
+    for window in word_boundary_windows(&pieces, config.max_content_tokens) {
+        let ids: Vec<u32> = window.iter().map(|piece| piece.token_id).collect();
+        let labels = classifier.predict_window_labels(&ids)?;
+        if labels.len() != window.len() {
+            return Err(PunctuationError::LabelCountMismatch {
+                got: labels.len(),
+                expected: window.len(),
+            });
+        }
+        for (piece, label) in window.iter().zip(labels) {
+            // Only attach at word-final subwords so a mark never lands inside a
+            // word; ignore the "no punctuation" class (label 0).
+            if !piece.word_final {
+                continue;
+            }
+            if let Some(mark) = punctuation_for_label(label) {
+                insertions.push((piece.char_end, mark));
+            }
+        }
+    }
+
+    Ok(apply_insertions(text, &mut insertions))
+}
+
+/// Split content pieces into windows of at most `max_content_tokens`, cutting
+/// only after a word-final piece so a word's subwords stay in one window. A
+/// single word longer than the budget is kept whole (it cannot be split).
+fn word_boundary_windows(
+    pieces: &[WordPiecePiece],
+    max_content_tokens: usize,
+) -> Vec<&[WordPiecePiece]> {
+    let budget = max_content_tokens.max(1);
+    let mut windows = Vec::new();
+    let mut start = 0usize;
+    let mut last_word_end: Option<usize> = None;
+    for (idx, piece) in pieces.iter().enumerate() {
+        let len_if_included = idx - start + 1;
+        if len_if_included > budget && last_word_end.map(|end| end > start).unwrap_or(false) {
+            let cut = last_word_end.expect("checked Some above");
+            windows.push(&pieces[start..cut]);
+            start = cut;
+            last_word_end = None;
+        }
+        if piece.word_final {
+            last_word_end = Some(idx + 1);
+        }
+    }
+    if start < pieces.len() {
+        windows.push(&pieces[start..]);
+    }
+    windows
+}
+
+/// Insert punctuation marks into `text` at the given original char offsets.
+/// Skips an insertion whose slot is already occupied by punctuation (avoids
+/// doubling when the transcript already carries a mark).
+fn apply_insertions(text: &str, insertions: &mut [(usize, char)]) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    // Apply right-to-left so earlier offsets stay valid; dedup by offset.
+    insertions.sort_by_key(|&(offset, _)| std::cmp::Reverse(offset));
+    let mut result = chars.clone();
+    let mut last_offset: Option<usize> = None;
+    for &(offset, mark) in insertions.iter() {
+        if offset > result.len() {
+            continue;
+        }
+        if last_offset == Some(offset) {
+            continue;
+        }
+        last_offset = Some(offset);
+        // Skip when the transcript already has a punctuation mark at this slot.
+        if offset < chars.len() && is_existing_punctuation(chars[offset]) {
+            continue;
+        }
+        if offset > 0 && is_existing_punctuation(chars[offset - 1]) {
+            continue;
+        }
+        result.insert(offset, mark);
+    }
+    result.into_iter().collect()
+}
+
+fn is_existing_punctuation(c: char) -> bool {
+    matches!(c, '，' | '。' | '？' | '！' | '、' | '；' | '：') || c.is_ascii_punctuation()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_tokenizer() -> FireRedPuncTokenizer {
+        let vocab = [
+            "[PAD]", "[UNK]", "[CLS]", "[SEP]", "你", "好", "世", "界", "hello", "wor", "##ld",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        FireRedPuncTokenizer::new(vocab).expect("vocab has special tokens")
+    }
+
+    /// Returns caller-scripted labels per content token, in order across all
+    /// windows (the harness concatenates window predictions).
+    struct ScriptedClassifier {
+        labels: std::cell::RefCell<std::collections::VecDeque<usize>>,
+    }
+
+    impl ScriptedClassifier {
+        fn new(labels: Vec<usize>) -> Self {
+            Self {
+                labels: std::cell::RefCell::new(labels.into()),
+            }
+        }
+    }
+
+    impl PunctuationClassifier for ScriptedClassifier {
+        fn predict_window_labels(
+            &self,
+            content_token_ids: &[u32],
+        ) -> Result<Vec<usize>, PunctuationError> {
+            let mut queue = self.labels.borrow_mut();
+            let out: Vec<usize> = content_token_ids
+                .iter()
+                .map(|_| queue.pop_front().unwrap_or(0))
+                .collect();
+            Ok(out)
+        }
+    }
+
+    #[test]
+    fn gating_only_runs_for_unpunctuated_models() {
+        assert!(should_apply_punctuation(Some(false)));
+        assert!(!should_apply_punctuation(Some(true)));
+        assert!(!should_apply_punctuation(None));
+    }
+
+    #[test]
+    fn readme_golden_period_after_final_char() {
+        // "你好世界" -> label 2 ('。') on the last char, none elsewhere.
+        let tok = test_tokenizer();
+        let classifier = ScriptedClassifier::new(vec![0, 0, 0, 2]);
+        let out = restore_punctuation(
+            "你好世界",
+            &tok,
+            &classifier,
+            PunctuationRestoreConfig::default(),
+        )
+        .expect("restore");
+        assert_eq!(out, "你好世界。");
+    }
+
+    #[test]
+    fn comma_and_period_are_inserted_at_char_boundaries() {
+        // "你好世界" -> comma after '好' (idx1), period after '界' (idx3).
+        let tok = test_tokenizer();
+        let classifier = ScriptedClassifier::new(vec![0, 1, 0, 2]);
+        let out = restore_punctuation(
+            "你好世界",
+            &tok,
+            &classifier,
+            PunctuationRestoreConfig::default(),
+        )
+        .expect("restore");
+        assert_eq!(out, "你好，世界。");
+    }
+
+    #[test]
+    fn mid_word_labels_are_ignored_only_word_final_attaches() {
+        // "world" -> pieces [wor(not final), ##ld(final)]. A label on the
+        // non-final piece must be dropped; the mark attaches after the word.
+        let tok = test_tokenizer();
+        let classifier = ScriptedClassifier::new(vec![2, 1]);
+        let out = restore_punctuation(
+            "world",
+            &tok,
+            &classifier,
+            PunctuationRestoreConfig::default(),
+        )
+        .expect("restore");
+        assert_eq!(out, "world，", "period on 'wor' dropped; comma after word");
+    }
+
+    #[test]
+    fn original_casing_and_spacing_preserved() {
+        let tok = test_tokenizer();
+        // "HELLO" is one piece; label period after it.
+        let classifier = ScriptedClassifier::new(vec![2]);
+        let out = restore_punctuation(
+            "HELLO",
+            &tok,
+            &classifier,
+            PunctuationRestoreConfig::default(),
+        )
+        .expect("restore");
+        assert_eq!(out, "HELLO。", "uppercase preserved, mark appended");
+    }
+
+    #[test]
+    fn existing_punctuation_is_not_doubled() {
+        let tok = test_tokenizer();
+        // Text already ends with a period char at index 4; predicting another
+        // period after '界' (char_end 4) must be skipped.
+        let classifier = ScriptedClassifier::new(vec![0, 0, 0, 2]);
+        let out = restore_punctuation(
+            "你好世界。",
+            &tok,
+            &classifier,
+            PunctuationRestoreConfig::default(),
+        )
+        .expect("restore");
+        assert_eq!(out, "你好世界。");
+    }
+
+    #[test]
+    fn empty_text_is_returned_unchanged() {
+        let tok = test_tokenizer();
+        let classifier = ScriptedClassifier::new(vec![]);
+        let out = restore_punctuation("", &tok, &classifier, PunctuationRestoreConfig::default())
+            .expect("restore");
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn windows_cut_at_word_boundaries_cover_all_pieces() {
+        // Force a tiny budget so "你好世界" splits into multiple windows; every
+        // char must still be classified and its label applied.
+        let tok = test_tokenizer();
+        let pieces = tok.encode("你好世界");
+        let windows = word_boundary_windows(&pieces, 2);
+        assert!(windows.len() >= 2, "tiny budget splits the sequence");
+        let total: usize = windows.iter().map(|w| w.len()).sum();
+        assert_eq!(total, pieces.len(), "windows partition all pieces");
+
+        let classifier = ScriptedClassifier::new(vec![0, 1, 0, 2]);
+        let cfg = PunctuationRestoreConfig {
+            max_content_tokens: 2,
+        };
+        let out = restore_punctuation("你好世界", &tok, &classifier, cfg).expect("restore");
+        assert_eq!(out, "你好，世界。");
+    }
+}


### PR DESCRIPTION
## Summary

Land the FireRedPunc Chinese-punctuation model as a new capability family: WordPiece tokenizer, the punctuation post-processing stage with per-model gating and offset-preserving re-insertion, the pack-metadata contract, the BERT forward graph + runtime (verified numerically with synthetic weights), and pull-time architecture recognition. This is the execution engine only; see Scope for what is deliberately deferred to publish time.

## Why

Punctuation-free ASR models (Dolphin, FireRedASR2-AED) output raw text with no punctuation. FireRedPunc (upstream FireRedTeam, Apache-2.0, a standard 12-layer chinese-lert BERT token classifier) restores it. Its released label set is 5 classes -- none plus the four full-width Chinese marks -- so this is Chinese-only by construction (it cannot emit half-width English punctuation). It is delivered as an optional, auto-gated post-processing capability.

## Changes

- `crates/openasr-core/src/models/firered_punc/`: config (BERT geometry + GGUF metadata keys + label set), tensor_names, WordPiece tokenizer (offset-preserving), BERT forward graph + runtime (reuses shared `nn::{attn,ffn,norm}` blocks; bidirectional attention, GELU-erf), pack-metadata contract validator, mod.
- `crates/openasr-core/src/punctuation/`: post-processing stage (finalize-only), gated on the ASR model's existing `emits_punctuation == Some(false)`, char-span re-insertion (word-final only, no double punctuation, original text preserved byte-for-byte).
- `crates/openasr-core/src/api/backend/native.rs`: additive pull-contract recognition of a `firered-punc` pack by `general.architecture` (mirrors diarize/hymt2; metadata-only, fail-closed).

## Tests run

- [x] `cargo fmt --check` (openasr-core)
- [x] `cargo clippy -p openasr-core --lib -- -D warnings`
- [x] `cargo nextest run -p openasr-core firered_punc punctuation` (36/36; the 3 graph tests run the real ggml forward)
- [x] `cargo test -p openasr-core --doc`
- [x] `cargo build --workspace`
- [x] `bundled_catalog_signature_verifies_committed_catalog_and_epoch` (unchanged; no catalog touched)

## Manual smoke checks

Forward correctness is proved by a synthetic-weight numeric test: a tiny 1-layer BERT with attention/FFN projections zeroed degenerates to `logits = head . LayerNorm(embed)`, and the per-position argmax is asserted against the hand-computed result -- exercising embedding, LayerNorm, the attention/FFN block wiring, residuals, the classification head, and the output layout. Real 407MB-weight parity (incl. the README golden) stays behind `OPENASR_FIRERED_PUNC_REAL_PACK`, run at publish time (same convention as hymt2/qwen).

## Docs updated

- [x] No overclaim. The subsystem is engine-only this PR (see Scope).

## Scope / non-goals

- **Engine only, not yet wired into transcription.** `punctuate()` / `should_apply_punctuation` have no finalize call site yet, so real transcription output is unchanged by this PR. Hooking the stage into the transcribe-finalize path (gated on user opt-in + `emits_punctuation == Some(false)` + pack installed) is a follow-up.
- **No pt -> .oasr converter.** The exact upstream tensor-name mapping can only be confirmed against the real 407MB checkpoint; writing it blind would freeze guessed key names. Deferred to publish time (confirm/adjust against the GGUF tensor contract defined here).
- **No catalog entry.** Adding a signed catalog entry requires the private signing key (not in-tree) and is a maintainer/publish operation; the pack ships `public:false` when published.
- Chinese-only by construction (5-class Chinese label set).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented and reviewed with AI assistance and this draft prepared for the maintainer's own review, verification, and merge.
