### PR TITLE
fix(core): persist verbose transcription history and derive honest export formats

### DIFF
--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -412,7 +412,13 @@ impl TranscriptionRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+// Serde shape is byte-for-byte the API's `JsonSegment`/`JsonWord` (see
+// `format/json.rs`): same field order, same `skip_serializing_if`. This is what
+// lets daemon history persist `segments_json` and hand it back to the desktop
+// export UI without a second, drifting segment schema. `#[serde(default)]` on
+// every skippable field makes the round-trip robust when those fields were
+// omitted on write.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WordTimestamp {
     pub word: String,
     pub start: f32,
@@ -420,17 +426,22 @@ pub struct WordTimestamp {
     /// Mean softmax probability of the decoded tokens forming this word
     /// (`0..=1`), when the family's decoder exposes per-token scores; `None`
     /// otherwise — never invented.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub confidence: Option<f32>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Segment {
     pub start: f32,
     pub end: f32,
     pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub speaker: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub speaker_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub speaker_profile_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub words: Vec<WordTimestamp>,
 }
 

--- a/crates/openasr-core/src/realtime/history_store.rs
+++ b/crates/openasr-core/src/realtime/history_store.rs
@@ -64,6 +64,16 @@ use crate::api::backend::Segment;
 /// rely on `busy_timeout` alone.
 static CONNECTION_SETUP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Columns shared by every query that needs to build a [`DaemonHistoryEntry`]
