### PR TITLE
perf(core): Arc-share the cohere tokenizer; retry and stall-guard backend downloads

### DIFF
--- a/crates/openasr-core/src/models/cohere/batched_decode.rs
+++ b/crates/openasr-core/src/models/cohere/batched_decode.rs
@@ -72,7 +72,7 @@ pub(crate) struct CohereServeBatchJob {
     pub backend: GgmlCpuGraphBackend,
     pub uses_scheduler: bool,
     pub decoder_weights: Arc<CohereTranscribeDecoderWeights>,
-    pub tokenizer: CohereTranscribeTokenizer,
+    pub tokenizer: Arc<CohereTranscribeTokenizer>,
     pub metadata: CohereTranscribeExecutionMetadata,
     pub encoder_output: CohereTranscribeEncoderOutput,
     pub decode_config: Seq2SeqGreedyDecodeConfig,
@@ -859,7 +859,7 @@ mod tests {
         backend: GgmlCpuGraphBackend,
         uses_scheduler: bool,
         decoder_weights: Arc<CohereTranscribeDecoderWeights>,
-        tokenizer: CohereTranscribeTokenizer,
+        tokenizer: Arc<CohereTranscribeTokenizer>,
         metadata: CohereTranscribeExecutionMetadata,
         encoder_output: CohereTranscribeEncoderOutput,
         prefer_cpu_backend: bool,
@@ -883,7 +883,7 @@ mod tests {
         backend: GgmlCpuGraphBackend,
         uses_scheduler: bool,
         decoder_weights: Arc<CohereTranscribeDecoderWeights>,
-        tokenizer: CohereTranscribeTokenizer,
+        tokenizer: Arc<CohereTranscribeTokenizer>,
         metadata: CohereTranscribeExecutionMetadata,
         encoder_output: CohereTranscribeEncoderOutput,
         prefer_cpu_backend: bool,
@@ -939,8 +939,9 @@ mod tests {
             )
             .expect("decoder weights"),
         );
-        let tokenizer =
-            CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata).expect("tokenizer");
+        let tokenizer = Arc::new(
+            CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata).expect("tokenizer"),
+        );
         let encoder_output_0 =
             sample_encoder_output_with_frame_count(metadata, 0.0, encoder_frame_count);
         let encoder_output_1 =
@@ -1069,8 +1070,9 @@ mod tests {
             )
             .expect("decoder weights"),
         );
