### PR TITLE
ci(release): attest build provenance for release assets

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -54,6 +54,16 @@ jobs:
     # run (their archives simply drop out of the artifact set) until they
     # prove green. Every current leg has, so none carry the flag today.
     continue-on-error: ${{ matrix.experimental || false }}
+    # id-token/attestations for the build-provenance attestation step below
+    # (every leg, including experimental ones, since they still ship a
+    # release asset); this job only reads the repo and uploads a workflow
+    # artifact, so contents stays read-only (narrower than the
+    # workflow-level default, and within whatever release-core.yml's
+    # `binaries` job granted when this runs via workflow_call).
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     # Distributed binaries must be portable. build.rs auto-enables GGML_NATIVE
     # (-march=native) when host==target on x86, which is correct for local
     # build-and-run but would tune these released x86 binaries to the CI
@@ -729,6 +739,16 @@ jobs:
           }
           Compress-Archive -Path "$distDir" -DestinationPath "dist\$archive.${{ matrix.archive_ext }}" -Force
 
+      # Covers every leg that reaches this point, including `experimental:
+      # true` ones (windows-arm64, musl) -- they still ship a release asset,
+      # so they still get provenance. Only the packaged archive is attested,
+      # not the SHA256SUMS text file assembled later in `checksums`.
+      - name: Attest build provenance
+        if: env.LEG_SELECTED == 'true'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/openasr-${{ env.OPENASR_VERSION }}-${{ matrix.asset }}.${{ matrix.archive_ext }}
+
       - name: Upload archive
         if: env.LEG_SELECTED == 'true'
         uses: actions/upload-artifact@v7
@@ -749,6 +769,13 @@ jobs:
     # ad-hoc dev-time builds off any branch; see the comment there.
     runs-on: macos-latest
     timeout-minutes: 60
+    # id-token/attestations for the build-provenance attestation step below;
+    # this job only reads the repo and uploads a workflow artifact, so
+    # contents stays read-only.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -795,6 +822,12 @@ jobs:
           (cd target/xcframework && zip -r -X -q "${GITHUB_WORKSPACE}/dist/${archive}.zip" OpenASR.xcframework)
           (cd dist && shasum -a 256 "${archive}.zip" > "${archive}.zip.sha256")
           cat "dist/${archive}.zip.sha256"
+
+      # Only the zip is attested, not its .sha256 sidecar text file.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/openasr-${{ env.OPENASR_VERSION }}-xcframework.zip
 
       - name: Upload xcframework archive
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -115,6 +115,13 @@ jobs:
     if: needs.resolve.outputs.should_release == 'true' && success()
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    # id-token/attestations for the build-provenance attestation step below;
+    # this job only reads the repo and uploads a workflow artifact, so
+    # contents stays read-only (narrower than the workflow-level default).
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     # Distributed binaries must be portable across end-user CPUs. build.rs
     # auto-enables GGML_NATIVE (-march=native) when host==target on x86, which
     # would tune the released Linux binary to the CI runner and SIGILL elsewhere.
@@ -165,6 +172,10 @@ jobs:
           cp target/release/openasr "${stage}/"
           cp README.md LICENSE "${stage}/"
           tar -czf "dist/openasr-${version}-${asset}.tar.gz" -C dist "openasr-${version}-${asset}"
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/openasr-${{ needs.resolve.outputs.version }}-${{ matrix.asset }}.tar.gz
       - name: Upload archive
         uses: actions/upload-artifact@v7
         with:
@@ -244,8 +255,14 @@ jobs:
     name: Build full release matrix
     needs: [resolve, release]
     if: needs.resolve.outputs.should_release == 'true' && success()
