### PR TITLE
ci(release): fix clang-cl step so the windows-arm64 cross-compile leg builds

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -356,16 +356,18 @@ jobs:
         # preinstalls LLVM, but pull it via choco if a runner image ever drops
         # it. build.rs invokes `clang-cl` off PATH.
         run: |
-          $clangCl = Get-Command clang-cl -ErrorAction SilentlyContinue
-          if (-not $clangCl) {
+          $existing = Get-Command clang-cl -ErrorAction SilentlyContinue
+          if ($existing) {
+            $clangClPath = $existing.Source
+          } else {
             $llvmBin = "C:\Program Files\LLVM\bin"
             if (-not (Test-Path "$llvmBin\clang-cl.exe")) { choco install llvm -y }
             Add-Content $env:GITHUB_PATH $llvmBin
-            $clangCl = "$llvmBin\clang-cl.exe"
+            $clangClPath = "$llvmBin\clang-cl.exe"
           }
           # GITHUB_PATH only affects later steps; verify via the resolved path so
           # this step works even right after a fresh install.
-          & (if ($clangCl -is [string]) { $clangCl } else { $clangCl.Source }) --version
+          & $clangClPath --version
 
       - name: Ensure Ninja
         if: runner.os == 'Windows' && (matrix.features == 'vulkan' || matrix.features == 'cuda' || matrix.features == 'hip' || matrix.rust_target == 'aarch64-pc-windows-msvc')


### PR DESCRIPTION
## Summary

Fix the PowerShell syntax error in the `Ensure clang-cl (windows-arm64)` release step that made the `aarch64-pc-windows-msvc` leg fail before ggml even started compiling.

## Why

The windows-arm64 release leg (experimental) has been failing. The ggml ARM64 cross-compile fixes in `build.rs` -- `CMAKE_SYSTEM_PROCESSOR=ARM64`, disabling `GGML_CPU_ALL_VARIANTS` for arm64, the clang-cl `--target=arm64-pc-windows-msvc` driver, and the Ninja generator -- were already in place, but never actually got exercised on CI because the clang-cl verification step itself errored out first:

```
The term 'if' is not recognized as a name of a cmdlet
```

The offending line used the call operator with an `if` expression inside its parentheses (`& (if ($x -is [string]) { $x } else { $x.Source }) --version`); PowerShell parses the leading `if` in that position as a command name, not an expression, and fails to parse the step.

## Changes

- `.github/workflows/release-binaries.yml`, `Ensure clang-cl (windows-arm64)` step only: resolve the clang-cl path into a plain string variable in the if/else branches and invoke `& $clangClPath --version`, avoiding the `if` expression inside the call-operator parentheses. (6 insertions, 4 deletions.)

## Tests run

- [x] Triggered one `workflow_dispatch` dry run (`dry_run=true`, no upload) on this branch.
  - The `aarch64-pc-windows-msvc` job completed **success** end to end: Install MSVC ARM64 tools -> Ensure clang-cl (now passes) -> Ninja -> add cross Rust target -> Build release binary (ggml ARM64 cross-compile + link) -> Package archive -> Upload archive.
  - The earlier `ggml-cpu-sse42` LNK1120 / x64-vs-ARM64 machine-type failures did not recur -- the build.rs arch fixes are now validated on CI.
- No Rust source changed; workspace build/test is unaffected by this workflow-only change.

## Manual smoke checks

Dry run only (`dry_run=true`, dispatched on a branch not a tag), so the upload leg is a no-op and no release was touched.

## Docs updated

- [x] The workflow comment already documents how to promote this leg once green (see Scope).

## Scope / non-goals

- Keeps the leg **experimental** (`continue-on-error`). Promoting it -- removing `experimental: true` and adding `windows-arm64` to the `verify-completeness` TARGETS so it becomes a required release asset -- is a separate release decision, not included here.
- Windows-arm64 asset is still not a gating asset for a release with this change.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- diagnosed from CI logs and fixed with AI assistance; the maintainer owns, verifies, and merges the change.
