### PR TITLE
fix(core): cap longform slices for quadratic-attention encoders to bound memory

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, path::Path, sync::OnceLock};
 
 use crate::NATIVE_RUNTIME_MODEL_ID_AUTO;
 use crate::api::audio_io::load_wav_16khz_mono_f32_v0;
-use crate::arch::OpenAsrArchitectureRegistry;
+use crate::arch::{DEFAULT_ENCODER_SAFE_CHUNK_SECONDS, OpenAsrArchitectureRegistry};
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphConfig, install_request_backend_override,
 };
@@ -34,7 +34,21 @@ use crate::models::qwen::{
 };
 
 const DEFAULT_NATIVE_LONGFORM_AUTO_TRIGGER_SECONDS: f32 = 30.0;
-const COHERE_LONGFORM_MAX_CHUNK_SECONDS: f32 = 10.0;
+/// Chunk-length ceiling for the decode-side `ConservativeSeq2SeqV1`
+/// repetition-guard profile (issue #60: cohere-transcribe, moonshine,
+/// firered-aed). Historically this was a hard-coded `10.0` with no model
+/// basis -- a defensive patch from when the repetition failure mode was
+/// first found, predating the structural fix (the shared greedy-decode
+/// driver's degenerate-loop guard, which is the actual anti-repetition
+/// mechanism and stays in place regardless of chunk length). That 10s value
+/// has since been surveyed against the same industry evidence backing
+/// `DEFAULT_ENCODER_SAFE_CHUNK_SECONDS` (Whisper/Moonshine/NeMo/FunASR/
+/// Dolphin/Cohere all converge near 30s) and found to have no independent
+/// justification, so it is unified with that default: the previous name
+/// (`COHERE_LONGFORM_MAX_CHUNK_SECONDS`) was also misleading on both counts
+/// (not 10s anymore, and not cohere-only -- moonshine and firered-aed carry
+/// the same profile).
+const CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS: f32 = DEFAULT_ENCODER_SAFE_CHUNK_SECONDS;
 const COHERE_LONGFORM_OVERLAP_SECONDS: f32 = 0.0;
 static NATIVE_GGML_EXECUTION_DISPATCH: OnceLock<GgmlAsrExecutionDispatch> = OnceLock::new();
 
