### PR TITLE
fix(core): bound decode runtime cache and right-size ggml graph contexts

### DIFF
--- a/crates/openasr-core/src/models/cohere/decoder_graph.rs
+++ b/crates/openasr-core/src/models/cohere/decoder_graph.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::ggml_runtime::{
-    GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlStaticTensor, GgmlStaticTensorArena,
+    GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlStaticTensor,
+    GgmlStaticTensorArena,
 };
 use crate::{Segment, Transcription};
 
@@ -35,7 +36,15 @@ use crate::nn::decoder::{
 use crate::nn::norm::{AffineLayerNormSteps, apply_affine_layer_norm};
 
 const COHERE_DECODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const COHERE_DECODER_GRAPH_CONTEXT_BYTES: usize = 512 * 1024 * 1024;
+/// Floor for the decoder's `no_alloc` metadata context node/tensor budget:
+/// covers both the per-step decode cgraph AND every static tensor allocated
+/// directly in the arena (weights, embeddings, cross-KV, self-KV -- see
+/// `GgmlStaticTensorArena`, which is metadata-only: real tensor bytes land in
+/// a backend buffer sized from the tensors' actual shapes, independent of
+/// this context's size). Mirrors the encoder's proven `16_384` headroom
+/// (`cohere_encoder_graph_config_with_overrides`) -- comfortably above the
+/// realistic weight+KV tensor count for any decoder layer depth.
+const COHERE_DECODER_GRAPH_SIZE_FLOOR: usize = 16_384;
 const COHERE_DISABLE_INCREMENTAL_SELF_KV_ENV: &str = "OPENASR_COHERE_DISABLE_INCREMENTAL_SELF_KV";
 const COHERE_MAX_GENERATED_TOKENS_OVERRIDE_ENV: &str =
     "OPENASR_COHERE_MAX_GENERATED_TOKENS_OVERRIDE";
@@ -431,6 +440,11 @@ pub(crate) struct CohereDecoderGraphRuntime {
     reuse: Option<Seq2SeqReusableDecodeGraph>,
     metadata: CohereTranscribeExecutionMetadata,
     runner: GgmlCpuGraphRunner,
+    /// The `no_alloc` metadata context size used for `runner`'s own graph
+    /// context and `arena`; reused verbatim for
+    /// `start_persistent_graph_session` in [`Self::build_reusable_decode_graph`]
+    /// so it does not have to be recomputed from a hardcoded constant.
+    persistent_graph_context_bytes: usize,
     arena: GgmlStaticTensorArena,
     token_embedding: GgmlStaticTensor,
     positional_embedding: GgmlStaticTensor,
@@ -584,7 +598,14 @@ impl CohereDecoderGraphRuntime {
         )?;
 
         let mut config = cohere_decoder_graph_config(prefer_cpu_backend);
-        config.context_bytes = COHERE_DECODER_GRAPH_CONTEXT_BYTES;
+        config.graph_size = config.graph_size.max(COHERE_DECODER_GRAPH_SIZE_FLOOR);
+        config.context_bytes =
+            config
+                .context_bytes
+                .max(GgmlCpuGraphConfig::metadata_context_bytes(
+                    config.graph_size,
+                ));
+        let persistent_graph_context_bytes = config.context_bytes;
         let runner = GgmlCpuGraphRunner::new(config).map_err(|source| {
             CohereDecoderGraphError::GraphBuildFailed {
                 step: "runner_init",
@@ -854,6 +875,7 @@ impl CohereDecoderGraphRuntime {
             reuse: None,
             metadata,
             runner,
+            persistent_graph_context_bytes,
             arena,
             token_embedding,
             positional_embedding,
@@ -1766,7 +1788,7 @@ impl CohereDecoderGraphRuntime {
         let n_seq = self.n_seq;
         let mut session = self
             .runner
-            .start_persistent_graph_session(COHERE_DECODER_GRAPH_CONTEXT_BYTES)
+            .start_persistent_graph_session(self.persistent_graph_context_bytes)
             .map_err(|source| CohereDecoderGraphError::GraphBuildFailed {
                 step: "cohere_reuse_session",
                 source,

--- a/crates/openasr-core/src/models/cohere/encoder_graph.rs
+++ b/crates/openasr-core/src/models/cohere/encoder_graph.rs
@@ -4,8 +4,8 @@ use std::time::Instant;
 use thiserror::Error;
 
 use crate::ggml_runtime::{
-    GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlLoadedTensor, GgmlLoadedWeightContext,
-    GgmlStaticTensor, GgmlStaticTensorArena,
+    GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlLoadedTensor,
+    GgmlLoadedWeightContext, GgmlStaticTensor, GgmlStaticTensorArena,
 };
 use crate::nn::conv::{
     Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation,
@@ -18,7 +18,6 @@ use super::graph_config::cohere_encoder_graph_config;
 use super::runtime_contract::CohereTranscribeExecutionMetadata;
 
 const COHERE_ENCODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const COHERE_ENCODER_GRAPH_CONTEXT_BYTES: usize = 512 * 1024 * 1024;
 const GGML_TYPE_F16: i32 = 1;
 const COHERE_DEBUG_ENCODER_ENV: &str = "OPENASR_COHERE_DEBUG_ENCODER";
 const COHERE_DEBUG_ENCODER_BUILD_ENV: &str = "OPENASR_COHERE_DEBUG_ENCODER_BUILD";
@@ -157,7 +156,17 @@ impl CohereTranscribeEncoderGraphRuntime {
         let build_debug = std::env::var_os(COHERE_DEBUG_ENCODER_BUILD_ENV).is_some();
         let runner_start = Instant::now();
         let mut config = cohere_encoder_graph_config();
-        config.context_bytes = COHERE_ENCODER_GRAPH_CONTEXT_BYTES;
+        // `no_alloc` metadata context: covers both the encoder's own forward
+        // graph AND the arena's weight tensors (see
+        // `GgmlStaticTensorArena` -- real tensor bytes land in a separately
+        // sized backend buffer, independent of this context's size).
+        // Previously hardcoded to a flat 512 MiB regardless of `graph_size`.
+        config.context_bytes =
+            config
+                .context_bytes
+                .max(GgmlCpuGraphConfig::metadata_context_bytes(
+                    config.graph_size,
+                ));
         let runner = GgmlCpuGraphRunner::new(config).map_err(|source| {
             CohereTranscribeEncoderError::GraphBuildFailed {
                 step: "runner_init",

--- a/crates/openasr-core/src/models/cohere/ggml_executor.rs
+++ b/crates/openasr-core/src/models/cohere/ggml_executor.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -50,7 +49,8 @@ use crate::models::runtime_prepared_registry::{
     BuiltinPreparedRuntimeCache, BuiltinPreparedRuntimeRegistryError,
 };
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 
 const COHERE_EXECUTOR_ID: &str = "cohere-transcribe-ggml-executor-v1";
@@ -60,10 +60,10 @@ const COHERE_DEBUG_TIMINGS_ENV: &str = "OPENASR_COHERE_DEBUG_TIMINGS";
 const COHERE_DEBUG_ENCODER_ENV: &str = "OPENASR_COHERE_DEBUG_ENCODER";
 
 thread_local! {
-    static COHERE_ENCODER_RUNTIME_BY_KEY: RefCell<HashMap<CohereEncoderRuntimeCacheKey, CohereTranscribeEncoderGraphRuntime>> =
-        RefCell::new(HashMap::new());
-    static COHERE_DECODER_RUNTIME_BY_KEY: RefCell<HashMap<CohereDecoderRuntimeCacheKey, CohereDecoderGraphRuntime>> =
-        RefCell::new(HashMap::new());
+    static COHERE_ENCODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<CohereEncoderRuntimeCacheKey, CohereTranscribeEncoderGraphRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
+    static COHERE_DECODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<CohereDecoderRuntimeCacheKey, CohereDecoderGraphRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 type CohereEncoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
@@ -394,6 +394,7 @@ fn encode_with_cached_cohere_encoder_runtime(
     with_thread_local_cached_mut_by_key(
         &COHERE_ENCODER_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || {
             CohereTranscribeEncoderGraphRuntime::new(
                 &prepared_runtime.encoder_weights,
@@ -429,6 +430,7 @@ fn decode_with_cached_cohere_decoder_runtime(
     with_thread_local_cached_mut_by_key(
         &COHERE_DECODER_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || {
             CohereDecoderGraphRuntime::new(
                 decoder_weights,

--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -48,9 +48,12 @@ use super::decoder_weights::{FireRedDecoderWeights, FireRedDecoderWeightsError};
 use super::runtime_contract::FireRedAedExecutionMetadata;
 
 const FIRERED_DECODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const FIRERED_DECODER_GRAPH_CONTEXT_BYTES: usize = 512 * 1024 * 1024;
-const FIRERED_DECODER_CACHE_ARENA_BYTES: usize = 256 * 1024 * 1024;
 const FIRERED_DECODER_GRAPH_SIZE: usize = 8192;
+/// Static tensors created directly in the decoder's arena (not through
+/// `start_graph`): one shared zero-bias vector plus, per decoder layer, a
+/// cross-K/cross-V pair and a self-K/self-V pair.
+const FIRERED_DECODER_ARENA_TENSORS_PER_LAYER: usize = 4;
+const FIRERED_DECODER_ARENA_FIXED_TENSORS: usize = 1;
 
 #[derive(Debug, Error)]
 pub(crate) enum FireRedDecoderError {
@@ -76,12 +79,33 @@ fn map_err(step: &'static str, source: GgmlCpuGraphError) -> FireRedDecoderError
 
 pub(crate) fn firered_decoder_graph_config() -> GgmlCpuGraphConfig {
     GgmlCpuGraphConfig {
-        context_bytes: FIRERED_DECODER_GRAPH_CONTEXT_BYTES,
+        // `no_alloc` metadata context: only needs `ggml_tensor_overhead()` per
+        // graph node plus the cgraph object itself (see
+        // `GgmlCpuGraphConfig::metadata_context_bytes`), NOT the real tensor
+        // byte sizes -- those live in a separately-sized backend buffer.
+        // Previously hardcoded to 512 MiB, which is what let a single cached
+        // per-encoder-frame-count decoder runtime (see the thread-local cache
+        // in `executor.rs`) balloon far past what the graph actually needs.
+        context_bytes: GgmlCpuGraphConfig::metadata_context_bytes(FIRERED_DECODER_GRAPH_SIZE),
         graph_size: FIRERED_DECODER_GRAPH_SIZE,
         n_threads: None,
         backend: GgmlCpuGraphBackend::Cpu,
         use_scheduler: false,
     }
+}
+
+/// Byte capacity for the decoder's static-tensor arena context. Like the
+/// graph context above, this is a `no_alloc` metadata pool: `start_static_tensor_arena`
+/// only needs room for the `ggml_tensor` struct + name of each tensor created
+/// in it (one shared zero-bias vector, plus a cross-K/V and self-K/V pair per
+/// decoder layer); the real cross-KV/self-KV bytes are allocated afterwards
+/// into their own backend buffer sized from the tensors' actual shapes
+/// (`ggml_backend_alloc_ctx_tensors`), independent of this context's size.
+/// Previously hardcoded to a flat 256 MiB regardless of layer count.
+fn firered_decoder_arena_context_bytes(decoder_n_layers: usize) -> usize {
+    let tensor_count = FIRERED_DECODER_ARENA_FIXED_TENSORS
+        .saturating_add(FIRERED_DECODER_ARENA_TENSORS_PER_LAYER.saturating_mul(decoder_n_layers));
+    GgmlCpuGraphConfig::metadata_context_bytes(tensor_count)
 }
 
 #[derive(Clone, Copy)]
@@ -134,7 +158,9 @@ impl FireRedDecoderGraphRuntime {
         let weights = FireRedDecoderWeights::load(&loaded, metadata.decoder_n_layers)?;
 
         let arena = runner
-            .start_static_tensor_arena(FIRERED_DECODER_CACHE_ARENA_BYTES)
+            .start_static_tensor_arena(firered_decoder_arena_context_bytes(
+                metadata.decoder_n_layers,
+            ))
             .map_err(|source| map_err("static_tensor_arena", source))?;
         let zero_bias = arena
             .new_tensor_1d_f32(metadata.d_model, "firered_dec_zero_bias")

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -50,7 +50,6 @@ use super::encoder_weights::{
 use super::runtime_contract::FireRedAedExecutionMetadata;
 
 const FIRERED_ENCODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const FIRERED_ENCODER_GRAPH_CONTEXT_BYTES: usize = 512 * 1024 * 1024;
 const FIRERED_ENCODER_GRAPH_SIZE: usize = 32_768;
 /// `Conv2dSubsampling.context = left_context(3) + 1 + right_context(3)`; the
 /// encoder pads the time axis by `context - 1` zero frames before the stem
@@ -100,7 +99,11 @@ pub(crate) fn firered_encoder_graph_config() -> GgmlCpuGraphConfig {
     // parity is established (matches the parakeet-ctc/sensevoice staging
     // precedent of correctness-first, backend-breadth-later).
     GgmlCpuGraphConfig {
-        context_bytes: FIRERED_ENCODER_GRAPH_CONTEXT_BYTES,
+        // `no_alloc` metadata context sized from the actual node count (see
+        // `GgmlCpuGraphConfig::metadata_context_bytes`); previously a flat
+        // hardcoded 512 MiB per cached encoder runtime (see the thread-local
+        // cache in `executor.rs`).
+        context_bytes: GgmlCpuGraphConfig::metadata_context_bytes(FIRERED_ENCODER_GRAPH_SIZE),
         graph_size: FIRERED_ENCODER_GRAPH_SIZE,
         n_threads: None,
         backend: GgmlCpuGraphBackend::Cpu,

--- a/crates/openasr-core/src/models/firered_aed/executor.rs
+++ b/crates/openasr-core/src/models/firered_aed/executor.rs
@@ -13,7 +13,6 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use thiserror::Error;
@@ -31,7 +30,8 @@ use crate::models::incremental_streaming_driver::{
 };
 use crate::models::runtime_preflight::build_runtime_tensor_reader_from_preflight;
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 
 use super::decoder_graph::firered_decoder_graph_config;
@@ -52,10 +52,10 @@ const CMVN_INV_STDDEV_TENSOR: &str = "frontend.cmvn.inv_stddev";
 const TOKENIZER_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
 
 thread_local! {
-    static FIRERED_AED_ENCODER_RUNTIME_BY_KEY: RefCell<HashMap<FireRedAedEncoderRuntimeCacheKey, FireRedEncoderGraphRuntime>> =
-        RefCell::new(HashMap::new());
-    static FIRERED_AED_DECODER_RUNTIME_BY_KEY: RefCell<HashMap<FireRedAedDecoderRuntimeCacheKey, FireRedDecoderGraphRuntime>> =
-        RefCell::new(HashMap::new());
+    static FIRERED_AED_ENCODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<FireRedAedEncoderRuntimeCacheKey, FireRedEncoderGraphRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
+    static FIRERED_AED_DECODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<FireRedAedDecoderRuntimeCacheKey, FireRedDecoderGraphRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 type FireRedAedEncoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
@@ -79,6 +79,7 @@ fn encode_with_cached_runtime(
     with_thread_local_cached_mut_by_key(
         &FIRERED_AED_ENCODER_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || FireRedEncoderGraphRuntime::new(runtime_path, metadata),
         |runtime| runtime.encode(cmvn_features, n_frames),
     )
@@ -102,6 +103,7 @@ fn decode_with_cached_runtime(
     with_thread_local_cached_mut_by_key(
         &FIRERED_AED_DECODER_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || FireRedDecoderGraphRuntime::new(runtime_path, metadata, encoder_frame_count),
         |runtime| {
             run_firered_aed_decoder_greedy_with_runtime(

--- a/crates/openasr-core/src/models/moonshine/decoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/decoder_graph.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::RefCell,
-    collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -9,9 +8,9 @@ use thiserror::Error;
 
 use crate::PhraseBiasConfig;
 use crate::ggml_runtime::{
-    GgmlCpuGraphBackend, GgmlCpuGraphBuilder, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor,
-    GgmlLoadedTensor, GgmlLoadedWeightContext, GgmlRopeExtParams, GgmlStaticTensor,
-    GgmlStaticTensorArena,
+    GgmlCpuGraphBackend, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError,
+    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor, GgmlLoadedWeightContext,
+    GgmlRopeExtParams, GgmlStaticTensor, GgmlStaticTensorArena,
 };
 use crate::models::decode_policy_component_registry::{
     BuiltinDecodePolicySeq2SeqTextPostprocessKind, BuiltinSeq2SeqDecodePolicyConfigInput,
@@ -23,7 +22,8 @@ use crate::models::seq2seq_greedy_decode::{
 };
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 use crate::nn::decoder::{
     LlmResidentKvArena, Seq2SeqReusableDecodeGraph, allocate_zeroed_llm_resident_kv_arena,
@@ -42,7 +42,14 @@ use super::tokenizer::MoonshineTokenizer;
 use super::weights::{MoonshineDecoderLayerWeights, MoonshineDecoderWeights, MoonshineWeight};
 
 const MOONSHINE_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const MOONSHINE_DECODER_GRAPH_CONTEXT_BYTES: usize = 512 * 1024 * 1024;
+/// Floor for the decoder's `no_alloc` metadata context node/tensor budget:
+/// covers the per-step decode cgraph, the weight+cross-KV arena, and the
+/// resident self-KV arena (all metadata-only -- see
+/// `GgmlStaticTensorArena`/`allocate_zeroed_llm_resident_kv_arena`: real
+/// tensor bytes land in a backend buffer sized from actual shapes,
+/// independent of this context's size). Mirrors the encoder's proven
+/// `16_384` headroom (`moonshine_encoder_graph_config`).
+const MOONSHINE_DECODER_GRAPH_SIZE_FLOOR: usize = 16_384;
 
 /// (canonical pack path, backend, cross frame count, adapter fingerprint).
 /// The adapter fingerprint MUST stay in this key: the runtime owns prepared
@@ -51,8 +58,8 @@ const MOONSHINE_DECODER_GRAPH_CONTEXT_BYTES: usize = 512 * 1024 * 1024;
 type MoonshineDecoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend, usize, String);
 
 thread_local! {
-    static MOONSHINE_DECODER_RUNTIME_BY_KEY: RefCell<HashMap<MoonshineDecoderRuntimeCacheKey, MoonshineDecoderGraphRuntime>> =
-        RefCell::new(HashMap::new());
+    static MOONSHINE_DECODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<MoonshineDecoderRuntimeCacheKey, MoonshineDecoderGraphRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -100,6 +107,7 @@ pub(crate) fn run_moonshine_decoder_short_form(
         return with_thread_local_cached_mut_by_key(
             &MOONSHINE_DECODER_RUNTIME_BY_KEY,
             key,
+            DEFAULT_RUNTIME_CACHE_CAPACITY,
             || {
                 MoonshineDecoderGraphRuntime::new(
                     decoder_weights,
@@ -394,6 +402,12 @@ pub(crate) struct MoonshineDecoderGraphRuntime {
     #[allow(dead_code)]
     loaded_weights: Option<GgmlLoadedWeightContext>,
     runner: GgmlCpuGraphRunner,
+    /// The `no_alloc` metadata context size used for `runner`'s own graph
+    /// context and `arena`; reused for the resident self-KV arena
+    /// ([`Self::ensure_resident_self_kv_arena`]) and for
+    /// `start_persistent_graph_session` in
+    /// [`Self::build_reusable_decode_graph`] instead of a hardcoded constant.
+    persistent_graph_context_bytes: usize,
     arena: GgmlStaticTensorArena,
     embedding: GgmlStaticTensor,
     out_norm: GgmlStaticTensor,
@@ -454,7 +468,7 @@ impl MoonshineDecoderGraphRuntime {
         self.resident_kv = Some(
             allocate_zeroed_llm_resident_kv_arena(
                 &self.runner,
-                MOONSHINE_DECODER_GRAPH_CONTEXT_BYTES,
+                self.persistent_graph_context_bytes,
                 self.layers.len(),
                 self.metadata.head_dim,
                 self.metadata.decoder_max_context,
@@ -517,7 +531,14 @@ impl MoonshineDecoderGraphRuntime {
         }
 
         let mut config = moonshine_decoder_graph_config(prefer_cpu_backend);
-        config.context_bytes = MOONSHINE_DECODER_GRAPH_CONTEXT_BYTES;
+        config.graph_size = config.graph_size.max(MOONSHINE_DECODER_GRAPH_SIZE_FLOOR);
+        config.context_bytes =
+            config
+                .context_bytes
+                .max(GgmlCpuGraphConfig::metadata_context_bytes(
+                    config.graph_size,
+                ));
+        let persistent_graph_context_bytes = config.context_bytes;
         let runner = GgmlCpuGraphRunner::new(config).map_err(build_err("runner_init"))?;
         // Bind the per-layer 2-D linears (self/cross attn + ffn) zero-copy from the
         // mmap'd pack (native q8_0 [in,out]); the loader supplies them meta-only, so
@@ -661,6 +682,7 @@ impl MoonshineDecoderGraphRuntime {
             resident_kv: None,
             loaded_weights,
             runner,
+            persistent_graph_context_bytes,
             arena,
             embedding,
             out_norm,
@@ -1179,7 +1201,7 @@ impl MoonshineDecoderGraphRuntime {
 
         let mut session = self
             .runner
-            .start_persistent_graph_session(MOONSHINE_DECODER_GRAPH_CONTEXT_BYTES)
+            .start_persistent_graph_session(self.persistent_graph_context_bytes)
             .map_err(build_err("moonshine_reuse_session"))?;
         let graph = session.builder();
         let token_id = graph

--- a/crates/openasr-core/src/models/moonshine/encoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/encoder_graph.rs
@@ -3,8 +3,8 @@ use thiserror::Error;
 use std::path::Path;
 
 use crate::ggml_runtime::{
-    GGML_TYPE_F16, GgmlCpuGraphBuilder, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor,
-    GgmlLoadedTensor, GgmlLoadedWeightContext, GgmlRopeExtParams, GgmlStaticTensor,
+    GGML_TYPE_F16, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner,
+    GgmlCpuTensor, GgmlLoadedTensor, GgmlLoadedWeightContext, GgmlRopeExtParams, GgmlStaticTensor,
     GgmlStaticTensorArena,
 };
 
@@ -16,7 +16,6 @@ use super::weights::{MoonshineEncoderLayerWeights, MoonshineEncoderWeights, Moon
 
 const MOONSHINE_LAYER_NORM_EPSILON: f32 = 1.0e-5;
 const MOONSHINE_GROUP_NORM_EPSILON: f32 = 1.0e-5;
-const MOONSHINE_ENCODER_GRAPH_CONTEXT_BYTES: usize = 512 * 1024 * 1024;
 
 // Conv stem strides/kernels are architecture constants.
 const CONV1_KERNEL: usize = 127;
@@ -166,7 +165,17 @@ impl MoonshineEncoderGraphRuntime {
         adapter: Option<&MoonshineLoraAdapter>,
     ) -> Result<Self, MoonshineEncoderError> {
         let mut config = moonshine_encoder_graph_config();
-        config.context_bytes = MOONSHINE_ENCODER_GRAPH_CONTEXT_BYTES;
+        // `no_alloc` metadata context: covers both the encoder's own forward
+        // graph AND the arena's weight tensors (see `GgmlStaticTensorArena`
+        // -- real tensor bytes land in a separately sized backend buffer,
+        // independent of this context's size). Previously hardcoded to a
+        // flat 512 MiB regardless of `graph_size`.
+        config.context_bytes =
+            config
+                .context_bytes
+                .max(GgmlCpuGraphConfig::metadata_context_bytes(
+                    config.graph_size,
+                ));
         let runner = GgmlCpuGraphRunner::new(config).map_err(build_err("runner_init"))?;
         // Goals 7+8 memory lever: bind the per-layer 2-D linears zero-copy from the
         // mmap'd pack (native q8_0 [in,out]) instead of dequantizing them to

--- a/crates/openasr-core/src/models/moonshine/ggml_executor.rs
+++ b/crates/openasr-core/src/models/moonshine/ggml_executor.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -35,15 +34,16 @@ use crate::models::incremental_streaming_driver::{
 };
 use crate::models::prepared_runtime_cache::PreparedRuntimeCache;
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 
 const MOONSHINE_EXECUTOR_ID: &str = "moonshine-ggml-executor-v1";
 const MOONSHINE_STREAMING_EXECUTOR_ID: &str = "moonshine-ggml-snapshot-streaming-executor-v1";
 
 thread_local! {
-    static MOONSHINE_ENCODER_RUNTIME_BY_KEY: RefCell<HashMap<MoonshineEncoderRuntimeCacheKey, MoonshineEncoderGraphRuntime>> =
-        RefCell::new(HashMap::new());
+    static MOONSHINE_ENCODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<MoonshineEncoderRuntimeCacheKey, MoonshineEncoderGraphRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 /// (canonical pack path, backend, adapter fingerprint). The adapter
@@ -244,6 +244,7 @@ fn encode_with_cached_runtime(
     with_thread_local_cached_mut_by_key(
         &MOONSHINE_ENCODER_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || {
             MoonshineEncoderGraphRuntime::new(
                 &prepared_runtime.encoder_weights,

--- a/crates/openasr-core/src/models/parakeet_ctc/executor.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/executor.rs
@@ -7,7 +7,6 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::PARAKEET_CTC_DECODE_POLICY_ID;
@@ -31,7 +30,8 @@ use crate::models::ggml_asr_executor::{
 use crate::models::ggml_streaming_session::GgmlAsrStreamingTranscriptSession;
 use crate::models::incremental_streaming_driver::STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT;
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 use crate::{NativeAsrSession, PARAKEET_CTC_GGML_ADAPTER_ID};
 
@@ -47,8 +47,8 @@ use super::tokenizer::ParakeetTokenizer;
 type ParakeetRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
 
 thread_local! {
-    static PARAKEET_CTC_RUNTIME_BY_KEY: RefCell<HashMap<ParakeetRuntimeCacheKey, ParakeetCtcPreparedRuntime>> =
-        RefCell::new(HashMap::new());
+    static PARAKEET_CTC_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<ParakeetRuntimeCacheKey, ParakeetCtcPreparedRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 /// Resolves the parakeet block-stack `layer_count_hparam` against the parsed
@@ -132,6 +132,7 @@ fn transcribe_parakeet_ctc_pcm_cached(
     with_thread_local_cached_mut_by_key(
         &PARAKEET_CTC_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || build_parakeet_prepared_runtime(pack_path),
         |runtime| runtime.transcribe(samples, phrase_bias, word_timestamps),
     )
@@ -147,6 +148,7 @@ fn decode_parakeet_ctc_pcm_cached(
     with_thread_local_cached_mut_by_key(
         &PARAKEET_CTC_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || build_parakeet_prepared_runtime(pack_path),
         |runtime| runtime.decode_result(samples, phrase_bias),
     )

--- a/crates/openasr-core/src/models/parakeet_tdt/executor.rs
+++ b/crates/openasr-core/src/models/parakeet_tdt/executor.rs
@@ -2,7 +2,6 @@
 //! joint encoder projection) -> host TDT greedy decode -> detokenize.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::api::backend::WordTimestamp;
@@ -16,7 +15,8 @@ use crate::models::incremental_streaming_driver::{
 };
 use crate::models::parakeet_ctc::frontend::ParakeetFrontend;
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 use crate::{NativeAsrSession, PARAKEET_TDT_GGML_ADAPTER_ID};
 
@@ -36,8 +36,8 @@ use super::tokenizer::ParakeetTdtTokenizer;
 type ParakeetTdtRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
 
 thread_local! {
-    static PARAKEET_TDT_RUNTIME_BY_KEY: RefCell<HashMap<ParakeetTdtRuntimeCacheKey, ParakeetTdtPreparedRuntime>> =
-        RefCell::new(HashMap::new());
+    static PARAKEET_TDT_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<ParakeetTdtRuntimeCacheKey, ParakeetTdtPreparedRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 const PARAKEET_TDT_STREAMING_EXECUTOR_ID: &str = "parakeet-tdt-ggml-redecode-streaming-executor-v1";
@@ -144,6 +144,7 @@ pub(crate) fn transcribe_parakeet_tdt_pcm_cached(
     with_thread_local_cached_mut_by_key(
         &PARAKEET_TDT_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || build_parakeet_tdt_prepared_runtime(pack_path),
         |runtime| runtime.transcribe(samples, word_timestamps),
     )

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -55,7 +55,8 @@ use crate::models::seq2seq_greedy_decode::{
 };
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 use crate::{
     GgmlAsrExecutionError, GgmlAsrExecutionRequest, GgmlAsrExecutionResult, GgmlAsrExecutor,
@@ -83,10 +84,15 @@ type WholeDecoderCacheKey = (PathBuf, GgmlCpuGraphBackend, String);
 type AudioEncoderCacheKey = (PathBuf, GgmlCpuGraphBackend);
 
 thread_local! {
+    // Kept as a plain `HashMap` (not the shared bounded LRU): keyed by
+    // (pack path, backend, adapter fingerprint), which does not explode
+    // per audio chunk the way a frame-count-keyed cache does -- one entry is
+    // built and reused across the whole longform run for a given pack, so
+    // there is no unbounded-growth hazard to bound here.
     static QWEN_WHOLE_DECODER_BY_KEY: RefCell<HashMap<WholeDecoderCacheKey, Qwen3AsrLlmWholeDecoderGraphExecutor>> =
         RefCell::new(HashMap::new());
-    static QWEN_AUDIO_ENCODER_BY_KEY: RefCell<HashMap<AudioEncoderCacheKey, Qwen3AsrAudioEncoderRuntime>> =
-        RefCell::new(HashMap::new());
+    static QWEN_AUDIO_ENCODER_BY_KEY: RefCell<BoundedRuntimeCache<AudioEncoderCacheKey, Qwen3AsrAudioEncoderRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 fn take_cached_whole_decoder(
@@ -114,6 +120,7 @@ fn encode_qwen_audio_embeddings_cached(
     with_thread_local_cached_mut_by_key(
         &QWEN_AUDIO_ENCODER_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || Qwen3AsrAudioEncoderRuntime::new(Some(runtime_source_path)),
         |runtime| runtime.encode(audio_encoder_weights, metadata, mel_features),
     )

--- a/crates/openasr-core/src/models/sensevoice/executor.rs
+++ b/crates/openasr-core/src/models/sensevoice/executor.rs
@@ -16,7 +16,6 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::PhraseBiasConfig;
@@ -38,7 +37,8 @@ use crate::models::ggml_asr_executor::{
 use crate::models::ggml_streaming_session::GgmlAsrStreamingTranscriptSession;
 use crate::models::incremental_streaming_driver::STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT;
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 use crate::{NativeAsrSession, SENSEVOICE_GGML_ADAPTER_ID};
 
@@ -53,8 +53,8 @@ use super::{SenseVoiceTagShadow, strip_sensevoice_tag_prefix};
 type SenseVoiceRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
 
 thread_local! {
-    static SENSEVOICE_RUNTIME_BY_KEY: RefCell<HashMap<SenseVoiceRuntimeCacheKey, SenseVoicePreparedRuntime>> =
-        RefCell::new(HashMap::new());
+    static SENSEVOICE_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<SenseVoiceRuntimeCacheKey, SenseVoicePreparedRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 const SENSEVOICE_STREAMING_EXECUTOR_ID: &str = "sensevoice-ggml-snapshot-streaming-executor-v1";
@@ -262,6 +262,7 @@ fn decode_sensevoice_pcm_cached(
     with_thread_local_cached_mut_by_key(
         &SENSEVOICE_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || build_sensevoice_prepared_runtime(pack_path),
         |runtime| runtime.decode_result(samples, language, phrase_bias),
     )
@@ -278,6 +279,7 @@ fn transcribe_sensevoice_pcm_cached(
     with_thread_local_cached_mut_by_key(
         &SENSEVOICE_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || build_sensevoice_prepared_runtime(pack_path),
         |runtime| runtime.transcribe(samples, language, phrase_bias),
     )

--- a/crates/openasr-core/src/models/thread_local_runtime_cache.rs
+++ b/crates/openasr-core/src/models/thread_local_runtime_cache.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::thread::LocalKey;
@@ -8,9 +8,70 @@ pub(crate) fn canonical_runtime_cache_path(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
+/// Default per-key entry cap for the model runtime caches keyed by
+/// `with_thread_local_cached_mut_by_key`. Small on purpose: long-form
+/// transcription of a single audio file can mint many distinct cache keys
+/// (e.g. firered-aed keys on `(path, backend, encoder_frame_count)`, and a
+/// 10s-chunked long clip commonly produces a dozen-plus distinct frame
+/// counts), and each cached runtime can own hundreds of MB of ggml graph
+/// context. Without a bound the per-thread cache grows without limit for the
+/// life of the thread -- this is the root cause of the multi-GB memory
+/// "roller coaster" during long-audio daemon transcription (issue tracked as
+/// the daemon long-audio OOM). 4 keeps the common case (a handful of chunk
+/// sizes, e.g. one steady-state frame count plus a shorter tail chunk) warm
+/// while capping worst-case resident runtimes for a pathological key
+/// explosion.
+pub(crate) const DEFAULT_RUNTIME_CACHE_CAPACITY: usize = 4;
+
+/// A small bounded LRU cache: at most `max_entries` `(key, value)` pairs are
+/// resident at once. Insertion order is tracked in `order` (front = least
+/// recently used, back = most recently used); eviction drops the least
+/// recently used entry, which runs that entry's `Drop` and frees whatever
+/// native resources (ggml graph context / static tensor arena / mmap) it
+/// owns.
+pub(crate) struct BoundedRuntimeCache<K, T> {
+    entries: HashMap<K, T>,
+    order: VecDeque<K>,
+}
+
+impl<K, T> BoundedRuntimeCache<K, T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+impl<K, T> Default for BoundedRuntimeCache<K, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Runs `build`/`use_cached` against a bounded, thread-local LRU cache of
+/// native runtimes keyed by `K`.
+///
+/// On a cache miss, a new entry is built via `build` and inserted; if the
+/// cache is already at `max_entries`, the single least-recently-used entry is
+/// evicted (and dropped, freeing its resources) first -- eviction only ever
+/// happens here, before any `&mut` reference into the map is handed out, so
+/// it never races with an in-flight borrow. On both a hit and a miss the
+/// accessed key is promoted to most-recently-used before `use_cached` runs
+/// against it.
+///
+/// `max_entries` must be at least 1 (a cache that can hold nothing is not a
+/// cache); callers should use [`DEFAULT_RUNTIME_CACHE_CAPACITY`] unless they
+/// have a specific reason to size differently.
 pub(crate) fn with_thread_local_cached_mut_by_key<K, T, E, R, F, U>(
-    cache: &'static LocalKey<RefCell<HashMap<K, T>>>,
+    cache: &'static LocalKey<RefCell<BoundedRuntimeCache<K, T>>>,
     key: K,
+    max_entries: usize,
     build: F,
     use_cached: U,
 ) -> Result<R, E>
@@ -19,13 +80,30 @@ where
     F: FnOnce() -> Result<T, E>,
     U: FnOnce(&mut T) -> Result<R, E>,
 {
+    debug_assert!(max_entries > 0, "runtime cache capacity must be >= 1");
+    let max_entries = max_entries.max(1);
     cache.with(|cache| -> Result<R, E> {
         let mut cache = cache.borrow_mut();
-        if !cache.contains_key(&key) {
+        if !cache.entries.contains_key(&key) {
+            if cache.entries.len() >= max_entries {
+                // Evict the single least-recently-used entry. This runs
+                // before `build()` and before any `&mut` borrow into
+                // `entries` is taken, so it never touches an entry that is
+                // currently on loan to a caller.
+                if let Some(lru_key) = cache.order.pop_front() {
+                    cache.entries.remove(&lru_key);
+                }
+            }
             let runtime = build()?;
-            cache.insert(key.clone(), runtime);
+            cache.entries.insert(key.clone(), runtime);
+        } else {
+            // Promote: drop the key's current position so it can be
+            // re-appended as most-recently-used below.
+            cache.order.retain(|existing| existing != &key);
         }
+        cache.order.push_back(key.clone());
         let runtime = cache
+            .entries
             .get_mut(&key)
             .expect("thread-local runtime cache must contain inserted entry");
         use_cached(runtime)
@@ -38,9 +116,12 @@ mod tests {
     use std::path::Path;
 
     thread_local! {
-        static STUB_MUT_CACHE: RefCell<HashMap<PathBuf, Vec<usize>>> = RefCell::new(HashMap::new());
-        static STUB_MUT_CACHE_BY_KEY: RefCell<HashMap<(PathBuf, usize), Vec<usize>>> =
-            RefCell::new(HashMap::new());
+        static STUB_MUT_CACHE: RefCell<BoundedRuntimeCache<PathBuf, Vec<usize>>> =
+            RefCell::new(BoundedRuntimeCache::new());
+        static STUB_MUT_CACHE_BY_KEY: RefCell<BoundedRuntimeCache<(PathBuf, usize), Vec<usize>>> =
+            RefCell::new(BoundedRuntimeCache::new());
+        static STUB_BOUNDED_CACHE: RefCell<BoundedRuntimeCache<usize, DropRecorder>> =
+            RefCell::new(BoundedRuntimeCache::new());
     }
 
     #[test]
@@ -49,6 +130,7 @@ mod tests {
         let first = with_thread_local_cached_mut_by_key(
             &STUB_MUT_CACHE,
             path.to_path_buf(),
+            DEFAULT_RUNTIME_CACHE_CAPACITY,
             || Ok::<_, &'static str>(vec![1]),
             |cached| {
                 cached.push(2);
@@ -59,6 +141,7 @@ mod tests {
         let second = with_thread_local_cached_mut_by_key(
             &STUB_MUT_CACHE,
             path.to_path_buf(),
+            DEFAULT_RUNTIME_CACHE_CAPACITY,
             || Ok::<_, &'static str>(vec![9]),
             |cached| {
                 cached.push(3);
@@ -77,6 +160,7 @@ mod tests {
         let cpu = with_thread_local_cached_mut_by_key(
             &STUB_MUT_CACHE_BY_KEY,
             (path.to_path_buf(), 0),
+            DEFAULT_RUNTIME_CACHE_CAPACITY,
             || Ok::<_, &'static str>(vec![1]),
             |cached| {
                 cached.push(2);
@@ -87,6 +171,7 @@ mod tests {
         let gpu = with_thread_local_cached_mut_by_key(
             &STUB_MUT_CACHE_BY_KEY,
             (path.to_path_buf(), 1),
+            DEFAULT_RUNTIME_CACHE_CAPACITY,
             || Ok::<_, &'static str>(vec![9]),
             |cached| {
                 cached.push(3);
@@ -103,5 +188,135 @@ mod tests {
     fn canonical_runtime_cache_path_falls_back_to_original_path() {
         let path = Path::new("/tmp/openasr-missing-runtime-cache-path.gguf");
         assert_eq!(canonical_runtime_cache_path(path), path.to_path_buf());
+    }
+
+    /// Records how many live `DropRecorder` instances exist (via a shared
+    /// counter) so eviction can be asserted by observing the count fall back
+    /// down as entries are dropped.
+    struct DropRecorder {
+        counter: std::rc::Rc<std::cell::Cell<usize>>,
+    }
+
+    impl DropRecorder {
+        fn new(counter: std::rc::Rc<std::cell::Cell<usize>>) -> Self {
+            counter.set(counter.get() + 1);
+            Self { counter }
+        }
+    }
+
+    impl Drop for DropRecorder {
+        fn drop(&mut self) {
+            self.counter.set(self.counter.get() - 1);
+        }
+    }
+
+    #[test]
+    fn bounded_cache_evicts_least_recently_used_entry_and_drops_it() {
+        let counter = std::rc::Rc::new(std::cell::Cell::new(0usize));
+        let cap = 2usize;
+
+        for key in 0..2 {
+            let counter = counter.clone();
+            with_thread_local_cached_mut_by_key(
+                &STUB_BOUNDED_CACHE,
+                key,
+                cap,
+                move || Ok::<_, &'static str>(DropRecorder::new(counter)),
+                |_recorder| Ok::<_, &'static str>(()),
+            )
+            .expect("insert within capacity");
+        }
+        assert_eq!(counter.get(), 2, "both entries within capacity stay live");
+
+        // Insert a third distinct key: the cache is at capacity, so the
+        // least-recently-used entry (key 0) must be evicted and dropped
+        // before the new one is built.
+        {
+            let counter = counter.clone();
+            with_thread_local_cached_mut_by_key(
+                &STUB_BOUNDED_CACHE,
+                2usize,
+                cap,
+                move || Ok::<_, &'static str>(DropRecorder::new(counter)),
+                |_recorder| Ok::<_, &'static str>(()),
+            )
+            .expect("insert beyond capacity evicts lru");
+        }
+
+        assert_eq!(
+            counter.get(),
+            2,
+            "cache never holds more than `max_entries` live entries"
+        );
+        STUB_BOUNDED_CACHE.with(|cache| {
+            let cache = cache.borrow();
+            assert_eq!(cache.len(), cap, "entry count stays at the configured cap");
+            assert!(
+                !cache.entries.contains_key(&0usize),
+                "least-recently-used key 0 was evicted"
+            );
+            assert!(cache.entries.contains_key(&1usize));
+            assert!(cache.entries.contains_key(&2usize));
+        });
+    }
+
+    #[test]
+    fn bounded_cache_promotes_recently_used_entry_ahead_of_eviction() {
+        let counter = std::rc::Rc::new(std::cell::Cell::new(0usize));
+        let cap = 2usize;
+        thread_local! {
+            static PROMOTE_CACHE: RefCell<BoundedRuntimeCache<usize, DropRecorder>> =
+                RefCell::new(BoundedRuntimeCache::new());
+        }
+
+        for key in 0..2 {
+            let counter = counter.clone();
+            with_thread_local_cached_mut_by_key(
+                &PROMOTE_CACHE,
+                key,
+                cap,
+                move || Ok::<_, &'static str>(DropRecorder::new(counter)),
+                |_recorder| Ok::<_, &'static str>(()),
+            )
+            .expect("insert within capacity");
+        }
+
+        // Touch key 0 again so it becomes most-recently-used; key 1 is now
+        // the least-recently-used one.
+        with_thread_local_cached_mut_by_key(
+            &PROMOTE_CACHE,
+            0usize,
+            cap,
+            || -> Result<DropRecorder, &'static str> {
+                panic!("key 0 must already be cached, build() must not run on a hit")
+            },
+            |_recorder| Ok::<_, &'static str>(()),
+        )
+        .expect("re-touch existing key");
+
+        {
+            let counter = counter.clone();
+            with_thread_local_cached_mut_by_key(
+                &PROMOTE_CACHE,
+                2usize,
+                cap,
+                move || Ok::<_, &'static str>(DropRecorder::new(counter)),
+                |_recorder| Ok::<_, &'static str>(()),
+            )
+            .expect("insert beyond capacity evicts lru");
+        }
+
+        PROMOTE_CACHE.with(|cache| {
+            let cache = cache.borrow();
+            assert!(
+                cache.entries.contains_key(&0usize),
+                "recently re-touched key 0 survives eviction"
+            );
+            assert!(
+                !cache.entries.contains_key(&1usize),
+                "untouched key 1 is the one evicted"
+            );
+            assert!(cache.entries.contains_key(&2usize));
+        });
     }
 }

--- a/crates/openasr-core/src/models/wav2vec2_ctc/executor.rs
+++ b/crates/openasr-core/src/models/wav2vec2_ctc/executor.rs
@@ -5,7 +5,6 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::PhraseBiasConfig;
@@ -29,7 +28,8 @@ use crate::models::ggml_asr_executor::{
 use crate::models::ggml_streaming_session::GgmlAsrStreamingTranscriptSession;
 use crate::models::incremental_streaming_driver::STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT;
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 use crate::{NativeAsrSession, WAV2VEC2_CTC_GGML_ADAPTER_ID};
 
@@ -45,8 +45,8 @@ use super::tokenizer::Wav2Vec2Tokenizer;
 type Wav2Vec2RuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
 
 thread_local! {
-    static WAV2VEC2_CTC_RUNTIME_BY_KEY: RefCell<HashMap<Wav2Vec2RuntimeCacheKey, Wav2Vec2CtcPreparedRuntime>> =
-        RefCell::new(HashMap::new());
+    static WAV2VEC2_CTC_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<Wav2Vec2RuntimeCacheKey, Wav2Vec2CtcPreparedRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 /// Resolves the wav2vec2 block-stack `layer_count_hparam` against the parsed
@@ -128,6 +128,7 @@ fn transcribe_wav2vec2_ctc_pcm_cached(
     with_thread_local_cached_mut_by_key(
         &WAV2VEC2_CTC_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || build_wav2vec2_prepared_runtime(pack_path),
         |runtime| runtime.transcribe(samples, phrase_bias, word_timestamps),
     )
@@ -143,6 +144,7 @@ fn decode_wav2vec2_ctc_pcm_cached(
     with_thread_local_cached_mut_by_key(
         &WAV2VEC2_CTC_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || build_wav2vec2_prepared_runtime(pack_path),
         |runtime| runtime.decode_result(samples, phrase_bias),
     )

--- a/crates/openasr-core/src/models/xasr_zipformer/executor.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/executor.rs
@@ -2,7 +2,6 @@
 //! stateless RNN-T greedy decode.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::NativeAsrSession;
@@ -16,7 +15,8 @@ use crate::models::ggml_asr_executor::{
 };
 use crate::models::ggml_streaming_session::GgmlAsrStreamingTranscriptSession;
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 
 use super::frontend::{XASR_FINAL_FLUSH_TAIL_PAD_SAMPLES, XASR_SAMPLE_RATE_HZ};
@@ -27,8 +27,8 @@ use super::streaming_decoder::XasrIncrementalDecoder;
 type XasrRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
 
 thread_local! {
-    static XASR_ZIPFORMER_RUNTIME_BY_KEY: RefCell<HashMap<XasrRuntimeCacheKey, XasrZipformerPreparedRuntime>> =
-        RefCell::new(HashMap::new());
+    static XASR_ZIPFORMER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<XasrRuntimeCacheKey, XasrZipformerPreparedRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -108,6 +108,7 @@ fn transcribe_xasr_zipformer_pcm_cached(
     with_thread_local_cached_mut_by_key(
         &XASR_ZIPFORMER_RUNTIME_BY_KEY,
         key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
         || XasrZipformerPreparedRuntime::load(pack_path),
         |runtime| {
             let result = runtime.transcribe(samples)?;


### PR DESCRIPTION
## Summary

Fix the daemon memory blowup (up to ~9 GB oscillating, swapping a 16 GB machine) when transcribing long audio, caused by an unbounded thread-local decode-runtime cache plus grossly over-allocated ggml graph contexts.

## Why

`with_thread_local_cached_mut_by_key` was insert-only (no eviction). The firered/cohere/moonshine decoder runtime is cached by `encoder_frame_count`, so each distinct slice length created a new ~768 MB runtime (512 MB graph context + 256 MB arena) that was never freed. A 27-min file slices into 160+ chunks with 12+ distinct frame counts -> ~9 GB. Systemic across the conservative-AED families, not firered-only.

## Changes

- `models/thread_local_runtime_cache.rs`: new `BoundedRuntimeCache` (true LRU, cap 4); all 12 call sites (firered/cohere/moonshine/zipformer/sensevoice/wav2vec2/qwen-audio/parakeet-tdt/parakeet-ctc encoders+decoders) use it. Evicted entries Drop -> `ggml_free`. The qwen whole-decoder cache stays a plain map (keyed by adapter fingerprint, not frame count -> no leak).
- Right-size the graph/arena contexts via `GgmlCpuGraphConfig::metadata_context_bytes(graph_size)` instead of hardcoded 512 MB / 256 MB (firered/cohere/moonshine). Both are `no_alloc` bookkeeping contexts -- real tensor bytes live in a separate backend buffer (confirmed against `ggml-alloc.c`), and `ggml_reset` clears the context per decode step, so it only needs one step's node overhead (10-20x margin over actual node counts; graph_size values unchanged).

## Tests run

- [x] `cargo nextest run --workspace` (2212 passed) incl. `cohere_executor_reaches_decode_boundary_with_runtime_ready_fixture` (real GGUF, real CPU backend -- validates the no_alloc sizing in a real build+decode path) and new `bounded_cache_evicts_least_recently_used` / `_promotes_recently_used` tests.
- [x] `golden_diff` (whisper 2 passed; firered 2 ignored -- need private pack), `bundled_catalog_signature_verifies...` (1 passed), `clippy -D warnings` (0), `fmt --check`.

## Scope / non-goals

- Memory-only; no decode numerical change (argmax/logits/stop logic untouched). firered/moonshine production-scale sizing rests on a structural argument (node count is step-local via `ggml_reset` and does not grow with frame/token count) plus a large margin; a production-pack smoke run is the recommended follow-up.

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented and reviewed with AI assistance; maintainer owns and merges.