### PR TITLE
refactor(core): share pack-quant classification and metadata helpers across importers

### DIFF
--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -29,6 +29,7 @@ pub(crate) mod local_source_import;
 pub(crate) mod lora_adapter;
 pub mod moonshine;
 pub mod oasr_metadata;
+pub mod pack_quant;
 pub(crate) mod parakeet_ctc;
 pub mod parakeet_tdt;
 pub(crate) mod phrase_bias_decode;

--- a/crates/openasr-core/src/models/cohere/package_import.rs
+++ b/crates/openasr-core/src/models/cohere/package_import.rs
@@ -20,8 +20,9 @@ use crate::models::local_source_import::{
 use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_AUDIO_FRONTEND, OASR_METADATA_KEY_DECODE_POLICY,
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
-    OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
+    OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1, OasrMetadataBuilder,
 };
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 use crate::models::runtime_tensor_contract_registry::validate_builtin_runtime_tensor_contract_for_architecture;
 use crate::models::{cohere::COHERE_TRANSCRIBE_MODEL_FAMILY, cohere::runtime_contract};
 use crate::{read_gguf_metadata_from_runtime_source, read_gguf_tensor_index_from_runtime_source};
@@ -66,14 +67,7 @@ pub struct CohereLocalSourceImportRuntimeResult {
     pub tensor_count: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum CohereRuntimeQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q4_K,
-}
+pub type CohereRuntimeQuantizationMode = PackQuant;
 
 #[derive(Debug, Deserialize)]
 struct CohereConfigJson {
@@ -554,13 +548,7 @@ fn quantized_tensor_type_for_cohere_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    if !ne0.is_multiple_of(32_u64) {
-        return None;
-    }
-    if quantization == CohereRuntimeQuantizationMode::Q4_K && ne0.is_multiple_of(256_u64) {
-        return Some(GgufWriteTensorType::Q4_K);
-    }
-    Some(GgufWriteTensorType::Q8_0)
+    classify_quant_tensor(ne0, quantization)
 }
 
 #[derive(Debug, Clone)]