@@ -1128,10 +1142,17 @@ fn apply_longform_safety_policy(
 /// Caps longform chunking for the decode-side `ConservativeSeq2SeqV1`
 /// repetition-guard profile (issue #60): plain `<sos>`-prompted AED decoders
 /// with a small effective context (cohere-transcribe, moonshine, firered-aed)
-/// repeat/hallucinate on long, pause-free chunks, so their chunk length is
-/// capped hard and prompt carry across slices is disabled. This is a decode
+/// repeat/hallucinate on long, pause-free chunks, so prompt carry across
+/// slices is disabled here. The chunk-length cap itself
+/// (`CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS`) is *not* the
+/// repetition fix -- that is the shared greedy-decode driver's
+/// degenerate-loop guard, which applies regardless of chunk length -- so
+/// this cap uses the same industry-surveyed default as the encoder-memory
+/// cap below rather than an arbitrarily tighter number. This is a decode
 /// semantics cap, independent of the encoder-memory cap below (which caps a
-/// different, larger set of architectures for a different reason).
+/// different, larger set of architectures for a different reason); the two
+/// happen to share the same default value today, but remain conceptually
+/// distinct and compose by taking the min if a future override diverges them.
 fn apply_conservative_seq2seq_longform_safety_policy(
     model_architecture: &str,
     options: &mut crate::LongFormOptions,
@@ -1144,16 +1165,16 @@ fn apply_conservative_seq2seq_longform_safety_policy(
         return;
     }
     let mut changed = false;
-    if options.chunk_seconds > COHERE_LONGFORM_MAX_CHUNK_SECONDS {
-        options.chunk_seconds = COHERE_LONGFORM_MAX_CHUNK_SECONDS;
+    if options.chunk_seconds > CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS {
+        options.chunk_seconds = CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS;
         changed = true;
     }
-    if options.max_chunk_seconds > COHERE_LONGFORM_MAX_CHUNK_SECONDS {
-        options.max_chunk_seconds = COHERE_LONGFORM_MAX_CHUNK_SECONDS;
+    if options.max_chunk_seconds > CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS {
+        options.max_chunk_seconds = CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS;
         changed = true;
     }
-    if options.min_chunk_seconds > COHERE_LONGFORM_MAX_CHUNK_SECONDS {
-        options.min_chunk_seconds = COHERE_LONGFORM_MAX_CHUNK_SECONDS;
+    if options.min_chunk_seconds > CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS {
+        options.min_chunk_seconds = CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS;
         changed = true;
     }
     if options.max_chunk_seconds < options.chunk_seconds {
@@ -1180,7 +1201,7 @@ fn apply_conservative_seq2seq_longform_safety_policy(
     if changed {
         provenance.push(format!(
             "core.native.longform.policy:cohere-chunk-cap={}",
-            COHERE_LONGFORM_MAX_CHUNK_SECONDS
+            CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS
         ));
     }
 }
@@ -1884,11 +1905,11 @@ mod tests {
         assert_eq!(resolution.options.mode, LongFormMode::Auto);
         assert_eq!(
             resolution.options.chunk_seconds,
-            COHERE_LONGFORM_MAX_CHUNK_SECONDS
+            CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS
         );
         assert_eq!(
             resolution.options.max_chunk_seconds,
-            COHERE_LONGFORM_MAX_CHUNK_SECONDS
+            CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS
         );
         assert_eq!(resolution.options.min_chunk_seconds, 1.0);
         assert_eq!(
@@ -1930,15 +1951,15 @@ mod tests {
         );
         assert_eq!(
             resolution.options.chunk_seconds,
-            COHERE_LONGFORM_MAX_CHUNK_SECONDS
+            CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS
         );
         assert_eq!(
             resolution.options.max_chunk_seconds,
-            COHERE_LONGFORM_MAX_CHUNK_SECONDS
+            CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS
         );
         assert_eq!(
             resolution.options.min_chunk_seconds,
-            COHERE_LONGFORM_MAX_CHUNK_SECONDS
+            CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS
         );
         assert_eq!(
             resolution.options.overlap_seconds,
@@ -1993,8 +2014,9 @@ mod tests {
         );
 
         // Correct wiring: keying off model_architecture applies BOTH the
-        // encoder-attention-span cap (30s) and the tighter conservative
-        // seq2seq cap (10s) -- the min of the two, 10s, wins.
+        // encoder-attention-span cap and the conservative seq2seq cap --
+        // both now resolve to the same default (30s), so composing them
+        // (taking the min) is a no-op, but both must still actually run.
         let correct = resolve_native_longform_policy_for_backend(
             None,
             120.0,
@@ -2003,7 +2025,7 @@ mod tests {
         );
         assert_eq!(
             correct.options.max_chunk_seconds,
-            COHERE_LONGFORM_MAX_CHUNK_SECONDS
+            CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS
         );
         assert!(correct.options.max_chunk_seconds < 120.0);
 
@@ -2024,7 +2046,14 @@ mod tests {
     /// (issue #68): a `GlobalQuadratic` encoder must never be handed a
     /// longform chunk longer than its declared safe ceiling, while
     /// `FixedWindow` (whisper) and `LocalChunked` (zipformer) architectures
-    /// need no additional cap and keep the unmodified 120s default.
+    /// need no additional cap and keep the unmodified 120s default. All nine
+    /// `GlobalQuadratic` builtins (including firered-aed/cohere-transcribe/
+    /// moonshine, which also carry the decode-side `ConservativeSeq2SeqV1`
+    /// cap) declare `DEFAULT_ENCODER_SAFE_CHUNK_SECONDS`, so this asserts
+    /// exact equality, not just an upper bound: the two caps stacked on the
+    /// conservative-seq2seq trio must resolve to the same 30s default, not
+    /// silently over-tighten to something smaller than either cap alone
+    /// intends.
     #[test]
     fn encoder_attention_span_caps_every_builtin_architecture_on_the_production_path() {
         for descriptor in OpenAsrArchitectureRegistry::with_builtins().descriptors() {
@@ -2036,11 +2065,16 @@ mod tests {
             );
             match descriptor.longform_max_safe_chunk_seconds() {
                 Some(max_safe_chunk_seconds) => {
-                    assert!(
-                        resolution.options.max_chunk_seconds <= max_safe_chunk_seconds,
-                        "'{}' must cap max_chunk_seconds to <= {max_safe_chunk_seconds}, got {}",
-                        descriptor.model_architecture,
-                        resolution.options.max_chunk_seconds
+                    assert_eq!(
+                        max_safe_chunk_seconds, DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
+                        "'{}' GlobalQuadratic ceiling must be the shared default absent a cited \
+                         upstream override",
+                        descriptor.model_architecture
+                    );
+                    assert_eq!(
+                        resolution.options.max_chunk_seconds, max_safe_chunk_seconds,
+                        "'{}' must resolve max_chunk_seconds to exactly {max_safe_chunk_seconds}, got {}",
+                        descriptor.model_architecture, resolution.options.max_chunk_seconds
                     );
                     assert!(
                         resolution.options.chunk_seconds <= max_safe_chunk_seconds,

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -575,7 +575,7 @@ fn run_native_transcription_impl(
     let longform_resolution = resolve_native_longform_policy(
         request.longform.as_ref(),
         audio_duration_seconds,
-        selected_family.adapter_id,
+        selected_family.model_architecture,
     );
     let longform_options = longform_resolution.options.clone();
     let run_longform = !matches!(longform_options.mode, LongFormMode::Off);
@@ -1108,7 +1108,31 @@ fn resolve_native_longform_policy_for_backend(
     }
 }
 
+/// Applies every family-specific longform safety cap for `model_architecture`.
+/// Two independent caps can apply to the same architecture (e.g.
+/// firered-aed/cohere/moonshine carry both), and they are combined by never
+/// letting a later cap *widen* a value an earlier cap already narrowed --
+/// each helper only clamps downward, so the net effect is always the min of
+/// whichever caps apply. Order does not matter for that reason; the
+/// repetition-guard profile runs first only because it is the
+/// longer-standing check.
 fn apply_longform_safety_policy(
+    model_architecture: &str,
+    options: &mut crate::LongFormOptions,
+    provenance: &mut Vec<String>,
+) {
+    apply_conservative_seq2seq_longform_safety_policy(model_architecture, options, provenance);
+    apply_encoder_attention_span_longform_safety_policy(model_architecture, options, provenance);
+}
+
+/// Caps longform chunking for the decode-side `ConservativeSeq2SeqV1`
+/// repetition-guard profile (issue #60): plain `<sos>`-prompted AED decoders
+/// with a small effective context (cohere-transcribe, moonshine, firered-aed)
+/// repeat/hallucinate on long, pause-free chunks, so their chunk length is
+/// capped hard and prompt carry across slices is disabled. This is a decode
+/// semantics cap, independent of the encoder-memory cap below (which caps a
+/// different, larger set of architectures for a different reason).
+fn apply_conservative_seq2seq_longform_safety_policy(
     model_architecture: &str,
     options: &mut crate::LongFormOptions,
     provenance: &mut Vec<String>,
@@ -1157,6 +1181,58 @@ fn apply_longform_safety_policy(
         provenance.push(format!(
             "core.native.longform.policy:cohere-chunk-cap={}",
             COHERE_LONGFORM_MAX_CHUNK_SECONDS
+        ));
+    }
+}
+
+/// Caps longform chunking to the architecture's declared
+/// `OpenAsrEncoderAttentionSpan::GlobalQuadratic` safety ceiling (issue #68):
+/// a global-quadratic-attention encoder's activation memory grows with the
+/// square of chunk length, so a long, pause-free recording that lets the
+/// auto/energy/VAD slicer grow a chunk up to the (much larger)
+/// `LongFormOptions::default().max_chunk_seconds` can exhaust RAM. Whisper
+/// (`FixedWindow`) and zipformer (`LocalChunked`) need no cap here -- their
+/// encoders do not scale with the logical chunk length -- so this is a no-op
+/// for them. Only ever clamps downward, so it composes safely with
+/// `apply_conservative_seq2seq_longform_safety_policy`'s tighter cap on the
+/// families that carry both.
+fn apply_encoder_attention_span_longform_safety_policy(
+    model_architecture: &str,
+    options: &mut crate::LongFormOptions,
+    provenance: &mut Vec<String>,
+) {
+    let Some(descriptor) =
+        OpenAsrArchitectureRegistry::with_builtins().find_by_model_architecture(model_architecture)
+    else {
+        return;
+    };
+    let Some(max_safe_chunk_seconds) = descriptor.longform_max_safe_chunk_seconds() else {
+        return;
+    };
+    let mut changed = false;
+    if options.chunk_seconds > max_safe_chunk_seconds {
+        options.chunk_seconds = max_safe_chunk_seconds;
+        changed = true;
+    }
+    if options.max_chunk_seconds > max_safe_chunk_seconds {
+        options.max_chunk_seconds = max_safe_chunk_seconds;
+        changed = true;
+    }
+    if options.min_chunk_seconds > max_safe_chunk_seconds {
+        options.min_chunk_seconds = max_safe_chunk_seconds;
+        changed = true;
+    }
+    if options.max_chunk_seconds < options.chunk_seconds {
+        options.max_chunk_seconds = options.chunk_seconds;
+        changed = true;
+    }
+    if options.min_chunk_seconds > options.chunk_seconds {
+        options.min_chunk_seconds = options.chunk_seconds;
+        changed = true;
+    }
+    if changed {
+        provenance.push(format!(
+            "core.native.longform.policy:encoder-attention-span-chunk-cap={max_safe_chunk_seconds}"
         ));
     }
 }
@@ -1873,6 +1949,12 @@ mod tests {
 
     #[test]
     fn qwen_metal_longform_policy_keeps_default_chunk_size() {
+        // qwen has no `ConservativeSeq2SeqV1` decode-side profile, so
+        // `chunk_seconds` (already 30.0 by default) is untouched. But qwen's
+        // audio encoder IS `GlobalQuadratic` (issue #68), so the much larger
+        // `max_chunk_seconds` default (120.0) -- the true ceiling the VAD/
+        // energy/auto slicer can grow a chunk to on long, pause-free audio --
+        // must still be capped down to the 30s safe ceiling.
         let resolution = resolve_native_longform_policy_for_backend(
             None,
             120.0,
@@ -1880,7 +1962,102 @@ mod tests {
             GgmlCpuGraphBackend::Metal,
         );
         assert_eq!(resolution.options.chunk_seconds, 30.0);
-        assert!(resolution.provenance.is_empty());
+        assert_eq!(resolution.options.max_chunk_seconds, 30.0);
+        assert!(resolution.provenance.iter().any(|entry| {
+            entry.contains("core.native.longform.policy:encoder-attention-span-chunk-cap=30")
+        }));
+    }
+
+    /// Production-path regression test for the issue #68 wiring bug: the real
+    /// call site (`run_native_transcription`) resolves the longform safety
+    /// cap from the `GgmlFamilyAdapterDescriptor` the same way
+    /// `validate_runtime_source_and_select_adapter` builds it, and MUST key
+    /// off `model_architecture` -- never `adapter_id`. The two are different
+    /// strings for every builtin family (asserted below), so passing the
+    /// wrong one makes `resolve_builtin_decode_policy_for_architecture` and
+    /// `OpenAsrArchitectureRegistry::find_by_model_architecture` both miss,
+    /// silently dropping every family-specific longform safety cap -- which
+    /// is exactly how firered-aed/cohere/moonshine's `ConservativeSeq2SeqV1`
+    /// cap and every `GlobalQuadratic` family's encoder-memory cap went live
+    /// but never actually applied in production (chunk length stayed at the
+    /// unsafe 120s default) until this fix.
+    #[test]
+    fn native_longform_policy_uses_selected_family_model_architecture_not_adapter_id() {
+        let selected_family = OpenAsrArchitectureRegistry::with_builtins()
+            .find_by_model_architecture(crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID)
+            .expect("firered-aed architecture")
+            .ggml_family_adapter_descriptor();
+        assert_ne!(
+            selected_family.adapter_id,
+            selected_family.model_architecture
+        );
+
+        // Correct wiring: keying off model_architecture applies BOTH the
+        // encoder-attention-span cap (30s) and the tighter conservative
+        // seq2seq cap (10s) -- the min of the two, 10s, wins.
+        let correct = resolve_native_longform_policy_for_backend(
+            None,
+            120.0,
+            selected_family.model_architecture,
+            GgmlCpuGraphBackend::Cpu,
+        );
+        assert_eq!(
+            correct.options.max_chunk_seconds,
+            COHERE_LONGFORM_MAX_CHUNK_SECONDS
+        );
+        assert!(correct.options.max_chunk_seconds < 120.0);
+
+        // The bug class this guards against: keying off adapter_id finds no
+        // matching architecture, so every safety cap silently no-ops and the
+        // unsafe 120s default max_chunk_seconds survives untouched.
+        let wrong = resolve_native_longform_policy_for_backend(
+            None,
+            120.0,
+            selected_family.adapter_id,
+            GgmlCpuGraphBackend::Cpu,
+        );
+        assert_eq!(wrong.options.max_chunk_seconds, 120.0);
+        assert!(wrong.provenance.is_empty());
+    }
+
+    /// Data-driven production-path coverage over every builtin architecture
+    /// (issue #68): a `GlobalQuadratic` encoder must never be handed a
+    /// longform chunk longer than its declared safe ceiling, while
+    /// `FixedWindow` (whisper) and `LocalChunked` (zipformer) architectures
+    /// need no additional cap and keep the unmodified 120s default.
+    #[test]
+    fn encoder_attention_span_caps_every_builtin_architecture_on_the_production_path() {
+        for descriptor in OpenAsrArchitectureRegistry::with_builtins().descriptors() {
+            let resolution = resolve_native_longform_policy_for_backend(
+                None,
+                120.0,
+                descriptor.model_architecture,
+                GgmlCpuGraphBackend::Cpu,
+            );
+            match descriptor.longform_max_safe_chunk_seconds() {
+                Some(max_safe_chunk_seconds) => {
+                    assert!(
+                        resolution.options.max_chunk_seconds <= max_safe_chunk_seconds,
+                        "'{}' must cap max_chunk_seconds to <= {max_safe_chunk_seconds}, got {}",
+                        descriptor.model_architecture,
+                        resolution.options.max_chunk_seconds
+                    );
+                    assert!(
+                        resolution.options.chunk_seconds <= max_safe_chunk_seconds,
+                        "'{}' must cap chunk_seconds to <= {max_safe_chunk_seconds}, got {}",
+                        descriptor.model_architecture,
+                        resolution.options.chunk_seconds
+                    );
+                }
+                None => {
+                    assert_eq!(
+                        resolution.options.max_chunk_seconds, 120.0,
+                        "'{}' (FixedWindow/LocalChunked) must keep the unmodified default",
+                        descriptor.model_architecture
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -167,7 +167,38 @@ pub(crate) struct OpenAsrComponentDescriptor {
     pub id: &'static str,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// How this architecture's encoder attends over time -- the single
+/// declaration of the encoder memory-scaling fact that longform safety caps
+/// consult (see `native_transcribe::apply_encoder_attention_span_longform_safety_policy`).
+/// A pure compute/memory-footprint property, independent of the
+/// `ConservativeSeq2SeqV1` decode-side longform profile
+/// (`BuiltinDecodePolicyLongformProfile`, issue #60's repetition guard): a
+/// family can carry both a `GlobalQuadratic` encoder cap and a tighter
+/// `ConservativeSeq2SeqV1` chunk cap at once. Both constrain the same
+/// `LongFormOptions` fields, so the tighter cap always wins (the policy
+/// applies them in sequence and never widens a value the other narrowed).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum OpenAsrEncoderAttentionSpan {
+    /// Full O(frames^2) self-attention over the whole encoder input: every
+    /// additional second of audio in a single chunk adds one more row and
+    /// column to every layer's attention matrix, so encoder activation memory
+    /// grows quadratically with the wall-clock length of that chunk.
+    /// `max_safe_chunk_seconds` is the longest chunk this repo has validated
+    /// as safe on commodity RAM; longform slicing must never hand this
+    /// architecture a chunk longer than that (issue #68).
+    GlobalQuadratic { max_safe_chunk_seconds: f32 },
+    /// Architecture-fixed attention window (whisper's 30s log-mel frame): the
+    /// encoder never attends beyond a fixed span regardless of the requested
+    /// longform chunk length, so no additional longform safety cap applies.
+    FixedWindow,
+    /// Local/chunked attention with a bounded per-chunk cache (zipformer's
+    /// streaming multi-scale encoder): encoder memory is bounded per chunk by
+    /// construction, independent of how long the logical longform chunk is,
+    /// so no additional longform safety cap applies.
+    LocalChunked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct OpenAsrArchitectureDescriptor {
     pub runtime_architecture_aliases: &'static [&'static str],
     pub model_family: &'static str,
@@ -216,9 +247,29 @@ pub(crate) struct OpenAsrArchitectureDescriptor {
     /// hand-written executor and are never composed (whisper, the bit-level
     /// regression gate). See [`block_stack`].
     pub block_stack: Option<OpenAsrBlockStackDescriptor>,
+    /// How this architecture's encoder scales with chunk length -- the single
+    /// source of truth `native_transcribe`'s longform safety policy consults
+    /// to keep long, pause-free audio from handing a quadratic-attention
+    /// encoder an unbounded chunk (issue #68). See
+    /// [`OpenAsrEncoderAttentionSpan`]. A mandatory field (not `Option`) so a
+    /// new architecture cannot compile without declaring it.
+    pub encoder_attention_span: OpenAsrEncoderAttentionSpan,
 }
 
 impl OpenAsrArchitectureDescriptor {
+    /// The longform chunk-length safety cap this architecture's encoder
+    /// tolerates, if any (`None` when the encoder needs no additional cap --
+    /// `FixedWindow`/`LocalChunked`). See [`OpenAsrEncoderAttentionSpan`].
+    pub(crate) fn longform_max_safe_chunk_seconds(self) -> Option<f32> {
+        match self.encoder_attention_span {
+            OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                max_safe_chunk_seconds,
+            } => Some(max_safe_chunk_seconds),
+            OpenAsrEncoderAttentionSpan::FixedWindow
+            | OpenAsrEncoderAttentionSpan::LocalChunked => None,
+        }
+    }
+
     fn matches_runtime_architecture_alias(&self, alias: &str) -> bool {
         self.runtime_architecture_aliases
             .iter()
@@ -256,7 +307,7 @@ pub(crate) fn emits_punctuation_for_model_architecture(model_architecture: &str)
         .and_then(|descriptor| descriptor.emits_punctuation)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum OpenAsrArchitectureRegistryError {
     MissingComponentReference {
         model_architecture: &'static str,
@@ -306,6 +357,13 @@ pub(crate) enum OpenAsrArchitectureRegistryError {
     NonCtcShapeMustHaveDecoderStage {
         model_architecture: &'static str,
         orchestration_shape: OpenAsrOrchestrationShape,
+    },
+    /// A `GlobalQuadratic` encoder declared a `max_safe_chunk_seconds` that is
+    /// not finite and positive. Garbage data here would silently disable the
+    /// longform safety cap it exists to enforce (issue #68).
+    EncoderAttentionSpanNotFinitePositive {
+        model_architecture: &'static str,
+        max_safe_chunk_seconds: f32,
     },
 }
 
@@ -400,6 +458,7 @@ impl OpenAsrArchitectureRegistry {
             )?;
             Self::validate_hparam_schema(*descriptor)?;
             Self::validate_block_stack(*descriptor)?;
+            Self::validate_encoder_attention_span(*descriptor)?;
         }
         Ok(())
     }
@@ -472,6 +531,29 @@ impl OpenAsrArchitectureRegistry {
                     key,
                 });
             }
+        }
+        Ok(())
+    }
+
+    /// Fail-closed consistency check on the encoder-attention-span cap: a
+    /// `GlobalQuadratic` architecture's `max_safe_chunk_seconds` must be
+    /// finite and positive, otherwise the longform safety policy that reads
+    /// it (`native_transcribe::apply_encoder_attention_span_longform_safety_policy`)
+    /// would silently no-op on garbage data.
+    fn validate_encoder_attention_span(
+        descriptor: OpenAsrArchitectureDescriptor,
+    ) -> Result<(), OpenAsrArchitectureRegistryError> {
+        if let OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds,
+        } = descriptor.encoder_attention_span
+            && !(max_safe_chunk_seconds.is_finite() && max_safe_chunk_seconds > 0.0)
+        {
+            return Err(
+                OpenAsrArchitectureRegistryError::EncoderAttentionSpanNotFinitePositive {
+                    model_architecture: descriptor.model_architecture,
+                    max_safe_chunk_seconds,
+                },
+            );
         }
         Ok(())
     }
@@ -835,6 +917,12 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
                 tensor_name_scope: "dec.blk",
             }),
         }),
+        // Conformer encoder is full self-attention over the whole chunk:
+        // quadratic in chunk length, same 30s safe ceiling as the other
+        // global-quadratic builtins (issue #68).
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds: 30.0,
+        },
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &["whisper"],
@@ -856,6 +944,10 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // never composed — no block-stack data until P9 sinks its optimizations
         // into the shared blocks.
         block_stack: None,
+        // Architecture-fixed 30s log-mel window: the encoder never sees more
+        // than a fixed span no matter how long the requested longform chunk
+        // is, so it needs no additional longform safety cap.
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::FixedWindow,
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &[QWEN3_ARCHITECTURE_VALUE],
@@ -893,6 +985,13 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
                 tensor_name_scope: "blk",
             }),
         }),
+        // The audio encoder is full self-attention over the whole chunk:
+        // quadratic in chunk length (issue #68); the LLM decoder side is
+        // autoregressive token generation, not chunk-length-scaled encoder
+        // attention, so it does not change this classification.
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds: 30.0,
+        },
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &["parakeet-ctc", "parakeet"],
@@ -925,6 +1024,11 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             }),
             decoder_stage: None,
         }),
+        // FastConformer encoder is full self-attention over the whole chunk:
+        // quadratic in chunk length (issue #68).
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds: 30.0,
+        },
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &["parakeet-tdt"],
@@ -959,6 +1063,13 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // orchestration shape -- dedicated executor, like xasr (block_stack:
         // None).
         block_stack: None,
+        // The FastConformer encoder is full self-attention over the whole
+        // chunk: quadratic in chunk length (issue #68). The TDT
+        // decoder/joiner is a separate autoregressive stage and does not
+        // change the encoder's scaling.
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds: 30.0,
+        },
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &["wav2vec2-ctc", "wav2vec2"],
@@ -988,6 +1099,11 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             }),
             decoder_stage: None,
         }),
+        // Post-norm transformer encoder is full self-attention over the
+        // whole chunk: quadratic in chunk length (issue #68).
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds: 30.0,
+        },
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &["xasr-zipformer", "xasr-zh-en"],
@@ -1011,6 +1127,12 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // decoder/joiner, so it stays on its dedicated executor rather than the
         // generic block-stack composer.
         block_stack: None,
