### PR TITLE
feat(core): wire FireRedPunc punctuation stage end to end

### DIFF
--- a/crates/openasr-cli/src/bench_suite_cli.rs
+++ b/crates/openasr-cli/src/bench_suite_cli.rs
@@ -209,7 +209,11 @@ fn run_entry(
             .with_model_pack_path(Some(validated_pack.clone()))
             .with_language(entry.language.clone())
             .with_task(entry.task)
-            .with_execution_target(bench_execution_target());
+            .with_execution_target(bench_execution_target())
+            // The perf suite measures ASR decode RTF/RSS; an optional
+            // post-process stage running when a FireRedPunc pack happens to be
+            // installed would skew both, so it stays off for every entry.
+            .with_punctuation(false);
         configure_native_cpu_inference_threads();
         let started = Instant::now();
         let transcription = transcribe_with_backend(BackendKind::Native, request)?;

--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -25,6 +25,8 @@ pub(crate) struct TranscribeCommandOptions<'a> {
     pub(crate) runtime_paths: RuntimePathOverrides,
     pub(crate) diarize: bool,
     pub(crate) speakers: Option<u8>,
+    /// Opt-out of the auto-gated punctuation-restoration stage (`--no-punctuate`).
+    pub(crate) punctuate: bool,
     pub(crate) word_timestamps_mode: Option<WordTimestampsMode>,
     pub(crate) model_pack: Option<&'a Path>,
     /// OADP Phase 0 `.oadp` adapter pack; plumbed through the transcription
@@ -291,6 +293,14 @@ pub(crate) enum Command {
         /// Force an exact speaker count during diarization clustering.
         #[arg(long, requires = "diarize", value_parser = clap::value_parser!(u8).range(1..))]
         speakers: Option<u8>,
+        /// Skip punctuation restoration for models whose transcripts are
+        /// honestly unpunctuated (e.g. dolphin). Punctuation restoration is
+        /// on by default but only ever activates when both the model's
+        /// catalog `emits_punctuation` capability is `false` and the
+        /// FireRedPunc capability pack is installed; this flag opts out even
+        /// then. Never installs anything either way.
+        #[arg(long)]
+        no_punctuate: bool,
         /// Request per-word timestamps (rendered in json/verbose_json and
         /// word-timed VTT output). Bare flag (or `=approximate`) uses the
         /// model's own decode-time timestamps; `=aligned` refines them with

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -183,6 +183,7 @@ async fn run() -> Result<()> {
             ffmpeg_bin,
             diarize,
             speakers,
+            no_punctuate,
             word_timestamps,
             model_pack,
             adapter,
@@ -202,6 +203,7 @@ async fn run() -> Result<()> {
             runtime_paths: RuntimePathOverrides { ffmpeg_bin },
             diarize,
             speakers,
+            punctuate: !no_punctuate,
             word_timestamps_mode: word_timestamps,
             model_pack: model_pack.as_deref(),
             adapter: adapter.as_deref(),
@@ -1074,6 +1076,7 @@ fn transcribe(options: TranscribeCommandOptions<'_>) -> Result<()> {
         .with_phrase_bias(phrase_bias)
         .with_diarization(options.diarize)
         .with_diarize_speakers(options.speakers)
+        .with_punctuation(options.punctuate)
         .with_word_timestamps(options.word_timestamps_mode.is_some())
         .with_word_timestamps_refine(matches!(
             options.word_timestamps_mode,

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -216,7 +216,13 @@ pub(super) fn run_benchmark(
                 file.file_name()
                     .and_then(|name| name.to_str())
                     .map(str::to_string),
-            );
+            )
+            // `--benchmark` measures plain ASR decode timing; punctuation
+            // restoration is an optional post-process (like diarization and
+            // word-timestamp alignment, neither of which this request enables
+            // either) and would silently skew the real-time factor for an
+            // unpunctuated model with the FireRedPunc pack installed.
+            .with_punctuation(false);
     let started = Instant::now();
     let transcription = transcribe_with_backend(prepared_run.backend_kind, request)?;
     let elapsed = started.elapsed();

--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -319,6 +319,14 @@ pub struct TranscriptionRequest {
     /// Exact speaker count to force during diarization clustering (the
     /// `DiarizeHint::NumSpeakers` hint); `None` lets the threshold decide.
     pub diarize_speakers: Option<u8>,
+    /// Whether the punctuation-restoration post-processing stage may run.
+    /// Defaults to `true` (auto-on): the stage itself is separately gated on
+    /// the resolved model's `emits_punctuation` capability being `Some(false)`
+    /// and on the FireRedPunc capability pack actually being installed, so
+    /// this flag is only a user-facing opt-out (the desktop punctuation
+    /// preference toggle), not the primary gate. Never triggers a download --
+    /// same fail-closed contract as `word_timestamps_refine`.
+    pub punctuate: bool,
 }
 
 impl TranscriptionRequest {
@@ -340,6 +348,7 @@ impl TranscriptionRequest {
             display_file_name: None,
             diarize: false,
             diarize_speakers: None,
+            punctuate: true,
         }
     }
 
@@ -410,6 +419,11 @@ impl TranscriptionRequest {
 
     pub fn with_diarize_speakers(mut self, diarize_speakers: Option<u8>) -> Self {
         self.diarize_speakers = diarize_speakers;
+        self
+    }
+
+    pub fn with_punctuation(mut self, punctuate: bool) -> Self {
+        self.punctuate = punctuate;
         self
     }
 }

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -2,9 +2,12 @@ use std::{collections::BTreeMap, path::Path, sync::OnceLock};
 
 use crate::NATIVE_RUNTIME_MODEL_ID_AUTO;
 use crate::api::audio_io::load_wav_16khz_mono_f32_v0;
-use crate::arch::{DEFAULT_ENCODER_SAFE_CHUNK_SECONDS, OpenAsrArchitectureRegistry};
+use crate::arch::{
+    DEFAULT_ENCODER_SAFE_CHUNK_SECONDS, GENERAL_ARCHITECTURE_KEY, OpenAsrArchitectureRegistry,
+    emits_punctuation_for_model_architecture,
+};
 use crate::ggml_runtime::{
-    GgmlCpuGraphBackend, GgmlCpuGraphConfig, install_request_backend_override,
+    GgmlCpuGraphBackend, GgmlCpuGraphConfig, install_request_backend_override, read_gguf_metadata,
 };
 use crate::longform::{
     AudioSliceKind, LongFormMode, LongFormVadProvider, SegmentMergePolicy, SegmentTimeDomain,
@@ -29,9 +32,12 @@ use super::{BackendError, Transcription, TranscriptionRequest};
 use crate::Segment;
 use crate::WordTimestamp;
 use crate::api::backend::TranscriptionLongFormMetadata;
+use crate::models::firered_punc::pack::resolve_firered_punc_pack_path;
+use crate::models::firered_punc::runtime::FireRedPuncRuntime;
 use crate::models::qwen::{
     ForcedAlignItem, forced_aligner_pack, refine_word_timestamps_with_forced_aligner,
 };
+use crate::punctuation::should_apply_punctuation;
 
 const DEFAULT_NATIVE_LONGFORM_AUTO_TRIGGER_SECONDS: f32 = 30.0;
 /// Chunk-length ceiling for the decode-side `ConservativeSeq2SeqV1`
@@ -379,13 +385,18 @@ struct NativeLongformPolicyResolution {
 
 /// Entry point for the native backend: runs the ordinary decode/longform/
 /// diarization pipeline unchanged (`run_native_transcription_impl`), then --
-/// only when the request opted into `--word-timestamps=aligned`
-/// (`word_timestamps_refine`) -- refines the finished transcript's per-word
-/// timestamps with the installed Qwen3-ForcedAligner-0.6B capability pack.
-/// Kept as a thin wrapper rather than threading the refinement into the
-/// (already long) decode/longform function: the aligner re-reads the whole
-/// file and the finished transcript text, so it has no dependency on any
-/// intermediate state that function computes.
+/// gated on the resolved model's `emits_punctuation` capability and the
+/// request's `punctuate` opt-out -- restores punctuation with the installed
+/// FireRedPunc capability pack, then -- only when the request opted into
+/// `--word-timestamps=aligned` (`word_timestamps_refine`) -- refines the
+/// finished transcript's per-word timestamps with the installed
+/// Qwen3-ForcedAligner-0.6B capability pack. Kept as a thin wrapper rather
+/// than threading either post-process into the (already long) decode/longform
+/// function: both re-read only the finished transcript (the aligner also
+/// re-reads the audio file), so neither has a dependency on any intermediate
+/// state that function computes. Punctuation runs before the forced-aligner
+/// refine so the aligner (and every other downstream consumer) sees the
+/// punctuated text.
 pub(super) fn run_native_transcription(
     request: TranscriptionRequest,
 ) -> Result<Transcription, BackendError> {
@@ -393,13 +404,18 @@ pub(super) fn run_native_transcription(
     if refine && !request.word_timestamps {
         return Err(BackendError::WordTimestampAlignmentRequiresWordTimestamps);
     }
-    // Spans the whole run (decode + assembly inside impl, then the forced-align
-    // refine below) so the progress slot is cleared on every exit and the align
-    // phase advances the same monotonic bar rather than running uncounted.
+    // Spans the whole run (decode + assembly inside impl, then the punctuation
+    // and forced-align post-processes below) so the progress slot is cleared
+    // on every exit and the align phase advances the same monotonic bar
+    // rather than running uncounted.
     let _progress = NativeProgressGuard::new();
     let input_path = request.input_path.clone();
     let language_hint = request.language.clone();
+    let model_pack_path = request.model_pack_path.clone();
+    let punctuate = request.punctuate;
     let transcription = run_native_transcription_impl(request)?;
+    let transcription =
+        apply_punctuation_stage_if_applicable(transcription, model_pack_path.as_deref(), punctuate);
     if refine {
         publish_align_progress();
         refine_transcription_word_timestamps_with_forced_aligner(
@@ -410,6 +426,78 @@ pub(super) fn run_native_transcription(
     } else {
         Ok(transcription)
     }
+}
+
+/// Whether the punctuation-restoration stage should attempt to run: the
+/// request has not opted out (`punctuate`, the desktop preference toggle) AND
+/// the resolved model's `emits_punctuation` capability is honestly `Some(false)`
+/// (see [`should_apply_punctuation`]) -- a model that already punctuates, or
+/// whose capability is unknown, is never re-punctuated.
+fn should_run_punctuation_stage(punctuate: bool, emits_punctuation: Option<bool>) -> bool {
+    punctuate && should_apply_punctuation(emits_punctuation)
+}
+
+/// The `general.architecture` value's `emits_punctuation` capability for the
+/// pack at `model_pack_path`, or `None` when the path is absent or its
+/// metadata cannot be read/does not declare a known architecture -- callers
+/// treat `None` exactly like an ASR family with unknown punctuation status
+/// (stage does not run), never a hard error: this is a best-effort read of
+/// metadata already validated once by `run_native_transcription_impl`.
+fn model_emits_punctuation(model_pack_path: Option<&Path>) -> Option<bool> {
+    let path = model_pack_path?;
+    let metadata = read_gguf_metadata(path).ok()?;
+    let architecture = metadata.get_string(GENERAL_ARCHITECTURE_KEY)?;
+    emits_punctuation_for_model_architecture(architecture)
+}
+
+/// Punctuation-restoration post-process: runs only for an ASR result the
+/// catalog honestly declares unpunctuated, and only when the FireRedPunc
+/// capability pack is installed. Fail-closed by design -- a missing pack, a
+/// corrupt pack, or a classifier failure all leave `transcription` exactly as
+/// the ASR family produced it rather than crashing the request or fabricating
+/// punctuation; the native backend never downloads this pack.
+fn apply_punctuation_stage_if_applicable(
+    transcription: Transcription,
+    model_pack_path: Option<&Path>,
+    punctuate: bool,
+) -> Transcription {
+    if !should_run_punctuation_stage(punctuate, model_emits_punctuation(model_pack_path)) {
+        return transcription;
+    }
+    let Some(punc_pack_path) = resolve_firered_punc_pack_path() else {
+        return transcription;
+    };
+    let Ok(runtime) = FireRedPuncRuntime::from_pack(&punc_pack_path) else {
+        return transcription;
+    };
+    punctuate_transcription_segments(transcription, &runtime)
+}
+
+/// Restores punctuation on each finalized segment's text independently (the
+/// stage's documented "finalize-only, per segment" contract -- see
+/// `crate::punctuation`'s module docs) and rebuilds the top-level `text` field
+/// from the punctuated segments the same way the longform assembler does
+/// (trim, drop empties, join with a space), so the punctuated text and
+/// segments stay consistent. A segment whose classifier call fails keeps its
+/// original (unpunctuated) text -- fail-closed per segment rather than
+/// aborting the whole transcript.
+fn punctuate_transcription_segments(
+    mut transcription: Transcription,
+    runtime: &FireRedPuncRuntime,
+) -> Transcription {
+    for segment in &mut transcription.segments {
+        if let Ok(punctuated) = runtime.punctuate(&segment.text) {
+            segment.text = punctuated;
+        }
+    }
+    transcription.text = transcription
+        .segments
+        .iter()
+        .map(|segment| segment.text.trim())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    transcription
 }
 
 /// Re-decodes `input_path` and calls the installed Qwen3-ForcedAligner pack
@@ -2484,5 +2572,90 @@ mod tests {
         assign_aligned_words_to_segments(&mut segments, &[]);
 
         assert_eq!(segments[0].words, original_words);
+    }
+
+    #[test]
+    fn should_run_punctuation_stage_requires_both_opt_in_and_unpunctuated_capability() {
+        // The stage only runs when the request has not opted out AND the
+        // model's capability is honestly `Some(false)` -- an unknown or
+        // already-punctuated model is never re-punctuated, and an explicit
+        // opt-out wins even for an unpunctuated model.
+        assert!(should_run_punctuation_stage(true, Some(false)));
+        assert!(!should_run_punctuation_stage(false, Some(false)));
+        assert!(!should_run_punctuation_stage(true, Some(true)));
+        assert!(!should_run_punctuation_stage(true, None));
+    }
+
+    #[test]
+    fn model_emits_punctuation_reads_the_architectures_capability_from_pack_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let dolphin_pack = dir.path().join("dolphin.oasr");
+        let mut dolphin_metadata = std::collections::BTreeMap::new();
+        dolphin_metadata.insert(
+            GENERAL_ARCHITECTURE_KEY.to_string(),
+            crate::arch::DOLPHIN_GGML_ARCHITECTURE_ID.to_string(),
+        );
+        crate::testing::write_tiny_gguf_runtime_source(
+            &dolphin_pack,
+            &crate::testing::TinyGgufFixtureSpec::new(dolphin_metadata),
+        )
+        .expect("write dolphin fixture");
+        // Dolphin's cn-dialect training corpus is honestly unpunctuated.
+        assert_eq!(model_emits_punctuation(Some(&dolphin_pack)), Some(false));
+
+        let whisper_pack = dir.path().join("whisper.oasr");
+        let mut whisper_metadata = std::collections::BTreeMap::new();
+        whisper_metadata.insert(
+            GENERAL_ARCHITECTURE_KEY.to_string(),
+            crate::arch::WHISPER_GGML_ARCHITECTURE_ID.to_string(),
+        );
+        crate::testing::write_tiny_gguf_runtime_source(
+            &whisper_pack,
+            &crate::testing::TinyGgufFixtureSpec::new(whisper_metadata),
+        )
+        .expect("write whisper fixture");
+        assert_eq!(model_emits_punctuation(Some(&whisper_pack)), Some(true));
+
+        let unknown_pack = dir.path().join("unknown.oasr");
+        crate::testing::write_tiny_gguf_runtime_source(
+            &unknown_pack,
+            &crate::testing::TinyGgufFixtureSpec::new(std::collections::BTreeMap::new()),
+        )
+        .expect("write unknown fixture");
+        assert_eq!(model_emits_punctuation(Some(&unknown_pack)), None);
+
+        assert_eq!(model_emits_punctuation(None), None);
+        assert_eq!(
+            model_emits_punctuation(Some(Path::new("/nonexistent/pack.oasr"))),
+            None
+        );
+    }
+
+    #[test]
+    fn apply_punctuation_stage_leaves_transcription_unchanged_when_stage_does_not_run() {
+        // No model pack path at all -> `model_emits_punctuation` is `None` ->
+        // the stage never runs, regardless of the FireRedPunc pack's install
+        // state on this machine -- fail-closed, never fabricated punctuation.
+        let transcription = Transcription {
+            text: "hello world".to_string(),
+            segments: vec![Segment {
+                start: 0.0,
+                end: 1.0,
+                text: "hello world".to_string(),
+                speaker: None,
+                speaker_label: None,
+                speaker_profile_id: None,
+                words: Vec::new(),
+            }],
+            longform: None,
+            language: None,
+        };
+        let unchanged = apply_punctuation_stage_if_applicable(transcription.clone(), None, true);
+        assert_eq!(unchanged, transcription);
+
+        // Explicit opt-out short-circuits before any pack resolution too.
+        let unchanged = apply_punctuation_stage_if_applicable(transcription.clone(), None, false);
+        assert_eq!(unchanged, transcription);
     }
 }

--- a/crates/openasr-core/src/models/firered_punc/mod.rs
+++ b/crates/openasr-core/src/models/firered_punc/mod.rs
@@ -11,18 +11,19 @@
 //! The released label space is Chinese-only, so the integration is Chinese-only
 //! by construction; the architecture cannot emit English half-width marks.
 //!
-//! Stage status:
-//! - [`config`] / [`tensor_names`] / [`tokenizer`] define the pack geometry,
-//!   GGUF tensor layout, and the offset-preserving WordPiece encoder.
-
-// Later integration stages (runtime, package import, pull-contract dispatch,
-// and the punctuation post-processing stage) consume the geometry, tensor
-// names, label table, and tokenizer defined here; allow the not-yet-wired
-// surface until those stages land.
+//! Stage status: the runtime, punctuation post-processing stage, and
+//! pull-time contract are wired (see below). What is left is package import --
+//! converting the upstream `.pt` checkpoint to a `.oasr` pack for publishing
+//! (`tooling/publish-model`) -- which is why a handful of geometry/tokenizer/
+//! weight-loader helpers meant for that conversion path (and one pull-contract
+//! helper exercised only by its own unit tests, see
+//! `runtime_contract::metadata_declares_firered_punc`) are still unused by the
+//! rest of the crate.
 #![allow(dead_code)]
 
 pub(crate) mod config;
 pub(crate) mod graph;
+pub(crate) mod pack;
 pub(crate) mod runtime;
 pub(crate) mod runtime_contract;
 pub(crate) mod tensor_names;

--- a/crates/openasr-core/src/models/firered_punc/pack.rs
+++ b/crates/openasr-core/src/models/firered_punc/pack.rs
@@ -1,0 +1,22 @@
+//! Runtime resolution of the installed FireRedPunc capability-pack file (the
+//! `punctuation` feature's post-processing model). Resolved from
+//! `OPENASR_FIRERED_PUNC_PACK` or the standard
+//! `openasr_home()/models/*firered-punc*/` location, mirroring
+//! `models::qwen::forced_aligner_pack`'s resolution built on the shared
+//! `crate::capability_pack` resolver (this pack is neither diarization nor
+//! forced alignment, but the same "installed support model" shape).
+
+use std::path::PathBuf;
+
+const FIRERED_PUNC_PACK_ENV: &str = "OPENASR_FIRERED_PUNC_PACK";
+const FIRERED_PUNC_INSTALLED_DIR_HINT: &str = "firered-punc";
+
+/// The resolved path to the installed FireRedPunc pack, or `None` if no pack
+/// is installed. Callers must treat `None` as "punctuation stays off" -- this
+/// capability pack is never auto-downloaded by the transcription path.
+pub(crate) fn resolve_firered_punc_pack_path() -> Option<PathBuf> {
+    crate::capability_pack::resolve_installed_capability_pack(
+        FIRERED_PUNC_PACK_ENV,
+        FIRERED_PUNC_INSTALLED_DIR_HINT,
+    )
+}

--- a/crates/openasr-core/src/punctuation/mod.rs
+++ b/crates/openasr-core/src/punctuation/mod.rs
@@ -23,10 +23,6 @@
 //! orchestration is fully unit-testable without model weights; the ggml
 //! FireRedPunc runtime implements the trait.
 
-// The runtime trait impl and the finalize-path caller land in following stages;
-// allow the not-yet-wired surface until then.
-#![allow(dead_code)]
-
 use crate::models::firered_punc::config::punctuation_for_label;
 use crate::models::firered_punc::tokenizer::{FireRedPuncTokenizer, WordPiecePiece};
 

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -455,6 +455,7 @@ struct TranscriptionRequestBuilder {
     timestamp_granularities: Vec<String>,
     diarize: bool,
     speakers: Option<u8>,
+    punctuate: bool,
     segment_mode: Option<String>,
     chunk_seconds: Option<f32>,
     segment_overlap_seconds: Option<f32>,
@@ -485,6 +486,12 @@ impl Default for TranscriptionRequestBuilder {
             timestamp_granularities: Vec::new(),
             diarize: false,
             speakers: None,
+            // Auto-on, mirroring `TranscriptionRequest::new`'s default: this
+            // form field is only a client-facing opt-out (the desktop
+            // punctuation preference toggle), not the primary gate -- the
+            // stage itself still requires `emits_punctuation == Some(false)`
+            // and the FireRedPunc capability pack to be installed.
+            punctuate: true,
             segment_mode: None,
             chunk_seconds: None,
             segment_overlap_seconds: None,
@@ -543,6 +550,10 @@ impl TranscriptionRequestBuilder {
             "diarize" => {
                 let value = field.text().await.map_err(ApiError::Multipart)?;
                 self.diarize = parse_bool_field("diarize", &value)?;
+            }
+            "punctuate" => {
+                let value = field.text().await.map_err(ApiError::Multipart)?;
+                self.punctuate = parse_bool_field("punctuate", &value)?;
             }
             "speakers" => {
                 let value = field.text().await.map_err(ApiError::Multipart)?;
@@ -637,6 +648,7 @@ impl TranscriptionRequestBuilder {
             timestamp_granularities,
             diarize,
             speakers,
+            punctuate,
             segment_mode,
             chunk_seconds,
             segment_overlap_seconds,
@@ -737,7 +749,8 @@ impl TranscriptionRequestBuilder {
             .with_word_timestamps_refine(word_timestamps_refine)
             .with_display_file_name(file_name)
             .with_diarization(diarize)
-            .with_diarize_speakers(speakers);
+            .with_diarize_speakers(speakers)
+            .with_punctuation(punctuate);
 
         Ok(ParsedTranscriptionRequest {
             request,


### PR DESCRIPTION
## Summary

Wire the already-implemented FireRedPunc engine into the transcription pipeline so no-punctuation ASR output can get punctuation restored. The engine (`FireRedPuncRuntime` + `restore_punctuation`/`should_apply_punctuation`, all unit-tested) existed but was dead code -- nothing called it.

## Changes

- New `firered_punc/pack.rs`: resolve an installed punctuation capability pack (`OPENASR_FIRERED_PUNC_PACK` env / `*firered-punc*` dir), mirroring `forced_aligner_pack.rs`.
- `native_transcribe.rs`: after ASR (before forced-aligner), a punctuation stage restores punctuation per segment and rebuilds the top-level text. Gated by `request.punctuate && should_apply_punctuation(model_emits_punctuation(pack))`. Fail-closed: missing/corrupt pack or classifier failure returns the transcription unchanged -- no panic, no fabricated punctuation.
- `TranscriptionRequest.punctuate` (default true, `with_punctuation()` builder) -- the landing point for the desktop preference. CLI `--no-punctuate`; server multipart `punctuate` field (mirrors `diarize`). This connects the desktop->daemon->core leg on the core/daemon side (desktop only needs to send the field).
- `--benchmark` and `BenchSuite` explicitly disable punctuation so it isn't counted into RTF/RSS.

## Tests run

- [x] New tests: `should_run_punctuation_stage` gating, `model_emits_punctuation` (dolphin/whisper/no-arch fixtures -> Some(false)/Some(true)/None), stage-noop-returns-unchanged.
- [x] `cargo nextest run --workspace` (2243 passed), `golden_diff` (whisper pass), `fmt`/`clippy -D`/`doc`, `bundled_catalog_signature_verifies...`, `regenerate_all.sh --check` (26), `python3 -m unittest` (155).

## Scope / non-goals

- Wiring only. Publishing the FireRedPunc capability pack to HF (pt->GGUF converter + golden + catalog role + upload) is separate. Desktop UI toggle lives in openasr-app.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance; maintainer owns and merges.