### PR TITLE
perf(qwen): flash attention for the audio encoder self-attention

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -28,6 +28,30 @@ const I32_WIDTH_BYTES: usize = std::mem::size_of::<i32>();
 const DEFAULT_CONTEXT_BYTES: usize = 1024 * 1024;
 const DEFAULT_GRAPH_SIZE: usize = 4096;
 
+/// `head_dim` (q/k/v ne0) values the Metal `GGML_OP_FLASH_ATTN_EXT` support
+/// check accepts, mirrored from `ggml-metal-device.m`'s
+/// `ggml_metal_device_supports_op` switch on `GGML_OP_FLASH_ATTN_EXT` ("for
+/// new head sizes, add checks here"). Any other head_dim silently falls back
+/// to a CPU-side (non-Metal) path inside ggml or asserts, depending on ggml
+/// version, so `flash_attn_ext` fails closed here instead of trusting the
+/// caller to have picked a supported head_dim.
+const METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS: &[usize] = &[
+    32, 40, 48, 64, 72, 80, 96, 112, 128, 192, 256, 320, 512, 576,
+];
+
+/// Pure predicate behind `ensure_flash_attn_ext_metal_head_dim_supported`,
+/// pulled out of the tensor-bearing method so the whitelist logic is testable
+/// without standing up a live Metal backend. Only the Metal backend enforces
+/// the whitelist; CPU/Gpu accept any head_dim `flash_attn_ext`'s other shape
+/// checks already allow.
+fn flash_attn_ext_head_dim_supported_on_backend(
+    backend_kind: GgmlCpuGraphBackend,
+    head_dim: usize,
+) -> bool {
+    backend_kind != GgmlCpuGraphBackend::Metal
+        || METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS.contains(&head_dim)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GgmlCpuGraphConfig {
     pub context_bytes: usize,
@@ -610,6 +634,13 @@ pub enum GgmlCpuGraphError {
         axis1: i32,
         axis2: i32,
         axis3: i32,
+    },
+    #[error(
+        "ggml_flash_attn_ext head_dim={head_dim} is not in the Metal backend's supported set {supported:?} (see ggml-metal-device.m FLASH_ATTN_EXT support check); use the naive attention fallback for this head_dim on Metal"
+    )]
+    FlashAttnExtUnsupportedMetalHeadDim {
+        head_dim: usize,
+        supported: &'static [usize],
     },
 }
 
@@ -1635,6 +1666,10 @@ impl GgmlStaticTensorArena {
 }
 
 impl<'a> GgmlCpuGraphBuilder<'a> {
+    pub(crate) fn backend_kind(&self) -> GgmlCpuGraphBackend {
+        self.backend_kind
+    }
+
     pub(crate) fn new_tensor_1d_f32(
         &self,
         len: usize,
@@ -2462,6 +2497,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             });
         }
         self.ensure_flash_attn_ext_compatible(q, k, v)?;
+        self.ensure_flash_attn_ext_metal_head_dim_supported(q)?;
 
         let mask_raw = if let Some(mask) = mask {
             self.ensure_tensor_type(mask, ffi::GGML_TYPE_F16, "ggml_flash_attn_ext mask")?;
@@ -2588,6 +2624,17 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         self.ensure_supported_storage_type(target_type, "ggml_cast target")?;
         let raw = unsafe { ffi::ggml_cast(self.context.as_ptr(), input.raw.as_ptr(), target_type) };
         self.new_tensor_checked(raw, "ggml_cast")
+    }
+
+    /// `cast` specialized to an F16 target, exposed so callers outside this
+    /// module (`ffi::GGML_TYPE_F16` is private to `ggml_runtime`) can convert
+    /// an additive f32 attention mask to the F16 type `flash_attn_ext`
+    /// requires without reaching into the ffi layer themselves.
+    pub(crate) fn cast_to_f16(
+        &self,
+        input: GgmlCpuTensor<'a>,
+    ) -> Result<GgmlCpuTensor<'a>, GgmlCpuGraphError> {
+        self.cast(input, ffi::GGML_TYPE_F16)
     }
 
     pub(crate) fn cont(
@@ -4530,6 +4577,27 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         Ok(())
     }
 