+        // Zipformer2's multi-scale streaming cache is local/chunked
+        // attention with a bounded per-chunk cache, not global quadratic
+        // attention: encoder memory is bounded independent of the logical
+        // longform chunk length, so no additional longform safety cap
+        // applies (issue #68).
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::LocalChunked,
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &["moonshine", "moonshine-encoder-decoder"],
@@ -1032,6 +1154,13 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // dedicated executor (not the data-driven block-stack composer — its
         // RoPE conv-stem encoder + cross-attn decoder are not composer blocks).
         block_stack: None,
+        // The RoPE encoder is full self-attention over the whole chunk:
+        // quadratic in chunk length (issue #68). Also carries the tighter
+        // `ConservativeSeq2SeqV1` decode-side longform profile (issue #60);
+        // the two caps combine by taking the min.
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds: 30.0,
+        },
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &[DOLPHIN_GGML_ARCHITECTURE_ID, "dolphin"],
@@ -1061,6 +1190,12 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // dedicated executor (the E-Branchformer block is not a composer block
         // kind), so no data-driven block-stack descriptor.
         block_stack: None,
+        // The E-Branchformer's rel-pos MHSA global branch is full
+        // self-attention over the whole chunk: quadratic in chunk length
+        // (issue #68).
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds: 30.0,
+        },
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &[SENSEVOICE_GGML_ARCHITECTURE_ID, "sensevoice"],
@@ -1092,6 +1227,11 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             }),
             decoder_stage: None,
         }),
