### PR TITLE
fix(cli): resolve live model refs through the catalog and reuse the pull progress reporter

### DIFF
--- a/crates/openasr-cli/src/live.rs
+++ b/crates/openasr-cli/src/live.rs
@@ -140,8 +140,13 @@ pub(crate) async fn run_live(options: LiveCommandOptions<'_>) -> Result<()> {
     if backend == BackendKind::Native && options.model_pack.is_none() {
         crate::pull_cli::ensure_asr_model_installed(options.model, &config, &options.consent)?;
     }
-    let model_pack_path =
-        resolve_live_model_pack(backend, options.model, &config, options.model_pack)?;
+    let model_pack_path = resolve_live_model_pack(
+        backend,
+        options.model,
+        &config,
+        options.model_pack,
+        catalog.as_ref(),
+    )?;
     ensure_cli_diarization_packs_installed(backend, model_pack_path.as_deref(), options.diarize)?;
     ensure_diarization_supported(backend, model_pack_path.as_deref(), options.diarize)?;
     ensure_live_backend_ready(backend, model_pack_path.as_deref())?;
@@ -446,6 +451,7 @@ fn resolve_live_model_pack(
     model: Option<&str>,
     config: &openasr_core::OpenAsrConfig,
     model_pack: Option<&Path>,
+    catalog: Option<&openasr_core::ModelCatalog>,
 ) -> Result<Option<PathBuf>> {
     if backend != BackendKind::Native {
         if model_pack.is_some() {
@@ -463,9 +469,11 @@ fn resolve_live_model_pack(
             Ok(Some(validated))
         }
         // No explicit pack: resolve an installed pack by model id. The consent-pull
-        // in run_live already ensured it is installed; this never pulls.
+        // in run_live already ensured it is installed; this never pulls. Forward
+        // the catalog already loaded by run_live so family:tag aliases (e.g.
+        // `qwen:q8`) resolve the same way here as they do for `transcribe`.
         None => Ok(Some(
-            crate::native_segment_cli::resolve_installed_native_pack(model, config, None)?,
+            crate::native_segment_cli::resolve_installed_native_pack(model, config, catalog)?,
         )),
     }
 }
@@ -2654,6 +2662,107 @@ mod tests {
             .to_string();
         assert!(error.contains("requires --model-pack"));
         assert!(error.contains("fail-closed"));
+    }
+
+    #[test]
+    fn live_model_pack_resolution_matches_transcribe_for_catalog_aliases() {
+        // Regression for the `openasr live` catalog-blindness bug: resolving an
+        // installed pack by a catalog family:tag alias (e.g. `qwen:q8`) must
+        // succeed the same way it does for `transcribe`'s
+        // `resolve_model_source_for_backend`, which forwards the loaded
+        // catalog into `resolve_installed_native_pack`. Before the fix, `live`
+        // hardcoded `None` for the catalog there, so the same alias that
+        // installed cleanly for `transcribe` was reported "not installed" for
+        // `live`.
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("OPENASR_HOME", temp.path()) };
+        let home = openasr_home().unwrap();
+        let config = openasr_core::OpenAsrConfig::default();
+        let catalog = load_cli_model_catalog(&home).unwrap();
+        assert!(
+            catalog.is_some(),
+            "repo-local model-registry/catalog.json must load"
+        );
+
+        // Hand-write an installed-pack record directly (bypassing the real
+        // download/signature-verified install path, which is orthogonal to
+        // this alias-resolution regression): `list_installed_packs` needs
+        // `models/<model_id>/<quant>/installed.json` plus a same-named pack
+        // file on disk that passes `validate_native_runtime_model_pack_contract`,
+        // so the pack payload itself must be a structurally valid (if tiny)
+        // runtime pack -- the registry-facing `model_id` label is independent
+        // of the pack's internal `openasr.*` GGUF metadata, so a generic
+        // one-layer fixture works under the "qwen3-asr-0.6b" registry id.
+        let model_id = "qwen3-asr-0.6b";
+        let quant = "q8_0";
+        let pack_dir = home.join("models").join(model_id).join(quant);
+        fs::create_dir_all(&pack_dir).unwrap();
+        let pack_filename = format!("{model_id}-{quant}.oasr");
+        let pack_path = pack_dir.join(&pack_filename);
+        let fixture_spec =
+            openasr_core::testing::TinyGgufFixtureSpec::whisper_oasr_v1_encoder_graph_one_layer(
+                model_id,
+            );
+        openasr_core::testing::write_tiny_gguf_runtime_source(&pack_path, &fixture_spec).unwrap();
+        let installed = openasr_core::InstalledPack {
+            model_id: model_id.to_string(),
+            display_name: "Qwen3-ASR 0.6B".to_string(),
+            quant: quant.to_string(),
+            suffix: "q8".to_string(),
+            pull: format!("{model_id}:{quant}"),
+            filename: pack_filename,
+            path: pack_path.clone(),
+            url: "https://example.invalid/qwen3-asr-0.6b-q8_0.oasr".to_string(),
+            hf_revision: "0".repeat(40),
+            sha256: "0".repeat(64),
+            size_bytes: fs::metadata(&pack_path).unwrap().len(),
+            installed_at_unix_seconds: 0,
+            source: None,
+        };
+        fs::write(
+            pack_dir.join("installed.json"),
+            serde_json::to_string(&installed).unwrap(),
+        )
+        .unwrap();
+
+        // Sanity check: the `qwen:q8` shorthand only resolves through the
+        // catalog (family alias "qwen" -> canonical id "qwen3-asr-0.6b");
+        // catalog-blind resolution must fail to prove the alias genuinely
+        // needs the catalog forwarded.
+        let without_catalog = crate::native_segment_cli::resolve_installed_native_pack(
+            Some("qwen:q8"),
+            &config,
+            None,
+        );
+        assert!(
+            without_catalog.is_err(),
+            "catalog-blind resolution unexpectedly matched the installed pack"
+        );
+
+        let transcribe_source = crate::native_segment_cli::resolve_model_source_for_backend(
+            "transcription",
+            Some("qwen:q8"),
+            BackendKind::Native,
+            None,
+            &config,
+        )
+        .expect("transcribe resolution must resolve the qwen:q8 alias via the catalog");
+        assert_eq!(
+            transcribe_source.model_pack_path,
+            Some(installed.path.clone())
+        );
+
+        let live_pack = resolve_live_model_pack(
+            BackendKind::Native,
+            Some("qwen:q8"),
+            &config,
+            None,
+            catalog.as_ref(),
+        )
+        .expect(
+            "live resolution must resolve the qwen:q8 alias via the catalog, matching transcribe",
+        );
+        assert_eq!(live_pack, Some(installed.path));
     }
 
     fn assert_eventually_file_equals(path: &Path, expected: &str) {

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -955,42 +955,12 @@ fn install_cli_capability_pack(
     home: &Path,
     source_chain: &[openasr_core::DownloadSource],
 ) -> Result<()> {
-    let mut last_reported = 0_u64;
-    let progress = |event: openasr_core::PullProgress| match event {
-        openasr_core::PullProgress::UsingInstalled { path } => {
-            eprintln!("Already installed: {}", path.display());
-        }
-        openasr_core::PullProgress::DownloadStarted {
-            bytes_total,
-            resume_from,
-        } => {
-            if resume_from > 0 {
-                eprintln!(
-                    "Resuming {} from {resume_from}/{bytes_total} bytes",
-                    resolved.pull
-                );
-            } else {
-                eprintln!("Downloading {} ({bytes_total} bytes)", resolved.pull);
-            }
-        }
-        openasr_core::PullProgress::Downloading {
-            bytes_done,
-            bytes_total,
-        } => {
-            if bytes_done == bytes_total
-                || bytes_done.saturating_sub(last_reported) >= 8 * 1024 * 1024
-            {
-                last_reported = bytes_done;
-                eprintln!("Downloaded {bytes_done}/{bytes_total} bytes");
-            }
-        }
-        openasr_core::PullProgress::Verifying { .. } => {
-            eprintln!("Verifying {}", resolved.pull);
-        }
-        openasr_core::PullProgress::Installed { path } => {
-            eprintln!("Installed {} at {}", resolved.pull, path.display());
-        }
-    };
+    // Reuse the same progress UX as the main `pull` command (indicatif bar on a
+    // TTY, plain periodic lines otherwise) instead of a second, weaker
+    // hand-rolled renderer that never showed a progress bar for
+    // diarization/word-timestamps/punc capability-pack downloads.
+    let mut reporter = crate::progress::PullReporter::new(&resolved.pull);
+    let progress = |event| reporter.on(event);
     openasr_core::PullModelPackRequest::new(resolved, home)
         .sources(source_chain)
         .execute(progress)?;


### PR DESCRIPTION
## Summary

Two independently audited CLI bugs, fixed together: `openasr live` was catalog-blind when resolving an installed native pack, and a capability-pack installer had a second, weaker download-progress renderer.

## Why

- `openasr live` loads the model catalog (for its consent-pull) but then resolved the installed pack with `resolve_installed_native_pack(model, config, None)` -- catalog hardcoded to `None`. Catalog-only aliases (family:tag shorthands like `qwen:q8`, or ids that differ from their catalog id) resolved fine for `transcribe` but were reported "not installed" for `live`, even when already pulled.
- `install_cli_capability_pack` (used to auto-install diarization/word-timestamps/punc capability packs) hand-rolled its own `PullProgress` renderer instead of reusing `progress::PullReporter`, so those downloads never showed the `indicatif` progress bar the main `pull` command shows on a TTY.

## Changes

- `crates/openasr-cli/src/live.rs`: `resolve_live_model_pack` now takes `catalog: Option<&ModelCatalog>` and forwards it into `resolve_installed_native_pack`; `run_live` passes the catalog it already loaded. Added `live_model_pack_resolution_matches_transcribe_for_catalog_aliases`, a regression test that installs a pack under a catalog alias (`qwen:q8` -> `qwen3-asr-0.6b`) and asserts `live` resolves it the same way `transcribe` does (verified it fails without the catalog forwarded).
- `crates/openasr-cli/src/native_segment_cli.rs`: `install_cli_capability_pack` now builds a `crate::progress::PullReporter` and drives it instead of a hand-rolled closure, matching `pull_cli.rs`'s `perform_consent_pull`.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2275 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

N/A - covered by the new unit regression test exercising the real repo-local catalog and a structurally valid tiny GGUF fixture pack.

## Docs updated

- [x] No behavior/limitation docs needed updating; this restores parity between two already-documented CLI paths.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Scoped to the two audited CLI bugs (catalog forwarding for `live`, progress-reporter reuse for capability packs). No catalog-format, trust-boundary, or server changes.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - Claude Code audited two pre-identified issues, implemented both fixes, and wrote the regression test under human direction.