### PR TITLE
feat(server): add pause/resume/cancel control for in-flight file transcriptions

### DIFF
--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -10,10 +10,11 @@ mod native;
 
 pub use mock::transcribe_with_mock_backend;
 pub use native::{
-    NativeBackend, NativeBackendExecutor, NativeRuntimeModelAdapter, NativeRuntimeModelIdSource,
-    NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError, NativeTranscriptionPhase,
-    NativeTranscriptionProgress, native_runtime_model_adapter_for_path,
-    native_runtime_realtime_capabilities_for_path,
+    ActiveTranscriptionControlGuard, NativeBackend, NativeBackendExecutor,
+    NativeRuntimeModelAdapter, NativeRuntimeModelIdSource, NativeRuntimeModelIdentity,
+    NativeRuntimeModelIdentityError, NativeTranscriptionPhase, NativeTranscriptionProgress,
+    SliceBoundaryControl, TranscriptionControl, install_active_transcription_control,
+    native_runtime_model_adapter_for_path, native_runtime_realtime_capabilities_for_path,
     native_runtime_transcription_capabilities_for_path, native_transcription_progress,
     resolve_local_native_runtime_model_identity, validate_local_native_model_pack_path,
     validate_native_runtime_model_pack_contract,
@@ -712,6 +713,10 @@ pub enum BackendError {
         "Native ASR Core serve-batch decode is temporarily unavailable: {reason}\nThis is a transient condition; retry the request."
     )]
     ServeBatchUnavailable { reason: String, retryable: bool },
+    #[error(
+        "Native ASR Core transcription was canceled at a slice boundary before completion.\nThe already-decoded portion was discarded; no partial transcript is returned."
+    )]
+    TranscriptionCanceled,
     #[error(
         "word_timestamps_refine=true (--word-timestamps=aligned) requires word_timestamps=true.\nThe request was rejected instead of silently aligning without emitting words."
     )]

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -42,11 +42,17 @@ mod native_model_id;
 mod native_path;
 #[path = "native_transcribe.rs"]
 mod native_transcribe;