+        // SAN-M/FSMN encoder's self-attention memory block is full attention
+        // over the whole chunk: quadratic in chunk length (issue #68).
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds: 30.0,
+        },
     },
     OpenAsrArchitectureDescriptor {
         runtime_architecture_aliases: &[FIRERED_AED_GGML_ARCHITECTURE_ID, "firered-aed"],
@@ -1120,6 +1260,13 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // on the dedicated executor (the Conformer block is not a composer
         // block kind), so no data-driven block-stack descriptor.
         block_stack: None,
+        // Conformer encoder is full self-attention over the whole chunk:
+        // quadratic in chunk length (issue #68). Also carries the tighter
+        // `ConservativeSeq2SeqV1` decode-side longform profile (issue #60);
+        // the two caps combine by taking the min.
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+            max_safe_chunk_seconds: 30.0,
+        },
     },
 ];
 
@@ -1185,6 +1332,149 @@ mod tests {
             registry.descriptors().len(),
             "expectation table must cover every builtin architecture, no more, no less"
         );
+    }
+
+    /// Pins `encoder_attention_span` per builtin architecture -- the single
+    /// Rust-side declaration `native_transcribe`'s longform safety policy
+    /// consults to cap chunk length for quadratic-attention encoders (issue
+    /// #68). Whisper's fixed 30s window and zipformer's local/chunked
+    /// streaming encoder need no additional cap; every other builtin
+    /// architecture's encoder is full self-attention over the whole chunk,
+    /// so all nine are `GlobalQuadratic` with the same validated-safe 30s
+    /// ceiling.
+    #[test]
+    fn builtin_architectures_declare_encoder_attention_span() {
+        let expected: &[(&str, OpenAsrEncoderAttentionSpan)] = &[
+            (
+                COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: 30.0,
+                },
+            ),
+            (
+                WHISPER_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::FixedWindow,
+            ),
+            (
+                QWEN3_ASR_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: 30.0,
+                },
+            ),
+            (
+                PARAKEET_CTC_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: 30.0,
+                },
+            ),
+            (
+                PARAKEET_TDT_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: 30.0,
+                },
+            ),
+            (
+                WAV2VEC2_CTC_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: 30.0,
+                },
+            ),
+            (
+                XASR_ZIPFORMER_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::LocalChunked,
+            ),
+            (
+                MOONSHINE_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: 30.0,
+                },
+            ),
+            (
+                DOLPHIN_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: 30.0,
+                },
+            ),
+            (
+                SENSEVOICE_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: 30.0,
+                },
+            ),
+            (
+                FIRERED_AED_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: 30.0,
+                },
+            ),
+        ];
+        let registry = OpenAsrArchitectureRegistry::with_builtins();
+        let mut seen = std::collections::BTreeSet::new();
+
+        for (model_architecture, expected_span) in expected.iter().copied() {
+            let descriptor = registry
+                .find_by_model_architecture(model_architecture)
+                .unwrap_or_else(|| panic!("missing builtin architecture '{model_architecture}'"));
+            assert_eq!(
+                descriptor.encoder_attention_span, expected_span,
+                "'{model_architecture}' encoder_attention_span mismatch"
+            );
+            assert_eq!(
+                descriptor.longform_max_safe_chunk_seconds(),
+                match expected_span {
+                    OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                        max_safe_chunk_seconds,
+                    } => Some(max_safe_chunk_seconds),
+                    OpenAsrEncoderAttentionSpan::FixedWindow
+                    | OpenAsrEncoderAttentionSpan::LocalChunked => None,
+                },
+                "'{model_architecture}' longform_max_safe_chunk_seconds accessor mismatch"
+            );
+            seen.insert(model_architecture);
+        }
+
+        assert_eq!(
+            seen.len(),
+            registry.descriptors().len(),
+            "expectation table must cover every builtin architecture, no more, no less"
+        );
+    }
+
+    #[test]
+    fn validate_references_rejects_non_finite_positive_encoder_attention_span_cap() {
+        let base = OpenAsrArchitectureRegistry::with_builtins()
+            .find_by_model_architecture(FIRERED_AED_GGML_ARCHITECTURE_ID)
+            .expect("firered architecture");
+
+        for bad_value in [0.0_f32, -1.0, f32::NAN, f32::INFINITY] {
+            let descriptor = OpenAsrArchitectureDescriptor {
+                encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
+                    max_safe_chunk_seconds: bad_value,
+                },
+                ..base
+            };
+            let error = OpenAsrArchitectureRegistry::validate_encoder_attention_span(descriptor)
+                .expect_err("non-finite/non-positive max_safe_chunk_seconds must fail closed");
+            // NaN != NaN under PartialEq, so match structurally instead of
+            // asserting equality against a NaN-carrying expected value.
+            match error {
+                OpenAsrArchitectureRegistryError::EncoderAttentionSpanNotFinitePositive {
+                    model_architecture,
+                    max_safe_chunk_seconds,
+                } => {
+                    assert_eq!(model_architecture, FIRERED_AED_GGML_ARCHITECTURE_ID);
+                    assert!(
+                        max_safe_chunk_seconds == bad_value
+                            || (max_safe_chunk_seconds.is_nan() && bad_value.is_nan())
+                    );
+                }
+                other => panic!("unexpected error variant: {other:?}"),
+            }
+        }
+
+        // A well-formed cap still validates.
+        OpenAsrArchitectureRegistry::validate_encoder_attention_span(base)
+            .expect("firered's real descriptor has a valid encoder_attention_span cap");
     }
 
     #[test]

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -167,6 +167,32 @@ pub(crate) struct OpenAsrComponentDescriptor {
     pub id: &'static str,
 }
 
