### PR TITLE
refactor(core): unify auxiliary pack pull-time dispatch into one table

### DIFF
--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -610,29 +610,18 @@ pub fn validate_native_runtime_model_pack_contract(path: &Path) -> Result<(), St
         .map_err(|error| error.to_string())?;
     let metadata = read_gguf_metadata_from_runtime_source(&runtime_source)
         .map_err(|error| format!("metadata read failed: {error}"))?;
-    // Diarization support packs (speaker embedder, pyannote segmenter) never
-    // select an ASR runtime adapter; their contract is "the diarize loader can
-    // construct the model from this pack" — checked here so `openasr pull`
-    // stays fail-closed for them too.
-    if let Some(result) = crate::diarize::validate_diarize_runtime_pack_contract(path, &metadata) {
-        return result.map_err(|error| format!("diarization pack validation failed: {error}"));
-    }
-    // Translation packs (Hy-MT2) never select an ASR runtime adapter either;
-    // their contract is "the translation runtime probe accepts this pack" —
-    // checked here so `openasr pull` stays fail-closed for them too.
-    if let Some(result) =
-        crate::models::hymt2::validate_translation_runtime_pack_contract(path, &metadata)
+    // Auxiliary (non-ASR) packs -- diarization support (speaker embedder,
+    // speaker segmenter), translation (Hy-MT2), punctuation (FireRedPunc) --
+    // never select an ASR runtime adapter; their contract is "this family's own
+    // runtime-loader probe accepts the pack". One table
+    // (`aux_pack_registry::AUX_PACK_DESCRIPTORS`) dispatches all of them by
+    // `general.architecture`, fail-closed the same way ASR family-adapter
+    // selection is below: an aux pack with no ASR-shaped selection metadata
+    // never reaches (and is never rejected by) ASR adapter selection.
+    if let Some((kind, result)) =
+        crate::models::aux_pack_registry::validate_aux_runtime_pack_contract(path, &metadata)
     {
-        return result.map_err(|error| format!("translation pack validation failed: {error}"));
-    }
-    // Punctuation packs (FireRedPunc) are a text-in/labels-out post-processor,
-    // not an ASR runtime adapter; their contract is "the punctuation metadata
-    // geometry validates" -- checked here so `openasr pull` stays fail-closed
-    // for them too.
-    if let Some(result) =
-        crate::models::firered_punc::validate_punctuation_runtime_pack_contract(path, &metadata)
-    {
-        return result.map_err(|error| format!("punctuation pack validation failed: {error}"));
+        return result.map_err(|error| format!("{}: {error}", kind.validation_failure_label()));
     }
     let selection_metadata = selection_metadata_from_gguf(&metadata);
     let registry = GgmlFamilyRegistry::with_builtin_adapters();

--- a/crates/openasr-core/src/diarize/mod.rs
+++ b/crates/openasr-core/src/diarize/mod.rs
@@ -18,30 +18,11 @@ pub fn vad_diarization_available() -> bool {
     embed::embedder_pack_installed()
 }
 
-/// Validate a diarization runtime pack by constructing its model from the pack
-/// exactly the way the runtime loaders do — every required tensor must be
-/// present with the right shape. Returns `None` when `metadata` does not
-/// identify a diarization pack (the caller falls through to ASR runtime
-/// validation).
-pub fn validate_diarize_runtime_pack_contract(
-    path: &std::path::Path,
-    metadata: &crate::GgufMetadata,
-) -> Option<Result<(), String>> {
-    let architecture = metadata.get_string("general.architecture")?;
-    match architecture.trim() {
-        crate::models::wespeaker::WESPEAKER_GGML_ARCHITECTURE_ID => Some(
-            embed::WeSpeakerEmbedder::from_oasr(path)
-                .map(|_| ())
-                .map_err(|error| error.to_string()),
-        ),
-        crate::models::pyannote::PYANNOTE_GGML_ARCHITECTURE_ID => Some(
-            segment::PyannoteSegmenter::from_oasr(path)
-                .map(|_| ())
-                .map_err(|error| error.to_string()),
-        ),
-        _ => None,
-    }
-}
+// Pull-time contract validation for diarization support packs (WeSpeaker
+// speaker embedder, pyannote speaker segmenter) is dispatched through
+// `crate::models::aux_pack_registry`, alongside the other auxiliary (non-ASR)
+// families (translation, punctuation) -- one table instead of a per-family
+// function called from an ad hoc chain in `api::backend::native`.
 
 pub mod attribution;
 #[doc(hidden)]

