### PR TITLE
refactor(core): converge AED greedy decoding onto the shared driver and root-fix FireRed long-audio repetition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,16 @@ and the open-core trust boundary. Treat them as hard constraints:
 - **Keep infrastructure model-agnostic.** Generic capabilities sink into the base
   layers; model-family semantics stay under `models/` and the `arch/` descriptors.
   Don't push family-specific tensor logic into shared infrastructure.
+- **One greedy decode driver.** Every AED / autoregressive seq2seq family reaches
+  greedy decode through the single shared driver
+  `run_seq2seq_greedy_decode_loop_v0` (via `run_builtin_seq2seq_decode_policy`). A
+  new such family MUST provide a `Seq2SeqGreedyDecodeStepExecutor` and declare a
+  decode-policy descriptor in `models/decode_policy_component_registry.rs`; it MUST
+  NOT hand-write its own argmax step loop or build a decode config that bypasses the
+  registry. Hand-rolled loops miss the shared degenerate-loop guard and drift the
+  argmax / suppression / stop-token semantics the driver centralizes (a hand-rolled
+  firered loop is what caused the long-audio repetition, issue #60). The
+  `*.greedy.seq2seq.*` registry-resolution test fails closed on a half-connect.
 
 ## Validation before you finish
 

--- a/crates/openasr-core/src/models/cohere/batched_decode.rs
+++ b/crates/openasr-core/src/models/cohere/batched_decode.rs
@@ -28,7 +28,7 @@ use crate::models::seq2seq_serve_batch::{
 };
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::serve_batch_env::{
-    ServeBatchStepOutcome, serve_batch_estimate_seq2seq_slot_bytes, serve_batch_select_greedy_step,
+    serve_batch_estimate_seq2seq_slot_bytes, serve_batch_select_and_apply_greedy_step,
 };
 use crate::{Segment, Transcription};
 
@@ -442,24 +442,15 @@ impl CohereBatchSlot {
         &mut self,
         logits: Vec<f32>,
     ) -> Result<(), CohereServeBatchError> {
-        match serve_batch_select_greedy_step(
+        serve_batch_select_and_apply_greedy_step(
             &self.job.decode_config,
-            &self.generated_tokens,
+            &mut self.generated_tokens,
+            &mut self.generated_probabilities,
+            &mut self.done,
             self.stop_token_ids.as_slice(),
             logits,
         )
-        .map_err(map_greedy_error)?
-        {
-            ServeBatchStepOutcome::ReachedEot => self.done = true,
-            ServeBatchStepOutcome::Token {
-                token_id,
-                probability,
-            } => {
-                self.generated_tokens.push(token_id);
-                self.generated_probabilities.push(probability);
-            }
-        }
-        Ok(())
+        .map_err(map_greedy_error)
     }
 
     fn finish(self) -> Result<CohereDecoderGraphDecodeOutput, CohereServeBatchError> {

--- a/crates/openasr-core/src/models/decode_policy_component_registry.rs
+++ b/crates/openasr-core/src/models/decode_policy_component_registry.rs
@@ -104,6 +104,25 @@ pub(crate) enum BuiltinDecodePolicyComponentRegistryError {
     },
 }
 
+/// Execution descriptors for every built-in decode policy whose runtime shape is
+/// one of the two the shared decode paths can drive: `Seq2SeqGreedyV0` (routed
+/// through `run_seq2seq_greedy_decode_loop_v0` via `run_builtin_seq2seq_decode_policy`)
+/// and `CtcGreedyV0` (routed through `run_builtin_ctc_decode_policy`).
+///
+/// Not every `*_DECODE_POLICY_ID` constant belongs here. A family is registered
+/// IFF its decode runs on one of those two shared shapes. Families whose decode
+/// is a dedicated non-shared loop are intentionally ABSENT, and that is the
+/// registration criterion, not an oversight. Both
+/// `xasr-zipformer.greedy.transducer.v0` and `parakeet-tdt.greedy.tdt.v0` are
+/// RNN-T / TDT transducers (prediction network plus joiner, duration-driven frame
+/// skipping): a transducer loop, not greedy seq2seq or CTC collapse. The policy
+/// `dolphin.attention-rescoring.v0` is CTC-prefix with attention rescoring, its
+/// own joint-decode loop. Those ride dedicated executors and never reach
+/// `resolve_builtin_decode_policy`.
+///
+/// The `all_seq2seq_greedy_arch_decode_policies_resolve` regression test enforces
+/// that every `*.greedy.seq2seq.*` policy IS registered, so a new seq2seq family
+/// cannot half-connect (constant present, execution descriptor missing).
 const BUILTIN_DECODE_POLICY_COMPONENTS: &[BuiltinDecodePolicyComponentDescriptor] = &[
     BuiltinDecodePolicyComponentDescriptor {
         decode_policy_id: crate::COHERE_TRANSCRIBE_DECODE_POLICY_ID,
@@ -137,6 +156,36 @@ const BUILTIN_DECODE_POLICY_COMPONENTS: &[BuiltinDecodePolicyComponentDescriptor
         seq2seq_suppression_kind: BuiltinDecodePolicySeq2SeqSuppressionKind::None,
         longform_prompt_carry_mode: BuiltinDecodePolicyLongformPromptCarryMode::Text,
         longform_profile: BuiltinDecodePolicyLongformProfile::Default,
+        ctc_blank_token_id: None,
+    },
+    BuiltinDecodePolicyComponentDescriptor {
+        decode_policy_id: crate::MOONSHINE_DECODE_POLICY_ID,
+        execution_kind: BuiltinDecodePolicyExecutionKind::Seq2SeqGreedyV0,
+        seq2seq_text_postprocess_kind: BuiltinDecodePolicySeq2SeqTextPostprocessKind::Identity,
+        seq2seq_trace_kind: BuiltinDecodePolicySeq2SeqTraceKind::None,
+        seq2seq_stop_token_kind: BuiltinDecodePolicySeq2SeqStopTokenKind::None,
+        seq2seq_suppression_kind: BuiltinDecodePolicySeq2SeqSuppressionKind::None,
+        // Token-history carry mirrors cohere (the other conservative AED). The
+        // conservative longform profile caps chunk length and disables prompt
+        // carry, keeping moonshine's small-context decoder off the long-audio
+        // repetition failure mode.
+        longform_prompt_carry_mode: BuiltinDecodePolicyLongformPromptCarryMode::TokenHistory,
+        longform_profile: BuiltinDecodePolicyLongformProfile::ConservativeSeq2SeqV1,
+        ctc_blank_token_id: None,
+    },
+    BuiltinDecodePolicyComponentDescriptor {
+        // Source of truth is `crate::arch`; firered has no crate-root re-export
+        // (it is not selected through the ggml_family_registry const surface).
+        decode_policy_id: crate::arch::FIRERED_AED_DECODE_POLICY_ID,
+        execution_kind: BuiltinDecodePolicyExecutionKind::Seq2SeqGreedyV0,
+        seq2seq_text_postprocess_kind: BuiltinDecodePolicySeq2SeqTextPostprocessKind::Identity,
+        seq2seq_trace_kind: BuiltinDecodePolicySeq2SeqTraceKind::None,
+        seq2seq_stop_token_kind: BuiltinDecodePolicySeq2SeqStopTokenKind::None,
+        seq2seq_suppression_kind: BuiltinDecodePolicySeq2SeqSuppressionKind::None,
+        // firered-aed is a plain `<sos>`-prompted AED; conservative slicing is the
+        // structural fix for its long-audio repetition (issue #60).
+        longform_prompt_carry_mode: BuiltinDecodePolicyLongformPromptCarryMode::TokenHistory,
+        longform_profile: BuiltinDecodePolicyLongformProfile::ConservativeSeq2SeqV1,
         ctc_blank_token_id: None,
     },
     BuiltinDecodePolicyComponentDescriptor {
@@ -624,6 +673,40 @@ mod tests {
             error,
             BuiltinDecodePolicyComponentRegistryError::UnknownDecodePolicy { .. }
         ));
+    }
+
+    #[test]
+    fn all_seq2seq_greedy_arch_decode_policies_resolve() {
+        // Half-connect guard: every architecture whose decode policy id is a
+        // greedy-seq2seq shape MUST have a matching execution descriptor here. A
+        // new seq2seq family that registers `*.greedy.seq2seq.*` in the arch
+        // registry but forgets the execution descriptor trips this test instead
+        // of silently failing at decode time.
+        let mut checked = 0usize;
+        for descriptor in OpenAsrArchitectureRegistry::with_builtins().descriptors() {
+            if !descriptor.decode_policy_id.contains(".greedy.seq2seq.") {
+                continue;
+            }
+            let policy = resolve_builtin_decode_policy(descriptor.decode_policy_id)
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "seq2seq-greedy decode policy '{}' for architecture '{}' is not registered: {error}",
+                        descriptor.decode_policy_id, descriptor.model_architecture
+                    )
+                });
+            assert_eq!(
+                policy.execution_kind,
+                BuiltinDecodePolicyExecutionKind::Seq2SeqGreedyV0,
+                "decode policy '{}' must be Seq2SeqGreedyV0",
+                descriptor.decode_policy_id
+            );
+            checked += 1;
+        }
+        // cohere-transcribe + whisper + qwen3-asr + moonshine + firered-aed.
+        assert_eq!(
+            checked, 5,
+            "expected exactly 5 greedy-seq2seq architectures to resolve"
+        );
     }
 
     struct SyntheticStepExecutor {

--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -29,6 +29,14 @@ use crate::ggml_runtime::{
     GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedWeightContext, GgmlStaticTensor,
     GgmlStaticTensorArena,
 };
+use crate::models::decode_policy_component_registry::{
+    BuiltinSeq2SeqDecodePolicyConfigInput, run_builtin_seq2seq_decode_policy,
+};
+use crate::models::decode_token_history::context_window_budget;
+use crate::models::seq2seq_greedy_decode::{
+    Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeResult, Seq2SeqGreedyDecodeStepExecutor,
+    Seq2SeqGreedyDecodeStepInput, Seq2SeqGreedyDecodeStepLogitsOutput,
+};
 use crate::nn::decoder::{
     CrossKvHandle, SelfKvHandle, Seq2SeqLayerConfig, Seq2SeqLayerWeights,
     build_causal_mask_f16_bits, seq2seq_layer,
@@ -482,6 +490,34 @@ impl FireRedDecoderGraphRuntime {
     }
 }
 
+/// firered-aed decodes through the shared seq2seq greedy driver: every step
+/// recomputes logits for the full `<sos> ++ generated` prefix (the incremental
+/// KV cache inside [`Self::compute_step_logits`] makes this cheap after the
+/// prefill). `greedy_token_hint: None` -- firered has no device-side argmax, so
+/// the shared loop owns the host argmax.
+impl Seq2SeqGreedyDecodeStepExecutor for FireRedDecoderGraphRuntime {
+    fn decode_step_logits(
+        &mut self,
+        input: Seq2SeqGreedyDecodeStepInput<'_>,
+    ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyDecodeError> {
+        let prefix: Vec<u32> = input
+            .initial_prompt_tokens
+            .iter()
+            .copied()
+            .chain(input.generated_tokens.iter().copied())
+            .collect();
+        let logits = self.compute_step_logits(&prefix).map_err(|error| {
+            Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                reason: error.to_string(),
+            }
+        })?;
+        Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+            logits,
+            greedy_token_hint: None,
+        })
+    }
+}
+
 fn apply_linear_with_bias<'a>(
     graph: &mut GgmlCpuGraphBuilder<'a>,
     input: GgmlCpuTensor<'a>,
