### PR TITLE
fix(core): route firered graphs through the reuse allocator to bound encoder memory

### DIFF
--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -90,7 +90,11 @@ pub(crate) fn firered_decoder_graph_config() -> GgmlCpuGraphConfig {
         graph_size: FIRERED_DECODER_GRAPH_SIZE,
         n_threads: None,
         backend: GgmlCpuGraphBackend::Cpu,
-        use_scheduler: false,
+        // See the matching comment in encoder_graph.rs: the CPU-backend
+        // gallocr scheduler reuses tensor buffer space by lifetime instead of
+        // allocating every non-view tensor independently, cutting memory
+        // without changing the graph's computed output (#68).
+        use_scheduler: true,
     }
 }
 
@@ -288,6 +292,13 @@ impl FireRedDecoderGraphRuntime {
         graph
             .set_output(output_root)
             .map_err(|source| map_err("cross_cache_set_output", source))?;
+        // Allocate the cross-KV precompute graph (side-effect cpy writes plus the
+        // output root) through the scheduler's gallocr for liveness-based buffer
+        // reuse before uploading the encoder rows -- same ordering as the encoder
+        // forward and the sibling cohere/moonshine decoders.
+        graph
+            .prepare_outputs_for_upload(&[output_root])
+            .map_err(|source| map_err("cross_cache_prepare_outputs", source))?;
         graph
             .set_f32_slice(encoder_tensor, encoder_rows, "firered_dec_encoder_rows")
             .map_err(|source| map_err("encoder_rows_upload", source))?;
@@ -397,6 +408,14 @@ impl FireRedDecoderGraphRuntime {
             .map_err(|source| map_err("embed_add_pos", source))?;
 
         let zero_bias_tensor = self.arena.graph_tensor(self.zero_bias);
+        // Deferred input uploads (mirrors cohere's decoder): every graph-input
+        // write is queued and applied AFTER `prepare_outputs_for_upload`, so no
+        // upload triggers an independent backend-buffer allocation mid-build and
+        // the scheduler's gallocr owns the whole graph's tensor allocation. For
+        // firered this queue always stays empty (the shared top-level causal mask
+        // means `seq2seq_layer` never emits a per-layer `deferred_self_mask`), but
+        // queuing keeps the ordering invariant robust and matches the sibling.
+        let mut deferred_self_masks = Vec::new();
         for (layer, (cross, self_kv)) in self
             .weights
             .layers
@@ -460,10 +479,8 @@ impl FireRedDecoderGraphRuntime {
                 cross_kv_handle,
                 map_err,
             )?;
-            if let Some((mask_tensor, bits)) = block.deferred_self_mask {
-                graph
-                    .set_f16_bits_slice(mask_tensor, &bits, "firered_dec_layer_self_mask")
-                    .map_err(|source| map_err("layer_self_mask_upload", source))?;
+            if let Some(deferred) = block.deferred_self_mask {
+                deferred_self_masks.push(deferred);
             }
             state = block.output;
         }
@@ -488,6 +505,14 @@ impl FireRedDecoderGraphRuntime {
         graph
             .set_output(logits)
             .map_err(|source| map_err("set_output", source))?;
+        // Allocate the decode graph through the scheduler's gallocr for
+        // liveness-based buffer reuse before uploading inputs (mirrors the
+        // cohere/moonshine decoders); the queued uploads below then write into the
+        // already-allocated input tensors instead of forcing an independent
+        // allocation.
+        graph
+            .prepare_outputs_for_upload(&[logits])
+            .map_err(|source| map_err("prepare_outputs", source))?;
 
         graph
             .set_i32_slice(token_ids_tensor, &token_ids_i32, "firered_dec_tokens")
@@ -504,6 +529,11 @@ impl FireRedDecoderGraphRuntime {
             graph
                 .set_f16_bits_slice(mask, &bits, "firered_dec_self_mask")
                 .map_err(|source| map_err("self_mask_upload", source))?;
+        }
+        for (mask_tensor, bits) in deferred_self_masks {
+            graph
+                .set_f16_bits_slice(mask_tensor, &bits, "firered_dec_layer_self_mask")
+                .map_err(|source| map_err("layer_self_mask_upload", source))?;
         }
 
         let output = graph

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -107,7 +107,13 @@ pub(crate) fn firered_encoder_graph_config() -> GgmlCpuGraphConfig {
         graph_size: FIRERED_ENCODER_GRAPH_SIZE,
         n_threads: None,
         backend: GgmlCpuGraphBackend::Cpu,
-        use_scheduler: false,
+        // ggml's gallocr scheduler reuses buffer space across tensors whose
+        // lifetimes don't overlap instead of giving every non-view tensor its
+        // own allocation (`ggml_backend_alloc_ctx_tensors`); on the CPU
+        // backend both allocators produce identical results, so this only
+        // changes memory footprint, never the encoder's output (see #68: a
+        // single 30s slice requested ~12.5 GiB without the scheduler).
+        use_scheduler: true,
     }
 }
 
@@ -327,6 +333,15 @@ fn encode_firered_aed_audio_embeddings(
     graph
         .set_output(state)
         .map_err(|source| map_err("ggml_set_output(encoder)", source))?;
+    // Peak-RSS lever (mirrors the cohere/moonshine encoder path): allocate the
+    // forward graph through the scheduler's gallocr (liveness-based buffer
+    // REUSE) BEFORE uploading inputs, collapsing the per-conformer-layer
+    // intermediate accumulation to the working-set peak instead of giving every
+    // non-view tensor its own allocation. The three inputs below are marked
+    // `set_input`, so gallocr keeps them live across the whole graph.
+    graph
+        .prepare_outputs_for_upload(&[state])
+        .map_err(|source| map_err("ggml_prepare_outputs(encoder)", source))?;
     graph
         .set_f32_slice(mel, &padded, "firered_enc_mel")
         .map_err(|source| map_err("ggml_set_f32_slice(mel)", source))?;


### PR DESCRIPTION
## Summary

Cut FireRed's per-slice encoder memory from ~4 GB to ~1 GB (30 s slice, measured) by routing its ggml graphs through the scheduler's lifetime-reuse allocator, like every other model family. Together with the slice cap (#56) this fixes the long-audio memory blowup (RSS was hitting ~12 GB on a full file).

## Why

FireRed was the only ggml graph family with `use_scheduler: false` AND not calling `prepare_outputs_for_upload`, so input upload fell back to `ggml_backend_alloc_ctx_tensors`, which gives every non-view tensor its own space with no lifetime reuse. A single 30 s slice therefore requested **12.48 GiB** -- all 16 encoder layers' attention-score/permute tensors resident at once. Every other seq2seq family (cohere, moonshine, ...) already routes through the scheduler + `ggml_gallocr` reuse allocator.

## Changes

- `firered_aed/encoder_graph.rs`, `decoder_graph.rs`: `use_scheduler: false -> true`.
- Call `prepare_outputs_for_upload` before uploading inputs in 3 places (encoder forward, decoder cross-attention cache, decoder step logits), so the graph is handed to the scheduler's `gallocr` before any tensor is materialized. The per-layer `deferred_self_mask` uploads are collected into a queue and posted after `prepare_outputs_for_upload` (mirroring cohere/moonshine) -- verified `deferred_self_mask` is always `None` for FireRed (it always passes a shared top-level mask), so the queue is empty in practice but the ordering invariant matches the sibling families and avoids `GraphFrozenAfterAllocation`.

## Tests run

- [x] **Measured RSS on a 30 s FireRed slice: 4,207,584 KB (~4.11 GiB) -> 1,063,712 KB (~1.04 GiB)**; transcription output byte-identical before/after (no repetition/truncation).
- [x] `golden_diff` (whisper pass; firered ignored -- private pack), `cargo nextest run --workspace` (2235 passed), `fmt --check`, `clippy -D warnings`, `doc`, `bundled_catalog_signature_verifies...`.

## Scope / non-goals

- FireRed only. parakeet_ctc/sensevoice already use the scheduler on the default CPU path (their `false` is only in a GPU-disabled fallback). #51 (bounded runtime cache) and #56 (slice cap) are retained. Encoder flash-attention (O(T) attention activations) remains a separate follow-up.

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance; maintainer owns and merges.