### PR TITLE
fix(core): reuse ggml scheduler allocator for dolphin and moonshine graphs

### DIFF
--- a/crates/openasr-core/src/models/cohere/decoder_graph.rs
+++ b/crates/openasr-core/src/models/cohere/decoder_graph.rs
@@ -1293,11 +1293,52 @@ impl CohereDecoderGraphRuntime {
                 step: "ggml_set_output(logits)",
                 source,
             })?;
+        let debug_prompt_step =
+            std::env::var_os("OPENASR_COHERE_DEBUG_TOKENS").is_some() && position_offset == 0;
+        // When the debug-token dump is enabled, the intermediate taps below must
+        // also be marked as graph outputs (like logits) before
+        // `prepare_outputs_for_upload` runs the gallocr scheduler -- otherwise the
+        // scheduler's liveness-based buffer reuse would recycle their backend
+        // storage as soon as the last consumer inside the first decoder layer
+        // finishes, and the debug read-back below would return reused memory
+        // instead of the tap's actual values.
+        if debug_prompt_step {
+            let debug = prompt_debug_tensors.ok_or(CohereDecoderGraphError::InvalidInput {
+                reason: "missing prompt debug tensors for first decoder layer".to_string(),
+            })?;
+            for tap in [
+                debug.token_state,
+                debug.position_state,
+                debug.emb_ln,
+                debug.l0_attn_norm,
+                debug.l0_q_proj,
+                debug.l0_k_proj,
+                debug.l0_v_proj,
+                debug.h0_after_sa,
+                debug.h0_after_ca,
+                debug.h0_after_ffn,
+                debug.final_state,
+            ] {
+                graph.set_output(tap).map_err(|source| {
+                    CohereDecoderGraphError::GraphBuildFailed {
+                        step: "ggml_set_output(debug_tap)",
+                        source,
+                    }
+                })?;
+            }
+        }
+        // Allocate the decode graph through the scheduler's gallocr for
+        // liveness-based buffer reuse before uploading inputs, same ordering as
+        // the sibling firered/moonshine decoders.
+        graph
+            .prepare_outputs_for_upload(&[logits])
+            .map_err(|source| CohereDecoderGraphError::GraphBuildFailed {
+                step: "ggml_prepare_outputs(logits)",
+                source,
+            })?;
         for upload in uploads {
             upload.apply(&mut graph)?;
         }