@@ -554,28 +590,18 @@ pub(crate) struct FireRedAedGreedyDecodeOutput {
     pub generated_tokens: Vec<u32>,
 }
 
-/// Run the full attention-based greedy decode for one utterance: build a
-/// fresh decoder runtime sized to `encoder_frame_count`, precompute the
-/// cross-KV cache from `encoder_rows`, then autoregress from `<sos>` one
-/// token at a time (argmax logits) until `<eos>` or the generation budget is
-/// exhausted.
-pub(crate) fn run_firered_aed_decoder_greedy(
-    runtime_path: &Path,
-    metadata: FireRedAedExecutionMetadata,
-    encoder_rows: &[f32],
-    encoder_frame_count: usize,
-    decode_text: impl Fn(&[u32]) -> Result<String, String>,
-) -> Result<FireRedAedGreedyDecodeOutput, FireRedDecoderError> {
-    let mut runtime = FireRedDecoderGraphRuntime::new(runtime_path, metadata, encoder_frame_count)?;
-    run_firered_aed_decoder_greedy_with_runtime(&mut runtime, metadata, encoder_rows, decode_text)
-}
-
-/// Same greedy decode loop as [`run_firered_aed_decoder_greedy`], but against
-/// an already-built (and possibly cached/reused across transcriptions)
+/// Run the full attention-based greedy decode for one utterance against an
+/// already-built (and possibly cached/reused across transcriptions)
 /// [`FireRedDecoderGraphRuntime`]. Resets the runtime's cross-KV cache and
 /// incremental self-KV position for this utterance via
 /// [`FireRedDecoderGraphRuntime::populate_cross_attention_cache`] before