+    /// Metal's `GGML_OP_FLASH_ATTN_EXT` support check only accepts a fixed
+    /// whitelist of head sizes (`METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS`).
+    /// Building the op with an unsupported head_dim on Metal degrades into a
+    /// backend-scheduler fallback or, on some ggml versions, an assert deep in
+    /// the Metal kernel dispatch. Fail closed here with a typed error instead,
+    /// so callers (e.g. a future encoder with head_dim 36/52 such as
+    /// moonshine) can catch it and fall back to the naive attention path.
+    fn ensure_flash_attn_ext_metal_head_dim_supported(
+        &self,
+        q: GgmlCpuTensor<'a>,
+    ) -> Result<(), GgmlCpuGraphError> {
+        let head_dim = self.tensor_shape_4d(q)?[0];
+        if flash_attn_ext_head_dim_supported_on_backend(self.backend_kind, head_dim) {
+            return Ok(());
+        }
+        Err(GgmlCpuGraphError::FlashAttnExtUnsupportedMetalHeadDim {
+            head_dim,
+            supported: METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS,
+        })
+    }
+
     fn validate_permute_axes(
         &self,
         axis0: i32,
@@ -5074,6 +5142,7 @@ mod tests {
     use super::{
         GgmlCpuBinaryOp, GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphCpuAcceleratorPolicy,
         GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuGraphThreadingWorkload, GgmlRopeExtParams,
+        METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS, flash_attn_ext_head_dim_supported_on_backend,
         runtime_gpu_is_available,
     };
 
@@ -6983,6 +7052,71 @@ mod tests {
                     reason: "ggml_flash_attn_ext max_bias > 0 requires a mask tensor",
                 }
             ),
+        }
+    }
+
+    #[test]
+    fn flash_attn_ext_metal_head_dim_whitelist_matches_ggml_metal_device_support_check() {
+        // Every whitelisted head_dim must be accepted on Metal...
+        for &head_dim in METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS {
+            assert!(
+                flash_attn_ext_head_dim_supported_on_backend(GgmlCpuGraphBackend::Metal, head_dim),
+                "head_dim={head_dim} should be Metal-supported"
+            );
+        }
+        // ...and a handful of unsupported values (including moonshine's
+        // relative-position head sizes 36/52, the concrete future-caller risk
+        // this guard exists for) must be rejected on Metal.
+        for head_dim in [1, 16, 36, 52, 60, 100, 200, 577] {
+            assert!(
+                !flash_attn_ext_head_dim_supported_on_backend(GgmlCpuGraphBackend::Metal, head_dim),
+                "head_dim={head_dim} should not be Metal-supported"
+            );
+        }
+        // Cpu/Gpu never enforce the whitelist -- only Metal's kernel dispatch
+        // is fixed to this set of head sizes.
+        for head_dim in [1, 36, 52, 64, 577] {
+            assert!(flash_attn_ext_head_dim_supported_on_backend(
+                GgmlCpuGraphBackend::Cpu,
+                head_dim
+            ));
+            assert!(flash_attn_ext_head_dim_supported_on_backend(
+                GgmlCpuGraphBackend::Gpu,
+                head_dim
+            ));
+        }
+    }
+
+    #[test]
+    fn flash_attn_ext_rejects_unsupported_metal_head_dim_end_to_end() {
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default())
+            .expect("cpu graph runner should initialize");
+        let graph = runner.start_graph();
+        // head_dim=3 is not in the Metal whitelist; the guard must fire even
+        // though this graph never touches a real Metal backend (backend_kind
+        // is a config value the builder carries, independent of which
+        // physical device the test happens to run compute on).
+        let mut metal_graph = graph;
+        metal_graph.backend_kind = GgmlCpuGraphBackend::Metal;
+        let q = metal_graph
+            .new_tensor_4d_f32(3, 1, 1, 1, "q")
+            .expect("q should allocate");
+        let k = metal_graph
+            .new_tensor_4d_f32(3, 2, 1, 1, "k")
+            .expect("k should allocate");
+        let v = metal_graph
+            .new_tensor_4d_f32(3, 2, 1, 1, "v")
+            .expect("v should allocate");
+        match metal_graph.flash_attn_ext(q, k, v, None, 1.0, 0.0, 0.0) {
+            Ok(_) => panic!("flash_attn_ext must reject head_dim=3 on the Metal backend"),
+            Err(GgmlCpuGraphError::FlashAttnExtUnsupportedMetalHeadDim {
+                head_dim,
+                supported,
+            }) => {
+                assert_eq!(head_dim, 3);
+                assert_eq!(supported, METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS);
+            }
+            Err(err) => panic!("unexpected flash_attn_ext error: {err}"),
         }
     }
 

--- a/crates/openasr-core/src/models/qwen/audio_encoder.rs
+++ b/crates/openasr-core/src/models/qwen/audio_encoder.rs
@@ -24,6 +24,19 @@ use super::runtime_contract::Qwen3AsrExecutionMetadata;
 /// graph build/upload; `compute_us` covers the GPU graph compute. Used to
 /// confirm whether the longform encoder bottleneck is upload/setup or compute.
 const QWEN3_ENCODER_PROFILE_ENV: &str = "OPENASR_QWEN_ENCODER_PROFILE";
+
+/// Opt-out escape hatch for `transformer_layer`'s flash-attention branch in
+/// the qwen audio encoder self-attention, mirrored from the Whisper encoder's
+/// `OPENASR_WHISPER_GGML_DISABLE_ENCODER_FLASH_ATTN` convention
+/// (`models/whisper/execution_policy.rs`): fused softmax/scale on a trusted
+/// backend (Metal/CPU), no materialized `[seq, seq]` scores tensor, default
+/// on.
+const OPENASR_QWEN_GGML_DISABLE_AUDIO_ENCODER_FLASH_ATTN: &str =
+    "OPENASR_QWEN_GGML_DISABLE_AUDIO_ENCODER_FLASH_ATTN";
+
+fn qwen_audio_encoder_flash_attention_enabled() -> bool {
+    std::env::var_os(OPENASR_QWEN_GGML_DISABLE_AUDIO_ENCODER_FLASH_ATTN).is_none()
+}
 use super::tensor_names::{
     AUDIO_CONV_OUT_BIAS, AUDIO_CONV_OUT_WEIGHT, AUDIO_CONV1_BIAS, AUDIO_CONV1_WEIGHT,
     AUDIO_CONV2_BIAS, AUDIO_CONV2_WEIGHT, AUDIO_CONV3_BIAS, AUDIO_CONV3_WEIGHT, AUDIO_LN_POST_BIAS,
@@ -503,6 +516,7 @@ fn encode_qwen3_audio_embeddings_with_graph<'a>(
         metadata.audio_heads,
         chunked_mel.row_count,
         mask_tensor,
+        qwen_audio_encoder_flash_attention_enabled(),
     )?;
 
     state = graph
