### PR TITLE
feat(firered): enable Metal GPU backend for encoder/decoder graphs

### DIFF
--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -14,9 +14,11 @@
 //! Built on the shared incremental seq2seq decoder block
 //! ([`crate::nn::decoder::seq2seq_layer`]): pre-norm causal self-attention
 //! with an f16 KV cache, pre-norm cross-attention over cross-KV precomputed
-//! once from the encoder output, and a GELU feed-forward. Runs CPU-only,
-//! rebuilding a fresh graph every decode step (matches the Stage 2 encoder's
-//! CPU-only staging -- GPU reuse can follow once parity is established).
+//! once from the encoder output, and a GELU feed-forward. Rebuilds a fresh
+//! graph every decode step regardless of backend (see [`super::graph_config`]
+//! for the dynamic CPU/Metal backend selection -- unlike cohere's serve-batch
+//! path, this never reuses a fixed-span-KV graph across tokens, so it carries
+//! none of the reused-graph caveats that motivate CPU-only fallback there).
 
 #![allow(dead_code)]
 
@@ -25,9 +27,8 @@ use std::path::Path;
 use thiserror::Error;
 
 use crate::ggml_runtime::{
-    GgmlCpuGraphBackend, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError,
-    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedWeightContext, GgmlStaticTensor,
-    GgmlStaticTensorArena,
+    GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor,
+    GgmlLoadedWeightContext, GgmlStaticTensor, GgmlStaticTensorArena,
 };
 use crate::models::decode_policy_component_registry::{
     BuiltinSeq2SeqDecodePolicyConfigInput, run_builtin_seq2seq_decode_policy,
@@ -45,10 +46,10 @@ use crate::nn::ffn::FeedForwardActivation;
 use crate::nn::norm::{AffineLayerNormSteps, apply_affine_layer_norm};
 
 use super::decoder_weights::{FireRedDecoderWeights, FireRedDecoderWeightsError};
+use super::graph_config::firered_decoder_graph_config;
 use super::runtime_contract::FireRedAedExecutionMetadata;
 
 const FIRERED_DECODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const FIRERED_DECODER_GRAPH_SIZE: usize = 8192;
 /// Static tensors created directly in the decoder's arena (not through
 /// `start_graph`): one shared zero-bias vector plus, per decoder layer, a
 /// cross-K/cross-V pair and a self-K/self-V pair.
@@ -75,27 +76,6 @@ pub(crate) enum FireRedDecoderError {
 
 fn map_err(step: &'static str, source: GgmlCpuGraphError) -> FireRedDecoderError {
     FireRedDecoderError::GraphBuildFailed { step, source }
-}
-
-pub(crate) fn firered_decoder_graph_config() -> GgmlCpuGraphConfig {
-    GgmlCpuGraphConfig {
-        // `no_alloc` metadata context: only needs `ggml_tensor_overhead()` per
-        // graph node plus the cgraph object itself (see
-        // `GgmlCpuGraphConfig::metadata_context_bytes`), NOT the real tensor
-        // byte sizes -- those live in a separately-sized backend buffer.
-        // Previously hardcoded to 512 MiB, which is what let a single cached
-        // per-encoder-frame-count decoder runtime (see the thread-local cache
-        // in `executor.rs`) balloon far past what the graph actually needs.
-        context_bytes: GgmlCpuGraphConfig::metadata_context_bytes(FIRERED_DECODER_GRAPH_SIZE),
-        graph_size: FIRERED_DECODER_GRAPH_SIZE,
-        n_threads: None,
-        backend: GgmlCpuGraphBackend::Cpu,
-        // See the matching comment in encoder_graph.rs: the CPU-backend
-        // gallocr scheduler reuses tensor buffer space by lifetime instead of
-        // allocating every non-view tensor independently, cutting memory
-        // without changing the graph's computed output (#68).
-        use_scheduler: true,
-    }
 }
 
 /// Byte capacity for the decoder's static-tensor arena context. Like the

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -26,10 +26,7 @@ use std::path::Path;
 
 use thiserror::Error;
 
-use crate::ggml_runtime::{
-    GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner,
-    GgmlLoadedWeightContext,
-};
+use crate::ggml_runtime::{GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlLoadedWeightContext};
 use crate::models::cohere::encoder_graph::build_relative_positional_encoding;
 use crate::nn::attn::{
     AttentionHeadLayout, AttentionReshapeSteps, AttentionValueMergeSteps,
@@ -47,10 +44,10 @@ use crate::nn::norm::{AffineLayerNormSteps, apply_affine_layer_norm};
 use super::encoder_weights::{
     FireRedEncoderLayerWeights, FireRedEncoderWeights, FireRedEncoderWeightsError,
 };
+use super::graph_config::firered_encoder_graph_config;
 use super::runtime_contract::FireRedAedExecutionMetadata;
 
 const FIRERED_ENCODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const FIRERED_ENCODER_GRAPH_SIZE: usize = 32_768;
 /// `Conv2dSubsampling.context = left_context(3) + 1 + right_context(3)`; the
 /// encoder pads the time axis by `context - 1` zero frames before the stem
 /// (`fireredasr` `ConformerEncoder.forward(..., pad=True)`).
@@ -92,29 +89,6 @@ fn conv_out_dim(input: usize, kernel: usize, stride: usize) -> Result<usize, Fir
         .and_then(|v| v.checked_div(stride))
         .and_then(|v| v.checked_add(1))
         .ok_or(FireRedEncoderError::ShapeOverflow)
-}
-
-pub(crate) fn firered_encoder_graph_config() -> GgmlCpuGraphConfig {
-    // Stage 2 lands CPU-only; GPU backends can follow once decoder/executor
-    // parity is established (matches the parakeet-ctc/sensevoice staging
-    // precedent of correctness-first, backend-breadth-later).
-    GgmlCpuGraphConfig {
-        // `no_alloc` metadata context sized from the actual node count (see
-        // `GgmlCpuGraphConfig::metadata_context_bytes`); previously a flat
-        // hardcoded 512 MiB per cached encoder runtime (see the thread-local
-        // cache in `executor.rs`).
-        context_bytes: GgmlCpuGraphConfig::metadata_context_bytes(FIRERED_ENCODER_GRAPH_SIZE),
-        graph_size: FIRERED_ENCODER_GRAPH_SIZE,
-        n_threads: None,
-        backend: GgmlCpuGraphBackend::Cpu,
-        // ggml's gallocr scheduler reuses buffer space across tensors whose
-        // lifetimes don't overlap instead of giving every non-view tensor its
-        // own allocation (`ggml_backend_alloc_ctx_tensors`); on the CPU
-        // backend both allocators produce identical results, so this only
-        // changes memory footprint, never the encoder's output (see #68: a
-        // single 30s slice requested ~12.5 GiB without the scheduler).
-        use_scheduler: true,
-    }
 }
 
 /// Owns the encoder's mmap'd weight context plus the ggml graph runner across

--- a/crates/openasr-core/src/models/firered_aed/executor.rs
+++ b/crates/openasr-core/src/models/firered_aed/executor.rs
@@ -34,14 +34,12 @@ use crate::models::thread_local_runtime_cache::{
     with_thread_local_cached_mut_by_key,
 };
 
-use super::decoder_graph::firered_decoder_graph_config;
 use super::decoder_graph::{
     FireRedDecoderGraphRuntime, run_firered_aed_decoder_greedy_with_runtime,
 };
-use super::encoder_graph::{
-    FireRedEncoderGraphRuntime, FireRedEncoderOutput, firered_encoder_graph_config,
-};
+use super::encoder_graph::{FireRedEncoderGraphRuntime, FireRedEncoderOutput};
 use super::frontend::{FireRedFbankFrontend, apply_cmvn};
+use super::graph_config::{firered_decoder_graph_config, firered_encoder_graph_config};
 use super::runtime_contract::{FireRedAedExecutionMetadata, parse_firered_aed_execution_metadata};
 use super::tokenizer::FireRedTokenizer;
 

--- a/crates/openasr-core/src/models/firered_aed/graph_config.rs
+++ b/crates/openasr-core/src/models/firered_aed/graph_config.rs
@@ -1,0 +1,140 @@
+//! firered-aed ggml graph backend/threading policy.
+//!
+//! Stage 2/3 landed CPU-only by design (correctness-first, GPU staged as an
+//! explicit follow-up once decoder/executor parity was established -- see the
+//! prior module docs on [`super::encoder_graph`] and [`super::decoder_graph`]
+//! for the CPU-only-era history). That parity is now verified end to end
+//! (CPU vs Metal transcripts match byte-for-byte on real packs), so this
+//! mirrors the cohere/moonshine template -- dynamic backend resolution via
+//! [`configure_model_runtime_graph_config_from_env`] (Metal auto-selected
+//! through `GgmlCpuGraphConfig::resolve_runtime_backend()`), with an explicit
+//! per-stage opt-out that falls back to CPU. Unlike cohere, firered-aed never
+//! does multi-chunk longform batching (the executor is single-segment plain
+//! transcription -- see `executor.rs` module docs), so there is no
+//! `prefer_cpu_backend` request-level override to thread through here.
+
+use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphThreadingWorkload};
+use crate::models::graph_runtime_config::{
+    ModelMetalRuntimeOverrides, configure_model_runtime_graph_config_from_env,
+    gpu_stage_enabled_for_backend, has_explicit_thread_override,
+};
+
+const FIRERED_ENCODER_GRAPH_SIZE: usize = 32_768;
+const FIRERED_DECODER_GRAPH_SIZE: usize = 8192;
+
+const OPENASR_FIRERED_ENABLE_ENCODER_METAL: &str = "OPENASR_FIRERED_ENABLE_ENCODER_METAL";
+const OPENASR_FIRERED_ENABLE_DECODER_METAL: &str = "OPENASR_FIRERED_ENABLE_DECODER_METAL";
+const OPENASR_FIRERED_ENABLE_ENCODER_GPU: &str = "OPENASR_FIRERED_ENABLE_ENCODER_GPU";
+const OPENASR_FIRERED_ENABLE_DECODER_GPU: &str = "OPENASR_FIRERED_ENABLE_DECODER_GPU";
+
+pub(crate) fn firered_runtime_graph_config() -> GgmlCpuGraphConfig {
+    configure_model_runtime_graph_config_from_env(
+        GgmlCpuGraphConfig::default(),
+        ModelMetalRuntimeOverrides {
+            default_use_scheduler_when_unset: Some(true),
+            default_n_threads_when_unset: Some(1),
+        },
+    )
+}
+
+pub(crate) fn firered_encoder_graph_config() -> GgmlCpuGraphConfig {
+    // `no_alloc` metadata context sized from the actual node count (see
+    // `GgmlCpuGraphConfig::metadata_context_bytes`); previously a flat
+    // hardcoded 512 MiB per cached encoder runtime (see the thread-local
+    // cache in `executor.rs`).
+    let mut config = firered_runtime_graph_config();
+    config.graph_size = config.graph_size.max(FIRERED_ENCODER_GRAPH_SIZE);
+    config.context_bytes = config
+        .context_bytes
+        .max(GgmlCpuGraphConfig::metadata_context_bytes(
+            config.graph_size,
+        ));
+    if config.backend.is_gpu_class() && !firered_encoder_gpu_enabled(config.backend) {
+        config.backend = GgmlCpuGraphBackend::Cpu;
+        config.use_scheduler = false;
+    }
+    if !has_explicit_thread_override() {
+        config.n_threads = GgmlCpuGraphConfig::resolve_runtime_thread_count_for(
+            config.backend,
+            GgmlCpuGraphThreadingWorkload::EncoderPrelude,
+        );
+    }
+    config
+}
+
+pub(crate) fn firered_decoder_graph_config() -> GgmlCpuGraphConfig {
+    // See the matching comment in `firered_encoder_graph_config`: this is a
+    // `no_alloc` metadata pool sized from the actual node count, not the real
+    // tensor bytes (those live in the arena's own backend buffer).
+    let mut config = firered_runtime_graph_config();
+    config.graph_size = config.graph_size.max(FIRERED_DECODER_GRAPH_SIZE);
+    config.context_bytes = config
+        .context_bytes
+        .max(GgmlCpuGraphConfig::metadata_context_bytes(
+            config.graph_size,
+        ));
+    if config.backend.is_gpu_class() && !firered_decoder_gpu_enabled(config.backend) {
+        config.backend = GgmlCpuGraphBackend::Cpu;
+        config.use_scheduler = false;
+    }
+    if !has_explicit_thread_override() {
+        config.n_threads = GgmlCpuGraphConfig::resolve_runtime_thread_count_for(
+            config.backend,
+            GgmlCpuGraphThreadingWorkload::Decoder,
+        );
+    }
+    config
+}
+
+fn firered_encoder_gpu_enabled(backend: GgmlCpuGraphBackend) -> bool {
+    gpu_stage_enabled_for_backend(
+        backend,
+        OPENASR_FIRERED_ENABLE_ENCODER_GPU,
+        true,
+        Some(OPENASR_FIRERED_ENABLE_ENCODER_METAL),
+        true,
+    )
+}
+
+fn firered_decoder_gpu_enabled(backend: GgmlCpuGraphBackend) -> bool {
+    gpu_stage_enabled_for_backend(
+        backend,
+        OPENASR_FIRERED_ENABLE_DECODER_GPU,
+        true,
+        Some(OPENASR_FIRERED_ENABLE_DECODER_METAL),
+        true,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encoder_gpu_defaults_to_unified_gpu_lane() {
+        assert!(firered_encoder_gpu_enabled(GgmlCpuGraphBackend::Gpu));
+    }
+
+    #[test]
+    fn decoder_gpu_defaults_to_unified_gpu_lane() {
+        assert!(firered_decoder_gpu_enabled(GgmlCpuGraphBackend::Gpu));
+    }
+
+    #[test]
+    fn encoder_and_decoder_gpu_keep_cpu_and_metal_defaults() {
+        assert!(firered_encoder_gpu_enabled(GgmlCpuGraphBackend::Cpu));
+        assert!(firered_encoder_gpu_enabled(GgmlCpuGraphBackend::Metal));
+        assert!(firered_decoder_gpu_enabled(GgmlCpuGraphBackend::Cpu));
+        assert!(firered_decoder_gpu_enabled(GgmlCpuGraphBackend::Metal));
+    }
+
+    #[test]
+    fn encoder_graph_size_floor_is_preserved() {
+        assert!(firered_encoder_graph_config().graph_size >= FIRERED_ENCODER_GRAPH_SIZE);
+    }
+
+    #[test]
+    fn decoder_graph_size_floor_is_preserved() {
+        assert!(firered_decoder_graph_config().graph_size >= FIRERED_DECODER_GRAPH_SIZE);
+    }
+}

--- a/crates/openasr-core/src/models/firered_aed/mod.rs
+++ b/crates/openasr-core/src/models/firered_aed/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod encoder_graph;
 pub(crate) mod encoder_weights;
 pub(crate) mod executor;
 pub(crate) mod frontend;
+pub(crate) mod graph_config;
 pub mod package_import;
 pub(crate) mod runtime_contract;
 pub(crate) mod tokenizer;


### PR DESCRIPTION
## Summary

FireRed-AED was hardcoded CPU-only since it launched (a deliberate staging decision -- 'GPU backends can follow once decoder/executor parity is established'). This enables a dynamic backend (Metal on Apple Silicon) mirroring the cohere/moonshine `graph_config` pattern. On the shipped q4_k pack, **CPU vs Metal output is byte-identical** across 4 samples (incl. bilingual), and Metal is ~1.5x faster.

## Changes

- New `firered_aed/graph_config.rs`: `firered_runtime_graph_config()` goes through `configure_model_runtime_graph_config_from_env` + `GgmlCpuGraphConfig::default()` (which resolves the runtime backend, auto-selecting Metal). Encoder/decoder configs keep their `context_bytes`/`graph_size` (32768/8192 floor) and fall back to CPU when the per-stage GPU gate is off. New env `OPENASR_FIRERED_ENABLE_ENCODER_GPU`/`_DECODER_GPU` (+ legacy `_METAL` aliases), default on.
- `encoder_graph.rs`/`decoder_graph.rs`: drop the hardcoded `backend: Cpu`, use the shared config. `executor.rs`: import path only (backend was already in the runtime cache key -- the hook was left for exactly this).
- FireRed's decoder does no multichunk longform batching, so it does not take cohere's `prefer_cpu_backend` request param (noted in the doc comment). #57's reuse allocator is unchanged.

## Tests run

- [x] **CPU vs Metal transcription byte-identical** on 4 clips (black_cat 20s + 30s, jfk.wav, zh_sample.wav). Metal confirmed on GPU (`ggml_metal_init/free` only on Metal-forced runs). RTF 0.251x (CPU) -> 0.168x (Metal), ~1.5x.
- [x] `cargo nextest run --workspace` (2240 passed), `golden_diff` (whisper pass; firered ignored -- private pack), `fmt` / `clippy -D` / `doc` / `bundled_catalog_signature_verifies...`.

## Scope / non-goals

- Parity verified on the shipped q4_k pack; other quants not covered in this pass (env gate allows disabling). Broadening Metal to dolphin/xasr-zipformer stays a separate product decision (their CPU-default is intentional).

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented and parity-verified with AI assistance; maintainer owns and merges.