+/// Default `GlobalQuadratic` safe chunk-length ceiling (issue #68) -- the
+/// value every new `GlobalQuadratic` builtin architecture should declare
+/// unless the upstream model publishes a different explicit recommendation.
+/// This is not an arbitrary number: it is where the major encoder families
+/// this repo has surveyed independently converge --
+///
+/// - Whisper's encoder is architecture-fixed at a 30s log-mel window (see
+///   `FixedWindow` below, which needs no cap at all because of this).
+/// - Moonshine's model card recommends audio chunks "less than 30 seconds".
+/// - NVIDIA NeMo/Parakeet's published offline/streaming guidance targets
+///   20-30s chunks for FastConformer encoders.
+/// - FunASR's default VAD max single-segment length is 30000ms.
+/// - Dolphin (WeNet E-Branchformer) is trained and evaluated with audio
+///   padded/truncated to 30s.
+/// - Cohere's own longform reference decoder uses a 30s sliding window.
+///
+/// A new `GlobalQuadratic` architecture should use this default. Only
+/// override `max_safe_chunk_seconds` with a different value when the
+/// upstream model card states an explicit, different recommended chunk
+/// length -- and cite that source in a comment next to the override (see
+/// firered-aed's descriptor entry below, whose upstream guidance --
+/// 60s-warn/200s-error -- is wider than this default; it still uses this
+/// default rather than the wider figure, for RAM margin and cross-family
+/// consistency, and says so in its own comment).
+pub(crate) const DEFAULT_ENCODER_SAFE_CHUNK_SECONDS: f32 = 30.0;
+
 /// How this architecture's encoder attends over time -- the single
 /// declaration of the encoder memory-scaling fact that longform safety caps
 /// consult (see `native_transcribe::apply_encoder_attention_span_longform_safety_policy`).