@@ -690,160 +678,110 @@ fn cohere_runtime_gguf_metadata(
     model_id: &str,
     vocab_tokens: &[String],
 ) -> BTreeMap<String, GgufWriteValue> {
-    let mut metadata = BTreeMap::new();
-    insert_metadata(
-        &mut metadata,
-        OASR_METADATA_KEY_PACKAGE_VERSION,
-        OASR_PACKAGE_VERSION_V1,
-    );
-    insert_metadata(
-        &mut metadata,
-        OASR_METADATA_KEY_MODEL_FAMILY,
-        COHERE_TRANSCRIBE_MODEL_FAMILY,
-    );
-    insert_metadata(
-        &mut metadata,
-        OASR_METADATA_KEY_MODEL_ARCHITECTURE,
-        COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
-    );
-    insert_metadata(
-        &mut metadata,
-        OASR_METADATA_KEY_AUDIO_FRONTEND,
-        COHERE_TRANSCRIBE_AUDIO_FRONTEND_ID,
-    );
-    insert_metadata(
-        &mut metadata,
-        OASR_METADATA_KEY_DECODE_POLICY,
-        COHERE_TRANSCRIBE_DECODE_POLICY_ID,
-    );
-    insert_metadata(
-        &mut metadata,
-        GGML_TOKENIZER_ID_KEY,
-        COHERE_TRANSCRIBE_TOKENIZER_ID,
-    );
-    insert_metadata(&mut metadata, OPENASR_MODEL_ID_KEY, model_id);
-    insert_metadata(
-        &mut metadata,
-        GENERAL_ARCHITECTURE_KEY,
-        COHERE_ARCHITECTURE_VALUE,
-    );
-
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_VOCAB_SIZE_KEY,
-        fields.vocab_size as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_ENCODER_LAYERS_KEY,
-        fields.encoder_layers as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_ENCODER_D_MODEL_KEY,
-        fields.encoder_d_model as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_ENCODER_HEADS_KEY,
-        fields.encoder_heads as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_ENCODER_HEAD_DIM_KEY,
-        fields.encoder_head_dim as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_ENCODER_FFN_DIM_KEY,
-        fields.encoder_ffn_dim as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_ENCODER_CONV_KERNEL_KEY,
-        fields.encoder_conv_kernel as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_DECODER_LAYERS_KEY,
-        fields.decoder_layers as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_DECODER_D_MODEL_KEY,
-        fields.decoder_d_model as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_DECODER_HEADS_KEY,
-        fields.decoder_heads as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_DECODER_HEAD_DIM_KEY,
-        fields.decoder_head_dim as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_DECODER_FFN_DIM_KEY,
-        fields.decoder_ffn_dim as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_DECODER_MAX_CONTEXT_KEY,
-        fields.decoder_max_context as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_DECODER_START_TOKEN_ID_KEY,
-        fields.decoder_start_token_id as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_AUDIO_SAMPLE_RATE_KEY,
-        fields.sample_rate_hz,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_AUDIO_MELS_COUNT_KEY,
-        fields.n_mels as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_AUDIO_N_FFT_KEY,
-        fields.n_fft as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_AUDIO_HOP_LENGTH_KEY,
-        fields.hop_length as u32,
-    );
-    insert_metadata_u32(
-        &mut metadata,
-        runtime_contract::COHERE_TRANSCRIBE_AUDIO_WIN_LENGTH_KEY,
-        fields.win_length as u32,
-    );
-
-    insert_metadata(
-        &mut metadata,
-        TOKENIZER_GGML_MODEL_KEY,
-        TOKENIZER_GGML_MODEL_VALUE_LLAMA,
-    );
-    insert_metadata_string_array(&mut metadata, TOKENIZER_GGML_TOKENS_KEY, vocab_tokens);
-
-    insert_metadata(&mut metadata, "openasr.source.name", &request.source_name);
-    insert_metadata(
-        &mut metadata,
-        "openasr.source.revision",
-        &request.source_revision,
-    );
-    insert_metadata(&mut metadata, "openasr.license.name", &request.license_name);
-    insert_metadata(
-        &mut metadata,
-        "openasr.license.source",
-        &request.license_source,
-    );
-    metadata
+    OasrMetadataBuilder::new()
+        .str(OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1)
+        .str(
+            OASR_METADATA_KEY_MODEL_FAMILY,
+            COHERE_TRANSCRIBE_MODEL_FAMILY,
+        )
+        .str(
+            OASR_METADATA_KEY_MODEL_ARCHITECTURE,
+            COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
+        )
+        .str(
+            OASR_METADATA_KEY_AUDIO_FRONTEND,
+            COHERE_TRANSCRIBE_AUDIO_FRONTEND_ID,
+        )
+        .str(
+            OASR_METADATA_KEY_DECODE_POLICY,
+            COHERE_TRANSCRIBE_DECODE_POLICY_ID,
+        )
+        .str(GGML_TOKENIZER_ID_KEY, COHERE_TRANSCRIBE_TOKENIZER_ID)
+        .str(OPENASR_MODEL_ID_KEY, model_id)
+        .str(GENERAL_ARCHITECTURE_KEY, COHERE_ARCHITECTURE_VALUE)
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_VOCAB_SIZE_KEY,
+            fields.vocab_size as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_ENCODER_LAYERS_KEY,
+            fields.encoder_layers as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_ENCODER_D_MODEL_KEY,
+            fields.encoder_d_model as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_ENCODER_HEADS_KEY,
+            fields.encoder_heads as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_ENCODER_HEAD_DIM_KEY,
+            fields.encoder_head_dim as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_ENCODER_FFN_DIM_KEY,
+            fields.encoder_ffn_dim as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_ENCODER_CONV_KERNEL_KEY,
+            fields.encoder_conv_kernel as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_DECODER_LAYERS_KEY,
+            fields.decoder_layers as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_DECODER_D_MODEL_KEY,
+            fields.decoder_d_model as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_DECODER_HEADS_KEY,
+            fields.decoder_heads as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_DECODER_HEAD_DIM_KEY,
+            fields.decoder_head_dim as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_DECODER_FFN_DIM_KEY,
+            fields.decoder_ffn_dim as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_DECODER_MAX_CONTEXT_KEY,
+            fields.decoder_max_context as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_DECODER_START_TOKEN_ID_KEY,
+            fields.decoder_start_token_id as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_AUDIO_SAMPLE_RATE_KEY,
+            fields.sample_rate_hz,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_AUDIO_MELS_COUNT_KEY,
+            fields.n_mels as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_AUDIO_N_FFT_KEY,
+            fields.n_fft as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_AUDIO_HOP_LENGTH_KEY,
+            fields.hop_length as u32,
+        )
+        .u32(
+            runtime_contract::COHERE_TRANSCRIBE_AUDIO_WIN_LENGTH_KEY,
+            fields.win_length as u32,
+        )
+        .str(TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_MODEL_VALUE_LLAMA)
+        .string_array(TOKENIZER_GGML_TOKENS_KEY, vocab_tokens)
+        .str("openasr.source.name", &request.source_name)
+        .str("openasr.source.revision", &request.source_revision)
+        .str("openasr.license.name", &request.license_name)
+        .str("openasr.license.source", &request.license_source)
+        .build()
 }
 
 fn build_vocab_tokens(
@@ -927,29 +865,6 @@ fn validate_request(
     }
     validate_output_pack_extension(&request.output_root)?;
     Ok(())
-}
-
-fn insert_metadata(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    value: impl ToString,
-) {
-    metadata.insert(key.to_string(), GgufWriteValue::String(value.to_string()));
-}
-
-fn insert_metadata_u32(metadata: &mut BTreeMap<String, GgufWriteValue>, key: &str, value: u32) {
-    metadata.insert(key.to_string(), GgufWriteValue::U32(value));
-}
-
-fn insert_metadata_string_array(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    values: &[String],
-) {
-    metadata.insert(
-        key.to_string(),
-        GgufWriteValue::StringArray(values.to_vec()),
-    );
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -876,6 +876,10 @@ mod tests {
             DolphinQuantizationMode::Fp16 => 3.0e-3,
             DolphinQuantizationMode::Q8_0 => 5.0e-2,
             DolphinQuantizationMode::Q4_K => 2.5e-1,
+            // Dolphin's importer only ever produces fp16/q8_0/q4_k (see
+            // `DOLPHIN_QUANT_RUNGS`); q3_k is unreachable for this family even
+            // though the shared `PackQuant` enum also carries it for qwen.
+            DolphinQuantizationMode::Q3_K => unreachable!("dolphin never produces a q3_k pack"),
         }
     }
 