+#[path = "transcription_control.rs"]
+mod transcription_control;
 pub use native_model_id::{
     NativeRuntimeModelIdSource, NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError,
 };
 pub use native_transcribe::{
     NativeTranscriptionPhase, NativeTranscriptionProgress, native_transcription_progress,
+};
+pub use transcription_control::{
+    ActiveTranscriptionControlGuard, SliceBoundaryControl, TranscriptionControl,
+    install_active_transcription_control,
 };
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -713,7 +713,22 @@ fn run_native_transcription_impl(
                 .map(|slice| slice.duration_samples() as u64)
                 .sum();
             let mut decode_progress = DecodeProgress::begin(total_decode_samples, with_align);
+            // In-session pause/cancel control for this in-flight transcription,
+            // bound to this decode thread by the caller (see
+            // `install_active_transcription_control`). Checked at each slice
+            // boundary: a cancel unwinds cleanly with `TranscriptionCanceled`
+            // (dropping the assembler and progress guard), and a pause blocks the
+            // worker here until resume or cancel. Absent (CLI / no control
+            // registered) leaves the decode byte-identical to before.
+            let transcription_control =
+                super::transcription_control::current_transcription_control();
             for slice in plan.slices {
+                if let Some(control) = &transcription_control
+                    && control.wait_at_slice_boundary()
+                        == super::transcription_control::SliceBoundaryControl::Canceled
+                {
+                    return Err(BackendError::TranscriptionCanceled);
+                }
                 let slice_samples = slice.duration_samples() as u64;
                 let relative_start = slice
                     .content_start_sample

--- a/crates/openasr-core/src/api/backend/transcription_control.rs
+++ b/crates/openasr-core/src/api/backend/transcription_control.rs
@@ -1,0 +1,272 @@
+//! In-session pause / resume / cancel control for a running native file
+//! transcription.
+//!
+//! Mirrors the pull-job control model (an `Arc` of shared control flags held by
+//! both the request handler and the worker), but the signal reaches the deep
+//! long-form decode loop through a thread-local install guard -- the same trick
+//! [`super::native_transcribe::native_transcription_progress`] uses to avoid
+//! threading a handle through the whole executor API surface. The native decode
+//! runs synchronously on one thread (the server's `spawn_blocking` worker or the
+//! CLI's calling thread), so a thread-local is enough for the slice loop to find
+//! its control.
+//!
+//! Scope is deliberately in-session: the control lives only for one in-flight
+//! transcription. Cross-request or cross-restart resume (which would need
+//! persisted partial decode state) is out of scope.
+
+use std::cell::RefCell;
+use std::sync::{Arc, Condvar, Mutex};
+
+/// Outcome of a slice-boundary control check inside the long-form decode loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SliceBoundaryControl {
+    /// Keep decoding the next slice.
+    Continue,
+    /// A cancel was requested; stop decoding and unwind cleanly.
+    Canceled,
+}
+
+#[derive(Default)]
+struct ControlState {
+    cancel: bool,
+    pause: bool,
+}
+
+/// Shared pause / cancel control for one in-flight native transcription.
+///
+/// The server registers one of these per in-flight file transcription (keyed by
+/// a client-supplied job id) so its pause/resume/cancel HTTP handlers can flip
+/// the flags while the blocking decode runs on a `spawn_blocking` worker. The
+/// worker reads the same handle at each long-form slice boundary via
+/// [`current_transcription_control`]. Cancel wins over pause.
+pub struct TranscriptionControl {
+    state: Mutex<ControlState>,
+    // Signaled on resume or cancel so a worker blocked at a paused slice
+    // boundary wakes promptly instead of busy-waiting.
+    resumed_or_canceled: Condvar,
+}
+
+impl TranscriptionControl {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(ControlState::default()),
+            resumed_or_canceled: Condvar::new(),
+        }
+    }
+
+    /// Request cancellation at the next slice boundary. Idempotent. Wakes a
+    /// paused worker so it observes the cancel instead of staying blocked.
+    pub fn request_cancel(&self) {
+        let mut state = self.lock();
+        state.cancel = true;
+        self.resumed_or_canceled.notify_all();
+    }
+
+    /// Request a pause at the next slice boundary. Idempotent, and a no-op once
+    /// canceled (cancel wins and must not be masked by a late pause).
+    pub fn request_pause(&self) {
+        let mut state = self.lock();
+        if !state.cancel {
+            state.pause = true;
+        }
+    }
+
+    /// Clear a pending pause and wake a worker blocked at a slice boundary.
+    pub fn request_resume(&self) {
+        let mut state = self.lock();
+        state.pause = false;
+        self.resumed_or_canceled.notify_all();
+    }
+
+    /// Whether a cancel has been requested.
+    pub fn is_canceled(&self) -> bool {
+        self.lock().cancel
+    }
+
+    /// Whether a pause is pending (and not superseded by a cancel).
+    pub fn is_paused(&self) -> bool {
+        let state = self.lock();
+        state.pause && !state.cancel
+    }
+
+    /// Called by the decode loop at each slice boundary. Returns immediately with
+    /// `Canceled` when a cancel is pending; otherwise blocks while paused until a
+    /// resume or cancel arrives, then returns `Continue` (or `Canceled` if the
+    /// wait ended in a cancel).
+    ///
+    /// Holds the worker thread while paused. That is acceptable for the
+    /// single-file desktop scenario this targets: a paused transcription keeps
+    /// its `spawn_blocking` worker and its open HTTP request until it is resumed
+    /// or canceled. Releasing and re-entering the decode would require persisting
+    /// partial decode state, which is the out-of-scope cross-request resume.
+    pub fn wait_at_slice_boundary(&self) -> SliceBoundaryControl {
+        let mut state = self.lock();
+        loop {
+            if state.cancel {
+                return SliceBoundaryControl::Canceled;
+            }
+            if !state.pause {
+                return SliceBoundaryControl::Continue;
+            }
+            state = self
+                .resumed_or_canceled
+                .wait(state)
+                .expect("transcription control mutex poisoned");
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, ControlState> {
+        self.state
+            .lock()
+            .expect("transcription control mutex poisoned")
+    }
+}
+
+impl Default for TranscriptionControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for TranscriptionControl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (cancel, pause) = match self.state.lock() {
+            Ok(state) => (state.cancel, state.pause),
+            Err(_) => (false, false),
+        };
+        f.debug_struct("TranscriptionControl")
+            .field("cancel", &cancel)
+            .field("pause", &pause)
+            .finish()
+    }
+}
+
+thread_local! {
+    // The control bound to the run currently executing on *this* thread, set by
+    // `install_active_transcription_control` and read by the long-form decode
+    // loop. Native transcription runs synchronously on a single thread, so this
+    // is enough to attribute the slice-boundary checks to the right control
+    // without threading a handle through the executor API.
+    static CURRENT_TRANSCRIPTION_CONTROL: RefCell<Option<Arc<TranscriptionControl>>> =
+        const { RefCell::new(None) };
+}
+
+/// RAII guard that binds a [`TranscriptionControl`] to the current thread for the
+/// duration of one native transcription and restores the previous binding on
+/// drop (normal return, early `?`, or panic), so a control never leaks into an
+/// unrelated later run on the same pooled worker thread.
+#[must_use = "the control binding is cleared when this guard is dropped"]
+pub struct ActiveTranscriptionControlGuard {
+    previous: Option<Arc<TranscriptionControl>>,
+}
+
+impl Drop for ActiveTranscriptionControlGuard {
+    fn drop(&mut self) {
+        CURRENT_TRANSCRIPTION_CONTROL.with(|cell| {
+            *cell.borrow_mut() = self.previous.take();
+        });
+    }
+}
+
+/// Bind `control` to the current thread so the in-flight native transcription's
+/// long-form slice loop observes pause/cancel requests. Returns a guard that
+/// restores the previous binding on drop. Install this at the top of the
+/// synchronous decode (e.g. inside the server's `spawn_blocking` closure).
+pub fn install_active_transcription_control(
+    control: Arc<TranscriptionControl>,
+) -> ActiveTranscriptionControlGuard {
+    let previous = CURRENT_TRANSCRIPTION_CONTROL.with(|cell| cell.replace(Some(control)));
+    ActiveTranscriptionControlGuard { previous }
+}
+
+/// The control bound to the current thread, if any. Read by the long-form decode
+/// loop at each slice boundary.
+pub(crate) fn current_transcription_control() -> Option<Arc<TranscriptionControl>> {
+    CURRENT_TRANSCRIPTION_CONTROL.with(|cell| cell.borrow().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn cancel_before_boundary_returns_canceled() {
+        let control = TranscriptionControl::new();
+        control.request_cancel();
+        assert!(control.is_canceled());
+        assert_eq!(
+            control.wait_at_slice_boundary(),
+            SliceBoundaryControl::Canceled
+        );
+    }
+
+    #[test]
+    fn no_control_boundary_continues() {
+        let control = TranscriptionControl::new();
+        assert_eq!(
+            control.wait_at_slice_boundary(),
+            SliceBoundaryControl::Continue
+        );
+    }
+
+    #[test]
+    fn pause_blocks_until_resume_then_continues() {
+        let control = Arc::new(TranscriptionControl::new());
+        control.request_pause();
+        assert!(control.is_paused());
+
+        let entered = Arc::new(AtomicBool::new(false));
+        let worker_control = Arc::clone(&control);
+        let worker_entered = Arc::clone(&entered);
+        let worker = thread::spawn(move || {
+            worker_entered.store(true, Ordering::SeqCst);
+            worker_control.wait_at_slice_boundary()
+        });
+
+        // Give the worker time to reach the blocking wait, then confirm it has
+        // not returned yet (it is parked on the paused boundary).
+        while !entered.load(Ordering::SeqCst) {
+            thread::yield_now();
+        }
+        thread::sleep(Duration::from_millis(50));
+        assert!(!worker.is_finished(), "worker returned before resume");
+
+        control.request_resume();
+        assert_eq!(worker.join().unwrap(), SliceBoundaryControl::Continue);
+    }
+
+    #[test]
+    fn cancel_while_paused_wakes_and_returns_canceled() {
+        let control = Arc::new(TranscriptionControl::new());
+        control.request_pause();
+
+        let worker_control = Arc::clone(&control);
+        let worker = thread::spawn(move || worker_control.wait_at_slice_boundary());
+
+        thread::sleep(Duration::from_millis(20));
+        control.request_cancel();
+        assert_eq!(worker.join().unwrap(), SliceBoundaryControl::Canceled);
+        // Cancel wins: a pause requested afterward must not clear the cancel.
+        control.request_pause();
+        assert!(control.is_canceled());
+        assert!(!control.is_paused());
+    }
+
+    #[test]
+    fn install_guard_binds_and_clears_thread_local() {
+        assert!(current_transcription_control().is_none());
+        let control = Arc::new(TranscriptionControl::new());
+        {
+            let _guard = install_active_transcription_control(Arc::clone(&control));
+            let bound = current_transcription_control().expect("control bound while guard alive");
+            assert!(Arc::ptr_eq(&bound, &control));
+        }
+        assert!(
+            current_transcription_control().is_none(),
+            "control binding must clear when the guard drops"
+        );
+    }
+}

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -46,11 +46,12 @@ pub mod testing;
 pub(crate) mod translation;
 
 pub use api::backend::{
-    BackendError, BackendKind, ExecutionTarget, NATIVE_RUNTIME_MODEL_ID_AUTO, NativeBackend,
-    NativeBackendExecutor, NativeRuntimeModelAdapter, NativeRuntimeModelIdSource,
-    NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError, Segment, Transcription,
-    TranscriptionBackend, TranscriptionRequest, TranscriptionTask, WordTimestamp,
-    add_segment_word_timestamps, native_adapter_supports_source_language_hint,
+    ActiveTranscriptionControlGuard, BackendError, BackendKind, ExecutionTarget,
+    NATIVE_RUNTIME_MODEL_ID_AUTO, NativeBackend, NativeBackendExecutor, NativeRuntimeModelAdapter,
+    NativeRuntimeModelIdSource, NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError,
+    Segment, SliceBoundaryControl, Transcription, TranscriptionBackend, TranscriptionControl,
+    TranscriptionRequest, TranscriptionTask, WordTimestamp, add_segment_word_timestamps,
+    install_active_transcription_control, native_adapter_supports_source_language_hint,
     native_runtime_model_adapter_for_path, native_runtime_realtime_capabilities_for_path,
     native_runtime_transcription_capabilities_for_path,
     resolve_local_native_runtime_model_identity, validate_local_native_model_pack_path,

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -180,6 +180,18 @@ pub fn app_with_runtime_and_distribution_and_launch_options(
             "/v1/audio/transcriptions/progress",
             get(transcription_progress),
         )
+        .route(
+            "/v1/audio/transcriptions/{id}/cancel",
+            post(cancel_transcription_job),
+        )
+        .route(
+            "/v1/audio/transcriptions/{id}/pause",
+            post(pause_transcription_job),
+        )
+        .route(
+            "/v1/audio/transcriptions/{id}/resume",
+            post(resume_transcription_job),
+        )
         .route("/v1/audio/translations", post(translations))
         .route("/v1/audio/realtime", any(realtime::websocket))
         .layer(middleware::from_fn_with_state(
@@ -838,14 +850,50 @@ impl Default for DistributionRuntime {
 pub(crate) struct DistributionContext {
     runtime: DistributionRuntime,
     jobs: Arc<DistributionJobs>,
+    // In-flight file transcriptions that opted into control, keyed by the
+    // client-supplied transcription id. The pause/resume/cancel HTTP handlers
+    // flip these flags while the blocking decode runs on a `spawn_blocking`
+    // worker. In-session only: an entry lives just for one transcription's
+    // lifetime and is cleared when the request returns.
+    transcriptions: Arc<Mutex<HashMap<String, Arc<openasr_core::TranscriptionControl>>>>,
 }
 
 impl DistributionContext {
     fn new(runtime: DistributionRuntime) -> Self {
         Self {
             jobs: Arc::new(DistributionJobs::new(load_persisted_pull_jobs(&runtime))),
+            transcriptions: Arc::new(Mutex::new(HashMap::new())),
             runtime,
         }
+    }
+
+    fn register_transcription(
+        &self,
+        transcription_id: &str,
+        control: Arc<openasr_core::TranscriptionControl>,
+    ) {
+        self.transcriptions
+            .lock()
+            .expect("active transcription registry mutex poisoned")
+            .insert(transcription_id.to_string(), control);
+    }
+
+    fn clear_transcription(&self, transcription_id: &str) {
+        self.transcriptions
+            .lock()
+            .expect("active transcription registry mutex poisoned")
+            .remove(transcription_id);
+    }
+
+    fn transcription_control(
+        &self,
+        transcription_id: &str,
+    ) -> Option<Arc<openasr_core::TranscriptionControl>> {
+        self.transcriptions
+            .lock()
+            .expect("active transcription registry mutex poisoned")
+            .get(transcription_id)
+            .cloned()
     }
 
     fn openasr_home(&self) -> Result<PathBuf, ApiError> {
@@ -1707,6 +1755,10 @@ impl IntoResponse for ApiError {
                             StatusCode::SERVICE_UNAVAILABLE
                         }
                     }
+                    // A caller-requested cancel is not a fault: the client asked
+                    // to stop this in-flight transcription. 409 distinguishes it
+                    // from the 400 fail-closed refusals and the 5xx faults.
+                    openasr_core::BackendError::TranscriptionCanceled => StatusCode::CONFLICT,
                 };
                 (status, format!("Could not transcribe audio: {error}"))
             }

--- a/crates/openasr-server/src/realtime/mod.rs
+++ b/crates/openasr-server/src/realtime/mod.rs
@@ -194,7 +194,7 @@ pub(crate) async fn stream_transcription(
             send_sse(&sender, started).await;
         }
 
-        match transcribe_with_runtime(runtime, request).await {
+        match transcribe_with_runtime(runtime, request, None).await {
             Ok(transcription) => {
                 let end_ms = transcription_end_ms(&transcription);
                 let history_transcription = transcription.clone();

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -670,7 +670,7 @@ async fn run_realtime_backend_job(runtime: ServerRuntime, job: BackendJob) -> Ba
         .with_execution_target(job.execution_target)
         .with_word_timestamps(job.word_timestamps)
         .with_display_file_name(Some(job.display_name));
-    match transcribe_with_runtime(runtime, request).await {
+    match transcribe_with_runtime(runtime, request, None).await {
         Ok(transcription) => {
             let words = realtime_words_from_transcription(&transcription);
             BackendResult::Final(BackendSuccess {

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1,7 +1,7 @@
 //! HTTP transcription/translation handlers and all supporting helpers.
 //! Pure code-motion from `lib.rs`; shared crate-root items come via `use crate::*`.
 
-use std::{io::Write, path::Path, str::FromStr};
+use std::{io::Write, path::Path, str::FromStr, sync::Arc};
 
 use openasr_core::config::load_config_document;
 use openasr_core::realtime::history::{
@@ -114,6 +114,85 @@ pub(crate) async fn transcription_progress() -> Json<TranscriptionProgressBody> 
     Json(body)
 }
 
+/// Wire status returned by the pause/resume/cancel control endpoints.
+#[derive(serde::Serialize)]
+pub(crate) struct TranscriptionControlBody {
+    /// The client-supplied transcription id the control acted on.
+    id: String,
+    /// The requested control state: `"paused"`, `"running"` (after resume), or
+    /// `"canceled"`. This is the request that was recorded on the in-flight run;
+    /// the actual decode observes it at the next long-form slice boundary.
+    state: &'static str,
+}
+
+/// RAII cleanup that removes an in-flight transcription's control from the
+/// registry when the request handler returns (success, error, or cancel), so a
+/// finished transcription's id can never be paused/canceled afterward.
+struct ActiveTranscriptionCleanup {
+    distribution: DistributionContext,
+    transcription_id: String,
+}
+
+impl Drop for ActiveTranscriptionCleanup {
+    fn drop(&mut self) {
+        self.distribution
+            .clear_transcription(&self.transcription_id);
+    }
+}
+
+fn control_body_response(id: String, state: &'static str) -> Result<Response, ApiError> {
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(TranscriptionControlBody { id, state }),
+    )
+        .into_response())
+}
+
+fn active_transcription_control(
+    distribution: &DistributionContext,
+    id: &str,
+) -> Result<Arc<openasr_core::TranscriptionControl>, ApiError> {
+    distribution.transcription_control(id).ok_or_else(|| {
+        ApiError::NotFound(format!(
+            "No in-flight transcription with id '{id}'. It may have already finished, been canceled, or never opted into control (missing transcription_id)."
+        ))
+    })
+}
+
+/// `POST /v1/audio/transcriptions/{id}/cancel`: cancel an in-flight file
+/// transcription. The decode stops at the next long-form slice boundary and the
+/// original transcription request fails closed with a canceled status; the
+/// already-decoded portion is discarded (see `BackendError::TranscriptionCanceled`).
+pub(crate) async fn cancel_transcription_job(
+    AxumPath(id): AxumPath<String>,
+    Extension(distribution): Extension<DistributionContext>,
+) -> Result<Response, ApiError> {
+    active_transcription_control(&distribution, &id)?.request_cancel();
+    control_body_response(id, "canceled")
+}
+
+/// `POST /v1/audio/transcriptions/{id}/pause`: pause an in-flight file
+/// transcription at the next long-form slice boundary. The decode thread (and
+/// the original request) block until a matching resume or cancel arrives.
+pub(crate) async fn pause_transcription_job(
+    AxumPath(id): AxumPath<String>,
+    Extension(distribution): Extension<DistributionContext>,
+) -> Result<Response, ApiError> {
+    active_transcription_control(&distribution, &id)?.request_pause();
+    control_body_response(id, "paused")
+}
+
+/// `POST /v1/audio/transcriptions/{id}/resume`: resume a paused in-flight file
+/// transcription. Decoding continues from the next slice within the same
+/// in-flight run, keeping the already-accumulated segments.
+pub(crate) async fn resume_transcription_job(
+    AxumPath(id): AxumPath<String>,
+    Extension(distribution): Extension<DistributionContext>,
+) -> Result<Response, ApiError> {
+    active_transcription_control(&distribution, &id)?.request_resume();
+    control_body_response(id, "running")
+}
+
 /// Shared non-streaming transcription/translation core. `task_override` forces
 /// the task regardless of the request body (used by the translations alias) and
 /// wins over both the multipart field and saved preferences.
@@ -160,7 +239,40 @@ async fn run_offline_transcription(
         validate_native_request_model(&runtime, &parsed.request.model_id)
             .map_err(ApiError::BadRequest)?;
     }
-    let transcription = transcribe_with_runtime(runtime, parsed.request).await?;
+    // Register an in-session pause/cancel control when the client supplied a
+    // transcription id and the native backend is in use (control acts at
+    // long-form slice boundaries; the mock backend has no such loop). The
+    // cleanup guard removes the registry entry on every exit -- success, error,
+    // or cancel.
+    let control = (runtime.backend == BackendKind::Native)
+        .then(|| parsed.transcription_id.clone())
+        .flatten()
+        .map(|id| {
+            let control = Arc::new(openasr_core::TranscriptionControl::new());
+            distribution.register_transcription(&id, Arc::clone(&control));
+            (id, control)
+        });
+    let _control_cleanup = control.as_ref().map(|(id, _)| ActiveTranscriptionCleanup {
+        distribution: distribution.clone(),
+        transcription_id: id.clone(),
+    });
+    let control_handle = control.as_ref().map(|(_, control)| Arc::clone(control));
+    let transcription =
+        match transcribe_with_runtime(runtime, parsed.request, control_handle.clone()).await {
+            Ok(transcription) => transcription,
+            Err(error) => {
+                // A cancel surfaces from core as a generic fail-closed error (the
+                // typed cancel is flattened through the NativeAsrError layer), so
+                // consult the control to report it honestly as a 409 canceled result
+                // rather than a 400 fail-closed refusal.
+                if control_handle.is_some_and(|control| control.is_canceled()) {
+                    return Err(ApiError::Backend(
+                        openasr_core::BackendError::TranscriptionCanceled,
+                    ));
+                }
+                return Err(error);
+            }
+        };
     let rendered = render_transcription(&transcription, parsed.response_format)
         .map_err(ApiError::Serialize)?;
     // History is a best-effort audit side-write: a successful transcription must
@@ -268,6 +380,12 @@ pub(crate) struct TranscriptionQuery {
 pub(crate) struct ParsedTranscriptionRequest {
     pub(crate) request: TranscriptionRequest,
     pub(crate) response_format: ResponseFormat,
+    /// Optional client-supplied id for this transcription. When present, the
+    /// handler registers a pause/cancel control under it so the
+    /// `/v1/audio/transcriptions/{id}/{pause,resume,cancel}` endpoints can act on
+    /// the in-flight run. Absent (older clients) keeps today's uncontrolled,
+    /// run-to-completion behavior.
+    pub(crate) transcription_id: Option<String>,
     pub(crate) _uploaded_file: tempfile::TempPath,
 }
 
@@ -275,6 +393,7 @@ struct TranscriptionRequestBuilder {
     file_name: Option<String>,
     saw_file: bool,
     uploaded_file: Option<tempfile::TempPath>,
+    transcription_id: Option<String>,
     model: Option<String>,
     language: Option<String>,
     task: Option<TranscriptionTask>,
@@ -304,6 +423,7 @@ impl Default for TranscriptionRequestBuilder {
             file_name: None,
             saw_file: false,
             uploaded_file: None,
+            transcription_id: None,
             model: None,
             language: None,
             task: None,
@@ -342,6 +462,11 @@ impl TranscriptionRequestBuilder {
                     .and_then(safe_extension_suffix)
                     .unwrap_or_default();
                 self.uploaded_file = Some(write_upload_temp_file_streaming(field, &suffix).await?);
+            }
+            "transcription_id" => {
+                let value = field.text().await.map_err(ApiError::Multipart)?;
+                let trimmed = value.trim();
+                self.transcription_id = (!trimmed.is_empty()).then(|| trimmed.to_string());
             }
             "model" => {
                 self.model = Some(field.text().await.map_err(ApiError::Multipart)?);
@@ -450,6 +575,7 @@ impl TranscriptionRequestBuilder {
             file_name,
             saw_file,
             uploaded_file,
+            transcription_id,
             model,
             language,
             task,
@@ -563,6 +689,7 @@ impl TranscriptionRequestBuilder {
         Ok(ParsedTranscriptionRequest {
             request,
             response_format,
+            transcription_id,
             _uploaded_file: uploaded_file,
         })
     }
@@ -1019,9 +1146,14 @@ fn validate_timestamp_granularities(values: &[String]) -> Result<(), ApiError> {
 pub(crate) async fn transcribe_with_runtime(
     runtime: ServerRuntime,
     request: TranscriptionRequest,
+    control: Option<Arc<openasr_core::TranscriptionControl>>,
 ) -> Result<openasr_core::Transcription, ApiError> {
     match runtime.backend {
         BackendKind::Mock => {
+            // The mock backend runs a single opaque decode with no slice loop, so
+            // there is no boundary to observe a pause/cancel; the control (if any)
+            // is simply not installed here.
+            let _ = &control;
             let prepared = prepare_audio_input(
                 &request.input_path,
                 &AudioPreparationOptions::new(runtime.backend),
@@ -1039,6 +1171,11 @@ pub(crate) async fn transcribe_with_runtime(
             Ok(transcription)
         }
         BackendKind::Native => tokio::task::spawn_blocking(move || {
+            // Bind the pause/cancel control to this decode thread for the whole
+            // synchronous run so the long-form slice loop can observe it; the
+            // guard clears the binding on any exit. `None` (no control requested)
+            // leaves the decode byte-identical to before.
+            let _control_guard = control.map(openasr_core::install_active_transcription_control);
             let model_pack_path = runtime.model_pack_path.clone().ok_or_else(|| {
                 TranscriptionRuntimeError::Backend(
                     openasr_core::BackendError::NativeModelPackPathRejected {

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -128,13 +128,55 @@ pub(crate) struct TranscriptionControlBody {
 /// RAII cleanup that removes an in-flight transcription's control from the
 /// registry when the request handler returns (success, error, or cancel), so a
 /// finished transcription's id can never be paused/canceled afterward.
+///
+/// This is also the leak-prevention safety net for a client that disconnects
+/// mid-run. A paused (or still-decoding) native transcription holds its
+/// `spawn_blocking` worker thread parked on `TranscriptionControl`'s Condvar
+/// until a resume/cancel arrives; if the client goes away first (closes the
+/// connection, or the app quits), nothing would ever wake that thread. Axum
+/// drops the handler's async future when the connection closes, which drops
+/// every local still live at the suspended `.await` point -- including this
+/// guard. While `armed`, `Drop` fires `control.request_cancel()` so the
+/// worker wakes at the next slice boundary (immediately, if it was parked
+/// mid-pause) and unwinds through `TranscriptionCanceled` instead of leaking
+/// its thread forever. `disarm()` is called right after the decode call
+/// returns on its own (success or failure) -- from that point on there is no
+/// more worker thread to protect, so a normal completion must never also
+/// fire a spurious cancel.
 struct ActiveTranscriptionCleanup {
     distribution: DistributionContext,
     transcription_id: String,
+    control: Arc<openasr_core::TranscriptionControl>,
+    armed: bool,
+}
+
+impl ActiveTranscriptionCleanup {
+    fn new(
+        distribution: DistributionContext,
+        transcription_id: String,
+        control: Arc<openasr_core::TranscriptionControl>,
+    ) -> Self {
+        Self {
+            distribution,
+            transcription_id,
+            control,
+            armed: true,
+        }
+    }
+
+    /// Disarms the disconnect-cancel safety net. Call this once the decode
+    /// call has returned by itself (success or failure); doing so before then
+    /// would let a genuine mid-decode disconnect leak the worker thread.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
 }
 
 impl Drop for ActiveTranscriptionCleanup {
     fn drop(&mut self) {
+        if self.armed {
+            self.control.request_cancel();
+        }
         self.distribution
             .clear_transcription(&self.transcription_id);
     }
@@ -252,15 +294,26 @@ async fn run_offline_transcription(
             distribution.register_transcription(&id, Arc::clone(&control));
             (id, control)
         });
-    let _control_cleanup = control.as_ref().map(|(id, _)| ActiveTranscriptionCleanup {
-        distribution: distribution.clone(),
-        transcription_id: id.clone(),
+    // Armed for as long as the decode call below is in flight: if the client
+    // disconnects and axum drops this handler future first, `Drop` cancels the
+    // control so the (possibly paused) worker thread wakes and exits instead
+    // of leaking. Disarmed immediately after that call returns, either way.
+    let mut control_cleanup = control.as_ref().map(|(id, control)| {
+        ActiveTranscriptionCleanup::new(distribution.clone(), id.clone(), Arc::clone(control))
     });
     let control_handle = control.as_ref().map(|(_, control)| Arc::clone(control));
     let transcription =
         match transcribe_with_runtime(runtime, parsed.request, control_handle.clone()).await {
-            Ok(transcription) => transcription,
+            Ok(transcription) => {
+                if let Some(cleanup) = control_cleanup.as_mut() {
+                    cleanup.disarm();
+                }
+                transcription
+            }
             Err(error) => {
+                if let Some(cleanup) = control_cleanup.as_mut() {
+                    cleanup.disarm();
+                }
                 // A cancel surfaces from core as a generic fail-closed error (the
                 // typed cancel is flattened through the NativeAsrError layer), so
                 // consult the control to report it honestly as a 409 canceled result
@@ -933,6 +986,77 @@ mod native_model_ref_tests {
             "qwen3-asr-0.6b:typo",
             "qwen3-asr-0.6b:q8_0"
         ));
+    }
+}
+
+/// Coverage for the disconnect-cancel safety net: `ActiveTranscriptionCleanup`
+/// must cancel the control when dropped while still armed (simulating the
+/// handler future being dropped mid-decode on a client disconnect), and must
+/// not when disarmed first (the normal completion path).
+#[cfg(test)]
+mod active_transcription_cleanup_tests {
+    use std::sync::Arc;
+
+    use super::{ActiveTranscriptionCleanup, DistributionContext, DistributionRuntime};
+
+    fn distribution_for_test() -> DistributionContext {
+        DistributionContext::new(DistributionRuntime {
+            openasr_home: None,
+            catalog_url: None,
+        })
+    }
+
+    #[test]
+    fn drop_while_armed_cancels_control_and_clears_registry() {
+        let distribution = distribution_for_test();
+        let control = Arc::new(openasr_core::TranscriptionControl::new());
+        distribution.register_transcription("txn-disconnect", Arc::clone(&control));
+
+        {
+            let _cleanup = ActiveTranscriptionCleanup::new(
+                distribution.clone(),
+                "txn-disconnect".to_string(),
+                Arc::clone(&control),
+            );
+            assert!(!control.is_canceled());
+            // Dropped here without ever calling `disarm()`, exactly as happens
+            // when a client disconnects and axum drops the handler future
+            // before the decode call above it returns.
+        }
+
+        assert!(
+            control.is_canceled(),
+            "a disconnect before disarm must cancel the control so a paused/decoding worker thread wakes and exits"
+        );
+        assert!(
+            distribution
+                .transcription_control("txn-disconnect")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn disarm_then_drop_does_not_cancel_but_still_clears_registry() {
+        let distribution = distribution_for_test();
+        let control = Arc::new(openasr_core::TranscriptionControl::new());
+        distribution.register_transcription("txn-normal", Arc::clone(&control));
+
+        {
+            let mut cleanup = ActiveTranscriptionCleanup::new(
+                distribution.clone(),
+                "txn-normal".to_string(),
+                Arc::clone(&control),
+            );
+            cleanup.disarm();
+            // Normal completion path: disarmed right after the decode call
+            // returns, before this guard drops at the end of the handler.
+        }
+
+        assert!(
+            !control.is_canceled(),
+            "a normal completion must never fire a spurious cancel"
+        );
+        assert!(distribution.transcription_control("txn-normal").is_none());
     }
 }
 

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -1282,6 +1282,56 @@ async fn pull_job_control_ack_sets_flag_without_terminal_state_flip() {
     distribution.clear_active_job("pull-control");
 }
 
+#[tokio::test]
+async fn transcription_control_endpoints_flip_pause_resume_cancel_flags() {
+    let temp = tempfile::tempdir().unwrap();
+    let distribution = distribution_context_for_test(temp.path());
+    let control = Arc::new(openasr_core::TranscriptionControl::new());
+    distribution.register_transcription("txn-1", Arc::clone(&control));
+
+    pause_transcription_job(
+        AxumPath("txn-1".to_string()),
+        Extension(distribution.clone()),
+    )
+    .await
+    .unwrap();
+    assert!(control.is_paused());
+
+    resume_transcription_job(
+        AxumPath("txn-1".to_string()),
+        Extension(distribution.clone()),
+    )
+    .await
+    .unwrap();
+    assert!(!control.is_paused());
+
+    cancel_transcription_job(
+        AxumPath("txn-1".to_string()),
+        Extension(distribution.clone()),
+    )
+    .await
+    .unwrap();
+    assert!(control.is_canceled());
+
+    // Cleared entry (finished run) and unknown ids both fail closed with 404.
+    distribution.clear_transcription("txn-1");
+    assert!(distribution.transcription_control("txn-1").is_none());
+    let error = cancel_transcription_job(
+        AxumPath("txn-1".to_string()),
+        Extension(distribution.clone()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(error, ApiError::NotFound(_)));
+}
+
+#[test]
+fn transcription_canceled_backend_error_maps_to_409() {
+    let response =
+        ApiError::Backend(openasr_core::BackendError::TranscriptionCanceled).into_response();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
 #[test]
 fn pull_job_reuses_existing_nonterminal_snapshot_for_same_pull() {
     let temp = tempfile::tempdir().unwrap();
@@ -1407,7 +1457,9 @@ async fn native_transcribe_stays_fail_closed_with_local_pack_only_validation() {
         model_pack_path: Some(pack_root),
     };
     let request = TranscriptionRequest::new(sample_wav, "whisper-large-v3-turbo");
-    let error = transcribe_with_runtime(runtime, request).await.unwrap_err();
+    let error = transcribe_with_runtime(runtime, request, None)
+        .await
+        .unwrap_err();
     let rendered = error.to_string();
     assert!(rendered.contains("Could not transcribe audio"));
 }


### PR DESCRIPTION
## Summary

The file-transcription path had no real cancellation pipeline: the `POST
/v1/audio/transcriptions` handler blocked until the `spawn_blocking` decode
thread finished, so a client-side "cancel" only dropped the HTTP response --
the daemon kept decoding to completion, burning CPU for nothing. This PR adds
real in-session pause/resume/cancel control for native file transcriptions,
plus an automatic cancel-on-disconnect safety net.

## Why

A user reported being unable to pause a long file transcription mid-run.
Investigating showed the "cancel" was cosmetic: there was no control plane
reaching the decode thread at all.

## Changes

- New `TranscriptionControl` (Mutex + Condvar, cancel takes priority over
  pause) with a thread-local install guard binding the handle to the decode
  thread, mirroring the existing progress owner-generation pattern so the
  deep slice-loop code doesn't need to thread a new parameter through the
  executor API.
- `native_transcribe.rs`: the slice loop now calls `wait_at_slice_boundary()`
  at each slice boundary. Cancel does a clean early-return unwind (the
  assembler/progress guards drop via normal stack unwind -- no panic, no
  partial output emitted); pause blocks on the Condvar until resume or
  cancel; resume continues the same task, keeping already-accumulated
  segments. With no control installed, behavior is byte-identical to before.
- An active-transcription registry keyed by the client-supplied
  `transcription_id`.
- Server routes: `POST /v1/audio/transcriptions/{id}/pause|resume|cancel`
  return `202 {id, state}`; unknown/not-in-flight ids return `404`; a POST to
  a transcription cancelled this way completes with `409`. The original
  transcribe request accepts an optional multipart `transcription_id` field
  -- omitting it falls back to the previous, uncontrollable behavior, so this
  is backward compatible.
- Client-disconnect safety net: a RAII guard calls `request_cancel()` if the
  handler future is dropped (client disconnect) before decode returns. This
  immediately wakes a paused decode thread via the Condvar and prevents
  thread leaks; normal completion disarms the guard so it never fires
  spuriously.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2205 passed)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

9 new tests cover: control-primitive cancel / pause-blocks-then-resume /
cancel-while-paused wakes immediately / thread-local binding cleanup; server
endpoints flipping control flags plus 404 on unknown id; the 409 mapping for
POSTs cancelled this way; and the disconnect guard (armed -> cancel fires,
disarmed -> no cancel). Also re-ran `golden_diff` (byte-exact, 2 passed) and
the bundled catalog signature check, since this touches the native
transcription path.

## Manual smoke checks

N/A -- covered by the automated integration tests above (server route tests
exercise the pause/resume/cancel HTTP contract end-to-end against the
in-process test server).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

No user-facing docs describe the previous (fake) cancel behavior, so there is
nothing to correct; the new HTTP control endpoints are internal/API-surface
additions without an existing doc section to update in this PR. A follow-up
should document the new endpoints once the desktop UI consumes them.

## Scope / non-goals

- Cancelling discards already-transcribed partial output and returns `409`
  on the original request -- cancel means "abandon this run", not "return
  what we have so far".
- Cancel/pause only take effect on the long-audio / multi-slice path. A
  short single-slice decode has no slice boundary to check at and will run
  to completion (fast in practice) -- consistent with the in-session,
  slice-boundary design.
- `transcription_id` uniqueness is the client's responsibility. The registry
  is keyed by that id, so a reused id overwrites the earlier slot; the worst
  case is that HTTP control becomes unreliable for one of the runs or hits
  the wrong run, but it never leaks a thread, corrupts a result, or panics --
  the disconnect safety net holds its own `Arc` directly rather than going
  through the registry, so it is unaffected by id collisions. This is a
  client-error fail-safe, not silent data corruption.
- The desktop UI pause button is not part of this PR; the endpoint/contract
  is in place for a follow-up.
- Cross-request or cross-restart persisted resume is out of scope -- control
  is in-session only, for the lifetime of the original HTTP request.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implementation drafted with AI assistance (control primitive, slice-boundary wiring, server routes, and tests), reviewed and approved by the maintainer before merge.