@@ -185,7 +211,9 @@ pub(crate) enum OpenAsrEncoderAttentionSpan {
     /// grows quadratically with the wall-clock length of that chunk.
     /// `max_safe_chunk_seconds` is the longest chunk this repo has validated
     /// as safe on commodity RAM; longform slicing must never hand this
-    /// architecture a chunk longer than that (issue #68).
+    /// architecture a chunk longer than that (issue #68). Use
+    /// [`DEFAULT_ENCODER_SAFE_CHUNK_SECONDS`] unless the upstream model card
+    /// gives an explicit different recommendation (see that constant's doc).
     GlobalQuadratic { max_safe_chunk_seconds: f32 },
     /// Architecture-fixed attention window (whisper's 30s log-mel frame): the
     /// encoder never attends beyond a fixed span regardless of the requested
@@ -918,10 +946,13 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             }),
         }),
         // Conformer encoder is full self-attention over the whole chunk:
-        // quadratic in chunk length, same 30s safe ceiling as the other
-        // global-quadratic builtins (issue #68).
+        // quadratic in chunk length, same safe ceiling as the other
+        // global-quadratic builtins (issue #68). Also carries the
+        // `ConservativeSeq2SeqV1` decode-side longform profile (issue #60's
+        // repetition guard); the two caps now agree at the same default, so
+        // composing them (taking the min) is a no-op here.
         encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-            max_safe_chunk_seconds: 30.0,