@@ -888,6 +892,7 @@ mod tests {
             DolphinQuantizationMode::Fp16 => 0.0,
             DolphinQuantizationMode::Q8_0 => 5.0e-2,
             DolphinQuantizationMode::Q4_K => 2.5e-1,
+            DolphinQuantizationMode::Q3_K => unreachable!("dolphin never produces a q3_k pack"),
         }
     }
 

--- a/crates/openasr-core/src/models/dolphin/package_import.rs
+++ b/crates/openasr-core/src/models/dolphin/package_import.rs
@@ -71,6 +71,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 
 // --- E-Branchformer / Transformer configuration -------------------------------
 // Every structural hparam (layer counts, d_model, head count/dim, FFN/cgMLP
@@ -107,31 +108,10 @@ const DROPPED_TENSOR_PREFIXES: [&str; 2] = [
     "context_module.context_decoder_ctc_linear.",
 ];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-#[allow(non_camel_case_types)]
-pub enum DolphinQuantizationMode {
-    /// fp16 weights (rank>=2), f32 for 1-D vectors + CMVN + mel filterbank.
-    #[default]
-    Fp16,
-    /// q8_0 for the rank-2 `.weight` matrices (ne0 % 32 == 0); everything else
-    /// keeps its fp16-mode representation.
-    Q8_0,
-    /// q4_k for the rank-2 `.weight` matrices whose ne0 % 256 == 0, else q8_0;
-    /// everything else keeps its fp16-mode representation.
-    Q4_K,
-}
-
-impl DolphinQuantizationMode {
-    /// Canonical lowercase pack-quant tag (`fp16`/`q8_0`/`q4_k`), used to name the
-    /// output pack and report the produced rung.
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Fp16 => "fp16",
-            Self::Q8_0 => "q8_0",
-            Self::Q4_K => "q4_k",
-        }
-    }
-}
+/// fp16 weights (rank>=2), f32 for 1-D vectors + CMVN + mel filterbank; q8_0 for
+/// the rank-2 `.weight` matrices (ne0 % 32 == 0); q4_k for the rank-2 `.weight`
+/// matrices whose ne0 % 256 == 0 (else q8_0). See `PackQuant`.
+pub type DolphinQuantizationMode = PackQuant;
 
 /// Which decode-prefix scheme this checkpoint's vocab uses. The cn-dialect
 /// family (small.cn, cn-dialect-base) fixes the OWSM `<lang>` slot at `<zh>`
@@ -740,14 +720,7 @@ fn dolphin_quant_type_for_tensor(
     }
     // Reversed ne0 == the safetensors innermost (last) dim == `in`.
     let ne0 = *shape.last()?;
-    if !ne0.is_multiple_of(32) {
-        return None;
-    }
-    if quantization == DolphinQuantizationMode::Q4_K && ne0.is_multiple_of(256) {
-        Some(GgufWriteTensorType::Q4_K)
-    } else {
-        Some(GgufWriteTensorType::Q8_0)
-    }
+    classify_quant_tensor(ne0, quantization)
 }
 
 /// Build one runtime tensor. Quantizable rank-2 `.weight` matrices are block-
@@ -953,7 +926,9 @@ fn dolphin_runtime_gguf_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use DolphinQuantizationMode::Fp16;
+    // `DolphinQuantizationMode` is now a type alias for the shared `PackQuant`;
+    // `use`-importing a bare variant has to name the real enum, not the alias.
+    use PackQuant::Fp16;
 
     fn string_metadata(metadata: &BTreeMap<String, GgufWriteValue>, key: &str) -> Option<String> {
         match metadata.get(key) {

--- a/crates/openasr-core/src/models/firered_aed/package_import.rs
+++ b/crates/openasr-core/src/models/firered_aed/package_import.rs
@@ -60,6 +60,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 
 const SOURCE_MODEL_SAFETENSORS: &str = "model.safetensors";
 const SOURCE_DICT_TXT: &str = "dict.txt";
@@ -78,24 +79,7 @@ const MEL_LOW_HZ: f32 = 20.0;
 /// Kaldi CMVN variance floor (upstream `fireredasr/data/asr_feat.py`).
 const CMVN_VARIANCE_FLOOR: f64 = 1e-20;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum FireRedAedQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q4_K,
-}
-
-impl FireRedAedQuantizationMode {
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Fp16 => "fp16",
-            Self::Q8_0 => "q8_0",
-            Self::Q4_K => "q4_k",
-        }
-    }
-}
+pub type FireRedAedQuantizationMode = PackQuant;
 
 #[derive(Debug, Clone)]
 pub struct FireRedAedImportRequest {
@@ -730,13 +714,7 @@ fn quantized_tensor_type_for_firered_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    if !ne0.is_multiple_of(32_u64) {
-        return None;
-    }
-    if quantization == FireRedAedQuantizationMode::Q4_K && ne0.is_multiple_of(256_u64) {
-        return Some(GgufWriteTensorType::Q4_K);
-    }
-    Some(GgufWriteTensorType::Q8_0)
+    classify_quant_tensor(ne0, quantization)
 }
 
 fn build_firered_runtime_tensors(

--- a/crates/openasr-core/src/models/moonshine/package_import.rs
+++ b/crates/openasr-core/src/models/moonshine/package_import.rs
@@ -21,8 +21,10 @@ use crate::models::moonshine::runtime_contract;
 use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_AUDIO_FRONTEND, OASR_METADATA_KEY_DECODE_POLICY,
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
-    OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
+    OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1, insert_metadata,
+    insert_metadata_string_array as insert_string_array, insert_metadata_u32 as insert_u32,
 };
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 use crate::{read_gguf_metadata_from_runtime_source, read_gguf_tensor_index_from_runtime_source};
 
 const SOURCE_CONFIG_JSON: &str = "config.json";
