### PR TITLE
perf(server): stage timing and timestamps in daemon logs

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::Path, sync::OnceLock};
+use std::{collections::BTreeMap, path::Path, sync::OnceLock, time::Instant};
 
 use crate::NATIVE_RUNTIME_MODEL_ID_AUTO;
 use crate::api::audio_io::load_wav_16khz_mono_f32_v0;
@@ -413,10 +413,25 @@ pub(super) fn run_native_transcription(
     let language_hint = request.language.clone();
     let model_pack_path = request.model_pack_path.clone();
     let punctuate = request.punctuate;
+    // Coarse per-request stage timing: "inference" spans model resolution +
+    // audio prep (see the `audio_prep` stage logged inside `_impl` around the
+    // WAV load) + decode/longform-assembly, i.e. the whole
+    // `run_native_transcription_impl` call; "postprocess" covers the
+    // optional punctuation-restoration and forced-align refine stages below.
+    // Grain matches what the task asked for (per-request, not per-frame); the
+    // finer `audio_prep` sub-stage nests inside `inference`'s span rather than
+    // being disjoint from it, which is called out in both log lines' names.
+    let inference_started = Instant::now();
     let transcription = run_native_transcription_impl(request)?;
+    crate::stage_timing::log_stage(
+        "native_transcribe",
+        "inference",
+        inference_started.elapsed(),
+    );
+    let postprocess_started = Instant::now();
     let transcription =
         apply_punctuation_stage_if_applicable(transcription, model_pack_path.as_deref(), punctuate);
-    if refine {
+    let result = if refine {
         publish_align_progress();
         refine_transcription_word_timestamps_with_forced_aligner(
             transcription,
@@ -425,7 +440,13 @@ pub(super) fn run_native_transcription(
         )
     } else {
         Ok(transcription)
-    }
+    };
+    crate::stage_timing::log_stage(
+        "native_transcribe",
+        "postprocess",
+        postprocess_started.elapsed(),
+    );
+    result
 }
 
 /// Whether the punctuation-restoration stage should attempt to run: the
@@ -574,6 +595,7 @@ fn assign_aligned_words_to_segments(segments: &mut [Segment], items: &[ForcedAli
 fn run_native_transcription_impl(
     request: TranscriptionRequest,
 ) -> Result<Transcription, BackendError> {
+    let model_resolve_started = Instant::now();
     let requested_model_id = normalize_and_validate_model_id(&request)?;
     let model_pack_path = request
         .model_pack_path
@@ -651,6 +673,17 @@ fn run_native_transcription_impl(
             });
         }
     }
+    // OPENASR_TIMING=1 detail: model-pack path validation + gguf metadata/
+    // tensor-index preflight + family/adapter selection, i.e. everything
+    // above this point in the request path. Nested inside the coarse
+    // `inference` stage the caller (`run_native_transcription`) already logs
+    // unconditionally.
+    crate::stage_timing::log_detail_stage(
+        "native_transcribe",
+        "model_resolve",
+        model_resolve_started.elapsed(),
+    );
+    let audio_prep_started = Instant::now();
     let prepared_audio = load_wav_16khz_mono_f32_v0(
         &request.input_path,
         "Native ASR Core backend",
@@ -659,6 +692,11 @@ fn run_native_transcription_impl(
     .map_err(|error| BackendError::NativeUnsupportedInputFormat {
         reason: error.to_string(),
     })?;
+    crate::stage_timing::log_stage(
+        "native_transcribe",
+        "audio_prep",
+        audio_prep_started.elapsed(),
+    );
 
     // Compute speaker turns up front (independent of the transcript) so they can
     // be attributed onto whichever transcription path runs below.
@@ -824,6 +862,7 @@ fn run_native_transcription_impl(
             // registered) leaves the decode byte-identical to before.
             let transcription_control =
                 super::transcription_control::current_transcription_control();
+            let mut slice_index = 0usize;
             for slice in plan.slices {
                 if let Some(control) = &transcription_control
                     && control.wait_at_slice_boundary()
@@ -872,6 +911,8 @@ fn run_native_transcription_impl(
                         }
                     }
                 }
+                slice_index += 1;
+                let slice_decode_started = Instant::now();
                 let result = run_dispatch_once(
                     dispatch,
                     &runtime_preflight,
@@ -880,6 +921,18 @@ fn run_native_transcription_impl(
                     slice_options,
                     backend_preference,
                 )?;
+                // OPENASR_TIMING=1 detail: per-longform-slice decode time.
+                // Coarse by default (only the whole-request `inference` stage
+                // is logged unconditionally) since a long recording can chunk
+                // into many slices -- one line per slice would be noisy for
+                // the always-on tier.
+                crate::stage_timing::log_detail_event(
+                    "native_transcribe",
+                    format_args!(
+                        "stage=longform_slice_decode index={slice_index} samples={slice_samples} duration_ms={:.3}",
+                        slice_decode_started.elapsed().as_secs_f64() * 1000.0
+                    ),
+                );
                 // Destructure instead of `result.clone().into_transcription()`:
                 // both fields are consumed below and nothing needs `result`
                 // as a whole afterwards, so there is nothing left to clone.

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod realtime;
 pub(crate) mod registry;
 pub(crate) mod remote_compute;
 pub(crate) mod safety;
+pub mod stage_timing;
 mod tensor;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;

--- a/crates/openasr-core/src/models/prepared_runtime_cache.rs
+++ b/crates/openasr-core/src/models/prepared_runtime_cache.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use crate::stage_timing;
 
 fn prepared_runtime_cache_key(runtime_path: &Path) -> PathBuf {
     std::fs::canonicalize(runtime_path).unwrap_or_else(|_| runtime_path.to_path_buf())
@@ -34,7 +37,23 @@ impl<T> PreparedRuntimeCache<T> {
         if let Some(runtime) = self.get_by_key(&cache_key, &map_poisoned_lock)? {
             return Ok(runtime);
         }
+        // Model pack loading (mmap + tensor materialization + context/graph
+        // construction, up to inference-ready) happens exactly here, exactly
+        // once per distinct runtime path per process (subsequent calls hit the
+        // cache check above). This one call site covers every builtin model
+        // family that goes through this cache, so it is the single place to
+        // time "how long did loading this pack take" without instrumenting
+        // each family's build function separately.
+        let load_started = Instant::now();
         let prepared = Arc::new(build()?);
+        stage_timing::log_event(
+            "model_pack_load",
+            format_args!(
+                "path={} duration_ms={:.3}",
+                runtime_path.display(),
+                load_started.elapsed().as_secs_f64() * 1000.0
+            ),
+        );
         let mut cache = self.cache_by_path.lock().map_err(|_| map_poisoned_lock())?;
         let entry = cache
             .entry(cache_key)

--- a/crates/openasr-core/src/stage_timing.rs
+++ b/crates/openasr-core/src/stage_timing.rs
@@ -1,0 +1,223 @@
+//! Local-only, dependency-free timestamp and coarse stage-timing helpers for
+//! daemon/server/CLI logs.
+//!
+//! `daemon.log` (stdout+stderr of `openasr serve`, captured by the desktop
+//! sidecar -- see `openasr-app/apps/desktop/src-tauri/src/sidecar.rs`) had no
+//! timestamps at all: server boot, model-pack loading, and realtime warm-up
+//! were each a plain `println!`/`eprintln!` with no timing, so diagnosing how
+//! long any of it took meant guessing from wall-clock reads of unrelated
+//! surrounding events. This module is the single place that formats a dual
+//! timestamp for every new stage-boundary log line added alongside it:
+//!
+//! - a wall-clock ISO 8601 UTC instant, for correlating against other
+//!   timestamped logs (crash reporters, desktop-side logs, support bundles);
+//! - a monotonic "ms since this process's first stage-timing call" counter,
+//!   immune to wall-clock adjustments (NTP step, DST, manual clock changes)
+//!   corrupting an elapsed-time calculation.
+//!
+//! Deliberately dependency-free: no `chrono`/`time` crate pulled in for one
+//! narrow purpose, matching this workspace's existing posture (see the
+//! `symphonia`/`rubato` feature-trimming comments in the workspace
+//! `Cargo.toml`). Every function here only ever writes to local stderr --
+//! never a network call -- matching the no-telemetry product promise; see
+//! `AGENTS.md` and `docs/agents/domain.md`.
+//!
+//! This is intentionally additive: existing log lines this workspace's tests
+//! match on exact text (e.g. the `"OpenASR server listening on http://"`
+//! banner `crates/openasr-cli/tests/cli.rs` waits for) are left byte-for-byte
+//! unchanged. Stage timing is emitted as new, separate lines instead of
+//! rewriting anything a consumer might already parse.
+
+use std::sync::OnceLock;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+static PROCESS_START: OnceLock<Instant> = OnceLock::new();
+
+/// Pins the monotonic zero point for this process on first call (idempotent
+/// afterwards). Call this as early as possible in `main` (before any other
+/// stage timing) so "ms since start" reads as true process uptime rather than
+/// "time since the first log line happened to fire"; every other function in
+/// this module also calls it lazily, so correctness never depends on the
+/// caller remembering to do this -- only the precision of the very first
+/// delta does.
+pub fn process_start() -> Instant {
+    *PROCESS_START.get_or_init(Instant::now)
+}
+
+fn monotonic_ms_since_start() -> u128 {
+    process_start().elapsed().as_millis()
+}
+
+/// Wall-clock UTC timestamp, `YYYY-MM-DDTHH:MM:SS.mmmZ` (ISO 8601, millisecond
+/// precision).
+pub fn now_iso8601() -> String {
+    let since_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO);
+    format_iso8601(since_epoch)
+}
+
+fn format_iso8601(since_epoch: Duration) -> String {
+    let total_seconds = since_epoch.as_secs();
+    let millis = since_epoch.subsec_millis();
+    let days = (total_seconds / 86_400) as i64;
+    let secs_of_day = total_seconds % 86_400;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day / 60) % 60;
+    let second = secs_of_day % 60;
+    let (year, month, day) = civil_from_days(days);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
+}
+
+/// Days-since-Unix-epoch -> proleptic Gregorian (year, month, day). Howard
+/// Hinnant's well-known dependency-free `civil_from_days` algorithm:
+/// <http://howardhinnant.github.io/date_algorithms.html#civil_from_days>.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let day = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    let year = if month <= 2 { y + 1 } else { y };
+    (year, month, day)
+}
+
+/// The `[<iso8601> +<mono_ms>ms]` prefix shared by every timestamped line this
+/// module writes.
+pub fn prefix() -> String {
+    format!("[{} +{}ms]", now_iso8601(), monotonic_ms_since_start())
+}
+
+/// Logs one timestamped line to stderr: `<prefix> <component>: <message>`.
+/// Always on -- not gated by an env var -- this is baseline daemon-log
+/// observability, not opt-in profiling (contrast with the existing
+/// `OPENASR_<FAMILY>_PROFILE`-gated fine-grained hooks such as
+/// `diarize::embed::wespeaker`'s `OPENASR_WESPEAKER_PROFILE`). Cheap: one
+/// `SystemTime`/`Instant` read plus one `eprintln!`; callers must still only
+/// call this at coarse boundaries (stage/request granularity), never inside a
+/// per-frame or per-token hot loop.
+pub fn log_event(component: &str, message: impl std::fmt::Display) {
+    eprintln!("{} {component}: {message}", prefix());
+}
+
+/// Convenience over [`log_event`] for the common "named stage finished, here
+/// is how long it took" line: `<prefix> <component>: stage=<stage>
+/// duration_ms=<elapsed>`.
+pub fn log_stage(component: &str, stage: &str, elapsed: Duration) {
+    log_event(
+        component,
+        format_args!(
+            "stage={stage} duration_ms={:.3}",
+            elapsed.as_secs_f64() * 1000.0
+        ),
+    );
+}
+
+/// Whether `OPENASR_TIMING` opts into the finer-grained detail tier (e.g.
+/// per-longform-slice decode timing, model-resolution sub-stage timing) on
+/// top of the coarse, always-on lines `log_event`/`log_stage` produce. Reread
+/// on every call (like the existing `OPENASR_<FAMILY>_PROFILE` gates) rather
+/// than cached, since this is checked at most once per request/stage, never
+/// in a per-frame loop.
+pub fn detail_enabled() -> bool {
+    std::env::var("OPENASR_TIMING")
+        .map(|value| {
+            let value = value.trim();
+            !value.is_empty() && value != "0" && !value.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
+/// [`log_event`], but only when [`detail_enabled`] -- for finer breakdowns
+/// that would otherwise be too noisy to leave on by default (e.g. one line
+/// per longform slice on a long recording).
+pub fn log_detail_event(component: &str, message: impl std::fmt::Display) {
+    if detail_enabled() {
+        log_event(component, message);
+    }
+}
+
+/// [`log_stage`], but only when [`detail_enabled`].
+pub fn log_detail_stage(component: &str, stage: &str, elapsed: Duration) {
+    if detail_enabled() {
+        log_stage(component, stage, elapsed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn civil_from_days_matches_known_dates() {
+        // Unix epoch itself.
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        // A well-known leap day.
+        assert_eq!(civil_from_days(19_051), (2022, 2, 28));
+        assert_eq!(civil_from_days(19_052), (2022, 3, 1));
+        // 2026-07-10 is 20_644 days after the epoch.
+        assert_eq!(civil_from_days(20_644), (2026, 7, 10));
+        // A leap-year Feb 29 (2024).
+        assert_eq!(civil_from_days(19_782), (2024, 2, 29));
+    }
+
+    #[test]
+    fn format_iso8601_renders_expected_shape() {
+        let rendered = format_iso8601(Duration::from_millis(20_644 * 86_400_000 + 12_345_678));
+        assert_eq!(rendered, "2026-07-10T03:25:45.678Z");
+    }
+
+    #[test]
+    fn now_iso8601_has_the_expected_length_and_terminators() {
+        let rendered = now_iso8601();
+        assert_eq!(rendered.len(), "2026-07-10T12:34:56.789Z".len());
+        assert!(rendered.ends_with('Z'));
+        assert!(rendered.contains('T'));
+    }
+
+    #[test]
+    fn prefix_contains_brackets_and_a_monotonic_millisecond_marker() {
+        let rendered = prefix();
+        assert!(rendered.starts_with('['));
+        assert!(rendered.contains("ms]"));
+    }
+
+    #[test]
+    fn monotonic_ms_since_start_is_nondecreasing() {
+        let first = monotonic_ms_since_start();
+        std::thread::sleep(Duration::from_millis(5));
+        let second = monotonic_ms_since_start();
+        assert!(second >= first);
+    }
+
+    #[test]
+    fn log_event_and_log_stage_do_not_panic() {
+        // These write to stderr; the only contract under test is that they
+        // never panic on ordinary inputs (this is a hot-adjacent path called
+        // from server boot, model-pack load, and the request path).
+        log_event("test_component", "message with duration_ms=1.5");
+        log_stage("test_component", "example_stage", Duration::from_millis(42));
+    }
+
+    #[test]
+    fn detail_enabled_defaults_to_false_when_unset() {
+        // Best-effort rather than setting/unsetting the env var here: mutating
+        // process env from a test races other tests in the same process
+        // (`std::env::set_var` is not safe to call concurrently across
+        // threads), and no other test in this workspace touches
+        // `OPENASR_TIMING`, so an ordinary local/CI run has it unset.
+        if std::env::var("OPENASR_TIMING").is_err() {
+            assert!(!detail_enabled());
+        }
+    }
+
+    #[test]
+    fn log_detail_event_and_log_detail_stage_do_not_panic() {
+        log_detail_event("test_component", "detail message");
+        log_detail_stage("test_component", "detail_stage", Duration::from_millis(1));
+    }
+}

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -214,29 +214,88 @@ pub async fn serve_with_launch_options(
     runtime: ServerRuntime,
     launch_options: ServerLaunchOptions,
 ) -> anyhow::Result<()> {
+    // Boot stage timing: each phase logged as its own timestamped line so a
+    // slow daemon start (validate/bind/router-build/model-bind) can be
+    // attributed to a specific phase from `daemon.log` alone, instead of
+    // guessing from wall-clock reads of surrounding, untimed events. Additive
+    // only -- the existing "OpenASR server listening on ..." banners below are
+    // left byte-for-byte unchanged, since `crates/openasr-cli/tests/cli.rs`
+    // waits on that exact prefix and the desktop sidecar's readiness probe
+    // must keep working unmodified.
+    let boot_started = Instant::now();
+    let mut stage_started = boot_started;
     validate_listen_security(addr, &launch_options)?;
+    openasr_core::stage_timing::log_stage(
+        "server_boot",
+        "validate_listen_security",
+        stage_started.elapsed(),
+    );
+    stage_started = Instant::now();
     runtime.validate()?;
+    openasr_core::stage_timing::log_stage(
+        "server_boot",
+        "runtime_validate",
+        stage_started.elapsed(),
+    );
+    stage_started = Instant::now();
     let listener = TcpListener::bind(addr).await?;
+    openasr_core::stage_timing::log_stage(
+        "server_boot",
+        "tcp_listener_bind",
+        stage_started.elapsed(),
+    );
     match &launch_options.tls.clone() {
         ServerTlsConfig::Disabled => {
+            stage_started = Instant::now();
             let app = app_with_runtime_and_distribution_and_launch_options(
                 runtime,
                 DistributionRuntime::default(),
                 launch_options,
             );
+            openasr_core::stage_timing::log_stage(
+                "server_boot",
+                "router_build",
+                stage_started.elapsed(),
+            );
+            openasr_core::stage_timing::log_event(
+                "server_boot",
+                format_args!(
+                    "stage=ready total_ms={:.3} addr=http://{addr}",
+                    boot_started.elapsed().as_secs_f64() * 1000.0
+                ),
+            );
             println!("OpenASR server listening on http://{addr}");
             axum::serve(listener, app).await?;
         }
         ServerTlsConfig::SelfSigned { subject_alt_names } => {
+            stage_started = Instant::now();
             let identity = self_signed_tls_identity(subject_alt_names)?;
+            openasr_core::stage_timing::log_stage(
+                "server_boot",
+                "tls_self_signed_identity",
+                stage_started.elapsed(),
+            );
             let mut launch_options = launch_options;
             launch_options.auth = launch_options.auth.with_pairing_safety_code(Some(
                 pairing_safety_code_for_certificate_fingerprint(&identity.certificate_sha256),
             ));
+            stage_started = Instant::now();
             let app = app_with_runtime_and_distribution_and_launch_options(
                 runtime,
                 DistributionRuntime::default(),
                 launch_options,
+            );
+            openasr_core::stage_timing::log_stage(
+                "server_boot",
+                "router_build",
+                stage_started.elapsed(),
+            );
+            openasr_core::stage_timing::log_event(
+                "server_boot",
+                format_args!(
+                    "stage=ready total_ms={:.3} addr=https://{addr}",
+                    boot_started.elapsed().as_secs_f64() * 1000.0
+                ),
             );
             println!(
                 "OpenASR server listening on https://{addr} (certificate sha256:{}, pairing code {})",

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -455,7 +455,10 @@ pub(crate) fn warm_up_native_streaming_session_once(
     if WARMED.with(std::cell::Cell::get) {
         return Ok(());
     }
+    openasr_core::stage_timing::log_event("realtime_warmup", "stage=start");
+    let warmup_started = Instant::now();
     session.warm_up()?;
+    openasr_core::stage_timing::log_stage("realtime_warmup", "complete", warmup_started.elapsed());
     WARMED.with(|warmed| warmed.set(true));
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds timestamps and coarse stage timing to `daemon.log` (stdout+stderr of `openasr serve`, captured by the desktop sidecar). Server boot, model-pack loading, realtime warm-up, and each transcription request now log timestamped, duration-bearing lines instead of daemon.log having no timestamps at all.

## Why

Bootstraps observability for the 0.1.12 performance track. Today, diagnosing how long server boot, model loading, or warm-up took requires guessing from wall-clock reads of surrounding untimed log lines. This PR is the prerequisite for validating any later optimization work.

## Changes

- New `openasr_core::stage_timing` module: dependency-free (no chrono/time crate) dual timestamp -- ISO 8601 UTC wall clock + monotonic ms-since-process-start -- plus `log_event`/`log_stage` (always-on, coarse) and `log_detail_event`/`log_detail_stage` (gated behind `OPENASR_TIMING=1`, finer-grained).
- Server boot stages logged in `openasr-server/src/lib.rs`: `validate_listen_security` / `runtime_validate` / `tcp_listener_bind` / `router_build` / `ready` (with total boot ms).
- Model pack load (mmap + tensor materialization + context build to inference-ready) timed once, generically, at the shared `PreparedRuntimeCache::get_or_try_insert_with` build call site -- covers every builtin family that goes through it (whisper, moonshine, cohere, qwen) without touching each family's code.
- Realtime warm-up start/complete timed in `native_worker.rs`.
- Per-transcription-request `audio_prep` / `inference` / `postprocess` coarse stages in `native_transcribe.rs`, plus `OPENASR_TIMING=1` detail: model-resolution sub-stage and per-longform-slice decode timing (gated so a long recording's slice count never floods the default log).
- All additive: existing log lines (including the exact `"OpenASR server listening on http://"` banner `crates/openasr-cli/tests/cli.rs` waits on) are left byte-for-byte unchanged, so nothing that parses daemon.log today breaks. Checked `openasr-app/apps/desktop` for daemon.log parsing -- it only appends raw bytes and rotates by size, no line-format parsing, so this is safe.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2264 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

## Manual smoke checks

Real daemon boot + first-request timing against locally installed packs (dolphin-base:fp16, firered-aed-l-v2:q4, qwen3-asr-0.6b:q4_k) on this M1 dev machine, confirming boot stage lines, `model_pack_load` firing for cache-backed families, and per-request stage lines all render correctly end to end.

## Docs updated

- [ ] N/A -- internal log format, no user-facing docs/behavior change.

## Scope / non-goals

Does not add OS-level tracing/metrics export, does not touch the desktop (app repo) side, does not change what daemon.log parsing exists today (there is none to preserve compatibility with beyond the one exact-text banner line). Per-slice/model-resolve detail timing is opt-in via `OPENASR_TIMING=1`, not part of the default coarse tier.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with Claude Code (agent-assisted); design (insertion points, additive-only approach preserving the existing readiness-detection line, cache-based instrumentation covering multiple model families generically) and verification (real-machine boot/load timing runs) done by the assistant under human supervision per this repo's AI usage policy.