### PR TITLE
perf(pull): parallel chunked downloads

### DIFF
--- a/crates/openasr-core/src/http.rs
+++ b/crates/openasr-core/src/http.rs
@@ -14,13 +14,30 @@ pub(crate) fn blocking_client(
 /// A client that does NOT follow redirects, so the caller can inspect and
 /// rewrite each `Location` hop (used by the model downloader to route the
 /// Hugging Face CDN redirect through the mirror when `HF_ENDPOINT` is set).
+///
+/// Used for large model-pack downloads (`pull::HttpDownloadClient`), so it
+/// deliberately does **not** set a total-request timeout: `reqwest::blocking`
+/// exposes only `ClientBuilder::timeout`, which its own doc comment
+/// describes as covering "connect, read and write operations" as a *single*
+/// deadline that starts at request-send and keeps counting down through
+/// every subsequent response-body read (it is carried into the returned
+/// `Response` and re-checked on each read, not reset by progress). Worse,
+/// this is not opt-in: reqwest's blocking `Timeout` defaults to
+/// `Some(Duration::from_secs(30))` even if `.timeout()` is never called, so
+/// leaving it unset would silently keep killing any download whose
+/// wall-clock time exceeds 30 seconds -- every real multi-hundred-MB model
+/// pack on any non-trivial connection -- regardless of active progress,
+/// long before the application-level stall detection
+/// (`pull::StallGuardedReader`, `pull::LowSpeedWindow`) ever gets a chance
+/// to run. `.timeout(None)` below explicitly disables it; only
+/// `connect_timeout` (bounding the TCP/TLS handshake, which legitimately
+/// should be short) is left as a hard deadline here.
 pub(crate) fn blocking_client_no_redirect(
     connect_timeout: Duration,
-    timeout: Duration,
 ) -> Result<reqwest::blocking::Client, reqwest::Error> {
     reqwest::blocking::Client::builder()
         .connect_timeout(connect_timeout)
-        .timeout(timeout)
+        .timeout(None)
         .redirect(reqwest::redirect::Policy::none())
         .build()
 }

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -1,7 +1,13 @@
 use std::{
+    collections::VecDeque,
     fs::{self, File, OpenOptions},
     io::{self, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -30,6 +36,39 @@ const HTTP_STALL_TIMEOUT: Duration = Duration::from_secs(30);
 const DOWNLOAD_LOW_SPEED_TIMEOUT: Duration = Duration::from_secs(60);
 const DOWNLOAD_LOW_SPEED_MIN_BYTES: u64 = 64 * 1024;
 const DOWNLOAD_USER_AGENT: &str = concat!("OpenASR/", env!("CARGO_PKG_VERSION"));
+/// Fixed segment size for concurrent chunked downloads. 64 MiB amortizes
+/// per-segment overhead (redirect resolution, TLS/connection setup) over a
+/// large body while still giving the default connection count real
+/// parallelism on typical multi-hundred-MB to multi-GB model packs (e.g. a
+/// 300 MB pack still splits into 5 segments at 4 connections). This is a
+/// fixed build-time constant, not an env knob: resumable segment bitmaps
+/// (`SegmentedPartialMeta`) are keyed on it, so changing it is a format
+/// change, not a runtime tuning parameter (see `PARALLEL_META_FORMAT`).
+const DOWNLOAD_SEGMENT_BYTES: u64 = 64 * 1024 * 1024;
+/// Default number of concurrent Range connections for chunked downloads.
+const DEFAULT_PULL_CONNECTIONS: usize = 4;
+/// Hard upper clamp on `OPENASR_PULL_CONNECTIONS` so a misconfigured
+/// environment can't open an unbounded number of sockets against a download
+/// source.
+const MAX_PULL_CONNECTIONS: usize = 8;
+/// Environment override for the concurrent chunked-download connection
+/// count; clamped to `[1, MAX_PULL_CONNECTIONS]`. Setting it to `1` disables
+/// concurrent chunking entirely (the single-stream path is always used when
+/// `connections <= 1`), which doubles as the escape hatch for a source that
+/// misbehaves under concurrent Range requests.
+const PULL_CONNECTIONS_ENV_VAR: &str = "OPENASR_PULL_CONNECTIONS";
+/// Bounded per-segment retry attempts before the whole chunked attempt fails
+/// and control returns to the outer `download_with_retries` retry loop
+/// (which retries the whole attempt, resuming from the on-disk segment
+/// bitmap). Deliberately smaller than `DOWNLOAD_MAX_RETRIES`: a segment this
+/// persistently broken likely reflects a source-wide problem the outer loop
+/// is already positioned to retry or fall back away from.
+const SEGMENT_MAX_RETRIES: usize = 3;
+/// Discriminator stamped into the segmented-download partial-meta file so a
+/// resume never misreads a legacy (pre-chunking) `PartialMeta` -- or a future
+/// incompatible format -- as a valid segment bitmap. Bumping the segment size
+/// or the bitmap's shape must also bump this string.
+const PARALLEL_META_FORMAT: &str = "segmented-v1";
 const GGUF_DEFAULT_ALIGNMENT: u64 = 32;
 const MAX_GGUF_METADATA_ENTRIES: u64 = 100_000;
 const MAX_GGUF_TENSORS: u64 = 1_000_000;
@@ -171,6 +210,24 @@ pub enum PullError {
         expected: String,
         actual: String,
     },
+    #[error(
+        "Concurrent chunk fetch for '{url}' returned a different ETag than the first segment; the download was restarted"
+    )]
+    EtagChanged { url: String },
+    #[error(
+        "Downloaded segment [{start}-{end}] size mismatch for '{path}': expected {expected} bytes, got {actual}"
+    )]
+    SegmentSizeMismatch {
+        path: PathBuf,
+        start: u64,
+        end: u64,
+        expected: u64,
+        actual: u64,
+    },
+    #[error(
+        "Concurrent chunk fetch for '{url}' returned a Content-Range starting at a different offset than requested"
+    )]
+    SegmentRangeMismatch { url: String },
     #[error("Downloaded pack failed Rust-only GGUF preflight for '{path}': {reason}")]
     GgufPreflight { path: PathBuf, reason: String },
     #[error("Downloaded backend file failed binary preflight for '{path}': {reason}")]
@@ -220,6 +277,13 @@ struct PullPaths {
     final_path: PathBuf,
     partial_path: PathBuf,
     partial_meta_path: PathBuf,
+    /// Segment-completion bitmap for the chunked-download path. Deliberately
+    /// a separate file from `partial_meta_path` (rather than a new variant
+    /// of the same file) so the existing single-stream `PartialMeta` format
+    /// and its resume logic are untouched by this feature: a resume only
+    /// ever reads the meta file matching the mode it is about to use, and
+    /// `cleanup_partial` removes both unconditionally.
+    partial_segments_meta_path: PathBuf,
     installed_meta_path: PathBuf,
     lock_path: PathBuf,
 }
@@ -229,6 +293,12 @@ struct PullOptions {
     available_space_override: Option<u64>,
     low_speed_timeout: Duration,
     low_speed_min_bytes: u64,
+    /// Test-only override for `DOWNLOAD_SEGMENT_BYTES`, so unit tests can
+    /// exercise multi-segment concurrent download logic (splitting, resume
+    /// bitmap, ETag invalidation, ...) against small in-memory fixtures
+    /// instead of needing real multi-hundred-MB bodies. `None` in
+    /// production, always -- the real segment size is the fixed constant.
+    parallel_segment_bytes_override: Option<u64>,
 }
 
 impl PullOptions {
@@ -237,12 +307,43 @@ impl PullOptions {
             available_space_override: None,
             low_speed_timeout: DOWNLOAD_LOW_SPEED_TIMEOUT,
             low_speed_min_bytes: DOWNLOAD_LOW_SPEED_MIN_BYTES,
+            parallel_segment_bytes_override: None,
+        }
+    }
+}
+
+/// An HTTP byte-range request bound: open-ended (`bytes=start-`) when `end`
+/// is `None` -- used by the single-stream resume path exactly as before --
+/// or the inclusive `bytes=start-end` window a concurrent chunk fetch asks
+/// for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ByteRange {
+    start: u64,
+    end: Option<u64>,
+}
+
+impl ByteRange {
+    fn from_start(start: u64) -> Self {
+        Self { start, end: None }
+    }
+
+    fn bounded(start: u64, end_inclusive: u64) -> Self {
+        Self {
+            start,
+            end: Some(end_inclusive),
+        }
+    }
+
+    fn header_value(self) -> String {
+        match self.end {
+            Some(end) => format!("bytes={}-{end}", self.start),
+            None => format!("bytes={}-", self.start),
         }
     }
 }
 
 trait DownloadClient {
-    fn open(&mut self, url: &str, range_start: Option<u64>) -> Result<DownloadResponse, PullError>;
+    fn open(&mut self, url: &str, range: Option<ByteRange>) -> Result<DownloadResponse, PullError>;
 }
 
 struct DownloadResponse {
@@ -253,12 +354,41 @@ struct DownloadResponse {
     reader: Box<dyn Read>,
 }
 
+/// A `DownloadClient` boxed for use across worker threads: each concurrent
+/// segment worker owns one, produced fresh by a `ParallelDownloadConfig`
+/// factory (see its doc comment for why -- `DownloadClient::open` takes
+/// `&mut self`, so a single client instance can't be shared between threads).
+type BoxedDownloadClient = Box<dyn DownloadClient + Send>;
+
+/// Concurrency knobs for the chunked-download path, threaded through from
+/// `PullModelPackRequest::execute` (production, env-configured) or
+/// constructed directly by tests. Absent (`None`) anywhere upstream simply
+/// means "never chunk" -- the single-stream path is unconditionally correct
+/// and is what every caller falls back to.
+struct ParallelDownloadConfig<'a> {
+    /// Upper bound on simultaneous Range connections; the actual worker
+    /// count is `min(connections, remaining segment count)`.
+    connections: usize,
+    /// Produces one fresh, independently usable `DownloadClient` per worker
+    /// thread. For `HttpDownloadClient` this clones the underlying
+    /// `reqwest::blocking::Client`, which is an `Arc`-backed connection pool
+    /// designed to be shared across threads -- so cloning it (rather than
+    /// building a brand new pool per worker) lets concurrent segment
+    /// requests to the same host reuse keep-alive connections.
+    factory: &'a dyn Fn() -> Result<BoxedDownloadClient, PullError>,
+}
+
 struct DownloadedPartial {
     bytes_done: u64,
     sha256: String,
 }
 
+#[derive(Clone)]
 struct HttpDownloadClient {
+    /// `reqwest::blocking::Client` wraps an `Arc`-backed connection pool, so
+    /// cloning is cheap and shares keep-alive connections across threads --
+    /// exactly what the chunked-download worker threads want (see
+    /// `ParallelDownloadConfig::factory`).
     client: reqwest::blocking::Client,
     /// Optional Hugging Face access token (`OPENASR_HF_TOKEN`). Attached only to
     /// requests whose host is `huggingface.co`, never to the CDN/mirror redirect
@@ -331,12 +461,26 @@ impl<'a> PullModelPackRequest<'a> {
                 &env_sources
             }
         };