@@ -938,6 +952,7 @@ pub(crate) fn load_qwen3_audio_encoder_weights_from_reader(
 /// `qwen3-asr.audio.n_layers` hparam) and the block KIND is `transformer_layer`
 /// (the descriptor's `TransformerEncoderLayer`). The encoder mirror of the
 /// LlmDecoder composer (S2); the emitted op sequence is unchanged.
+#[allow(clippy::too_many_arguments)]
 fn compose_transformer_encoder_layer_stack<'a>(
     graph: &mut crate::ggml_runtime::GgmlCpuGraphBuilder<'a>,
     mut state: crate::ggml_runtime::GgmlCpuTensor<'a>,
@@ -946,6 +961,7 @@ fn compose_transformer_encoder_layer_stack<'a>(
     attention_heads: usize,
     token_count: usize,
     mask: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    use_flash_attention: bool,
 ) -> Result<crate::ggml_runtime::GgmlCpuTensor<'a>, Qwen3AsrAudioEncoderError> {
     for (layer_idx, tensors) in layer_inputs {
         state = run_audio_encoder_layer(
@@ -956,12 +972,14 @@ fn compose_transformer_encoder_layer_stack<'a>(
             attention_heads,
             token_count,
             mask,
+            use_flash_attention,
             tensors,
         )?;
     }
     Ok(state)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_audio_encoder_layer<'a>(
     graph: &mut crate::ggml_runtime::GgmlCpuGraphBuilder<'a>,
     layer_idx: usize,
@@ -970,6 +988,7 @@ fn run_audio_encoder_layer<'a>(
     attention_heads: usize,
     token_count: usize,
     mask: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    use_flash_attention: bool,
     tensors: &AudioLayerGraphTensors<'a>,
 ) -> Result<crate::ggml_runtime::GgmlCpuTensor<'a>, Qwen3AsrAudioEncoderError> {
     let _ = layer_idx;
@@ -983,6 +1002,7 @@ fn run_audio_encoder_layer<'a>(
             token_count,
             layer_norm_epsilon: QWEN3_AUDIO_LAYER_NORM_EPSILON,
             ffn_activation: FeedForwardActivation::GeluErf,
+            use_flash_attention,
         },
         TransformerEncoderLayerWeights {
             attn_norm_weight: tensors.attn_norm_weight,
@@ -1478,6 +1498,86 @@ mod tests {
         assert!(
             mean_abs_diff < 0.01,
             "audio encoder output diverges from Python reference on average: mean_abs_diff={mean_abs_diff}"
+        );
+    }
+
+    const QWEN_AUDIO_ENCODER_REAL_PACK_ENV: &str = "OPENASR_QWEN_AUDIO_ENCODER_REAL_PACK";
+
+    /// Long-audio degradation guard for the flash-attention self-attention
+    /// path: run the real audio encoder near the family's
+    /// `DEFAULT_ENCODER_SAFE_CHUNK_SECONDS` (30s) chunk cap -- this test does
+    /// NOT change that cap, it only probes flash's numerical behavior at the
+    /// edge of it -- and confirm the output stays finite and bounded over the
+    /// full self-attention sequence length. Dev-machine-only (needs a real
+    /// qwen3-asr `.oasr` pack); skips via `#[ignore]` like the other
+    /// `*_REAL_PACK` harnesses in this family (see `llm_transformer.rs`).
+    #[test]
+    #[ignore = "manual real-pack harness: set OPENASR_QWEN_AUDIO_ENCODER_REAL_PACK to a qwen3-asr .oasr model pack"]
+    fn qwen_audio_encoder_flash_attention_stays_finite_near_chunk_cap() {
+        use std::path::PathBuf;
+
+        use crate::arch::DEFAULT_ENCODER_SAFE_CHUNK_SECONDS;
+        use crate::{read_gguf_metadata_from_runtime_source, validate_ggml_runtime_source_path};
+
+        let pack_path = std::env::var_os(QWEN_AUDIO_ENCODER_REAL_PACK_ENV)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{QWEN_AUDIO_ENCODER_REAL_PACK_ENV} must point to a qwen3-asr .oasr model pack"
+                )
+            });
+
+        let runtime_source =
+            validate_ggml_runtime_source_path(&pack_path).expect("valid qwen3-asr runtime source");
+        let raw_metadata = read_gguf_metadata_from_runtime_source(&runtime_source)
+            .expect("read qwen3-asr runtime metadata");
+        let metadata =
+            super::super::runtime_contract::parse_qwen3_execution_metadata(&raw_metadata)
+                .expect("parse qwen3-asr metadata");
+
+        let reader = GgufTensorDataReader::from_path(&pack_path).expect("gguf reader");
+        let weights = load_qwen3_audio_encoder_weights_from_reader(&reader, metadata)
+            .expect("audio encoder weights");
+
+        // Just under the 30s cap this test deliberately does not touch.
+        let target_seconds = DEFAULT_ENCODER_SAFE_CHUNK_SECONDS - 2.0;
+        let frames_per_second = metadata.sample_rate_hz as usize / metadata.hop_length;
+        let n_frames = (frames_per_second as f32 * target_seconds) as usize;
+        // Deterministic pseudo-mel data (not real speech): this test targets
+        // NUMERICAL degeneration (NaN/Inf/unbounded growth) in the flash
+        // self-attention over a long sequence, which real-speech content
+        // would not exercise any more directly than a dense synthetic signal.
+        let data: Vec<f32> = (0..metadata.n_mels * n_frames)
+            .map(|index| ((index % 97) as f32 - 48.0) / 97.0)
+            .collect();
+        let mel_features = Qwen3AsrMelFeatures {
+            n_mels: metadata.n_mels,
+            n_frames,
+            data,
+        };
+
+        let mut runtime = Qwen3AsrAudioEncoderRuntime::new(Some(&pack_path)).expect("runtime");
+        let output = runtime
+            .encode(&weights, metadata, &mel_features)
+            .expect("encode near the chunk cap");
+
+        assert!(!output.rows.is_empty());
+        assert_eq!(output.rows.len(), output.row_count * metadata.llm_d_model);
+        let mut max_abs = 0.0_f32;
+        for &value in &output.rows {
+            assert!(
+                value.is_finite(),
+                "flash-attention encoder output must stay finite near the chunk cap"
+            );
+            max_abs = max_abs.max(value.abs());
+        }
+        eprintln!(
+            "qwen_audio_encoder_flash_attention_stays_finite_near_chunk_cap: n_frames={n_frames} row_count={} max_abs={max_abs}",
+            output.row_count
+        );
+        assert!(
+            max_abs < 1.0e4,
+            "flash-attention encoder output magnitude blew up near the chunk cap: max_abs={max_abs}"
         );
     }
 }

