### PR TITLE
fix(core/progress): phase-aware progress + owner-token concurrency fix (#61)

### DIFF
--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -11,8 +11,9 @@ mod native;
 pub use mock::transcribe_with_mock_backend;
 pub use native::{
     NativeBackend, NativeBackendExecutor, NativeRuntimeModelAdapter, NativeRuntimeModelIdSource,
-    NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError,
-    native_runtime_model_adapter_for_path, native_runtime_realtime_capabilities_for_path,
+    NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError, NativeTranscriptionPhase,
+    NativeTranscriptionProgress, native_runtime_model_adapter_for_path,
+    native_runtime_realtime_capabilities_for_path,
     native_runtime_transcription_capabilities_for_path, native_transcription_progress,
     resolve_local_native_runtime_model_identity, validate_local_native_model_pack_path,
     validate_native_runtime_model_pack_contract,

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -45,7 +45,9 @@ mod native_transcribe;
 pub use native_model_id::{
     NativeRuntimeModelIdSource, NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError,
 };
-pub use native_transcribe::native_transcription_progress;
+pub use native_transcribe::{
+    NativeTranscriptionPhase, NativeTranscriptionProgress, native_transcription_progress,
+};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NativeBackend;

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -38,51 +38,196 @@ const COHERE_LONGFORM_MAX_CHUNK_SECONDS: f32 = 10.0;
 const COHERE_LONGFORM_OVERLAP_SECONDS: f32 = 0.0;
 static NATIVE_GGML_EXECUTION_DISPATCH: OnceLock<GgmlAsrExecutionDispatch> = OnceLock::new();
 
-// Coarse long-form transcription progress, published as a single global slot.
-// The local desktop daemon transcribes one file at a time, so one slot is enough
-// to drive the UI progress bar; concurrent runs on a single daemon would share
-// it. Short single-pass decodes never touch it (there are no slices to count),
-// so callers see None and fall back to a time-based estimate.
-static PROGRESS_SLICES_DONE: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-static PROGRESS_SLICES_TOTAL: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+// Phase-aware progress for the in-flight native file transcription, published as
+// a single global slot. The local desktop daemon transcribes one file at a time,
+// so one slot is enough to drive the UI progress bar; concurrent runs on a single
+// daemon would share it. Progress is a monotonic overall fraction (0..=1) plus a
+// coarse phase label, so the UI advances smoothly across decode -> assemble ->
+// forced-align refine instead of stalling once the last slice decodes. The old
+// bare slice counter reached "done" at the last decode and then sat frozen through
+// assembly/merge and the whole-file forced-align pass, which read to users as a
+// bar stuck near the end (issue #61). Short single-pass decodes never activate the
+// slot (there are no slices to weight, and a single opaque decode call exposes no
+// sub-step), so callers see None and fall back to a time-based estimate.
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 
-/// `(slices_done, slices_total)` of the in-flight native long-form run, or `None`
-/// when no multi-slice run is active.
-pub fn native_transcription_progress() -> Option<(usize, usize)> {
-    use std::sync::atomic::Ordering;
-    let total = PROGRESS_SLICES_TOTAL.load(Ordering::Relaxed);
-    if total == 0 {
+static PROGRESS_ACTIVE: AtomicBool = AtomicBool::new(false);
+static PROGRESS_PHASE: AtomicU8 = AtomicU8::new(0);
+static PROGRESS_FRACTION_BITS: AtomicU32 = AtomicU32::new(0);
+
+// Heuristic phase ceilings the monotonic overall fraction climbs to at each phase
+// boundary -- not measured timings. Decode (autoregressive, per-slice) dominates;
+// the assembly/merge/resegment tail is short; the forced-align refine is a single
+// non-autoregressive forward pass over the whole file, present only when the caller
+// opted into word_timestamps=aligned. The monotonic clamp keeps the bar honest even
+// when a run's real mix differs from these shares.
+const DECODE_CEIL_WITH_ALIGN: f32 = 0.75;
+const ASSEMBLE_CEIL_WITH_ALIGN: f32 = 0.80;
+const ALIGN_CEIL: f32 = 0.92;
+const DECODE_CEIL_NO_ALIGN: f32 = 0.92;
+const ASSEMBLE_CEIL_NO_ALIGN: f32 = 0.97;
+
+/// Coarse phase of the in-flight native file transcription.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeTranscriptionPhase {
+    /// Decoding audio slices.
+    Decode,
+    /// Merging slice transcripts and re-segmenting into subtitle cues.
+    Assemble,
+    /// Refining per-word timestamps with the forced aligner (word_timestamps=aligned).
+    Align,
+}
+
+impl NativeTranscriptionPhase {
+    fn to_tag(self) -> u8 {
+        match self {
+            NativeTranscriptionPhase::Decode => 0,
+            NativeTranscriptionPhase::Assemble => 1,
+            NativeTranscriptionPhase::Align => 2,
+        }
+    }
+
+    fn from_tag(tag: u8) -> Self {
+        match tag {
+            1 => NativeTranscriptionPhase::Assemble,
+            2 => NativeTranscriptionPhase::Align,
+            _ => NativeTranscriptionPhase::Decode,
+        }
+    }
+
+    /// Stable lowercase label for the wire contract and the optional UI phase text.
+    pub fn label(self) -> &'static str {
+        match self {
+            NativeTranscriptionPhase::Decode => "decode",
+            NativeTranscriptionPhase::Assemble => "assemble",
+            NativeTranscriptionPhase::Align => "align",
+        }
+    }
+}
+
+/// Snapshot of the in-flight native run: a monotonic overall `fraction` in
+/// `0..=1` plus the current `phase`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NativeTranscriptionProgress {
+    pub phase: NativeTranscriptionPhase,
+    pub fraction: f32,
+}
+
+/// Progress of the in-flight native long-form / forced-align run, or `None` when
+/// no multi-slice / refine run is active (short single-pass decodes report
+/// nothing and the caller estimates from elapsed time).
+pub fn native_transcription_progress() -> Option<NativeTranscriptionProgress> {
+    if !PROGRESS_ACTIVE.load(Ordering::Acquire) {
         return None;
     }
-    let done = PROGRESS_SLICES_DONE.load(Ordering::Relaxed).min(total);
-    Some((done, total))
+    let fraction = f32::from_bits(PROGRESS_FRACTION_BITS.load(Ordering::Relaxed));
+    let phase = NativeTranscriptionPhase::from_tag(PROGRESS_PHASE.load(Ordering::Relaxed));
+    Some(NativeTranscriptionProgress { phase, fraction })
 }
 
-/// RAII guard: publishes the slice total on creation and resets the slot on drop,
-/// so normal completion, an early `?` return, or a panic all clear it.
-struct LongformProgressGuard;
+/// Publish `phase` and raise the overall fraction monotonically (a later phase or a
+/// further-along slice never moves the bar backward). Activates the slot on the
+/// first report of a run.
+fn publish_progress(phase: NativeTranscriptionPhase, fraction: f32) {
+    let clamped = fraction.clamp(0.0, 1.0);
+    PROGRESS_PHASE.store(phase.to_tag(), Ordering::Relaxed);
+    // Monotonic max on the f32 bits via a CAS loop: only ever raise the fraction.
+    let mut current = PROGRESS_FRACTION_BITS.load(Ordering::Relaxed);
+    loop {
+        let next = f32::from_bits(current).max(clamped);
+        match PROGRESS_FRACTION_BITS.compare_exchange_weak(
+            current,
+            next.to_bits(),
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(observed) => current = observed,
+        }
+    }
+    // Release so a reader that observes `active` (Acquire) also sees the phase and
+    // fraction written above.
+    PROGRESS_ACTIVE.store(true, Ordering::Release);
+}
 
-impl LongformProgressGuard {
-    fn begin(total: usize) -> Self {
-        use std::sync::atomic::Ordering;
-        PROGRESS_SLICES_DONE.store(0, Ordering::Relaxed);
-        PROGRESS_SLICES_TOTAL.store(total, Ordering::Relaxed);
+/// Enter the assembly/merge phase, raising the bar to that phase's ceiling.
+fn publish_assemble_progress(with_align: bool) {
+    let ceil = if with_align {
+        ASSEMBLE_CEIL_WITH_ALIGN
+    } else {
+        ASSEMBLE_CEIL_NO_ALIGN
+    };
+    publish_progress(NativeTranscriptionPhase::Assemble, ceil);
+}
+
+/// Enter the forced-align refine phase, raising the bar to the align ceiling. The
+/// refine is a single opaque forward pass, so the bar holds here (with the "align"
+/// phase label explaining the pause) until the run completes and the slot clears.
+fn publish_align_progress() {
+    publish_progress(NativeTranscriptionPhase::Align, ALIGN_CEIL);
+}
+
+/// Decode-phase progress for the multi-slice long-form path. Each slice is weighted
+/// by its audio sample count (not a flat per-slice tick) so the bar tracks decode
+/// time -- which scales with audio duration -- rather than slice number, which makes
+/// variable-length VAD slices advance the bar unevenly.
+struct DecodeProgress {
+    total_samples: u64,
+    decoded_samples: u64,
+    decode_ceil: f32,
+}
+
+impl DecodeProgress {
+    fn begin(total_samples: u64, with_align: bool) -> Self {
+        let decode_ceil = if with_align {
+            DECODE_CEIL_WITH_ALIGN
+        } else {
+            DECODE_CEIL_NO_ALIGN
+        };
+        publish_progress(NativeTranscriptionPhase::Decode, 0.0);
+        Self {
+            total_samples,
+            decoded_samples: 0,
+            decode_ceil,
+        }
+    }
+
+    /// Mark one slice decoded (or skipped as silent -- silence still consumes its
+    /// share of the audio timeline), advancing the bar by that slice's sample share.
+    fn complete_slice(&mut self, slice_samples: u64) {
+        self.decoded_samples = self.decoded_samples.saturating_add(slice_samples);
+        let ratio = if self.total_samples == 0 {
+            1.0
+        } else {
+            (self.decoded_samples as f32 / self.total_samples as f32).clamp(0.0, 1.0)
+        };
+        publish_progress(NativeTranscriptionPhase::Decode, self.decode_ceil * ratio);
+    }
+}
+
+/// RAII reset for the global progress slot: clears it on normal completion, an early
+/// `?` return, or a panic, so a stale fraction never leaks into the next run. Created
+/// once per `run_native_transcription` so its lifetime spans decode, assembly, and
+/// the forced-align refine.
+struct NativeProgressGuard;
+
+impl NativeProgressGuard {
+    fn new() -> Self {
+        clear_progress_slot();
         Self
     }
+}
 
-    fn advance(&self) {
-        PROGRESS_SLICES_DONE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+impl Drop for NativeProgressGuard {
+    fn drop(&mut self) {
+        clear_progress_slot();
     }
 }
 
-impl Drop for LongformProgressGuard {
-    fn drop(&mut self) {
-        use std::sync::atomic::Ordering;
-        PROGRESS_SLICES_DONE.store(0, Ordering::Relaxed);
-        PROGRESS_SLICES_TOTAL.store(0, Ordering::Relaxed);
-    }
+fn clear_progress_slot() {
+    PROGRESS_ACTIVE.store(false, Ordering::Release);
+    PROGRESS_FRACTION_BITS.store(0, Ordering::Relaxed);
+    PROGRESS_PHASE.store(0, Ordering::Relaxed);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -114,10 +259,15 @@ pub(super) fn run_native_transcription(
     if refine && !request.word_timestamps {
         return Err(BackendError::WordTimestampAlignmentRequiresWordTimestamps);
     }
+    // Spans the whole run (decode + assembly inside impl, then the forced-align
+    // refine below) so the progress slot is cleared on every exit and the align
+    // phase advances the same monotonic bar rather than running uncounted.
+    let _progress = NativeProgressGuard::new();
     let input_path = request.input_path.clone();
     let language_hint = request.language.clone();
     let transcription = run_native_transcription_impl(request)?;
     if refine {
+        publish_align_progress();
         refine_transcription_word_timestamps_with_forced_aligner(
             transcription,
             &input_path,
@@ -431,11 +581,20 @@ fn run_native_transcription_impl(
                 .processed_audio
                 .as_deref()
                 .unwrap_or(prepared_audio.as_slice());
-            // Publish per-slice progress for the UI; the guard clears the slot on
-            // any exit from this long-form path.
-            let slice_progress = LongformProgressGuard::begin(plan.slices.len());
+            // Publish per-slice decode progress for the UI, weighted by each
+            // slice's audio samples so the bar tracks decode time rather than slice
+            // number. The forced-align refine (if any) continues the same monotonic
+            // bar from the outer wrapper; the run-scoped guard clears the slot on
+            // any exit. `word_timestamps_refine` reserves headroom for that phase.
+            let with_align = request.word_timestamps_refine;
+            let total_decode_samples: u64 = plan
+                .slices
+                .iter()
+                .map(|slice| slice.duration_samples() as u64)
+                .sum();
+            let mut decode_progress = DecodeProgress::begin(total_decode_samples, with_align);
             for slice in plan.slices {
-                slice_progress.advance();
+                let slice_samples = slice.duration_samples() as u64;
                 let relative_start = slice
                     .content_start_sample
                     .saturating_sub(slice.start_sample);
@@ -457,6 +616,7 @@ fn run_native_transcription_impl(
                         segments: Vec::new(),
                         time_domain: SegmentTimeDomain::AbsoluteOriginal,
                     });
+                    decode_progress.complete_slice(slice_samples);
                     continue;
                 }
                 let mut slice_options = request_options.clone();
@@ -511,7 +671,11 @@ fn run_native_transcription_impl(
                     segments: transcription.segments,
                     time_domain: SegmentTimeDomain::RelativeToSliceContent,
                 });
+                decode_progress.complete_slice(slice_samples);
             }
+            // Decode done; the merge/resegment tail below runs uncounted otherwise,
+            // which is where the bar used to sit frozen at the last slice count.
+            publish_assemble_progress(with_align);
             let (assembled, assemble_stats) = assembler.into_parts();
             let run_metadata = build_longform_metadata(
                 &longform_options,
@@ -1279,15 +1443,47 @@ mod tests {
     use super::*;
 
     #[test]
-    fn longform_progress_guard_publishes_and_clears() {
+    fn native_progress_is_monotonic_across_phases_and_clears() {
         // No run active -> None (short single-pass decodes report nothing).
         assert_eq!(native_transcription_progress(), None);
         {
-            let guard = LongformProgressGuard::begin(3);
-            assert_eq!(native_transcription_progress(), Some((0, 3)));
-            guard.advance();
-            guard.advance();
-            assert_eq!(native_transcription_progress(), Some((2, 3)));
+            let _guard = NativeProgressGuard::new();
+            // Decode phase, weighted by sample share; a run that will forced-align
+            // reserves headroom above the decode ceiling.
+            let mut decode = DecodeProgress::begin(1000, true);
+            let start = native_transcription_progress().expect("run is active");
+            assert_eq!(start.phase, NativeTranscriptionPhase::Decode);
+            assert_eq!(start.fraction, 0.0);
+
+            decode.complete_slice(400);
+            let mid = native_transcription_progress().unwrap();
+            assert_eq!(mid.phase, NativeTranscriptionPhase::Decode);
+            assert!(mid.fraction >= start.fraction);
+            assert!((mid.fraction - DECODE_CEIL_WITH_ALIGN * 0.4).abs() < 1e-6);
+
+            decode.complete_slice(600);
+            let decoded = native_transcription_progress().unwrap();
+            assert!(decoded.fraction >= mid.fraction);
+            // All samples decoded -> exactly the decode ceiling.
+            assert!((decoded.fraction - DECODE_CEIL_WITH_ALIGN).abs() < 1e-6);
+
+            publish_assemble_progress(true);
+            let assembled = native_transcription_progress().unwrap();
+            assert_eq!(assembled.phase, NativeTranscriptionPhase::Assemble);
+            assert!(assembled.fraction >= decoded.fraction);
+            assert!((assembled.fraction - ASSEMBLE_CEIL_WITH_ALIGN).abs() < 1e-6);
+
+            publish_align_progress();
+            let aligning = native_transcription_progress().unwrap();
+            assert_eq!(aligning.phase, NativeTranscriptionPhase::Align);
+            assert!(aligning.fraction >= assembled.fraction);
+            assert!(aligning.fraction <= 1.0);
+
+            // A late lower report (e.g. an out-of-order slice) never moves the bar
+            // backward; only the phase label follows the latest report.
+            publish_progress(NativeTranscriptionPhase::Decode, 0.1);
+            let after = native_transcription_progress().unwrap();
+            assert_eq!(after.fraction, aligning.fraction);
         }
         // Guard dropped (completion / early return / panic) -> slot cleared.
         assert_eq!(native_transcription_progress(), None);

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -40,20 +40,49 @@ static NATIVE_GGML_EXECUTION_DISPATCH: OnceLock<GgmlAsrExecutionDispatch> = Once
 
 // Phase-aware progress for the in-flight native file transcription, published as
 // a single global slot. The local desktop daemon transcribes one file at a time,
-// so one slot is enough to drive the UI progress bar; concurrent runs on a single
-// daemon would share it. Progress is a monotonic overall fraction (0..=1) plus a
-// coarse phase label, so the UI advances smoothly across decode -> assemble ->
-// forced-align refine instead of stalling once the last slice decodes. The old
-// bare slice counter reached "done" at the last decode and then sat frozen through
-// assembly/merge and the whole-file forced-align pass, which read to users as a
-// bar stuck near the end (issue #61). Short single-pass decodes never activate the
-// slot (there are no slices to weight, and a single opaque decode call exposes no
-// sub-step), so callers see None and fall back to a time-based estimate.
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
+// so one slot is enough to drive the UI progress bar. The server's native path
+// has no concurrency gate, though (each request's native transcription runs on
+// its own `spawn_blocking` thread; see `routes/transcription.rs`), so more than
+// one `run_native_transcription` can be in flight at once against this one slot.
+// An owner generation (`PROGRESS_OWNER` / `NativeProgressGuard::generation`)
+// keeps a second, unrelated run from clobbering the first: only the run that is
+// actually reporting progress ever claims the slot, and only that run clears it
+// on exit. A short single-pass decode that never calls `publish_progress` (there
+// are no slices to weight, and a single opaque decode call exposes no sub-step)
+// never claims the slot and so never clears someone else's in-progress run out
+// from under it -- see `NativeProgressGuard` and `publish_progress` below.
+// Progress is a monotonic overall fraction (0..=1) plus a coarse phase label, so
+// the UI advances smoothly across decode -> assemble -> forced-align refine
+// instead of stalling once the last slice decodes. The old bare slice counter
+// reached "done" at the last decode and then sat frozen through assembly/merge
+// and the whole-file forced-align pass, which read to users as a bar stuck near
+// the end (issue #61). Short single-pass decodes never activate the slot, so
+// callers see None and fall back to a time-based estimate.
+use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
 
 static PROGRESS_ACTIVE: AtomicBool = AtomicBool::new(false);
 static PROGRESS_PHASE: AtomicU8 = AtomicU8::new(0);
 static PROGRESS_FRACTION_BITS: AtomicU32 = AtomicU32::new(0);
+
+// Owner generation of the progress slot: 0 means unclaimed. A non-zero value
+// names the `NativeProgressGuard` generation currently allowed to publish to
+// (and clear) the slot -- see `claim_or_check_progress_owner`.
+static PROGRESS_OWNER: AtomicU64 = AtomicU64::new(0);
+// Monotonically increasing counter, one draw per `NativeProgressGuard`, so
+// concurrent runs never collide on the same generation number. Starts
+// handing out generation 1 (0 is reserved for "unclaimed").
+static PROGRESS_GENERATION_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+thread_local! {
+    // The generation of the run currently executing on *this* thread, set by
+    // `NativeProgressGuard::new()` and read by the `publish_*` helpers so they
+    // don't need an extra parameter threaded through the whole decode/longform
+    // call stack. Native transcription runs synchronously on a single thread
+    // (the server's `spawn_blocking` worker, or the CLI's calling thread), so
+    // this is enough to attribute a `publish_progress` call to its guard.
+    static CURRENT_PROGRESS_GENERATION: Cell<u64> = const { Cell::new(0) };
+}
 
 // Heuristic phase ceilings the monotonic overall fraction climbs to at each phase
 // boundary -- not measured timings. Decode (autoregressive, per-slice) dominates;
@@ -125,29 +154,81 @@ pub fn native_transcription_progress() -> Option<NativeTranscriptionProgress> {
     Some(NativeTranscriptionProgress { phase, fraction })
 }
 
+/// Outcome of checking/claiming the progress slot's ownership for a generation.
+enum ProgressOwnership {
+    /// This generation already owns the slot; fold the report into the
+    /// existing monotonic max.
+    Owned,
+    /// The slot was unclaimed and this generation just claimed it. The
+    /// reported fraction is a fresh run's starting point, not a continuation,
+    /// so it must be written directly rather than maxed against whatever a
+    /// previous (already-cleared) owner left behind.
+    JustAcquired,
+    /// A different, still-live generation owns the slot; this generation must
+    /// not touch it.
+    Blocked,
+}
+
+/// Check whether `generation` owns the global progress slot, claiming it from
+/// the unclaimed (`0`) state if possible. Never takes the slot away from a
+/// different non-zero owner -- that owner is a live run and must not be
+/// clobbered by a second, unrelated run sharing this single global slot (the
+/// server has no concurrency gate on native transcription).
+fn claim_or_check_progress_owner(generation: u64) -> ProgressOwnership {
+    let owner = PROGRESS_OWNER.load(Ordering::Acquire);
+    if owner == generation {
+        return ProgressOwnership::Owned;
+    }
+    if owner != 0 {
+        return ProgressOwnership::Blocked;
+    }
+    match PROGRESS_OWNER.compare_exchange(0, generation, Ordering::AcqRel, Ordering::Acquire) {
+        Ok(_) => ProgressOwnership::JustAcquired,
+        Err(observed) if observed == generation => ProgressOwnership::Owned,
+        Err(_) => ProgressOwnership::Blocked,
+    }
+}
+
 /// Publish `phase` and raise the overall fraction monotonically (a later phase or a
 /// further-along slice never moves the bar backward). Activates the slot on the
-/// first report of a run.
+/// first report of a run. A no-op if a different, still-live run's generation
+/// currently owns the slot: a second run sharing this one global slot must never
+/// clobber another in-flight run's progress (see `NativeProgressGuard`).
 fn publish_progress(phase: NativeTranscriptionPhase, fraction: f32) {
+    let generation = CURRENT_PROGRESS_GENERATION.with(Cell::get);
     let clamped = fraction.clamp(0.0, 1.0);
-    PROGRESS_PHASE.store(phase.to_tag(), Ordering::Relaxed);
-    // Monotonic max on the f32 bits via a CAS loop: only ever raise the fraction.
-    let mut current = PROGRESS_FRACTION_BITS.load(Ordering::Relaxed);
-    loop {
-        let next = f32::from_bits(current).max(clamped);
-        match PROGRESS_FRACTION_BITS.compare_exchange_weak(
-            current,
-            next.to_bits(),
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-        ) {
-            Ok(_) => break,
-            Err(observed) => current = observed,
+    match claim_or_check_progress_owner(generation) {
+        ProgressOwnership::Blocked => {}
+        ProgressOwnership::JustAcquired => {
+            // Fresh start for this run: write directly instead of maxing
+            // against a stale value a previous (now-cleared) owner left.
+            PROGRESS_PHASE.store(phase.to_tag(), Ordering::Relaxed);
+            PROGRESS_FRACTION_BITS.store(clamped.to_bits(), Ordering::Relaxed);
+            // Release so a reader that observes `active` (Acquire) also sees the phase and
+            // fraction written above.
+            PROGRESS_ACTIVE.store(true, Ordering::Release);
+        }
+        ProgressOwnership::Owned => {
+            PROGRESS_PHASE.store(phase.to_tag(), Ordering::Relaxed);
+            // Monotonic max on the f32 bits via a CAS loop: only ever raise the fraction.
+            let mut current = PROGRESS_FRACTION_BITS.load(Ordering::Relaxed);
+            loop {
+                let next = f32::from_bits(current).max(clamped);
+                match PROGRESS_FRACTION_BITS.compare_exchange_weak(
+                    current,
+                    next.to_bits(),
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => break,
+                    Err(observed) => current = observed,
+                }
+            }
+            // Release so a reader that observes `active` (Acquire) also sees the phase and
+            // fraction written above.
+            PROGRESS_ACTIVE.store(true, Ordering::Release);
         }
     }
-    // Release so a reader that observes `active` (Acquire) also sees the phase and
-    // fraction written above.
-    PROGRESS_ACTIVE.store(true, Ordering::Release);
 }
 
 /// Enter the assembly/merge phase, raising the bar to that phase's ceiling.
@@ -209,18 +290,57 @@ impl DecodeProgress {
 /// `?` return, or a panic, so a stale fraction never leaks into the next run. Created
 /// once per `run_native_transcription` so its lifetime spans decode, assembly, and
 /// the forced-align refine.
-struct NativeProgressGuard;
+///
+/// Holds a unique `generation` so this guard only clears the slot in `Drop` if it
+/// is still the recognized owner (see `PROGRESS_OWNER` / `claim_or_check_progress_owner`).
+/// The server has no concurrency gate on native transcription, so a second,
+/// unrelated `run_native_transcription` can start and finish while a first one is
+/// still decoding; without this check the second run's guard would unconditionally
+/// clear the slot on both construction and drop and blank out the first run's
+/// progress mid-flight. A run that never calls `publish_progress` (a short
+/// single-pass decode has no slices to weight) never claims the slot at all, so it
+/// can never steal or clear another run's ownership.
+struct NativeProgressGuard {
+    generation: u64,
+}
 
 impl NativeProgressGuard {
     fn new() -> Self {
-        clear_progress_slot();
-        Self
+        // `fetch_add` returns the pre-increment value, so the first guard gets
+        // generation 1 -- 0 stays reserved for "unclaimed".
+        let generation = PROGRESS_GENERATION_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+        CURRENT_PROGRESS_GENERATION.with(|cell| cell.set(generation));
+        Self { generation }
     }
 }
 
 impl Drop for NativeProgressGuard {
     fn drop(&mut self) {
-        clear_progress_slot();
+        // Only clear this thread's attribution if it still names this guard's
+        // run (defensive against any future nested-guard usage on one thread).
+        CURRENT_PROGRESS_GENERATION.with(|cell| {
+            if cell.get() == self.generation {
+                cell.set(0);
+            }
+        });
+        // Only clear the shared slot if this generation is still the recognized
+        // owner -- i.e. this run actually published progress and no one else has
+        // claimed the slot since. A run that never published (never became
+        // owner) leaves the slot untouched, so it can't blank out a different,
+        // still-live run sharing this global slot.
+        //
+        // Order matters: reset the display atomics *before* releasing
+        // ownership (storing 0), not after. While `PROGRESS_OWNER` still reads
+        // this generation, `claim_or_check_progress_owner` blocks every other
+        // generation from claiming or publishing, so nothing can race the
+        // reset below. Releasing ownership first (e.g. via a plain
+        // compare-and-clear) would leave a window where a new run claims the
+        // slot and publishes its own fresh fraction, only for this drop's
+        // trailing `clear_progress_slot()` to immediately blank it back out.
+        if PROGRESS_OWNER.load(Ordering::Acquire) == self.generation {
+            clear_progress_slot();
+            PROGRESS_OWNER.store(0, Ordering::Release);
+        }
     }
 }
 
@@ -1441,9 +1561,22 @@ fn prefers_cpu_decoder_for_multichunk_metal(model_architecture: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // The tests in this module that exercise `native_transcription_progress`
+    // manipulate the real process-global progress statics (that is the point --
+    // they are the only way to observe the slot's owner-token behavior end to
+    // end), so they must not run concurrently with each other or one test's
+    // writes bleed into another's assertions. `cargo test` / `cargo nextest`
+    // run test functions across threads within one process, so serialize with
+    // a lock rather than relying on scheduling luck.
+    static PROGRESS_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn native_progress_is_monotonic_across_phases_and_clears() {
+        let _serialize = PROGRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         // No run active -> None (short single-pass decodes report nothing).
         assert_eq!(native_transcription_progress(), None);
         {
@@ -1486,6 +1619,109 @@ mod tests {
             assert_eq!(after.fraction, aligning.fraction);
         }
         // Guard dropped (completion / early return / panic) -> slot cleared.
+        assert_eq!(native_transcription_progress(), None);
+    }
+
+    /// Regression for the owner-token fix: the server has no concurrency gate
+    /// on native transcription, so a short single-pass decode (which never
+    /// calls `publish_progress`) can start and finish entirely while a longer,
+    /// still-decoding run owns the global progress slot. Before this fix,
+    /// `NativeProgressGuard::new()`/`Drop` unconditionally cleared the slot,
+    /// so the short run's guard blanked out the long run's progress out from
+    /// under it even though the short run never reported anything. This test
+    /// uses a real background thread for the long run (a distinct generation
+    /// lives in a distinct thread's `CURRENT_PROGRESS_GENERATION`) so the
+    /// short run's guard, created on the test's own thread, is a genuinely
+    /// different, concurrently-live generation -- not just a second guard in
+    /// the same call stack.
+    #[test]
+    fn native_progress_concurrent_short_run_does_not_clobber_owner() {
+        use std::sync::mpsc;
+        use std::thread;
+
+        let _serialize = PROGRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(native_transcription_progress(), None);
+
+        // The long run claims the slot and reports partial progress, then
+        // blocks (parked on `resume_rx`) until told to finish, standing in
+        // for a still-decoding long file.
+        let (resume_tx, resume_rx) = mpsc::channel::<()>();
+        let (owner_ready_tx, owner_ready_rx) = mpsc::channel::<()>();
+        let long_run = thread::spawn(move || {
+            let _long_guard = NativeProgressGuard::new();
+            publish_progress(NativeTranscriptionPhase::Decode, 0.4);
+            owner_ready_tx.send(()).expect("test thread still waiting");
+            resume_rx.recv().expect("test thread must signal resume");
+        });
+
+        owner_ready_rx
+            .recv()
+            .expect("long run must publish before signaling");
+        let owned = native_transcription_progress().expect("long run owns the slot");
+        assert_eq!(owned.phase, NativeTranscriptionPhase::Decode);
+        assert!((owned.fraction - 0.4).abs() < 1e-6);
+
+        // A second, unrelated run starts and finishes on this thread without
+        // ever publishing progress -- exactly what a short single-pass decode
+        // does. Its guard must not touch the long run's ownership at all.
+        {
+            let _short_guard = NativeProgressGuard::new();
+        }
+
+        let still_owned =
+            native_transcription_progress().expect("short run must not clear the long run");
+        assert_eq!(still_owned, owned);
+
+        // Only once the long run itself drops its guard does the slot clear.
+        resume_tx
+            .send(())
+            .expect("long run still waiting to resume");
+        long_run.join().expect("long run thread must not panic");
+        assert_eq!(native_transcription_progress(), None);
+    }
+
+    /// Sequential (non-overlapping) runs on the owner-token slot: the second
+    /// run's first report must reset the bar to its own starting point rather
+    /// than being maxed against whatever the first run left behind, and each
+    /// run's `Drop` must clear the slot for the next one.
+    #[test]
+    fn native_progress_sequential_runs_reset_start_and_clear() {
+        let _serialize = PROGRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(native_transcription_progress(), None);
+
+        {
+            let _run1 = NativeProgressGuard::new();
+            publish_progress(NativeTranscriptionPhase::Decode, 0.1);
+            publish_progress(NativeTranscriptionPhase::Decode, 0.9);
+            let run1_progress = native_transcription_progress().unwrap();
+            assert!((run1_progress.fraction - 0.9).abs() < 1e-6);
+        }
+        // run1's guard dropped -> cleared before run2 starts.
+        assert_eq!(native_transcription_progress(), None);
+
+        {
+            let _run2 = NativeProgressGuard::new();
+            // run2's first report is lower than run1's last fraction; it must
+            // become the new starting point, not be maxed against 0.9.
+            publish_progress(NativeTranscriptionPhase::Decode, 0.2);
+            let run2_start = native_transcription_progress().unwrap();
+            assert_eq!(run2_start.phase, NativeTranscriptionPhase::Decode);
+            assert!((run2_start.fraction - 0.2).abs() < 1e-6);
+
+            // Within run2 the monotonic max still holds.
+            publish_progress(NativeTranscriptionPhase::Decode, 0.05);
+            let run2_after_lower = native_transcription_progress().unwrap();
+            assert_eq!(run2_after_lower.fraction, run2_start.fraction);
+
+            publish_progress(NativeTranscriptionPhase::Assemble, 0.6);
+            let run2_assembled = native_transcription_progress().unwrap();
+            assert_eq!(run2_assembled.phase, NativeTranscriptionPhase::Assemble);
+            assert!((run2_assembled.fraction - 0.6).abs() < 1e-6);
+        }
         assert_eq!(native_transcription_progress(), None);
     }
 

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -66,23 +66,52 @@ pub(crate) async fn translations(
     .await
 }
 
+/// Fixed denominator for the backward-compatible `done`/`total` ratio: `done /
+/// total == fraction`. Only exists so clients that predate the `fraction` field
+/// keep working; new clients read `fraction` directly.
+const PROGRESS_LEGACY_SCALE: u32 = 1000;
+
 #[derive(serde::Serialize)]
 pub(crate) struct TranscriptionProgressBody {
-    /// Slices decoded so far in the in-flight long-form run.
-    done: usize,
-    /// Total slices in the in-flight long-form run; `0` when no long-form run is
-    /// active (the client then falls back to a time-based estimate).
-    total: usize,
+    /// Coarse phase label of the in-flight run (`"decode"`, `"assemble"`, or
+    /// `"align"`), or `null` when no native run is in flight. The UI may show this
+    /// as phase text (e.g. "Refining word timestamps") next to the bar.
+    phase: Option<&'static str>,
+    /// Monotonic overall progress in `0.0..=1.0`; `0.0` when idle. The UI progress
+    /// bar reads this directly -- it already spans decode, assembly, and the
+    /// forced-align refine, so it no longer stalls near the end.
+    fraction: f32,
+    /// Backward-compatible ratio for clients that predate `fraction`: `done/total`
+    /// equals `fraction`. `total` is `0` when idle, so legacy clients still fall
+    /// back to a time-based estimate exactly as before.
+    done: u32,
+    total: u32,
 }
 
-/// Coarse progress of the in-flight long-form file transcription, for the UI
-/// progress bar. Returns `{done:0,total:0}` when nothing long-form is running:
-/// short single-pass decodes have no slices to count, so the client estimates.
-/// Auth is enforced by the shared middleware like every other non-operator route.
+/// Progress of the in-flight file transcription, for the UI progress bar. Returns
+/// `{phase:null,fraction:0,done:0,total:0}` when nothing is running: short
+/// single-pass decodes expose no sub-step, so the client estimates from elapsed
+/// time. Auth is enforced by the shared middleware like every other non-operator
+/// route.
 pub(crate) async fn transcription_progress() -> Json<TranscriptionProgressBody> {
-    let (done, total) =
-        openasr_core::api::backend::native_transcription_progress().unwrap_or((0, 0));
-    Json(TranscriptionProgressBody { done, total })
+    let body = match openasr_core::api::backend::native_transcription_progress() {
+        Some(progress) => {
+            let fraction = progress.fraction.clamp(0.0, 1.0);
+            TranscriptionProgressBody {
+                phase: Some(progress.phase.label()),
+                fraction,
+                done: (fraction * PROGRESS_LEGACY_SCALE as f32).round() as u32,
+                total: PROGRESS_LEGACY_SCALE,
+            }
+        }
+        None => TranscriptionProgressBody {
+            phase: None,
+            fraction: 0.0,
+            done: 0,
+            total: 0,
+        },
+    };
+    Json(body)
 }
 
 /// Shared non-streaming transcription/translation core. `task_override` forces
@@ -1327,6 +1356,21 @@ mod native_runtime_tests {
         // uploads on that basis, matching pull.rs's `ensure_available_space`.
         let dir = std::path::Path::new("/tmp/openasr-upload-test");
         assert!(check_disk_headroom_bytes(None, dir).is_ok());
+    }
+
+    // Locks the wire shape of GET /v1/audio/transcriptions/progress. No native run
+    // is in flight in this unit test, so the idle body must stay backward
+    // compatible: `total == 0` keeps legacy clients on their time-based estimate,
+    // and the new `phase`/`fraction` fields are present (null / 0.0) for clients
+    // that read them.
+    #[tokio::test]
+    async fn transcription_progress_idle_body_is_backward_compatible() {
+        let axum::Json(body) = super::transcription_progress().await;
+        let value = serde_json::to_value(&body).expect("progress body serializes");
+        assert_eq!(value["phase"], serde_json::Value::Null);
+        assert_eq!(value["fraction"], serde_json::json!(0.0));
+        assert_eq!(value["done"], serde_json::json!(0));
+        assert_eq!(value["total"], serde_json::json!(0));
     }
 }
 


### PR DESCRIPTION
## Summary

Root-fixes the "progress bar stuck near the end" bug (#61) with a phase-aware,
monotonic overall-fraction progress model spanning decode -> assemble ->
forced-align refine, and closes a concurrency regression found in review: a
short, non-reporting native transcription could otherwise clear a longer
concurrent run's in-flight progress out from under it.

## Why

The old progress signal was a bare per-slice counter that advanced at the top
of the slice loop (off-by-one against real completion) and reached "done" at
the last slice decode, then sat frozen through assembly/merge and the
whole-file forced-align pass -- reading to users as a bar stuck near the end.

Additionally, the server has no concurrency gate on native transcription
(each request's native path runs on its own `spawn_blocking` thread), so more
than one `run_native_transcription` can be in flight against the single
global progress slot at once. The original `NativeProgressGuard` cleared that
slot unconditionally in both `new()` and `Drop`, so a short single-pass
decode (which never reports progress) racing a longer run could clear the
longer run's fraction mid-flight, flashing the UI back to idle.

## Changes

- `NativeTranscriptionPhase` (Decode/Assemble/Align) + a monotonic overall
  `fraction` (0..=1) replace the old per-slice counter. Decode is weighted by
  each slice's audio sample share (not a flat per-slice tick); assemble/merge
  and the forced-align refine each raise the bar to a phase ceiling. A later
  report never moves the bar backward.
- `run_native_transcription` spans the whole run (decode + assembly +
  optional forced-align refine) with one `NativeProgressGuard` so the slot
  clears on completion, an early `?` return, or a panic.
- Server `GET /v1/audio/transcriptions/progress` now returns
  `{ phase, fraction, done, total }`; `done`/`total` stay a backward-compatible
  ratio equal to `fraction` (`total=0` when idle) so existing clients keep
  working unchanged.
- **Concurrency fix (owner-token):** the global progress slot now has an
  owner generation (`PROGRESS_OWNER`, one unique generation per
  `NativeProgressGuard`). `publish_progress` only writes when the calling
  generation currently owns the slot (claiming it fresh from the unclaimed
  state resets the fraction to that call's value instead of maxing against a
  stale value); a different, still-live generation's report is a no-op.
  `Drop` only clears the slot if its generation is still the owner, and
  resets the display atomics *before* releasing ownership so a new owner's
  fresh publish can never be raced by a stale owner's trailing clear. A run
  that never calls `publish_progress` (a short single-pass decode has no
  slices to weight) never claims the slot at all, so it can no longer touch
  another run's progress.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2196 passed, 121 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

New/changed tests covering the concurrency fix:
- `native_progress_concurrent_short_run_does_not_clobber_owner`: a real
  background thread claims the slot and publishes partial progress (a
  distinct generation on a distinct thread); a second guard is created and
  dropped on the test's own thread without ever publishing (simulating a
  short single-pass decode racing it); asserts the long run's progress and
  ownership are untouched, and that only the long run's own `Drop` clears the
  slot.
- `native_progress_sequential_runs_reset_start_and_clear`: run1 publishes and
  its `Drop` clears the slot; run2's first (lower) report becomes the new
  starting point rather than being maxed against run1's stale value, then
  monotonic-max and phase behavior hold within run2, and its `Drop` clears.
- Existing `native_progress_is_monotonic_across_phases_and_clears` still
  passes unchanged (single-run monotonic/backward-compat shape).

## Manual smoke checks

None beyond the automated test suite above -- this is an internal progress
plumbing fix with no user-facing CLI/API surface change beyond the already
backward-compatible progress response shape.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

(No behavior/limitations doc changes needed: the wire contract
`{phase, fraction, done, total}` and backward-compat `done`/`total` semantics
were already documented/introduced by the base commit in this PR.)

## Scope / non-goals

- Does not add a concurrency gate to the server's native transcription path
  itself (multiple native runs can still execute concurrently); it only
  ensures the single shared progress slot's owner is never clobbered by an
  unrelated run.
- Two concurrent *long* runs still share one global slot, so the second
  long run's progress reports are no-ops (not displayed) while the first
  owns the slot -- an accepted limitation of a single global slot, not a
  regression from this change (the fix's job is to stop clobbering, not to
  add per-request progress tracking).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance (Claude), reviewed and validated locally by the submitter before opening this PR.