+            max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
     OpenAsrArchitectureDescriptor {
@@ -990,7 +1021,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // autoregressive token generation, not chunk-length-scaled encoder
         // attention, so it does not change this classification.
         encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-            max_safe_chunk_seconds: 30.0,
+            max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
     OpenAsrArchitectureDescriptor {
@@ -1027,7 +1058,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // FastConformer encoder is full self-attention over the whole chunk:
         // quadratic in chunk length (issue #68).
         encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-            max_safe_chunk_seconds: 30.0,
+            max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
     OpenAsrArchitectureDescriptor {
@@ -1068,7 +1099,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // decoder/joiner is a separate autoregressive stage and does not
         // change the encoder's scaling.
         encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-            max_safe_chunk_seconds: 30.0,
+            max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
     OpenAsrArchitectureDescriptor {
@@ -1102,7 +1133,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // Post-norm transformer encoder is full self-attention over the
         // whole chunk: quadratic in chunk length (issue #68).
         encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-            max_safe_chunk_seconds: 30.0,
+            max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
     OpenAsrArchitectureDescriptor {
@@ -1155,11 +1186,13 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // RoPE conv-stem encoder + cross-attn decoder are not composer blocks).
         block_stack: None,
         // The RoPE encoder is full self-attention over the whole chunk:
-        // quadratic in chunk length (issue #68). Also carries the tighter
-        // `ConservativeSeq2SeqV1` decode-side longform profile (issue #60);
-        // the two caps combine by taking the min.
+        // quadratic in chunk length (issue #68), matching Moonshine's own
+        // model-card guidance to keep chunks under 30 seconds. Also carries
+        // the `ConservativeSeq2SeqV1` decode-side longform profile (issue
+        // #60's repetition guard); the two caps now agree at the same
+        // default, so composing them (taking the min) is a no-op here.
         encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-            max_safe_chunk_seconds: 30.0,
+            max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
     OpenAsrArchitectureDescriptor {
@@ -1194,7 +1227,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // self-attention over the whole chunk: quadratic in chunk length
         // (issue #68).
         encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-            max_safe_chunk_seconds: 30.0,
+            max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
     OpenAsrArchitectureDescriptor {
@@ -1230,7 +1263,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // SAN-M/FSMN encoder's self-attention memory block is full attention
         // over the whole chunk: quadratic in chunk length (issue #68).
         encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-            max_safe_chunk_seconds: 30.0,
+            max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
     OpenAsrArchitectureDescriptor {
@@ -1261,11 +1294,17 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         // block kind), so no data-driven block-stack descriptor.
         block_stack: None,
         // Conformer encoder is full self-attention over the whole chunk:
-        // quadratic in chunk length (issue #68). Also carries the tighter
-        // `ConservativeSeq2SeqV1` decode-side longform profile (issue #60);
-        // the two caps combine by taking the min.
+        // quadratic in chunk length (issue #68). FireRedASR's own upstream
+        // guidance is wider than the shared default -- it warns past 60s and
+        // errors past 200s -- so `DEFAULT_ENCODER_SAFE_CHUNK_SECONDS` (30s)
+        // is comfortably inside FireRedASR's own safe range; used here for
+        // RAM margin and cross-family consistency rather than the wider
+        // upstream figure. Also carries the `ConservativeSeq2SeqV1`
+        // decode-side longform profile (issue #60's repetition guard, not a
+        // model-accuracy limit); the two caps now agree at the same default,
+        // so composing them (taking the min) is a no-op here.
         encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-            max_safe_chunk_seconds: 30.0,
+            max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
 ];
@@ -1340,15 +1379,16 @@ mod tests {
     /// #68). Whisper's fixed 30s window and zipformer's local/chunked
     /// streaming encoder need no additional cap; every other builtin
     /// architecture's encoder is full self-attention over the whole chunk,
-    /// so all nine are `GlobalQuadratic` with the same validated-safe 30s
-    /// ceiling.
+    /// so all nine are `GlobalQuadratic` at `DEFAULT_ENCODER_SAFE_CHUNK_SECONDS`
+    /// (none of the nine has an upstream-recommended value that overrides
+    /// the shared default; see that constant's doc for the survey).
     #[test]
     fn builtin_architectures_declare_encoder_attention_span() {
         let expected: &[(&str, OpenAsrEncoderAttentionSpan)] = &[
             (
                 COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-                    max_safe_chunk_seconds: 30.0,
+                    max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
             ),
             (
@@ -1358,25 +1398,25 @@ mod tests {
             (
                 QWEN3_ASR_GGML_ARCHITECTURE_ID,
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-                    max_safe_chunk_seconds: 30.0,
+                    max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
             ),
             (
                 PARAKEET_CTC_GGML_ARCHITECTURE_ID,
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-                    max_safe_chunk_seconds: 30.0,
+                    max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
             ),
             (
                 PARAKEET_TDT_GGML_ARCHITECTURE_ID,
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-                    max_safe_chunk_seconds: 30.0,
+                    max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
             ),
             (
                 WAV2VEC2_CTC_GGML_ARCHITECTURE_ID,
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-                    max_safe_chunk_seconds: 30.0,
+                    max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
             ),
             (
@@ -1386,25 +1426,25 @@ mod tests {
             (
                 MOONSHINE_GGML_ARCHITECTURE_ID,
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-                    max_safe_chunk_seconds: 30.0,
+                    max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
             ),
             (
                 DOLPHIN_GGML_ARCHITECTURE_ID,
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-                    max_safe_chunk_seconds: 30.0,
+                    max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
             ),
             (
                 SENSEVOICE_GGML_ARCHITECTURE_ID,
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-                    max_safe_chunk_seconds: 30.0,
+                    max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
             ),
             (
                 FIRERED_AED_GGML_ARCHITECTURE_ID,
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
-                    max_safe_chunk_seconds: 30.0,
+                    max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
             ),
         ];

--- a/crates/openasr-core/src/models/builtin_execution_dispatch.rs
+++ b/crates/openasr-core/src/models/builtin_execution_dispatch.rs
@@ -23,7 +23,7 @@ use super::wav2vec2_ctc::executor::Wav2Vec2CtcGgmlExecutor;
 use super::whisper::WhisperGgmlExecutor;
 use super::xasr_zipformer::executor::XasrZipformerGgmlExecutor;
 
-#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[derive(Debug, Error, Clone, PartialEq)]
 pub(crate) enum BuiltinGgmlExecutionDispatchError {
     #[error("builtin executor materialization failed: {source}")]
     ExecutorMaterialization {

--- a/docs/design/model-onboarding-contract.md
+++ b/docs/design/model-onboarding-contract.md
@@ -35,6 +35,28 @@ matching `BUILTIN_COMPONENT_DESCRIPTORS`, and wire the executor through
 `materialize_builtin_executor_component` in
 `crates/openasr-core/src/models/executor_component_registry.rs`.
 
+The descriptor also requires an `encoder_attention_span`
+(`OpenAsrEncoderAttentionSpan`, issue #68) declaring how the new
+architecture's encoder scales with chunk length -- this is a mandatory field,
+so a new architecture cannot compile without it:
+
+- Full self-attention over the whole encoder input (the common case for a
+  Conformer/Transformer/E-Branchformer/RoPE encoder) is `GlobalQuadratic`.
+  Use `arch::DEFAULT_ENCODER_SAFE_CHUNK_SECONDS` (30s) for
+  `max_safe_chunk_seconds` -- the value every major encoder family this repo
+  has surveyed converges on (Whisper's fixed window, Moonshine's own "<30s"
+  guidance, NeMo/Parakeet's 20-30s guidance, FunASR's 30000ms default,
+  Dolphin's 30s training/eval padding, Cohere's 30s reference sliding
+  window). **Only** override it with a different `max_safe_chunk_seconds`
+  when the upstream model card states an explicit, different recommended
+  chunk length, and cite that source in a comment next to the override (see
+  `DEFAULT_ENCODER_SAFE_CHUNK_SECONDS`'s own doc comment for the citation
+  format).
+- An architecture-fixed attention window (like Whisper's 30s log-mel frame)
+  is `FixedWindow`.
+- A local/chunked streaming encoder with a bounded per-chunk cache (like
+  Zipformer2's multi-scale cache) is `LocalChunked`.
+
 **Do not** add a parallel hand-written family dispatch branch in
 `crates/openasr-core/src/api/backend/native.rs` (`validate_local_native_model_pack_path`,
 `validate_native_runtime_model_pack_contract`) or in
@@ -146,6 +168,13 @@ with a one-line structural justification for going another way):
       `dispatch_reports_unknown_family` / `returns_ambiguous_when_multiple_descriptors_match`
       in `crates/openasr-core/src/models/ggml_family_registry.rs` for the
       pattern to extend).
+- [ ] Descriptor declares `encoder_attention_span` (issue #68). A
+      `GlobalQuadratic` encoder uses `arch::DEFAULT_ENCODER_SAFE_CHUNK_SECONDS`
+      unless the upstream model card states an explicit, different
+      recommended chunk length -- if it does, the override cites that source
+      in a comment. `builtin_architectures_declare_encoder_attention_span`
+      (`arch/mod.rs`) and `encoder_attention_span_caps_every_builtin_architecture_on_the_production_path`
+      (`api/backend/native_transcribe.rs`) must cover the new architecture.
 - [ ] No hand-written decode step loop: `grep -rn 'for .*argmax\|while .*argmax'`
       (or an equivalent manual scan of the new executor) turns up nothing; the
       family implements `Seq2SeqGreedyDecodeStepExecutor` or calls


### PR DESCRIPTION
## Summary

Fix the daemon memory blowup (RSS sawtooth up to ~10 GB, hitting the Metal working-set ceiling ~12.5 GB) when transcribing long audio. Root cause: global quadratic-attention encoders were being fed slices up to 120 s because a wrong-parameter wiring bug silently disabled the existing chunk cap. Adds a descriptor-declared encoder attention span (single source, validated), fixes the wiring, and caps every quadratic encoder.

## Why (runtime-confirmed)

RSS is a sawtooth (0.38 <-> 9.88 GB) correlated with slice length -- a per-slice O(frame_count^2) encoder-attention peak, NOT a leak. `native_transcribe.rs` passed `adapter_id` where `model_architecture` was expected, so `apply_longform_safety_policy` looked up nothing, hit `Err`, and silently `return`ed -- the `ConservativeSeq2SeqV1` cap never applied. firered/cohere/moonshine (and 5 more quadratic encoders with no cap at all) fell back to the 120 s default -> ~3000 frames -> ~10 GB.

## Changes

- `arch/mod.rs`: new required `OpenAsrEncoderAttentionSpan` field (`GlobalQuadratic { max_safe_chunk_seconds } | FixedWindow | LocalChunked`) on every descriptor (non-Option -> a new architecture cannot compile without declaring it). 9 quadratic families = `GlobalQuadratic { 30.0 }`, whisper = `FixedWindow`, xasr-zipformer = `LocalChunked`. `validate_references()` rejects a non-finite/non-positive cap.
- Fix the wiring bug: pass `selected_family.model_architecture` (not `adapter_id`) into the longform policy resolution.
- `apply_longform_safety_policy` split into two tighten-only passes (conservative-seq2seq for #60, and the new encoder-attention-span cap) -> natural min: firered/cohere/moonshine stay at their designed 10 s (no #60 regression), the 5 previously-uncapped quadratic models are capped to 30 s, whisper/zipformer unaffected.

## Tests run

- [x] New production-path tests: `native_longform_policy_uses_selected_family_model_architecture_not_adapter_id` (proves correct key caps, wrong key silently no-ops -- the bug) and `encoder_attention_span_caps_every_builtin_architecture_on_the_production_path` (all 11 archs). Plus `builtin_architectures_declare_encoder_attention_span` + validate rejection test.
- [x] `cargo nextest run --workspace` (2235 passed), `golden_diff` (whisper 2 passed; firered ignored -- private pack), `bundled_catalog_signature_verifies...`, `clippy -D`, `fmt`, `doc`.

## Scope / non-goals

- Behavior change: 6 models (qwen/parakeet-ctc/parakeet-tdt/wav2vec2/sensevoice/dolphin) slice at 30 s instead of up to 120 s for >30 s continuous speech (assembler dedups overlaps; quality impact expected minimal, verified on real audio by the maintainer). cohere/moonshine/firered move from a buggy 'never applied' to their intended 10 s cap. whisper/zipformer unchanged.
- #51 (bounded runtime cache) retained. Encoder flash-attention (O(T) activations) is a separate follow-up.

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance; maintainer owns and merges.