### PR TITLE
ci(release): add experimental linux musl legs via cargo-zigbuild

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -526,7 +526,6 @@ jobs:
           python3 -m pip install --user ziglang
           cargo install cargo-zigbuild --version 0.23.0 --locked
           python3 -m ziglang version
-          cargo zigbuild --version
 
       # ggml's CPU backend pulls in ALSA transitively (openasr-cli -> cpal ->
       # alsa-sys) on Linux, and a fully static musl binary needs a musl-built

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -203,26 +203,46 @@ jobs:
             archive_ext: zip
             experimental: true
             timeout: 120
-          # DEFERRED (intentionally not in the matrix): the two Linux musl CPU
-          # legs -- x86_64-unknown-linux-musl (asset linux-x86_64-musl) and
-          # aarch64-unknown-linux-musl (asset linux-arm64-musl). They cannot be
-          # built cleanly on a stock GitHub-hosted ubuntu runner today:
-          #   * ggml is C++ (compiled by build.rs via CMake). A musl target
-          #     needs a musl C++ compiler, but Ubuntu's `musl-tools` ships only
-          #     `musl-gcc` (C) -- there is no apt `musl-g++`. So the ggml C++
-          #     objects cannot be produced for musl without a musl-cross
-          #     toolchain (musl.cc / musl-cross-make) or building inside an
-          #     Alpine container.
-          #   * musl defaults to crt-static ON, but build.rs links libstdc++
-          #     and libgomp dynamically on Linux (see the `target.contains(
-          #     "linux")` block), which a fully static musl binary cannot pull;
-          #     enabling them needs `-C target-feature=-crt-static` (a dynamic
-          #     musl binary) plus a musl libstdc++, or static-libstdc++ wiring.
-          # Enabling musl is therefore a build.rs + toolchain task, not an
-          # asset-rename one. When done, add two legs here with rust_target set
-          # (like the windows-arm64 leg), the friendly assets above, and -- once
-          # green -- the TARGETS entries linux-x86_64-musl:tar.gz and
-          # linux-arm64-musl:tar.gz.
+          # Fully static Linux musl CPU legs (single self-contained binary that
+          # runs on any Linux userland -- Alpine, distroless, glibc hosts alike).
+          # Both are cross-compiled with cargo-zigbuild (zig cc/c++ = clang plus a
+          # bundled musl libc + libc++) on the stock x86_64 ubuntu runner: zig is
+          # a reliable, self-contained cross toolchain (installed via pip's
+          # `ziglang` wheel + `cargo install cargo-zigbuild`), which sidesteps the
+          # old blockers -- Ubuntu ships no apt `musl-g++` for ggml's C++, and a
+          # musl-cross download source (musl.cc) proved flaky/offline in CI. See
+          # the "Install musl cross build toolchain" + "Build static ALSA for
+          # musl" + zigbuild branch in the build step below, and the is_musl
+          # handling in crates/openasr-core/build.rs (static libc++ instead of
+          # dynamic libstdc++/libgomp; explicit CMake cross toolchain file).
+          #
+          # `zigbuild: true` selects `cargo zigbuild` over `cargo build`;
+          # rust_target is set so RELEASE_DIR / the cross-leg smoke skips behave
+          # exactly like the windows-arm64 cross leg (build + package only -- the
+          # x86_64 static binary could run on the runner, but the aarch64 one
+          # cannot, so both are treated as cross for a uniform code path). Kept
+          # `experimental: true` (non-blocking, excluded from
+          # verify-completeness) until they prove green on a real runner; once
+          # green, drop `experimental` and add linux-x86_64-musl:tar.gz +
+          # linux-arm64-musl:tar.gz to verify-completeness TARGETS.
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            asset: linux-x86_64-musl
+            rust_target: x86_64-unknown-linux-musl
+            binary_name: openasr
+            archive_ext: tar.gz
+            zigbuild: true
+            experimental: true
+            timeout: 90
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            asset: linux-arm64-musl
+            rust_target: aarch64-unknown-linux-musl
+            binary_name: openasr
+            archive_ext: tar.gz
+            zigbuild: true
+            experimental: true
+            timeout: 90
           # Linux GPU-feature variants, same rationale as the Windows ones
           # above (no GPU on the hosted runner; build+package validated
           # here, GPU inference validated on real hardware). Pinned to
