### PR TITLE
refactor(core): single-source model capability declarations in arch descriptors

### DIFF
--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -17,11 +17,10 @@ use crate::models::builtin_execution_dispatch::build_builtin_ggml_streaming_exec
 use crate::models::executor_component_registry::builtin_executor_supports_phrase_bias_for_model_architecture;
 use crate::models::ggml_family_adapter::GgmlFamilyAdapterDescriptor;
 use crate::models::ggml_family_registry::{
-    COHERE_TRANSCRIBE_GGML_ADAPTER_ID, COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
-    DOLPHIN_GGML_ARCHITECTURE_ID, GgmlFamilyRegistry, MOONSHINE_GGML_ARCHITECTURE_ID,
-    PARAKEET_CTC_GGML_ARCHITECTURE_ID, QWEN3_ASR_GGML_ARCHITECTURE_ID,
-    WAV2VEC2_CTC_GGML_ARCHITECTURE_ID, WHISPER_GGML_ARCHITECTURE_ID,
-    XASR_ZIPFORMER_GGML_ARCHITECTURE_ID,
+    COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID, DOLPHIN_GGML_ARCHITECTURE_ID, GgmlFamilyRegistry,
+    MOONSHINE_GGML_ARCHITECTURE_ID, PARAKEET_CTC_GGML_ARCHITECTURE_ID,
+    QWEN3_ASR_GGML_ARCHITECTURE_ID, WAV2VEC2_CTC_GGML_ARCHITECTURE_ID,
+    WHISPER_GGML_ARCHITECTURE_ID, XASR_ZIPFORMER_GGML_ARCHITECTURE_ID,
 };
 use crate::models::oasr_metadata::{
     OASR_FEATURE_DIARIZATION_COHERE_TOKEN_STREAM_V1, OASR_METADATA_KEY_FEATURE_DIARIZATION,
@@ -86,7 +85,7 @@ impl NativeRuntimeModelAdapter {
             .with_timestamps(true)
             .with_diarization(native_runtime_metadata_supports_diarization(
                 metadata,
-                descriptor.adapter_id,
+                descriptor.self_diarizes,
             ))
             .with_quantized_models(true)
             .with_hardware_acceleration(true);
@@ -789,11 +788,18 @@ pub(crate) fn native_runtime_path_supports_diarization(path: &Path) -> bool {
         .is_some_and(|adapter| adapter.capabilities().supports_diarization)
 }
 
+/// Diarization support for a runtime pack: the family must be capable of
+/// self-diarizing (`GgmlFamilyAdapterDescriptor::self_diarizes`, declared once
+/// on the arch descriptor -- see `arch::OpenAsrArchitectureDescriptor::self_diarizes`)
+/// AND the specific pack must carry the runtime metadata/tokens a real
+/// self-diarizing decode needs. The family-level fact is descriptor-driven so
+/// no call site re-derives "which family self-diarizes" from an `adapter_id`
+/// string match; only the per-pack verification stays here.
 pub(crate) fn native_runtime_metadata_supports_diarization(
     metadata: &crate::GgufMetadata,
-    adapter_id: &str,
+    self_diarizes: bool,
 ) -> bool {
-    adapter_id == COHERE_TRANSCRIBE_GGML_ADAPTER_ID
+    self_diarizes
         && metadata
             .get_string(OASR_METADATA_KEY_FEATURE_DIARIZATION)
             .is_some_and(|value| value.trim() == OASR_FEATURE_DIARIZATION_COHERE_TOKEN_STREAM_V1)
@@ -1281,7 +1287,10 @@ mod tests {
 
         let adapter = native_runtime_model_adapter_for_path(&runtime_path).unwrap();
 
-        assert_eq!(adapter.adapter_id(), COHERE_TRANSCRIBE_GGML_ADAPTER_ID);
+        assert_eq!(
+            adapter.adapter_id(),
+            crate::COHERE_TRANSCRIBE_GGML_ADAPTER_ID
+        );
         assert_eq!(adapter.model_family(), "cohere-transcribe");
         let capabilities = adapter.capabilities();
         assert!(capabilities.is_native_adapter());

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -524,7 +524,7 @@ fn run_native_transcription_impl(
     // model-agnostic neural VAD + active speaker-embedder pack is available.
     let model_self_diarizes = super::native_runtime_metadata_supports_diarization(
         &runtime_preflight.metadata,
-        selected_family.adapter_id,
+        selected_family.self_diarizes,
     );
     let vad_diarization = request.diarize && !model_self_diarizes;
     if vad_diarization

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -182,6 +182,31 @@ pub(crate) struct OpenAsrArchitectureDescriptor {
     pub executor_component_id: &'static str,
     pub execution_capability: GgmlExecutionCapability,
     pub prefer_cpu_decoder_for_multichunk_metal: bool,
+    /// Whether this family's own decode loop can emit diarization tokens (the
+    /// cohere token-stream is the only builtin case today). The single
+    /// declaration of this architecture-level capability fact -- runtime
+    /// dispatch reads it via `GgmlFamilyAdapterDescriptor::self_diarizes`
+    /// rather than matching on `adapter_id` (see
+    /// `native_runtime_metadata_supports_diarization`, which still verifies
+    /// the specific pack actually carries the tokens before trusting this).
+    pub self_diarizes: bool,
+    /// Whether this family's transcripts include punctuation -- an
+    /// architecture/training-corpus property, not a per-release editorial
+    /// choice (e.g. Dolphin's training corpus has no punctuation to learn
+    /// from, so it is honestly `Some(false)`). `None` means "no fixed
+    /// per-family answer" (e.g. a CTC/character family whose vocab depends on
+    /// the specific imported checkpoint, not the architecture).
+    ///
+    /// This is the single Rust-side declaration of the fact; catalog
+    /// authoring (`tooling/publish-model/scripts/_catalog.py`'s
+    /// `PUNCTUATION_BY_FAMILY`) is hand-kept in lockstep with it (no
+    /// Rust<->Python codegen bridge exists yet) and
+    /// `registry/tests/catalog.rs`'s `embedded_catalog_emits_punctuation_matches_family`
+    /// cross-checks the shipped catalog against
+    /// [`emits_punctuation_for_model_architecture`] so the two cannot drift
+    /// silently. `registry::CatalogModel::emits_punctuation` is a read-only
+    /// wire mirror of the catalog value, not an independent declaration.
+    pub emits_punctuation: Option<bool>,
     /// Canonical required GGUF/`.oasr` hparam keys for this architecture.
     /// Authoritative source of truth for the hparam schema; the per-arch
     /// runtime contract resolves aliases and optional consistency keys on top.
@@ -210,8 +235,25 @@ impl OpenAsrArchitectureDescriptor {
             tokenizer_id: self.tokenizer_id,
             decode_policy_id: self.decode_policy_id,
             execution_capability: self.execution_capability,
+            self_diarizes: self.self_diarizes,
         }
     }
+}
+
+/// Whether a builtin family's decoder ever predicts a punctuation token (see
+/// [`OpenAsrArchitectureDescriptor::emits_punctuation`]), looked up by GGUF
+/// `model_architecture`. The single Rust-side accessor for this fact --
+/// mirrors `executor_component_registry::builtin_executor_supports_phrase_bias_for_model_architecture`'s
+/// per-architecture lookup shape. Only test-consumed today (same pending-wiring
+/// status as `punctuation::should_apply_punctuation`, which this is meant to
+/// feed once the restoration stage is wired into a transcription path), hence
+/// the explicit allow rather than `#[cfg(test)]` -- this is the intended
+/// production accessor, not test-only scaffolding.
+#[allow(dead_code)]
+pub(crate) fn emits_punctuation_for_model_architecture(model_architecture: &str) -> Option<bool> {
+    OpenAsrArchitectureRegistry::with_builtins()
+        .find_by_model_architecture(model_architecture)
+        .and_then(|descriptor| descriptor.emits_punctuation)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -777,6 +819,8 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: COHERE_TRANSCRIBE_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: true,
+        self_diarizes: true,
+        emits_punctuation: Some(true),
         hparam_schema: COHERE_TRANSCRIBE_HPARAM_SCHEMA,
         block_stack: Some(OpenAsrBlockStackDescriptor {
             orchestration_shape: OpenAsrOrchestrationShape::Seq2SeqEncoderDecoder,
@@ -805,6 +849,8 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: WHISPER_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        emits_punctuation: Some(true),
         hparam_schema: WHISPER_HPARAM_SCHEMA,
         // whisper remains the hand-written bit-level regression gate and is
         // never composed — no block-stack data until P9 sinks its optimizations
@@ -831,6 +877,8 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: QWEN3_ASR_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::NativeGraphLoweringV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        emits_punctuation: Some(true),
         hparam_schema: QWEN3_ASR_HPARAM_SCHEMA,
         block_stack: Some(OpenAsrBlockStackDescriptor {
             orchestration_shape: OpenAsrOrchestrationShape::LlmDecoder,
@@ -859,6 +907,13 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: PARAKEET_CTC_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        // Character/BPE CTC: whether an imported checkpoint's vocab includes
+        // punctuation depends on that specific checkpoint's training corpus,
+        // not the architecture, so this cannot be stated as a fixed
+        // per-family fact (mirrors `_catalog.py`'s `PUNCTUATION_BY_FAMILY`
+        // module docstring, which deliberately omits parakeet/wav2vec2).
+        emits_punctuation: None,
         hparam_schema: PARAKEET_CTC_HPARAM_SCHEMA,
         // Non-autoregressive CTC: encoder + CTC head only, no decoder stage.
         block_stack: Some(OpenAsrBlockStackDescriptor {
@@ -892,6 +947,11 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: PARAKEET_TDT_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        // Verified on the imported pack: trained on transcripts that preserve
+        // punctuation and capitalization (mirrors `_catalog.py`'s
+        // `PUNCTUATION_BY_FAMILY["parakeet-tdt"]`).
+        emits_punctuation: Some(true),
         hparam_schema: PARAKEET_TDT_HPARAM_SCHEMA,
         // The FastConformer encoder reuses the composer conformer block, but
         // the TDT decode loop (LSTM prediction network + duration-driven
@@ -913,6 +973,9 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: WAV2VEC2_CTC_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        // Character CTC: same BYO-checkpoint reasoning as parakeet-ctc above.
+        emits_punctuation: None,
         hparam_schema: WAV2VEC2_CTC_HPARAM_SCHEMA,
         // Non-autoregressive CTC: raw-waveform conv extractor + post-norm
         // transformer encoder + CTC head, no decoder stage.
@@ -941,6 +1004,8 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: XASR_ZIPFORMER_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        emits_punctuation: Some(true),
         hparam_schema: XASR_ZIPFORMER_HPARAM_SCHEMA,
         // Zipformer2 uses multi-scale streaming cache topology plus RNN-T
         // decoder/joiner, so it stays on its dedicated executor rather than the
@@ -960,6 +1025,8 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: MOONSHINE_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        emits_punctuation: Some(true),
         hparam_schema: MOONSHINE_HPARAM_SCHEMA,
         // Raw-waveform conv-stem + partial-RoPE seq2seq with a self-contained
         // dedicated executor (not the data-driven block-stack composer — its
@@ -984,6 +1051,11 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: DOLPHIN_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        // DataoceanAI's cn-dialect-small training corpus is transcribed
+        // without punctuation and the model has no punctuation-prediction
+        // head/token to enable -- honestly unpunctuated, not "unknown".
+        emits_punctuation: Some(false),
         hparam_schema: DOLPHIN_HPARAM_SCHEMA,
         // E-Branchformer encoder + Transformer decoder + CTC head stay on the
         // dedicated executor (the E-Branchformer block is not a composer block
@@ -1005,6 +1077,8 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: SENSEVOICE_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        emits_punctuation: Some(true),
         hparam_schema: SENSEVOICE_HPARAM_SCHEMA,
         // Non-autoregressive CTC: SAN-M/FSMN encoder + CTC head, no decoder
         // stage. The `tp.blk` stage rides the same dedicated executor; the
@@ -1036,6 +1110,11 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: FIRERED_AED_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        self_diarizes: false,
+        // The reference tokenizer's dict.txt has no punctuation/<space>
+        // entries (char + SPM vocab trained on unpunctuated Mandarin ASR
+        // corpora); verified on the golden-diff fixture transcript.
+        emits_punctuation: Some(false),
         hparam_schema: FIRERED_AED_HPARAM_SCHEMA,
         // Conformer encoder + Transformer decoder attention-only decode stays
         // on the dedicated executor (the Conformer block is not a composer
@@ -1053,6 +1132,59 @@ mod tests {
         OpenAsrArchitectureRegistry::with_builtins()
             .validate_references()
             .expect("builtins must reference known components");
+    }
+
+    /// Pins `self_diarizes` and `emits_punctuation` per builtin architecture --
+    /// the single Rust-side declaration of both capability-single-source facts
+    /// this test protects against silent drift. Cohere-transcribe is the only
+    /// builtin family that self-diarizes; `emits_punctuation` values mirror
+    /// `tooling/publish-model/scripts/_catalog.py`'s `PUNCTUATION_BY_FAMILY`
+    /// (`registry/tests/catalog.rs`'s `embedded_catalog_emits_punctuation_matches_family`
+    /// cross-checks the shipped catalog against
+    /// [`emits_punctuation_for_model_architecture`] so the two stay in lockstep).
+    #[test]
+    fn builtin_architectures_declare_self_diarizes_and_emits_punctuation() {
+        let expected: &[(&str, bool, Option<bool>)] = &[
+            (COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID, true, Some(true)),
+            (WHISPER_GGML_ARCHITECTURE_ID, false, Some(true)),
+            (QWEN3_ASR_GGML_ARCHITECTURE_ID, false, Some(true)),
+            (PARAKEET_CTC_GGML_ARCHITECTURE_ID, false, None),
+            (PARAKEET_TDT_GGML_ARCHITECTURE_ID, false, Some(true)),
+            (WAV2VEC2_CTC_GGML_ARCHITECTURE_ID, false, None),
+            (XASR_ZIPFORMER_GGML_ARCHITECTURE_ID, false, Some(true)),
+            (MOONSHINE_GGML_ARCHITECTURE_ID, false, Some(true)),
+            (DOLPHIN_GGML_ARCHITECTURE_ID, false, Some(false)),
+            (SENSEVOICE_GGML_ARCHITECTURE_ID, false, Some(true)),
+            (FIRERED_AED_GGML_ARCHITECTURE_ID, false, Some(false)),
+        ];
+        let registry = OpenAsrArchitectureRegistry::with_builtins();
+        let mut seen = std::collections::BTreeSet::new();
+
+        for (model_architecture, self_diarizes, emits_punctuation) in expected.iter().copied() {
+            let descriptor = registry
+                .find_by_model_architecture(model_architecture)
+                .unwrap_or_else(|| panic!("missing builtin architecture '{model_architecture}'"));
+            assert_eq!(
+                descriptor.self_diarizes, self_diarizes,
+                "'{model_architecture}' self_diarizes mismatch"
+            );
+            assert_eq!(
+                descriptor.emits_punctuation, emits_punctuation,
+                "'{model_architecture}' emits_punctuation mismatch"
+            );
+            assert_eq!(
+                emits_punctuation_for_model_architecture(model_architecture),
+                emits_punctuation,
+                "'{model_architecture}' accessor must match the descriptor field"
+            );
+            seen.insert(model_architecture);
+        }
+
+        assert_eq!(
+            seen.len(),
+            registry.descriptors().len(),
+            "expectation table must cover every builtin architecture, no more, no less"
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/models/ggml_family_adapter.rs
+++ b/crates/openasr-core/src/models/ggml_family_adapter.rs
@@ -70,6 +70,14 @@ pub struct GgmlFamilyAdapterDescriptor {
     pub decode_policy_id: &'static str,
     pub execution_capability: GgmlExecutionCapability,
     pub language_family_hint: LanguageFamilyHint,
+    /// Whether this family's own decode loop produces the diarization tokens
+    /// (e.g. the cohere token-stream's `<|diarize|>`/`<|spltoken0|>`), the
+    /// single declaration of this architecture-level fact. Mirrored from
+    /// `arch::OpenAsrArchitectureDescriptor::self_diarizes`; a pack still has
+    /// to carry the actual runtime metadata for this to activate (see
+    /// `native_runtime_metadata_supports_diarization`), so this flag alone is
+    /// "capable of", not "this exact pack does".
+    pub self_diarizes: bool,
 }
 
 impl GgmlFamilyAdapterDescriptor {

--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -277,11 +277,19 @@ pub struct CatalogModel {
     // signed catalog stays byte-identical while empty.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upstream_release_date: Option<String>,
-    // Whether the model's transcripts include punctuation, derived at
-    // catalog-authoring time (tooling/publish-model/scripts/_catalog.py's
-    // `punctuation_for_model`) from the model's family -- an architecture/
-    // training-corpus property, not a per-release editorial choice. `None`
-    // means "unknown" (a catalog predating this field, or a kind core has no
+    // Whether the model's transcripts include punctuation -- an architecture/
+    // training-corpus property, not a per-release editorial choice. This field
+    // is a read-only wire mirror, not an independent declaration: the single
+    // Rust-side source of truth is
+    // `arch::OpenAsrArchitectureDescriptor::emits_punctuation` (see
+    // `arch::emits_punctuation_for_model_architecture`), and catalog authoring
+    // (`tooling/publish-model/scripts/_catalog.py`'s `punctuation_for_model` /
+    // `PUNCTUATION_BY_FAMILY`) is hand-kept in lockstep with it -- there is no
+    // Rust<->Python codegen bridge yet, so
+    // `registry/tests/catalog.rs`'s `embedded_catalog_emits_punctuation_matches_family`
+    // cross-checks the shipped catalog against the descriptor value for every
+    // family both sides know about, to catch drift. `None` means "unknown" (a
+    // catalog predating this field, or a kind core has no
     // transcript-punctuation axis for, e.g. capability-pack); consumers must
     // treat `None` as "assume punctuated" (`true`) rather than surfacing a
     // false "no punctuation" notice for an older/omitted entry. Only

--- a/crates/openasr-core/src/registry/tests/catalog.rs
+++ b/crates/openasr-core/src/registry/tests/catalog.rs
@@ -1055,6 +1055,40 @@ fn embedded_catalog_emits_punctuation_matches_family() {
         "dolphin's training corpus is unpunctuated; it never predicts punctuation tokens"
     );
 
+    // Cross-check the catalog's Python-authored values against the Rust arch
+    // descriptor's single declaration of this fact
+    // (`arch::OpenAsrArchitectureDescriptor::emits_punctuation`, via
+    // `emits_punctuation_for_model_architecture`) so `_catalog.py`'s
+    // `PUNCTUATION_BY_FAMILY` cannot silently drift from the compiled-in
+    // engine fact for any family both sides know about.
+    for (id, model_architecture) in [
+        ("qwen3-asr-1.7b", crate::QWEN3_ASR_GGML_ARCHITECTURE_ID),
+        (
+            "xasr-zh-en",
+            crate::arch::XASR_ZIPFORMER_GGML_ARCHITECTURE_ID,
+        ),
+        (
+            "cohere-transcribe-03-2026",
+            crate::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
+        ),
+        ("moonshine-tiny", crate::MOONSHINE_GGML_ARCHITECTURE_ID),
+        (
+            "sensevoice-small",
+            crate::arch::SENSEVOICE_GGML_ARCHITECTURE_ID,
+        ),
+        ("whisper-base", crate::WHISPER_GGML_ARCHITECTURE_ID),
+        (
+            "dolphin-cn-dialect-small",
+            crate::arch::DOLPHIN_GGML_ARCHITECTURE_ID,
+        ),
+    ] {
+        assert_eq!(
+            find(id).emits_punctuation,
+            crate::arch::emits_punctuation_for_model_architecture(model_architecture),
+            "'{id}' catalog emits_punctuation must match the arch descriptor's declared value"
+        );
+    }
+
     // hymt2 (translation-model) and the diarization capability packs have no
     // ASR transcript-punctuation axis, so the field is omitted rather than guessed.
     for id in [

--- a/tooling/publish-model/scripts/_catalog.py
+++ b/tooling/publish-model/scripts/_catalog.py
@@ -374,6 +374,21 @@ def language_mode_for_model(entry: dict, languages: list[str]) -> dict:
 # disclose this in the model card and market UI rather than leave it
 # unexplained. Every other current asr-model family's training data/tokenizer
 # supports punctuation and its transcripts include it.
+#
+# Conceptual single source of truth: the Rust engine's own declaration of this
+# fact is `OpenAsrArchitectureDescriptor::emits_punctuation` in
+# crates/openasr-core/src/arch/mod.rs (one field per builtin architecture,
+# looked up via `emits_punctuation_for_model_architecture`). There is no
+# Rust<->Python codegen bridge yet -- and this dict is keyed by the catalog's
+# `family` string (e.g. "qwen", "cohere"), a different vocabulary from the
+# engine's `model_family`/`model_architecture` constants (e.g. "qwen3-asr",
+# "cohere-transcribe-conformer-transformer") -- so this table is hand-kept in
+# lockstep with the Rust descriptor rather than generated from it. Rust's
+# `registry/tests/catalog.rs::embedded_catalog_emits_punctuation_matches_family`
+# cross-checks the shipped catalog's values against the descriptor for every
+# family it can map, so a hand-edit here that drifts from the engine fact
+# fails that test. Keep any change to a family's punctuation behavior
+# synchronized on both sides.
 PUNCTUATION_BY_FAMILY = {
     "qwen": True,
     # parakeet-tdt: trained on transcripts that preserve punctuation and


### PR DESCRIPTION
## Summary

Consolidate model-family capability declarations into the `arch` descriptors as the conceptual single source, and replace a hardcoded diarization string-match with a descriptor field, so cross-language/cross-module capability drift fails a test instead of shipping silently.

## Changes

- `arch/mod.rs`: add `emits_punctuation` and `self_diarizes` to `OpenAsrArchitectureDescriptor` (all 11 built-in architectures declare once) + accessors.
- `api/backend/native.rs` + `native_transcribe.rs`: diarization self-report now reads the descriptor (`self_diarizes`) instead of matching `adapter_id == COHERE_...` string. Behavior unchanged.
- `models/ggml_family_adapter.rs`: carry `self_diarizes` through the adapter descriptor.
- `registry/tests/catalog.rs`: cross-check that the embedded catalog's `emits_punctuation` matches `emits_punctuation_for_model_architecture` for every mappable family -- drift on either side fails the test. `_catalog.py` comment points to the Rust descriptor as the conceptual source.

## Tests run

- [x] `cargo fmt --check`; `cargo clippy --all-targets -- -D warnings` (0 warnings)
- [x] `cargo nextest run --workspace` (2211 passed) incl. new `builtin_architectures_declare_self_diarizes_and_emits_punctuation` + extended catalog cross-check
- [x] `cargo test --workspace --doc`; `golden_diff` (2 passed); `bundled_catalog_signature_verifies...` (1 passed)
- [x] `python3 -m unittest` (155 passed); `regenerate_all.sh --check` (26 models pass)

## Scope / non-goals

- `supports_phrase_bias` stays per-family (11 executor trait methods) -- by-design explicitness, unchanged. A Rust->Python catalog codegen bridge (to make Python derive from the descriptor) would be new infrastructure and is intentionally out of scope; the consistency test guards drift in the meantime.

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance; maintainer owns and merges.