-        let tokenizer =
-            CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata).expect("tokenizer");
+        let tokenizer = Arc::new(
+            CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata).expect("tokenizer"),
+        );
 
         let envelope = |encoder_phase: f32, max_generated_tokens: usize| {
             let job = batch_job_with_max_generated_tokens(
@@ -1162,8 +1164,10 @@ mod tests {
                 )
                 .expect("decoder weights"),
             );
-            let tokenizer = CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
-                .expect("tokenizer");
+            let tokenizer = Arc::new(
+                CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
+                    .expect("tokenizer"),
+            );
 
             let envelope = |encoder_phase: f32, max_generated_tokens: usize| {
                 let job = batch_job_with_max_generated_tokens(
@@ -1241,8 +1245,10 @@ mod tests {
                 )
                 .expect("decoder weights"),
             );
-            let tokenizer = CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
-                .expect("tokenizer");
+            let tokenizer = Arc::new(
+                CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
+                    .expect("tokenizer"),
+            );
 
             let envelope = |encoder_phase: f32, max_generated_tokens: usize| {
                 let job = batch_job_with_max_generated_tokens(
@@ -1327,8 +1333,10 @@ mod tests {
                 )
                 .expect("decoder weights"),
             );
-            let tokenizer = CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
-                .expect("tokenizer");
+            let tokenizer = Arc::new(
+                CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
+                    .expect("tokenizer"),
+            );
 
             let envelope = |encoder_phase: f32, max_generated_tokens: usize| {
                 let job = batch_job_with_max_generated_tokens(
@@ -1420,8 +1428,10 @@ mod tests {
                 )
                 .expect("decoder weights"),
             );
-            let tokenizer = CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
-                .expect("tokenizer");
+            let tokenizer = Arc::new(
+                CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
+                    .expect("tokenizer"),
+            );
 
             let envelope = |encoder_phase: f32, max_generated_tokens: usize| {
                 let job = batch_job_with_max_generated_tokens(
@@ -1508,8 +1518,10 @@ mod tests {
                 )
                 .expect("decoder weights"),
             );
-            let tokenizer = CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
-                .expect("tokenizer");
+            let tokenizer = Arc::new(
+                CohereTranscribeTokenizer::from_gguf_metadata(&preflight.metadata)
+                    .expect("tokenizer"),
+            );
 
             let envelope = |encoder_phase: f32, max_generated_tokens: usize| {
                 let job = batch_job_with_max_generated_tokens(

--- a/crates/openasr-core/src/models/cohere/prepared_runtime.rs
+++ b/crates/openasr-core/src/models/cohere/prepared_runtime.rs
@@ -24,7 +24,7 @@ use crate::models::runtime_weight_component_registry::{
 #[derive(Debug, Clone)]
 pub(crate) struct CoherePreparedRuntime {
     pub metadata: CohereTranscribeExecutionMetadata,
-    pub tokenizer: CohereTranscribeTokenizer,
+    pub tokenizer: Arc<CohereTranscribeTokenizer>,
     pub frontend_plan: CohereTranscribeFrontendPlan,
     pub encoder_weights: Arc<CohereTranscribeEncoderWeights>,
     pub decoder_weights: Arc<CohereTranscribeDecoderWeights>,
@@ -122,7 +122,7 @@ pub(crate) fn build_cohere_prepared_runtime_from_components(
     }
     Ok(CoherePreparedRuntime {
         metadata,
-        tokenizer,
+        tokenizer: Arc::new(tokenizer),
         frontend_plan,
         encoder_weights: Arc::new(encoder_weights),
         decoder_weights: Arc::new(decoder_weights),

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -1077,7 +1077,7 @@ fn download_response(
             });
         }
     };
-    if append && !resume_content_range_matches(target, &response, resume_from) {
+    if append && !resume_content_range_matches(target.size_bytes, &response, resume_from) {
         let _ = fs::remove_file(&paths.partial_path);
         let _ = fs::remove_file(&paths.partial_meta_path);
         return Err(PullError::RestartedPartial {
@@ -1150,7 +1150,7 @@ fn download_response(
         }
         let read = reader
             .read(&mut buffer)
-            .map_err(|source| map_download_read_error(target, &paths.partial_path, source))?;
+            .map_err(|source| map_download_read_error(&target.url, &paths.partial_path, source))?;
         if read == 0 {
             break;
         }
@@ -1165,7 +1165,13 @@ fn download_response(
             bytes_done,
             bytes_total: target.size_bytes,
         });
-        low_speed.observe(target, bytes_done, read as u64, options)?;
+        low_speed.observe(
+            &target.url,
+            target.size_bytes,
+            bytes_done,
+            read as u64,
+            options,
+        )?;
         if bytes_done >= next_meta_write {
             write_partial_meta(
                 &paths.partial_meta_path,
@@ -2197,8 +2203,11 @@ struct ParsedContentRange {
     total: Option<u64>,
 }
 
+/// Shared by the model-pack single-stream resume path and the backend-pack
+/// downloader ([`download_backend_file`]): only needs the expected total
+/// size, so it takes that directly rather than a whole `&PullTarget`.
 fn resume_content_range_matches(
-    target: &PullTarget,
+    expected_size_bytes: u64,
     response: &DownloadResponse,
     resume_from: u64,
 ) -> bool {
@@ -2208,14 +2217,14 @@ fn resume_content_range_matches(
     let Some(parsed) = parse_content_range(content_range) else {
         return false;
     };
-    let Some(expected_end) = target.size_bytes.checked_sub(1) else {
+    let Some(expected_end) = expected_size_bytes.checked_sub(1) else {
         return false;
     };
     parsed.start == resume_from
         && parsed.end == expected_end
         && parsed
             .total
-            .map(|total| total == target.size_bytes)
+            .map(|total| total == expected_size_bytes)
             .unwrap_or(true)
 }
 
@@ -2362,14 +2371,18 @@ impl LowSpeedWindow {
         }
     }
 
+    /// Shared by the model-pack and backend-pack downloaders; only needs the
+    /// URL (for the error message) and the expected total size, not a whole
+    /// `&PullTarget`.
     fn observe(
         &mut self,
-        target: &PullTarget,
+        url: &str,
+        size_bytes: u64,
         bytes_done: u64,
         bytes_read: u64,
         options: &PullOptions,
     ) -> Result<(), PullError> {
-        if options.low_speed_min_bytes == 0 || bytes_done >= target.size_bytes {
+        if options.low_speed_min_bytes == 0 || bytes_done >= size_bytes {
             return Ok(());
         }
         self.bytes_read = self.bytes_read.saturating_add(bytes_read);
@@ -2379,7 +2392,7 @@ impl LowSpeedWindow {
         }
         if self.bytes_read < options.low_speed_min_bytes {
             return Err(PullError::Http {
-                url: target.url.clone(),
+                url: url.to_string(),
                 message: format!(
                     "download stalled: received {} bytes in {:.1}s, below the {} byte minimum",
                     self.bytes_read,
@@ -2394,10 +2407,15 @@ impl LowSpeedWindow {
     }
 }
 
-fn map_download_read_error(target: &PullTarget, path: &Path, source: io::Error) -> PullError {
+/// Shared by the model-pack and backend-pack ([`download_backend_file`])
+/// stream-to-file loops: turns the stall-guard's `TimedOut` read error into
+/// the retryable `PullError::Http` variant `is_retryable_download_error`
+/// recognizes, everything else into a plain `Io` error. Takes the URL
+/// directly rather than a whole `&PullTarget` so both callers can share it.
+fn map_download_read_error(url: &str, path: &Path, source: io::Error) -> PullError {
     if source.kind() == io::ErrorKind::TimedOut {
         return PullError::Http {
-            url: target.url.clone(),
+            url: url.to_string(),
             message: format!("download stalled while reading response body: {source}"),
         };
     }
@@ -3272,48 +3290,163 @@ fn install_backend_pack_with_client<C: DownloadClient>(
     Ok(record)
 }
 
+/// Download a single backend-pack file (plugin binary or archive) to `dest`,
+/// streamed to a `.partial` file and sha256-verified before the atomic
+/// rename -- the backend-pack analogue of the model-pack single-stream path
+/// (`download_with_retries` / `download_response`), sharing its retry
+/// backoff, resume, and stall/low-speed detection rather than a second,
+/// weaker re-derivation of that machinery (previously: any dropped
+/// connection failed the whole ~150 MB backend pack permanently). Every
+/// `DownloadClient::open` response already comes back wrapped in
+/// `StallGuardedReader`, so `map_download_read_error` promotes a stalled
+/// read into the retryable `PullError::Http` variant here exactly as it does
+/// for model packs.
+///
+/// Resume spans retries within this one call only (an in-memory
+/// `expected_etag`, not a persisted meta file like the model-pack path
+/// uses): a `.partial` left over from a previous process invocation has no
+/// such provenance and is discarded up front, so only an in-process retry
+/// after a transient failure resumes from a `.partial` offset.
 fn download_backend_file<C: DownloadClient>(
     client: &mut C,
     file: &CatalogBackendFile,
     dest: &Path,
     progress: &mut impl FnMut(PullProgress),
 ) -> Result<(), PullError> {
-    let response = client.open(&file.url, None)?;
-    if response.status != 200 {
-        return Err(PullError::UnexpectedStatus {
-            url: file.url.clone(),
-            status: response.status,
-        });
-    }
-    if let Some(content_length) = response.content_length
-        && content_length != file.size_bytes
-    {
-        return Err(PullError::SizeMismatch {
-            path: dest.to_path_buf(),
-            expected: file.size_bytes,
-            actual: content_length,
-        });
-    }
     let partial = dest.with_extension("partial");
-    let mut hasher = Sha256::new();
-    let mut out = File::create(&partial).map_err(|source| PullError::Io {
-        path: partial.clone(),
-        source,
-    })?;
-    let mut reader = response.reader;
-    let mut buffer = vec![0_u8; DOWNLOAD_BUFFER_BYTES];
-    let mut bytes_done = 0_u64;
+    let _ = fs::remove_file(&partial);
+
+    let mut attempt = 0_usize;
+    let mut expected_etag: Option<String> = None;
     loop {
-        let read = reader.read(&mut buffer).map_err(|source| PullError::Io {
-            path: partial.clone(),
+        match download_backend_file_attempt(
+            client,
+            file,
+            dest,
+            &partial,
+            &mut expected_etag,
+            progress,
+        ) {
+            Ok(()) => return Ok(()),
+            Err(error) if attempt < DOWNLOAD_MAX_RETRIES && is_retryable_download_error(&error) => {
+                attempt += 1;
+                std::thread::sleep(retry_backoff(attempt));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn prepare_backend_partial_for_resume(partial: &Path, size_bytes: u64) -> Result<u64, PullError> {
+    if !partial.exists() {
+        return Ok(0);
+    }
+    let partial_len = fs::metadata(partial)
+        .map_err(|source| PullError::Io {
+            path: partial.to_path_buf(),
+            source,
+        })?
+        .len();
+    if partial_len > size_bytes {
+        let _ = fs::remove_file(partial);
+        return Ok(0);
+    }
+    Ok(partial_len)
+}
+
+fn download_backend_file_attempt<C: DownloadClient>(
+    client: &mut C,
+    file: &CatalogBackendFile,
+    dest: &Path,
+    partial: &Path,
+    expected_etag: &mut Option<String>,
+    progress: &mut impl FnMut(PullProgress),
+) -> Result<(), PullError> {
+    let resume_from = prepare_backend_partial_for_resume(partial, file.size_bytes)?;
+    let response = client.open(
+        &file.url,
+        (resume_from > 0).then(|| ByteRange::from_start(resume_from)),
+    )?;
+
+    if resume_from > 0
+        && let (Some(expected), Some(actual)) = (expected_etag.as_deref(), response.etag.as_deref())
+        && expected != actual
+    {
+        let _ = fs::remove_file(partial);
+        return Err(PullError::RestartedPartial {
+            url: file.url.clone(),
+        });
+    }
+    if expected_etag.is_none() {
+        *expected_etag = response.etag.clone();
+    }
+
+    let append = match (resume_from, response.status) {
+        (0, 200 | 206) => false,
+        (_, 206) => true,
+        (_, 200) => false,
+        (_, status) => {
+            return Err(PullError::UnexpectedStatus {
+                url: file.url.clone(),
+                status,
+            });
+        }
+    };
+    if append && !resume_content_range_matches(file.size_bytes, &response, resume_from) {
+        let _ = fs::remove_file(partial);
+        return Err(PullError::RestartedPartial {
+            url: file.url.clone(),
+        });
+    }
+    let actual_resume = if append { resume_from } else { 0 };
+    if resume_from > 0 && !append {
+        let _ = fs::remove_file(partial);
+    }
+    if let Some(content_length) = response.content_length {
+        let expected_body = file.size_bytes.saturating_sub(actual_resume);
+        if content_length != expected_body {
+            let _ = fs::remove_file(partial);
+            return Err(PullError::SizeMismatch {
+                path: dest.to_path_buf(),
+                expected: expected_body,
+                actual: content_length,
+            });
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    if append {
+        hash_existing_partial(partial, &mut hasher)?;
+    }
+    let mut out = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .append(append)
+        .truncate(!append)
+        .open(partial)
+        .map_err(|source| PullError::Io {
+            path: partial.to_path_buf(),
             source,
         })?;
+    let mut reader = response.reader;
+    let mut buffer = vec![0_u8; DOWNLOAD_BUFFER_BYTES];
+    let mut bytes_done = actual_resume;
+    let mut low_speed = LowSpeedWindow::new();
+    let low_speed_options = PullOptions::default();
+    progress(PullProgress::DownloadStarted {
+        bytes_total: file.size_bytes,
+        resume_from: actual_resume,
+    });
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|source| map_download_read_error(&file.url, partial, source))?;
         if read == 0 {
             break;
         }
         out.write_all(&buffer[..read])
             .map_err(|source| PullError::Io {
-                path: partial.clone(),
+                path: partial.to_path_buf(),
                 source,
             })?;
         hasher.update(&buffer[..read]);
@@ -3322,22 +3455,29 @@ fn download_backend_file<C: DownloadClient>(
             bytes_done,
             bytes_total: file.size_bytes,
         });
+        low_speed.observe(
+            &file.url,
+            file.size_bytes,
+            bytes_done,
+            read as u64,
+            &low_speed_options,
+        )?;
     }
     out.sync_all().map_err(|source| PullError::Io {
-        path: partial.clone(),
+        path: partial.to_path_buf(),
         source,
     })?;
     drop(out);
     let actual = format!("{:x}", hasher.finalize());
     if actual != file.sha256 {
-        let _ = fs::remove_file(&partial);
+        let _ = fs::remove_file(partial);
         return Err(PullError::ShaMismatch {
             path: dest.to_path_buf(),
             expected: file.sha256.clone(),
             actual,
         });
     }
-    fs::rename(&partial, dest).map_err(|source| PullError::Io {
+    fs::rename(partial, dest).map_err(|source| PullError::Io {
         path: dest.to_path_buf(),
         source,
     })?;

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -2197,6 +2197,140 @@ fn install_backend_pack_rejects_unsafe_version_segment() {
     ));
 }
 
+/// A reader that yields the first `remaining` bytes of `inner` and then
+/// fails with a plain (non-timeout) I/O error, simulating a dropped
+/// connection mid-body -- distinct from `TimedOutReader`'s stall, but the
+/// same "retryable, should resume" class per `is_retryable_download_error`.
+struct DropAfterBytesReader {
+    inner: Cursor<Vec<u8>>,
+    remaining: usize,
+}
+
+impl Read for DropAfterBytesReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.remaining == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "simulated mid-stream connection drop",
+            ));
+        }
+        let cap = buf.len().min(self.remaining);
+        let read = self.inner.read(&mut buf[..cap])?;
+        self.remaining -= read;
+        Ok(read)
+    }
+}
+
+/// First `open()` call drops the connection after `split` bytes; every
+/// subsequent call serves the remainder as a proper Range (206) response,
+/// so a real resume (not a from-scratch restart) is what makes the transfer
+/// finish -- this is what `download_backend_file`'s retry loop must do.
+struct BackendMidStreamDropThenResumeClient {
+    bytes: Vec<u8>,
+    split: usize,
+    attempts: usize,
+    ranges: Vec<Option<u64>>,
+}
+
+impl BackendMidStreamDropThenResumeClient {
+    fn new(bytes: Vec<u8>, split: usize) -> Self {
+        Self {
+            bytes,
+            split,
+            attempts: 0,
+            ranges: Vec::new(),
+        }
+    }
+
+    fn ranges(&self) -> Vec<Option<u64>> {
+        self.ranges.clone()
+    }
+}
+
+impl DownloadClient for BackendMidStreamDropThenResumeClient {
+    fn open(
+        &mut self,
+        _url: &str,
+        range: Option<ByteRange>,
+    ) -> Result<DownloadResponse, PullError> {
+        let range_start = range.map(|range| range.start);
+        self.ranges.push(range_start);
+        self.attempts += 1;
+        if self.attempts == 1 {
+            return Ok(DownloadResponse {
+                status: 200,
+                content_length: Some(self.bytes.len() as u64),
+                content_range: None,
+                etag: Some("etag-test".to_string()),
+                reader: Box::new(DropAfterBytesReader {
+                    inner: Cursor::new(self.bytes.clone()),
+                    remaining: self.split,
+                }),
+            });
+        }
+        let start = range_start.unwrap_or(0) as usize;
+        let total = self.bytes.len() as u64;
+        let body = self.bytes[start..].to_vec();
+        Ok(DownloadResponse {
+            status: if start > 0 { 206 } else { 200 },
+            content_length: Some(body.len() as u64),
+            content_range: if start > 0 {
+                Some(format!("bytes {start}-{}/{total}", total - 1))
+            } else {
+                None
+            },
+            etag: Some("etag-test".to_string()),
+            reader: Box::new(Cursor::new(body)),
+        })
+    }
+}
+
+#[test]
+fn install_backend_pack_retries_stalled_read_and_succeeds() {
+    let home = tempfile::tempdir().unwrap();
+    let plugin = minimal_pe_bytes();
+    let mut resolved = hip_pack_resolved(&plugin, &tensile_zip_bytes());
+    resolved.files.truncate(1); // plugin only
+    let mut client = StalledThenSuccessClient::new(plugin.clone(), FirstResponse::Timeout);
+
+    let installed =
+        install_backend_pack_with_client(&resolved, home.path(), &mut client, |_| {}).unwrap();
+
+    let dir = home.path().join("backends").join("hip").join("0.13.1");
+    assert_eq!(installed.dir, dir);
+    assert!(dir.join("ggml-hip.dll").is_file());
+    assert_eq!(fs::read(dir.join("ggml-hip.dll")).unwrap(), plugin);
+}
+
+#[test]
+fn install_backend_pack_resumes_after_mid_stream_drop_and_retries() {
+    let home = tempfile::tempdir().unwrap();
+    // Long enough that a partial prefix is meaningfully smaller than the
+    // whole file (the minimal PE fixture is only 0x44 bytes). Starts with
+    // the ELF magic so `preflight_backend_file` accepts it as a native
+    // library after the (fake) content is written.
+    let mut plugin: Vec<u8> = vec![0x7F, b'E', b'L', b'F'];
+    plugin.extend((0_u32..2000).map(|value| (value % 251) as u8));
+    let mut resolved = hip_pack_resolved(&plugin, &tensile_zip_bytes());
+    resolved.files.truncate(1); // plugin only
+    resolved.files[0].filename = "libbackend.so".to_string();
+    resolved.files[0].sha256 = sha256_hex(&plugin);
+    resolved.files[0].size_bytes = plugin.len() as u64;
+    let mut client = BackendMidStreamDropThenResumeClient::new(plugin.clone(), 700);
+
+    let installed =
+        install_backend_pack_with_client(&resolved, home.path(), &mut client, |_| {}).unwrap();
+
+    let dir = home.path().join("backends").join("hip").join("0.13.1");
+    assert_eq!(installed.dir, dir);
+    assert_eq!(fs::read(dir.join("libbackend.so")).unwrap(), plugin);
+    // Second attempt must have asked for a Range starting at the byte the
+    // dropped connection had already delivered -- a from-scratch restart
+    // would instead show `[None, None]`.
+    assert_eq!(client.ranges(), vec![None, Some(700)]);
+    assert!(!dir.join("libbackend.so.partial").exists());
+}
+
 #[cfg(windows)]
 #[test]
 fn windows_in_use_os_errors_classify_as_model_in_use() {


### PR DESCRIPTION
## Summary

Two fixes from a whole-repo audit, one per commit:

1. `perf(cohere)`: `CoherePreparedRuntime.tokenizer` and `CohereServeBatchJob.tokenizer` are now `Arc<CohereTranscribeTokenizer>`, so serve-batch submissions stop deep-copying the whole vocabulary per request.
2. `fix(pull)`: the backend-pack downloader (`download_backend_file`) now has the same retry/backoff, in-process resume, and stall/low-speed detection as the model-pack path, instead of failing the whole pack permanently on a single network hiccup.

## Why

- The cohere serve-batch path cloned the full tokenizer (`Vec<String>` + `BTreeMap`) into every `CohereServeBatchJob`, while the encoder/decoder weights in the same struct were already `Arc`-shared and Moonshine already shares its whole prepared runtime. Pure avoidable per-request allocation on the serve hot path.
- `download_backend_file` had copied the model-pack read/hash/write loop but dropped resume, retry backoff, and stall detection. The GPU backend-pack path serves the ~150 MB rocBLAS Tensile archive; one dropped connection = permanent failure. Not yet user-reachable in a release, but it would regress the moment backend packs ship.

## Changes

- `crates/openasr-core/src/models/cohere/prepared_runtime.rs`, `batched_decode.rs`: tokenizer field/params to `Arc<...>`; construction sites wrap once; test fixtures updated.
- `crates/openasr-core/src/pull.rs`:
  - `download_backend_file` is now a `DOWNLOAD_MAX_RETRIES` retry loop (shared `retry_backoff` + `is_retryable_download_error`) around `download_backend_file_attempt`;
  - each attempt resumes from the `.partial` byte offset with a Range request, validated by the shared `resume_content_range_matches` and an in-memory ETag guard (mismatch discards the partial, `RestartedPartial`);
  - stall detection comes from the `StallGuardedReader` every `HttpDownloadClient` response is already wrapped in — the shared `map_download_read_error` promotes a `TimedOut` read into the retryable `PullError::Http` variant — plus the shared `LowSpeedWindow` for slow-but-alive stalls;
  - `resume_content_range_matches` / `map_download_read_error` / `LowSpeedWindow::observe` now take URL/size directly instead of `&PullTarget` so both downloaders share them.
- `crates/openasr-core/src/pull_tests.rs`: new `install_backend_pack_retries_stalled_read_and_succeeds` and `install_backend_pack_resumes_after_mid_stream_drop_and_retries` (asserts the second attempt sends `Range: bytes=<offset>-`, not a from-scratch restart).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2276 passed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (left to CI)

Also: `cargo test -p openasr-core golden_diff` (byte-identical, pass) and `bundled_catalog_signature_verifies_committed_catalog_and_epoch` (pass).

## Manual smoke checks

None beyond the unit suites; the backend-pack path is not yet reachable from a released command surface.

## Docs updated

- [x] No docs overclaim current capabilities (no behavior surface change; internal robustness + perf only).

## Scope / non-goals

- No persisted cross-process resume meta for backend files (model packs keep their `PartialMeta` file; backend resume is in-process across retries only — a fresh process restarts the file).
- No concurrent chunked download for backend files; single-stream with resume is sufficient at ~150 MB.
- No change to catalog schema, verification, or the fail-closed install preflights.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — implemented with Claude Code under maintainer direction and review.