@@ -493,10 +513,80 @@ jobs:
         with:
           shared-key: release-binaries-${{ matrix.target }}
 
+      # musl legs are cross-compiled with cargo-zigbuild: zig cc/c++ is a
+      # self-contained clang + bundled musl libc/libc++ cross toolchain, so no
+      # apt musl-cross (or the flaky musl.cc download) is needed. ziglang ships
+      # as a pip wheel (cargo-zigbuild auto-discovers `python3 -m ziglang`); the
+      # target std comes from the "Add cross Rust target" step above.
+      - name: Install musl cross build toolchain
+        if: matrix.zigbuild && env.LEG_SELECTED == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --user ziglang
+          cargo install cargo-zigbuild --version 0.23.0 --locked
+          python3 -m ziglang version
+          cargo zigbuild --version
+
+      # ggml's CPU backend pulls in ALSA transitively (openasr-cli -> cpal ->
+      # alsa-sys) on Linux, and a fully static musl binary needs a musl-built
+      # static libasound.a -- the runner's apt libasound2-dev is glibc-only.
+      # Cross-build ALSA from its official release tarball with the same zig cc
+      # (targeting <arch>-linux-musl), then point alsa-sys' pkg-config probe at
+      # it via the target-scoped PKG_CONFIG_* vars (PKG_CONFIG_LIBDIR_<target>
+      # replaces the search path so the host glibc alsa.pc is never picked).
+      - name: Build static ALSA for musl
+        if: matrix.zigbuild && env.LEG_SELECTED == 'true'
+        shell: bash
+        env:
+          ALSA_VERSION: 1.2.13
+        run: |
+          set -euo pipefail
+          arch="${{ matrix.rust_target }}"; arch="${arch%%-*}"   # x86_64 | aarch64
+          zig_triple="${arch}-linux-musl"
+          wrapper="${RUNNER_TEMP}/zigcc-${arch}.sh"
+          cat > "${wrapper}" <<EOF
+          #!/bin/sh
+          exec python3 -m ziglang cc -target ${zig_triple} "\$@"
+          EOF
+          chmod +x "${wrapper}"
+
+          cd "${RUNNER_TEMP}"
+          curl -fL --retry 5 --retry-all-errors --connect-timeout 30 \
+            -o alsa-lib.tar.bz2 \
+            "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_VERSION}.tar.bz2"
+          tar xjf alsa-lib.tar.bz2
+          cd "alsa-lib-${ALSA_VERSION}"
+          CC="${wrapper}" ./configure \
+            --host="${zig_triple}" \
+            --prefix="${RUNNER_TEMP}/alsa-musl" \
+            --enable-static --disable-shared --disable-python \
+            --disable-topology --disable-ucm --disable-alisp --disable-old-symbols
+          CC="${wrapper}" make -j"$(nproc)"
+          CC="${wrapper}" make install
+
+          # Target-scoped pkg-config wiring so alsa-sys probes the freshly
+          # cross-built static libasound instead of the host's glibc one.
+          et="$(echo "${{ matrix.rust_target }}" | tr '-' '_')"
+          pc_dir="${RUNNER_TEMP}/alsa-musl/lib/pkgconfig"
+          {
+            echo "PKG_CONFIG_ALLOW_CROSS=1"
+            echo "PKG_CONFIG_ALLOW_CROSS_${et}=1"
+            echo "PKG_CONFIG_PATH_${et}=${pc_dir}"
+            echo "PKG_CONFIG_LIBDIR_${et}=${pc_dir}"
+            echo "PKG_CONFIG_SYSROOT_DIR_${et}=${RUNNER_TEMP}/alsa-musl"
+          } >> "${GITHUB_ENV}"
+
       - name: Build release binary
         if: env.LEG_SELECTED == 'true'
         shell: bash