-/// decoding, so a cache hit never leaks state from a prior utterance.
+/// decoding, then autoregresses from `<sos>` through the shared seq2seq greedy
+/// driver (`run_builtin_seq2seq_decode_policy` -> `run_seq2seq_greedy_decode_loop_v0`)
+/// under the firered decode-policy descriptor. Routing through the shared driver
+/// (rather than a hand-written argmax loop) is what gives firered the degenerate
+/// n-gram-repeat guard for free (issue #60): firered declares no phrase bias,
+/// no suppression and no extra stop tokens, so the policy config is a plain
+/// `<sos>`-prompted greedy decode to `<eos>`.
 pub(crate) fn run_firered_aed_decoder_greedy_with_runtime(
     runtime: &mut FireRedDecoderGraphRuntime,
     metadata: FireRedAedExecutionMetadata,
@@ -584,37 +610,59 @@ pub(crate) fn run_firered_aed_decoder_greedy_with_runtime(
 ) -> Result<FireRedAedGreedyDecodeOutput, FireRedDecoderError> {
     runtime.populate_cross_attention_cache(encoder_rows)?;
 
-    let max_new_tokens =
-        crate::models::decode_token_history::context_window_budget(metadata.decoder_pe_len, 1)
-            .unwrap_or(0);
-    let mut prefix = vec![metadata.sos_token_id];
-    let mut generated_tokens = Vec::new();
-    for _ in 0..max_new_tokens {
-        let logits = runtime.compute_step_logits(&prefix)?;
-        let next_token = argmax_token_id(&logits)?;
-        if next_token == metadata.eos_token_id {
-            break;
+    let max_generated_tokens = context_window_budget(metadata.decoder_pe_len, 1).unwrap_or(0);
+    let config = BuiltinSeq2SeqDecodePolicyConfigInput {
+        initial_prompt_tokens: vec![metadata.sos_token_id],
+        eot_token_id: metadata.eos_token_id,
+        vocab_size: metadata.vocab_size,
+        max_generated_tokens,
+    };
+    let decode_text_token_ids = |token_ids: &[u32]| {
+        decode_text(token_ids)
+            .map_err(|reason| Seq2SeqGreedyDecodeError::TokenizerDecodeFailed { reason })
+    };
+    let decode = match run_builtin_seq2seq_decode_policy::<Seq2SeqGreedyDecodeError>(
+        crate::arch::FIRERED_AED_DECODE_POLICY_ID,
+        &config,
+        // firered has no special tokens and no phrase bias (supports_phrase_bias
+        // is false), so the unit token source with `phrase_bias: None` never
+        // needs to encode anything.
+        &(),
+        None,
+        runtime,
+        &decode_text_token_ids,
+        |error| error,
+        |error| error,
+        |error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
+            reason: error.to_string(),
+        },
+    ) {
+        Ok(output) => output,
+        // Budget exhausted before `<eos>`: keep the generated prefix and
+        // detokenize it, matching the pre-unification behavior (return the
+        // partial transcript rather than erroring out).
+        Err(Seq2SeqGreedyDecodeError::EotNotReachedBeforeMaxTokens {
+            generated_tokens, ..
+        }) => {
+            let text = decode_text(&generated_tokens).map_err(|reason| {
+                FireRedDecoderError::InvalidInput {
+                    reason: format!("tokenizer decode failed: {reason}"),
+                }
+            })?;
+            Seq2SeqGreedyDecodeResult {
+                text,
+                generated_tokens,
+                generated_probabilities: Vec::new(),
+            }
         }
-        prefix.push(next_token);
-        generated_tokens.push(next_token);
-    }
-    let text =
-        decode_text(&generated_tokens).map_err(|reason| FireRedDecoderError::InvalidInput {
-            reason: format!("tokenizer decode failed: {reason}"),
-        })?;
+        Err(error) => {
+            return Err(FireRedDecoderError::InvalidInput {
+                reason: error.to_string(),
+            });
+        }
+    };
     Ok(FireRedAedGreedyDecodeOutput {
-        text,
-        generated_tokens,
+        text: decode.text,
+        generated_tokens: decode.generated_tokens,
     })
-}
-
-fn argmax_token_id(logits: &[f32]) -> Result<u32, FireRedDecoderError> {
-    logits
-        .iter()
-        .enumerate()
-        .max_by(|(_, a), (_, b)| a.total_cmp(b))
-        .map(|(index, _)| index as u32)
-        .ok_or(FireRedDecoderError::InvalidInput {
-            reason: "decoder step produced empty logits".to_string(),
-        })
 }

--- a/crates/openasr-core/src/models/moonshine/batched_decode.rs
+++ b/crates/openasr-core/src/models/moonshine/batched_decode.rs
@@ -24,7 +24,7 @@ use crate::models::seq2seq_serve_batch::{
 };
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::serve_batch_env::{
-    ServeBatchStepOutcome, serve_batch_estimate_seq2seq_slot_bytes, serve_batch_select_greedy_step,
+    serve_batch_estimate_seq2seq_slot_bytes, serve_batch_select_and_apply_greedy_step,
 };
 use crate::{Segment, Transcription};
 
@@ -438,24 +438,15 @@ impl MoonshineBatchSlot {
         &mut self,
         logits: Vec<f32>,
     ) -> Result<(), MoonshineServeBatchError> {
-        match serve_batch_select_greedy_step(
+        serve_batch_select_and_apply_greedy_step(
             &self.job.decode_config,
-            &self.generated_tokens,
+            &mut self.generated_tokens,
+            &mut self.generated_probabilities,
+            &mut self.done,
             self.stop_token_ids.as_slice(),
             logits,
         )
-        .map_err(map_greedy_error)?
-        {
-            ServeBatchStepOutcome::ReachedEot => self.done = true,
-            ServeBatchStepOutcome::Token {
-                token_id,
-                probability,
-            } => {
-                self.generated_tokens.push(token_id);
-                self.generated_probabilities.push(probability);
-            }
-        }
-        Ok(())
+        .map_err(map_greedy_error)
     }
 
     fn finish(self) -> Result<MoonshineDecodeOutput, MoonshineServeBatchError> {

--- a/crates/openasr-core/src/models/moonshine/decoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/decoder_graph.rs
@@ -13,13 +13,13 @@ use crate::ggml_runtime::{
     GgmlLoadedTensor, GgmlLoadedWeightContext, GgmlRopeExtParams, GgmlStaticTensor,
     GgmlStaticTensorArena,
 };
-use crate::models::decode_policy_component_registry::BuiltinDecodePolicySeq2SeqTextPostprocessKind;
-use crate::models::phrase_bias_decode::build_token_phrase_biases;
+use crate::models::decode_policy_component_registry::{
+    BuiltinDecodePolicySeq2SeqTextPostprocessKind, BuiltinSeq2SeqDecodePolicyConfigInput,
+    BuiltinSeq2SeqDecodePolicyTokenSource, run_builtin_seq2seq_decode_policy,
+};
 use crate::models::seq2seq_greedy_decode::{
-    Seq2SeqGreedyDecodeConfig, Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeResult,
-    Seq2SeqGreedyDecodeStepExecutor, Seq2SeqGreedyDecodeStepInput,
-    Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyTokenDecoder,
-    run_seq2seq_greedy_decode_loop_v0,
+    Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeResult, Seq2SeqGreedyDecodeStepExecutor,
+    Seq2SeqGreedyDecodeStepInput, Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyTokenDecoder,
 };
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::thread_local_runtime_cache::{
@@ -176,29 +176,30 @@ fn run_moonshine_decoder_short_form_with_runtime(
         .decoder_max_context
         .saturating_sub(prompt_tokens.len())
         .max(1);
-    let config = Seq2SeqGreedyDecodeConfig {
+    // moonshine routes through the shared decode-policy registry (same path as
+    // whisper/cohere/qwen) instead of hand-building a config: the descriptor
+    // declares no suppression, no extra stop tokens and Identity postprocess, so
+    // the resolved config is byte-identical to the previous inline one, and the
+    // registry owns phrase-bias tokenization against the tokenizer token source.
+    let config = BuiltinSeq2SeqDecodePolicyConfigInput {
         initial_prompt_tokens: prompt_tokens,
         eot_token_id: metadata.eos_token_id,
-        stop_token_ids: Vec::new(),
         vocab_size: metadata.vocab_size,
         max_generated_tokens,
-        suppress_first_step_token_ids: Vec::new(),
-        suppress_token_ids: Vec::new(),
-        phrase_biases: build_token_phrase_biases(phrase_bias, tokenizer).map_err(|error| {
-            MoonshineDecoderGraphError::InvalidInput {
-                reason: format!("moonshine phrase-bias tokenization failed: {error}"),
-            }
-        })?,
     };
-
-    let mut trace_token = |_: usize, _: u32, _: bool| {};
-    let mut on_topk = |_: usize, _: &[f32]| {};
-    let decode = match run_seq2seq_greedy_decode_loop_v0(
+    let decode_text_token_ids = |token_ids: &[u32]| token_decoder.decode_text_token_ids(token_ids);
+    let decode = match run_builtin_seq2seq_decode_policy::<Seq2SeqGreedyDecodeError>(
+        crate::MOONSHINE_DECODE_POLICY_ID,
         &config,
+        tokenizer,
+        phrase_bias,
         &mut step_executor,
-        &token_decoder,
-        &mut trace_token,
-        &mut on_topk,
+        &decode_text_token_ids,
+        |error| error,
+        |error| error,
+        |error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
+            reason: error.to_string(),
+        },
     ) {
         Ok(output) => output,
         Err(Seq2SeqGreedyDecodeError::EotNotReachedBeforeMaxTokens {
@@ -275,6 +276,12 @@ impl Seq2SeqGreedyTokenDecoder for MoonshineGreedyTokenDecoder<'_> {
             })
     }
 }
+
+/// moonshine has no whisper-style special control tokens (no stop tokens beyond
+/// `<eos>`, no suppression list), so the decode-policy token source is the empty
+/// default over the tokenizer, which supplies phrase-bias encoding via the
+/// [`PhraseBiasTokenEncoder`] supertrait it already implements.
+impl BuiltinSeq2SeqDecodePolicyTokenSource for MoonshineTokenizer {}
 
 /// A 2-D linear: bound zero-copy from the mmap'd pack (native q8_0 `[in,out]`)
 /// or, as a fallback, an arena-resident f32 tensor. moonshine loads its bindable

--- a/crates/openasr-core/src/models/qwen/batched_decode.rs
+++ b/crates/openasr-core/src/models/qwen/batched_decode.rs
@@ -27,10 +27,10 @@ use crate::models::seq2seq_greedy_decode::{
 };
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::serve_batch_env::{
-    OwnerAliveGuard, ServeBatchEnvError, ServeBatchStepOutcome, serve_batch_bucket_width,
+    OwnerAliveGuard, ServeBatchEnvError, serve_batch_bucket_width,
     serve_batch_collect_window_from_env, serve_batch_compact_active_slots,
     serve_batch_drain_compatible_batch, serve_batch_estimate_llm_kv_slot_bytes,
-    serve_batch_max_from_env, serve_batch_owner_alive, serve_batch_select_greedy_step,
+    serve_batch_max_from_env, serve_batch_owner_alive, serve_batch_select_and_apply_greedy_step,
     serve_batch_submit_with_timeout, serve_batch_trace_enabled, serve_batch_vram_capped_max_batch,
 };
 use crate::nn::decoder::reusable_decode_graph_supported;
@@ -1928,25 +1928,17 @@ impl Qwen3AsrBatchSlot {
         &mut self,
         logits: Vec<f32>,
     ) -> Result<(), Qwen3AsrServeBatchError> {
-        match serve_batch_select_greedy_step(
+        serve_batch_select_and_apply_greedy_step(
             &self.job.decode_config,
-            &self.generated_tokens,
+            &mut self.generated_tokens,
+            &mut self.generated_probabilities,
+            &mut self.done,
             self.stop_token_ids.as_slice(),
             logits,
         )
         .map_err(|error| Qwen3AsrServeBatchError::DecodeFailed {
             reason: error.to_string(),
-        })? {
-            ServeBatchStepOutcome::ReachedEot => self.done = true,
-            ServeBatchStepOutcome::Token {
-                token_id,
-                probability,
-            } => {
-                self.generated_tokens.push(token_id);
-                self.generated_probabilities.push(probability);
-            }
-        }
-        Ok(())
+        })
     }
 
     fn finish(self) -> Result<GgmlAsrExecutionResult, Qwen3AsrServeBatchError> {

--- a/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
+++ b/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
@@ -6,7 +6,7 @@ use crate::models::phrase_bias_decode::{TokenPhraseBias, apply_phrase_bias_to_lo
 /// characters). An observed greedy loop is a very short cycle - a single
 /// stuttered token, or a 2-4 token phrase emitted back to back - so 8 covers
 /// the field failures while keeping the per-step tail scan tiny.
-const MAX_REPEAT_NGRAM: usize = 8;
+pub(crate) const MAX_REPEAT_NGRAM: usize = 8;
 
 /// Consecutive identical cycles that mark a greedy loop as degenerate. Kept
 /// deliberately high so legitimate human repetition never trips it: Mandarin
@@ -14,7 +14,7 @@ const MAX_REPEAT_NGRAM: usize = 8;
 /// 3 cycles, so a threshold of 4 leaves normal speech untouched while still
 /// catching the degenerate loops (a phrase repeated 5+ times). Set to 0 to
 /// disable the guard entirely (fail-safe).
-const MAX_CONSECUTIVE_NGRAM_REPEATS: usize = 4;
+pub(crate) const MAX_CONSECUTIVE_NGRAM_REPEATS: usize = 4;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Seq2SeqGreedyDecodeConfig {
@@ -156,6 +156,17 @@ pub(crate) fn run_seq2seq_greedy_decode_loop_with_adapter_v0<E>(
     })
 }
 
+/// The single greedy autoregressive decode driver for every AED / seq2seq
+/// family (whisper, cohere, qwen, moonshine, firered-aed, ...). It owns the step
+/// loop, argmax selection, suppression/phrase-bias/stop-token handling, and the
+/// degenerate-loop guard, so every family shares one hardened implementation.
+///
+/// INVARIANT (see the repo AGENTS.md "One greedy decode driver"): a new autoregressive family
+/// MUST reach greedy decode through this driver -- provide a
+/// [`Seq2SeqGreedyDecodeStepExecutor`] and declare a decode-policy descriptor in
+/// `decode_policy_component_registry` (route via `run_builtin_seq2seq_decode_policy`)
+/// -- and MUST NOT hand-write its own argmax step loop. Hand-rolled loops miss the
+/// shared guard and drift the semantics this driver centralizes.
 pub(crate) fn run_seq2seq_greedy_decode_loop_v0(
     config: &Seq2SeqGreedyDecodeConfig,
     step_executor: &mut dyn Seq2SeqGreedyDecodeStepExecutor,
@@ -349,12 +360,12 @@ fn suppress_logits(logits: &mut [f32], token_ids: &[u32]) {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct DegenerateNgramRepeat {
+pub(crate) struct DegenerateNgramRepeat {
     /// Number of leading tokens to keep: the sequence truncated to a single
     /// occurrence of the repeated n-gram (loop start + one cycle).
-    keep_len: usize,
-    ngram_len: usize,
-    repeats: usize,
+    pub(crate) keep_len: usize,
+    pub(crate) ngram_len: usize,
+    pub(crate) repeats: usize,
 }
 
 /// Detect a degenerate consecutive-n-gram loop in the tail of `tokens`.
@@ -368,7 +379,9 @@ struct DegenerateNgramRepeat {
 ///
 /// Pure over the token-id tail: no logits, no tokenizer, unit-testable in
 /// isolation and shared by every seq2seq family that routes through the loop.
-fn detect_degenerate_ngram_repeat(
+/// Also reused by the serve-batch selection helper so the continuous-batching
+/// slots trip the exact same guard as the single-utterance loop.
+pub(crate) fn detect_degenerate_ngram_repeat(
     tokens: &[u32],
     max_ngram: usize,
     max_consecutive_repeats: usize,

--- a/crates/openasr-core/src/models/serve_batch_env.rs
+++ b/crates/openasr-core/src/models/serve_batch_env.rs
@@ -9,7 +9,8 @@ use crate::ggml_runtime::{
     GgmlBackendKind, GgmlCpuGraphBackend, GgmlDeviceMemory, ggml_available_devices,
 };
 use crate::models::seq2seq_greedy_decode::{
-    Seq2SeqGreedyDecodeConfig, Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeStepLogitsOutput,
+    MAX_CONSECUTIVE_NGRAM_REPEATS, MAX_REPEAT_NGRAM, Seq2SeqGreedyDecodeConfig,
+    Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeStepLogitsOutput, detect_degenerate_ngram_repeat,
     select_seq2seq_greedy_step_token,
 };
 
@@ -109,6 +110,45 @@ pub(crate) fn serve_batch_select_greedy_step(
             probability: selection.probability,
         }
     })
+}
+
+/// Select the next greedy token for a serve-batch slot AND fold the outcome into
+/// the slot's `(generated_tokens, generated_probabilities, done)` state. This is
+/// the one place every seq2seq serve-batch family (whisper / cohere / moonshine /
+/// qwen) mutates its slot, so the degenerate-loop guard that the single-utterance
+/// `run_seq2seq_greedy_decode_loop_v0` applies is applied here too, byte-for-byte:
+/// after appending a token, if the generated tail turns into a short cycle
+/// repeated to the degenerate threshold, keep a single occurrence and finish the
+/// slot instead of letting the batched decode spin to the token cap (issue #60,
+/// server side). Inert on healthy decodes.
+pub(crate) fn serve_batch_select_and_apply_greedy_step(
+    decode_config: &Seq2SeqGreedyDecodeConfig,
+    generated_tokens: &mut Vec<u32>,
+    generated_probabilities: &mut Vec<f32>,
+    done: &mut bool,
+    stop_token_ids: &[u32],
+    logits: Vec<f32>,
+) -> Result<(), Seq2SeqGreedyDecodeError> {
+    match serve_batch_select_greedy_step(decode_config, generated_tokens, stop_token_ids, logits)? {
+        ServeBatchStepOutcome::ReachedEot => *done = true,
+        ServeBatchStepOutcome::Token {
+            token_id,
+            probability,
+        } => {
+            generated_tokens.push(token_id);
+            generated_probabilities.push(probability);
+            if let Some(loop_hit) = detect_degenerate_ngram_repeat(
+                generated_tokens,
+                MAX_REPEAT_NGRAM,
+                MAX_CONSECUTIVE_NGRAM_REPEATS,
+            ) {
+                generated_tokens.truncate(loop_hit.keep_len);
+                generated_probabilities.truncate(loop_hit.keep_len);
+                *done = true;
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn serve_batch_max_from_env(
@@ -499,6 +539,55 @@ pub(crate) fn with_serve_batch_env_lock<T>(run: impl FnOnce() -> T) -> T {
 mod tests {
     use super::*;
     use std::ffi::OsString;
+
+    fn one_hot_logits(vocab_size: usize, index: usize) -> Vec<f32> {
+        let mut logits = vec![-1000.0_f32; vocab_size];
+        logits[index] = 1000.0;
+        logits
+    }
+
+    #[test]
+    fn serve_batch_apply_step_trips_degenerate_loop_guard_like_single_path() {
+        // The batched serve path must trip the same degenerate n-gram guard as the
+        // single-utterance `run_seq2seq_greedy_decode_loop_v0`: argmax would emit
+        // token 5 forever (EOT id 7 never wins), so after the stutter reaches the
+        // degenerate threshold the slot keeps one occurrence and finishes, instead
+        // of spinning to the token cap (issue #60, server side).
+        let config = Seq2SeqGreedyDecodeConfig {
+            initial_prompt_tokens: vec![42],
+            eot_token_id: 7,
+            stop_token_ids: Vec::new(),
+            vocab_size: 16,
+            max_generated_tokens: 32,
+            suppress_first_step_token_ids: Vec::new(),
+            suppress_token_ids: Vec::new(),
+            phrase_biases: Vec::new(),
+        };
+        let stop_token_ids = [config.eot_token_id];
+        let mut generated_tokens = Vec::new();
+        let mut generated_probabilities = Vec::new();
+        let mut done = false;
+        let mut steps = 0usize;
+        while !done && steps < 10 {
+            serve_batch_select_and_apply_greedy_step(
+                &config,
+                &mut generated_tokens,
+                &mut generated_probabilities,
+                &mut done,
+                &stop_token_ids,
+                one_hot_logits(config.vocab_size, 5),
+            )
+            .expect("serve batch step selects");
+            steps += 1;
+        }
+
+        // Same outcome as the single-path guard test: truncated to one occurrence.
+        assert!(done, "guard must finish the slot");
+        assert_eq!(generated_tokens, vec![5]);
+        assert_eq!(generated_probabilities.len(), 1);
+        // Tripped at the 4th identical token (steps 0..=3), so no further steps.
+        assert_eq!(steps, 4);
+    }
 
     #[test]
     fn owner_alive_guard_marks_dead_on_panic() {

--- a/crates/openasr-core/src/models/whisper/batched_decode.rs
+++ b/crates/openasr-core/src/models/whisper/batched_decode.rs
@@ -40,7 +40,7 @@ use crate::models::seq2seq_serve_batch::{
 };
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::serve_batch_env::{
-    ServeBatchStepOutcome, serve_batch_estimate_seq2seq_slot_bytes, serve_batch_select_greedy_step,
+    serve_batch_estimate_seq2seq_slot_bytes, serve_batch_select_and_apply_greedy_step,
 };
 
 const WHISPER_SERVE_BATCH_MAX_BATCH_LIMIT: usize = 8;
@@ -671,24 +671,15 @@ impl WhisperBatchSlot {
         &mut self,
         logits: Vec<f32>,
     ) -> Result<(), WhisperServeBatchError> {
-        match serve_batch_select_greedy_step(
+        serve_batch_select_and_apply_greedy_step(
             &self.job.decode_config,
-            &self.generated_tokens,
+            &mut self.generated_tokens,
+            &mut self.generated_probabilities,
+            &mut self.done,
             self.stop_token_ids.as_slice(),
             logits,
         )
-        .map_err(map_greedy_error)?
-        {
-            ServeBatchStepOutcome::ReachedEot => self.done = true,
-            ServeBatchStepOutcome::Token {
-                token_id,
-                probability,
-            } => {
-                self.generated_tokens.push(token_id);
-                self.generated_probabilities.push(probability);
-            }
-        }
-        Ok(())
+        .map_err(map_greedy_error)
     }
 
     fn finish(self) -> Result<WhisperExecutionOutput, WhisperServeBatchError> {


### PR DESCRIPTION
## Summary

Converge FireRed-AED greedy decoding onto the single shared seq2seq decode
driver, and extend the same driver's degenerate-repeat guard to the
server's concurrent decode path (serve-batch) for whisper/cohere/moonshine/qwen.

## Why

FireRed-AED degenerates into large repeated spans on long audio (e.g. a
50-minute meeting recording). Root cause: the FireRed integration hand-wrote
its own argmax decode loop instead of going through the shared seq2seq
driver (`run_seq2seq_greedy_decode_loop_v0` /
`run_builtin_seq2seq_decode_policy`), so it bypassed the driver's
degenerate n-gram repeat guard (`detect_degenerate_ngram_repeat`) that
whisper/cohere/qwen already rely on. Per `AGENTS.md`'s "one greedy decode
driver" invariant, the fix is to make FireRed conform to the shared driver,
not to patch its standalone loop. While auditing this, the same guard was
found missing from the server's concurrent decode path (serve-batch) across
all four families, which is a same-class defect fixed in the same PR.

## Changes

- `serve_batch_env.rs`: extract a shared
  `serve_batch_select_and_apply_greedy_step` helper; whisper/cohere/moonshine/qwen
  batched decode now delegate token selection through it and get the
  degenerate-repeat guard applied (fixes the same-class gap on the server's
  concurrent decode path).
- `decode_policy_component_registry.rs`: register decode policies for
  moonshine and firered in `BUILTIN_DECODE_POLICY_COMPONENTS`; add a
  regression test that walks the arch registry and asserts every seq2seq
  greedy policy resolves, so a half-connected registration fails the test
  instead of silently falling back. `AGENTS.md` gets the "one greedy decode
  driver" invariant documented (new AED families must implement a
  `Seq2SeqGreedyDecodeStepExecutor` and register a decode policy; hand-written
  argmax loops are disallowed).
- `firered_aed/decoder_graph.rs`: implement `Seq2SeqGreedyDecodeStepExecutor`
  and switch to `run_builtin_seq2seq_decode_policy`; delete the hand-written
  argmax loop (`run_firered_aed_decoder_greedy`, `argmax_token_id`, and the
  old `for` loop body).
- `moonshine/decoder_graph.rs`: remove hand-rolled decode config in favor of
  the decode-policy registry (now structurally identical to whisper).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2190 passed)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (not run this pass; no dependency changes in this PR)

Additional verification specific to this change:

- **Golden byte-identical**: FireRed fp16 golden fixtures (English `jfk` and a
  Chinese clip) run against a private fp16 dev pack and match the reference
  PyTorch decode byte-for-byte. Moonshine real-pack decode oracle: 4/4 pass.
- decode / serve-batch / registry unit tests: 75/75; registry resolution
  test: 6/6.
- `bundled_catalog_signature_verifies_committed_catalog_and_epoch` passes
  (no catalog touched).
- Manually confirmed the serve-batch guard matches serial-path behavior and
  does not fire on ordinary repeated words (guard threshold requires 4+
  consecutive repeats).

## Manual smoke checks

Ran the fp16 FireRed golden fixtures (jfk English + a Chinese clip) end to
end through `native` and diffed against the stored reference transcript:
byte-identical. Ran the moonshine real-pack decode oracle (4 cases): all 4
pass.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (`AGENTS.md`
  now documents the "one greedy decode driver" invariant for new AED
  families.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- This PR intentionally does **not** add repetition/EOS/length penalties.
  The shared n-gram degenerate-repeat guard is the existing, already-verified
  mechanism being extended to FireRed and to serve-batch; penalty-based
  decoding controls are a separate, independent decision for a future PR.
- The only observable behavior change is FireRed's argmax tie-break: it goes
  from last-max to first-max, converging with the other four families and
  with the PyTorch reference (which is also first-max). The golden fixtures
  have no ties, so this does not change golden output. Budget-exhaustion
  semantics are unchanged (partial transcript is still returned).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented and reviewed with AI assistance; this draft was prepared for the maintainer's own review, verification, and merge.
