### PR TITLE
ci(weights): parse build_commit with jq in deploy verify

### DIFF
--- a/.github/workflows/deploy-weights.yml
+++ b/.github/workflows/deploy-weights.yml
@@ -56,7 +56,7 @@ jobs:
           # failing on the first stale hit.
           for attempt in $(seq 1 12); do
             body="$(curl -fsSL "https://weights.openasr.org/_version?cb=${GITHUB_SHA}-${attempt}" || true)"
-            if echo "$body" | grep -q "\"build_commit\":\"${GITHUB_SHA}\""; then
+            if [ "$(printf '%s' "$body" | jq -r '.build_commit // empty' 2>/dev/null)" = "${GITHUB_SHA}" ]; then
               echo "live weights.openasr.org reports build_commit=${GITHUB_SHA}"
               exit 0
             fi


### PR DESCRIPTION
## Summary

Fix the `Deploy weights proxy` verify step so it stops failing on a correct deploy.

## Why

The step grepped for `"build_commit":"<sha>"` (no space after the colon), but `GET /_version` returns pretty-printed JSON with a space (`"build_commit": "<sha>"`). The pattern never matched, so every weights-worker deploy failed the verify step even when the live `BUILD_COMMIT` already equalled `github.sha` (observed on the #45 merge: the deploy succeeded, the worker reported the right commit, but verify still errored after 12 attempts).

## Changes

- `.github/workflows/deploy-weights.yml`: extract `build_commit` with `jq -r` and compare it exactly to `github.sha`, instead of a whitespace-sensitive grep.

## Tests run

- [x] Workflow-only change; no Rust source touched. The fixed verify will be exercised by the next deploy-weights run.

## Scope / non-goals

- Comparison/robustness fix only; deploy logic, provenance model, and trust model are unchanged.

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio committed.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- diagnosed and fixed with AI assistance; maintainer owns and merges.