+/// via [`row_to_entry`]. Deliberately selects `segments_json` instead of the
+/// persisted (and no longer trusted -- see that column's schema comment)
+/// `formats` column: `row_to_entry` derives the advertised formats from
+/// whether this row actually has segments, at read time, rather than
+/// replaying whatever a past write recorded.
+const ENTRY_COLUMNS: &str = "e.id, e.kind, e.model, e.created_at_unix_seconds, e.source_name, \
+     e.duration_seconds, e.output_format, e.diarization_active, e.provenance, e.segments_json, \
+     e.preview";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DaemonHistoryKind {
@@ -224,8 +234,6 @@ pub enum DaemonHistoryStoreError {
     },
     #[error("History database query failed: {0}")]
     Query(#[source] rusqlite::Error),
-    #[error("Could not serialize history segments: {0}")]
-    SerializeSegments(#[source] serde_json::Error),
 }
 
 impl DaemonHistoryStore {
@@ -302,9 +310,7 @@ impl DaemonHistoryStore {
             }
         };
         let sql = format!(
-            "SELECT e.id, e.kind, e.model, e.created_at_unix_seconds, e.source_name, \
-             e.duration_seconds, e.output_format, e.diarization_active, e.provenance, \
-             e.formats, e.preview \
+            "SELECT {ENTRY_COLUMNS} \
              FROM {from_sql} {where_sql} \
              ORDER BY e.created_at_unix_seconds DESC, e.id DESC{limit_sql}"
         );
@@ -324,22 +330,20 @@ impl DaemonHistoryStore {
         validate_history_id(id)?;
         let conn = self.connection()?;
         conn.query_row(
-            "SELECT e.id, e.kind, e.model, e.created_at_unix_seconds, e.source_name, \
-             e.duration_seconds, e.output_format, e.diarization_active, e.provenance, \
-             e.formats, e.preview, e.text, e.segments_json \
-             FROM history_entries e WHERE e.id = ?1",
+            &format!("SELECT {ENTRY_COLUMNS}, e.text FROM history_entries e WHERE e.id = ?1"),
             params![id],
             |row| {
                 let entry = row_to_entry(row)?;
                 let text: String = row.get(11)?;
-                let segments_json: Option<String> = row.get(12)?;
-                // A NULL column (rows written before segments were persisted, or
-                // live entries) or an unparseable blob degrades to no segments:
-                // the transcript text still comes back and detail fetches never
-                // 500 on a corrupt segment payload.
-                let segments = segments_json
-                    .and_then(|json| serde_json::from_str::<Vec<Segment>>(&json).ok())
-                    .unwrap_or_default();
+                // segments_json lives at the same ordinal `row_to_entry` already
+                // read to derive `entry.formats`; re-read it here for the full
+                // segment payload. A NULL column (rows written before segments
+                // were persisted, or Live entries, which persist only aggregated
+                // text) or an unparseable blob degrades to no segments: the
+                // transcript text still comes back and detail fetches never 500
+                // on a corrupt segment payload.
+                let segments_json: Option<String> = row.get(9)?;
+                let segments = parse_segments_json(segments_json);
                 Ok(DaemonHistoryDetail {
                     entry,
                     text,
@@ -428,17 +432,31 @@ impl DaemonHistoryStore {
         // Serialize segments (word/speaker timing) alongside the text so exports
         // can rebuild SRT/VTT/JSON later; `formats` is derived from their
         // presence so we never advertise a format the stored data can't render.
+        // Serialization only fails on non-finite floats (NaN/Inf timestamps), a
+        // narrow case that must not cost the whole row: degrade to a
+        // segments-less (text-only) row instead of erroring out of the INSERT,
+        // symmetric with the read path treating a corrupt/legacy blob as "no
+        // segments" rather than failing the whole fetch.
         let segments_json = if record.segments.is_empty() {
             None
         } else {
-            Some(
-                serde_json::to_string(&record.segments)
-                    .map_err(DaemonHistoryStoreError::SerializeSegments)?,
-            )
+            match serde_json::to_string(&record.segments) {
+                Ok(json) => Some(json),
+                Err(error) => {
+                    eprintln!(
+                        "history: could not serialize segments, recording \
+                         text-only for this row: {error}"
+                    );
+                    None
+                }
+            }
         };
-        let formats = formats_for_content(!record.segments.is_empty());
+        let formats = formats_for_content(segments_json.is_some());
         let preview = preview_text(&record.text);
         let created_at_unix_seconds = unix_seconds_now();
+        // `formats` is written for backward-compatible schema reasons only
+        // (the column is `NOT NULL`); no read path trusts it -- see the
+        // `formats` column comment in `ensure_schema` and `ENTRY_COLUMNS`.
         let formats_json = serde_json::to_string(&formats).expect("Vec<String> always serializes");
         let search_text = format!(
             "{model} {} {}",
@@ -579,6 +597,13 @@ fn ensure_schema(conn: &Connection) -> rusqlite::Result<()> {
             output_format TEXT,
             diarization_active INTEGER,
             provenance TEXT,
+            -- Legacy: written for schema/back-compat continuity (NOT NULL) but
+            -- no longer trusted by any read path. Rows written under 0.1.10 and
+            -- earlier persisted a build-time `ResponseFormat::ALL` here that
+            -- overclaimed srt/vtt for text-only rows; every read now derives
+            -- `formats` from `segments_json` instead (see `ENTRY_COLUMNS` /
+            -- `row_to_entry`), so old and new rows report equally honest
+            -- formats regardless of what this column says.
             formats TEXT NOT NULL,
             preview TEXT NOT NULL,
             text TEXT NOT NULL,
@@ -615,13 +640,32 @@ fn ensure_segments_json_column(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
+/// Parses a persisted `segments_json` column into segments. A `NULL` column
+/// (rows written before segments were persisted, or Live entries, which
+/// persist only aggregated text) or an unparseable blob degrades to "no
+/// segments" rather than surfacing an error -- callers must not 500 (or, for
+/// `row_to_entry`, misreport `formats`) on a corrupt/legacy payload.
+fn parse_segments_json(segments_json: Option<String>) -> Vec<Segment> {
+    segments_json
+        .and_then(|json| serde_json::from_str::<Vec<Segment>>(&json).ok())
+        .unwrap_or_default()
+}
+
+/// Builds a [`DaemonHistoryEntry`] from a row selected via [`ENTRY_COLUMNS`].
+/// `formats` is derived here from whether `segments_json` actually holds
+/// segments, not read back from the persisted `formats` column: that column
+/// can lie (rows written under 0.1.10 and earlier claimed srt/vtt for every
+/// row regardless of content), so trusting it would let a stale write-time
+/// snapshot re-surface a bug already fixed at read time. Deriving at read time
+/// keeps old and new rows equally honest and needs no data migration.
 fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<DaemonHistoryEntry> {
     let kind: String = row.get(1)?;
     let created_at_unix_seconds: i64 = row.get(3)?;
     let output_format: Option<String> = row.get(6)?;
     let diarization_active: Option<bool> = row.get(7)?;
     let provenance: Option<String> = row.get(8)?;
-    let formats_json: String = row.get(9)?;
+    let segments_json: Option<String> = row.get(9)?;
+    let has_segments = !parse_segments_json(segments_json).is_empty();
 
     Ok(DaemonHistoryEntry {
         id: row.get(0)?,
@@ -637,7 +681,7 @@ fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<DaemonHistoryEntry>
         provenance: provenance
             .as_deref()
             .and_then(DaemonHistoryProvenance::parse),
-        formats: serde_json::from_str(&formats_json).unwrap_or_else(|_| vec!["text".to_string()]),
+        formats: formats_for_content(has_segments),
         preview: row.get(10)?,
     })
 }
@@ -1336,6 +1380,73 @@ mod tests {
         assert_eq!(fresh_detail.segments.len(), 1);
         assert_eq!(fresh_detail.segments[0].text, "new body");
     }
+
+    /// Regression for the read-path fix: rows written under 0.1.10 and earlier
+    /// persisted a `formats` column that unconditionally claimed every format
+    /// (including srt/vtt) regardless of whether segments were ever stored.
+    /// `segments_json` is `NULL` for these rows (segments did not exist yet),
+    /// so the old "trust the persisted column" read path rendered an empty
+    /// SRT/VTT for them. `row_to_entry` must ignore that lying column and
+    /// derive `formats` from `segments_json` instead, so both `list()`/`query()`
+    /// and `get()` report the honest (text-shaped only) set.
+    #[test]
+    fn daemon_history_store_read_path_corrects_legacy_lying_formats() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = DaemonHistoryStore::open(temp.path());
+        // Force schema creation (including the segments_json column) before
+        // hand-inserting a row that predates it in spirit: formats overclaims
+        // srt/vtt/verbose_json, segments_json is NULL.
+        let conn = store.connection().unwrap();
+        conn.execute(
+            "INSERT INTO history_entries (\
+                id, kind, model, created_at_unix_seconds, source_name, duration_seconds, \
+                output_format, diarization_active, provenance, formats, preview, text, \
+                segments_json\
+            ) VALUES ('hist-legacy-lie', 'file', 'whisper', 100, NULL, NULL, 'text', NULL, \
+                NULL, '[\"text\",\"srt\",\"vtt\",\"verbose_json\",\"json\",\"markdown\"]', \
+                'legacy lie', 'legacy lie body', NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO history_entries_fts (id, search_text) VALUES ('hist-legacy-lie', 'legacy lie body')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let honest_formats = vec![
+            "json".to_string(),
+            "markdown".to_string(),
+            "text".to_string(),
+        ];
+
+        let entries = store.list().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].formats, honest_formats,
+            "list() must not echo the persisted formats column's srt/vtt overclaim"
+        );
+
+        let detail = store.get("hist-legacy-lie").unwrap().unwrap();
+        assert_eq!(detail.entry.formats, honest_formats);
+        assert!(detail.segments.is_empty());
+    }
+
+    // No test exercises `record()`'s "segments fail to serialize -> degrade to
+    // text-only" branch (the fix B change in `record`) with a real trigger:
+    // `serde_json::to_string` cannot actually fail for `Vec<Segment>`. Its only
+    // fields are `String`/`f32`/`Option`/`Vec` with derived `Serialize` impls,
+    // and non-finite floats do not error -- confirmed empirically
+    // (`serde_json::to_string(&f32::NAN)` and `&f64::INFINITY` both return
+    // `Ok("null")` on serde_json 1.0.149, the version pinned here). There is no
+    // reachable input that produces `Err` from that call today, so the branch
+    // is unreachable in practice; it is kept as defense-in-depth (symmetric
+    // with the read path's "corrupt/legacy blob -> no segments" degrade) in
+    // case that ever changes, e.g. a future field with a fallible custom
+    // `Serialize` impl. Manufacturing a fake failure would require injecting a
+    // test-only non-`Segment` payload into `record()`, which isn't a real
+    // regression guard and isn't worth the extra surface.
 
     fn record_history_for_test(store: &DaemonHistoryStore, text: &str) -> DaemonHistoryEntry {
         store

--- a/crates/openasr-core/src/realtime/history_store.rs
+++ b/crates/openasr-core/src/realtime/history_store.rs
@@ -57,6 +57,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::ResponseFormat;
+use crate::api::backend::Segment;
 
 /// Guards the one-time-per-database WAL switch and schema creation in
 /// [`DaemonHistoryStore::connection`]. See that method for why this can't
@@ -136,6 +137,29 @@ pub struct DaemonHistoryDetail {
     #[serde(flatten)]
     pub entry: DaemonHistoryEntry,
     pub text: String,
+    /// Per-segment transcript with word/speaker timing, in the same JSON shape
+    /// as the transcription API's segments (`format/json.rs`). Empty for rows
+    /// written before segments were persisted (and for live entries, which
+    /// store only aggregated text). The desktop export UI reconstructs
+    /// SRT/VTT/JSON from these; see [`DaemonHistoryDetail::to_transcription`].
+    #[serde(default)]
+    pub segments: Vec<Segment>,
+}
+
+impl DaemonHistoryDetail {
+    /// Reconstructs a [`Transcription`](crate::api::backend::Transcription) from
+    /// the stored transcript text and segments so the authoritative
+    /// [`render_transcription`](crate::render_transcription) renderer can emit
+    /// any export format. Language and long-form metadata are not persisted in
+    /// daemon history, so they come back `None` rather than being fabricated.
+    pub fn to_transcription(&self) -> crate::api::backend::Transcription {
+        crate::api::backend::Transcription {
+            text: self.text.clone(),
+            segments: self.segments.clone(),
+            longform: None,
+            language: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -147,8 +171,13 @@ pub struct DaemonHistoryRecord {
     pub output_format: Option<ResponseFormat>,
     pub diarization_active: Option<bool>,
     pub provenance: Option<DaemonHistoryProvenance>,
-    pub formats: Vec<String>,
     pub text: String,
+    /// Per-segment transcript (word/speaker timing). File transcriptions pass
+    /// `transcription.segments`; live entries pass an empty vec (they persist
+    /// only aggregated text). The available export `formats` are derived from
+    /// whether this is non-empty -- callers cannot claim a format the stored
+    /// data cannot render.
+    pub segments: Vec<Segment>,
 }
 
 /// Filter/pagination request for [`DaemonHistoryStore::query`].
@@ -195,6 +224,8 @@ pub enum DaemonHistoryStoreError {
     },
     #[error("History database query failed: {0}")]
     Query(#[source] rusqlite::Error),
+    #[error("Could not serialize history segments: {0}")]
+    SerializeSegments(#[source] serde_json::Error),
 }
 
 impl DaemonHistoryStore {
@@ -295,13 +326,25 @@ impl DaemonHistoryStore {
         conn.query_row(
             "SELECT e.id, e.kind, e.model, e.created_at_unix_seconds, e.source_name, \
              e.duration_seconds, e.output_format, e.diarization_active, e.provenance, \
-             e.formats, e.preview, e.text \
+             e.formats, e.preview, e.text, e.segments_json \
              FROM history_entries e WHERE e.id = ?1",
             params![id],
             |row| {
                 let entry = row_to_entry(row)?;
                 let text: String = row.get(11)?;
-                Ok(DaemonHistoryDetail { entry, text })
+                let segments_json: Option<String> = row.get(12)?;
+                // A NULL column (rows written before segments were persisted, or
+                // live entries) or an unparseable blob degrades to no segments:
+                // the transcript text still comes back and detail fetches never
+                // 500 on a corrupt segment payload.
+                let segments = segments_json
+                    .and_then(|json| serde_json::from_str::<Vec<Segment>>(&json).ok())
+                    .unwrap_or_default();
+                Ok(DaemonHistoryDetail {
+                    entry,
+                    text,
+                    segments,
+                })
             },
         )
         .optional()
@@ -382,7 +425,18 @@ impl DaemonHistoryStore {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned);
-        let formats = normalized_formats(record.formats);
+        // Serialize segments (word/speaker timing) alongside the text so exports
+        // can rebuild SRT/VTT/JSON later; `formats` is derived from their
+        // presence so we never advertise a format the stored data can't render.
+        let segments_json = if record.segments.is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::to_string(&record.segments)
+                    .map_err(DaemonHistoryStoreError::SerializeSegments)?,
+            )
+        };
+        let formats = formats_for_content(!record.segments.is_empty());
         let preview = preview_text(&record.text);
         let created_at_unix_seconds = unix_seconds_now();
         let formats_json = serde_json::to_string(&formats).expect("Vec<String> always serializes");
@@ -399,8 +453,9 @@ impl DaemonHistoryStore {
             let insert_result = tx.execute(
                 "INSERT INTO history_entries (\
                     id, kind, model, created_at_unix_seconds, source_name, duration_seconds, \
-                    output_format, diarization_active, provenance, formats, preview, text\
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                    output_format, diarization_active, provenance, formats, preview, text, \
+                    segments_json\
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
                 params![
                     id,
                     record.kind.as_str(),
@@ -414,6 +469,7 @@ impl DaemonHistoryStore {
                     formats_json,
                     preview,
                     record.text,
+                    segments_json,
                 ],
             );
             match insert_result {
@@ -525,7 +581,8 @@ fn ensure_schema(conn: &Connection) -> rusqlite::Result<()> {
             provenance TEXT,
             formats TEXT NOT NULL,
             preview TEXT NOT NULL,
-            text TEXT NOT NULL
+            text TEXT NOT NULL,
+            segments_json TEXT
         );
         CREATE INDEX IF NOT EXISTS history_entries_created_at_idx
             ON history_entries (created_at_unix_seconds DESC, id DESC);
@@ -535,7 +592,27 @@ fn ensure_schema(conn: &Connection) -> rusqlite::Result<()> {
             search_text,
             tokenize = 'trigram'
         );",
-    )
+    )?;
+    ensure_segments_json_column(conn)
+}
+
+/// Additive migration for databases created before `segments_json` existed:
+/// `CREATE TABLE IF NOT EXISTS` never alters an existing table, so an older
+/// `history.db` keeps its columnless-of-`segments_json` shape until this adds
+/// the nullable column. Existing rows read back as `NULL` (no segments), which
+/// the query paths already treat as "text only". Idempotent: a fresh database
+/// already has the column from the `CREATE TABLE` above and skips the `ALTER`.
+fn ensure_segments_json_column(conn: &Connection) -> rusqlite::Result<()> {
+    let has_column = conn
+        .prepare("SELECT 1 FROM pragma_table_info('history_entries') WHERE name = 'segments_json'")?
+        .exists([])?;
+    if !has_column {
+        conn.execute(
+            "ALTER TABLE history_entries ADD COLUMN segments_json TEXT",
+            [],
+        )?;
+    }
+    Ok(())
 }
 
 fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<DaemonHistoryEntry> {
@@ -618,11 +695,6 @@ fn validate_record(record: &DaemonHistoryRecord) -> Result<(), DaemonHistoryStor
     {
         return invalid_record("duration_seconds", "must be finite and non-negative");
     }
-    for format in &record.formats {
-        if format.trim().is_empty() {
-            return invalid_record("formats", "must not contain empty entries");
-        }
-    }
     Ok(())
 }
 
@@ -636,18 +708,24 @@ fn invalid_record(
     })
 }
 
-fn normalized_formats(formats: Vec<String>) -> Vec<String> {
-    let mut normalized = formats
-        .into_iter()
-        .map(|format| format.trim().to_string())
-        .filter(|format| !format.is_empty())
-        .collect::<Vec<_>>();
-    if normalized.is_empty() {
-        normalized.push("text".to_string());
+/// Export formats the stored transcript can actually render, derived from
+/// whether per-segment timing was persisted. Text/JSON/Markdown need only the
+/// flat text; SRT/VTT additionally need segment timestamps. Deriving this here
+/// (rather than trusting a caller-supplied list) is what keeps the advertised
+/// `formats` honest -- a transcript with no segments never claims SRT/VTT.
+/// Returned sorted to match the previous column ordering.
+fn formats_for_content(has_segments: bool) -> Vec<String> {
+    let mut formats = vec![
+        ResponseFormat::Json.as_str().to_string(),
+        ResponseFormat::Markdown.as_str().to_string(),
+        ResponseFormat::Text.as_str().to_string(),
+    ];
+    if has_segments {
+        formats.push(ResponseFormat::Srt.as_str().to_string());
+        formats.push(ResponseFormat::Vtt.as_str().to_string());
     }
-    normalized.sort();
-    normalized.dedup();
-    normalized
+    formats.sort();
+    formats
 }
 
 fn preview_text(text: &str) -> String {
@@ -672,6 +750,7 @@ fn unix_millis_now() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::backend::WordTimestamp;
 
     #[test]
     fn daemon_history_store_records_lists_gets_and_deletes() {
@@ -686,8 +765,16 @@ mod tests {
                 output_format: Some(ResponseFormat::Srt),
                 diarization_active: Some(true),
                 provenance: Some(DaemonHistoryProvenance::Recorded),
-                formats: vec!["json".to_string()],
                 text: "hello OpenASR history".to_string(),
+                segments: vec![Segment {
+                    start: 0.0,
+                    end: 1.5,
+                    text: "hello OpenASR history".to_string(),
+                    speaker: None,
+                    speaker_label: None,
+                    speaker_profile_id: None,
+                    words: Vec::new(),
+                }],
             })
             .unwrap();
 
@@ -699,6 +786,17 @@ mod tests {
             entries[0].provenance,
             Some(DaemonHistoryProvenance::Recorded)
         );
+        // A row with segments advertises the timing-dependent formats too.
+        assert_eq!(
+            entries[0].formats,
+            vec![
+                "json".to_string(),
+                "markdown".to_string(),
+                "srt".to_string(),
+                "text".to_string(),
+                "vtt".to_string(),
+            ]
+        );
         let detail = store.get(&entry.id).unwrap().unwrap();
         assert_eq!(detail.text, "hello OpenASR history");
         assert_eq!(detail.entry.output_format, Some(ResponseFormat::Srt));
@@ -707,6 +805,14 @@ mod tests {
             detail.entry.provenance,
             Some(DaemonHistoryProvenance::Recorded)
         );
+        // Segments round-trip through the store and rebuild a Transcription that
+        // the authoritative renderer turns into SRT with the persisted timing.
+        assert_eq!(detail.segments.len(), 1);
+        assert_eq!(detail.segments[0].end, 1.5);
+        let srt =
+            crate::render_transcription(&detail.to_transcription(), ResponseFormat::Srt).unwrap();
+        assert!(srt.contains("00:00:00,000 --> 00:00:01,500"), "{srt}");
+        assert!(srt.contains("hello OpenASR history"), "{srt}");
 
         assert!(store.delete(&entry.id).unwrap());
         assert!(store.list().unwrap().is_empty());
@@ -732,7 +838,7 @@ mod tests {
                         output_format: Some(ResponseFormat::Text),
                         diarization_active: Some(false),
                         provenance: Some(DaemonHistoryProvenance::Recorded),
-                        formats: vec!["text".to_string()],
+                        segments: Vec::new(),
                         text: format!("hello from session {index}"),
                     })
                     .unwrap();
@@ -835,6 +941,20 @@ mod tests {
         let detail = DaemonHistoryDetail {
             entry,
             text: "hello world".to_string(),
+            segments: vec![Segment {
+                start: 0.0,
+                end: 1.0,
+                text: "hello world".to_string(),
+                speaker: Some("Speaker 1".to_string()),
+                speaker_label: None,
+                speaker_profile_id: None,
+                words: vec![WordTimestamp {
+                    word: "hello".to_string(),
+                    start: 0.0,
+                    end: 0.5,
+                    confidence: None,
+                }],
+            }],
         };
 
         let value = serde_json::to_value(&detail).unwrap();
@@ -850,6 +970,16 @@ mod tests {
         assert_eq!(value["text"], "hello world");
         assert!(value.get("response_format").is_none());
         assert!(value.get("text_path").is_none());
+        // Segments serialize in the transcription API's JsonSegment shape so the
+        // desktop export UI can reuse its existing segment deserializer: fields
+        // in the same order, empty/None fields skipped.
+        assert_eq!(value["segments"][0]["start"], 0.0);
+        assert_eq!(value["segments"][0]["end"], 1.0);
+        assert_eq!(value["segments"][0]["text"], "hello world");
+        assert_eq!(value["segments"][0]["speaker"], "Speaker 1");
+        assert!(value["segments"][0].get("speaker_label").is_none());
+        assert_eq!(value["segments"][0]["words"][0]["word"], "hello");
+        assert!(value["segments"][0]["words"][0].get("confidence").is_none());
     }
 
     #[test]
@@ -865,7 +995,7 @@ mod tests {
                 output_format: None,
                 diarization_active: None,
                 provenance: None,
-                formats: vec![],
+                segments: Vec::new(),
                 text: "legacy text".to_string(),
             })
             .unwrap();
@@ -963,7 +1093,7 @@ mod tests {
                 output_format: None,
                 diarization_active: None,
                 provenance: None,
-                formats: vec![],
+                segments: Vec::new(),
                 text: "file transcript".to_string(),
             })
             .unwrap();
@@ -1047,11 +1177,164 @@ mod tests {
                     output_format: None,
                     diarization_active: None,
                     provenance: None,
-                    formats: vec![],
+                    segments: Vec::new(),
                     text: "should not persist".to_string(),
                 })
                 .is_err()
         );
+    }
+
+    #[test]
+    fn daemon_history_store_derives_formats_from_segment_presence() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = DaemonHistoryStore::open(temp.path());
+
+        // No segments: only the text-shaped formats are advertised.
+        let text_only = store
+            .record(DaemonHistoryRecord {
+                kind: DaemonHistoryKind::File,
+                model: "whisper".to_string(),
+                source_name: None,
+                duration_seconds: None,
+                output_format: Some(ResponseFormat::Text),
+                diarization_active: None,
+                provenance: None,
+                segments: Vec::new(),
+                text: "plain body".to_string(),
+            })
+            .unwrap();
+        assert_eq!(
+            text_only.formats,
+            vec![
+                "json".to_string(),
+                "markdown".to_string(),
+                "text".to_string()
+            ]
+        );
+        // NULL segments_json round-trips to an empty segment list.
+        let detail = store.get(&text_only.id).unwrap().unwrap();
+        assert!(detail.segments.is_empty());
+
+        // With segments: SRT/VTT join the set because timing is now available.
+        let with_segments = store
+            .record(DaemonHistoryRecord {
+                kind: DaemonHistoryKind::File,
+                model: "whisper".to_string(),
+                source_name: None,
+                duration_seconds: Some(2.0),
+                output_format: Some(ResponseFormat::Srt),
+                diarization_active: None,
+                provenance: None,
+                segments: vec![Segment {
+                    start: 0.0,
+                    end: 2.0,
+                    text: "timed body".to_string(),
+                    speaker: None,
+                    speaker_label: None,
+                    speaker_profile_id: None,
+                    words: Vec::new(),
+                }],
+                text: "timed body".to_string(),
+            })
+            .unwrap();
+        assert_eq!(
+            with_segments.formats,
+            vec![
+                "json".to_string(),
+                "markdown".to_string(),
+                "srt".to_string(),
+                "text".to_string(),
+                "vtt".to_string(),
+            ]
+        );
+        // Segments rebuild a Transcription that the shared renderer turns into VTT.
+        let detail = store.get(&with_segments.id).unwrap().unwrap();
+        let vtt =
+            crate::render_transcription(&detail.to_transcription(), ResponseFormat::Vtt).unwrap();
+        assert!(vtt.starts_with("WEBVTT"), "{vtt}");
+        assert!(vtt.contains("00:00:00.000 --> 00:00:02.000"), "{vtt}");
+        assert!(vtt.contains("timed body"), "{vtt}");
+    }
+
+    #[test]
+    fn daemon_history_store_adds_segments_column_to_a_legacy_database() {
+        let temp = tempfile::tempdir().unwrap();
+        let history_root = history_dir(temp.path());
+        std::fs::create_dir_all(&history_root).unwrap();
+        let db_path = history_root.join("history.db");
+
+        // Recreate the pre-`segments_json` schema and a row written under it, so
+        // the additive `ALTER TABLE` migration has something to upgrade.
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE history_entries (
+                    id TEXT PRIMARY KEY,
+                    kind TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    created_at_unix_seconds INTEGER NOT NULL,
+                    source_name TEXT,
+                    duration_seconds REAL,
+                    output_format TEXT,
+                    diarization_active INTEGER,
+                    provenance TEXT,
+                    formats TEXT NOT NULL,
+                    preview TEXT NOT NULL,
+                    text TEXT NOT NULL
+                );
+                CREATE VIRTUAL TABLE history_entries_fts USING fts5(
+                    id UNINDEXED, search_text, tokenize = 'trigram'
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO history_entries (\
+                    id, kind, model, created_at_unix_seconds, source_name, duration_seconds, \
+                    output_format, diarization_active, provenance, formats, preview, text\
+                ) VALUES ('hist-legacy', 'file', 'whisper', 100, NULL, NULL, 'text', NULL, \
+                    NULL, '[\"text\"]', 'legacy', 'legacy body')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO history_entries_fts (id, search_text) VALUES ('hist-legacy', 'legacy body')",
+                [],
+            )
+            .unwrap();
+        }
+
+        // Opening through the store runs the migration; the legacy row survives
+        // and reads back with no segments (not a crash).
+        let store = DaemonHistoryStore::open(temp.path());
+        let detail = store.get("hist-legacy").unwrap().unwrap();
+        assert_eq!(detail.text, "legacy body");
+        assert!(detail.segments.is_empty());
+
+        // New writes populate the freshly added column end to end.
+        let fresh = store
+            .record(DaemonHistoryRecord {
+                kind: DaemonHistoryKind::File,
+                model: "whisper".to_string(),
+                source_name: None,
+                duration_seconds: Some(1.0),
+                output_format: Some(ResponseFormat::Srt),
+                diarization_active: None,
+                provenance: None,
+                segments: vec![Segment {
+                    start: 0.0,
+                    end: 1.0,
+                    text: "new body".to_string(),
+                    speaker: None,
+                    speaker_label: None,
+                    speaker_profile_id: None,
+                    words: Vec::new(),
+                }],
+                text: "new body".to_string(),
+            })
+            .unwrap();
+        let fresh_detail = store.get(&fresh.id).unwrap().unwrap();
+        assert_eq!(fresh_detail.segments.len(), 1);
+        assert_eq!(fresh_detail.segments[0].text, "new body");
     }
 
     fn record_history_for_test(store: &DaemonHistoryStore, text: &str) -> DaemonHistoryEntry {
@@ -1064,7 +1347,7 @@ mod tests {
                 output_format: Some(ResponseFormat::Text),
                 diarization_active: Some(false),
                 provenance: Some(DaemonHistoryProvenance::Recorded),
-                formats: vec!["text".to_string()],
+                segments: Vec::new(),
                 text: text.to_string(),
             })
             .unwrap()

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -3186,7 +3186,10 @@ impl WsSession {
             output_format: Some(ResponseFormat::Text),
             diarization_active: Some(self.streaming_diarizer.is_some()),
             provenance: Some(DaemonHistoryProvenance::Recorded),
-            formats: vec!["text".to_string()],
+            // Live daemon history persists only the aggregated transcript text;
+            // per-segment timing lives in the realtime transcript history. No
+            // segments here means the store advertises text-shaped exports only.
+            segments: Vec::new(),
             text,
         }) {
             self.emit_error(

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -207,10 +207,10 @@ pub(crate) fn record_file_transcription_history(
             output_format: Some(output_format),
             diarization_active: Some(request.diarize),
             provenance: Some(DaemonHistoryProvenance::Recorded),
-            formats: ResponseFormat::ALL
-                .iter()
-                .map(|format| (*format).to_string())
-                .collect(),
+            // Persist the per-segment timing so exports can rebuild SRT/VTT/JSON
+            // later; the store derives the advertised `formats` from these so we
+            // never claim a format the stored transcript cannot render.
+            segments: transcription.segments.clone(),
             text: transcription.text.clone(),
         })
         .map_err(ApiError::History)?;

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -1081,7 +1081,7 @@ fn history_retention_last5_prunes_store() {
                 output_format: Some(ResponseFormat::Text),
                 diarization_active: Some(false),
                 provenance: Some(DaemonHistoryProvenance::Recorded),
-                formats: vec!["text".to_string()],
+                segments: Vec::new(),
                 text: format!("transcript {index}"),
             })
             .unwrap();
@@ -1120,7 +1120,7 @@ fn history_retention_off_prunes_store_empty() {
                 output_format: Some(ResponseFormat::Text),
                 diarization_active: Some(false),
                 provenance: Some(DaemonHistoryProvenance::Recorded),
-                formats: vec!["text".to_string()],
+                segments: Vec::new(),
                 text: format!("transcript {index}"),
             })
             .unwrap();
@@ -1144,7 +1144,7 @@ fn history_retention_off_prunes_store_empty() {
             output_format: Some(ResponseFormat::Text),
             diarization_active: Some(false),
             provenance: Some(DaemonHistoryProvenance::Recorded),
-            formats: vec!["text".to_string()],
+            segments: Vec::new(),
             text: "keep me".to_string(),
         })
         .unwrap();

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -3339,6 +3339,21 @@ async fn transcriptions_record_file_history_in_sqlite_store() {
     // Transcript text lives in the SQLite row, not a filesystem sidecar; it
     // must not leak a path into the wire contract.
     assert!(entry.get("text_path").is_none());
+    // `formats` is derived from the stored transcript: this file transcription
+    // has timed segments, so the timing-dependent exports are advertised too
+    // (no longer the old blanket ResponseFormat::ALL claim).
+    let format_strs: Vec<&str> = entry["formats"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|value| value.as_str().unwrap())
+        .collect();
+    for expected in ["text", "json", "markdown", "srt", "vtt"] {
+        assert!(
+            format_strs.contains(&expected),
+            "missing {expected}: {format_strs:?}"
+        );
+    }
     let history_db = home.join("history").join("history.db");
     assert!(history_db.exists());
 
@@ -3367,6 +3382,13 @@ async fn transcriptions_record_file_history_in_sqlite_store() {
             .unwrap()
             .contains("OpenASR mock transcription")
     );
+    // Detail carries the per-segment transcript in the transcription API's
+    // JsonSegment shape so the desktop export UI can rebuild SRT/VTT/JSON.
+    let detail_segments = detail["segments"].as_array().unwrap();
+    assert!(!detail_segments.is_empty());
+    assert!(detail_segments[0]["text"].as_str().is_some());
+    assert!(detail_segments[0]["start"].as_f64().is_some());
+    assert!(detail_segments[0]["end"].as_f64().is_some());
 
     let response = app
         .clone()
@@ -3462,7 +3484,7 @@ async fn history_list_supports_search_pagination_and_kind_filter() {
         output_format: Some(ResponseFormat::Text),
         diarization_active: Some(false),
         provenance: None,
-        formats: vec!["text".to_string()],
+        segments: Vec::new(),
         text: text.to_string(),
     };
     let oldest = store


### PR DESCRIPTION
## Summary

Persist per-segment transcription data (segments/timestamps) in file
transcription history, and derive `formats` honestly from what a history
row actually has, instead of trusting a stored claim.

## Why

File transcription history only stored plain text, not `segments`, so SRT/VTT
could never be reconstructed from history and even partial word/segment data
was unavailable after the fact. Worse, the persisted `formats` field
unconditionally claimed `ResponseFormat::ALL` (text/json/srt/vtt/md) even
though segments were never stored, so history rows lied about which export
formats were actually derivable.

## Changes

- SQLite `history_entries`: add a `segments_json` column via an idempotent,
  pragma-based column-probe migration (backward compatible with existing
  rows that predate the column). The write path now persists
  `transcription.segments` (including words, start/end, speaker). The
  detail/get path returns segments. `Segment` / `WordTimestamp` gain serde
  support and are field-for-field aligned with the API's `JsonSegment` /
  `JsonWord` shapes so desktop can reuse them directly. SRT/VTT/json/md
  rendering reuses the existing authoritative `render_transcription`
  function rather than introducing a new renderer.
- **Honest `formats` derivation, and a fix for already-persisted bad data**:
  the list/query/get read paths now compute `formats` from whether the row
  actually has segments, rather than trusting the persisted snapshot. This
  also retroactively fixes rows written by the already-shipped 0.1.10 (which
  claimed srt/vtt support with a NULL `segments` column) -- reading them back
  now reports formats honestly. Removed the write-path `ResponseFormat::ALL`
  claim and structurally deleted the `DaemonHistoryRecord.formats` field.
  Segment (de)serialization failures degrade to a row with no segments
  rather than dropping the whole history entry.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2191 passed)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (not run this pass; no dependency changes in this PR)

Additional verification specific to this change:

- History-store tests: 33/33, including two key regressions: (1) a legacy
  DB without the `segments_json` column migrates and reads without crashing,
  and (2) a pre-existing row with the old dishonest `formats` claim (srt/vtt
  claimed, segments NULL) now reads back with honest, derived formats.
- Golden fixtures: 2/2 pass.
- `bundled_catalog_signature_verifies_committed_catalog_and_epoch` passes
  (no catalog touched).
- Confirmed realtime caption history (`RealtimeHistoryEntry`) is unaffected
  -- this PR only touches file-transcription history.

## Manual smoke checks

Ran the history-store test suite against both a fresh DB and a legacy
fixture DB (pre-`segments_json` schema, with a row carrying the old
`formats: [text, json, srt, vtt]` claim and a NULL segments column) and
confirmed: the legacy DB opens and migrates without error, and the legacy
row's `formats` now reports only what its (absent) segments support.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- This PR does not touch realtime/live-caption history
  (`RealtimeHistoryEntry`), only file-transcription history.
- This PR does not add a new SRT/VTT renderer; it wires stored segments into
  the existing `render_transcription` path.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented and reviewed with AI assistance; this draft was prepared for the maintainer's own review, verification, and merge.
