### PR TITLE
feat(firered-punc): add pt-to-GGUF converter and punctuation capability-pack role

### DIFF
--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -754,6 +754,34 @@ pub(crate) enum ImportCommand {
         #[arg(long, value_enum, default_value_t = ImportFireredAedQuantization::Fp16)]
         quantization: ImportFireredAedQuantization,
     },
+    /// Import a local FireRedPunc (chinese-lert-base BERT + 5-class head) source into one punctuation runtime pack file (`.oasr`).
+    #[command(name = "firered-punc")]
+    FireredPunc {
+        /// Source F32 model.safetensors (from pt_to_safetensors.py of model.pth.tar).
+        source_safetensors: PathBuf,
+        /// Upstream WordPiece vocab.txt (21128 lines).
+        vocab_txt: PathBuf,
+        /// Output path for one runtime pack file (`.oasr`).
+        output_pack: PathBuf,
+        /// Model id written to pack metadata (openasr.model.id).
+        #[arg(long, default_value = "firered-punc")]
+        package_id: String,
+        /// Source name written to openasr.source.name.
+        #[arg(long, default_value = "FireRedTeam/FireRedPunc")]
+        source_name: String,
+        /// Source revision written to openasr.source.revision.
+        #[arg(long, default_value = "main")]
+        source_revision: String,
+        /// License name written to openasr.license.name.
+        #[arg(long, default_value = "Apache-2.0")]
+        license_name: String,
+        /// License/source URL written to openasr.license.source.
+        #[arg(long, default_value = "https://huggingface.co/FireRedTeam/FireRedPunc")]
+        license_source: String,
+        /// Runtime tensor quantization for GGUF-backed `.oasr` output (1D biases/norms always stay f16).
+        #[arg(long, value_enum, default_value_t = ImportFireredPuncQuantization::Fp16)]
+        quantization: ImportFireredPuncQuantization,
+    },
     /// Import one local X-ASR Zipformer2 transducer source directory into one runtime pack file (`.oasr`).
     #[command(name = "xasr-zipformer")]
     XasrZipformer {
@@ -939,6 +967,14 @@ pub(crate) enum ImportDolphinQuantization {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[allow(non_camel_case_types)]
 pub(crate) enum ImportFireredAedQuantization {
+    Fp16,
+    Q8_0,
+    Q4_K,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[allow(non_camel_case_types)]
+pub(crate) enum ImportFireredPuncQuantization {
     Fp16,
     Q8_0,
     Q4_K,

--- a/crates/openasr-cli/src/model_pack_cli.rs
+++ b/crates/openasr-cli/src/model_pack_cli.rs
@@ -117,6 +117,27 @@ fn import_command(command: ImportCommand) -> Result<()> {
         } => {
             import_firered_aed_local_command(&source_root, &output_root, &package_id, quantization)
         }
+        ImportCommand::FireredPunc {
+            source_safetensors,
+            vocab_txt,
+            output_pack,
+            package_id,
+            source_name,
+            source_revision,
+            license_name,
+            license_source,
+            quantization,
+        } => import_firered_punc_local_command(
+            &source_safetensors,
+            &vocab_txt,
+            &output_pack,
+            &package_id,
+            &source_name,
+            &source_revision,
+            &license_name,
+            &license_source,
+            quantization,
+        ),
         ImportCommand::XasrZipformer {
             source_root,
             output_root,
@@ -321,6 +342,47 @@ fn import_firered_aed_local_command(
         result.output_path.display(),
         result.tensor_count,
         result.vocab_size
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn import_firered_punc_local_command(
+    source_safetensors: &Path,
+    vocab_txt: &Path,
+    output_pack: &Path,
+    package_id: &str,
+    source_name: &str,
+    source_revision: &str,
+    license_name: &str,
+    license_source: &str,
+    quantization: ImportFireredPuncQuantization,
+) -> Result<()> {
+    let request = openasr_core::FireRedPuncImportRequest {
+        source_safetensors: source_safetensors.to_path_buf(),
+        vocab_txt: vocab_txt.to_path_buf(),
+        output_pack: output_pack.to_path_buf(),
+        model_id: package_id.to_string(),
+        source_name: source_name.to_string(),
+        source_revision: source_revision.to_string(),
+        license_name: license_name.to_string(),
+        license_source: license_source.to_string(),
+        quantization: match quantization {
+            ImportFireredPuncQuantization::Fp16 => openasr_core::FireRedPuncQuantizationMode::Fp16,
+            ImportFireredPuncQuantization::Q8_0 => openasr_core::FireRedPuncQuantizationMode::Q8_0,
+            ImportFireredPuncQuantization::Q4_K => openasr_core::FireRedPuncQuantizationMode::Q4_K,
+        },
+    };
+
+    ensure_ggml_package_output_suffix(output_pack)?;
+    let result = openasr_core::convert_local_firered_punc_source_to_runtime_pack(&request)
+        .map_err(anyhow::Error::new)?;
+    println!(
+        "Imported FireRedPunc local source into punctuation runtime pack:\n- source: {}\n- output: {}\n- tensor_count: {}\n- token_count: {}",
+        source_safetensors.display(),
+        result.output_path.display(),
+        result.tensor_count,
+        result.token_count
     );
     Ok(())
 }

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -151,6 +151,10 @@ pub use models::{
         FireRedAedImportRequest, FireRedAedImportResult, FireRedAedQuantizationMode,
         convert_local_firered_aed_source_to_runtime_pack,
     },
+    firered_punc::package_import::{
+        FireRedPuncImportRequest, FireRedPuncImportResult, FireRedPuncQuantizationMode,
+        convert_local_firered_punc_source_to_runtime_pack,
+    },
     ggml_asr_executor::{
         GgmlAsrBackendPreference, GgmlAsrExecutionDispatch, GgmlAsrExecutionError,
         GgmlAsrExecutionOptions, GgmlAsrExecutionRequest, GgmlAsrExecutionResult, GgmlAsrExecutor,

--- a/crates/openasr-core/src/models/firered_punc/mod.rs
+++ b/crates/openasr-core/src/models/firered_punc/mod.rs
@@ -23,6 +23,7 @@
 
 pub(crate) mod config;
 pub(crate) mod graph;
+pub(crate) mod package_import;
 pub(crate) mod runtime;
 pub(crate) mod runtime_contract;
 pub(crate) mod tensor_names;

--- a/crates/openasr-core/src/models/firered_punc/package_import.rs
+++ b/crates/openasr-core/src/models/firered_punc/package_import.rs
@@ -1,0 +1,445 @@
+//! Convert a local FireRedPunc source (`chinese-lert-base` BERT encoder + a
+//! 5-class token-classification head, upstream `FireRedTeam/FireRedPunc`) into a
+//! punctuation `.oasr` (GGUF-v0) pack.
+//!
+//! Source layout: an F32 `.safetensors` produced from the upstream
+//! `model.pth.tar` by `tooling/publish-model/scripts/pt_to_safetensors.py`
+//! (keeps the HuggingFace `bert.*` / `classifier.*` `state_dict` names), plus
+//! the upstream WordPiece `vocab.txt` (21128 lines). This module maps those
+//! names onto the GGUF tensor contract the runtime binds by
+//! (`super::tensor_names`), reversing the 2D linear/embedding dims to ggml `ne`
+//! order (PyTorch `[out, in]` row-major -> ggml `[in, out]`, so `mul_mat`/
+//! `get_rows` read the same bytes correctly), and writes the pack geometry +
+//! tokenizer tokens as metadata. It runs only offline at publish time; the
+//! numeric parity of the result is proven against the upstream PyTorch forward
+//! by the env-gated golden test (see `runtime::tests`).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::ggml_runtime::{
+    GgufWriteTensor, GgufWriteTensorType, GgufWriteValue, quantize_f32_to_ggml_tensor_data,
+    write_gguf_file_v0,
+};
+use crate::models::local_source_import::{
+    LocalSourceImportError, SafetensorsFile, SafetensorsTensorHeader,
+    decode_safetensors_payload_as_f32, encode_f16_bits_le, f32_to_f16_bits, validate_error,
+    validate_output_pack_extension,
+};
+use crate::models::oasr_metadata::{
+    OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
+    OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
+};
+
+use super::config::{
+    FIRERED_PUNC_ARCHITECTURE_VALUE, FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY,
+    FIRERED_PUNC_BLOCK_COUNT_KEY, FIRERED_PUNC_CONTEXT_LENGTH_KEY,
+    FIRERED_PUNC_EMBEDDING_LENGTH_KEY, FIRERED_PUNC_EXPECTED_D_MODEL,
+    FIRERED_PUNC_EXPECTED_FFN_DIM, FIRERED_PUNC_EXPECTED_HEADS, FIRERED_PUNC_EXPECTED_LAYERS,
+    FIRERED_PUNC_EXPECTED_MAX_POSITIONS, FIRERED_PUNC_EXPECTED_VOCAB_SIZE,
+    FIRERED_PUNC_FEED_FORWARD_LENGTH_KEY, FIRERED_PUNC_LABEL_COUNT, FIRERED_PUNC_LABEL_COUNT_KEY,
+    FIRERED_PUNC_VOCAB_SIZE_KEY, TOKENIZER_GGML_TOKENS_KEY,
+};
+use super::tensor_names::{
+    EMBD_NORM_BIAS, EMBD_NORM_WEIGHT, POSITION_EMBD_WEIGHT, PUNC_HEAD_BIAS, PUNC_HEAD_WEIGHT,
+    TOKEN_EMBD_WEIGHT, TOKEN_TYPE_EMBD_WEIGHT, firered_punc_layer_tensor_names,
+};
+
+pub(crate) const FIRERED_PUNC_MODEL_FAMILY: &str = "firered-punc";
+
+/// Runtime tensor quantization for the GGUF-backed `.oasr` output. The runtime
+/// loader dequantizes every tensor to f32 on read (BERT-base runs as an
+/// occasional finalize-only pass), so quantization only trades pack size for a
+/// small numeric perturbation; `Fp16` is the exact-parity default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub enum FireRedPuncQuantizationMode {
+    Fp16,
+    Q8_0,
+    Q4_K,
+}
+
+#[derive(Debug, Clone)]
+pub struct FireRedPuncImportRequest {
+    /// F32 `.safetensors` with the upstream `bert.*` / `classifier.*` names.
+    pub source_safetensors: PathBuf,
+    /// Upstream WordPiece `vocab.txt` (one token per line, 21128 lines).
+    pub vocab_txt: PathBuf,
+    /// Output `.oasr` pack path (must end in `.oasr`).
+    pub output_pack: PathBuf,
+    /// Catalog model id recorded in the pack metadata.
+    pub model_id: String,
+    pub source_name: String,
+    pub source_revision: String,
+    pub license_name: String,
+    pub license_source: String,
+    pub quantization: FireRedPuncQuantizationMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FireRedPuncImportResult {
+    pub output_path: PathBuf,
+    pub tensor_count: usize,
+    pub token_count: usize,
+}
+
+/// One tensor to emit: its GGUF (target) name, the upstream `state_dict` source
+/// name, and whether it is a 2D weight whose dims must be reversed to ggml `ne`.
+struct TensorMapping {
+    target: String,
+    source: String,
+    reverse_dims: bool,
+}
+
+fn mapping(target: &str, source: &str, reverse_dims: bool) -> TensorMapping {
+    TensorMapping {
+        target: target.to_string(),
+        source: source.to_string(),
+        reverse_dims,
+    }
+}
+
+/// The full target<-source tensor map, derived from the fixed chinese-lert-base
+/// BERT structure so it cannot drift from the runtime's tensor-name contract
+/// (`super::tensor_names`).
+fn tensor_mappings() -> Vec<TensorMapping> {
+    let mut mappings = vec![
+        mapping(
+            TOKEN_EMBD_WEIGHT,
+            "bert.embeddings.word_embeddings.weight",
+            true,
+        ),
+        mapping(
+            POSITION_EMBD_WEIGHT,
+            "bert.embeddings.position_embeddings.weight",
+            true,
+        ),
+        mapping(
+            TOKEN_TYPE_EMBD_WEIGHT,
+            "bert.embeddings.token_type_embeddings.weight",
+            true,
+        ),
+        mapping(EMBD_NORM_WEIGHT, "bert.embeddings.LayerNorm.weight", false),
+        mapping(EMBD_NORM_BIAS, "bert.embeddings.LayerNorm.bias", false),
+    ];
+    for layer in 0..FIRERED_PUNC_EXPECTED_LAYERS {
+        let names = firered_punc_layer_tensor_names(layer);
+        let src = format!("bert.encoder.layer.{layer}");
+        mappings.extend([
+            mapping(
+                &names.attn_q_weight,
+                &format!("{src}.attention.self.query.weight"),
+                true,
+            ),
+            mapping(
+                &names.attn_q_bias,
+                &format!("{src}.attention.self.query.bias"),
+                false,
+            ),
+            mapping(
+                &names.attn_k_weight,
+                &format!("{src}.attention.self.key.weight"),
+                true,
+            ),
+            mapping(
+                &names.attn_k_bias,
+                &format!("{src}.attention.self.key.bias"),
+                false,
+            ),
+            mapping(
+                &names.attn_v_weight,
+                &format!("{src}.attention.self.value.weight"),
+                true,
+            ),
+            mapping(
+                &names.attn_v_bias,
+                &format!("{src}.attention.self.value.bias"),
+                false,
+            ),
+            mapping(
+                &names.attn_output_weight,
+                &format!("{src}.attention.output.dense.weight"),
+                true,
+            ),
+            mapping(
+                &names.attn_output_bias,
+                &format!("{src}.attention.output.dense.bias"),
+                false,
+            ),
+            mapping(
+                &names.attn_norm_weight,
+                &format!("{src}.attention.output.LayerNorm.weight"),
+                false,
+            ),
+            mapping(
+                &names.attn_norm_bias,
+                &format!("{src}.attention.output.LayerNorm.bias"),
+                false,
+            ),
+            mapping(
+                &names.ffn_up_weight,
+                &format!("{src}.intermediate.dense.weight"),
+                true,
+            ),
+            mapping(
+                &names.ffn_up_bias,
+                &format!("{src}.intermediate.dense.bias"),
+                false,
+            ),
+            mapping(
+                &names.ffn_down_weight,
+                &format!("{src}.output.dense.weight"),
+                true,
+            ),
+            mapping(
+                &names.ffn_down_bias,
+                &format!("{src}.output.dense.bias"),
+                false,
+            ),
+            mapping(
+                &names.ffn_norm_weight,
+                &format!("{src}.output.LayerNorm.weight"),
+                false,
+            ),
+            mapping(
+                &names.ffn_norm_bias,
+                &format!("{src}.output.LayerNorm.bias"),
+                false,
+            ),
+        ]);
+    }
+    mappings.push(mapping(PUNC_HEAD_WEIGHT, "classifier.weight", true));
+    mappings.push(mapping(PUNC_HEAD_BIAS, "classifier.bias", false));
+    mappings
+}
+
+/// ggml `ne` dims for a mapped tensor: 2D linear/embedding weights are stored
+/// with reversed dims (PyTorch `[out, in]` -> `[in, out]`); everything else
+/// keeps its logical shape (rank-0 scalars, which BERT has none of, would map
+/// to `[1]`).
+fn ggml_dims(header: &SafetensorsTensorHeader, reverse_dims: bool) -> Vec<u64> {
+    if reverse_dims && header.shape.len() == 2 {
+        vec![header.shape[1], header.shape[0]]
+    } else if header.shape.is_empty() {
+        vec![1]
+    } else {
+        header.shape.clone()
+    }
+}
+
+/// Whether a 2D weight can be K-quantized (ggml K-quant superblock needs
+/// `ne0 % 256 == 0`). BERT-base's `ne0` is always 768 or 3072, so all 2D
+/// weights qualify; anything that does not falls back to F16.
+fn kquant_eligible(dims: &[u64]) -> bool {
+    dims.len() == 2 && dims[0].is_multiple_of(256)
+}
+
+fn build_tensor(
+    safetensors: &SafetensorsFile,
+    map: &TensorMapping,
+    quantization: FireRedPuncQuantizationMode,
+) -> Result<GgufWriteTensor, LocalSourceImportError> {
+    let header = safetensors.tensor(&map.source).ok_or_else(|| {
+        validate_error(format!(
+            "FireRedPunc source is missing required tensor '{}'",
+            map.source
+        ))
+    })?;
+    let data = safetensors.tensor_data(header)?;
+    let values = decode_safetensors_payload_as_f32(&header.name, &header.dtype, data)?;
+    let dims = ggml_dims(header, map.reverse_dims);
+    let expected: u64 = dims.iter().product();
+    if expected as usize != values.len() {
+        return Err(validate_error(format!(
+            "FireRedPunc tensor '{}' decoded {} values but dims {dims:?} need {expected}",
+            map.source,
+            values.len(),
+        )));
+    }
+
+    // Quantize the 2D weights per the requested mode; keep 1D tensors (biases,
+    // LayerNorm affines) exact in F16. The loader dequantizes everything on
+    // read either way.
+    let quant_type = match quantization {
+        FireRedPuncQuantizationMode::Fp16 => None,
+        FireRedPuncQuantizationMode::Q8_0 if dims.len() == 2 => Some(GgufWriteTensorType::Q8_0),
+        FireRedPuncQuantizationMode::Q4_K if kquant_eligible(&dims) => {
+            Some(GgufWriteTensorType::Q4_K)
+        }
+        _ => None,
+    };
+
+    let (tensor_type, tensor_data) = match quant_type {
+        Some(qtype) => {
+            let quantized = quantize_f32_to_ggml_tensor_data(qtype, &dims, &values)
+                .map_err(|error| validate_error(format!("FireRedPunc quantize failed: {error}")))?;
+            (qtype, quantized)
+        }
+        None => (
+            GgufWriteTensorType::F16,
+            encode_f16_bits_le(values.into_iter().map(f32_to_f16_bits).collect()),
+        ),
+    };
+    Ok(GgufWriteTensor {
+        name: map.target.clone(),
+        dims,
+        tensor_type,
+        data: tensor_data,
+    })
+}
+
+/// Read the upstream WordPiece `vocab.txt` (one token per line) into the token
+/// list stored as `tokenizer.ggml.tokens`. The trailing newline is dropped;
+/// interior blank lines are preserved as tokens (BERT `[unusedNN]` slots), so
+/// the count stays byte-faithful to the upstream vocabulary.
+fn read_vocab_tokens(path: &Path) -> Result<Vec<String>, LocalSourceImportError> {
+    let text = std::fs::read_to_string(path).map_err(|source| LocalSourceImportError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let tokens: Vec<String> = text
+        .strip_suffix('\n')
+        .unwrap_or(&text)
+        .split('\n')
+        .map(|line| line.to_string())
+        .collect();
+    Ok(tokens)
+}
+
+fn runtime_metadata(
+    request: &FireRedPuncImportRequest,
+    tokens: &[String],
+) -> BTreeMap<String, GgufWriteValue> {
+    let mut metadata = BTreeMap::new();
+    let mut put = |key: &str, value: &str| {
+        metadata.insert(key.to_string(), GgufWriteValue::String(value.to_string()));
+    };
+    put("general.architecture", FIRERED_PUNC_ARCHITECTURE_VALUE);
+    put(OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1);
+    put(OASR_METADATA_KEY_MODEL_FAMILY, FIRERED_PUNC_MODEL_FAMILY);
+    put(
+        OASR_METADATA_KEY_MODEL_ARCHITECTURE,
+        FIRERED_PUNC_ARCHITECTURE_VALUE,
+    );
+    put("openasr.model.id", &request.model_id);
+    put("openasr.source.name", &request.source_name);
+    put("openasr.source.revision", &request.source_revision);
+    put("openasr.license.name", &request.license_name);
+    put("openasr.license.source", &request.license_source);
+
+    let mut put_u32 = |key: &str, value: u32| {
+        metadata.insert(key.to_string(), GgufWriteValue::U32(value));
+    };
+    put_u32(
+        FIRERED_PUNC_BLOCK_COUNT_KEY,
+        FIRERED_PUNC_EXPECTED_LAYERS as u32,
+    );
+    put_u32(
+        FIRERED_PUNC_EMBEDDING_LENGTH_KEY,
+        FIRERED_PUNC_EXPECTED_D_MODEL as u32,
+    );
+    put_u32(
+        FIRERED_PUNC_FEED_FORWARD_LENGTH_KEY,
+        FIRERED_PUNC_EXPECTED_FFN_DIM as u32,
+    );
+    put_u32(
+        FIRERED_PUNC_ATTENTION_HEAD_COUNT_KEY,
+        FIRERED_PUNC_EXPECTED_HEADS as u32,
+    );
+    put_u32(
+        FIRERED_PUNC_CONTEXT_LENGTH_KEY,
+        FIRERED_PUNC_EXPECTED_MAX_POSITIONS as u32,
+    );
+    put_u32(
+        FIRERED_PUNC_VOCAB_SIZE_KEY,
+        FIRERED_PUNC_EXPECTED_VOCAB_SIZE as u32,
+    );
+    put_u32(
+        FIRERED_PUNC_LABEL_COUNT_KEY,
+        FIRERED_PUNC_LABEL_COUNT as u32,
+    );
+
+    metadata.insert(
+        TOKENIZER_GGML_TOKENS_KEY.to_string(),
+        GgufWriteValue::StringArray(tokens.to_vec()),
+    );
+    metadata
+}
+
+/// Convert a local FireRedPunc safetensors + vocab source into a punctuation
+/// `.oasr` pack.
+pub fn convert_local_firered_punc_source_to_runtime_pack(
+    request: &FireRedPuncImportRequest,
+) -> Result<FireRedPuncImportResult, LocalSourceImportError> {
+    validate_output_pack_extension(&request.output_pack)?;
+    let safetensors = SafetensorsFile::open(&request.source_safetensors)?;
+    let tokens = read_vocab_tokens(&request.vocab_txt)?;
+    if tokens.len() != FIRERED_PUNC_EXPECTED_VOCAB_SIZE {
+        return Err(validate_error(format!(
+            "FireRedPunc vocab.txt has {} tokens, expected {FIRERED_PUNC_EXPECTED_VOCAB_SIZE}",
+            tokens.len()
+        )));
+    }
+    for special in ["[PAD]", "[UNK]", "[CLS]", "[SEP]"] {
+        if !tokens.iter().any(|token| token == special) {
+            return Err(validate_error(format!(
+                "FireRedPunc vocab.txt is missing required special token '{special}'"
+            )));
+        }
+    }
+
+    let mappings = tensor_mappings();
+    let mut tensors = Vec::with_capacity(mappings.len());
+    for map in &mappings {
+        tensors.push(build_tensor(&safetensors, map, request.quantization)?);
+    }
+
+    let metadata = runtime_metadata(request, &tokens);
+    write_gguf_file_v0(&request.output_pack, &metadata, &tensors).map_err(|error| {
+        validate_error(format!(
+            "FireRedPunc GGUF writer failed for '{}': {error}",
+            request.output_pack.display()
+        ))
+    })?;
+    Ok(FireRedPuncImportResult {
+        output_path: request.output_pack.clone(),
+        tensor_count: tensors.len(),
+        token_count: tokens.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tensor_map_covers_every_runtime_tensor_name_once() {
+        let mappings = tensor_mappings();
+        // 5 embedding/norm + 16 per layer * 12 + 2 head = 5 + 192 + 2 = 199.
+        assert_eq!(mappings.len(), 199);
+        let mut targets: Vec<&str> = mappings.iter().map(|m| m.target.as_str()).collect();
+        targets.sort_unstable();
+        let count = targets.len();
+        targets.dedup();
+        assert_eq!(targets.len(), count, "target tensor names must be unique");
+    }
+
+    #[test]
+    fn ggml_dims_reverse_only_2d_weights() {
+        let header = SafetensorsTensorHeader {
+            name: "w".to_string(),
+            dtype: "F32".to_string(),
+            shape: vec![5, 768],
+            data_offsets: [0, 0],
+        };
+        assert_eq!(ggml_dims(&header, true), vec![768, 5]);
+        assert_eq!(ggml_dims(&header, false), vec![5, 768]);
+        let bias = SafetensorsTensorHeader {
+            name: "b".to_string(),
+            dtype: "F32".to_string(),
+            shape: vec![768],
+            data_offsets: [0, 0],
+        };
+        assert_eq!(ggml_dims(&bias, true), vec![768]);
+    }
+}

--- a/crates/openasr-core/src/models/firered_punc/runtime.rs
+++ b/crates/openasr-core/src/models/firered_punc/runtime.rs
@@ -120,4 +120,54 @@ mod tests {
         let out = runtime.punctuate("你好世界").expect("punctuate");
         assert_eq!(out, "你好世界。", "upstream README golden");
     }
+
+    /// Converter golden gate: the engine's per-token argmax labels for the
+    /// converted `.oasr` pack must exactly match the upstream PyTorch forward.
+    /// Both env vars are dev-only (the pack is uncommitted; the JSON is emitted
+    /// by `tmp/firered-punc-src/reference_forward.py`), so the default suite
+    /// skips this -- it is the publish-time parity proof, mirroring the qwen
+    /// forced-aligner reference convention. The JSON is a list of
+    /// `{content_ids: [u32], ref_labels: [usize]}` entries; the same content
+    /// ids are fed to both sides so this isolates the numeric forward from
+    /// tokenization.
+    #[test]
+    fn real_pack_labels_match_pytorch_reference_golden() {
+        let (Some(pack), Some(json)) = (
+            std::env::var_os("OPENASR_FIRERED_PUNC_REAL_PACK"),
+            std::env::var_os("OPENASR_FIRERED_PUNC_GOLDEN_JSON"),
+        ) else {
+            return;
+        };
+        let runtime = FireRedPuncRuntime::from_pack(Path::new(&pack)).expect("load real pack");
+        let text = std::fs::read_to_string(Path::new(&json)).expect("read golden json");
+        let entries: serde_json::Value = serde_json::from_str(&text).expect("parse golden json");
+        let entries = entries.as_array().expect("golden json is a list");
+        let mut checked = 0usize;
+        for entry in entries {
+            let content_ids: Vec<u32> = entry["content_ids"]
+                .as_array()
+                .expect("content_ids array")
+                .iter()
+                .map(|value| value.as_u64().expect("id is u64") as u32)
+                .collect();
+            let ref_labels: Vec<usize> = entry["ref_labels"]
+                .as_array()
+                .expect("ref_labels array")
+                .iter()
+                .map(|value| value.as_u64().expect("label is u64") as usize)
+                .collect();
+            let engine_labels = runtime
+                .predict_window_labels(&content_ids)
+                .expect("engine predict");
+            assert_eq!(
+                engine_labels,
+                ref_labels,
+                "label mismatch for sentence {:?}",
+                entry.get("sentence")
+            );
+            checked += 1;
+        }
+        assert!(checked > 0, "golden json had no entries");
+        eprintln!("firered-punc golden: {checked} sentences matched PyTorch reference");
+    }
 }

--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -35,6 +35,12 @@ const CATALOG_SPEAKER_EMBEDDER_WESPEAKER_ID: &str = "wespeaker-voxceleb-resnet34
 /// `CATALOG_FEATURE_SPEAKER_DIARIZATION`'s role as the shared vocabulary
 /// between the catalog and the CLI/server opt-in wiring.
 pub const CATALOG_FEATURE_WORD_TIMESTAMPS: &str = "word-timestamps";
+/// Capability-pack feature key for the optional punctuation-restoration
+/// post-processing stage (restores Chinese full-width marks on an unpunctuated
+/// family's transcript). Mirrors `CATALOG_FEATURE_SPEAKER_DIARIZATION` /
+/// `CATALOG_FEATURE_WORD_TIMESTAMPS` as the shared catalog<->runtime vocabulary
+/// for an opt-in capability pack.
+pub const CATALOG_FEATURE_PUNCTUATION: &str = "punctuation";
 // Soft-disabled for the initial public release lane. The ModelScope URL
 // validation block below stays in place so re-enabling is a one-switch decision.
 const MODELSCOPE_CATALOG_MIRRORS_ENABLED: bool = false;
@@ -356,6 +362,13 @@ pub enum CatalogCapabilityRole {
     /// per-word timestamps with aligner-refined spans. Opt-in only; the
     /// family's own approximate timestamps remain the default.
     ForcedAligner,
+    /// A punctuation-restoration model for the `punctuation` feature (e.g.
+    /// FireRedPunc): a text-in/labels-out BERT classifier that adds Chinese
+    /// full-width marks to an unpunctuated family's transcript in a
+    /// finalize-only post-process. Opt-in and auto-gated on the ASR model's
+    /// `emits_punctuation == Some(false)`; never re-punctuates a punctuating
+    /// family.
+    PunctuationRestorer,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -489,6 +502,21 @@ impl ModelCatalog {
             .find(|model| {
                 model.capability.as_ref().is_some_and(|capability| {
                     capability.role == CatalogCapabilityRole::ForcedAligner
+                })
+            })
+    }
+
+    /// The punctuation-restoration capability pack for the `punctuation`
+    /// feature, when the catalog carries one. Any public pack advertising
+    /// `(punctuation, PunctuationRestorer)` qualifies -- there is exactly one
+    /// today (FireRedPunc) but callers should not hardcode its id (mirrors
+    /// `word_timestamps_forced_aligner_pack`).
+    pub fn punctuation_restorer_pack(&self) -> Option<&CatalogModel> {
+        self.capability_packs_for_feature(CATALOG_FEATURE_PUNCTUATION)
+            .into_iter()
+            .find(|model| {
+                model.capability.as_ref().is_some_and(|capability| {
+                    capability.role == CatalogCapabilityRole::PunctuationRestorer
                 })
             })
     }

--- a/crates/openasr-core/src/registry/tests/catalog.rs
+++ b/crates/openasr-core/src/registry/tests/catalog.rs
@@ -495,6 +495,35 @@ fn word_timestamps_forced_aligner_pack_ignores_staged_non_public_entries() {
 }
 
 #[test]
+fn punctuation_restorer_pack_selects_the_punctuation_capability_pack() {
+    let mut catalog = alias_contract_catalog();
+    catalog.models.push(capability_pack_model_with_feature(
+        "firered-punc",
+        CATALOG_FEATURE_PUNCTUATION,
+        CatalogCapabilityRole::PunctuationRestorer,
+    ));
+
+    let pack = catalog
+        .punctuation_restorer_pack()
+        .expect("punctuation capability pack");
+    assert_eq!(pack.id, "firered-punc");
+}
+
+#[test]
+fn punctuation_restorer_pack_ignores_staged_non_public_entries() {
+    let mut catalog = alias_contract_catalog();
+    let mut staged = capability_pack_model_with_feature(
+        "firered-punc",
+        CATALOG_FEATURE_PUNCTUATION,
+        CatalogCapabilityRole::PunctuationRestorer,
+    );
+    staged.public = false;
+    catalog.models.push(staged);
+
+    assert!(catalog.punctuation_restorer_pack().is_none());
+}
+
+#[test]
 fn catalog_capability_pack_requires_capability_metadata() {
     let mut catalog = alias_contract_catalog();
     let mut pack = capability_pack_model(

--- a/tooling/publish-model/cards/firered-punc.toml
+++ b/tooling/publish-model/cards/firered-punc.toml
@@ -1,0 +1,105 @@
+# Per-model card prose for OpenASR/firered-punc. Distilled (paraphrased, not
+# copied) from the upstream FireRedTeam/FireRedPunc model card and the
+# FireRedASR2S technical report. Claims are kept to what the upstream repo and
+# architecture state; re-verify against the upstream card when the upstream
+# weights change.
+#
+# STAGING NOTE (not public): this is a NEW capability-pack catalog entry --
+# there is no prior public listing for this model. Published to a PRIVATE HF
+# repo only; the catalog entry stays public:false until a deliberate later
+# --public flip (same convention as the diarization / forced-aligner packs).
+
+tagline = "Chinese punctuation restoration for OpenASR -- a BERT token classifier that adds full-width marks to unpunctuated transcripts, fully on-device"
+tagline_zh = "为 OpenASR 提供中文标点恢复 — 基于 BERT 逐词分类器，为无标点转写补回全角标点，全程在设备本地运行"
+
+highlights = [
+  "🈶 **Chinese punctuation restoration** -- restores full-width `，。？！` on an unpunctuated ASR transcript (e.g. Dolphin, FireRedASR2-AED) in a finalize-only post-processing pass",
+  "🧠 **BERT token classifier** -- a 12-layer `chinese-lert-base` encoder with a 5-class head predicting which of none/，。？！ follows each subword",
+  "🇨🇳 **Chinese-only by construction** -- the released label set has no English half-width marks, so only Chinese text is punctuated",
+  "🔌 **Opt-in and auto-gated** -- runs only when the ASR model is unpunctuated and this pack is installed, so punctuating families are never double-punctuated",
+  "🦀 **Native in OpenASR** -- `.oasr` packs run with no Python at inference, all decoding local",
+]
+
+highlights_zh = [
+  "🈶 **中文标点恢复** — 在无标点的 ASR 转写（如 Dolphin、FireRedASR2-AED）上，以仅终稿的后处理阶段补回全角 `，。？！`",
+  "🧠 **BERT 逐词分类器** — 12 层 `chinese-lert-base` 编码器，配 5 分类输出头，预测每个子词后面接哪一种（无标点或 ，。？！）",
+  "🇨🇳 **天生仅支持中文** — 发布的标签集不含英文半角标点，因此只为中文文本补标点",
+  "🔌 **可选且自动门控** — 仅当 ASR 模型本身无标点且已安装本包时才运行，带标点的家族绝不会被重复加标点",
+  "🦀 **OpenASR 原生运行** — `.oasr` 包推理阶段无需 Python，全部解码均在本地完成",
+]
+
+intro = """
+FireRedPunc is a **punctuation-prediction** model from **FireRedTeam**, part of the
+FireRedASR2S all-in-one ASR system. It adopts a BERT-style encoder initialized from
+`chinese-lert-base` (a 12-layer, 768-hidden, 12-head BERT) with a token-classification head
+that predicts, for each subword, which of five classes follows it: none, or one of the four
+Chinese full-width marks `，`, `。`, `？`, `！`. It is a text-in / labels-out post-processor,
+not an ASR model -- no audio frontend, no autoregressive decode.
+
+In OpenASR it is packaged as an optional **punctuation capability pack**: an unpunctuated
+family's finished transcript (e.g. Dolphin or FireRedASR2-AED) is passed through the classifier
+once, and the predicted marks are re-inserted into the original characters. The stage is
+auto-gated on the ASR model's catalog `emits_punctuation == false` and only runs when this pack
+is installed, so punctuating families are never double-punctuated. Because the released label
+set is Chinese-only, the integration is Chinese-only by construction (the architecture cannot
+emit English half-width marks).
+
+This OpenASR repo repackages the upstream weights as `.oasr` packs that run natively in the
+OpenASR runtime -- no Python at inference, all decoding local. It ships in **fp16**.
+
+**Not a standalone transcription model.** This pack cannot transcribe audio by itself; it is an
+opt-in post-process applied to an unpunctuated ASR model's output.
+
+**Verification status:** this is a brand-new catalog entry (no prior public listing). Local
+verification covers exact per-token label parity against the upstream PyTorch forward across a
+set of Chinese golden sentences (all four punctuation classes plus the no-mark class). This
+pack is staged in a private repo, not yet publicly listed.
+"""
+
+intro_zh = """
+FireRedPunc 是 **FireRedTeam** 推出的**标点预测**模型，属于 FireRedASR2S 一体化 ASR 系统的一
+部分。它采用 BERT 风格的编码器，从 `chinese-lert-base`（12 层、768 隐藏维、12 头的 BERT）初始化，
+并接一个逐词分类输出头：对每个子词预测其后接的五个类别之一——无标点，或四个中文全角标点
+`，`、`。`、`？`、`！` 之一。它是文本进、标签出的后处理器，不是 ASR 模型——没有音频前端，也没有
+自回归解码。
+
+在 OpenASR 中，它被打包为一个可选的**标点能力包**：无标点家族（如 Dolphin 或 FireRedASR2-AED）
+的最终转写会经分类器处理一次，预测出的标点被重新插回原始字符。该阶段依据 ASR 模型 catalog 中的
+`emits_punctuation == false` 自动门控，且仅在安装本包时运行，因此带标点的家族绝不会被重复加标点。
+由于发布的标签集仅含中文标点，本集成天生仅支持中文（该架构无法输出英文半角标点）。
+
+这个仓库提供 OpenASR `.oasr` 格式包。OpenASR 会在本地完成加载、校验和推理，不会把文本上传到
+云端。提供 `fp16` 量化版本。
+
+**不是独立的转写模型。** 本模型包本身无法转写音频；它是应用于无标点 ASR 模型输出的可选后处理步骤。
+
+**验证状态:** 这是一个全新的 catalog 条目（此前没有公开上架记录）。本地验证覆盖了在一组中文黄金句
+（涵盖全部四种标点类别以及无标点类别）上，与上游 PyTorch 前向逐词标签完全一致的对齐检查。本模型包
+目前仅暂存于私有仓库，尚未公开上架。
+"""
+
+acknowledgement = """
+This pack is a redistribution of **FireRedPunc**, created and open-sourced by **FireRedTeam**
+([FireRedTeam/FireRedPunc](https://huggingface.co/FireRedTeam/FireRedPunc)). All credit for the
+original architecture, training, and weights belongs to the authors; the license is inherited
+from and identical to the upstream model (Apache-2.0). OpenASR only performs format conversion,
+runtime verification, and local-inference adaptation.
+"""
+
+acknowledgement_zh = """
+本模型包重新分发自 FireRedTeam 开源的 FireRedPunc
+([FireRedTeam/FireRedPunc](https://huggingface.co/FireRedTeam/FireRedPunc))。原始架构、训练和
+权重归作者所有，许可证继承上游 Apache-2.0。OpenASR 仅进行格式转换、运行时校验和本地推理适配。
+"""
+
+[prose_locales."zh-CN"]
+tagline = "为 OpenASR 提供中文标点恢复 — 基于 BERT 逐词分类器，为无标点转写补回全角标点，全程在设备本地运行"
+
+highlights = [
+  "🈶 **中文标点恢复** — 在无标点的 ASR 转写（如 Dolphin、FireRedASR2-AED）上，以仅终稿的后处理阶段补回全角 `，。？！`",
+  "🧠 **BERT 逐词分类器** — 12 层 `chinese-lert-base` 编码器，配 5 分类输出头，预测每个子词后面接哪一种（无标点或 ，。？！）",
+  "🇨🇳 **天生仅支持中文** — 发布的标签集不含英文半角标点，因此只为中文文本补标点",
+  "🔌 **可选且自动门控** — 仅当 ASR 模型本身无标点且已安装本包时才运行，带标点的家族绝不会被重复加标点",
+  "🦀 **OpenASR 原生运行** — `.oasr` 包推理阶段无需 Python，全部解码均在本地完成",
+]
+source_sha256 = "36f5bf2afcf768b9eeacb93bd632dfd43738fb9a623cf57435ecde2436826d98"

--- a/tooling/publish-model/models-core.toml
+++ b/tooling/publish-model/models-core.toml
@@ -594,3 +594,34 @@ min_core_version = "0.1.9"
 ["qwen3-forced-aligner-0.6b".capability]
 feature = "word-timestamps"
 role = "forced-aligner"
+
+# Punctuation-restoration support pack: a chinese-lert-base BERT token
+# classifier (upstream FireRedTeam/FireRedPunc) that adds Chinese full-width
+# marks to an unpunctuated family's transcript in a finalize-only post-process.
+# Not an ASR model. Chinese-only by construction (the released label set is the
+# 5 classes none/，。？！). Staged to a PRIVATE HF repo; the catalog entry stays
+# public:false (published without --public) until a deliberate later flip, like
+# the diarization/forced-aligner capability packs above.
+["firered-punc"]
+kind = "capability-pack"
+family = "firered-punc"
+hf_repo = "OpenASR/firered-punc"
+release_public = true
+size = "base"
+registry_id = "firered-punc"
+display_name = "FireRedPunc"
+license_name = "Apache-2.0"
+license_source = "https://huggingface.co/FireRedTeam/FireRedPunc"
+license_class = "permissive"
+# Chinese-only by construction: the released label set cannot emit English
+# half-width marks, so this documents the single supported recognition language
+# rather than inheriting a family default.
+languages = ["zh"]
+quants = ["fp16"]
+recommended_quant = "fp16"
+upstream_release_date = "2026-02-12"
+min_core_version = "0.1.11"
+
+["firered-punc".capability]
+feature = "punctuation"
+role = "punctuation-restorer"

--- a/tooling/publish-model/models-publish.toml
+++ b/tooling/publish-model/models-publish.toml
@@ -194,3 +194,14 @@ import_subcommand = "not yet a public model-pack import subcommand"
 upstream_repo = "Qwen/Qwen3-ForcedAligner-0.6B"
 source_revision = "main"
 needs_license_flags = false
+
+# FireRedPunc punctuation capability pack. Imported via the public
+# `openasr model-pack import firered-punc` subcommand from the upstream
+# model.pth.tar (chinese-lert-base BERT + 5-class head) normalized to
+# safetensors by pt_to_safetensors.py. Staged to a private HF repo; the
+# catalog entry stays public:false until a deliberate later --public flip.
+["firered-punc"]
+import_subcommand = "import firered-punc"
+upstream_repo = "FireRedTeam/FireRedPunc"
+source_revision = "e448fd967f44182a1c323cc30f5d89f2400c28da"
+needs_license_flags = false

--- a/tooling/publish-model/scripts/_catalog.py
+++ b/tooling/publish-model/scripts/_catalog.py
@@ -46,7 +46,12 @@ REGISTRY_CARD_DEFAULTS = {
 }
 DEFAULT_CATALOG_MODEL_KIND = "asr-model"
 SUPPORTED_CATALOG_MODEL_KINDS = {"asr-model", "capability-pack", "translation-model"}
-SUPPORTED_CAPABILITY_ROLES = {"speaker-embedder", "speaker-segmenter", "forced-aligner"}
+SUPPORTED_CAPABILITY_ROLES = {
+    "speaker-embedder",
+    "speaker-segmenter",
+    "forced-aligner",
+    "punctuation-restorer",
+}
 GIT_REVISION_RE = re.compile(r"[0-9a-fA-F]{40}")
 TRANSLATION_REQUIRED_LICENSE_FILES = {"LICENSE.txt", "NOTICE.openasr.txt"}
 

--- a/tooling/publish-model/scripts/publish_helpers_test.py
+++ b/tooling/publish-model/scripts/publish_helpers_test.py
@@ -19,14 +19,17 @@ from _file_loaders import load_toml
 
 
 EXPECTED_CAPABILITY_PACKS = {
+    "firered-punc": "punctuation-restorer",
     "pyannote-segmentation-3.0": "speaker-segmenter",
     "qwen3-forced-aligner-0.6b": "forced-aligner",
     "wespeaker-voxceleb-resnet34-lm": "speaker-embedder",
 }
 # Capability-pack feature per model: most existing packs serve
 # speaker-diarization, but qwen3-forced-aligner-0.6b serves the distinct
-# word-timestamps feature (see registry.rs CATALOG_FEATURE_WORD_TIMESTAMPS).
+# word-timestamps feature (see registry.rs CATALOG_FEATURE_WORD_TIMESTAMPS) and
+# firered-punc serves the punctuation feature (CATALOG_FEATURE_PUNCTUATION).
 EXPECTED_CAPABILITY_FEATURES = {
+    "firered-punc": "punctuation",
     "pyannote-segmentation-3.0": "speaker-diarization",
     "qwen3-forced-aligner-0.6b": "word-timestamps",
     "wespeaker-voxceleb-resnet34-lm": "speaker-diarization",

--- a/tooling/publish-model/scripts/publish_model_targets.py
+++ b/tooling/publish-model/scripts/publish_model_targets.py
@@ -30,6 +30,7 @@ QWEN3_ASR_EXPECTED_GENERAL_ARCHITECTURE = b"qwen3-asr"
 QWEN3_ASR_LEGACY_GENERAL_ARCHITECTURE = b"qwen3asr"
 XASR_ZIPFORMER_EXPECTED_GENERAL_ARCHITECTURE = b"xasr-zipformer-transducer"
 HYMT2_EXPECTED_GENERAL_ARCHITECTURE = b"hunyuan-dense"
+FIRERED_PUNC_EXPECTED_GENERAL_ARCHITECTURE = b"firered-punc"
 HYMT2_REQUIRED_HEADER_MARKERS = (
     b"openasr.model.kind",
     b"translation-model",
@@ -71,6 +72,7 @@ RELEASE_LANE_MODELS = (
     "parakeet-tdt-0.6b-v3",
     "firered-aed-l-v2",
     "qwen3-forced-aligner-0.6b",
+    "firered-punc",
 )
 GGUF_GENERAL_ARCHITECTURE_KEY = b"general.architecture"
 
@@ -104,6 +106,8 @@ def expected_general_architecture(model: str) -> bytes | None:
         return XASR_ZIPFORMER_EXPECTED_GENERAL_ARCHITECTURE
     if model == "hymt2-1.8b":
         return HYMT2_EXPECTED_GENERAL_ARCHITECTURE
+    if model == "firered-punc":
+        return FIRERED_PUNC_EXPECTED_GENERAL_ARCHITECTURE
     return None
 
 

--- a/tooling/publish-model/scripts/render_card.py
+++ b/tooling/publish-model/scripts/render_card.py
@@ -39,12 +39,13 @@ TRANSLATION_FAMILIES = {"hymt2"}
 # no ASR pipeline tags/transcribe quickstart, no diarize-specific wording --
 # just quant/file/size and a note that this model augments another model's
 # decode path.
-CAPABILITY_FAMILIES = {"qwen3-forced-aligner"}
+CAPABILITY_FAMILIES = {"qwen3-forced-aligner", "firered-punc"}
 # HF YAML pipeline tag per diarize/capability family (the prose card may override).
 DIARIZE_PIPELINE_TAG_BY_FAMILY = {
     "wespeaker": "feature-extraction",
     "pyannote-segmentation": "voice-activity-detection",
     "qwen3-forced-aligner": "automatic-speech-recognition",
+    "firered-punc": "automatic-speech-recognition",
 }
 # SPDX ids (lowercased) that HF's YAML `license:` field accepts directly. A
 # license outside this set (e.g. the FunASR Model License) must use the HF


### PR DESCRIPTION
## Summary

Add the FireRedPunc capability-pack onboarding: a pt->GGUF converter and a punctuation `CatalogCapabilityRole`. The .oasr was golden-verified against the original PyTorch model and published to HF (private repo `OpenASR/firered-punc`). This PR is the code/scaffold only -- the signed catalog release (epoch bump + re-sign + deploy to catalog.openasr.org) is intentionally NOT included; that public-release step is left for the maintainer's explicit go.

## Changes

- `firered_punc/package_import.rs`: `convert_local_firered_punc_source_to_runtime_pack` (pt -> safetensors -> GGUF `.oasr`; 2D weight dims reversed per the ggml convention, geometry matches the engine constants). CLI `model-pack import firered-punc`.
- `CatalogCapabilityRole::PunctuationRestorer` (kebab `punctuation-restorer`) + `CATALOG_FEATURE_PUNCTUATION` + `punctuation_restorer_pack()` accessor (mirrors forced-aligner). `models-core.toml` entry (capability-pack, feature=punctuation, fp16, zh, min_core 0.1.11) + bilingual card. Python `SUPPORTED_CAPABILITY_ROLES` updated.

## Tests run

- [x] **Golden: 8/8 sentences label-identical** vs a hand-written PyTorch f32 BERT forward from the original pt (env-gated `real_pack_labels_match_pytorch_reference_golden`); README golden passes.
- [x] `cargo nextest run --workspace` (2245 passed), `fmt`/`clippy -D`/`doc`, `golden_diff` (core pass), `bundled_catalog_signature_verifies...`, `regenerate_all.sh --check` (27 models, firered-punc in valid staged-lag), `python3 -m unittest` (155).

## Scope / non-goals

- **Catalog public release/deploy is NOT in this PR** (epoch bump + catalog.signature re-sign + catalog.public.json). HF pack is private. Making it installable/visible is a separate maintainer-authorized release step.

## Requirements

- [x] I understand the change and own its maintenance.
- AI usage disclosure: YES -- implemented and golden-verified with AI assistance; maintainer owns and merges.