-        let debug_prompt_step =
-            std::env::var_os("OPENASR_COHERE_DEBUG_TOKENS").is_some() && position_offset == 0;
         let output = if debug_prompt_step {
             let debug = prompt_debug_tensors.ok_or(CohereDecoderGraphError::InvalidInput {
                 reason: "missing prompt debug tensors for first decoder layer".to_string(),
@@ -1741,6 +1782,17 @@ impl CohereDecoderGraphRuntime {
             .set_output(logits)
             .map_err(|source| CohereDecoderGraphError::GraphBuildFailed {
                 step: "ggml_set_output(prefill_logits)",
+                source,
+            })?;
+        // Allocate the batched prefill graph through the scheduler's gallocr
+        // before uploading inputs, same ordering as the single-step decoder
+        // above and the sibling firered/moonshine decoders. `uploads` is always
+        // empty here (n_seq > 1 never emits cross-KV deferred writes; see the
+        // debug_assert above), so there is nothing to defer past this point.
+        graph
+            .prepare_outputs_for_upload(&[logits])
+            .map_err(|source| CohereDecoderGraphError::GraphBuildFailed {
+                step: "ggml_prepare_outputs(prefill_logits)",
                 source,
             })?;
 

--- a/crates/openasr-core/src/models/dolphin/decoder_graph.rs
+++ b/crates/openasr-core/src/models/dolphin/decoder_graph.rs
@@ -584,7 +584,11 @@ pub(crate) fn decode_prompt_logits(
             crate::ggml_runtime::GgmlCpuGraphThreadingWorkload::Decoder,
         ),
         backend,
-        use_scheduler: backend.is_gpu_class(),
+        // See the matching comment in encoder_graph.rs: unconditionally
+        // enabling the gallocr scheduler (like the sibling cohere/moonshine
+        // decoders) only bounds memory footprint, never the decoder's
+        // computed output.
+        use_scheduler: true,
     };
     let mut runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml_err("runner_init"))?;
     let mut graph = runner.start_graph();
@@ -664,6 +668,36 @@ pub(crate) fn decode_prompt_logits(
         .add(logits, weights.output_bias)
         .map_err(ggml_err("output_layer_bias"))?;
     graph.set_output(logits).map_err(ggml_err("set_output"))?;
+    // Every tensor this graph uploads to (rather than computes) must be
+    // flagged `set_input`: dolphin has no persistent weight arena, so every
+    // weight and every non-weight input is a fresh leaf tensor in this
+    // per-call graph with no buffer yet -- without the flag the scheduler's
+    // backend-assignment pass has no rule to place it on and aborts.
+    graph
+        .set_input(token_ids)
+        .map_err(ggml_err("mark_input(tokens)"))?;
+    graph
+        .set_input(encoder_mem)
+        .map_err(ggml_err("mark_input(encoder_out)"))?;
+    graph
+        .set_input(causal_mask)
+        .map_err(ggml_err("mark_input(causal_mask)"))?;
+    for (tensor, _, _) in &builder.uploads {
+        graph
+            .set_input(*tensor)
+            .map_err(ggml_err("mark_input(weight)"))?;
+    }
+    for (tensor, _, _, _) in &builder.native_uploads {
+        graph
+            .set_input(*tensor)
+            .map_err(ggml_err("mark_input(weight_native)"))?;
+    }
+    // Allocate the forward graph through the scheduler's gallocr for
+    // liveness-based buffer reuse before uploading inputs (mirrors the
+    // encoder above and the sibling cohere/moonshine decoders).
+    graph
+        .prepare_outputs_for_upload(&[logits])
+        .map_err(ggml_err("prepare_outputs"))?;
 
     // Phase C: upload inputs + weights, then compute.
     let token_ids_i32: Vec<i32> = prompt_tokens.iter().map(|&t| t as i32).collect();

--- a/crates/openasr-core/src/models/dolphin/encoder_graph.rs
+++ b/crates/openasr-core/src/models/dolphin/encoder_graph.rs
@@ -995,7 +995,13 @@ pub(crate) fn encode(
             crate::ggml_runtime::GgmlCpuGraphThreadingWorkload::EncoderPrelude,
         ),
         backend,
-        use_scheduler: backend.is_gpu_class(),
+        // Ggml's gallocr scheduler reuses buffer space across tensors whose
+        // lifetimes don't overlap instead of giving every non-view tensor its
+        // own allocation; on the CPU backend both allocators produce
+        // identical results, so unconditionally enabling it (like the
+        // sibling cohere/moonshine encoders) only bounds memory footprint on
+        // long audio, never the encoder's output.
+        use_scheduler: true,
     };
     let mut runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml_err("runner_init"))?;
     let mut graph = runner.start_graph();
@@ -1081,6 +1087,37 @@ pub(crate) fn encode(
     for tap in &taps {
         graph.set_output(*tap).map_err(ggml_err("set_output"))?;
     }
+    // Every tensor this graph uploads to (rather than computes) must be
+    // flagged `set_input`: unlike firered/moonshine/cohere, dolphin has no
+    // persistent weight arena -- every weight (and the audio features / the
+    // relative-position table) is a fresh leaf tensor in this per-call graph
+    // with no buffer of its own yet, so without the flag the scheduler's
+    // backend-assignment pass has no rule to place it on and aborts.
+    graph
+        .set_input(input)
+        .map_err(ggml_err("mark_input(features)"))?;
+    if is_multilingual {
+        graph
+            .set_input(pos_emb)
+            .map_err(ggml_err("mark_input(rel_pos)"))?;
+    }
+    for (tensor, _, _) in &builder.uploads {
+        graph
+            .set_input(*tensor)
+            .map_err(ggml_err("mark_input(weight)"))?;
+    }
+    for (tensor, _, _, _) in &builder.native_uploads {
+        graph
+            .set_input(*tensor)
+            .map_err(ggml_err("mark_input(weight_native)"))?;
+    }
+    // Allocate the forward graph through the scheduler's gallocr for
+    // liveness-based buffer reuse before uploading inputs -- every tap above
+    // is already marked as an output, so gallocr keeps each one's buffer
+    // resident instead of recycling it once a later block stops reading it.
+    graph
+        .prepare_outputs_for_upload(&taps)
+        .map_err(ggml_err("prepare_outputs"))?;
 
     // Phase C: upload inputs + weights, then compute. Native (quantized/f16)
     // rank-2 `.weight` operands upload their raw block bytes verbatim so they stay

--- a/crates/openasr-core/src/models/dolphin/hotword_context.rs
+++ b/crates/openasr-core/src/models/dolphin/hotword_context.rs
@@ -519,7 +519,10 @@ pub(crate) fn apply_hotword_deep_biasing(
             crate::ggml_runtime::GgmlCpuGraphThreadingWorkload::Default,
         ),
         backend,
-        use_scheduler: backend.is_gpu_class(),
+        // See the matching comment in encoder_graph.rs: unconditionally
+        // enabling the gallocr scheduler only bounds memory footprint, never
+        // the hotword biasing layer's computed output.
+        use_scheduler: true,
     };
     let mut runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml_err("runner_init"))?;
     let mut graph = runner.start_graph();