+    # Grants the ceiling for every job in the called workflow -- reusable
+    # workflows cannot elevate beyond what the caller job grants here. The
+    # called workflow's own build/xcframework jobs need id-token/attestations
+    # to attest each packaged archive's build provenance.
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release-binaries.yml
     with:
       ref: ${{ needs.resolve.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ During development run without installing via
 `cargo run -p openasr-cli -- <args>`; `--backend mock` gives deterministic,
 network-free output for CI.
 
+### Verifying downloads
+
+Prebuilt binaries on the [Releases page](https://github.com/QuintinShaw/openasr/releases)
+carry a [GitHub Actions build provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds),
+proving each archive was built by this repository's own CI from the tagged
+source, not hand-assembled or tampered with in transit. Verify a downloaded
+archive with the [GitHub CLI](https://cli.github.com/):
+
+```bash
+gh attestation verify <downloaded-archive> --repo QuintinShaw/openasr
+```
+
 ## Execution posture
 
 - **`native` is the default backend.** It runs local ggml-backed `.oasr` model


### PR DESCRIPTION
## Summary

Add `actions/attest-build-provenance@v4` to every job that packages a release
binary archive, so each shipped `.tar.gz`/`.zip` carries a verifiable SLSA
build provenance attestation (`gh attestation verify`) tying it back to the
CI run and source tag that built it.

## Why

Release assets currently ship with a `SHA256SUMS` integrity check but no way
to prove *who* built them. GitHub build provenance attestations let a
downloader cryptographically verify an asset came from this repository's own
Actions run for a given tag, not a tampered-with or third-party rebuild.

## Changes

- `.github/workflows/release-core.yml`:
  - `build` job (fast-path macOS arm64 + Linux x86_64 archives): added a
    job-level `permissions` block (`contents: read`, `id-token: write`,
    `attestations: write`) and an `Attest build provenance` step right after
    the archive is packaged, before it is uploaded as a workflow artifact.
  - `binaries` job (calls `release-binaries.yml` via `workflow_call`): added
    `id-token: write` and `attestations: write` to its existing
    `contents: write` permissions, since a reusable workflow cannot use a
    scope the caller job does not grant.
- `.github/workflows/release-binaries.yml`:
  - `build` job (full release matrix, including GPU variants and
    `experimental: true` legs like windows-arm64/musl): added the same
    job-level permissions block and an attestation step for every leg that
    reaches packaging (still gated by the existing `LEG_SELECTED` filter).
  - `xcframework` job: added the same job-level permissions block and an
    attestation step for the packaged xcframework zip (not its `.sha256`
    sidecar).
  - Only packaged archives (`.tar.gz`/`.zip`) are attested; `SHA256SUMS` and
    `.sha256` sidecar text files are not subjects.
  - No `continue-on-error` added to the attestation steps themselves: a
    failed attestation fails that job the same way a failed build would,
    rather than silently shipping an asset without provenance.
- `README.md`: new "Verifying downloads" subsection documenting
  `gh attestation verify <downloaded-archive> --repo QuintinShaw/openasr`.

## Tests run

- [x] `actionlint` on both changed workflow files -- no new findings (the two
      shellcheck warnings actionlint reports pre-exist on `main` at shifted
      line numbers, confirmed via `git stash` diff).
- [ ] `cargo fmt --check` -- N/A, no Rust source changed.
- [ ] `cargo clippy --all-targets -- -D warnings` -- N/A, no Rust source changed.
- [ ] `cargo nextest run --workspace` -- N/A, no Rust source changed.
- [ ] `cargo test --workspace --doc` -- N/A, no Rust source changed.
- [ ] `cargo deny check` -- N/A, no Rust source changed.

## Manual smoke checks

This change cannot be exercised locally (it only takes effect inside a real
`vX.Y.Z` release run driven by `release-core.yml`/`release-binaries.yml`).
Verification plan for the next tagged release:

```bash
# after the next vX.Y.Z release finishes:
gh release download vX.Y.Z --repo QuintinShaw/openasr -p '<some-asset>'
gh attestation verify <some-asset> --repo QuintinShaw/openasr
```
Expected: attestation verifies successfully, referencing the
`release-core.yml`/`release-binaries.yml` workflow run for that tag.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not backfill attestations for already-published releases (not
  possible after the fact); takes effect starting with the next tag.
- Does not switch to the newer generic `actions/attest` action (upstream
  `attest-build-provenance` v4 is a thin wrapper around it but keeps the
  simpler `subject-path` interface already used here).
- Does not add `artifact-metadata: write` permission -- that scope only
  matters when `push-to-registry: true` (container image attestations),
  which this PR does not use.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — drafted and reviewed the workflow/permissions changes and README docs with AI assistance (Claude Code), verified against GitHub's reusable-workflow permissions model and `actions/attest-build-provenance`'s current major version via `gh api`/docs fetch, and confirmed with `actionlint` + a `git stash` diff against `main` that no new lint findings were introduced.