### PR TITLE
fix(core): harden the shared safetensors parser trust boundary

### DIFF
--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -45,6 +45,7 @@ pub(crate) mod runtime_prepared_registry;
 pub(crate) mod runtime_selection_metadata;
 pub(crate) mod runtime_tensor_contract_registry;
 pub(crate) mod runtime_weight_component_registry;
+pub(crate) mod safetensors_json;
 pub(crate) mod sensevoice;
 pub(crate) mod sentencepiece_word_timestamps;
 pub(crate) mod seq2seq_greedy_decode;

--- a/crates/openasr-core/src/models/local_source_import.rs
+++ b/crates/openasr-core/src/models/local_source_import.rs
@@ -88,6 +88,14 @@ struct RawSafetensorsTensorHeader {
     data_offsets: [u64; 2],
 }
 
+/// Upper bound on the safetensors JSON header size, checked *before* the
+/// header-length prefix is ever used to size an allocation (see [`SafetensorsFile::open`]).
+/// 128 MiB comfortably covers every real header in the tree (a header holds one
+/// small JSON record per tensor, not tensor payloads) while bounding the
+/// allocation a hostile file can force. Mirrors
+/// `whisper::local_source::safetensors::SAFETENSORS_HEADER_MAX_BYTES_V0`.
+pub(crate) const SAFETENSORS_HEADER_MAX_BYTES: u64 = 128 * 1024 * 1024;
+
 pub(crate) struct SafetensorsFile {
     path: PathBuf,
     _file: File,
@@ -104,6 +112,12 @@ impl SafetensorsFile {
             path: path.clone(),
             source,
         })?;