@@ -691,6 +694,36 @@ pub(crate) fn apply_hotword_deep_biasing(
         |s, source| DolphinHotwordError::Ggml { stage: s, source },
     )?;
     graph.set_output(output).map_err(ggml_err("set_output"))?;
+    // Every tensor this graph uploads to (rather than computes) must be
+    // flagged `set_input`: each is a fresh leaf tensor in this per-call graph
+    // with no buffer yet, so without the flag the scheduler's
+    // backend-assignment pass has no rule to place it on and aborts.
+    for tensor in [
+        encoder_tensor,
+        context_tensor,
+        q_w,
+        q_b,
+        k_w,
+        k_b,
+        v_w,
+        v_b,
+        out_w,
+        out_b,
+        combiner_w,
+        combiner_b,
+        norm_w,
+        norm_b,
+    ] {
+        graph
+            .set_input(tensor)
+            .map_err(ggml_err("mark_input(hotword_tensor)"))?;
+    }
+    // Allocate the forward graph through the scheduler's gallocr for
+    // liveness-based buffer reuse before uploading inputs (mirrors the other
+    // dolphin graphs).
+    graph
+        .prepare_outputs_for_upload(&[output])
+        .map_err(ggml_err("prepare_outputs"))?;
 
     // Phase C: upload inputs + weights, then compute.
     graph

--- a/crates/openasr-core/src/models/dolphin/joint_decode.rs
+++ b/crates/openasr-core/src/models/dolphin/joint_decode.rs
@@ -190,7 +190,10 @@ fn compute_ctc_log_probs(
             crate::ggml_runtime::GgmlCpuGraphThreadingWorkload::Default,
         ),
         backend,
-        use_scheduler: backend.is_gpu_class(),
+        // See the matching comment in encoder_graph.rs: unconditionally
+        // enabling the gallocr scheduler only bounds memory footprint, never
+        // the CTC head's computed output.
+        use_scheduler: true,
     };
     let ggml = |stage: &'static str| move |source| DolphinJointDecodeError::Ggml { stage, source };
     let mut runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml("runner_init"))?;