-        run: cargo build --release -p openasr-cli ${{ matrix.rust_target && format('--target {0}', matrix.rust_target) || '' }} ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.zigbuild }}" = "true" ]; then
+            cargo zigbuild --release -p openasr-cli --target ${{ matrix.rust_target }} ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
+          else
+            cargo build --release -p openasr-cli ${{ matrix.rust_target && format('--target {0}', matrix.rust_target) || '' }} ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
+          fi
 
       # Same GPU-less-runner caveat as the Windows CUDA/HIP legs: those two
       # exes dlopen the CUDA/ROCm runtime at launch, which needs a real

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -31,6 +31,10 @@ fn main() {
     // The android triple (e.g. aarch64-linux-android) also contains "linux", so
     // it must be detected explicitly and BEFORE any `contains("linux")` check.
     let is_android = target.contains("android");
+    // musl triples (e.g. x86_64-unknown-linux-musl) also contain "linux" and must
+    // be detected explicitly before any `contains("linux")` check; see the
+    // is_musl link-lib arm below for why they need a different C++ runtime.
+    let is_musl = target.contains("musl");
     // iOS device or simulator target (aarch64-apple-ios /
     // aarch64-apple-ios-sim). Deliberately distinct from `is_macos` (which only
     // matches "apple-darwin"): iOS builds have no bundled libomp (same as
@@ -95,6 +99,9 @@ fn main() {
     //  - android: bionic ships no `libgomp` and lacks `pthread_setaffinity` (the
     //    NDK's OpenMP is opt-in `libomp`, not the GOMP runtime ggml-cpu links); CPU
     //    threading on android comes from ggml's own thread pool instead.
+    //  - musl: built with zig cc/c++ (clang), which does not bundle libomp for
+    //    musl targets, so `-fopenmp` would fail to link the same way it does on
+    //    android; CPU threading falls back to ggml's own thread pool there too.
     // We neutralize OpenMP for those rather than forcing the whole feature
     // opt-in. `OPENASR_GGML_OPENMP=0` force-disables everywhere.
     let openmp_requested = feat_openmp
@@ -102,7 +109,8 @@ fn main() {
             env::var("OPENASR_GGML_OPENMP").ok().as_deref(),
             Some("0" | "off" | "OFF" | "false" | "FALSE")
         );
-    let openmp_unsupported_target = is_macos || is_ios || is_android || (feat_hip && is_windows);
+    let openmp_unsupported_target =
+        is_macos || is_ios || is_android || is_musl || (feat_hip && is_windows);
     let effective_openmp = openmp_requested && !openmp_unsupported_target;
     if openmp_requested && !effective_openmp && feat_hip && is_windows {
         println!(
@@ -413,6 +421,33 @@ fn main() {
             }
         }
     }
+    if is_musl {
+        // Every musl leg is a cross build (there is no musl GitHub-hosted host
+        // runner): without an explicit toolchain file cmake configures for the
+        // HOST compiler/arch, silently producing host-arch objects that rustc's
+        // linker skips as format-incompatible -- which surfaces downstream as a
+        // confusing wall of "undefined symbol: ggml_*" at the final binary link,
+        // not a clear cross-compile error here.
+        //
+        // `cargo zigbuild` (the required build entry point for musl targets; see
+        // CI) sets `CMAKE_TOOLCHAIN_FILE_<target>` to a toolchain file it
+        // generates, pinning CC/CXX/AR/RANLIB to its zig cc/zig c++ wrappers plus
+        // the CMAKE_FIND_ROOT_PATH_MODE_* settings cross-compiling CMake needs;
+        // prefer that. Fall back to a minimal, self-authored toolchain file built
+        // from CC_<target>/CXX_<target> (or plain CC/CXX) so a build that
+        // exports those manually (without `cargo zigbuild`) still cross-compiles
+        // correctly instead of silently falling back to the host toolchain.
+        let env_target = target.replace('-', "_");
+        let toolchain_file = env::var(format!("CMAKE_TOOLCHAIN_FILE_{env_target}"))
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| write_musl_cmake_toolchain_file(&target, &out_dir));
+        configure.arg(format!(
+            "-DCMAKE_TOOLCHAIN_FILE={}",
+            cmake_path(&toolchain_file)
+        ));
+    }
     if feat_hip {
         configure.arg("-DCMAKE_HIP_PLATFORM=amd");
         if let Some(path) = hip_path.as_deref() {
@@ -671,6 +706,30 @@ fn main() {
         // so link the shared libc++ runtime and emit no gomp. This MUST be checked
         // before the `linux` arm because aarch64-linux-android also contains "linux".
         println!("cargo:rustc-link-lib=dylib=c++_shared");
+    } else if is_musl {
+        // musl targets are built with zig cc/c++ (clang), not GCC, and crt-static
+        // defaults ON: there is no dynamic libstdc++/libgomp to link against in a
+        // musl sysroot, and a portable static musl binary must not require them at
+        // runtime anyway. Statically link LLVM's libc++ (the runtime clang/zig
+        // pairs ggml's C++ objects with) instead of GNU libstdc++. No gomp: clang
+        // silently ignores `#pragma omp` without `-fopenmp` (unlike GCC, which
+        // partially recognizes it even when GGML_OPENMP=OFF), so a clang-built
+        // ggml-cpu.a has no GOMP_*/omp_* undefined symbols to satisfy. This MUST be
+        // checked before the `linux` arm below because musl triples also contain
+        // "linux" (e.g. x86_64-unknown-linux-musl).
+        //
+        // rustc validates a `kind=static` native library's existence (via the
+        // emitted `-L` search paths) while compiling THIS crate, not later at the
+        // final binary's link step -- so the .a files must already exist in
+        // `lib_dir` by the time this build script exits. zig only builds its
+        // bundled libc++/libc++abi/libunwind from source (into its own opaque,
+        // content-hashed global cache) on demand, the first time something asks
+        // to link them; materialize them into `lib_dir` here so both the
+        // existence check and the real link succeed.
+        materialize_musl_libcxx_archives(&target, &lib_dir);
+        println!("cargo:rustc-link-lib=static=c++");
+        println!("cargo:rustc-link-lib=static=c++abi");
+        println!("cargo:rustc-link-lib=static=unwind");
     } else if target.contains("linux") {
         println!("cargo:rustc-link-lib=dylib=stdc++");
         // The static ggml-cpu.a references OpenMP runtime symbols (GOMP_*/omp_*)
@@ -851,6 +910,160 @@ fn main() {
 
 fn cmake_flag(name: &str, enabled: bool) -> String {
     format!("-D{}={}", name, if enabled { "ON" } else { "OFF" })
+}
+
+/// Fallback CMake toolchain file for a musl cross build when `cargo zigbuild`'s
+/// own `CMAKE_TOOLCHAIN_FILE_<target>` env var isn't set (e.g. a manual `cargo
+/// build` with CC/CXX exported by hand). Mirrors the shape cargo-zigbuild itself
+/// generates: explicit CMAKE_SYSTEM_NAME/PROCESSOR (cross-compiling cmake does
+/// NOT infer these from the target triple on its own -- left alone it detects
+/// the BUILD host, which is wrong for a cross build) and the FIND_ROOT_PATH
+/// modes that keep `find_package`/`find_library` (e.g. ggml's `pkg-config`-based
+/// probes) scoped to the target sysroot rather than falling back to the host.
+fn write_musl_cmake_toolchain_file(target: &str, out_dir: &Path) -> PathBuf {
+    let env_target = target.replace('-', "_");
+    let cc = env::var(format!("CC_{env_target}"))
+        .or_else(|_| env::var("CC"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "no C compiler found for musl target {target}: set CC_{env_target} (cargo \
+                 zigbuild sets this automatically -- build via `cargo zigbuild`, not plain \
+                 `cargo build`) or CC to a zig-cc-for-musl wrapper"
+            )
+        });
+    let cxx = env::var(format!("CXX_{env_target}"))
+        .or_else(|_| env::var("CXX"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "no C++ compiler found for musl target {target}: set CXX_{env_target} (cargo \
+                 zigbuild sets this automatically -- build via `cargo zigbuild`, not plain \
+                 `cargo build`) or CXX to a zig-c++-for-musl wrapper"
+            )
+        });
+    let processor = if target.starts_with("aarch64") {
+        "aarch64"
+    } else if target.starts_with("x86_64") {
+        "x86_64"
+    } else {
+        panic!("unsupported musl cross arch in target {target}: only x86_64/aarch64 are wired up")
+    };
+    let content = format!(
+        "set(CMAKE_SYSTEM_NAME Linux)\n\
+         set(CMAKE_SYSTEM_PROCESSOR {processor})\n\
+         set(CMAKE_C_COMPILER {cc})\n\
+         set(CMAKE_CXX_COMPILER {cxx})\n\
+         set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\n\
+         set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)\n\
+         set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)\n\
+         set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)\n"
+    );
+    let path = out_dir.join("musl-toolchain.cmake");
+    fs::write(&path, content).expect("write fallback musl cmake toolchain file");
+    path
+}
+
+/// Ensure `libc++.a` / `libc++abi.a` / `libunwind.a` for a musl cross target exist
+/// in `lib_dir` (already on the crate's `-L` search path), building them via zig's
+/// C++ frontend if needed. A no-op if they are already there (keeps incremental
+/// rebuilds fast).
+///
+/// Why this exists: musl targets are cross-compiled with zig cc/c++ (see
+/// `docs`/CI: `cargo zigbuild`, which sets `CC_<target>`/`CXX_<target>` env vars to
+/// its generated wrapper scripts). Zig bundles LLVM's libc++/libc++abi/libunwind
+/// source for musl targets and compiles+archives them on first use into its own
+/// global cache (`zig env`'s `global_cache_dir`, content-hashed, not a stable
+/// path) -- there is no prebuilt musl libc++ package to fetch instead (unlike
+/// e.g. Alpine's alsa-lib, which ships a normal shared build). rustc's own
+/// `#[link(kind = "static")]` handling requires the archive to already exist in a
+/// `-L` dir at the time THIS crate compiles (unlike `dylib` links, which are only
+/// resolved at the final binary's link step) -- so it must be produced here in
+/// build.rs, not left for the final `openasr` binary link to trigger lazily.
+///
+/// Approach: compile+link a trivial `<iostream>`-using stub with `-v` (verbose),
+/// which makes zig print the exact `ld.lld` invocation it runs -- including the
+/// fully resolved, absolute paths to the three archives it just built into its
+/// cache -- then copy those three files into `lib_dir` under their conventional
+/// names so the plain `cargo:rustc-link-lib=static=c++` (+ c++abi, unwind)
+/// directives resolve normally.
+fn materialize_musl_libcxx_archives(target: &str, lib_dir: &Path) {
+    let archives = ["libc++.a", "libc++abi.a", "libunwind.a"];
+    if archives.iter().all(|name| lib_dir.join(name).is_file()) {
+        return;
+    }
+
+    let env_target = target.replace('-', "_");
+    let cxx = env::var(format!("CXX_{env_target}"))
+        .or_else(|_| env::var("CXX"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "no C++ compiler found for musl target {target}: set CXX_{env_target} (cargo \
+                 zigbuild sets this automatically -- build via `cargo zigbuild`, not plain \
+                 `cargo build`) or CXX to a zig-c++-for-musl wrapper (`zig c++ -target \
+                 {target_arch}-linux-musl`)",
+                target_arch = target.split('-').next().unwrap_or("x86_64"),
+            )
+        });
+
+    let stub_source = lib_dir.join("musl_libcxx_probe.cpp");
+    fs::write(
+        &stub_source,
+        "#include <iostream>\nint main() { std::cout << \"probe\"; return 0; }\n",
+    )
+    .expect("write musl libc++ probe source");
+    let stub_binary = lib_dir.join("musl_libcxx_probe");
+
+    // Split on whitespace: CXX_<target>/CXX may be a "compiler plus flags" string
+    // (as cargo/cc-rs conventionally allow), not just a bare executable path.
+    let mut parts = cxx.split_whitespace();
+    let cxx_program = parts
+        .next()
+        .unwrap_or_else(|| panic!("CXX_{env_target}/CXX is empty"));
+    let mut probe = Command::new(cxx_program);
+    probe
+        .args(parts)
+        .arg("-v")
+        .arg("-static")
+        .arg("-o")
+        .arg(&stub_binary)
+        .arg(&stub_source);
+    let output = probe
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run {cxx} to build the musl libc++ probe: {e}"));
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if !output.status.success() {
+        panic!(
+            "musl libc++ probe build failed (exit {:?}) using `{cxx}`:\n{combined}",
+            output.status.code()
+        );
+    }
+
+    for name in archives {
+        let found = combined
+            .split_whitespace()
+            .find(|tok| tok.ends_with(name) && Path::new(tok).is_file())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                panic!(
+                    "could not find an absolute path to {name} in the musl libc++ probe's \
+                     verbose link output; zig's `-v` output format may have changed. Full \
+                     output:\n{combined}"
+                )
+            });
+        fs::copy(&found, lib_dir.join(name)).unwrap_or_else(|e| {
+            panic!(
+                "failed to copy {} to {}: {e}",
+                found.display(),
+                lib_dir.display()
+            )
+        });
+    }
+
+    let _ = fs::remove_file(&stub_source);
+    let _ = fs::remove_file(&stub_binary);
 }
 
 /// Copy the backend-DL runtime DLLs (ggml-base / ggml / ggml-cpu-<variant>) next