--- a/crates/openasr-core/src/models/serve_batch_env.rs
+++ b/crates/openasr-core/src/models/serve_batch_env.rs
@@ -913,19 +913,29 @@ mod tests {
         assert_eq!(deferred.into_iter().collect::<Vec<_>>(), vec![2, 4]);
     }
 
+    // The two receiver-draining tests below intentionally use a GENEROUS
+    // collect window and a dropped sender: their loops must terminate via the
+    // batch cap or channel disconnect, never via the wall clock. A tiny (1ms)
+    // window makes the collect loop's `now >= deadline` check a race against
+    // scheduler preemption on a loaded runner -- the loop can expire before
+    // the first `recv_timeout` even runs, silently truncating the batch
+    // (observed as a CI-only flake). The window never actually elapses, so
+    // the generous value does not slow the tests down.
+
     #[test]
     fn serve_batch_drain_compatible_batch_collects_receiver_until_cap() {
         let (sender, receiver) = std::sync::mpsc::channel();
         sender.send(1).expect("first");
         sender.send(2).expect("second");
         sender.send(3).expect("third");
+        drop(sender);
         let mut deferred = VecDeque::new();
 
         let batch = serve_batch_drain_compatible_batch(
             &mut deferred,
             &receiver,
             2,
-            Duration::from_millis(1),
+            Duration::from_secs(30),
             |_, _| true,
         )
         .expect("drained batch");
@@ -948,7 +958,7 @@ mod tests {
             &mut deferred,
             &receiver,
             3,
-            Duration::from_millis(1),
+            Duration::from_secs(30),
             |first, next| first % 2 == next % 2,
         )
         .expect("drained batch");

--- a/crates/openasr-core/src/nn/encoder.rs
+++ b/crates/openasr-core/src/nn/encoder.rs
@@ -557,6 +557,14 @@ pub(crate) struct TransformerEncoderConfig {
     pub token_count: usize,
     pub layer_norm_epsilon: f32,
     pub ffn_activation: FeedForwardActivation,
+    /// Route self-attention through `ggml_flash_attn_ext` instead of the
+    /// naive `mul_mat -> add(mask) -> soft_max_ext` sequence. Mirrors the
+    /// Whisper encoder's `use_flash_attention` convention (see
+    /// `models/whisper/ggml_executor.rs`): fused softmax/scale, no materialized
+    /// `[seq, seq]` scores tensor. Callers building the additive `mask` passed
+    /// to `transformer_layer` keep it f32; the flash branch casts its own
+    /// F16 copy since `flash_attn_ext` requires an F16 contiguous mask.
+    pub use_flash_attention: bool,
 }
 
 /// Per-block graph tensors: attn (norm, q/k/v/out + biases) → ffn (norm,
@@ -661,12 +669,19 @@ where
         "attn_v",
         map_err,
     )?;