@@ -55,14 +57,7 @@ pub struct MoonshineLocalSourceImportRuntimeResult {
     pub tensor_count: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum MoonshineRuntimeQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q4_K,
-}
+pub type MoonshineRuntimeQuantizationMode = PackQuant;
 
 #[derive(Debug, Deserialize)]
 struct MoonshineConfigJson {
@@ -418,10 +413,7 @@ fn quantized_tensor_type_for_moonshine_tensor(
     if name == "dec.emb.weight" {
         return Some(GgufWriteTensorType::Q8_0);
     }
-    if quantization == MoonshineRuntimeQuantizationMode::Q4_K && ne0.is_multiple_of(256_u64) {
-        return Some(GgufWriteTensorType::Q4_K);
-    }
-    Some(GgufWriteTensorType::Q8_0)
+    classify_quant_tensor(ne0, quantization)
 }
 
 #[derive(Debug, Clone)]
@@ -679,29 +671,6 @@ fn validate_request(
     }
     validate_output_pack_extension(&request.output_root)?;
     Ok(())
-}
-
-fn insert_metadata(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    value: impl ToString,
-) {
-    metadata.insert(key.to_string(), GgufWriteValue::String(value.to_string()));
-}
-
-fn insert_u32(metadata: &mut BTreeMap<String, GgufWriteValue>, key: &str, value: u32) {
-    metadata.insert(key.to_string(), GgufWriteValue::U32(value));
-}
-
-fn insert_string_array(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    values: &[String],
-) {
-    metadata.insert(
-        key.to_string(),
-        GgufWriteValue::StringArray(values.to_vec()),
-    );
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/oasr_metadata.rs
+++ b/crates/openasr-core/src/models/oasr_metadata.rs
@@ -1,3 +1,7 @@
+use std::collections::BTreeMap;
+
+use crate::ggml_runtime::GgufWriteValue;
+
 pub const OASR_METADATA_KEY_PACKAGE_VERSION: &str = "openasr.package.version";
 pub const OASR_METADATA_KEY_MODEL_FAMILY: &str = "openasr.model.family";
 pub const OASR_METADATA_KEY_MODEL_ARCHITECTURE: &str = "openasr.model.architecture";
@@ -7,3 +11,88 @@ pub const OASR_METADATA_KEY_FEATURE_DIARIZATION: &str = "openasr.features.diariz
 
 pub const OASR_PACKAGE_VERSION_V1: &str = "1";
 pub const OASR_FEATURE_DIARIZATION_COHERE_TOKEN_STREAM_V1: &str = "cohere-token-stream-v1";
+
+/// Insert a string-valued GGUF metadata entry. Shared by every family's
+/// `*_runtime_gguf_metadata` builder in place of a per-file copy of the same
+/// four-line helper.
+pub(crate) fn insert_metadata(
+    metadata: &mut BTreeMap<String, GgufWriteValue>,
+    key: &str,
+    value: impl ToString,
+) {
+    metadata.insert(key.to_string(), GgufWriteValue::String(value.to_string()));
+}
+
+/// Insert a `u32`-valued GGUF metadata entry.
+pub(crate) fn insert_metadata_u32(
+    metadata: &mut BTreeMap<String, GgufWriteValue>,
+    key: &str,
+    value: u32,
+) {
+    metadata.insert(key.to_string(), GgufWriteValue::U32(value));
+}
+
+/// Insert a string-array-valued GGUF metadata entry (e.g. `tokenizer.ggml.tokens`).
+pub(crate) fn insert_metadata_string_array(
+    metadata: &mut BTreeMap<String, GgufWriteValue>,
+    key: &str,
+    values: &[String],
+) {
+    metadata.insert(
+        key.to_string(),
+        GgufWriteValue::StringArray(values.to_vec()),
+    );
+}
+
+/// Insert a `u32`-array-valued GGUF metadata entry.
+pub(crate) fn insert_metadata_u32_array(
+    metadata: &mut BTreeMap<String, GgufWriteValue>,
+    key: &str,
+    values: &[u32],
+) {
+    metadata.insert(key.to_string(), GgufWriteValue::U32Array(values.to_vec()));
+}
+
+/// Fluent wrapper around the four `insert_metadata*` helpers above, for
+/// importers that build up their GGUF metadata map in one pass rather than via
+/// a closure over a local `BTreeMap`. Equivalent to calling the free functions
+/// directly -- `build()` just returns the accumulated map -- so adopting it is
+/// a pure naming/ergonomics choice, not a behavior change.
+#[derive(Debug, Default)]
+pub(crate) struct OasrMetadataBuilder {
+    metadata: BTreeMap<String, GgufWriteValue>,
+}
+
+impl OasrMetadataBuilder {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn str(mut self, key: &str, value: impl ToString) -> Self {
+        insert_metadata(&mut self.metadata, key, value);
+        self
+    }
+
+    pub(crate) fn u32(mut self, key: &str, value: u32) -> Self {
+        insert_metadata_u32(&mut self.metadata, key, value);
+        self
+    }
+
+    pub(crate) fn string_array(mut self, key: &str, values: &[String]) -> Self {
+        insert_metadata_string_array(&mut self.metadata, key, values);
+        self
+    }
+
+    // No current importer needs a chained u32-array insert (whisper is the only
+    // u32-array user today and still calls the free function directly); kept
+    // for parity with the other three primitives for the next adopter.
+    #[allow(dead_code)]
+    pub(crate) fn u32_array(mut self, key: &str, values: &[u32]) -> Self {
+        insert_metadata_u32_array(&mut self.metadata, key, values);
+        self
+    }
+
+    pub(crate) fn build(self) -> BTreeMap<String, GgufWriteValue> {
+        self.metadata
+    }
+}

--- a/crates/openasr-core/src/models/pack_quant.rs
+++ b/crates/openasr-core/src/models/pack_quant.rs
@@ -1,0 +1,117 @@
+//! Shared pack-quant classification, used by every model family's local-source
+//! importer.
+//!
+//! Each family keeps its own tensor-eligibility rule (name suffix, a
+//! `TensorClass`/`TensorStorage` enum, a `force_f32` override flag, a rank
+//! check) and its own choice of which axis is `ne0` -- most families quantize
+//! along `dims[0]`, but a reversed-dim family (dolphin) uses the last axis
+//! instead. Only the truly family-agnostic tail -- 32/256 block-alignment
+//! gating and which K-quant rung a request selects -- lives here, so a
+//! per-family `Fp16`-mode short-circuit and eligibility check always run
+//! first at the call site.
+
+use crate::ggml_runtime::GgufWriteTensorType;
+
+/// The pack-quant rungs a family's local-source importer can produce. `Fp16`
+/// keeps the family's non-quantized representation (fp16 for rank>=2 weights,
+/// f32 for 1-D vectors/CMVN/mel filterbanks, per family); `Q8_0`/`Q3_K`/`Q4_K`
+/// block-quantize eligible rank-2 `.weight` matrices. Families whose rung set
+/// is exactly this one alias their public `<Family>QuantizationMode` type
+/// straight to `PackQuant` (see `models::cohere::CohereRuntimeQuantizationMode`
+/// and friends); `Q3_K` is presently only reachable by `qwen`, and a family
+/// with a materially different scheme (e.g. wespeaker's single-rung `F32`)
+/// keeps its own enum instead of aliasing here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[allow(non_camel_case_types)]
+pub enum PackQuant {
+    #[default]
+    Fp16,
+    Q8_0,
+    Q3_K,
+    Q4_K,
+}
+
+impl PackQuant {
+    /// Canonical lowercase pack-quant tag (`fp16`/`q8_0`/`q3_k`/`q4_k`), used to
+    /// name the output pack and report the produced rung.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Fp16 => "fp16",
+            Self::Q8_0 => "q8_0",
+            Self::Q3_K => "q3_k",
+            Self::Q4_K => "q4_k",
+        }
+    }
+}
+
+/// Shared 32/256-alignment + K-quant-rung selection tail.
+///
+/// Callers first resolve their own family-specific tensor eligibility
+/// (name/class/storage flags, rank, the `Fp16`-mode short-circuit) and the
+/// correct `ne0` (the ggml-quantized axis length) before calling this; it only
+/// decides, given an already-eligible rank-2 axis length, whether
+/// q8_0/q3_k/q4_k applies or the tensor falls back to `None` (its fp16-mode
+/// representation).
+pub(crate) fn classify_quant_tensor(
+    ne0: u64,
+    quantization: PackQuant,
+) -> Option<GgufWriteTensorType> {
+    if !ne0.is_multiple_of(32_u64) {
+        return None;
+    }
+    if ne0.is_multiple_of(256_u64) {
+        if quantization == PackQuant::Q3_K {
+            return Some(GgufWriteTensorType::Q3_K);
+        }
+        if quantization == PackQuant::Q4_K {
+            return Some(GgufWriteTensorType::Q4_K);
+        }
+    }
+    Some(GgufWriteTensorType::Q8_0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unaligned_ne0_falls_back_to_fp16_representation() {
+        assert_eq!(classify_quant_tensor(31, PackQuant::Q8_0), None);
+        assert_eq!(
+            classify_quant_tensor(32, PackQuant::Q8_0),
+            Some(GgufWriteTensorType::Q8_0)
+        );
+    }
+
+    #[test]
+    fn q4_k_requires_256_alignment_else_falls_back_to_q8_0() {
+        assert_eq!(
+            classify_quant_tensor(32, PackQuant::Q4_K),
+            Some(GgufWriteTensorType::Q8_0)
+        );
+        assert_eq!(
+            classify_quant_tensor(256, PackQuant::Q4_K),
+            Some(GgufWriteTensorType::Q4_K)
+        );
+    }
+
+    #[test]
+    fn q3_k_requires_256_alignment_else_falls_back_to_q8_0() {
+        assert_eq!(
+            classify_quant_tensor(32, PackQuant::Q3_K),
+            Some(GgufWriteTensorType::Q8_0)
+        );
+        assert_eq!(
+            classify_quant_tensor(256, PackQuant::Q3_K),
+            Some(GgufWriteTensorType::Q3_K)
+        );
+    }
+
+    #[test]
+    fn label_matches_canonical_pack_quant_tags() {
+        assert_eq!(PackQuant::Fp16.label(), "fp16");
+        assert_eq!(PackQuant::Q8_0.label(), "q8_0");
+        assert_eq!(PackQuant::Q3_K.label(), "q3_k");
+        assert_eq!(PackQuant::Q4_K.label(), "q4_k");
+    }
+}

--- a/crates/openasr-core/src/models/parakeet_ctc/package_import.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/package_import.rs
@@ -35,6 +35,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 
 use super::{PARAKEET_CTC_GGML_ARCHITECTURE_ID, PARAKEET_CTC_MODEL_FAMILY};
 
@@ -42,24 +43,7 @@ const SOURCE_CONFIG_JSON: &str = "config.json";
 const SOURCE_TOKENIZER_JSON: &str = "tokenizer.json";
 const SOURCE_MODEL_SAFETENSORS: &str = "model.safetensors";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum ParakeetCtcQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q4_K,
-}
-
-impl ParakeetCtcQuantizationMode {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Fp16 => "fp16",
-            Self::Q8_0 => "q8_0",
-            Self::Q4_K => "q4_k",
-        }
-    }
-}
+pub type ParakeetCtcQuantizationMode = PackQuant;
 
 #[derive(Debug, Clone)]
 pub struct ParakeetCtcImportRequest {
@@ -369,13 +353,7 @@ fn quantized_tensor_type_for_parakeet_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    if !ne0.is_multiple_of(32_u64) {
-        return None;
-    }
-    if quantization == ParakeetCtcQuantizationMode::Q4_K && ne0.is_multiple_of(256_u64) {
-        return Some(GgufWriteTensorType::Q4_K);
-    }
-    Some(GgufWriteTensorType::Q8_0)
+    classify_quant_tensor(ne0, quantization)
 }
 
 fn parakeet_runtime_gguf_metadata(

--- a/crates/openasr-core/src/models/parakeet_tdt/package_import.rs
+++ b/crates/openasr-core/src/models/parakeet_tdt/package_import.rs
@@ -34,6 +34,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 
 use super::runtime_contract::{
     PARAKEET_TDT_BLANK_TOKEN_ID_KEY, PARAKEET_TDT_CONV_KERNEL_KEY, PARAKEET_TDT_DURATIONS_KEY,
@@ -50,26 +51,7 @@ const SOURCE_CONFIG_JSON: &str = "config.json";
 const SOURCE_TOKENIZER_JSON: &str = "tokenizer.json";
 const SOURCE_MODEL_SAFETENSORS: &str = "model.safetensors";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum ParakeetTdtQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q4_K,
-}
-
-impl ParakeetTdtQuantizationMode {
-    // Consumed by the CLI import command wired with the executor stage.
-    #[allow(dead_code)]
-    fn label(self) -> &'static str {
-        match self {
-            Self::Fp16 => "fp16",
-            Self::Q8_0 => "q8_0",
-            Self::Q4_K => "q4_k",
-        }
-    }
-}
+pub type ParakeetTdtQuantizationMode = PackQuant;
 
 #[derive(Debug, Clone)]
 pub struct ParakeetTdtImportRequest {
@@ -436,13 +418,7 @@ fn quantized_tensor_type_for_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    if !ne0.is_multiple_of(32_u64) {
-        return None;
-    }
-    if quantization == ParakeetTdtQuantizationMode::Q4_K && ne0.is_multiple_of(256_u64) {
-        return Some(GgufWriteTensorType::Q4_K);
-    }
-    Some(GgufWriteTensorType::Q8_0)
+    classify_quant_tensor(ne0, quantization)
 }
 
 fn parakeet_tdt_runtime_gguf_metadata(

--- a/crates/openasr-core/src/models/qwen/package_import.rs
+++ b/crates/openasr-core/src/models/qwen/package_import.rs
@@ -25,6 +25,12 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
+// Re-exported at `pub(super)` (not just imported) because `forced_aligner_import.rs`
+// pulls these in via `use super::package_import::{insert_metadata, ...}`.
+pub(super) use crate::models::oasr_metadata::{
+    insert_metadata, insert_metadata_string_array, insert_metadata_u32,
+};
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 use crate::models::runtime_tensor_contract_registry::validate_builtin_runtime_tensor_contract_for_architecture;
 use crate::models::{qwen::QWEN3_ASR_MODEL_FAMILY, qwen::runtime_contract};
 
@@ -69,15 +75,7 @@ pub struct Qwen3AsrLocalSourceImportRuntimeResult {
     pub tensor_count: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum Qwen3AsrRuntimeQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q3_K,
-    Q4_K,
-}
+pub type Qwen3AsrRuntimeQuantizationMode = PackQuant;
 
 #[derive(Debug, Deserialize)]
 struct Qwen3AsrConfigJson {
@@ -772,18 +770,7 @@ fn quantized_tensor_type_for_qwen(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    if !ne0.is_multiple_of(32_u64) {
-        return None;
-    }
-    if ne0.is_multiple_of(256_u64) {
-        if quantization == Qwen3AsrRuntimeQuantizationMode::Q3_K {
-            return Some(GgufWriteTensorType::Q3_K);
-        }
-        if quantization == Qwen3AsrRuntimeQuantizationMode::Q4_K {
-            return Some(GgufWriteTensorType::Q4_K);
-        }
-    }
-    Some(GgufWriteTensorType::Q8_0)
+    classify_quant_tensor(ne0, quantization)
 }
 
 fn f32_tensor(name: &str, dims: Vec<u64>, values: Vec<f32>) -> GgufWriteTensor {
@@ -839,33 +826,6 @@ fn validate_request(
     }
     validate_output_pack_extension(&request.output_root)?;
     Ok(())
-}
-
-pub(super) fn insert_metadata(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    value: impl ToString,
-) {
-    metadata.insert(key.to_string(), GgufWriteValue::String(value.to_string()));
-}
-
-pub(super) fn insert_metadata_u32(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    value: u32,
-) {
-    metadata.insert(key.to_string(), GgufWriteValue::U32(value));
-}
-
-pub(super) fn insert_metadata_string_array(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    values: &[String],
-) {
-    metadata.insert(
-        key.to_string(),
-        GgufWriteValue::StringArray(values.to_vec()),
-    );
 }
 
 fn hann_window(length: usize) -> Vec<f32> {

--- a/crates/openasr-core/src/models/sensevoice/package_import.rs
+++ b/crates/openasr-core/src/models/sensevoice/package_import.rs
@@ -40,6 +40,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 
 use crate::arch::{SENSEVOICE_GGML_ARCHITECTURE_ID, SENSEVOICE_MODEL_FAMILY};
 
@@ -51,24 +52,7 @@ const SOURCE_SPM_MODEL: &str = "chn_jpn_yue_eng_ko_spectok.bpe.model";
 /// FunASR's CTC blank id (piece 0, `<unk>`, doubles as the blank).
 const SENSEVOICE_CTC_BLANK_ID: u32 = 0;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum SenseVoiceQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q4_K,
-}
-
-impl SenseVoiceQuantizationMode {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Fp16 => "fp16",
-            Self::Q8_0 => "q8_0",
-            Self::Q4_K => "q4_k",
-        }
-    }
-}
+pub type SenseVoiceQuantizationMode = PackQuant;
 
 #[derive(Debug, Clone)]
 pub struct SenseVoiceImportRequest {
@@ -610,13 +594,7 @@ fn quantized_tensor_type_for_sensevoice_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    if !ne0.is_multiple_of(32_u64) {
-        return None;
-    }
-    if quantization == SenseVoiceQuantizationMode::Q4_K && ne0.is_multiple_of(256_u64) {
-        return Some(GgufWriteTensorType::Q4_K);
-    }
-    Some(GgufWriteTensorType::Q8_0)
+    classify_quant_tensor(ne0, quantization)
 }
 
 fn sensevoice_runtime_gguf_metadata(

--- a/crates/openasr-core/src/models/wav2vec2_ctc/package_import.rs
+++ b/crates/openasr-core/src/models/wav2vec2_ctc/package_import.rs
@@ -32,6 +32,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 use crate::nn::wav2vec2::fold_pos_conv_weight_norm;
 
 use super::{WAV2VEC2_CTC_GGML_ARCHITECTURE_ID, WAV2VEC2_CTC_MODEL_FAMILY};
@@ -64,24 +65,7 @@ fn canonicalize_backbone_prefix(name: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Borrowed(name)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum Wav2Vec2CtcQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q4_K,
-}
-
-impl Wav2Vec2CtcQuantizationMode {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Fp16 => "fp16",
-            Self::Q8_0 => "q8_0",
-            Self::Q4_K => "q4_k",
-        }
-    }
-}
+pub type Wav2Vec2CtcQuantizationMode = PackQuant;
 
 #[derive(Debug, Clone)]
 pub struct Wav2Vec2CtcImportRequest {
@@ -579,13 +563,7 @@ fn quantized_tensor_type_for_wav2vec2_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    if !ne0.is_multiple_of(32_u64) {
-        return None;
-    }
-    if quantization == Wav2Vec2CtcQuantizationMode::Q4_K && ne0.is_multiple_of(256_u64) {
-        return Some(GgufWriteTensorType::Q4_K);
-    }
-    Some(GgufWriteTensorType::Q8_0)
+    classify_quant_tensor(ne0, quantization)
 }
 
 fn wav2vec2_runtime_gguf_metadata(

--- a/crates/openasr-core/src/models/whisper/package_import.rs
+++ b/crates/openasr-core/src/models/whisper/package_import.rs
@@ -22,8 +22,10 @@ use crate::models::{
     oasr_metadata::{
         OASR_METADATA_KEY_AUDIO_FRONTEND, OASR_METADATA_KEY_DECODE_POLICY,
         OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
-        OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
+        OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1, insert_metadata,
+        insert_metadata_string_array, insert_metadata_u32, insert_metadata_u32_array,
     },
+    pack_quant::{PackQuant, classify_quant_tensor},
     whisper::WHISPER_MODEL_FAMILY,
 };
 
@@ -71,24 +73,7 @@ pub struct WhisperLocalSourceImportRuntimeResult {
     pub tensor_count: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum WhisperRuntimeQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q4_K,
-}
-
-impl WhisperRuntimeQuantizationMode {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Fp16 => "fp16",
-            Self::Q8_0 => "q8_0",
-            Self::Q4_K => "q4_k",
-        }
-    }
-}
+pub type WhisperRuntimeQuantizationMode = PackQuant;
 
 #[derive(Debug, Deserialize)]
 struct WhisperConfigJson {
@@ -236,13 +221,7 @@ fn quantization_tensor_type_for_whisper_tensor(
     }
     let dims = gguf_runtime_tensor_dims_from_source_tensor(tensor);
     let ne0 = dims.first().copied()?;
-    if ne0.is_multiple_of(32_u64) {
-        if quantization == WhisperRuntimeQuantizationMode::Q4_K && ne0.is_multiple_of(256_u64) {
-            return Some(GgufWriteTensorType::Q4_K);
-        }
-        return Some(GgufWriteTensorType::Q8_0);
-    }
-    None
+    classify_quant_tensor(ne0, quantization)
 }
 
 fn gguf_quantized_tensor_from_safetensors(
@@ -889,37 +868,6 @@ fn whisper_runtime_gguf_metadata(
     );
 
     metadata
-}
-
-fn insert_metadata(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    value: impl ToString,
-) {
-    metadata.insert(key.to_string(), GgufWriteValue::String(value.to_string()));
-}
-
-fn insert_metadata_u32(metadata: &mut BTreeMap<String, GgufWriteValue>, key: &str, value: u32) {
-    metadata.insert(key.to_string(), GgufWriteValue::U32(value));
-}
-
-fn insert_metadata_string_array(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    values: &[String],
-) {
-    metadata.insert(
-        key.to_string(),
-        GgufWriteValue::StringArray(values.to_vec()),
-    );
-}
-
-fn insert_metadata_u32_array(
-    metadata: &mut BTreeMap<String, GgufWriteValue>,
-    key: &str,
-    values: &[u32],
-) {
-    metadata.insert(key.to_string(), GgufWriteValue::U32Array(values.to_vec()));
 }
 
 fn whisper_gguf_tensor_binding_context(

--- a/crates/openasr-core/src/models/xasr_zipformer/package_import.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/package_import.rs
@@ -44,6 +44,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 
 const SOURCE_CONFIG_JSON: &str = "config.json";
 const SOURCE_TOKENS_TXT: &str = "tokens.txt";
@@ -94,24 +95,7 @@ pub(crate) fn compact_xasr_name(name: &str) -> String {
     out
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(non_camel_case_types)]
-pub enum XasrZipformerQuantizationMode {
-    #[default]
-    Fp16,
-    Q8_0,
-    Q4_K,
-}
-
-impl XasrZipformerQuantizationMode {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Fp16 => "fp16",
-            Self::Q8_0 => "q8_0",
-            Self::Q4_K => "q4_k",
-        }
-    }
-}
+pub type XasrZipformerQuantizationMode = PackQuant;
 
 #[derive(Debug, Clone)]
 pub struct XasrZipformerImportRequest {
@@ -386,13 +370,7 @@ fn quantized_tensor_type_for_xasr_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    if !ne0.is_multiple_of(32_u64) {
-        return None;
-    }
-    if quantization == XasrZipformerQuantizationMode::Q4_K && ne0.is_multiple_of(256_u64) {
-        return Some(GgufWriteTensorType::Q4_K);
-    }
-    Some(GgufWriteTensorType::Q8_0)
+    classify_quant_tensor(ne0, quantization)
 }
 
 fn join_u32(values: &[u32]) -> String {


### PR DESCRIPTION
## Summary

Consolidate the byte-identical `QuantizationMode` enums, quant-tensor classification tails, and metadata-insert helpers that were duplicated across 11 model-family importers into shared `PackQuant` / `classify_quant_tensor` / `OasrMetadataBuilder`.

## Changes

- New `models/pack_quant.rs`: shared `PackQuant` (`Fp16/Q8_0/Q3_K/Q4_K`) + `classify_quant_tensor(ne0, mode)` (the common 32/256 alignment + K-quant tier tail) + `label()`.
- `oasr_metadata.rs`: shared `insert_metadata*` helpers + a fluent `OasrMetadataBuilder`.
- 11 families (cohere/dolphin/firered_aed/moonshine/parakeet_ctc/parakeet_tdt/qwen/sensevoice/wav2vec2_ctc/xasr_zipformer/whisper) now alias `type XQuantizationMode = PackQuant` (public API names unchanged) and call the shared classify tail; each keeps its own quantizability predicate. 4 families drop duplicate metadata helpers; cohere's metadata is rewritten via `OasrMetadataBuilder` as the reference use. Net ~272 lines of duplication removed.
- `wespeaker` (single F32 tier) and `pyannote` (no quantization) correctly excluded. Python-side quant metadata already single-source (`_catalog.py`), untouched.

## Tests run

- [x] `golden_diff` (2 passed, 2 ignored -- private pack); `canonical_quant_tag_matches_shared_fixture` (quant tag contract not drifted); `bundled_catalog_signature_verifies...`
- [x] `regenerate_all.sh --check` (26 models); `python3 -m unittest` (155); `cargo nextest run --workspace` (2214 passed); fmt / clippy -D / doc all clean

## Scope / non-goals (follow-up)

- Closure-style metadata builders in 7 families (many call sites) not migrated this pass.
- whisper NOT retrofitted to `local_source_import`: its safetensors parser carries two trust-boundary protections the shared layer lacks (128 MiB header-length cap; duplicate-JSON-key rejection). A safe retrofit must first harden the shared layer, then unify error types + re-verify golden -- deferred as a separate higher-risk change.
- hymt2 is a GGUF-to-.oasr metadata repack (no safetensors source), so `local_source_import` does not apply.

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance; maintainer owns and merges.