### PR DESCRIPTION
## Summary

Add x86_64 and aarch64 linux **musl** static-build legs to the release matrix (experimental), built with `cargo-zigbuild`, plus the `build.rs` support needed to cross-compile ggml against musl. Replaces the earlier approach that pulled a toolchain from musl.cc (unreachable -- `curl` timed out).

## Changes

- `build.rs`: `is_musl` detection; under musl link the C++ runtime statically (libc++/libc++abi/libunwind instead of libstdc++/libgomp); cmake cross toolchain file; materialize zig's static libc++ archive at build time.
- `.github/workflows/release-binaries.yml`: musl legs install `ziglang` (pip) + `cargo-zigbuild` + rustup targets on the CI runner and build via `cargo zigbuild`. Legs are `experimental: true` (continue-on-error), friendly asset names `linux-x86_64-musl` / `linux-arm64-musl`.

## Tests run

- [x] Single-leg `workflow_dispatch` dry runs (`only_target`, no upload) built **both** legs to success: `Build x86_64-unknown-linux-musl: success` and `Build aarch64-unknown-linux-musl: success` (run 28966668223). All toolchain install/build/package steps on the CI runner (no local host builds).
- Non-musl builds are unaffected (all `build.rs` changes are gated behind `is_musl`).

## Scope / non-goals

- Legs stay experimental (not gating release assets). Promoting them (removing `experimental` + adding to `verify-completeness`) is a separate release decision.

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance; maintainer owns and merges.