--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -1,3 +1,4 @@
+pub(crate) mod aux_pack_registry;
 pub(crate) mod builtin_execution_dispatch;
 pub mod cohere;
 pub(crate) mod ctc_greedy_decode;

--- a/crates/openasr-core/src/models/aux_pack_registry.rs
+++ b/crates/openasr-core/src/models/aux_pack_registry.rs
@@ -1,0 +1,180 @@
+//! Single dispatch point for auxiliary (non-ASR) runtime pack contracts.
+//!
+//! ASR families are looked up through one data-driven table --
+//! [`crate::arch::OpenAsrArchitectureRegistry`] -- keyed by `general.architecture`
+//! and cross-checked (`openasr.model.family` / audio-frontend / decode-policy /
+//! tokenizer) before an adapter is selected. Auxiliary packs (speaker
+//! embedder, speaker segmenter, translation, punctuation) are not ASR
+//! transcription architectures -- they have no audio frontend, tokenizer, or
+//! decode policy in that sense -- so forcing them into
+//! `OpenAsrArchitectureDescriptor` would model a shape they don't have (see
+//! `models::pyannote`/`models::wespeaker`'s module docs, which already say so
+//! explicitly). They still deserve **one** table instead of an ad hoc chain of
+//! `if let Some(...)` calls in `api::backend::native`, so this module is that
+//! table: one `general.architecture` value per aux family, matched by a single
+//! lookup, fail-closed (`None` when no aux entry matches, so the caller falls
+//! through to ASR adapter selection, which then fails closed on its own if the
+//! pack matches nothing at all).
+//!
+//! [`aux_pack_architecture_ids_are_unique_and_disjoint_from_asr`] is the safety
+//! net a hand-rolled chain never had: it fails the test suite if a future aux
+//! family ever reuses a `general.architecture` value already claimed by an ASR
+//! descriptor (which would otherwise silently shadow one or the other,
+//! depending on chain order, instead of raising `Ambiguous`).
+
+use std::path::Path;
+
+use crate::GgufMetadata;
+use crate::arch::GENERAL_ARCHITECTURE_KEY;
+
+/// Which pull-time error prefix a matched aux family reports, preserving the
+/// exact wording `api::backend::native`'s tests assert on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AuxPackKind {
+    /// Speaker embedder (WeSpeaker) / speaker segmenter (pyannote) diarization
+    /// support packs.
+    Diarization,
+    /// Translation runtime packs (Hy-MT2).
+    Translation,
+    /// Punctuation-restoration packs (FireRedPunc).
+    Punctuation,
+}
+
+impl AuxPackKind {
+    /// The `"<label> failed: <error>"` prefix `validate_native_runtime_model_pack_contract`
+    /// reports for this kind (unchanged from the pre-consolidation call sites).
+    pub(crate) fn validation_failure_label(self) -> &'static str {
+        match self {
+            AuxPackKind::Diarization => "diarization pack validation failed",
+            AuxPackKind::Translation => "translation pack validation failed",
+            AuxPackKind::Punctuation => "punctuation pack validation failed",
+        }
+    }
+}
+
+struct AuxPackDescriptor {
+    /// `general.architecture` value that identifies this aux family's packs.
+    architecture_id: &'static str,
+    kind: AuxPackKind,
+    /// Cheap pull-time contract probe: constructs/parses just enough of the
+    /// pack to prove the runtime loader can build from it, without
+    /// materializing full weights for execution.
+    validate: fn(&Path, &GgufMetadata) -> Result<(), String>,
+}
+
+fn validate_wespeaker(path: &Path, _metadata: &GgufMetadata) -> Result<(), String> {
+    crate::diarize::embed::WeSpeakerEmbedder::from_oasr(path)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+fn validate_pyannote(path: &Path, _metadata: &GgufMetadata) -> Result<(), String> {
+    crate::diarize::segment::PyannoteSegmenter::from_oasr(path)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+fn validate_hymt2(path: &Path, _metadata: &GgufMetadata) -> Result<(), String> {
+    crate::models::hymt2::Hymt2Runtime::probe_path(path)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+fn validate_firered_punc(_path: &Path, metadata: &GgufMetadata) -> Result<(), String> {
+    crate::models::firered_punc::runtime_contract::parse_and_validate_firered_punc_metadata(
+        metadata,
+    )
+    .map(|_| ())
+    .map_err(|error| error.to_string())
+}
+
+const AUX_PACK_DESCRIPTORS: &[AuxPackDescriptor] = &[
+    AuxPackDescriptor {
+        architecture_id: crate::models::wespeaker::WESPEAKER_GGML_ARCHITECTURE_ID,
+        kind: AuxPackKind::Diarization,
+        validate: validate_wespeaker,
+    },
+    AuxPackDescriptor {
+        architecture_id: crate::models::pyannote::PYANNOTE_GGML_ARCHITECTURE_ID,
+        kind: AuxPackKind::Diarization,
+        validate: validate_pyannote,
+    },
+    AuxPackDescriptor {
+        architecture_id: crate::models::hymt2::config::HUNYUAN_DENSE_ARCHITECTURE_VALUE,
+        kind: AuxPackKind::Translation,
+        validate: validate_hymt2,
+    },
+    AuxPackDescriptor {
+        architecture_id: crate::models::firered_punc::config::FIRERED_PUNC_ARCHITECTURE_VALUE,
+        kind: AuxPackKind::Punctuation,
+        validate: validate_firered_punc,
+    },
+];
+
+/// Pull-time contract dispatch for auxiliary (non-ASR) runtime packs.
+///
+/// Returns `None` when `metadata` does not declare one of the known aux
+/// `general.architecture` values, so the caller (`validate_native_runtime_model_pack_contract`)
+/// falls through to ASR family-adapter selection -- which then fails closed on
+/// its own for a pack that matches neither table. Returns `Some((kind,
+/// result))` when an aux family claims the pack, `result` being that family's
+/// cheap runtime-loader probe (no weight materialization).
+pub(crate) fn validate_aux_runtime_pack_contract(
+    path: &Path,
+    metadata: &GgufMetadata,
+) -> Option<(AuxPackKind, Result<(), String>)> {
+    let architecture = metadata.get_string(GENERAL_ARCHITECTURE_KEY)?.trim();
+    let descriptor = AUX_PACK_DESCRIPTORS
+        .iter()
+        .find(|descriptor| descriptor.architecture_id == architecture)?;
+    Some((descriptor.kind, (descriptor.validate)(path, metadata)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arch::OpenAsrArchitectureRegistry;
+
+    /// Fail-closed safety net the previous hand-rolled `if let Some(...)` chain
+    /// in `api::backend::native` never had: every aux `general.architecture`
+    /// value must be unique among aux families AND disjoint from every ASR
+    /// `OpenAsrArchitectureDescriptor::model_architecture`. A collision would
+    /// otherwise be resolved by chain/table iteration order instead of an
+    /// explicit `Ambiguous` error -- exactly the silent-shadowing failure mode
+    /// `GgmlFamilyRegistry::select_from_fields` refuses to allow within the ASR
+    /// table.
+    #[test]
+    fn aux_pack_architecture_ids_are_unique_and_disjoint_from_asr() {
+        let mut seen: Vec<&'static str> = Vec::new();
+        for descriptor in AUX_PACK_DESCRIPTORS {
+            assert!(
+                !seen.contains(&descriptor.architecture_id),
+                "duplicate aux architecture id: {}",
+                descriptor.architecture_id
+            );
+            seen.push(descriptor.architecture_id);
+        }
+
+        let asr_registry = OpenAsrArchitectureRegistry::with_builtins();
+        for descriptor in AUX_PACK_DESCRIPTORS {
+            assert!(
+                asr_registry
+                    .find_by_model_architecture(descriptor.architecture_id)
+                    .is_none(),
+                "aux architecture id '{}' collides with a registered ASR architecture",
+                descriptor.architecture_id
+            );
+        }
+    }
+
+    #[test]
+    fn dispatch_returns_none_for_unknown_architecture() {
+        let mut values = std::collections::BTreeMap::new();
+        values.insert(
+            GENERAL_ARCHITECTURE_KEY.to_string(),
+            crate::ggml_runtime::GgufMetadataValue::String("totally-unknown-arch".to_string()),
+        );
+        let metadata = GgufMetadata::from_values_for_test(values);
+        assert!(validate_aux_runtime_pack_contract(Path::new("/nonexistent"), &metadata).is_none());
+    }
+}

--- a/crates/openasr-core/src/models/firered_punc/mod.rs
+++ b/crates/openasr-core/src/models/firered_punc/mod.rs
@@ -29,23 +29,11 @@ pub(crate) mod tensor_names;
 pub(crate) mod tokenizer;
 pub(crate) mod weights;
 
-/// Pull-time contract for FireRedPunc punctuation packs.
-///
-/// Returns `Some` only when the pack declares the `firered-punc` GGUF
-/// architecture; ASR/translation packs fall through to their own adapters. The
-/// check is the cheap metadata-only geometry validation (no weight load), so
-/// `openasr pull` stays fail-closed for punctuation packs without paying a full
-/// model build.
-pub(crate) fn validate_punctuation_runtime_pack_contract(
-    _path: &std::path::Path,
-    metadata: &crate::GgufMetadata,
-) -> Option<Result<(), String>> {
-    if !runtime_contract::metadata_declares_firered_punc(metadata) {
-        return None;
-    }
-    Some(
-        runtime_contract::parse_and_validate_firered_punc_metadata(metadata)
-            .map(|_| ())
-            .map_err(|error| error.to_string()),
-    )
-}
+// Pull-time contract validation for FireRedPunc punctuation packs
+// (`general.architecture = "firered-punc"`) is dispatched through
+// `crate::models::aux_pack_registry`, alongside the other auxiliary (non-ASR)
+// families (diarization, translation) -- one table instead of a per-family
+// function called from an ad hoc chain in `api::backend::native`. The contract
+// itself is still the cheap metadata-only geometry validation in
+// [`runtime_contract::parse_and_validate_firered_punc_metadata`] (no weight
+// load).

--- a/crates/openasr-core/src/models/firered_punc/runtime_contract.rs
+++ b/crates/openasr-core/src/models/firered_punc/runtime_contract.rs
@@ -19,9 +19,11 @@ use super::config::{
 };
 use crate::arch::GENERAL_ARCHITECTURE_KEY;
 
-/// Returns `true` when the pack declares the FireRedPunc architecture. Used by
-/// the pull-time dispatch to route punctuation packs to this family instead of
-/// the ASR/translation adapters.
+/// Returns `true` when the pack declares the FireRedPunc architecture. The
+/// pull-time dispatch (`crate::models::aux_pack_registry`) matches the same
+/// `general.architecture` value directly against
+/// [`FIRERED_PUNC_ARCHITECTURE_VALUE`] rather than calling this helper; it
+/// stays as the geometry-parsing internal check and its own unit tests below.
 pub(crate) fn metadata_declares_firered_punc<M: ScalarMetadataView>(metadata: &M) -> bool {
     metadata
         .get_string_scalar(GENERAL_ARCHITECTURE_KEY)

--- a/crates/openasr-core/src/models/hymt2/mod.rs
+++ b/crates/openasr-core/src/models/hymt2/mod.rs
@@ -16,25 +16,10 @@ pub use runtime::{
 };
 pub use tokenizer::Hymt2Tokenizer;
 
-/// Pull-time contract for translation runtime packs.
-///
-/// Returns `Some` only when the pack declares the Hy-MT2 GGUF architecture
-/// (`general.architecture = "hunyuan-dense"`); ASR packs fall through to
-/// family-adapter selection. The contract is the cheap [`runtime::Hymt2Runtime`]
-/// probe (metadata + tensor-index validation, no weight materialization), so
-/// `openasr pull` stays fail-closed for translation packs without paying a
-/// full model load.
-pub(crate) fn validate_translation_runtime_pack_contract(
-    path: &std::path::Path,
-    metadata: &crate::GgufMetadata,
-) -> Option<Result<(), String>> {
-    let architecture = metadata.get_string(crate::arch::GENERAL_ARCHITECTURE_KEY)?;
-    if architecture.trim() != config::HUNYUAN_DENSE_ARCHITECTURE_VALUE {
-        return None;
-    }
-    Some(
-        runtime::Hymt2Runtime::probe_path(path)
-            .map(|_| ())
-            .map_err(|error| error.to_string()),
-    )
-}
+// Pull-time contract validation for translation runtime packs (Hy-MT2,
+// `general.architecture = "hunyuan-dense"`) is dispatched through
+// `crate::models::aux_pack_registry`, alongside the other auxiliary (non-ASR)
+// families (diarization, punctuation) -- one table instead of a per-family
+// function called from an ad hoc chain in `api::backend::native`. The contract
+// itself is still the cheap [`runtime::Hymt2Runtime`] probe (metadata +
+// tensor-index validation, no weight materialization).

--- a/docs/DIARIZATION_PACK_PUBLISHING.md
+++ b/docs/DIARIZATION_PACK_PUBLISHING.md
@@ -23,9 +23,10 @@ Everything except the actual HF upload + catalog re-sign is committed in-repo:
   `template/DIARIZE_CARD.md.tmpl` + `cards/<id>.toml` prose (no ASR pipeline
   tags / bench table).
 - `openasr pull` validates these packs by **constructing the diarize model from
-  the pack** (`crate::diarize::validate_diarize_runtime_pack_contract`, routed
-  from `validate_native_runtime_model_pack_contract`) instead of ASR runtime
-  adapter selection — fail-closed either way.
+  the pack** (dispatched through `crate::models::aux_pack_registry`, which
+  `validate_native_runtime_model_pack_contract` calls before ASR runtime
+  adapter selection) instead of ASR runtime adapter selection — fail-closed
+  either way.
 
 The published packs are raw **f32** GGUF-v0 so embeddings and the 7-class
 powerset logits stay bit-exact.


### PR DESCRIPTION
## Summary

Consolidate the hardcoded if-let dispatch chain for auxiliary (non-ASR) pack pull-time validation into a single table, and add a collision safety-net -- without forcing the heterogeneous aux models into the ASR arch descriptor.

## Why

ASR families dispatch through the data-driven `BUILTIN_ARCHITECTURE_DESCRIPTORS` -> `GgmlFamilyRegistry` (multi-field, fail-closed). The 4 aux models (wespeaker, pyannote, hymt2, firered_punc) instead each had their own `validate_*_runtime_pack_contract` called from a hardcoded `if let Some(...)` chain in `native.rs` -- a parallel special-case path with no collision protection (a future aux id reusing an ASR architecture would silently shadow rather than report `Ambiguous`).

## Changes

- New `models/aux_pack_registry.rs`: `AUX_PACK_DESCRIPTORS` table (wespeaker/pyannote/hymt2/firered_punc, each `{architecture_id, kind, validate}`) + single `validate_aux_runtime_pack_contract` (one lookup by `general.architecture`; `None` falls through to the ASR registry exactly as before).
- `native.rs`: the 3-branch chain becomes one call; error prefixes preserved (byte-identical). Redundant wrapper fns removed from diarize/hymt2/firered_punc modules (their `from_oasr`/`probe_path`/parse logic is unchanged, just relocated call sites). `DIARIZATION_PACK_PUBLISHING.md` reference updated.
- New test `aux_pack_architecture_ids_are_unique_and_disjoint_from_asr` (safety net the old chain lacked).

## Scope / non-goals

- The 4 aux models are deliberately NOT pushed into `OpenAsrArchitectureDescriptor`: they are embedding / segmentation / text->text shapes with no audio frontend or decode policy, so forcing them in would fabricate meaningless fields (matches the existing pyannote/wespeaker module-doc decision). Only the dispatch layer is unified, not model semantics.
- firered_punc: only its pull-time contract validation is routed through the table; runtime wiring (desktop->daemon->core stage) is untouched and remains deferred.

## Tests run

- [x] `cargo nextest run --workspace` (2231 passed) incl. fail-closed `dispatch_reports_unknown_family` / `returns_ambiguous...` / `pull_contract_validation_routes_diarize_packs...` + 2 new tests
- [x] `golden_diff` (2 passed, 2 ignored), `bundled_catalog_signature_verifies...`, `clippy -D`, `fmt --check`, `doc`

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance; maintainer owns and merges.