### PR TITLE
fix(punctuation): gate FireRedPunc on Han content and run the stage on streaming finals

### DIFF
--- a/crates/openasr-core/src/api/native/tests/support/session.rs
+++ b/crates/openasr-core/src/api/native/tests/support/session.rs
@@ -63,7 +63,10 @@ impl TestOnlyNativeStreamingSession {
             return Ok(Vec::new());
         }
         let mut events = self.drain_pending_events();
-        let finalized = self.emitter.finalize_pending_output_at(test_time(89))?;
+        let finalized = match self.emitter.take_pending_partial_update() {
+            Some(update) => self.emitter.apply_final(update, test_time(89))?,
+            None => Vec::new(),
+        };
         if !finalized.is_empty() {
             self.utterance_index += 1;
         }

--- a/crates/openasr-core/src/api/native/tests/support/session/lifecycle.rs
+++ b/crates/openasr-core/src/api/native/tests/support/session/lifecycle.rs
@@ -14,7 +14,9 @@ impl TestOnlyNativeStreamingSession {
 
         match mode {
             CloseMode::Finish | CloseMode::Close => {
-                events.extend(self.emitter.finalize_pending_output_at(test_time(89))?);
+                if let Some(update) = self.emitter.take_pending_partial_update() {
+                    events.extend(self.emitter.apply_final(update, test_time(89))?);
+                }
                 self.push_stop_close_events(mode, &mut events)?;
             }
             CloseMode::Cancel => {

--- a/crates/openasr-core/src/api/native/transcript_emitter.rs
+++ b/crates/openasr-core/src/api/native/transcript_emitter.rs
@@ -154,14 +154,14 @@ impl NativeStreamingTranscriptEmitter {
         self.emit_transcript_lifecycle(result, created_at)
     }
 
-    pub(crate) fn finalize_pending_output_at(
-        &mut self,
-        created_at: impl Into<String>,
-    ) -> Result<Vec<RealtimeEventEnvelope>, NativeAsrError> {
-        let Some(update) = self.pending_partial_update.take() else {
-            return Ok(Vec::new());
-        };
-        self.apply_final(update, created_at)
+    /// Takes the pending tail partial (if any) so the caller can post-process
+    /// its text before promoting it into a FINAL with [`Self::apply_final`].
+    /// Deliberately the only way to promote the pending tail: a session that
+    /// runs a FINAL post-processing stage (e.g. the ggml streaming session's
+    /// punctuation stage) gets no emitter-level shortcut that could promote
+    /// the text as-is behind that stage's back.
+    pub(crate) fn take_pending_partial_update(&mut self) -> Option<TranscriptUpdate> {
+        self.pending_partial_update.take()
     }
 
     pub(crate) fn lifecycle_event(

--- a/crates/openasr-core/src/models/firered_punc/runtime.rs
+++ b/crates/openasr-core/src/models/firered_punc/runtime.rs
@@ -17,8 +17,21 @@ use crate::punctuation::{
 use super::config::{FireRedPuncExecutionMetadata, TOKENIZER_GGML_TOKENS_KEY};
 use super::graph::{FireRedPuncGraph, FireRedPuncGraphError, argmax_labels_per_position};
 use super::runtime_contract::parse_and_validate_firered_punc_metadata;
-use super::tokenizer::FireRedPuncTokenizer;
+use super::tokenizer::{FireRedPuncTokenizer, is_cjk_char};
 use super::weights::load_firered_punc_weights;
+
+/// Whether `text` contains at least one Han ideograph (per the tokenizer's
+/// BERT `is_cjk_char` definition -- single source of truth, do not fork it).
+///
+/// This is the per-segment language gate for [`FireRedPuncRuntime::punctuate`]:
+/// the checkpoint's label space is five full-width Chinese marks and its
+/// training data is Chinese-only, so a segment with no Han ideograph is
+/// outside its training domain. Skipping such segments keeps the stage from
+/// planting Chinese punctuation into e.g. all-English FireRed output --
+/// honest no-op over cross-language mislabeling.
+pub(crate) fn segment_qualifies_for_chinese_punctuation(text: &str) -> bool {
+    text.chars().any(is_cjk_char)
+}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum FireRedPuncRuntimeError {
@@ -66,13 +79,45 @@ impl FireRedPuncRuntime {
     }
 
     /// Restore punctuation on `text` (finalize-only, Chinese full-width marks).
+    ///
+    /// Segments with no Han ideograph are returned verbatim without running
+    /// the classifier: see [`segment_qualifies_for_chinese_punctuation`].
     pub(crate) fn punctuate(&self, text: &str) -> Result<String, PunctuationError> {
+        if !segment_qualifies_for_chinese_punctuation(text) {
+            return Ok(text.to_string());
+        }
         restore_punctuation(
             text,
             &self.tokenizer,
             self,
             PunctuationRestoreConfig::default(),
         )
+    }
+}
+
+/// Exclusive-ownership `Send` wrapper around [`FireRedPuncRuntime`] for
+/// callers that must hold the runtime inside a `Send` value (the streaming
+/// session caches one per session, and `NativeAsrSession: Send`).
+///
+/// SAFETY rationale (same pattern as `xasr_zipformer::runtime`'s
+/// `SendableRuntime`): the runtime owns ggml context/backend handles with no
+/// thread-affine state; it is moved as an exclusive value and only accessed
+/// through `&self` from one thread at a time. The wrapper is `Send`, NOT
+/// `Sync` (the inner `RefCell` already forbids cross-thread sharing), so no
+/// concurrent access to the graph can ever be observed.
+pub(crate) struct SendableFireRedPuncRuntime(FireRedPuncRuntime);
+
+unsafe impl Send for SendableFireRedPuncRuntime {}
+
+impl SendableFireRedPuncRuntime {
+    pub(crate) fn from_pack(path: &Path) -> Result<Self, FireRedPuncRuntimeError> {
+        FireRedPuncRuntime::from_pack(path).map(Self)
+    }
+
+    /// See [`FireRedPuncRuntime::punctuate`] (including its per-segment Han
+    /// gate).
+    pub(crate) fn punctuate(&self, text: &str) -> Result<String, PunctuationError> {
+        self.0.punctuate(text)
     }
 }
 
@@ -107,6 +152,32 @@ impl PunctuationClassifier for FireRedPuncRuntime {
 mod tests {
     use super::*;
 
+    #[test]
+    fn han_gate_rejects_segments_without_han_ideographs() {
+        // Regression guard for the FireRed English-transcript bug: FireRed is
+        // FixedMultilingual (its `Transcription.language` is always `None`),
+        // so an all-English segment reaches the punctuation stage and must be
+        // filtered by content, not by language metadata.
+        assert!(!segment_qualifies_for_chinese_punctuation(
+            "THIS IS A LIBRIVOX RECORDING"
+        ));
+        assert!(!segment_qualifies_for_chinese_punctuation(""));
+        // Half/full-width Latin, digits, and CJK punctuation without any Han
+        // ideograph do not qualify either (is_cjk_char is Han-blocks only).
+        assert!(!segment_qualifies_for_chinese_punctuation(
+            "ｈｅｌｌｏ 123 。"
+        ));
+    }
+
+    #[test]
+    fn han_gate_accepts_chinese_and_mixed_segments() {
+        assert!(segment_qualifies_for_chinese_punctuation("你好世界"));
+        // One Han ideograph is enough: mixed zh/en segments must still be
+        // punctuated (full-width marks throughout is the correct GB/T 15834
+        // treatment of Chinese text with embedded Latin).
+        assert!(segment_qualifies_for_chinese_punctuation("打开 hello 模式"));
+    }
+
     /// Real-weights parity: only runs when `OPENASR_FIRERED_PUNC_REAL_PACK`
     /// points at a converted FireRedPunc `.oasr` pack. Left env-gated (like the
     /// hymt2 / qwen real-pack tests) so the default suite stays weight-free; the
@@ -119,6 +190,13 @@ mod tests {
         let runtime = FireRedPuncRuntime::from_pack(Path::new(&path)).expect("load real pack");
         let out = runtime.punctuate("你好世界").expect("punctuate");
         assert_eq!(out, "你好世界。", "upstream README golden");
+
+        // The Han gate short-circuits before the classifier: an all-English
+        // segment must come back byte-for-byte unchanged even with real
+        // weights loaded.
+        let english = "THIS IS A LIBRIVOX RECORDING";
+        let out = runtime.punctuate(english).expect("punctuate english");
+        assert_eq!(out, english, "no-Han segment passes through verbatim");
     }
 
     /// Converter golden gate: the engine's per-token argmax labels for the

--- a/crates/openasr-core/src/models/firered_punc/tokenizer.rs
+++ b/crates/openasr-core/src/models/firered_punc/tokenizer.rs
@@ -262,7 +262,12 @@ fn is_unicode_punctuation(c: char) -> bool {
 /// BERT `_is_chinese_char`: the CJK Unified Ideograph blocks. Note this is the
 /// upstream definition -- it deliberately excludes CJK punctuation/kana, which
 /// are handled as punctuation/other words.
-fn is_cjk_char(c: char) -> bool {
+///
+/// `pub(crate)`: also the definition `crate::punctuation` uses to gate the
+/// restoration stage per segment (this classifier's vocab and training data
+/// are Chinese-only, so a segment with no Han ideograph is not something it
+/// can honestly punctuate -- see that module's `restore_punctuation`).
+pub(crate) fn is_cjk_char(c: char) -> bool {
     let cp = c as u32;
     (0x4E00..=0x9FFF).contains(&cp)
         || (0x3400..=0x4DBF).contains(&cp)

--- a/crates/openasr-core/src/models/ggml_streaming_session.rs
+++ b/crates/openasr-core/src/models/ggml_streaming_session.rs
@@ -1,14 +1,53 @@
 #![cfg_attr(not(test), allow(dead_code))]
 
 use crate::api::native::NativeStreamingTranscriptEmitter;
+use crate::arch::emits_punctuation_for_model_architecture;
+use crate::models::firered_punc::pack::resolve_firered_punc_pack_path;
+use crate::models::firered_punc::runtime::SendableFireRedPuncRuntime;
 use crate::models::ggml_asr_executor::{
     GgmlAsrExecutionError, GgmlAsrStreamingSessionConfig, GgmlAsrStreamingSessionRequest,
 };
+use crate::punctuation::{PunctuationError, should_apply_punctuation};
 use crate::realtime::events::realtime_timestamp_now;
 use crate::{
     NativeAsrError, NativeAsrRequestOptions, NativeAsrSession, NativeAsrStreamingSessionConfig,
     RealtimeAudioFrame, RealtimeEventEnvelope, RealtimeSessionState, TranscriptUpdate,
 };
+
+/// Punctuates one FINAL segment's text before it is emitted. `Err` means
+/// "leave the segment text unchanged" (fail-closed, mirroring the batch
+/// stage's `punctuate_transcription_segments` contract); partials never go
+/// through this (re-punctuating every partial re-runs a bidirectional encoder
+/// per revision and reintroduces caption flicker).
+pub(crate) type StreamingFinalPunctuator =
+    Box<dyn Fn(&str) -> Result<String, PunctuationError> + Send>;
+
+/// Whether the punctuation stage applies to this model architecture: same
+/// capability fact the batch path reads from the pack's
+/// `general.architecture` (see `model_emits_punctuation` in
+/// `native_transcribe`), sourced here from the already-selected adapter
+/// descriptor so no pack re-read is needed.
+fn streaming_punctuation_stage_applies(model_architecture: &str) -> bool {
+    should_apply_punctuation(emits_punctuation_for_model_architecture(model_architecture))
+}
+
+/// Streaming counterpart of the batch `apply_punctuation_stage_if_applicable`
+/// gate, resolved once at session construction: the stage activates only for
+/// a model family the catalog honestly declares unpunctuated AND when the
+/// FireRedPunc capability pack is installed ("pack installed => stage on",
+/// no protocol field). A missing or unloadable pack deactivates the stage
+/// (fail-closed, never an error); the loaded runtime is cached on the session
+/// so finals do not reload BERT weights.
+fn resolve_streaming_final_punctuator(
+    request: &GgmlAsrStreamingSessionRequest,
+) -> Option<StreamingFinalPunctuator> {
+    if !streaming_punctuation_stage_applies(request.selected_family.model_architecture) {
+        return None;
+    }
+    let pack_path = resolve_firered_punc_pack_path()?;
+    let runtime = SendableFireRedPuncRuntime::from_pack(&pack_path).ok()?;
+    Some(Box::new(move |text| runtime.punctuate(text)))
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum GgmlAsrStreamingTranscriptUpdate {
@@ -139,6 +178,10 @@ where
     emitter: NativeStreamingTranscriptEmitter,
     driver: D,
     clock: Box<dyn FnMut() -> String + Send>,
+    /// FINAL-segment punctuation stage (see [`StreamingFinalPunctuator`]);
+    /// `None` when the stage does not apply to this model family or no
+    /// FireRedPunc pack is installed.
+    final_punctuator: Option<StreamingFinalPunctuator>,
     queued_audio_frames: usize,
     closed: bool,
 }
@@ -164,19 +207,32 @@ where
         request: &GgmlAsrStreamingSessionRequest,
         driver: D,
     ) -> Result<Self, GgmlAsrExecutionError> {
-        Self::new_with_clock(
+        Self::new_with_clock_and_punctuator(
             executor_id,
             request,
             driver,
             Box::new(realtime_timestamp_now),
+            resolve_streaming_final_punctuator(request),
         )
     }
 
+    /// Test constructor: injectable clock, punctuation stage off (no probing
+    /// of the environment for an installed FireRedPunc pack).
     pub(crate) fn new_with_clock(
         executor_id: &'static str,
         request: &GgmlAsrStreamingSessionRequest,
         driver: D,
+        clock: Box<dyn FnMut() -> String + Send>,
+    ) -> Result<Self, GgmlAsrExecutionError> {
+        Self::new_with_clock_and_punctuator(executor_id, request, driver, clock, None)
+    }
+
+    pub(crate) fn new_with_clock_and_punctuator(
+        executor_id: &'static str,
+        request: &GgmlAsrStreamingSessionRequest,
+        driver: D,
         mut clock: Box<dyn FnMut() -> String + Send>,
+        final_punctuator: Option<StreamingFinalPunctuator>,
     ) -> Result<Self, GgmlAsrExecutionError> {
         let adapter_id = request.selected_family.adapter_id;
         let native_options = NativeAsrRequestOptions::new()
@@ -214,6 +270,7 @@ where
             emitter,
             driver,
             clock,
+            final_punctuator,
             queued_audio_frames: 0,
             closed: false,
         })
@@ -232,7 +289,16 @@ where
             GgmlAsrStreamingTranscriptUpdate::Partial(update) => {
                 self.emitter.apply_partial(update, created_at)
             }
-            GgmlAsrStreamingTranscriptUpdate::Final(update) => {
+            GgmlAsrStreamingTranscriptUpdate::Final(mut update) => {
+                // FINAL-only punctuation stage: a segment's text is
+                // punctuated exactly once, at the moment it stops being
+                // revised. Fail-closed per segment -- a classifier error
+                // keeps the driver's original text.
+                if let Some(punctuate) = &self.final_punctuator
+                    && let Ok(punctuated) = punctuate(&update.text)
+                {
+                    update.text = punctuated;
+                }
                 self.emitter.apply_final(update, created_at)
             }
         }
@@ -475,6 +541,7 @@ mod tests {
     use std::{collections::VecDeque, path::PathBuf};
 
     use super::*;
+    use crate::models::ggml_family_registry::firered_aed_runtime_descriptor_v1;
     use crate::{
         GgmlAsrBackendPreference, GgmlAsrExecutionOptions, RealtimeEvent, RealtimeTranscriptEvent,
         qwen3_asr_runtime_descriptor_v1,
@@ -771,5 +838,104 @@ mod tests {
             &["transcript.final", "audio.input.started"],
         );
         assert_transcript_text(&second_finalized[0], "second final", 4);
+    }
+
+    #[test]
+    fn punctuation_stage_applies_only_to_unpunctuated_architectures() {
+        // Same capability fact as the batch gate: firered (catalog
+        // emits_punctuation = false) opts in; qwen (already punctuates) and
+        // unknown architectures stay off.
+        assert!(streaming_punctuation_stage_applies(
+            firered_aed_runtime_descriptor_v1().model_architecture
+        ));
+        assert!(!streaming_punctuation_stage_applies(
+            qwen3_asr_runtime_descriptor_v1().model_architecture
+        ));
+        assert!(!streaming_punctuation_stage_applies("no-such-architecture"));
+    }
+
+    #[test]
+    fn final_updates_are_punctuated_partials_are_not() {
+        // The FINAL-only punctuation stage runs at the single point where a
+        // driver update becomes a transcript event, so every entry path
+        // (push_audio / poll / flush / finalize / finish) is covered; partial
+        // updates must reach the emitter untouched.
+        let request = request(true);
+        let driver = ScriptDriver::new([
+            ScriptStep::Partial {
+                revision: 1,
+                text: "你好世",
+            },
+            ScriptStep::Final {
+                revision: 2,
+                text: "你好世界",
+            },
+        ]);
+        let mut session = GgmlAsrStreamingTranscriptSession::new_with_clock_and_punctuator(
+            "script-streaming-executor",
+            &request,
+            driver,
+            test_clock(),
+            Some(Box::new(|text: &str| Ok(format!("{text}。")))),
+        )
+        .unwrap();
+        let _ = session.poll_events().unwrap();
+
+        let partial = session.push_audio(test_frame(1, 0)).unwrap();
+        assert_event_types(&partial, &["transcript.partial"]);
+        assert_transcript_text(&partial[0], "你好世", 1);
+
+        let final_event = session.push_audio(test_frame(2, 20)).unwrap();
+        assert_event_types(&final_event, &["transcript.final"]);
+        assert_transcript_text(&final_event[0], "你好世界。", 2);
+    }
+
+    #[test]
+    fn final_punctuator_error_keeps_original_text() {
+        // Fail-closed, mirroring the batch stage: a classifier failure leaves
+        // the driver's text exactly as produced instead of dropping the final.
+        let request = request(true);
+        let driver = ScriptDriver::new([ScriptStep::Final {
+            revision: 1,
+            text: "你好世界",
+        }]);
+        let mut session = GgmlAsrStreamingTranscriptSession::new_with_clock_and_punctuator(
+            "script-streaming-executor",
+            &request,
+            driver,
+            test_clock(),
+            Some(Box::new(|_: &str| {
+                Err(PunctuationError::Classifier("forward failed".to_string()))
+            })),
+        )
+        .unwrap();
+        let _ = session.poll_events().unwrap();
+
+        let final_event = session.push_audio(test_frame(1, 0)).unwrap();
+        assert_event_types(&final_event, &["transcript.final"]);
+        assert_transcript_text(&final_event[0], "你好世界", 1);
+    }
+
+    #[test]
+    fn sessions_without_punctuator_leave_finals_untouched() {
+        // `new_with_clock` (and any family the stage does not apply to)
+        // carries no punctuator: finals pass through byte-for-byte.
+        let request = request(true);
+        let driver = ScriptDriver::new([ScriptStep::Final {
+            revision: 1,
+            text: "hello world",
+        }]);
+        let mut session = GgmlAsrStreamingTranscriptSession::new_with_clock(
+            "script-streaming-executor",
+            &request,
+            driver,
+            test_clock(),
+        )
+        .unwrap();
+        let _ = session.poll_events().unwrap();
+
+        let final_event = session.push_audio(test_frame(1, 0)).unwrap();
+        assert_event_types(&final_event, &["transcript.final"]);
+        assert_transcript_text(&final_event[0], "hello world", 1);
     }
 }

--- a/crates/openasr-core/src/models/ggml_streaming_session.rs
+++ b/crates/openasr-core/src/models/ggml_streaming_session.rs
@@ -280,6 +280,40 @@ where
         (self.clock)()
     }
 
+    /// FINAL-only punctuation stage: a segment's text is punctuated exactly
+    /// once, at the moment it stops being revised. Fail-closed per segment --
+    /// a classifier error keeps the driver's original text.
+    ///
+    /// INVARIANT: every update that can surface as a visible FINAL passes
+    /// through here first. There are exactly two producers of finals in this
+    /// session -- driver-emitted finals ([`Self::emit_update`]'s `Final`
+    /// branch) and the session-promoted pending tail partial
+    /// ([`Self::finalize_pending_output`]) -- and both call this before
+    /// `apply_final`. Never call `emitter.apply_final` or
+    /// `emitter.finalize_pending_output_at` from anywhere else in this
+    /// session, or a final can bypass the stage.
+    fn punctuate_final_update(&self, update: &mut TranscriptUpdate) {
+        if let Some(punctuate) = &self.final_punctuator
+            && let Ok(punctuated) = punctuate(&update.text)
+        {
+            update.text = punctuated;
+        }
+    }
+
+    /// Promotes the emitter's pending tail partial (if any) into a FINAL,
+    /// running the punctuation stage on it exactly like a driver-emitted
+    /// final. A driver that only ever emits partials (relying on the session
+    /// to finalize the tail on flush/finalize/finish) therefore cannot leak
+    /// an unpunctuated final.
+    fn finalize_pending_output(&mut self) -> Result<Vec<RealtimeEventEnvelope>, NativeAsrError> {
+        let finalized_at = self.now();
+        let Some(mut update) = self.emitter.take_pending_partial_update() else {
+            return Ok(Vec::new());
+        };
+        self.punctuate_final_update(&mut update);
+        self.emitter.apply_final(update, finalized_at)
+    }
+
     fn emit_update(
         &mut self,
         update: GgmlAsrStreamingTranscriptUpdate,
@@ -290,15 +324,7 @@ where
                 self.emitter.apply_partial(update, created_at)
             }
             GgmlAsrStreamingTranscriptUpdate::Final(mut update) => {
-                // FINAL-only punctuation stage: a segment's text is
-                // punctuated exactly once, at the moment it stops being
-                // revised. Fail-closed per segment -- a classifier error
-                // keeps the driver's original text.
-                if let Some(punctuate) = &self.final_punctuator
-                    && let Ok(punctuated) = punctuate(&update.text)
-                {
-                    update.text = punctuated;
-                }
+                self.punctuate_final_update(&mut update);
                 self.emitter.apply_final(update, created_at)
             }
         }
@@ -347,8 +373,7 @@ where
             .flush_updates()
             .map_err(|error| self.driver_error_to_native(error))?;
         let mut events = self.emit_updates(updates)?;
-        let finalized_at = self.now();
-        let finalized = self.emitter.finalize_pending_output_at(finalized_at)?;
+        let finalized = self.finalize_pending_output()?;
         self.emitter
             .ensure_output_capacity(events.len() + finalized.len())?;
         events.extend(finalized);
@@ -414,8 +439,7 @@ where
             .finish_updates()
             .map_err(|error| self.driver_error_to_native(error))?;
         let mut events = self.emit_updates(updates)?;
-        let finalized_at = self.now();
-        let finalized = self.emitter.finalize_pending_output_at(finalized_at)?;
+        let finalized = self.finalize_pending_output()?;
         self.emitter
             .ensure_output_capacity(events.len() + finalized.len())?;
         events.extend(finalized);
@@ -454,8 +478,7 @@ where
             return self.emit_updates(Vec::new());
         }
         let mut events = self.emit_updates(updates)?;
-        let finalized_at = self.now();
-        let finalized = self.emitter.finalize_pending_output_at(finalized_at)?;
+        let finalized = self.finalize_pending_output()?;
         self.emitter
             .ensure_output_capacity(events.len() + finalized.len())?;
         events.extend(finalized);
@@ -476,8 +499,7 @@ where
             .finish_updates()
             .map_err(|error| self.driver_error_to_native(error))?;
         let mut events = self.emit_updates(updates)?;
-        let finalized_at = self.now();
-        let finalized = self.emitter.finalize_pending_output_at(finalized_at)?;
+        let finalized = self.finalize_pending_output()?;
         self.emitter
             .ensure_output_capacity(events.len() + finalized.len())?;
         events.extend(finalized);
@@ -914,6 +936,65 @@ mod tests {
         let final_event = session.push_audio(test_frame(1, 0)).unwrap();
         assert_event_types(&final_event, &["transcript.final"]);
         assert_transcript_text(&final_event[0], "你好世界", 1);
+    }
+
+    #[test]
+    fn promoted_pending_partial_is_punctuated_on_flush() {
+        // A driver that only ever emits partials relies on the session to
+        // promote the pending tail into a FINAL on flush/finalize/finish
+        // (`finalize_pending_output`); that promotion path never goes through
+        // `emit_update`'s Final branch, so it must run the punctuation stage
+        // itself -- this is the seam the ScriptStep::Final-based tests above
+        // do not cover.
+        let request = request(false);
+        let driver = ScriptDriver::new([ScriptStep::Partial {
+            revision: 1,
+            text: "你好世界",
+        }]);
+        let mut session = GgmlAsrStreamingTranscriptSession::new_with_clock_and_punctuator(
+            "script-streaming-executor",
+            &request,
+            driver,
+            test_clock(),
+            Some(Box::new(|text: &str| Ok(format!("{text}。")))),
+        )
+        .unwrap();
+        let _ = session.poll_events().unwrap();
+
+        assert!(session.push_audio(test_frame(1, 0)).unwrap().is_empty());
+        let flushed = session.flush().unwrap();
+
+        assert_event_types(&flushed, &["transcript.final"]);
+        assert_transcript_text(&flushed[0], "你好世界。", 1);
+    }
+
+    #[test]
+    fn promoted_pending_partial_is_punctuated_on_finalize_utterance() {
+        // Same promotion seam via finalize_utterance with visible partials:
+        // the emitted partial must stay untouched, and the tail promoted at
+        // the utterance boundary must be punctuated.
+        let request = request(true);
+        let driver = ScriptDriver::new([ScriptStep::Partial {
+            revision: 1,
+            text: "你好世界",
+        }]);
+        let mut session = GgmlAsrStreamingTranscriptSession::new_with_clock_and_punctuator(
+            "script-streaming-executor",
+            &request,
+            driver,
+            test_clock(),
+            Some(Box::new(|text: &str| Ok(format!("{text}。")))),
+        )
+        .unwrap();
+        let _ = session.poll_events().unwrap();
+
+        let partial = session.push_audio(test_frame(1, 0)).unwrap();
+        assert_event_types(&partial, &["transcript.partial"]);
+        assert_transcript_text(&partial[0], "你好世界", 1);
+
+        let finalized = session.finalize_utterance().unwrap();
+        assert_event_types(&finalized, &["transcript.final", "audio.input.started"]);
+        assert_transcript_text(&finalized[0], "你好世界。", 1);
     }
 
     #[test]

--- a/crates/openasr-core/src/punctuation/mod.rs
+++ b/crates/openasr-core/src/punctuation/mod.rs
@@ -12,6 +12,29 @@
 //!   (`Some(false)` -> run; `Some(true)`/`None` -> leave the text untouched, so
 //!   punctuating families like whisper/qwen are never double-punctuated). See
 //!   [`should_apply_punctuation`].
+//! - **Chinese-only by construction, gated at the runtime entry.** FireRedPunc's
+//!   label space is five full-width Chinese marks and its training data is
+//!   Chinese-only, but `emits_punctuation` is a model-family-wide capability
+//!   flag -- it cannot see that a *given segment* has no Chinese in it (e.g. a
+//!   `LanguageFamilyHint::FixedMultilingual` family like FireRed, whose
+//!   `Transcription.language` is always `None`, can still emit an all-English
+//!   segment). That per-segment check lives in
+//!   `FireRedPuncRuntime::punctuate` (the single entry both the batch stage
+//!   and the streaming session call): a segment with zero Han ideographs (per
+//!   [`crate::models::firered_punc::tokenizer::is_cjk_char`], the same
+//!   definition the tokenizer was built against) is returned verbatim. The
+//!   [`restore_punctuation`] mechanism below stays deliberately
+//!   language-agnostic -- policy belongs to the caller, not the walk.
+//!
+//!   Known boundaries of that gate (accepted, documented, not bugs):
+//!   - A mixed zh/en segment that *does* contain Han ideographs is punctuated
+//!     with full-width marks throughout, which is the correct GB/T 15834
+//!     treatment of Chinese text with embedded Latin; no half-width mapping is
+//!     attempted on the Latin spans.
+//!   - For multilingual families like dolphin, a Japanese segment containing
+//!     kanji passes the Han gate and gets Chinese punctuation (pre-existing
+//!     limitation). Honest en/mixed punctuation needs an upstream zh+en punc
+//!     checkpoint (long-term item), not more gating here.
 //! - **Finalize-only.** It is meant to run once on a finalized segment, not per
 //!   streaming partial -- re-punctuating every partial with a bidirectional
 //!   encoder is expensive and reintroduces caption flicker.


### PR DESCRIPTION
## Summary

Fixes two defects in the FireRedPunc punctuation stage observed on FireRed English transcripts: (1) all-English segments received Chinese full-width punctuation ("THIS IS A LIBRIVOX RECORDING。"), and (2) the stage never ran on the true streaming path (dictation / live captions), so streamed output stayed unpunctuated while batch output was punctuated.

## Why

- FireRed is a `FixedMultilingual` family: `Transcription.language` is always `None`, and the stage gated only on the family-wide `emits_punctuation` capability, so an all-English segment reached the classifier. FireRedPunc's label space is five full-width Chinese marks and its training data is Chinese-only; it cannot honestly punctuate text outside that domain.
- Streaming transcripts flow through the ggml streaming session, which never passes `run_native_transcription`, so the batch-only punctuation stage was simply not wired there.

## Changes

- `models/firered_punc/tokenizer.rs`: `is_cjk_char` (BERT `_is_chinese_char`) is now `pub(crate)` -- single source of truth for the Han judgment.
- `models/firered_punc/runtime.rs`: `FireRedPuncRuntime::punctuate` (the single entry shared by batch and streaming) returns a segment verbatim when it contains no Han ideograph, via the new testable `segment_qualifies_for_chinese_punctuation`. Adds `SendableFireRedPuncRuntime`, an exclusive-ownership `Send` wrapper following the existing `xasr_zipformer` `SendableRuntime` pattern.
- `models/ggml_streaming_session.rs`: resolves the same gate as the batch stage at session construction (family `emits_punctuation == Some(false)` + installed FireRedPunc pack; no protocol field), caches the loaded runtime, and punctuates FINAL updates only -- partials are never touched. Fail-closed like batch: a classifier error keeps the driver's text. All four pending-tail promotion sites (flush/finalize/split/finish) funnel through one `finalize_pending_output` helper so a partials-only driver cannot surface an unpunctuated final.
- `api/native/transcript_emitter.rs`: the promote-as-is `finalize_pending_output_at` is replaced by `take_pending_partial_update`, so promotion structurally cannot bypass a session's FINAL post-processing.
- `punctuation/mod.rs`: module docs -- the restoration walk stays language-agnostic (policy at the runtime entry), plus documented boundaries: mixed zh/en segments with Han keep full-width marks throughout (GB/T 15834), and kanji-bearing Japanese segments from multilingual families still pass the Han gate (pre-existing limitation; honest en punctuation needs an upstream zh+en checkpoint).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2256 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

New tests: Han-gate unit tests (reject no-Han incl. full-width Latin/CJK punctuation; accept pure zh and mixed), env-gated real-pack English passthrough assertion, and streaming-session tests for capability gating, final-only punctuation, fail-closed classifier errors, no-punctuator passthrough, and the promoted-pending-partial seam via flush and finalize_utterance.

## Manual smoke checks

Env-gated real-weights test run locally against the installed `firered-punc-fp16.oasr`: Chinese README golden still punctuated ("你好世界。"), English passthrough byte-identical.

## Docs updated

- [x] Module docs updated (`punctuation/mod.rs` known boundaries); no user-facing docs overclaim.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No half-width punctuation mapping for Latin spans inside Han segments (GB/T 15834-correct as-is).
- No en/mixed punctuation support (needs an upstream zh+en punc checkpoint; long-term item).
- No protocol/request field for streaming punctuation ("pack installed => stage on", matching batch semantics).
- End-to-end streaming verification with real FireRed ASR + punc packs is left to the next packaging round.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with Claude Code under maintainer direction and review; design, review gates, and merge decision are the maintainer's.