+
+        // S1: read the 8-byte little-endian header-length prefix and bound it
+        // against SAFETENSORS_HEADER_MAX_BYTES *before* it is trusted for any
+        // allocation size. Without this, a crafted prefix (up to u64::MAX)
+        // would let an untrusted file drive `vec![0; header_length]` straight
+        // into an OOM / abort.
         let mut header_len_prefix = [0_u8; 8];
         file.read_exact(&mut header_len_prefix)
             .map_err(|source| LocalSourceImportError::Read {
@@ -111,6 +125,35 @@ impl SafetensorsFile {
                 source,
             })?;
         let header_length_bytes = u64::from_le_bytes(header_len_prefix);
+        if header_length_bytes > SAFETENSORS_HEADER_MAX_BYTES {
+            return Err(validate_error(format!(
+                "safetensors header length {header_length_bytes} exceeds max allowed {SAFETENSORS_HEADER_MAX_BYTES} bytes"
+            )));
+        }
+
+        // S1 (continued): cross-check the (now bounded) header length against
+        // the actual file size before allocating the header buffer -- a small
+        // file can still declare a header length that fits under the byte cap
+        // but does not fit the file itself.
+        let file_metadata = file
+            .metadata()
+            .map_err(|source| LocalSourceImportError::Read {
+                path: path.clone(),
+                source,
+            })?;
+        let total_len = file_metadata.len();
+        let header_section_len = 8_u64.checked_add(header_length_bytes).ok_or_else(|| {
+            validate_error(format!(
+                "safetensors header length {header_length_bytes} overflows file indexing bounds"
+            ))
+        })?;
+        if total_len < header_section_len {
+            return Err(validate_error(format!(
+                "safetensors file '{}' is smaller than its declared header ({header_section_len} bytes needed, {total_len} available)",
+                path.display()
+            )));
+        }
+
         let header_length = usize::try_from(header_length_bytes).map_err(|_| {
             validate_error(format!(
                 "safetensors header length {header_length_bytes} is not representable on this platform"
@@ -122,12 +165,30 @@ impl SafetensorsFile {
                 path: path.clone(),
                 source,
             })?;
+
+        let data_length_bytes = total_len - header_section_len;
+
+        let header_text = std::str::from_utf8(&header_bytes).map_err(|error| {
+            validate_error(format!(
+                "safetensors header is not valid UTF-8 JSON: {error}"
+            ))
+        })?;
+        // S2: serde_json silently keeps the *last* value for a duplicate JSON
+        // object key, so a crafted header could smuggle a tensor definition
+        // past review under a repeated key. Reject duplicates outright before
+        // the normal typed parse below.
+        crate::models::safetensors_json::reject_duplicate_json_keys(header_text).map_err(
+            |error| {
+                validate_error(format!(
+                    "safetensors header has duplicate JSON keys: {error}"
+                ))
+            },
+        )?;
+
         let raw_value: serde_json::Value =
-            serde_json::from_slice(&header_bytes).map_err(|source| {
-                LocalSourceImportError::Parse {
-                    path: path.clone(),
-                    source,
-                }
+            serde_json::from_str(header_text).map_err(|source| LocalSourceImportError::Parse {
+                path: path.clone(),
+                source,
             })?;
         let raw_object = raw_value
             .as_object()
@@ -156,11 +217,40 @@ impl SafetensorsFile {
                     "safetensors tensor '{name}' dtype must not be empty"
                 )));
             }
-            if raw.data_offsets[1] < raw.data_offsets[0] {
+            let [start, end] = raw.data_offsets;
+            if end < start {
                 return Err(validate_error(format!(
                     "safetensors tensor '{name}' has inverted offsets {:?}",
                     raw.data_offsets
                 )));
+            }
+            if end > data_length_bytes {
+                return Err(validate_error(format!(
+                    "safetensors tensor '{name}' data_offsets end ({end}) exceeds data section length ({data_length_bytes})"
+                )));
+            }
+            // S4/S5: cross-check the declared byte range against
+            // shape-element-count * dtype-size for dtypes this parser has a
+            // size entry for. A family may pass an exotic/family-specific
+            // dtype string through unrecognized here (by design -- the shared
+            // layer does not own every family's dtype vocabulary), in which
+            // case only the range/overflow checks above apply.
+            if let Some(dtype_size) = dtype_size_bytes(&raw.dtype) {
+                let element_count = tensor_element_count(name, &raw.shape)?;
+                let expected_bytes = (element_count as u64)
+                    .checked_mul(dtype_size)
+                    .ok_or_else(|| {
+                        validate_error(format!(
+                            "safetensors tensor '{name}' expected byte size overflow from shape/dtype"
+                        ))
+                    })?;
+                let actual_bytes = end - start;
+                if actual_bytes != expected_bytes {
+                    return Err(validate_error(format!(
+                        "safetensors tensor '{name}' byte range ({actual_bytes}) does not match expected bytes ({expected_bytes}) from dtype '{}' and shape {:?}",
+                        raw.dtype, raw.shape
+                    )));
+                }
             }
             tensors.push(SafetensorsTensorHeader {
                 name: name.clone(),
@@ -174,23 +264,19 @@ impl SafetensorsFile {
                 "safetensors header must include at least one tensor entry",
             ));
         }
+
+        // S3: safetensors's on-disk contract is that tensor byte ranges are
+        // sorted-contiguous, non-overlapping, and exactly cover the data
+        // section. `Mmap::get` bounds-checking in `tensor_data` is a lazy
+        // last line of defense, not a substitute for this -- without it a
+        // header can claim disjoint or overlapping regions that still each
+        // individually pass the per-tensor range check above.
+        validate_tensor_offset_ranges(&tensors, data_length_bytes)?;
+
         tensors.sort_by(|left, right| left.name.cmp(&right.name));
-        let file_metadata = file
-            .metadata()
-            .map_err(|source| LocalSourceImportError::Read {
-                path: path.clone(),
-                source,
-            })?;
-        let total_len = file_metadata.len();
-        let data_offset_bytes = usize::try_from(8_u64.saturating_add(header_length_bytes))
+
+        let data_offset_bytes = usize::try_from(header_section_len)
             .map_err(|_| validate_error("safetensors data offset overflowed platform usize"))?;
-        if total_len < (8_u64.saturating_add(header_length_bytes)) {
-            return Err(validate_error(format!(
-                "safetensors file '{}' is smaller than its declared header",
-                path.display()
-            )));
-        }
-        let data_length_bytes = total_len - 8_u64 - header_length_bytes;
         let mmap = unsafe { Mmap::map(&file) }.map_err(|source| LocalSourceImportError::Read {
             path: path.clone(),
             source,
@@ -254,6 +340,70 @@ impl SafetensorsFile {
             ))
         })
     }
+}
+
+/// Byte size of one element for the safetensors dtypes this shared importer
+/// recognizes. `None` for anything else (family-specific/exotic dtype
+/// strings a given model family may pass through) -- callers must only run
+/// the shape/dtype byte cross-check for a `Some` result, per the S4/S5
+/// design: unknown dtypes still get the range/overflow checks, just not the
+/// cross-check against a size table entry that does not exist for them.
+/// Mirrors `whisper::local_source::safetensors::dtype::safetensors_dtype_size_bytes`.
+fn dtype_size_bytes(dtype: &str) -> Option<u64> {
+    match dtype.trim().to_ascii_uppercase().as_str() {
+        "BOOL" | "U8" | "I8" | "F8_E5M2" | "F8_E4M3" => Some(1),
+        "I16" | "U16" | "F16" | "BF16" => Some(2),
+        "I32" | "U32" | "F32" => Some(4),
+        "I64" | "U64" | "F64" => Some(8),
+        _ => None,
+    }
+}
+
+/// Validate that `tensors`' `data_offsets` ranges are sorted-contiguous,
+/// non-overlapping, and exactly cover a data section of `data_length_bytes`.
+/// This is the safetensors on-disk contract; mmap bounds-checking on
+/// individual tensor reads (see `SafetensorsFile::tensor_data`) is a lazy
+/// last line of defense and does not by itself catch a header whose tensors
+/// leave gaps or overlap each other. Mirrors
+/// `whisper::local_source::safetensors::dtype::validate_safetensors_tensor_offset_ranges`.
+fn validate_tensor_offset_ranges(
+    tensors: &[SafetensorsTensorHeader],
+    data_length_bytes: u64,
+) -> Result<(), LocalSourceImportError> {
+    let mut ranges = tensors
+        .iter()
+        .map(|tensor| {
+            (
+                tensor.data_offsets[0],
+                tensor.data_offsets[1],
+                tensor.name.as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+    ranges.sort_by(|left, right| left.0.cmp(&right.0).then(left.1.cmp(&right.1)));
+
+    let mut expected_offset = 0_u64;
+    for (start, end, name) in ranges {
+        if start > expected_offset {
+            return Err(validate_error(format!(
+                "safetensors tensor '{name}' data_offsets start ({start}) leaves a gap before expected offset {expected_offset}"
+            )));
+        }
+        if start < expected_offset {
+            return Err(validate_error(format!(
+                "safetensors tensor '{name}' data_offsets start ({start}) overlaps previous tensor range ending at {expected_offset}"
+            )));
+        }
+        if end > expected_offset {
+            expected_offset = end;
+        }
+    }
+    if expected_offset != data_length_bytes {
+        return Err(validate_error(format!(
+            "safetensors tensor ranges must fully cover data section length {data_length_bytes}; covered length is {expected_offset}"
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn decode_safetensors_payload_as_f32(
@@ -434,8 +584,13 @@ fn decode_bf16_payload_as_f32(
 
 #[cfg(test)]
 mod tests {
-    use super::{LocalSourceImportError, validate_output_pack_extension};
-    use std::path::Path;
+    use super::{
+        LocalSourceImportError, SAFETENSORS_HEADER_MAX_BYTES, SafetensorsFile,
+        validate_output_pack_extension,
+    };
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
 
     #[test]
     fn output_pack_extension_accepts_oasr() {
@@ -466,5 +621,262 @@ mod tests {
     fn output_pack_extension_rejects_missing_extension() {
         validate_output_pack_extension(Path::new("/tmp/whisper-small"))
             .expect_err("extensionless output must be rejected");
+    }
+
+    // --- SafetensorsFile::open hardening (trust-boundary negative tests) ---
+    //
+    // These fixtures build the raw on-disk safetensors wire format by hand
+    // (8-byte little-endian header length, then the header JSON bytes, then
+    // the data section) rather than through `serde_json::Map`, since several
+    // cases (duplicate keys, a declared length independent of what's on
+    // disk) are deliberately unrepresentable through a normal `Value`.
+
+    /// Each test gets its own `tempfile::TempDir` (auto-unique, auto-cleaned
+    /// up) rather than a hand-rolled path under `env::temp_dir()` -- tests in
+    /// this module run concurrently in the same process, so anything keyed
+    /// only by a short human-readable label risks two tests colliding on the
+    /// same on-disk fixture file.
+    fn fixture_dir() -> TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    fn fixture_path(dir: &TempDir) -> PathBuf {
+        dir.path().join("model.safetensors")
+    }
+
+    fn write_raw_safetensors_file(path: &Path, header_bytes: &[u8], data_bytes: &[u8]) {
+        let mut file = std::fs::File::create(path).unwrap();
+        file.write_all(&(header_bytes.len() as u64).to_le_bytes())
+            .unwrap();
+        file.write_all(header_bytes).unwrap();
+        file.write_all(data_bytes).unwrap();
+    }
+
+    /// Writes only the 8-byte header-length prefix (no header bytes, no data
+    /// bytes) so the S1 max-length check can be exercised without ever
+    /// allocating or reading the (fictitious) declared header.
+    fn write_header_length_prefix_only(path: &Path, declared_header_length_bytes: u64) {
+        let mut file = std::fs::File::create(path).unwrap();
+        file.write_all(&declared_header_length_bytes.to_le_bytes())
+            .unwrap();
+    }
+
+    fn expect_validate_error(
+        result: Result<SafetensorsFile, LocalSourceImportError>,
+        contains: &str,
+    ) -> String {
+        match result {
+            Ok(_) => panic!("expected a Validate error containing '{contains}', got Ok"),
+            Err(LocalSourceImportError::Validate(message)) => {
+                assert!(
+                    message.contains(contains),
+                    "error message '{message}' should contain '{contains}'"
+                );
+                message
+            }
+            Err(other) => panic!("expected LocalSourceImportError::Validate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_rejects_header_length_far_over_the_byte_cap_without_allocating() {
+        // S1: a declared header length of 2^40 (1 TiB) must be rejected by the
+        // byte-cap check before any allocation or further file I/O is
+        // attempted -- this file on disk is 8 bytes long, so if the importer
+        // ever tried to honor the declared length it would either fail a
+        // later read or (pre-hardening) attempt a terabyte-sized `vec![0; _]`.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        write_header_length_prefix_only(&path, 1_u64 << 40);
+        let error = expect_validate_error(SafetensorsFile::open(&path), "exceeds max allowed");
+        assert!(
+            error.contains(&SAFETENSORS_HEADER_MAX_BYTES.to_string()),
+            "error should cite the byte cap: {error}"
+        );
+    }
+
+    #[test]
+    fn open_rejects_header_length_at_u64_max_without_allocating() {
+        // Same as above at the absolute extreme of the prefix's range, to
+        // rule out a wraparound in the bound check itself.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        write_header_length_prefix_only(&path, u64::MAX);
+        expect_validate_error(SafetensorsFile::open(&path), "exceeds max allowed");
+    }
+
+    #[test]
+    fn open_rejects_header_length_exceeding_actual_file_size() {
+        // A header length under the byte cap but larger than the file
+        // actually on disk must still fail closed (not attempt to read past
+        // EOF or read garbage).
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        write_header_length_prefix_only(&path, 4096);
+        expect_validate_error(
+            SafetensorsFile::open(&path),
+            "smaller than its declared header",
+        );
+    }
+
+    #[test]
+    fn open_rejects_duplicate_json_object_keys() {
+        // S2: serde_json keeps the *last* value for a repeated key; the
+        // shared importer must reject the header outright instead of
+        // silently picking one definition for tensor "w".
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"w": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}, "w": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}}"#;
+        write_raw_safetensors_file(&path, header, &0.0f32.to_le_bytes());
+        expect_validate_error(SafetensorsFile::open(&path), "duplicate JSON keys");
+    }
+
+    #[test]
+    fn open_rejects_tensor_ranges_with_a_gap() {
+        // S3: tensor "a" covers [0,4), tensor "b" covers [8,12) -- bytes
+        // [4,8) belong to no tensor. Must fail closed rather than silently
+        // ignoring the unclaimed region.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"a": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}, "b": {"dtype": "F32", "shape": [1], "data_offsets": [8, 12]}}"#;
+        write_raw_safetensors_file(&path, header, &[0_u8; 12]);
+        expect_validate_error(SafetensorsFile::open(&path), "leaves a gap");
+    }
+
+    #[test]
+    fn open_rejects_overlapping_tensor_ranges() {
+        // S3: tensor "a" covers [0,8), tensor "b" covers [4,12) -- bytes
+        // [4,8) are claimed by both.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"a": {"dtype": "F32", "shape": [2], "data_offsets": [0, 8]}, "b": {"dtype": "F32", "shape": [2], "data_offsets": [4, 12]}}"#;
+        write_raw_safetensors_file(&path, header, &[0_u8; 12]);
+        expect_validate_error(
+            SafetensorsFile::open(&path),
+            "overlaps previous tensor range",
+        );
+    }
+
+    #[test]
+    fn open_rejects_tensor_ranges_that_do_not_cover_the_full_data_section() {
+        // S3: a single tensor claims only the first half of the data section;
+        // the remaining bytes are unaccounted for.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"a": {"dtype": "F32", "shape": [2], "data_offsets": [0, 8]}}"#;
+        write_raw_safetensors_file(&path, header, &[0_u8; 16]);
+        expect_validate_error(
+            SafetensorsFile::open(&path),
+            "must fully cover data section length",
+        );
+    }
+
+    #[test]
+    fn open_rejects_tensor_range_exceeding_the_data_section() {
+        // A tensor's declared `data_offsets` end reaches past the file's
+        // actual data section (as computed from total file size minus the
+        // header), independent of the header-vs-file-size check above.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"a": {"dtype": "F32", "shape": [2], "data_offsets": [0, 8]}}"#;
+        write_raw_safetensors_file(&path, header, &[0_u8; 4]);
+        expect_validate_error(SafetensorsFile::open(&path), "exceeds data section length");
+    }
+
+    #[test]
+    fn open_rejects_inverted_data_offsets() {
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"a": {"dtype": "F32", "shape": [1], "data_offsets": [10, 4]}}"#;
+        write_raw_safetensors_file(&path, header, &[0_u8; 16]);
+        expect_validate_error(SafetensorsFile::open(&path), "inverted offsets");
+    }
+
+    #[test]
+    fn open_rejects_shape_dtype_byte_mismatch_for_known_dtype() {
+        // S4/S5: dtype F32 with shape [3] expects 12 bytes, but the declared
+        // range is only 8 bytes -- a known dtype's byte size must agree with
+        // shape * data_offsets width.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"a": {"dtype": "F32", "shape": [3], "data_offsets": [0, 8]}}"#;
+        write_raw_safetensors_file(&path, header, &[0_u8; 8]);
+        expect_validate_error(
+            SafetensorsFile::open(&path),
+            "does not match expected bytes",
+        );
+    }
+
+    #[test]
+    fn open_accepts_unknown_dtype_with_only_range_checks_applied() {
+        // Design intent (S4/S5): a family-specific/exotic dtype string this
+        // shared parser does not recognize must NOT be rejected outright --
+        // it still gets range/overflow checks, just not the byte-size
+        // cross-check against a size-table entry that does not exist for it.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"a": {"dtype": "MYFAM_Q4", "shape": [999], "data_offsets": [0, 5]}}"#;
+        write_raw_safetensors_file(&path, header, &[0_u8; 5]);
+        let file = SafetensorsFile::open(&path)
+            .expect("unrecognized dtype must pass through with only range checks");
+        assert_eq!(file.header().tensors.len(), 1);
+        assert_eq!(file.header().tensors[0].dtype, "MYFAM_Q4");
+    }
+
+    #[test]
+    fn open_rejects_overflowing_shape_element_count() {
+        // A shape whose element-count product overflows u64 (here
+        // [u64::MAX, 2]) must fail closed via the checked multiplication
+        // rather than wrapping.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = format!(
+            r#"{{"a": {{"dtype": "F32", "shape": [{}, 2], "data_offsets": [0, 8]}}}}"#,
+            u64::MAX
+        );
+        write_raw_safetensors_file(&path, header.as_bytes(), &[0_u8; 8]);
+        expect_validate_error(SafetensorsFile::open(&path), "overflow");
+    }
+
+    #[test]
+    fn open_rejects_non_object_header() {
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        write_raw_safetensors_file(&path, b"[]", &[]);
+        expect_validate_error(SafetensorsFile::open(&path), "must be a JSON object");
+    }
+
+    #[test]
+    fn open_rejects_empty_dtype() {
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"a": {"dtype": "", "shape": [1], "data_offsets": [0, 4]}}"#;
+        write_raw_safetensors_file(&path, header, &[0_u8; 4]);
+        expect_validate_error(SafetensorsFile::open(&path), "dtype must not be empty");
+    }
+
+    #[test]
+    fn open_rejects_header_with_no_tensor_entries() {
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        write_raw_safetensors_file(&path, b"{}", &[]);
+        expect_validate_error(
+            SafetensorsFile::open(&path),
+            "must include at least one tensor entry",
+        );
+    }
+
+    #[test]
+    fn open_accepts_a_well_formed_multi_tensor_file() {
+        // Happy-path control: contiguous, non-overlapping, fully-covering
+        // ranges with a byte-size-consistent known dtype must still open
+        // cleanly after all of the above hardening.
+        let dir = fixture_dir();
+        let path = fixture_path(&dir);
+        let header = br#"{"a": {"dtype": "F32", "shape": [2], "data_offsets": [0, 8]}, "b": {"dtype": "F16", "shape": [3], "data_offsets": [8, 14]}}"#;
+        write_raw_safetensors_file(&path, header, &[0_u8; 14]);
+        let file = SafetensorsFile::open(&path).expect("well-formed safetensors must open");
+        assert_eq!(file.header().tensors.len(), 2);
+        assert_eq!(file.header().data_length_bytes, 14);
     }
 }

--- a/crates/openasr-core/src/models/safetensors_json.rs
+++ b/crates/openasr-core/src/models/safetensors_json.rs
@@ -1,0 +1,141 @@
+//! Model-agnostic JSON hardening helpers shared by every safetensors header
+//! parser in the tree (the shared `local_source_import` importer used by 14+
+//! model families, and the whisper-specific local-source path). Kept here
+//! rather than under `models/whisper/` so no model family logic leaks into
+//! infrastructure that every family depends on.
+//!
+//! `serde_json` silently keeps the *last* value for a duplicate object key,
+//! which would let a crafted safetensors header smuggle a tensor definition
+//! past a naive "one entry per name" review while a byte-identical duplicate
+//! key sits unused earlier in the file. Untrusted safetensors headers must be
+//! rejected outright instead.
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use serde::Deserializer;
+use serde::de::{MapAccess, SeqAccess, Visitor};
+
+/// Parse `contents` far enough to detect duplicate JSON object keys at any
+/// nesting depth, without allocating a full DOM. Returns `Err` on the first
+/// duplicate key found (or on any structural parse error, since a caller is
+/// expected to also run a normal `serde_json::from_str` afterwards for the
+/// typed decode).
+pub(crate) fn reject_duplicate_json_keys(contents: &str) -> Result<(), serde_json::Error> {
+    let mut deserializer = serde_json::Deserializer::from_str(contents);
+    deserializer.deserialize_any(DuplicateKeyVisitor)?;
+    deserializer.end()
+}
+
+#[derive(Clone, Copy)]
+struct DuplicateKeyVisitor;
+
+impl<'de> serde::de::DeserializeSeed<'de> for DuplicateKeyVisitor {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for DuplicateKeyVisitor {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("JSON without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_i64<E>(self, _value: i64) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_u64<E>(self, _value: u64) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_f64<E>(self, _value: f64) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_str<E>(self, _value: &str) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_borrowed_str<E>(self, _value: &'de str) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_string<E>(self, _value: String) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_none<E>(self) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_unit<E>(self) -> Result<(), E> {
+        Ok(())
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<(), A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while seq.next_element_seed(DuplicateKeyVisitor)?.is_some() {}
+        Ok(())
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<(), A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut keys = BTreeSet::new();
+        while let Some(key) = map.next_key::<String>()? {
+            if !keys.insert(key.clone()) {
+                return Err(serde::de::Error::custom(format!(
+                    "duplicate JSON object key `{key}`"
+                )));
+            }
+            map.next_value_seed(DuplicateKeyVisitor)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reject_duplicate_json_keys;
+
+    #[test]
+    fn accepts_json_without_duplicate_keys() {
+        reject_duplicate_json_keys(r#"{"a": 1, "b": {"c": 2}}"#)
+            .expect("no duplicate keys should be accepted");
+    }
+
+    #[test]
+    fn rejects_duplicate_top_level_key() {
+        let error = reject_duplicate_json_keys(r#"{"a": 1, "a": 2}"#)
+            .expect_err("duplicate top-level key must be rejected");
+        assert!(error.to_string().contains("duplicate JSON object key"));
+    }
+
+    #[test]
+    fn rejects_duplicate_nested_key() {
+        let error = reject_duplicate_json_keys(r#"{"a": {"x": 1, "x": 2}}"#)
+            .expect_err("duplicate nested key must be rejected");
+        assert!(error.to_string().contains("duplicate JSON object key"));
+    }
+
+    #[test]
+    fn rejects_duplicate_key_inside_array_of_objects() {
+        let error = reject_duplicate_json_keys(r#"[{"a": 1}, {"a": 1, "a": 2}]"#)
+            .expect_err("duplicate key nested in an array element must be rejected");
+        assert!(error.to_string().contains("duplicate JSON object key"));
+    }
+}

--- a/crates/openasr-core/src/models/whisper/local_source/mod.rs
+++ b/crates/openasr-core/src/models/whisper/local_source/mod.rs
@@ -1,19 +1,19 @@
 use std::{
-    collections::BTreeSet,
     fmt,
     path::{Path, PathBuf},
 };
 
-use serde::{
-    Deserializer,
-    de::{MapAccess, SeqAccess, Visitor},
-};
 use thiserror::Error;
 
 mod safetensors;
 pub(super) mod source_io;
 
 pub use safetensors::{SafetensorsHeaderV0, SafetensorsTensorHeaderV0, load_safetensors_header_v0};
+
+// Duplicate-JSON-key rejection is model-agnostic and shared with the
+// `local_source_import` importer used by every other family; see
+// `crate::models::safetensors_json` for the implementation and rationale.
+pub(super) use crate::models::safetensors_json::reject_duplicate_json_keys;
 
 #[derive(Debug, Error)]
 pub enum WhisperLocalSourceError {
@@ -57,91 +57,4 @@ pub(super) fn tensor_validation_error(
     detail: impl fmt::Display,
 ) -> WhisperLocalSourceError {
     validate_error(format!("tensor '{name}' {detail}"))
-}
-
-pub(super) fn reject_duplicate_json_keys(contents: &str) -> Result<(), serde_json::Error> {
-    let mut deserializer = serde_json::Deserializer::from_str(contents);
-    deserializer.deserialize_any(DuplicateKeyVisitor)?;
-    deserializer.end()
-}
-
-#[derive(Clone, Copy)]
-struct DuplicateKeyVisitor;
-
-impl<'de> serde::de::DeserializeSeed<'de> for DuplicateKeyVisitor {
-    type Value = ();
-
-    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_any(self)
-    }
-}
-
-impl<'de> Visitor<'de> for DuplicateKeyVisitor {
-    type Value = ();
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("JSON without duplicate object keys")
-    }
-
-    fn visit_bool<E>(self, _value: bool) -> Result<(), E> {
-        Ok(())
-    }
-    fn visit_i64<E>(self, _value: i64) -> Result<(), E> {
-        Ok(())
-    }
-    fn visit_u64<E>(self, _value: u64) -> Result<(), E> {
-        Ok(())
-    }
-    fn visit_f64<E>(self, _value: f64) -> Result<(), E> {
-        Ok(())
-    }
-    fn visit_str<E>(self, _value: &str) -> Result<(), E> {
-        Ok(())
-    }
-    fn visit_borrowed_str<E>(self, _value: &'de str) -> Result<(), E> {
-        Ok(())
-    }
-    fn visit_string<E>(self, _value: String) -> Result<(), E> {
-        Ok(())
-    }
-    fn visit_none<E>(self) -> Result<(), E> {
-        Ok(())
-    }
-    fn visit_unit<E>(self) -> Result<(), E> {
-        Ok(())
-    }
-
-    fn visit_some<D>(self, deserializer: D) -> Result<(), D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_any(self)
-    }
-
-    fn visit_seq<A>(self, mut seq: A) -> Result<(), A::Error>
-    where
-        A: SeqAccess<'de>,
-    {
-        while seq.next_element_seed(DuplicateKeyVisitor)?.is_some() {}
-        Ok(())
-    }
-
-    fn visit_map<A>(self, mut map: A) -> Result<(), A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut keys = BTreeSet::new();
-        while let Some(key) = map.next_key::<String>()? {
-            if !keys.insert(key.clone()) {
-                return Err(serde::de::Error::custom(format!(
-                    "duplicate JSON object key `{key}`"
-                )));
-            }
-            map.next_value_seed(DuplicateKeyVisitor)?;
-        }
-        Ok(())
-    }
 }


### PR DESCRIPTION
## Summary

Harden the shared `SafetensorsFile::open` parser in `crates/openasr-core/src/models/local_source_import.rs` — the trust boundary every non-whisper model family's package importer (14+ families) crosses when reading an untrusted `.safetensors` file — bringing it up to parity with the already-hardened whisper local-source parser.

## Why

The shared importer trusted several attacker-controlled header fields:

- The 8-byte header-length prefix directly sized a `vec![0; header_length]` allocation (a crafted prefix up to `u64::MAX` could drive an OOM/abort before any other validation ran).
- `serde_json` silently keeps the last value for a duplicate object key, letting a crafted header smuggle a second tensor definition under a repeated key.
- `data_offsets` ranges were only checked for inversion; gaps, overlaps, and under-coverage of the data section passed, leaving `Mmap::get` bounds checks as the only (lazy) defense.
- Declared byte ranges were never cross-checked against `shape x dtype` element size.

The whisper local-source parser already rejects all of these; the shared layer used by every other family did not.

## Changes

- S1: new `SAFETENSORS_HEADER_MAX_BYTES` (128 MiB) cap on the header-length prefix, plus a header-vs-file-size cross-check, both applied before any allocation is sized.
- S2: hoist the whisper duplicate-JSON-key visitor into a model-agnostic `models/safetensors_json.rs` module; call it from the shared parser and re-point whisper at the shared copy (net deletion in `whisper/local_source/mod.rs`).
- S3: port the sorted-contiguous / no-gap / no-overlap / exact-coverage validation over `data_offsets` (`validate_tensor_offset_ranges`), keeping the lazy mmap bound check as a last line of defense.
- S4/S5: for dtypes with a known element size, require `element_count(shape) * dtype_size == end - start` with checked multiplication; unknown family-specific dtype strings pass through with range/overflow checks only, by design.
- All new failures surface as `LocalSourceImportError::Validate` typed errors; no panic paths.
- Negative tests with hand-built malicious fixtures: oversized prefix (2^40 and `u64::MAX`), prefix larger than the file, duplicate keys (top-level/nested/in-array), gap/overlap/under-coverage, range past the data section, inverted offsets, shape-dtype byte mismatch, overflowing shape product, non-object header, empty dtype, empty header; positive controls for unknown-dtype passthrough and a well-formed multi-tensor file.

No public API changes; all 14+ family package importers keep their existing call sites.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2290 passed, 121 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

## Manual smoke checks

- `golden_diff` whisper decoder tests and `bundled_catalog_signature_verifies_committed_catalog_and_epoch` pass within the nextest run (byte-identical import paths unaffected).

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (No behavior change for well-formed files; module docs added inline.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- This PR only hardens the shared parser. Re-pointing `whisper/package_import.rs` at the shared `SafetensorsFile` (replacing its `fs::read` whole-file read with mmap) and deleting the duplicated whisper `local_source/safetensors/` parser is a follow-up refactor PR. `hymt2` is untouched (GGUF repack, no safetensors).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — implemented with Claude Code under my direction and review.