@@ -223,6 +226,25 @@ fn compute_ctc_log_probs(
         .add(logits, bias_tensor)
         .map_err(ggml("ctc_bias_add"))?;
     graph.set_output(logits).map_err(ggml("set_output"))?;
+    // Every tensor this graph uploads to (rather than computes) must be
+    // flagged `set_input`: it is a fresh leaf tensor in this per-call graph
+    // with no buffer yet, so without the flag the scheduler's
+    // backend-assignment pass has no rule to place it on and aborts.
+    graph
+        .set_input(weight_tensor)
+        .map_err(ggml("mark_input(weight)"))?;
+    graph
+        .set_input(bias_tensor)
+        .map_err(ggml("mark_input(bias)"))?;
+    graph
+        .set_input(encoder_tensor)
+        .map_err(ggml("mark_input(encoder_out)"))?;
+    // Allocate the forward graph through the scheduler's gallocr for
+    // liveness-based buffer reuse before uploading inputs (mirrors the
+    // encoder/decoder graphs).
+    graph
+        .prepare_outputs_for_upload(&[logits])
+        .map_err(ggml("prepare_outputs"))?;
 
     match (native_weight, weight) {
         (Some(native), _) => graph

--- a/crates/openasr-core/src/models/moonshine/decoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/decoder_graph.rs
@@ -1167,6 +1167,12 @@ impl MoonshineDecoderGraphRuntime {
         graph
             .set_output(logits)
             .map_err(build_err("ggml_set_output(prefill_logits)"))?;
+        // Allocate the batched prefill graph through the scheduler's gallocr
+        // before uploading inputs, mirroring the single-step reuse graph above
+        // and the sibling cohere/firered decoders.
+        graph
+            .prepare_outputs_for_upload(&[logits])
+            .map_err(build_err("ggml_prepare_outputs(prefill_logits)"))?;
 
         graph
             .set_i32_slice(token_ids_tensor, &token_ids, "moonshine_prefill_token")
@@ -1396,6 +1402,12 @@ impl MoonshineDecoderGraphRuntime {
         graph
             .set_output(logits)
             .map_err(build_err("ggml_set_output(logits)"))?;
+        // Allocate the full-prefix step graph through the scheduler's gallocr
+        // before uploading inputs, mirroring the single-step reuse graph and
+        // batched prefill above.
+        graph
+            .prepare_outputs_for_upload(&[logits])
+            .map_err(build_err("ggml_prepare_outputs(logits)"))?;
 
         let token_values = tokens_as_i32(tokens)?;
         let position_values: Vec<i32> = (0..token_count as i32).collect();

--- a/crates/openasr-core/src/models/moonshine/encoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/encoder_graph.rs
@@ -476,6 +476,12 @@ impl MoonshineEncoderGraphRuntime {
         graph
             .set_output(hidden)
             .map_err(build_err("ggml_set_output(enc)"))?;
+        // Allocate the forward graph through the scheduler's gallocr (liveness-
+        // based buffer reuse) before uploading inputs, same ordering as the
+        // moonshine decoder graphs and the sibling cohere/firered encoders.
+        graph
+            .prepare_outputs_for_upload(&[hidden])
+            .map_err(build_err("ggml_prepare_outputs(enc)"))?;
 
         // Upload inputs after the graph is fully built (deferred allocation).
         graph


### PR DESCRIPTION
## Summary

Apply the same reuse-allocator fix as #57 to dolphin and moonshine, which had the same non-reuse-allocator bug (all graph tensors resident at once -> long-audio memory blowup). dolphin-base: 1.83 GiB -> 0.90 GiB (~2.1x), byte-identical.

## Changes

- **dolphin** (4 graphs: encoder/decoder/joint_decode/hotword_context): `use_scheduler` `backend.is_gpu_class()` -> `true`. dolphin builds all weight tensors in-graph each call (no resident weight arena like firered/cohere), so gallocr's `ggml_backend_sched_backend_id_from_cur` returns -1 for those bufferless leaves and `ggml_gallocr_allocate_node` asserts -- so every graph marks its audio features/positions/mask/weights as `set_input` before `prepare_outputs_for_upload`. Verified on dolphin-base + dolphin-cn-dialect-small `--hotword`.
- **moonshine** (encoder + `compute_batched_prefill_logits` + `compute_full_prefix_step_logits`): add `prepare_outputs_for_upload` after `set_output` (use_scheduler was already dynamic true; single-step reuse graph was already correct).
- **cohere** (minor, batched in): `compute_batched_prefill_logits` + `compute_step_logits` (the latter also marks its `OPENASR_COHERE_DEBUG_TOKENS` tap tensors as outputs so gallocr doesn't recycle them before readback).

## Tests run

- [x] Real-machine: dolphin-base on zh_sample.wav peak RSS **1.83 GiB -> 0.90 GiB** (~2.1x), transcription byte-identical; dolphin-cn-dialect-small `--hotword` path works (no crash); moonshine-tiny on jfk.wav identical (11s too short to show the quadratic saving, mechanism same as firered).
- [x] `golden_diff` (whisper pass; dolphin/moonshine/firered ignored -- private pack), `cargo nextest run --workspace` (2235 passed), `fmt` / `clippy -D` / `doc` / `bundled_catalog_signature_verifies...`.

## Scope / non-goals

- Behavior-preserving (byte-identical). Broadening dolphin/xasr-zipformer auto-GPU stays a separate product decision (their CPU-default is intentional).

## Artifact confirmation

- [x] No weights, binaries, secrets, or private audio.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance; maintainer owns and merges.