+    // Flash-attn on a GPU-class backend consumes strided (permuted, not
+    // `cont`'d) q/k/v views directly -- mirrors the Whisper encoder's
+    // `reshape_encoder_projection_to_heads_for_flash` GPU/CPU split in
+    // `models/whisper/ggml_executor.rs`. The naive path (and flash on CPU)
+    // keeps the original `cont`'d heads unchanged.
+    let use_strided_views = config.use_flash_attention && graph.backend_kind().is_gpu_class();
+    let heads_contiguous = !use_strided_views;
     let q = reshape_projection_to_attention_heads(
         graph,
         q,
         layout,
         STANDARD_HEAD_PERMUTE_AXES,
-        true,
+        heads_contiguous,
         AttentionReshapeSteps {
             reshape: "ggml_reshape_3d(attn_q)",
             permute: "ggml_permute(attn_q)",
@@ -679,7 +694,7 @@ where
         k,
         layout,
         STANDARD_HEAD_PERMUTE_AXES,
-        true,
+        heads_contiguous,
         AttentionReshapeSteps {
             reshape: "ggml_reshape_3d(attn_k)",
             permute: "ggml_permute(attn_k)",
@@ -692,7 +707,7 @@ where
         v,
         layout,
         STANDARD_HEAD_PERMUTE_AXES,
-        true,
+        heads_contiguous,
         AttentionReshapeSteps {
             reshape: "ggml_reshape_3d(attn_v)",
             permute: "ggml_permute(attn_v)",
@@ -700,33 +715,54 @@ where
         },
         map_err,
     )?;
-    let scores = graph
-        .mul_mat(k, q)
-        .map_err(|source| map_err("ggml_mul_mat(attn_scores)", source))?;
-    let scores = graph
-        .add(scores, mask)
-        .map_err(|source| map_err("ggml_add(attn_mask)", source))?;
-    let scores = graph
-        .cont(scores)
-        .map_err(|source| map_err("ggml_cont(attn_scores)", source))?;
-    let scores = graph
-        .soft_max_ext(scores, None, 1.0 / (config.head_dim as f32).sqrt(), 0.0)
-        .map_err(|source| map_err("ggml_soft_max_ext(attn_probs)", source))?;
-    let context = attention_context_from_probs(
-        graph,
-        v,
-        scores,
-        layout,
-        AttentionValueMergeSteps {
-            value_permute: "ggml_permute(attn_v_t)",
-            value_cont: "ggml_cont(attn_v_t)",
-            context_mul: "ggml_mul_mat(attn_context)",
-            context_merge_permute: "ggml_permute(attn_merge)",
-            context_merge_cont: "ggml_cont(attn_merge)",
-            context_merge_reshape: "ggml_reshape_2d(attn_merge)",
-        },
-        map_err,
-    )?;
+    let scale = 1.0 / (config.head_dim as f32).sqrt();
+    let context = if config.use_flash_attention {
+        // `flash_attn_ext` requires an F16 contiguous mask (unlike
+        // `soft_max_ext`, which also accepts f32); cast the caller's additive
+        // f32 padding mask once per layer. See `nn/decoder.rs`'s shared
+        // seq2seq decoder for the same F16-mask convention.
+        let flash_mask = graph
+            .cast_to_f16(mask)
+            .map_err(|source| map_err("ggml_cast(attn_flash_mask)", source))?;
+        let flash = graph
+            .flash_attn_ext(q, k, v, Some(flash_mask), scale, 0.0, 0.0)
+            .map_err(|source| map_err("ggml_flash_attn_ext(attn)", source))?;
+        graph
+            .reshape_2d(
+                flash,
+                config.head_dim * config.attention_heads,
+                config.token_count,
+            )
+            .map_err(|source| map_err("ggml_reshape_2d(attn_flash_merge)", source))?
+    } else {
+        let scores = graph
+            .mul_mat(k, q)
+            .map_err(|source| map_err("ggml_mul_mat(attn_scores)", source))?;
+        let scores = graph
+            .add(scores, mask)
+            .map_err(|source| map_err("ggml_add(attn_mask)", source))?;
+        let scores = graph
+            .cont(scores)
+            .map_err(|source| map_err("ggml_cont(attn_scores)", source))?;
+        let scores = graph
+            .soft_max_ext(scores, None, scale, 0.0)
+            .map_err(|source| map_err("ggml_soft_max_ext(attn_probs)", source))?;
+        attention_context_from_probs(
+            graph,
+            v,
+            scores,
+            layout,
+            AttentionValueMergeSteps {
+                value_permute: "ggml_permute(attn_v_t)",
+                value_cont: "ggml_cont(attn_v_t)",
+                context_mul: "ggml_mul_mat(attn_context)",
+                context_merge_permute: "ggml_permute(attn_merge)",
+                context_merge_cont: "ggml_cont(attn_merge)",
+                context_merge_reshape: "ggml_reshape_2d(attn_merge)",
+            },
+            map_err,
+        )?
+    };
     let attn_out = linear_with_bias(
         graph,
         weights.attn_out_weight,
@@ -1055,4 +1091,238 @@ where
         },
         map_err,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphRunner};
+
+    // Mirrors the tiny fixed-size harness `nn/decoder.rs` uses for its shared
+    // seq2seq block tests (HIDDEN=4, HEAD_DIM=2, HEADS=2): small enough to hand
+    // -verify, big enough to actually exercise 2 attention heads.
+    const HIDDEN: usize = 4;
+    const HEAD_DIM: usize = 2;
+    const HEADS: usize = 2;
+    const TOKENS: usize = 3;
+    const IDENTITY_4X4: [f32; HIDDEN * HIDDEN] = [
+        1.0, 0.0, 0.0, 0.0, //
+        0.0, 1.0, 0.0, 0.0, //
+        0.0, 0.0, 1.0, 0.0, //
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    const ZERO_4X4: [f32; HIDDEN * HIDDEN] = [0.0; HIDDEN * HIDDEN];
+    const NORM_WEIGHT: [f32; HIDDEN] = [1.0; HIDDEN];
+    const ZERO_1D: [f32; HIDDEN] = [0.0; HIDDEN];
+
+    fn identity_map_err(step: &'static str, source: GgmlCpuGraphError) -> GgmlCpuGraphError {
+        let _ = step;
+        source
+    }
+
+    /// Build a tiny `transformer_layer` graph (identity QKV/out projections,
+    /// zero-bias FFN so it degenerates to a residual passthrough after
+    /// attention) and return the computed output. `mask_values` is the raw
+    /// f32 additive mask fed to both the naive and flash branches -- flash
+    /// casts its own F16 copy internally, so this is the one input the two
+    /// branches genuinely share unmodified.
+    fn run_transformer_layer(
+        backend: GgmlCpuGraphBackend,
+        use_flash_attention: bool,
+        state_values: &[f32; HIDDEN * TOKENS],
+        mask_values: &[f32; TOKENS * TOKENS],
+    ) -> Vec<f32> {
+        let config = GgmlCpuGraphConfig {
+            backend,
+            ..GgmlCpuGraphConfig::conservative_default()
+        };
+        let mut runner = GgmlCpuGraphRunner::new(config).expect("cpu graph runner should init");
+        let mut graph = runner.start_graph();
+
+        let input = graph
+            .new_tensor_2d_f32(HIDDEN, TOKENS, "input")
+            .expect("input tensor");
+        let mask = graph
+            .new_tensor_2d_f32(TOKENS, TOKENS, "mask")
+            .expect("mask tensor");
+        let attn_norm_weight = graph
+            .new_tensor_1d_f32(HIDDEN, "attn_norm_weight")
+            .expect("attn_norm_weight");
+        let attn_norm_bias = graph
+            .new_tensor_1d_f32(HIDDEN, "attn_norm_bias")
+            .expect("attn_norm_bias");
+        let attn_q_weight = graph
+            .new_tensor_2d_f32(HIDDEN, HIDDEN, "attn_q_weight")
+            .expect("attn_q_weight");
+        let attn_k_weight = graph
+            .new_tensor_2d_f32(HIDDEN, HIDDEN, "attn_k_weight")
+            .expect("attn_k_weight");
+        let attn_v_weight = graph
+            .new_tensor_2d_f32(HIDDEN, HIDDEN, "attn_v_weight")
+            .expect("attn_v_weight");
+        let attn_out_weight = graph
+            .new_tensor_2d_f32(HIDDEN, HIDDEN, "attn_out_weight")
+            .expect("attn_out_weight");
+        let attn_bias = graph
+            .new_tensor_1d_f32(HIDDEN, "attn_bias")
+            .expect("attn_bias");
+        let ffn_norm_weight = graph
+            .new_tensor_1d_f32(HIDDEN, "ffn_norm_weight")
+            .expect("ffn_norm_weight");
+        let ffn_norm_bias = graph
+            .new_tensor_1d_f32(HIDDEN, "ffn_norm_bias")
+            .expect("ffn_norm_bias");
+        let ffn_up_weight = graph
+            .new_tensor_2d_f32(HIDDEN, HIDDEN, "ffn_up_weight")
+            .expect("ffn_up_weight");
+        let ffn_down_weight = graph
+            .new_tensor_2d_f32(HIDDEN, HIDDEN, "ffn_down_weight")
+            .expect("ffn_down_weight");
+        let ffn_bias = graph
+            .new_tensor_1d_f32(HIDDEN, "ffn_bias")
+            .expect("ffn_bias");
+
+        for tensor in [
+            input,
+            mask,
+            attn_norm_weight,
+            attn_norm_bias,
+            attn_q_weight,
+            attn_k_weight,
+            attn_v_weight,
+            attn_out_weight,
+            attn_bias,
+            ffn_norm_weight,
+            ffn_norm_bias,
+            ffn_up_weight,
+            ffn_down_weight,
+            ffn_bias,
+        ] {
+            graph.set_input(tensor).expect("tensor should be an input");
+        }
+
+        let output = transformer_layer(
+            &mut graph,
+            input,
+            mask,
+            TransformerEncoderConfig {
+                head_dim: HEAD_DIM,
+                attention_heads: HEADS,
+                token_count: TOKENS,
+                layer_norm_epsilon: 1.0e-5,
+                ffn_activation: FeedForwardActivation::GeluErf,
+                use_flash_attention,
+            },
+            TransformerEncoderLayerWeights {
+                attn_norm_weight,
+                attn_norm_bias,
+                attn_q_weight,
+                attn_q_bias: attn_bias,
+                attn_k_weight,
+                attn_k_bias: attn_bias,
+                attn_v_weight,
+                attn_v_bias: attn_bias,
+                attn_out_weight,
+                attn_out_bias: attn_bias,
+                ffn_norm_weight,
+                ffn_norm_bias,
+                ffn_up_weight,
+                ffn_up_bias: ffn_bias,
+                ffn_down_weight,
+                ffn_down_bias: ffn_bias,
+            },
+            identity_map_err,
+        )
+        .expect("transformer_layer should build");
+        graph.set_output(output).expect("output should be settable");
+
+        graph
+            .set_f32_slice(input, state_values, "input")
+            .expect("input upload");
+        graph
+            .set_f32_slice(mask, mask_values, "mask")
+            .expect("mask upload");
+        graph
+            .set_f32_slice(attn_norm_weight, &NORM_WEIGHT, "attn_norm_weight")
+            .expect("attn_norm_weight upload");
+        graph
+            .set_f32_slice(attn_norm_bias, &ZERO_1D, "attn_norm_bias")
+            .expect("attn_norm_bias upload");
+        graph
+            .set_f32_slice(ffn_norm_weight, &NORM_WEIGHT, "ffn_norm_weight")
+            .expect("ffn_norm_weight upload");
+        graph
+            .set_f32_slice(ffn_norm_bias, &ZERO_1D, "ffn_norm_bias")
+            .expect("ffn_norm_bias upload");
+        graph
+            .set_f32_slice(attn_bias, &ZERO_1D, "attn_bias")
+            .expect("attn_bias upload");
+        graph
+            .set_f32_slice(ffn_bias, &ZERO_1D, "ffn_bias")
+            .expect("ffn_bias upload");
+        for (tensor, values, name) in [
+            (attn_q_weight, &IDENTITY_4X4, "attn_q_weight"),
+            (attn_k_weight, &IDENTITY_4X4, "attn_k_weight"),
+            (attn_v_weight, &IDENTITY_4X4, "attn_v_weight"),
+            (attn_out_weight, &IDENTITY_4X4, "attn_out_weight"),
+            // Zero the FFN so the block degenerates to a residual passthrough
+            // after attention; this test's job is comparing the ATTENTION
+            // branches, not exercising the (config-shared, unmodified) FFN.
+            (ffn_up_weight, &ZERO_4X4, "ffn_up_weight"),
+            (ffn_down_weight, &ZERO_4X4, "ffn_down_weight"),
+        ] {
+            graph.set_f32_slice(tensor, values, name).expect(name);
+        }
+
+        graph
+            .compute_output_f32(output, HIDDEN * TOKENS)
+            .expect("transformer_layer graph should compute")
+    }
+
+    #[test]
+    fn naive_fallback_builds_and_stays_finite_when_flash_disabled() {
+        let state = [
+            0.4, -0.3, 0.2, 0.1, //
+            -0.1, 0.5, -0.2, 0.3, //
+            0.2, 0.1, 0.4, -0.4,
+        ];
+        let zero_mask = [0.0_f32; TOKENS * TOKENS];
+        let output = run_transformer_layer(GgmlCpuGraphBackend::Cpu, false, &state, &zero_mask);
+        assert_eq!(output.len(), HIDDEN * TOKENS);
+        assert!(
+            output.iter().all(|value| value.is_finite()),
+            "naive attention fallback must produce a finite output: {output:?}"
+        );
+    }
+
+    /// Flash and naive attention reduce in different float orders and must
+    /// never be asserted bit-identical (see AGENTS-level golden-test
+    /// guidance); this only checks they land in the same numerical ballpark
+    /// for a tiny, hand-checkable case, including one masked (-inf) position
+    /// to exercise the f32->F16 flash-mask cast on a non-trivial mask.
+    #[test]
+    fn flash_attention_matches_naive_within_tolerance_on_cpu() {
+        let state = [
+            0.4, -0.3, 0.2, 0.1, //
+            -0.1, 0.5, -0.2, 0.3, //
+            0.2, 0.1, 0.4, -0.4,
+        ];
+        let mut mask = [0.0_f32; TOKENS * TOKENS];
+        // Mask token 2 out of every other token's attention (row-major
+        // [query, key]-ish additive mask, matching how the naive branch
+        // adds it to `mul_mat(k, q)` before softmax).
+        mask[2] = f32::NEG_INFINITY;
+        mask[TOKENS + 2] = f32::NEG_INFINITY;
+
+        let naive = run_transformer_layer(GgmlCpuGraphBackend::Cpu, false, &state, &mask);
+        let flash = run_transformer_layer(GgmlCpuGraphBackend::Cpu, true, &state, &mask);
+
+        assert_eq!(naive.len(), flash.len());
+        for (index, (a, b)) in naive.iter().zip(flash.iter()).enumerate() {
+            assert!(
+                (a - b).abs() <= 1.0e-3,
+                "flash vs naive diverge at element {index}: naive={a} flash={b}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Routes the qwen3-asr audio encoder's self-attention through `ggml_flash_attn_ext`, mirroring the Whisper encoder's established config-bool + naive-fallback pattern. Also hardens the shared `flash_attn_ext` wrapper with a Metal `head_dim` whitelist guard.

## Why

Consistency with the Whisper encoder's flash-attention convention, and closing a latent gap: the shared `flash_attn_ext` wrapper had no guard against Metal's fixed `head_dim` whitelist for `GGML_OP_FLASH_ATTN_EXT` (this also silently affected the existing Whisper call site, which gets the guard for free here).

## Changes

- `nn/encoder.rs`: `TransformerEncoderConfig` gains `use_flash_attention`. When set, `transformer_layer`'s self-attention branch builds `ggml_flash_attn_ext` instead of `mul_mat -> add(mask) -> soft_max_ext`, casting the caller's additive f32 padding mask to F16 once per layer (as `flash_attn_ext` requires). On GPU-class backends the q/k/v head reshape keeps strided (non-`cont`'d) views, matching the Whisper encoder's GPU/CPU split.
- `models/qwen/audio_encoder.rs`: threads `use_flash_attention` through the encoder layer composer, gated by a new `OPENASR_QWEN_GGML_DISABLE_AUDIO_ENCODER_FLASH_ATTN` opt-out env var (default on), mirroring Whisper's `OPENASR_WHISPER_GGML_DISABLE_ENCODER_FLASH_ATTN` convention.
- `ggml_runtime/cpu_graph.rs`: adds a Metal `head_dim` whitelist guard (mirrored from `ggml-metal-device.m`'s `GGML_OP_FLASH_ATTN_EXT` support check) to the shared `flash_attn_ext` wrapper. Building the op with an unsupported `head_dim` on the Metal backend now fails closed with a typed `FlashAttnExtUnsupportedMetalHeadDim` error instead of silently degrading or asserting deep in Metal kernel dispatch.
- Does not touch `DEFAULT_ENCODER_SAFE_CHUNK_SECONDS` or any other slice/chunk cap.
- `models/serve_batch_env.rs` (tests only): the first CI run of this PR hit a pre-existing timing flake unrelated to this change -- `serve_batch_drain_compatible_batch_defers_receiver_mismatch` used a 1ms collect window, so on a loaded runner the drain loop's `now >= deadline` check could expire before the first `recv_timeout` even ran, truncating the batch (`left: [1]`, `right: [1, 3]`). Both receiver-draining tests now drop the sender and use a generous window, so their loops terminate via the batch cap or channel disconnect instead of the wall clock; they still finish in milliseconds and the behavior under test is unchanged.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2274 passed, 0 failed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (Whisper's golden_diff tests, in files this PR does not touch, still pass byte-identical)
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

New tests added: Metal head_dim whitelist (pure-predicate + end-to-end graph rejection) in `cpu_graph.rs`; a naive-fallback-stays-finite test and a flash-vs-naive-within-1e-3-tolerance test (never asserted bit-identical -- they reduce in different float orders) in `nn/encoder.rs`; a real-pack (dev-machine only, `#[ignore]`) long-audio finite/bounded-output test in `audio_encoder.rs`, which I ran locally against the real `qwen3-asr-0.6b` q4_k pack and it passes (`max_abs=0.123`).

No qwen byte-exact golden fixture exists in-tree to repin -- the qwen encoder tests here are tolerance-based or dev-machine-gated by design (large model packs), so there was nothing to re-pin for this change.

## Manual smoke checks / perf measurement

M1, `qwen3-asr-0.6b` q4_k, `fixtures/jfk.wav` (11s) and a 66s clip (6x concatenated jfk.wav), 3-8 runs each side, median RTF via `--benchmark`:

- 11s clip: RTF ~0.23 both flash-on (default) and flash-off (`OPENASR_QWEN_GGML_DISABLE_AUDIO_ENCODER_FLASH_ATTN=1`) -- statistically unchanged.
- 66s clip: RTF ~0.22-0.23 both ways -- statistically unchanged (differences are within run-to-run noise).
- Peak process RSS (`/usr/bin/time -l`) on the 66s clip: ~2.03-2.15 GB both ways across samples -- also unchanged within noise.

A temporary instrumentation probe (not part of this commit) measured the actual naive `[seq, seq]` scores tensor this change avoids materializing: for this model's real dims (14 heads, head_dim=64, 18 layers) and the row counts seen transcribing the 66s clip (195-364 tokens per `encode()` call), that's only ~2-7 MiB per layer -- negligible against the ~2 GB steady-state footprint (model weights + LLM KV cache) that dominates peak RSS at this model size and audio length.

The flash path is expected to matter more for larger audio-encoder configs or much longer per-call sequences; at `qwen3-asr-0.6b`'s current scale, this change is correctness/consistency with the Whisper encoder plus future-proofing (the shared Metal `head_dim` guard) rather than a measured win, and this PR does not claim one.

## Docs updated

- [x] No docs overclaim current capabilities (no doc changes needed; behavior is opt-out via env var, matching the existing Whisper convention which is likewise undocumented in user-facing docs).

## Scope / non-goals

- Does not change any slice/chunk cap (`DEFAULT_ENCODER_SAFE_CHUNK_SECONDS`, `QWEN3_AUDIO_CHUNK_FRAMES`).
- Does not add automatic head_dim-based fallback logic in the qwen encoder itself (matches the existing Whisper precedent, which also relies on the config bool + the shared guard failing closed rather than probing head_dim compatibility at the call site).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented and tested with Claude Code (Anthropic).