+        // Each worker thread gets its own clone of `client` (a cheap,
+        // `Arc`-backed connection pool -- see `HttpDownloadClient`'s doc
+        // comment) rather than an independently constructed client, so
+        // concurrent segment requests to the same host can share keep-alive
+        // connections instead of each opening a fresh one.
+        let worker_client = client.clone();
+        let factory = move || -> Result<BoxedDownloadClient, PullError> {
+            Ok(Box::new(worker_client.clone()))
+        };
+        let parallel = ParallelDownloadConfig {
+            connections: pull_connections_from_env(),
+            factory: &factory,
+        };
         pull_model_pack_with_client_sources_and_cancel(
             resolved,
             home,
             &mut client,
             PullOptions::default(),
             sources,
+            Some(parallel),
             progress,
             || should_cancel.as_ref().is_some_and(|f| f()),
             || should_pause.as_ref().is_some_and(|f| f()),
@@ -442,23 +586,7 @@ fn resolved_catalog_pull_from_quant(
     model: &CatalogModel,
     quant: &CatalogQuant,
 ) -> ResolvedCatalogPull {
-    ResolvedCatalogPull {
-        requested: quant.pull.clone(),
-        model_id: model.id.clone(),
-        display_name: model.display_name.clone(),
-        quant: quant.quant.clone(),
-        suffix: quant.suffix.clone(),
-        pull: quant.pull.clone(),
-        filename: quant.filename.clone(),
-        url: quant.url.clone(),
-        mirrors: quant.mirrors.clone(),
-        hf_revision: model.hf_revision.clone(),
-        sha256: quant.sha256.clone(),
-        size_bytes: quant.size_bytes,
-        license: model.license.clone(),
-        license_url: model.license_url.clone(),
-        license_class: model.license_class.clone(),
-    }
+    ResolvedCatalogPull::from_model_and_quant(model, quant, quant.pull.clone())
 }
 
 pub fn list_installed_packs(home: impl AsRef<Path>) -> Result<Vec<InstalledPack>, PullError> {
@@ -692,18 +820,50 @@ fn pull_model_pack_with_client_and_cancel<C: DownloadClient>(
         client,
         options,
         &[DownloadSource::Hf],
+        None,
         progress,
         should_cancel,
         should_pause,
     )
 }
 
+/// Test-only entry point that exercises the concurrent chunked-download path
+/// (`pull_model_pack_with_client_and_cancel` / the production
+/// `PullModelPackRequest::execute` never pass `parallel: None` in production,
+/// but tests need to opt in explicitly with a mock client factory).
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn pull_model_pack_with_client_parallel<C: DownloadClient>(
+    resolved: &ResolvedCatalogPull,
+    home: &Path,
+    client: &mut C,
+    options: PullOptions,
+    parallel: ParallelDownloadConfig,
+    progress: impl FnMut(PullProgress),
+    should_cancel: impl Fn() -> bool,
+    should_pause: impl Fn() -> bool,
+) -> Result<InstalledPack, PullError> {
+    pull_model_pack_with_client_sources_and_cancel(
+        resolved,
+        home,
+        client,
+        options,
+        &[DownloadSource::Hf],
+        Some(parallel),
+        progress,
+        should_cancel,
+        should_pause,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 fn pull_model_pack_with_client_sources_and_cancel<C: DownloadClient>(
     resolved: &ResolvedCatalogPull,
     home: &Path,
     client: &mut C,
     options: PullOptions,
     sources: &[DownloadSource],
+    parallel: Option<ParallelDownloadConfig>,
     mut progress: impl FnMut(PullProgress),
     should_cancel: impl Fn() -> bool,
     should_pause: impl Fn() -> bool,
@@ -729,6 +889,7 @@ fn pull_model_pack_with_client_sources_and_cancel<C: DownloadClient>(
             &paths,
             client,
             options.clone(),
+            parallel.as_ref(),
             &mut progress,
             &should_cancel,
             &should_pause,
@@ -791,15 +952,25 @@ fn source_targets(
     Ok(targets)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn download_with_retries<C: DownloadClient>(
     target: &PullTarget,
     paths: &PullPaths,
     client: &mut C,
     options: PullOptions,
+    parallel: Option<&ParallelDownloadConfig>,
     progress: &mut impl FnMut(PullProgress),
     should_cancel: &impl Fn() -> bool,
     should_pause: &impl Fn() -> bool,
 ) -> Result<DownloadedPartial, PullError> {
+    let segment_bytes = options
+        .parallel_segment_bytes_override
+        .unwrap_or(DOWNLOAD_SEGMENT_BYTES);
+    // Sticky within this call: once a probe (or a mid-download segment
+    // response) shows the source ignores Range, don't keep re-probing on
+    // every retry -- fall back to the single-stream path for the rest of
+    // this pull attempt.
+    let mut range_supported = true;
     let mut attempt = 0_usize;
     loop {
         if should_cancel() {
@@ -813,6 +984,40 @@ fn download_with_retries<C: DownloadClient>(
                 reference: target.pull.clone(),
             });
         }
+
+        if range_supported
+            && let Some(parallel) = parallel
+            && parallel_download_eligible(target, parallel.connections, segment_bytes)
+        {
+            match download_parallel_attempt(
+                target,
+                paths,
+                client,
+                parallel,
+                segment_bytes,
+                &options,
+                progress,
+                should_cancel,
+                should_pause,
+            ) {
+                Ok(ParallelAttemptOutcome::Completed(downloaded)) => return Ok(downloaded),
+                Ok(ParallelAttemptOutcome::RangeNotSupported) => {
+                    range_supported = false;
+                    cleanup_partial(paths);
+                    // Fall through to the single-stream path below for this
+                    // same loop iteration -- no wasted attempt/backoff.
+                }
+                Err(error)
+                    if attempt < DOWNLOAD_MAX_RETRIES && is_retryable_download_error(&error) =>
+                {
+                    attempt += 1;
+                    std::thread::sleep(retry_backoff(attempt));
+                    continue;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
         let resume_from = prepare_partial_for_resume(target, paths)?;
         if resume_from == target.size_bytes {
             let (_, sha256) = file_size_and_sha256(&paths.partial_path)?;
@@ -824,7 +1029,10 @@ fn download_with_retries<C: DownloadClient>(
         let needed = reserve_space_bytes(target.size_bytes.saturating_sub(resume_from));
         ensure_available_space(&paths.dir, needed, options.clone())?;
         let result = client
-            .open(&target.url, (resume_from > 0).then_some(resume_from))
+            .open(
+                &target.url,
+                (resume_from > 0).then(|| ByteRange::from_start(resume_from)),
+            )
             .and_then(|response| {
                 download_response(
                     target,
@@ -985,6 +1193,734 @@ fn download_response(
 fn cleanup_partial(paths: &PullPaths) {
     let _ = fs::remove_file(&paths.partial_path);
     let _ = fs::remove_file(&paths.partial_meta_path);
+    let _ = fs::remove_file(&paths.partial_segments_meta_path);
+}
+
+/// The env override for the chunked-download connection count, clamped to
+/// `[1, MAX_PULL_CONNECTIONS]`. `connections <= 1` makes the download
+/// unconditionally single-stream (see `parallel_download_eligible`).
+fn pull_connections_from_env() -> usize {
+    std::env::var(PULL_CONNECTIONS_ENV_VAR)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|connections| *connections > 0)
+        .unwrap_or(DEFAULT_PULL_CONNECTIONS)
+        .min(MAX_PULL_CONNECTIONS)
+}
+
+/// A pack only benefits from chunking once it splits into at least 2
+/// segments -- otherwise a single Range request already reads the whole
+/// body, and going concurrent would only add a wasted probe request.
+fn parallel_download_eligible(target: &PullTarget, connections: usize, segment_bytes: u64) -> bool {
+    connections > 1 && target.size_bytes >= segment_bytes.saturating_mul(2)
+}
+
+fn segment_count(size_bytes: u64, segment_bytes: u64) -> usize {
+    size_bytes.div_ceil(segment_bytes) as usize
+}
+
+/// The inclusive `[start, end]` byte range for segment `index`, clamped to
+/// `size_bytes` for the final (possibly short) segment.
+fn segment_range(index: usize, size_bytes: u64, segment_bytes: u64) -> (u64, u64) {
+    let start = index as u64 * segment_bytes;
+    let end = start
+        .saturating_add(segment_bytes)
+        .saturating_sub(1)
+        .min(size_bytes.saturating_sub(1));
+    (start, end)
+}
+
+/// Per-segment completion bitmap for a chunked download, persisted next to
+/// the (preallocated, full-size) `.partial` file as a distinct file from the
+/// single-stream `PartialMeta` -- see `PullPaths::partial_segments_meta_path`.
+///
+/// Deliberately carries **no per-segment hash**: segments can complete out of
+/// order across worker threads, so an incrementally-advancing hash cursor
+/// (like the single-stream path's inline `Sha256`) would need to buffer or
+/// stall on out-of-order bytes to hash them in file order, which defeats the
+/// point of concurrency. Instead, integrity is checked once, the same way an
+/// already-fully-resumed single-stream download is
+/// (`download_with_retries`' `resume_from == target.size_bytes` shortcut):
+/// after every segment is marked done, `download_parallel_attempt` rereads
+/// the whole file and compares its sha256 against the catalog-pinned digest
+/// in `verify_partial_and_install`, exactly like every other pull path. The
+/// cost is one extra full-file sequential read, which is fast relative to
+/// network transfer (see the PR description for measured overhead).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct SegmentedPartialMeta {
+    /// Discriminator against the single-stream `PartialMeta` format and
+    /// against any future incompatible bitmap shape; see
+    /// `PARALLEL_META_FORMAT`.
+    format: String,
+    model_id: String,
+    quant: String,
+    filename: String,
+    hf_revision: String,
+    sha256: String,
+    size_bytes: u64,
+    /// The fixed segment size this bitmap was built against. A resume whose
+    /// current `DOWNLOAD_SEGMENT_BYTES` no longer matches is invalidated
+    /// (see `load_segmented_meta`) rather than reinterpreted, since segment
+    /// boundaries -- and therefore bitmap indices -- would no longer align.
+    segment_bytes: u64,
+    /// The ETag every segment's response is checked against
+    /// (`fetch_segment_once`); `None` when the source sent no ETag at all,
+    /// in which case cross-segment consistency can't be checked and the
+    /// final sha256 comparison is the only integrity gate (same gap the
+    /// single-stream path already has today).
+    etag: Option<String>,
+    segments_done: Vec<bool>,
+    updated_at_unix_seconds: u64,
+}
+
+impl SegmentedPartialMeta {
+    fn new(
+        target: &PullTarget,
+        segment_bytes: u64,
+        etag: Option<String>,
+        total_segments: usize,
+    ) -> Self {
+        Self {
+            format: PARALLEL_META_FORMAT.to_string(),
+            model_id: target.model_id.clone(),
+            quant: target.quant.clone(),
+            filename: target.filename.clone(),
+            hf_revision: target.hf_revision.clone(),
+            sha256: target.sha256.clone(),
+            size_bytes: target.size_bytes,
+            segment_bytes,
+            etag,
+            segments_done: vec![false; total_segments],
+            updated_at_unix_seconds: unix_seconds_now(),
+        }
+    }
+
+    /// Same content-identity comparison as `PartialMeta::matches_target` --
+    /// see its doc comment for why the transport URL is intentionally
+    /// excluded (mirrors serve the same bytes under different hosts).
+    fn matches_target(&self, target: &PullTarget) -> bool {
+        self.format == PARALLEL_META_FORMAT
+            && self.model_id == target.model_id
+            && self.quant == target.quant
+            && self.filename == target.filename
+            && self.hf_revision == target.hf_revision
+            && self.sha256 == target.sha256
+            && self.size_bytes == target.size_bytes
+    }
+
+    fn bytes_done(&self, size_bytes: u64, segment_bytes: u64) -> u64 {
+        self.segments_done
+            .iter()
+            .enumerate()
+            .filter(|(_, done)| **done)
+            .map(|(index, _)| {
+                let (start, end) = segment_range(index, size_bytes, segment_bytes);
+                end - start + 1
+            })
+            .sum()
+    }
+}
+
+fn write_partial_segments_meta(path: &Path, meta: &SegmentedPartialMeta) -> Result<(), PullError> {
+    let json = serde_json::to_string_pretty(meta).map_err(|source| PullError::SerializeMeta {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    write_json_atomic(path, &format!("{json}\n"))
+}
+
+/// Load a usable segment bitmap for `target`/`segment_bytes`, or start fresh.
+///
+/// Backward/forward compatibility choice: a bitmap is reused only if it
+/// parses as the current `SegmentedPartialMeta` shape, matches the target's
+/// content identity, was built with the *same* `segment_bytes`, has exactly
+/// `total_segments` entries, and the on-disk `.partial` file is already at
+/// full size (this path always preallocates to `size_bytes` up front, so
+/// anything else means the file predates this feature or is otherwise
+/// inconsistent). Anything else -- including a legacy single-stream
+/// `.partial` left by a version of OpenASR before chunked downloads existed
+/// -- is **not** reinterpreted: its bytes were never segment-aligned, so
+/// `cleanup_partial` wipes both partial files and the download restarts from
+/// segment 0. This trades a possible redundant re-download of an
+/// in-progress legacy partial for never having to guess at a foreign file's
+/// layout.
+fn load_segmented_meta(
+    target: &PullTarget,
+    paths: &PullPaths,
+    segment_bytes: u64,
+    total_segments: usize,
+) -> Result<SegmentedPartialMeta, PullError> {
+    let partial_len = fs::metadata(&paths.partial_path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    let parsed = if paths.partial_path.exists() {
+        fs::read_to_string(&paths.partial_segments_meta_path)
+            .ok()
+            .and_then(|contents| serde_json::from_str::<SegmentedPartialMeta>(&contents).ok())
+    } else {
+        None
+    };
+    if let Some(meta) = parsed
+        && meta.matches_target(target)
+        && meta.segment_bytes == segment_bytes
+        && meta.segments_done.len() == total_segments
+        && partial_len == target.size_bytes
+    {
+        return Ok(meta);
+    }
+    cleanup_partial(paths);
+    Ok(SegmentedPartialMeta::new(
+        target,
+        segment_bytes,
+        None,
+        total_segments,
+    ))
+}
+
+/// Outcome of one concurrent chunked-download attempt.
+enum ParallelAttemptOutcome {
+    /// Every segment verified complete; the caller feeds this straight into
+    /// `verify_partial_and_install` exactly like the single-stream path.
+    Completed(DownloadedPartial),
+    /// The probe request got a `200` instead of `206`: the source is
+    /// ignoring the `Range` header entirely. Concurrent chunking cannot work
+    /// against this URL (writing a `200`'s from-byte-0 body into a
+    /// mid-file segment window would corrupt the file), so the caller wipes
+    /// the preallocated partial state and falls back to the existing
+    /// single-stream path, which already handles a `200` response correctly.
+    RangeNotSupported,
+}
+
+/// Run one attempt of the concurrent chunked-download path for `target`.
+///
+/// Sequence: reuse or initialize the segment bitmap: `load_segmented_meta`
+/// -> if every segment is already done, skip the network entirely and
+/// re-verify the file (same shortcut `download_with_retries` uses for a
+/// fully-resumed single-stream download) -> otherwise probe the first
+/// missing segment synchronously (confirms Range support and establishes the
+/// reference ETag before any concurrency starts) -> spawn up to
+/// `parallel.connections` worker threads pulling remaining segment indices
+/// off a shared queue, each writing directly into its slice of the
+/// preallocated file at the matching offset -> aggregate progress and
+/// segment-done events over an `mpsc` channel on this (the caller's) thread,
+/// which is also the only thread that polls `should_cancel`/`should_pause`
+/// (matching how the single-stream path already confines those predicates to
+/// one thread) -> once all workers finish, fsync and reread the whole file's
+/// sha256 for the final integrity gate.
+#[allow(clippy::too_many_arguments)]
+fn download_parallel_attempt<C: DownloadClient + ?Sized>(
+    target: &PullTarget,
+    paths: &PullPaths,
+    probe_client: &mut C,
+    parallel: &ParallelDownloadConfig,
+    segment_bytes: u64,
+    options: &PullOptions,
+    progress: &mut impl FnMut(PullProgress),
+    should_cancel: &impl Fn() -> bool,
+    should_pause: &impl Fn() -> bool,
+) -> Result<ParallelAttemptOutcome, PullError> {
+    let total_segments = segment_count(target.size_bytes, segment_bytes);
+    let mut meta = load_segmented_meta(target, paths, segment_bytes, total_segments)?;
+
+    let missing: Vec<usize> = meta
+        .segments_done
+        .iter()
+        .enumerate()
+        .filter(|(_, done)| !**done)
+        .map(|(index, _)| index)
+        .collect();
+
+    if missing.is_empty() {
+        let (actual_size, sha256) = file_size_and_sha256(&paths.partial_path)?;
+        return Ok(ParallelAttemptOutcome::Completed(DownloadedPartial {
+            bytes_done: actual_size,
+            sha256,
+        }));
+    }
+
+    let resume_from = meta.bytes_done(target.size_bytes, segment_bytes);
+    progress(PullProgress::DownloadStarted {
+        bytes_total: target.size_bytes,
+        resume_from,
+    });
+
+    ensure_available_space(
+        &paths.dir,
+        reserve_space_bytes((missing.len() as u64).saturating_mul(segment_bytes)),
+        options.clone(),
+    )?;
+
+    // Probe the first still-missing segment with a real, bounded Range
+    // request before committing to concurrency. A single request both (a)
+    // confirms the source honors Range (206) rather than ignoring it (200 --
+    // handled by the caller falling back to the single-stream path) and (b)
+    // establishes the reference ETag every other segment's response is
+    // checked against, so this is not a wasted request: its bytes become the
+    // probed segment's real data below.
+    let probe_index = missing[0];
+    let (probe_start, probe_end) = segment_range(probe_index, target.size_bytes, segment_bytes);
+    let probe_response = probe_client.open(
+        &target.url,
+        Some(ByteRange::bounded(probe_start, probe_end)),
+    )?;
+    if probe_response.status == 200 {
+        return Ok(ParallelAttemptOutcome::RangeNotSupported);
+    }
+    if probe_response.status != 206 {
+        return Err(PullError::UnexpectedStatus {
+            url: target.url.clone(),
+            status: probe_response.status,
+        });
+    }
+    if let Some(reference) = meta.etag.as_deref()
+        && let Some(probe_etag) = probe_response.etag.as_deref()
+        && reference != probe_etag
+    {
+        // A prior run's reference ETag no longer matches: the object behind
+        // this URL changed since the segment bitmap was last written. Wipe
+        // the whole partial state (bytes from two versions of the file can't
+        // be selectively resumed) so the retry in `download_with_retries`
+        // restarts clean from segment 0 with a fresh reference ETag.
+        cleanup_partial(paths);
+        return Err(PullError::EtagChanged {
+            url: target.url.clone(),
+        });
+    }
+    let reference_etag = meta.etag.clone().or_else(|| probe_response.etag.clone());
+    meta.etag = reference_etag.clone();
+
+    {
+        // `truncate(false)`: a resumed download's `.partial` already holds
+        // previously-written segment bytes at their correct offsets (see
+        // `load_segmented_meta`) that must survive this open -- only a fresh
+        // download hits `create(true)` for real, and `set_len` below is what
+        // establishes the full preallocated size either way.
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&paths.partial_path)
+            .map_err(|source| PullError::Io {
+                path: paths.partial_path.clone(),
+                source,
+            })?;
+        file.set_len(target.size_bytes)
+            .map_err(|source| PullError::Io {
+                path: paths.partial_path.clone(),
+                source,
+            })?;
+    }
+    write_partial_segments_meta(&paths.partial_segments_meta_path, &meta)?;
+
+    let mut bytes_done = resume_from;
+    {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .open(&paths.partial_path)
+            .map_err(|source| PullError::Io {
+                path: paths.partial_path.clone(),
+                source,
+            })?;
+        let written = write_segment_body(
+            &mut file,
+            &paths.partial_path,
+            probe_start,
+            probe_end,
+            probe_response.reader,
+            |delta| {
+                bytes_done = bytes_done.saturating_add(delta);
+                progress(PullProgress::Downloading {
+                    bytes_done,
+                    bytes_total: target.size_bytes,
+                });
+            },
+            None,
+        )?;
+        let expected = probe_end - probe_start + 1;
+        if written != expected {
+            cleanup_partial(paths);
+            return Err(PullError::SegmentSizeMismatch {
+                path: paths.partial_path.clone(),
+                start: probe_start,
+                end: probe_end,
+                expected,
+                actual: written,
+            });
+        }
+    }
+    meta.segments_done[probe_index] = true;
+    write_partial_segments_meta(&paths.partial_segments_meta_path, &meta)?;
+
+    let remaining: VecDeque<usize> = missing
+        .into_iter()
+        .filter(|index| *index != probe_index)
+        .collect();
+    if remaining.is_empty() {
+        sync_partial_file(&paths.partial_path)?;
+        let (actual_size, sha256) = file_size_and_sha256(&paths.partial_path)?;
+        let _ = fs::remove_file(&paths.partial_segments_meta_path);
+        return Ok(ParallelAttemptOutcome::Completed(DownloadedPartial {
+            bytes_done: actual_size,
+            sha256,
+        }));
+    }
+
+    let remaining_count = remaining.len();
+    let queue = Arc::new(Mutex::new(remaining));
+    let abort = Arc::new(AtomicBool::new(false));
+    let (sender, receiver) = mpsc::channel::<SegmentEvent>();
+    // No lock needed yet: no worker thread exists before the spawn loop
+    // below, so `remaining_count` (captured before `remaining` moved into
+    // the mutex) is exact, not just a snapshot.
+    let worker_count = parallel.connections.min(remaining_count).max(1);
+    let size_bytes = target.size_bytes;
+    let mut handles = Vec::with_capacity(worker_count);
+    for _ in 0..worker_count {
+        let worker_client = (parallel.factory)()?;
+        let worker_queue = queue.clone();
+        let worker_abort = abort.clone();
+        let worker_sender = sender.clone();
+        let worker_path = paths.partial_path.clone();
+        let worker_url = target.url.clone();
+        let worker_reference_etag = reference_etag.clone();
+        handles.push(std::thread::spawn(move || {
+            run_segment_worker(
+                worker_client,
+                worker_queue,
+                worker_abort,
+                worker_sender,
+                worker_path,
+                worker_url,
+                size_bytes,
+                segment_bytes,
+                worker_reference_etag,
+            );
+        }));
+    }
+    drop(sender);
+
+    let mut first_error: Option<PullError> = None;
+    let mut canceled = false;
+    let mut paused = false;
+    loop {
+        match receiver.recv_timeout(Duration::from_millis(100)) {
+            Ok(SegmentEvent::Progress(delta)) => {
+                bytes_done = bytes_done.saturating_add(delta);
+                progress(PullProgress::Downloading {
+                    bytes_done,
+                    bytes_total: target.size_bytes,
+                });
+            }
+            Ok(SegmentEvent::Done(index)) => {
+                meta.segments_done[index] = true;
+                write_partial_segments_meta(&paths.partial_segments_meta_path, &meta)?;
+            }
+            Ok(SegmentEvent::Failed(error)) => {
+                let is_etag_change = matches!(error, PullError::EtagChanged { .. });
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+                abort.store(true, Ordering::SeqCst);
+                if is_etag_change {
+                    // Same "can't selectively resume across an object swap"
+                    // reasoning as the probe-time ETag check above.
+                    cleanup_partial(paths);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+        if !canceled && !paused {
+            if should_cancel() {
+                canceled = true;
+                abort.store(true, Ordering::SeqCst);
+            } else if should_pause() {
+                paused = true;
+                abort.store(true, Ordering::SeqCst);
+            }
+        }
+    }
+    for handle in handles {
+        let _ = handle.join();
+    }
+
+    if canceled {
+        cleanup_partial(paths);
+        return Err(PullError::Canceled {
+            reference: target.pull.clone(),
+        });
+    }
+    if let Some(error) = first_error {
+        return Err(error);
+    }
+    if paused {
+        return Err(PullError::Paused {
+            reference: target.pull.clone(),
+        });
+    }
+    if meta.segments_done.iter().any(|done| !done) {
+        // Unreachable in practice: every other exit path above requires the
+        // work queue to have drained without cancellation, pause, or error.
+        // Kept as a defensive fail-closed check so a future bug in the
+        // orchestration above can never mistake a partially-filled file for
+        // a complete one.
+        return Err(PullError::Io {
+            path: paths.partial_path.clone(),
+            source: io::Error::other(
+                "chunked download loop exited without completing every segment",
+            ),
+        });
+    }
+
+    sync_partial_file(&paths.partial_path)?;
+    let (actual_size, sha256) = file_size_and_sha256(&paths.partial_path)?;
+    let _ = fs::remove_file(&paths.partial_segments_meta_path);
+    Ok(ParallelAttemptOutcome::Completed(DownloadedPartial {
+        bytes_done: actual_size,
+        sha256,
+    }))
+}
+
+fn sync_partial_file(path: &Path) -> Result<(), PullError> {
+    let file = OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|source| PullError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    file.sync_all().map_err(|source| PullError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Stream `reader` (already capped to the segment's expected length by the
+/// caller's use of `.take`, applied inside this function) into `file` at
+/// `[start, end_inclusive]`, calling `on_progress` with each chunk's byte
+/// count as it's written. Stops early (without error) if `abort` is set,
+/// leaving the segment's on-disk bytes incomplete but never marked done by
+/// the caller. Shared by the synchronous probe-segment write (main thread,
+/// `abort: None`) and every worker's per-segment fetch
+/// (`fetch_segment_once`), so both paths write segments identically.
+fn write_segment_body(
+    file: &mut File,
+    path_for_errors: &Path,
+    start: u64,
+    end_inclusive: u64,
+    reader: Box<dyn Read>,
+    mut on_progress: impl FnMut(u64),
+    abort: Option<&AtomicBool>,
+) -> Result<u64, PullError> {
+    file.seek(SeekFrom::Start(start))
+        .map_err(|source| PullError::Io {
+            path: path_for_errors.to_path_buf(),
+            source,
+        })?;
+    let expected_len = end_inclusive - start + 1;
+    let mut reader = reader.take(expected_len);
+    let mut buffer = vec![0_u8; DOWNLOAD_BUFFER_BYTES];
+    let mut written = 0_u64;
+    loop {
+        if abort.is_some_and(|abort| abort.load(Ordering::SeqCst)) {
+            break;
+        }
+        let read = reader.read(&mut buffer).map_err(|source| PullError::Io {
+            path: path_for_errors.to_path_buf(),
+            source,
+        })?;
+        if read == 0 {
+            break;
+        }
+        file.write_all(&buffer[..read])
+            .map_err(|source| PullError::Io {
+                path: path_for_errors.to_path_buf(),
+                source,
+            })?;
+        written = written.saturating_add(read as u64);
+        on_progress(read as u64);
+    }
+    Ok(written)
+}
+
+/// Events a segment worker thread reports back to the orchestrating thread
+/// over the `mpsc` channel. Kept intentionally minimal: only the
+/// orchestrating thread touches `should_cancel`/`should_pause`, the segment
+/// bitmap, and the `progress` callback, so workers never need anything more
+/// than "here is a byte delta" / "this segment index is done" / "this
+/// segment failed".
+enum SegmentEvent {
+    Progress(u64),
+    Done(usize),
+    Failed(PullError),
+}
+
+/// One worker thread's loop: pop segment indices off the shared `queue`
+/// until it's empty or `abort` is set, fetching and writing each with
+/// `fetch_segment_with_retries`. Never panics on I/O failure -- every error
+/// path reports a `SegmentEvent::Failed` and returns instead.
+#[allow(clippy::too_many_arguments)]
+fn run_segment_worker(
+    mut client: BoxedDownloadClient,
+    queue: Arc<Mutex<VecDeque<usize>>>,
+    abort: Arc<AtomicBool>,
+    sender: mpsc::Sender<SegmentEvent>,
+    path: PathBuf,
+    url: String,
+    size_bytes: u64,
+    segment_bytes: u64,
+    reference_etag: Option<String>,
+) {
+    let mut file = match OpenOptions::new().write(true).open(&path) {
+        Ok(file) => file,
+        Err(source) => {
+            let _ = sender.send(SegmentEvent::Failed(PullError::Io {
+                path: path.clone(),
+                source,
+            }));
+            return;
+        }
+    };
+    loop {
+        if abort.load(Ordering::SeqCst) {
+            return;
+        }
+        let index = {
+            let mut queue = queue.lock().unwrap();
+            match queue.pop_front() {
+                Some(index) => index,
+                None => return,
+            }
+        };
+        let (start, end) = segment_range(index, size_bytes, segment_bytes);
+        match fetch_segment_with_retries(
+            client.as_mut(),
+            &mut file,
+            &path,
+            &url,
+            start,
+            end,
+            reference_etag.as_deref(),
+            &abort,
+            &sender,
+        ) {
+            Ok(true) => {
+                if sender.send(SegmentEvent::Done(index)).is_err() {
+                    return;
+                }
+            }
+            Ok(false) => return, // aborted mid-segment; no event, orchestrator already knows
+            Err(error) => {
+                let _ = sender.send(SegmentEvent::Failed(error));
+                return;
+            }
+        }
+    }
+}
+
+/// Retry one segment fetch up to `SEGMENT_MAX_RETRIES` times, backing off
+/// between attempts exactly like the single-stream path's outer retry loop.
+#[allow(clippy::too_many_arguments)]
+fn fetch_segment_with_retries(
+    client: &mut dyn DownloadClient,
+    file: &mut File,
+    path: &Path,
+    url: &str,
+    start: u64,
+    end: u64,
+    reference_etag: Option<&str>,
+    abort: &AtomicBool,
+    sender: &mpsc::Sender<SegmentEvent>,
+) -> Result<bool, PullError> {
+    let mut attempt = 0_usize;
+    loop {
+        if abort.load(Ordering::SeqCst) {
+            return Ok(false);
+        }
+        match fetch_segment_once(
+            client,
+            file,
+            path,
+            url,
+            start,
+            end,
+            reference_etag,
+            abort,
+            sender,
+        ) {
+            Ok(outcome) => return Ok(outcome),
+            Err(error) if attempt < SEGMENT_MAX_RETRIES && is_retryable_download_error(&error) => {
+                attempt += 1;
+                std::thread::sleep(retry_backoff(attempt));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn fetch_segment_once(
+    client: &mut dyn DownloadClient,
+    file: &mut File,
+    path: &Path,
+    url: &str,
+    start: u64,
+    end: u64,
+    reference_etag: Option<&str>,
+    abort: &AtomicBool,
+    sender: &mpsc::Sender<SegmentEvent>,
+) -> Result<bool, PullError> {
+    let response = client.open(url, Some(ByteRange::bounded(start, end)))?;
+    if response.status != 206 {
+        return Err(PullError::UnexpectedStatus {
+            url: url.to_string(),
+            status: response.status,
+        });
+    }
+    if let (Some(reference), Some(etag)) = (reference_etag, response.etag.as_deref())
+        && reference != etag
+    {
+        return Err(PullError::EtagChanged {
+            url: url.to_string(),
+        });
+    }
+    if let Some(content_range) = response.content_range.as_deref()
+        && let Some(parsed) = parse_content_range(content_range)
+        && parsed.start != start
+    {
+        // A 206 whose Content-Range doesn't start where we asked: a
+        // misbehaving proxy/CDN, not a normal condition. Treated the same
+        // way the single-stream path treats a resume Content-Range mismatch
+        // -- restart rather than trust a response at the wrong offset.
+        return Err(PullError::SegmentRangeMismatch {
+            url: url.to_string(),
+        });
+    }
+    let written = write_segment_body(
+        file,
+        path,
+        start,
+        end,
+        response.reader,
+        |delta| {
+            let _ = sender.send(SegmentEvent::Progress(delta));
+        },
+        Some(abort),
+    )?;
+    if abort.load(Ordering::SeqCst) {
+        return Ok(false);
+    }
+    let expected = end - start + 1;
+    if written != expected {
+        return Err(PullError::SegmentSizeMismatch {
+            path: path.to_path_buf(),
+            start,
+            end,
+            expected,
+            actual: written,
+        });
+    }
+    Ok(true)
 }
 
 fn verify_partial_and_install(
@@ -1232,6 +2168,7 @@ fn pull_paths(home: &Path, target: &PullTarget) -> Result<PullPaths, PullError> 
     Ok(PullPaths {
         partial_path: dir.join(format!("{}.partial", target.filename)),
         partial_meta_path: dir.join(format!("{}.partial.meta.json", target.filename)),
+        partial_segments_meta_path: dir.join(format!("{}.partial.segments.json", target.filename)),
         installed_meta_path: dir.join("installed.json"),
         lock_path: dir.join(format!("{}.lock", target.filename)),
         dir,
@@ -1297,6 +2234,119 @@ fn parse_content_range(value: &str) -> Option<ParsedContentRange> {
         value => Some(value.parse().ok()?),
     };
     Some(ParsedContentRange { start, end, total })
+}
+
+/// Bounds how long a single underlying `Read::read` call may hang before
+/// it's treated as a stall, filling the gap left by
+/// `http::blocking_client_no_redirect` deliberately setting no total request
+/// timeout (see its doc comment): without any bound at all, a connection
+/// that goes silently dead (no error, no EOF, no more bytes) could hang a
+/// `read` call forever, and the app-level `LowSpeedWindow` below can't catch
+/// that either -- it only measures elapsed time *between* successful reads,
+/// so it never gets a chance to run while a single `read` is stuck.
+///
+/// Runs the real `Read::read` calls on a dedicated background thread and
+/// relays each chunk (or EOF, or the underlying I/O error) over a bounded
+/// channel; `Read::read` below waits on that channel with
+/// `recv_timeout(stall_timeout)` and turns an elapsed wait into an
+/// `io::ErrorKind::TimedOut` error -- the same kind
+/// `map_download_read_error` already recognizes and reports as a stall, and
+/// the same kind `is_retryable_download_error` already retries.
+///
+/// A caveat this doesn't (and structurally can't) fully close: if the
+/// background thread's own `read` call is the one that's stuck, the thread
+/// itself is never reclaimed (its `Sender` just sits there, the channel
+/// recv on the foreground side keeps timing out every `stall_timeout` and
+/// reports the stall each time, and this download attempt is abandoned by
+/// the retry/fallback logic above it -- see `is_retryable_download_error`).
+/// The leaked thread is bounded in number by the download concurrency limit
+/// (`MAX_PULL_CONNECTIONS` for the chunked path, one for the single-stream
+/// path) and is reclaimed by the OS once the underlying connection is
+/// eventually torn down, so this trades an unbounded hang for a small,
+/// bounded resource cost -- an acceptable trade for a downloader.
+struct StallGuardedReader {
+    receiver: mpsc::Receiver<io::Result<Vec<u8>>>,
+    stall_timeout: Duration,
+    /// Bytes already received from the background thread but not yet
+    /// returned to the caller, because the caller's `buf` was smaller than
+    /// the chunk that arrived. `Read::read` is allowed to return fewer bytes
+    /// than `buf.len()`, but must never drop bytes it already has.
+    pending: VecDeque<u8>,
+    /// Set once EOF, an error, or a disconnect has been observed and
+    /// reported, so a `Read` contract-following caller that calls `read`
+    /// again afterward gets a clean `Ok(0)` instead of hanging on a closed
+    /// channel.
+    finished: bool,
+}
+
+impl StallGuardedReader {
+    fn new(mut reader: Box<dyn Read + Send>, stall_timeout: Duration) -> Self {
+        let (sender, receiver) = mpsc::sync_channel::<io::Result<Vec<u8>>>(1);
+        std::thread::spawn(move || {
+            let mut buffer = vec![0_u8; DOWNLOAD_BUFFER_BYTES];
+            loop {
+                let (message, stop) = match reader.read(&mut buffer) {
+                    Ok(0) => (Ok(Vec::new()), true),
+                    Ok(read) => (Ok(buffer[..read].to_vec()), false),
+                    Err(error) => (Err(error), true),
+                };
+                if sender.send(message).is_err() || stop {
+                    // Either the foreground gave up (dropped the receiver --
+                    // this attempt was abandoned) or this was the last
+                    // message (EOF/error); either way, stop reading.
+                    return;
+                }
+            }
+        });
+        Self {
+            receiver,
+            stall_timeout,
+            pending: VecDeque::new(),
+            finished: false,
+        }
+    }
+}
+
+impl Read for StallGuardedReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if !self.pending.is_empty() {
+            let len = self.pending.len().min(buf.len());
+            for slot in &mut buf[..len] {
+                *slot = self.pending.pop_front().expect("checked non-empty above");
+            }
+            return Ok(len);
+        }
+        if self.finished {
+            return Ok(0);
+        }
+        match self.receiver.recv_timeout(self.stall_timeout) {
+            Ok(Ok(chunk)) if chunk.is_empty() => {
+                self.finished = true;
+                Ok(0)
+            }
+            Ok(Ok(chunk)) => {
+                let len = chunk.len().min(buf.len());
+                buf[..len].copy_from_slice(&chunk[..len]);
+                self.pending.extend(&chunk[len..]);
+                Ok(len)
+            }
+            Ok(Err(error)) => {
+                self.finished = true;
+                Err(error)
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "no data received from the download source within {stall_timeout:?}",
+                    stall_timeout = self.stall_timeout
+                ),
+            )),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                self.finished = true;
+                Ok(0)
+            }
+        }
+    }
 }
 
 struct LowSpeedWindow {
@@ -1698,11 +2748,12 @@ impl HttpDownloadClient {
     fn new() -> Result<Self, PullError> {
         // The downloader follows redirects manually (see `open`) so it can route
         // the Hugging Face CDN hop through the mirror; hence a no-redirect client.
-        let client = http::blocking_client_no_redirect(HTTP_CONNECT_TIMEOUT, HTTP_STALL_TIMEOUT)
-            .map_err(|source| PullError::Http {
+        let client = http::blocking_client_no_redirect(HTTP_CONNECT_TIMEOUT).map_err(|source| {
+            PullError::Http {
                 url: "<client>".to_string(),
                 message: http::error_message(&source),
-            })?;
+            }
+        })?;
         Ok(Self {
             client,
             hf_token: hf_token_from_env(),
@@ -1745,7 +2796,7 @@ fn hf_token_allowed_for_host(host: Option<&str>) -> bool {
 }
 
 impl DownloadClient for HttpDownloadClient {
-    fn open(&mut self, url: &str, range_start: Option<u64>) -> Result<DownloadResponse, PullError> {
+    fn open(&mut self, url: &str, range: Option<ByteRange>) -> Result<DownloadResponse, PullError> {
         let mut current = url.to_string();
         let mut redirect_cookies: Vec<RedirectCookie> = Vec::new();
         for _ in 0..=DOWNLOAD_MAX_REDIRECTS {
@@ -1770,8 +2821,8 @@ impl DownloadClient for HttpDownloadClient {
                     request = request.header(reqwest::header::COOKIE, scoped.join("; "));
                 }
             }
-            if let Some(start) = range_start {
-                request = request.header(reqwest::header::RANGE, format!("bytes={start}-"));
+            if let Some(range) = range {
+                request = request.header(reqwest::header::RANGE, range.header_value());
             }
             let response = request.send().map_err(|source| PullError::Http {
                 url: url.to_string(),
@@ -1808,7 +2859,15 @@ impl DownloadClient for HttpDownloadClient {
                 content_length,
                 content_range,
                 etag,
-                reader: Box::new(response),
+                // `blocking_client_no_redirect` deliberately sets no total
+                // request timeout (see its doc comment), so a single `read`
+                // on this response body could otherwise hang indefinitely on
+                // a connection that goes silently dead without an error or
+                // EOF. `StallGuardedReader` bounds that per-read wait.
+                reader: Box::new(StallGuardedReader::new(
+                    Box::new(response),
+                    HTTP_STALL_TIMEOUT,
+                )),
             });
         }
         Err(PullError::Http {
@@ -1908,7 +2967,10 @@ fn is_retryable_download_error(error: &PullError) -> bool {
         PullError::Http { .. }
         | PullError::Io { .. }
         | PullError::RestartedPartial { .. }
-        | PullError::SizeMismatch { .. } => true,
+        | PullError::SizeMismatch { .. }
+        | PullError::EtagChanged { .. }
+        | PullError::SegmentSizeMismatch { .. }
+        | PullError::SegmentRangeMismatch { .. } => true,
         PullError::UnexpectedStatus { status, .. } => *status >= 500,
         _ => false,
     }
@@ -1923,7 +2985,10 @@ fn is_source_fallback_error(error: &PullError) -> bool {
         | PullError::ShaMismatch { .. }
         | PullError::GgufPreflight { .. }
         | PullError::BackendFilePreflight { .. }
-        | PullError::RuntimeValidation { .. } => true,
+        | PullError::RuntimeValidation { .. }
+        | PullError::EtagChanged { .. }
+        | PullError::SegmentSizeMismatch { .. }
+        | PullError::SegmentRangeMismatch { .. } => true,
         PullError::UnexpectedStatus { status, .. } => *status >= 500,
         _ => false,
     }

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -2,11 +2,12 @@ use std::{
     cell::Cell,
     collections::VecDeque,
     fs,
-    io::{self, Cursor, Read},
+    io::{self, Cursor, Read, Write},
+    net::TcpListener,
     path::Path,
     sync::{
         Arc, Barrier, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -58,7 +59,8 @@ impl FakeClient {
 }
 
 impl DownloadClient for FakeClient {
-    fn open(&mut self, url: &str, range_start: Option<u64>) -> Result<DownloadResponse, PullError> {
+    fn open(&mut self, url: &str, range: Option<ByteRange>) -> Result<DownloadResponse, PullError> {
+        let range_start = range.map(|range| range.start);
         self.urls.lock().unwrap().push(url.to_string());
         self.ranges.lock().unwrap().push(range_start);
         let response = self
@@ -124,8 +126,9 @@ impl DownloadClient for StalledThenSuccessClient {
     fn open(
         &mut self,
         _url: &str,
-        range_start: Option<u64>,
+        range: Option<ByteRange>,
     ) -> Result<DownloadResponse, PullError> {
+        let range_start = range.map(|range| range.start);
         self.ranges.push(range_start);
         self.attempts += 1;
         let reader: Box<dyn Read> = match (&self.first_response, self.attempts) {
@@ -188,8 +191,9 @@ impl DownloadClient for InvalidRangeThenSuccessClient {
     fn open(
         &mut self,
         _url: &str,
-        range_start: Option<u64>,
+        range: Option<ByteRange>,
     ) -> Result<DownloadResponse, PullError> {
+        let range_start = range.map(|range| range.start);
         self.ranges.push(range_start);
         self.attempts += 1;
         if self.attempts == 1 {
@@ -210,6 +214,107 @@ impl DownloadClient for InvalidRangeThenSuccessClient {
             etag: Some("etag-test".to_string()),
             reader: Box::new(Cursor::new(self.bytes.clone())),
         })
+    }
+}
+
+/// A range-aware mock `DownloadClient` for the concurrent chunked-download
+/// tests. Unlike `FakeClient`'s fixed response queue (which assumes requests
+/// arrive in a known sequential order), this serves any requested byte range
+/// directly out of an in-memory buffer -- exactly how a real Range server
+/// behaves -- so it gives deterministic, byte-correct responses regardless
+/// of which order concurrent worker threads happen to issue requests in.
+#[derive(Clone)]
+struct RangeServerClient {
+    bytes: Arc<Vec<u8>>,
+    supports_range: Arc<AtomicBool>,
+    /// ETags served in call order: the Nth call gets
+    /// `etags[min(N, etags.len() - 1)]`, so a test can make the ETag change
+    /// after a fixed number of requests to simulate a mid-download CDN swap.
+    etags: Arc<Vec<String>>,
+    calls: Arc<AtomicUsize>,
+    requests: Arc<Mutex<Vec<(u64, Option<u64>)>>>,
+}
+
+impl RangeServerClient {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes: Arc::new(bytes),
+            supports_range: Arc::new(AtomicBool::new(true)),
+            etags: Arc::new(vec!["etag-a".to_string()]),
+            calls: Arc::new(AtomicUsize::new(0)),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn without_range_support(self) -> Self {
+        self.supports_range.store(false, Ordering::SeqCst);
+        self
+    }
+
+    fn with_etag_sequence(mut self, etags: &[&str]) -> Self {
+        self.etags = Arc::new(etags.iter().map(|etag| etag.to_string()).collect());
+        self
+    }
+
+    fn requests(&self) -> Vec<(u64, Option<u64>)> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl DownloadClient for RangeServerClient {
+    fn open(
+        &mut self,
+        _url: &str,
+        range: Option<ByteRange>,
+    ) -> Result<DownloadResponse, PullError> {
+        let call_index = self.calls.fetch_add(1, Ordering::SeqCst);
+        self.requests.lock().unwrap().push((
+            range.map(|r| r.start).unwrap_or(0),
+            range.and_then(|r| r.end),
+        ));
+        let etag = self.etags[call_index.min(self.etags.len() - 1)].clone();
+        let total = self.bytes.len() as u64;
+        if !self.supports_range.load(Ordering::SeqCst) || range.is_none() {
+            return Ok(DownloadResponse {
+                status: 200,
+                content_length: Some(total),
+                content_range: None,
+                etag: Some(etag),
+                reader: Box::new(Cursor::new(self.bytes.as_ref().clone())),
+            });
+        }
+        let range = range.expect("checked above");
+        let end = range
+            .end
+            .unwrap_or(total.saturating_sub(1))
+            .min(total.saturating_sub(1));
+        let start = range.start.min(end);
+        let slice = self.bytes[start as usize..=end as usize].to_vec();
+        Ok(DownloadResponse {
+            status: 206,
+            content_length: Some(slice.len() as u64),
+            content_range: Some(format!("bytes {start}-{end}/{total}")),
+            etag: Some(etag),
+            reader: Box::new(Cursor::new(slice)),
+        })
+    }
+}
+
+/// A segment size that splits `total` bytes into roughly `segments` chunks,
+/// for tests that need real multi-segment behavior without multi-hundred-MB
+/// fixtures (see `PullOptions::parallel_segment_bytes_override`).
+fn small_segment_bytes(total: usize, segments: u64) -> u64 {
+    ((total as u64) / segments).max(1)
+}
+
+fn parallel_test_options(segment_bytes: u64) -> PullOptions {
+    PullOptions {
+        parallel_segment_bytes_override: Some(segment_bytes),
+        ..PullOptions::default()
     }
 }
 
@@ -721,6 +826,7 @@ fn pull_falls_back_to_next_source_after_sha_mismatch() {
         &mut client,
         PullOptions::default(),
         &[DownloadSource::Hf, DownloadSource::HfMirror],
+        None,
         |_| {},
         || false,
         || false,
@@ -758,6 +864,7 @@ fn pinned_source_does_not_fallback_after_sha_mismatch() {
         &mut client,
         PullOptions::default(),
         &[DownloadSource::Hf],
+        None,
         |_| {},
         || false,
         || false,
@@ -2133,5 +2240,401 @@ fn remove_existing_final_pack_reports_model_in_use_for_held_handle() {
     assert!(
         matches!(error, PullError::ModelInUse { .. }),
         "expected ModelInUse, got {error:?}"
+    );
+}
+
+// -- Concurrent chunked-download tests -------------------------------------
+//
+// These exercise `download_parallel_attempt` and friends via
+// `pull_model_pack_with_client_parallel`, using `RangeServerClient` (a
+// range-aware mock that serves any byte range from an in-memory buffer,
+// independent of request order) plus a small `parallel_segment_bytes_override`
+// so multi-segment behavior is exercised against tiny fixtures.
+
+/// Build a probe-client clone (for the caller's primary `client: &mut C`)
+/// plus a boxed worker-client factory, both backed by clones of `server`.
+/// Every clone shares the same `Arc`-backed state (bytes, ETag sequence,
+/// call counter, request log), so assertions against `server` after the
+/// pull see everything every worker thread (and the probe) did. Returns a
+/// concrete `Box<dyn Fn>` (rather than `-> impl Fn`) purely to sidestep
+/// edition-2024 RPIT lifetime-capture rules for a helper that borrows
+/// `server` only to clone it.
+fn parallel_probe_and_factory(
+    server: &RangeServerClient,
+) -> (
+    RangeServerClient,
+    Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>>,
+) {
+    let probe_client = server.clone();
+    let factory_server = server.clone();
+    let factory: Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>> =
+        Box::new(move || Ok(Box::new(factory_server.clone()) as BoxedDownloadClient));
+    (probe_client, factory)
+}
+
+#[test]
+fn parallel_download_splits_into_segments_and_reassembles_correctly() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 5);
+    let total_segments = segment_count(bytes.len() as u64, segment_bytes);
+    assert!(
+        total_segments >= 2,
+        "fixture too small to exercise chunking"
+    );
+
+    let server = RangeServerClient::new(bytes.clone());
+    let (mut probe_client, factory) = parallel_probe_and_factory(&server);
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    let installed = pull_model_pack_with_client_parallel(
+        &resolved,
+        temp.path(),
+        &mut probe_client,
+        parallel_test_options(segment_bytes),
+        parallel,
+        |_| {},
+        || false,
+        || false,
+    )
+    .unwrap();
+
+    assert_eq!(installed.pull, "moonshine-tiny:q8");
+    let paths = paths_for(temp.path(), &resolved);
+    assert_eq!(fs::read(&paths.final_path).unwrap(), bytes);
+    assert!(!paths.partial_path.exists());
+    assert!(!paths.partial_segments_meta_path.exists());
+    assert_eq!(server.call_count(), total_segments);
+    // Every request is a genuinely bounded Range (has an explicit `end`),
+    // confirming this went through the chunked path, not a bare open-ended
+    // sequential fetch that happened to succeed.
+    for (_, end) in server.requests() {
+        assert!(end.is_some());
+    }
+}
+
+#[test]
+fn parallel_download_falls_back_to_sequential_when_source_ignores_range() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+
+    let server = RangeServerClient::new(bytes.clone()).without_range_support();
+    let (mut probe_client, factory) = parallel_probe_and_factory(&server);
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    let installed = pull_model_pack_with_client_parallel(
+        &resolved,
+        temp.path(),
+        &mut probe_client,
+        parallel_test_options(segment_bytes),
+        parallel,
+        |_| {},
+        || false,
+        || false,
+    )
+    .unwrap();
+
+    assert_eq!(installed.pull, "moonshine-tiny:q8");
+    let paths = paths_for(temp.path(), &resolved);
+    assert_eq!(fs::read(&paths.final_path).unwrap(), bytes);
+    assert!(!paths.partial_segments_meta_path.exists());
+    // One wasted probe (200, ignored) plus one real single-stream fetch.
+    assert_eq!(server.call_count(), 2);
+}
+
+#[test]
+fn parallel_download_restarts_whole_download_when_etag_changes_mid_download() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let total_segments = segment_count(bytes.len() as u64, segment_bytes);
+    assert!(total_segments >= 2, "fixture too small for this ETag test");
+
+    // Call 0 (the synchronous probe) gets "etag-a"; every later call (every
+    // worker's first segment fetch) is clamped to the sequence's last entry,
+    // "etag-b" -- deterministically regardless of thread scheduling. So
+    // attempt 1 always: probes with "etag-a", then every worker sees
+    // "etag-b" and fails with `EtagChanged`, wiping the partial. Attempt 2's
+    // probe then itself gets "etag-b" (still the last entry) and every
+    // following call keeps matching it, so the retry succeeds cleanly.
+    let server = RangeServerClient::new(bytes.clone()).with_etag_sequence(&["etag-a", "etag-b"]);
+    let (mut probe_client, factory) = parallel_probe_and_factory(&server);
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    let installed = pull_model_pack_with_client_parallel(
+        &resolved,
+        temp.path(),
+        &mut probe_client,
+        parallel_test_options(segment_bytes),
+        parallel,
+        |_| {},
+        || false,
+        || false,
+    )
+    .unwrap();
+
+    assert_eq!(installed.pull, "moonshine-tiny:q8");
+    let paths = paths_for(temp.path(), &resolved);
+    assert_eq!(fs::read(&paths.final_path).unwrap(), bytes);
+    assert!(!paths.partial_path.exists());
+    assert!(!paths.partial_segments_meta_path.exists());
+    // At least one full failed attempt (whose segment fetches all errored)
+    // plus one fully successful attempt happened.
+    assert!(server.call_count() > total_segments);
+}
+
+#[test]
+fn parallel_download_resumes_from_segment_bitmap_without_refetching_done_segments() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let target = PullTarget::from_resolved(&resolved).unwrap();
+    let paths = pull_paths(temp.path(), &target).unwrap();
+    ensure_storage_dir_within_root(temp.path(), &paths).unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let total_segments = segment_count(bytes.len() as u64, segment_bytes);
+    assert!(
+        total_segments >= 3,
+        "fixture too small for this bitmap test"
+    );
+
+    // Pre-seed the on-disk state exactly as a prior (interrupted) attempt
+    // would leave it after segment 0 completed: a full-size `.partial` file
+    // with segment 0's window already correct (the rest is unwritten/zero)
+    // and a segment bitmap marking only index 0 done.
+    let (seg0_start, seg0_end) = segment_range(0, bytes.len() as u64, segment_bytes);
+    let mut partial_content = vec![0_u8; bytes.len()];
+    partial_content[seg0_start as usize..=seg0_end as usize]
+        .copy_from_slice(&bytes[seg0_start as usize..=seg0_end as usize]);
+    fs::write(&paths.partial_path, &partial_content).unwrap();
+    let mut segments_done = vec![false; total_segments];
+    segments_done[0] = true;
+    let meta = SegmentedPartialMeta {
+        format: PARALLEL_META_FORMAT.to_string(),
+        model_id: target.model_id.clone(),
+        quant: target.quant.clone(),
+        filename: target.filename.clone(),
+        hf_revision: target.hf_revision.clone(),
+        sha256: target.sha256.clone(),
+        size_bytes: target.size_bytes,
+        segment_bytes,
+        etag: Some("etag-a".to_string()),
+        segments_done,
+        updated_at_unix_seconds: 0,
+    };
+    write_partial_segments_meta(&paths.partial_segments_meta_path, &meta).unwrap();
+
+    let server = RangeServerClient::new(bytes.clone()).with_etag_sequence(&["etag-a"]);
+    let (mut probe_client, factory) = parallel_probe_and_factory(&server);
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    let installed = pull_model_pack_with_client_parallel(
+        &resolved,
+        temp.path(),
+        &mut probe_client,
+        parallel_test_options(segment_bytes),
+        parallel,
+        |_| {},
+        || false,
+        || false,
+    )
+    .unwrap();
+
+    assert_eq!(installed.pull, "moonshine-tiny:q8");
+    assert_eq!(fs::read(&paths.final_path).unwrap(), bytes);
+    // Segment 0's byte range is never requested again.
+    for (start, _) in server.requests() {
+        assert_ne!(
+            start, seg0_start,
+            "already-completed segment 0 should not be refetched"
+        );
+    }
+    assert_eq!(server.call_count(), total_segments - 1);
+}
+
+#[test]
+fn parallel_download_cancel_deletes_partial_and_allows_clean_restart() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+
+    let server = RangeServerClient::new(bytes.clone());
+    let (mut probe_client, factory) = parallel_probe_and_factory(&server);
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+    let cancel = Arc::new(AtomicBool::new(false));
+    let cancel_on_progress = cancel.clone();
+
+    let error = pull_model_pack_with_client_parallel(
+        &resolved,
+        temp.path(),
+        &mut probe_client,
+        parallel_test_options(segment_bytes),
+        parallel,
+        move |event| {
+            if matches!(event, PullProgress::Downloading { .. }) {
+                cancel_on_progress.store(true, Ordering::SeqCst);
+            }
+        },
+        move || cancel.load(Ordering::SeqCst),
+        || false,
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, PullError::Canceled { .. }));
+    let paths = paths_for(temp.path(), &resolved);
+    assert!(!paths.partial_path.exists());
+    assert!(!paths.partial_segments_meta_path.exists());
+    assert!(!paths.final_path.exists());
+
+    // A fresh, uncanceled pull afterward succeeds cleanly.
+    let server2 = RangeServerClient::new(bytes.clone());
+    let (mut probe_client2, factory2) = parallel_probe_and_factory(&server2);
+    let parallel2 = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory2,
+    };
+    let installed = pull_model_pack_with_client_parallel(
+        &resolved,
+        temp.path(),
+        &mut probe_client2,
+        parallel_test_options(segment_bytes),
+        parallel2,
+        |_| {},
+        || false,
+        || false,
+    )
+    .unwrap();
+    assert_eq!(installed.pull, "moonshine-tiny:q8");
+    assert_eq!(fs::read(&paths.final_path).unwrap(), bytes);
+}
+
+#[test]
+fn parallel_download_sha_mismatch_deletes_partial() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let mut corrupted = bytes.clone();
+    let mid = corrupted.len() / 2;
+    corrupted[mid] ^= 0x01;
+
+    // The source serves bit-flipped bytes, but `resolved` is still pinned to
+    // the original (correct) sha256/size -- every segment fetch and the
+    // per-segment content-range/ETag checks succeed, so only the final
+    // full-file re-hash catches this.
+    let server = RangeServerClient::new(corrupted);
+    let (mut probe_client, factory) = parallel_probe_and_factory(&server);
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    let error = pull_model_pack_with_client_parallel(
+        &resolved,
+        temp.path(),
+        &mut probe_client,
+        parallel_test_options(segment_bytes),
+        parallel,
+        |_| {},
+        || false,
+        || false,
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, PullError::ShaMismatch { .. }));
+    let paths = paths_for(temp.path(), &resolved);
+    assert!(!paths.partial_path.exists());
+    assert!(!paths.partial_segments_meta_path.exists());
+    assert!(!paths.final_path.exists());
+}
+
+/// Regression guard: `reqwest::blocking::ClientBuilder::timeout` defaults to
+/// `Some(Duration::from_secs(30))` even when `.timeout()` is never called
+/// (see `Timeout::default()` in reqwest's blocking client), and it caps
+/// connect + send + the ENTIRE response body read as a single deadline that
+/// keeps ticking while the body streams -- not an idle/stall timeout. A
+/// prior version of `blocking_client_no_redirect` passed
+/// `HTTP_STALL_TIMEOUT` (30s) straight into `.timeout(...)`, so any download
+/// whose wall-clock time exceeded 30 seconds -- every real multi-hundred-MB
+/// model pack on any non-trivial connection -- was silently killed
+/// regardless of active progress, before the low-speed/stall detection ever
+/// got a chance to run. This drives a real socket that dribbles the body
+/// slowly over > 30 seconds through the exact client constructor
+/// `HttpDownloadClient::new` uses, and asserts the transfer still completes.
+#[test]
+fn download_client_does_not_kill_a_slow_but_steadily_progressing_transfer() {
+    let body: Vec<u8> = (0_u8..32).cycle().take(32 * 16).collect();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server_body = body.clone();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        // Drain the request line and headers up to the blank-line terminator;
+        // this test never inspects it (a bare GET is all `reqwest` sends).
+        let mut request = Vec::new();
+        let mut buf = [0_u8; 4096];
+        loop {
+            let read = stream.read(&mut buf).unwrap();
+            request.extend_from_slice(&buf[..read]);
+            if read == 0 || request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        let header = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            server_body.len()
+        );
+        stream.write_all(header.as_bytes()).unwrap();
+        stream.flush().unwrap();
+        // 32 chunks of 16 bytes, paced 1 second apart (31 sleeps): a >= 31s
+        // transfer, comfortably past the historical 30s bug boundary, while
+        // keeping the data volume itself trivial.
+        let chunk_size = 16;
+        for (index, chunk) in server_body.chunks(chunk_size).enumerate() {
+            if index > 0 {
+                std::thread::sleep(Duration::from_secs(1));
+            }
+            stream.write_all(chunk).unwrap();
+            stream.flush().unwrap();
+        }
+    });
+
+    let client = http::blocking_client_no_redirect(HTTP_CONNECT_TIMEOUT).unwrap();
+    let started = Instant::now();
+    let mut response = client
+        .get(format!("http://{addr}/slow-file"))
+        .send()
+        .unwrap();
+    let mut received = Vec::new();
+    response.read_to_end(&mut received).unwrap();
+    let elapsed = started.elapsed();
+    server.join().unwrap();
+
+    assert_eq!(received, body);
+    assert!(
+        elapsed >= Duration::from_secs(30),
+        "expected the transfer to genuinely take >= 30s (was {elapsed:?}); a shorter \
+         elapsed time here means this test stopped exercising the historical 30s \
+         total-timeout bug"
     );
 }

--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -684,6 +684,41 @@ pub struct ResolvedCatalogPull {
     pub license_class: LicenseClass,
 }
 
+impl ResolvedCatalogPull {
+    /// Build a `ResolvedCatalogPull` from a matched `(model, quant)` pair.
+    /// `requested` is the only field that isn't derived from `model`/`quant`
+    /// -- callers resolving a user-typed reference pass that reference
+    /// through verbatim; callers matching by some other identity (e.g. a
+    /// local file's sha256/size digest) pass `quant.pull.clone()` so
+    /// `requested` still reads as a valid pull spec. Shared by
+    /// [`resolve_catalog_pull`] and [`crate::pull::resolve_catalog_pull_by_file_digest`]
+    /// so the 12 fields mapped straight from `model`/`quant` can't drift
+    /// between the two call sites.
+    pub fn from_model_and_quant(
+        model: &CatalogModel,
+        quant: &CatalogQuant,
+        requested: String,
+    ) -> Self {
+        Self {
+            requested,
+            model_id: model.id.clone(),
+            display_name: model.display_name.clone(),
+            quant: quant.quant.clone(),
+            suffix: quant.suffix.clone(),
+            pull: quant.pull.clone(),
+            filename: quant.filename.clone(),
+            url: quant.url.clone(),
+            mirrors: quant.mirrors.clone(),
+            hf_revision: model.hf_revision.clone(),
+            sha256: quant.sha256.clone(),
+            size_bytes: quant.size_bytes,
+            license: model.license.clone(),
+            license_url: model.license_url.clone(),
+            license_class: model.license_class.clone(),
+        }
+    }
+}
+
 /// A resolved backend-pack pull: the pack identity plus the files to download
 /// into `OPENASR_HOME/backends/<vendor>/<version>/`. The download orchestration
 /// fetches each file (sha256-verified, then [`crate::pull::preflight_backend_file`]),
@@ -1164,23 +1199,11 @@ pub fn resolve_catalog_pull_with_profile(
         (explicit, _) => resolve_catalog_quant(model, explicit)?,
     };
 
-    Ok(ResolvedCatalogPull {
-        requested: requested.to_string(),
-        model_id: model.id.clone(),
-        display_name: model.display_name.clone(),
-        quant: quant.quant.clone(),
-        suffix: quant.suffix.clone(),
-        pull: quant.pull.clone(),
-        filename: quant.filename.clone(),
-        url: quant.url.clone(),
-        mirrors: quant.mirrors.clone(),
-        hf_revision: model.hf_revision.clone(),
-        sha256: quant.sha256.clone(),
-        size_bytes: quant.size_bytes,
-        license: model.license.clone(),
-        license_url: model.license_url.clone(),
-        license_class: model.license_class.clone(),
-    })
+    Ok(ResolvedCatalogPull::from_model_and_quant(
+        model,
+        quant,
+        requested.to_string(),
+    ))
 }
 
 pub fn load_registry(path: impl AsRef<Path>) -> Result<Vec<ModelCard>, RegistryError> {


### PR DESCRIPTION
## Summary

Model-pack downloads now split large packs into fixed 64 MiB segments fetched
over up to `OPENASR_PULL_CONNECTIONS` (default 4, clamped to 8) concurrent
`Range` requests instead of one single-stream 64 KB-buffered read loop.
Small packs (< 2 segments) and `OPENASR_PULL_CONNECTIONS=1` are unaffected
(single-stream path, byte-for-byte unchanged).

Also fixes two issues an audit found in the same file (folded in per the
instruction that touched this file, so a second PR doesn't immediately
conflict):

- **Reliability bug**: the model-pack download client passed a
  stall-detection duration into reqwest's blocking `ClientBuilder::timeout`,
  which is a *total* request timeout (connect + send + the entire response
  body read as one deadline), and which reqwest defaults to 30s even if
  never called explicitly. Every download whose wall-clock time exceeded
  30s -- i.e. every real multi-hundred-MB pack on any non-trivial connection
  -- was silently killed regardless of active progress, before the existing
  app-level low-speed detector (`LowSpeedWindow`) ever got a chance to run.
- Deduplicated the 12-field `(CatalogModel, CatalogQuant) ->
  ResolvedCatalogPull` construction, previously hand-written twice
  (`registry.rs` and `pull.rs`), into `ResolvedCatalogPull::from_model_and_quant`.

## Why

Large packs (multi-hundred MB to a few GB) were bottlenecked on a single
HTTP stream's throughput against all three sources
(`weights.openasr.org` / `hf-mirror.com` / `huggingface.co`), all of which
support `Range`/206. The reliability bug was found during the same audit and
sits in code this PR already touches.

## Changes

- `crates/openasr-core/src/pull.rs`:
  - `DownloadClient::open` now takes a bounded-or-open-ended `ByteRange`
    (`bytes=start-` for resume, `bytes=start-end` for a segment) instead of
    a bare `Option<u64>` start offset.
  - New `SegmentedPartialMeta` (format `segmented-v1`) persisted as a
    **separate** `<filename>.partial.segments.json` file (not a new variant
    of the existing `.partial.meta.json`), so the single-stream resume path
    and its tests are completely untouched.
  - `download_parallel_attempt`: loads/initializes the segment bitmap,
    probes the first missing segment synchronously (confirms `Range`
    support + establishes the reference ETag, and its bytes are kept -- not
    wasted), then spawns `min(connections, remaining segments)` worker
    threads (`std::thread` + `mpsc`, no tokio) pulling segment indices off a
    shared queue and writing directly into a preallocated full-size
    `.partial` file at each segment's offset. Progress and segment-done
    events flow back over a channel to the caller's thread, which is the
    only thread that polls `should_cancel`/`should_pause` and calls the
    `progress` callback -- same single-thread-owns-those-callbacks shape the
    existing single-stream path already has.
  - `download_with_retries` dispatches to the parallel path only when
    eligible (`connections > 1` and `size_bytes >= 2 * segment_bytes`);
    a `200` on the probe (source ignores `Range`) falls back to the
    existing single-stream path for the rest of that call, without
    re-probing on every retry.
  - `StallGuardedReader` (see reliability fix above) + the `.timeout(None)`
    fix in `http.rs`.
  - `ResolvedCatalogPull::from_model_and_quant` moved into `registry.rs`,
    used by both `resolve_catalog_pull` (registry.rs) and
    `resolve_catalog_pull_by_file_digest` (pull.rs).
- `crates/openasr-core/src/http.rs`: `blocking_client_no_redirect` drops the
  `timeout` parameter and explicitly calls `.timeout(None)`.
- `crates/openasr-core/src/registry.rs`: `ResolvedCatalogPull::from_model_and_quant`.
- `crates/openasr-core/src/pull_tests.rs`: `RangeServerClient` (a range-aware
  mock DownloadClient, order-independent unlike the existing `FakeClient`
  queue) + 6 chunked-download tests + 1 real-socket regression test for the
  timeout fix.

## Design tradeoffs

**Hash cursor vs. full reread (both allowed by the task, one chosen):**
chose **full-file reread** after every segment lands, reusing the existing
`file_size_and_sha256` helper the single-stream "already fully resumed"
shortcut already uses. Segments complete out of order across threads; an
incrementally-advancing hash cursor would need to stall on gaps to hash
strictly in byte order, which defeats the point of concurrency. The reread
costs one sequential disk pass, which is fast next to network transfer.

**Backward compat for the partial-meta format:** a resume only reuses a
segment bitmap that parses as the current `SegmentedPartialMeta` shape,
matches the target's content identity, was built with the same segment
size, and whose `.partial` file is already at full preallocated size.
Anything else -- including a legacy single-stream `.partial` from before
this feature -- is **not** reinterpreted; `cleanup_partial` wipes both
partial files and the download restarts from segment 0. Chosen over trying
to guess a foreign file's layout.

**ETag cross-segment check:** a synchronous probe on the first missing
segment establishes a reference ETag before any worker spawns (deterministic
identity, no first-to-finish race). Every worker's segment response is
checked against it; a mismatch wipes the whole partial (bytes from two
object versions can't be selectively resumed) and the outer retry loop
restarts clean. Ordinary per-segment I/O errors do **not** trigger this wipe
-- only an ETag mismatch does; a transient error just retries that one
segment via the on-disk bitmap.

**Reliability fix, no true idle/read timeout on `reqwest::blocking`:**
`reqwest::blocking::ClientBuilder` only exposes a total `.timeout()`, not
the async client's `.read_timeout()`. `StallGuardedReader` reimplements the
equivalent at the application layer: the real body read runs on a
background thread relaying chunks over a bounded channel, and the
foreground `Read::read` bounds its wait with `recv_timeout`. Residual gap:
if the *background* thread's own read is what's hung, that one thread
leaks until the OS eventually tears down the dead connection -- bounded in
count by the connection concurrency limit, and an explicit tradeoff over an
unbounded hang.

## Semantic guarantee checklist

- [x] sha256 verified against the catalog-pinned digest for every install,
      chunked or not (`verify_partial_and_install`, unchanged, shared by
      both paths).
- [x] ETag mismatch across segments invalidates and restarts the whole
      download (probe-time check with the stored reference, and a
      per-segment check against workers) -- test:
      `parallel_download_restarts_whole_download_when_etag_changes_mid_download`.
- [x] Segment bitmap resume skips already-completed segments and never
      redownloads them -- test:
      `parallel_download_resumes_from_segment_bitmap_without_refetching_done_segments`.
- [x] `200` (Range ignored) falls back to the existing single-stream path,
      unchanged -- test:
      `parallel_download_falls_back_to_sequential_when_source_ignores_range`.
- [x] Cancel deletes the partial (both `.partial` and the segments meta) and
      a fresh pull afterward succeeds cleanly -- test:
      `parallel_download_cancel_deletes_partial_and_allows_clean_restart`.
- [x] sha mismatch (server silently serves wrong bytes) deletes the partial
      -- test: `parallel_download_sha_mismatch_deletes_partial`.
- [x] Multi-segment reassembly is byte-correct -- test:
      `parallel_download_splits_into_segments_and_reassembles_correctly`.
- [x] Progress (`PullProgress::Downloading`) is a monotonically increasing
      cumulative byte count across all concurrent segments, never derived
      from an individual segment's file offset.
- [x] Source routing/fallback chain, consent flow, server-never-downloads,
      and CLI-only-pull semantics: untouched.
- [x] No tokio introduced into `openasr-core`; concurrency is `std::thread` +
      `std::sync::mpsc`, matching the existing blocking-reqwest style.
- [x] Total-request-timeout reliability bug: fixed for the download client
      only; the catalog-fetch client (`registry.rs`) is untouched -- test
      (real socket, no mock): `download_client_does_not_kill_a_slow_but_steadily_progressing_transfer`
      (drives a >=31s dribbled transfer through the exact client constructor
      `HttpDownloadClient::new` uses).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (workspace)
- [x] `cargo nextest run --workspace` -- 2263 passed, 0 failed
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` -- advisories ok, bans ok, licenses ok, sources ok

## Manual smoke checks

Real network, `whisper-medium:q8_0` (874,284,640 bytes, Apache-2.0), built
`--release`, fresh `OPENASR_HOME` per run so nothing resumes across runs.
All runs verified sha256 successfully (no corruption in any run).

`weights.openasr.org` source, 4 back-to-back A/B pairs:

| run | `OPENASR_PULL_CONNECTIONS=1` | `OPENASR_PULL_CONNECTIONS=4` |
|-----|------|------|
| 1 | 38.97s | 28.91s |
| 2 | 22.04s | 24.79s |
| 3 | 21.82s | 25.22s |
| 4 | 22.07s | 36.24s |
| **median** | **22.06s (~39.6 MB/s)** | **27.07s (~32.7 MB/s)** |

Direct `huggingface.co` source, one pair: single 22.38s, 4-way 25.18s (same
pattern).

**Honest read of this data**: on today's network path, single-stream
already reaches ~35-40 MB/s to this source -- well above the ~7-12 MB/s
per-stream baseline the design doc's earlier probe measured (and above
which the 64 MiB / 4-connection split was sized against). With a single
stream already close to saturating the path, concurrent chunking has no
slack to reclaim and adds mild overhead (more TLS handshakes, thread/queue
coordination), showing up as a small regression in 3 of 4 runs here. I also
ran an isolated raw-`curl` A/B (bypassing this code entirely, straight range
requests) at a moment when single-stream measured only ~5.3 MB/s: 4-way
concurrent reached ~10.5 MB/s aggregate, a genuine ~2x, confirming the
mechanism does deliver the expected win specifically when a single
connection *is* the bottleneck -- which is the scenario this feature
targets and the scenario the original investigation observed. Network
conditions during this session were also visibly unstable independent of
this change (a bare `curl` single-stream run got cut off at 29 MB with
"transferred a partial file" mid-benchmark), so some of today's variance is
environmental, not code. I'm reporting the numbers as measured rather than
cherry-picking a favorable run.

For the reliability fix specifically: `download_client_does_not_kill_a_slow_but_steadily_progressing_transfer`
is a real-socket regression test (not a mock) that would have failed against
the pre-fix client construction.

## Docs updated

- [x] No README/docs behavior claims changed by this PR (internal pull
      implementation detail; `OPENASR_PULL_CONNECTIONS` is not yet
      documented as a public knob anywhere that needed updating).

## Scope / non-goals

- Does not change source routing/fallback order, consent flow, or the
  operator-gated server pull API.
- Does not touch `download_backend_file` (backend plugin packs) -- those
  are small, single-file downloads where chunking has no payoff.
- Does not touch the catalog-fetch HTTP client (`registry.rs`'s
  `blocking_client`) -- only the model-pack download client's timeout
  behavior changed.
- Does not add a true idle/read timeout via reqwest (not available on
  `reqwest::blocking::ClientBuilder` in the pinned 0.12 line); implements
  the equivalent at the application layer instead (see tradeoffs above).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts,
      secrets, or private audio.
- [x] I did not add vendored runtime sources outside
      `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI
      usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI
      assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with heavy AI (Claude) assistance
  per this repo's AI usage policy; design, code, and tests were reviewed
  against the stated trust-boundary/semantic requirements before submitting.
