### PR TITLE
refactor(core): extract the shared kaldi fbank frontend

### DIFF
--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -25,6 +25,7 @@ pub(crate) mod gpt2_bpe;
 pub(crate) mod graph_runtime_config;
 pub mod hymt2;
 pub(crate) mod incremental_streaming_driver;
+pub(crate) mod kaldi_fbank;
 pub(crate) mod language;
 pub(crate) mod local_source_import;
 pub(crate) mod lora_adapter;

--- a/crates/openasr-core/src/models/dolphin/frontend.rs
+++ b/crates/openasr-core/src/models/dolphin/frontend.rs
@@ -8,10 +8,12 @@
 //! magnitude kaldi expects), followed by the checkpoint's `global_cmvn`
 //! `(x - mean) * istd`.
 //!
-//! Fixed to the kaldi defaults the reference uses: Povey window, `remove_dc_offset`,
-//! pre-emphasis 0.97, HTK mel scale over 20-8000 Hz, `snip_edges=true`, and the
-//! `log(max(energy, eps))` floor. The frontend is family-local (like the X-ASR and
-//! whisper frontends) so nothing generic grows a Dolphin special case.
+//! The fbank math itself is the shared [`crate::models::kaldi_fbank`] engine:
+//! Povey window, `remove_dc_offset`, pre-emphasis 0.97, HTK mel scale over
+//! 20-8000 Hz, `snip_edges=true`, and the `log(max(energy, eps))` floor -- the
+//! firered_aed and sensevoice frontends run the identical computation over the
+//! same config (see that module's doc). What's Dolphin-local is the CMVN affine
+//! below (sign convention + tensor name) and the ESPnet frontend that follows.
 //!
 //! Parity: the pre-CMVN log-mel reproduces the golden `logmel_feats` fixture to a
 //! max abs diff ~1e-4 (f32 FFT/mel noise), and `(x - mean) * istd` reproduces
@@ -29,7 +31,8 @@
 //! periodic Hann window (not Povey), `torch.stft`-style reflect-centered
 //! framing (not kaldi `snip_edges`), no pre-emphasis/DC-removal/int16 scaling,
 //! and a **Slaney**-normalized librosa mel scale/filterbank (not HTK
-//! peak-normalized) -- see `build_slaney_mel_filters`.
+//! peak-normalized) -- see `build_slaney_mel_filters`. It stays family-local
+//! (not shared kaldi-fbank infrastructure).
 
 #![allow(dead_code)]
 
@@ -37,19 +40,27 @@ use std::sync::Arc;
 
 use realfft::{RealFftPlanner, RealToComplex};
 
+use crate::models::kaldi_fbank::{
+    KaldiFbankConfig, KaldiFbankError, KaldiFbankFrontend, KaldiWindowKind,
+};
+
 /// 16 kHz, 25 ms window / 10 ms shift, 80 mel bins (train.yaml `fbank_conf`).
 pub(crate) const SAMPLE_RATE_HZ: u32 = 16_000;
-const FRAME_LENGTH: usize = 400; // 25 ms @ 16 kHz
-const FRAME_SHIFT: usize = 160; // 10 ms @ 16 kHz
-const FFT_SIZE: usize = 512; // next pow2 >= 400 (kaldi rounds the window up)
 pub(crate) const NUM_MEL_BINS: usize = 80;
-const MEL_LOW_HZ: f32 = 20.0;
-const MEL_HIGH_HZ: f32 = 8_000.0; // high_freq <= 0 in kaldi => Nyquist (8 kHz)
-const PREEMPH_COEFF: f32 = 0.97;
-/// float `[-1, 1]` -> int16 magnitude, the domain kaldi fbank operates in.
-const INPUT_SCALE: f32 = 32_768.0;
-/// kaldi/torchaudio mel-energy floor before the log (`torch.finfo(f32).eps`).
-const LOG_ENERGY_FLOOR: f32 = 1.192_092_9e-7;
+
+const FRONTEND_CONFIG: KaldiFbankConfig = KaldiFbankConfig {
+    sample_rate_hz: SAMPLE_RATE_HZ,
+    frame_length: 400, // 25 ms @ 16 kHz
+    frame_shift: 160,  // 10 ms @ 16 kHz
+    fft_size: 512,     // next pow2 >= 400 (kaldi rounds the window up)
+    num_mel_bins: NUM_MEL_BINS,
+    mel_low_hz: 20.0,
+    mel_high_hz: 8_000.0, // high_freq <= 0 in kaldi => Nyquist (8 kHz)
+    preemph_coeff: 0.97,
+    input_scale: 32_768.0, // float [-1, 1] -> int16 magnitude
+    log_energy_floor: 1.192_092_9e-7,
+    window: KaldiWindowKind::Povey,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum DolphinFrontendError {
@@ -73,31 +84,26 @@ pub(crate) enum DolphinFrontendError {
     },
 }
 
+impl From<KaldiFbankError> for DolphinFrontendError {
+    fn from(error: KaldiFbankError) -> Self {
+        match error {
+            KaldiFbankError::UnsupportedAudio => Self::UnsupportedAudio,
+            KaldiFbankError::NoFrames { samples } => Self::NoFrames { samples },
+        }
+    }
+}
+
 /// Pre-CMVN log-mel features, row-major `[frame][mel]` (mel innermost), matching
 /// the golden `logmel_feats` layout and the tensor the encoder graph consumes.
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct DolphinFbankFeatures {
-    pub data: Vec<f32>,
-    pub n_frames: usize,
-    pub n_mels: usize,
-}
-
-/// One triangular mel filter as a contiguous weight run over FFT power bins.
-struct MelFilter {
-    first_bin: usize,
-    weights: Vec<f32>,
-}
+pub(crate) type DolphinFbankFeatures = crate::models::kaldi_fbank::KaldiFbankFeatures;
 
 pub(crate) struct DolphinFbankFrontend {
-    window: [f32; FRAME_LENGTH],
-    filters: Vec<MelFilter>,
-    fft: Arc<dyn RealToComplex<f32>>,
+    inner: KaldiFbankFrontend,
 }
 
 impl std::fmt::Debug for DolphinFbankFrontend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DolphinFbankFrontend")
-            .field("n_mels", &self.filters.len())
             .finish_non_exhaustive()
     }
 }
@@ -110,17 +116,8 @@ impl Default for DolphinFbankFrontend {
 
 impl DolphinFbankFrontend {
     pub(crate) fn new() -> Self {
-        let mut window = [0.0f32; FRAME_LENGTH];
-        for (n, w) in window.iter_mut().enumerate() {
-            // Povey window: a Hann raised to 0.85 (kaldi/torchaudio default).
-            let hann = 0.5
-                - 0.5 * (2.0 * std::f32::consts::PI * n as f32 / (FRAME_LENGTH as f32 - 1.0)).cos();
-            *w = hann.powf(0.85);
-        }
         Self {
-            window,
-            filters: build_mel_filters(),
-            fft: RealFftPlanner::<f32>::new().plan_fft_forward(FFT_SIZE),
+            inner: KaldiFbankFrontend::new(FRONTEND_CONFIG),
         }
     }
 
@@ -132,62 +129,7 @@ impl DolphinFbankFrontend {
         &self,
         samples: &[f32],
     ) -> Result<DolphinFbankFeatures, DolphinFrontendError> {
-        if samples.iter().any(|v| !v.is_finite()) {
-            return Err(DolphinFrontendError::UnsupportedAudio);
-        }
-        if samples.len() < FRAME_LENGTH {
-            return Err(DolphinFrontendError::NoFrames {
-                samples: samples.len(),
-            });
-        }
-        let n_frames = 1 + (samples.len() - FRAME_LENGTH) / FRAME_SHIFT;
-        let r2c = &self.fft;
-        let mut fft_in = r2c.make_input_vec();
-        let mut fft_out = r2c.make_output_vec();
-        let mut scratch = r2c.make_scratch_vec();
-        let mut power = vec![0.0f32; FFT_SIZE / 2 + 1];
-
-        let mut feats = vec![0.0f32; n_frames * NUM_MEL_BINS];
-        let mut frame = [0.0f32; FRAME_LENGTH];
-        for fr in 0..n_frames {
-            let start = fr * FRAME_SHIFT;
-            for (dst, src) in frame.iter_mut().zip(&samples[start..start + FRAME_LENGTH]) {
-                *dst = *src * INPUT_SCALE;
-            }
-            // remove_dc_offset: subtract the frame mean.
-            let mean = frame.iter().sum::<f32>() / FRAME_LENGTH as f32;
-            for v in &mut frame {
-                *v -= mean;
-            }
-            // pre-emphasis with replicate padding: x[i] -= 0.97 x[i-1] (i>=1),
-            // x[0] -= 0.97 x[0].
-            for i in (1..FRAME_LENGTH).rev() {
-                frame[i] -= PREEMPH_COEFF * frame[i - 1];
-            }
-            frame[0] -= PREEMPH_COEFF * frame[0];
-            // Povey window into the zero-padded FFT input.
-            fft_in.fill(0.0);
-            for (slot, (sample, w)) in fft_in.iter_mut().zip(frame.iter().zip(self.window.iter())) {
-                *slot = *sample * *w;
-            }
-            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
-                .expect("dolphin fbank rfft");
-            for (bin, value) in fft_out.iter().enumerate() {
-                power[bin] = value.re * value.re + value.im * value.im;
-            }
-            for (bin, filter) in self.filters.iter().enumerate() {
-                let mut energy = 0.0f32;
-                for (j, weight) in filter.weights.iter().enumerate() {
-                    energy += weight * power[filter.first_bin + j];
-                }
-                feats[fr * NUM_MEL_BINS + bin] = energy.max(LOG_ENERGY_FLOOR).ln();
-            }
-        }
-        Ok(DolphinFbankFeatures {
-            data: feats,
-            n_frames,
-            n_mels: NUM_MEL_BINS,
-        })
+        Ok(self.inner.compute(samples)?)
     }
 }
 
@@ -229,52 +171,6 @@ pub(crate) fn apply_global_cmvn(
     Ok(())
 }
 
-fn mel_scale(freq: f32) -> f32 {
-    1127.0 * (1.0 + freq / 700.0).ln()
-}
-
-/// Kaldi triangular mel filterbank over `FFT_SIZE/2 + 1` power bins: `NUM_MEL_BINS`
-/// filters spanning `[MEL_LOW_HZ, MEL_HIGH_HZ]` on the HTK mel scale, each a peak-
-/// normalized triangle (no Slaney area norm), gated to bins strictly inside the
-/// filter band.
-fn build_mel_filters() -> Vec<MelFilter> {
-    let n_fft_bins = FFT_SIZE / 2 + 1;
-    let fft_bin_width = SAMPLE_RATE_HZ as f32 / FFT_SIZE as f32;
-    let mel_low = mel_scale(MEL_LOW_HZ);
-    let mel_high = mel_scale(MEL_HIGH_HZ);
-    let mel_delta = (mel_high - mel_low) / (NUM_MEL_BINS as f32 + 1.0);
-
-    let mut filters = Vec::with_capacity(NUM_MEL_BINS);
-    for bin in 0..NUM_MEL_BINS {
-        let left = mel_low + bin as f32 * mel_delta;
-        let center = mel_low + (bin as f32 + 1.0) * mel_delta;
-        let right = mel_low + (bin as f32 + 2.0) * mel_delta;
-        let mut first_bin = None;
-        let mut weights = Vec::new();
-        for k in 0..n_fft_bins {
-            let mel = mel_scale(fft_bin_width * k as f32);
-            if mel > left && mel < right {
-                let weight = if mel <= center {
-                    (mel - left) / (center - left)
-                } else {
-                    (right - mel) / (right - center)
-                };
-                if first_bin.is_none() {
-                    first_bin = Some(k);
-                }
-                weights.push(weight);
-            } else if first_bin.is_some() {
-                break;
-            }
-        }
-        filters.push(MelFilter {
-            first_bin: first_bin.unwrap_or(0),
-            weights,
-        });
-    }
-    filters
-}
-
 // --- ESPnet DefaultFrontend (multilingual dolphin-small/dolphin-base) -------
 
 /// `frontend_conf` shared by dolphin-small and dolphin-base `train.yaml`:
@@ -292,7 +188,8 @@ const ESPNET_FMAX_HZ: f64 = 8_000.0;
 const ESPNET_LOG_ENERGY_FLOOR: f32 = 1.0e-10;
 
 /// One triangular Slaney mel filter over the full `0..=n_fft/2` power-bin
-/// range (unlike [`MelFilter`], not gated to a contiguous nonzero run: the
+/// range (unlike the shared kaldi engine's sparse filter, not gated to a
+/// contiguous nonzero run: the
 /// area-normalized Slaney weights are small enough near the band edges that
 /// hand-rolling a first/last-bin search buys little, and dense storage keeps
 /// the librosa reference formula ported verbatim below).

--- a/crates/openasr-core/src/models/firered_aed/frontend.rs
+++ b/crates/openasr-core/src/models/firered_aed/frontend.rs
@@ -7,31 +7,34 @@
 //! `frontend.cmvn.neg_mean` / `frontend.cmvn.inv_stddev`, applied as
 //! `(x + neg_mean) * inv_stddev`.
 //!
-//! The fbank math is byte-identical in structure to the dolphin frontend (both
-//! upstreams run kaldi fbank with the same 80/25ms/10ms/16kHz/dither-0 config
-//! and defaults: Povey window, remove_dc_offset, pre-emphasis 0.97, HTK mel
-//! 20 Hz..Nyquist, `log(max(energy, eps))`). Kept family-local like every
-//! other frontend so nothing generic grows a FireRed special case.
+//! The fbank math itself is the shared [`crate::models::kaldi_fbank`] engine
+//! (Povey window, remove_dc_offset, pre-emphasis 0.97, HTK mel 20 Hz..Nyquist,
+//! `log(max(energy, eps))`), which the dolphin and sensevoice frontends also
+//! use with the same 80/25ms/10ms/16kHz/dither-0 config -- see that module's
+//! doc for why the engine is shared but the CMVN/error types stay family-local.
 
 #![allow(dead_code)]
 
-use std::sync::Arc;
-
-use realfft::{RealFftPlanner, RealToComplex};
+use crate::models::kaldi_fbank::{
+    KaldiFbankConfig, KaldiFbankError, KaldiFbankFrontend, KaldiWindowKind,
+};
 
 pub(crate) const SAMPLE_RATE_HZ: u32 = 16_000;
-const FRAME_LENGTH: usize = 400; // 25 ms @ 16 kHz
-const FRAME_SHIFT: usize = 160; // 10 ms @ 16 kHz
-const FFT_SIZE: usize = 512; // next pow2 >= 400 (kaldi rounds the window up)
 pub(crate) const NUM_MEL_BINS: usize = 80;
-const MEL_LOW_HZ: f32 = 20.0;
-const MEL_HIGH_HZ: f32 = 8_000.0; // high_freq <= 0 in kaldi => Nyquist
-const PREEMPH_COEFF: f32 = 0.97;
-/// float `[-1, 1]` -> int16 magnitude, the domain kaldi fbank operates in
-/// (upstream feeds raw int16-valued waveforms from `kaldiio.load_mat`).
-const INPUT_SCALE: f32 = 32_768.0;
-/// kaldi mel-energy floor before the log.
-const LOG_ENERGY_FLOOR: f32 = 1.192_092_9e-7;
+
+const FRONTEND_CONFIG: KaldiFbankConfig = KaldiFbankConfig {
+    sample_rate_hz: SAMPLE_RATE_HZ,
+    frame_length: 400, // 25 ms @ 16 kHz
+    frame_shift: 160,  // 10 ms @ 16 kHz
+    fft_size: 512,     // next pow2 >= 400 (kaldi rounds the window up)
+    num_mel_bins: NUM_MEL_BINS,
+    mel_low_hz: 20.0,
+    mel_high_hz: 8_000.0, // high_freq <= 0 in kaldi => Nyquist
+    preemph_coeff: 0.97,
+    input_scale: 32_768.0, // float [-1, 1] -> int16 magnitude
+    log_energy_floor: 1.192_092_9e-7,
+    window: KaldiWindowKind::Povey,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum FireRedFrontendError {
@@ -53,30 +56,25 @@ pub(crate) enum FireRedFrontendError {
     },
 }
 
-/// Pre-CMVN log-mel features, row-major `[frame][mel]` (mel innermost).
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct FireRedFbankFeatures {
-    pub data: Vec<f32>,
-    pub n_frames: usize,
-    pub n_mels: usize,
+impl From<KaldiFbankError> for FireRedFrontendError {
+    fn from(error: KaldiFbankError) -> Self {
+        match error {
+            KaldiFbankError::UnsupportedAudio => Self::UnsupportedAudio,
+            KaldiFbankError::NoFrames { samples } => Self::NoFrames { samples },
+        }
+    }
 }
 
-/// One triangular mel filter as a contiguous weight run over FFT power bins.
-struct MelFilter {
-    first_bin: usize,
-    weights: Vec<f32>,
-}
+/// Pre-CMVN log-mel features, row-major `[frame][mel]` (mel innermost).
+pub(crate) type FireRedFbankFeatures = crate::models::kaldi_fbank::KaldiFbankFeatures;
 
 pub(crate) struct FireRedFbankFrontend {
-    window: [f32; FRAME_LENGTH],
-    filters: Vec<MelFilter>,
-    fft: Arc<dyn RealToComplex<f32>>,
+    inner: KaldiFbankFrontend,
 }
 
 impl std::fmt::Debug for FireRedFbankFrontend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FireRedFbankFrontend")
-            .field("n_mels", &self.filters.len())
             .finish_non_exhaustive()
     }
 }
@@ -89,17 +87,8 @@ impl Default for FireRedFbankFrontend {
 
 impl FireRedFbankFrontend {
     pub(crate) fn new() -> Self {
-        let mut window = [0.0f32; FRAME_LENGTH];
-        for (n, w) in window.iter_mut().enumerate() {
-            // Povey window: a Hann raised to 0.85 (kaldi default).
-            let hann = 0.5
-                - 0.5 * (2.0 * std::f32::consts::PI * n as f32 / (FRAME_LENGTH as f32 - 1.0)).cos();
-            *w = hann.powf(0.85);
-        }
         Self {
-            window,
-            filters: build_mel_filters(),
-            fft: RealFftPlanner::<f32>::new().plan_fft_forward(FFT_SIZE),
+            inner: KaldiFbankFrontend::new(FRONTEND_CONFIG),
         }
     }
 
@@ -111,62 +100,7 @@ impl FireRedFbankFrontend {
         &self,
         samples: &[f32],
     ) -> Result<FireRedFbankFeatures, FireRedFrontendError> {
-        if samples.iter().any(|v| !v.is_finite()) {
-            return Err(FireRedFrontendError::UnsupportedAudio);
-        }
-        if samples.len() < FRAME_LENGTH {
-            return Err(FireRedFrontendError::NoFrames {
-                samples: samples.len(),
-            });
-        }
-        let n_frames = 1 + (samples.len() - FRAME_LENGTH) / FRAME_SHIFT;
-        let r2c = &self.fft;
-        let mut fft_in = r2c.make_input_vec();
-        let mut fft_out = r2c.make_output_vec();
-        let mut scratch = r2c.make_scratch_vec();
-        let mut power = vec![0.0f32; FFT_SIZE / 2 + 1];
-
-        let mut feats = vec![0.0f32; n_frames * NUM_MEL_BINS];
-        let mut frame = [0.0f32; FRAME_LENGTH];
-        for fr in 0..n_frames {
-            let start = fr * FRAME_SHIFT;
-            for (dst, src) in frame.iter_mut().zip(&samples[start..start + FRAME_LENGTH]) {
-                *dst = *src * INPUT_SCALE;
-            }
-            // remove_dc_offset: subtract the frame mean.
-            let mean = frame.iter().sum::<f32>() / FRAME_LENGTH as f32;
-            for v in &mut frame {
-                *v -= mean;
-            }
-            // pre-emphasis with replicate padding: x[i] -= 0.97 x[i-1] (i>=1),
-            // x[0] -= 0.97 x[0].
-            for i in (1..FRAME_LENGTH).rev() {
-                frame[i] -= PREEMPH_COEFF * frame[i - 1];
-            }
-            frame[0] -= PREEMPH_COEFF * frame[0];
-            // Povey window into the zero-padded FFT input.
-            fft_in.fill(0.0);
-            for (slot, (sample, w)) in fft_in.iter_mut().zip(frame.iter().zip(self.window.iter())) {
-                *slot = *sample * *w;
-            }
-            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
-                .expect("firered fbank rfft");
-            for (bin, value) in fft_out.iter().enumerate() {
-                power[bin] = value.re * value.re + value.im * value.im;
-            }
-            for (bin, filter) in self.filters.iter().enumerate() {
-                let mut energy = 0.0f32;
-                for (j, weight) in filter.weights.iter().enumerate() {
-                    energy += weight * power[filter.first_bin + j];
-                }
-                feats[fr * NUM_MEL_BINS + bin] = energy.max(LOG_ENERGY_FLOOR).ln();
-            }
-        }
-        Ok(FireRedFbankFeatures {
-            data: feats,
-            n_frames,
-            n_mels: NUM_MEL_BINS,
-        })
+        Ok(self.inner.compute(samples)?)
     }
 }
 
@@ -206,51 +140,6 @@ pub(crate) fn apply_cmvn(
         }
     }
     Ok(())
-}
-
-fn mel_scale(freq: f32) -> f32 {
-    1127.0 * (1.0 + freq / 700.0).ln()
-}
-
-/// Kaldi triangular mel filterbank over `FFT_SIZE/2 + 1` power bins:
-/// `NUM_MEL_BINS` peak-normalized triangles spanning `[MEL_LOW_HZ, MEL_HIGH_HZ]`
-/// on the HTK mel scale, gated to bins strictly inside the filter band.
-fn build_mel_filters() -> Vec<MelFilter> {
-    let n_fft_bins = FFT_SIZE / 2 + 1;
-    let fft_bin_width = SAMPLE_RATE_HZ as f32 / FFT_SIZE as f32;
-    let mel_low = mel_scale(MEL_LOW_HZ);
-    let mel_high = mel_scale(MEL_HIGH_HZ);
-    let mel_delta = (mel_high - mel_low) / (NUM_MEL_BINS as f32 + 1.0);
-
-    let mut filters = Vec::with_capacity(NUM_MEL_BINS);
-    for bin in 0..NUM_MEL_BINS {
-        let left = mel_low + bin as f32 * mel_delta;
-        let center = mel_low + (bin as f32 + 1.0) * mel_delta;
-        let right = mel_low + (bin as f32 + 2.0) * mel_delta;
-        let mut first_bin = None;
-        let mut weights = Vec::new();
-        for k in 0..n_fft_bins {
-            let mel = mel_scale(fft_bin_width * k as f32);
-            if mel > left && mel < right {
-                let weight = if mel <= center {
-                    (mel - left) / (center - left)
-                } else {
-                    (right - mel) / (right - center)
-                };
-                if first_bin.is_none() {
-                    first_bin = Some(k);
-                }
-                weights.push(weight);
-            } else if first_bin.is_some() {
-                break;
-            }
-        }
-        filters.push(MelFilter {
-            first_bin: first_bin.unwrap_or(0),
-            weights,
-        });
-    }
-    filters
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/kaldi_fbank.rs
+++ b/crates/openasr-core/src/models/kaldi_fbank.rs
@@ -1,0 +1,303 @@
+//! Shared kaldi-style fbank frontend engine (batch, `snip_edges=true`).
+//!
+//! `firered_aed`, dolphin's kaldi frontend (`DolphinFbankFrontend`, the
+//! `small.cn`/`cn-dialect-base` pipeline), and sensevoice all run the exact
+//! same `torchaudio.compliance.kaldi.fbank`-equivalent computation: 25 ms
+//! window / 10 ms shift, N mel bins, `dither=0`, `remove_dc_offset`,
+//! pre-emphasis, HTK mel scale over `[low_hz, high_hz]`, `snip_edges=true`
+//! framing (no edge reflection), and `log(max(energy, floor))`. The three
+//! families differed only in their analysis window (Povey vs Hamming) and a
+//! couple of numeric constants -- the FFT/DC-removal/pre-emphasis/mel-filter
+//! math was byte-for-byte duplicated three times. This module is that shared
+//! engine, parameterized by [`KaldiFbankConfig`]; the family modules keep
+//! their own error types, CMVN affine (the tensor names and sign convention
+//! differ per checkpoint), and any family-specific post-processing (e.g.
+//! sensevoice's LFR stacking).
+//!
+//! `xasr_zipformer`'s HTK-variant frontend is deliberately **not** folded in
+//! here: it runs `snip_edges=false` streaming framing (reflect-padded,
+//! incremental frame-range computation with O(1)-memory caching), skips
+//! pre-emphasis/DC-removal/int16 rescale entirely, and stores mel filters
+//! densely (not the sparse first-bin+run representation below) to support
+//! O(1) range slicing. Making this engine cover that shape would mean
+//! threading streaming-specific control flow through a batch-oriented API --
+//! a shared-layer special case, not a config difference. See
+//! `models/xasr_zipformer/frontend.rs`'s module doc for its own rationale.
+
+use std::sync::Arc;
+
+use realfft::{RealFftPlanner, RealToComplex};
+
+/// Analysis window applied to each frame before the FFT.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KaldiWindowKind {
+    /// Hann raised to the kaldi/torchaudio Povey exponent (0.85).
+    Povey,
+    /// `0.54 - 0.46 * cos(2*pi*n / (N-1))`.
+    Hamming,
+}
+
+/// Frontend geometry + kaldi-fbank knobs. All fields are the same ones each
+/// family's frontend module documents on its own local `const`s; the values
+/// firered_aed/dolphin/sensevoice each currently pass are byte-identical
+/// except for `window`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct KaldiFbankConfig {
+    pub sample_rate_hz: u32,
+    pub frame_length: usize,
+    pub frame_shift: usize,
+    pub fft_size: usize,
+    pub num_mel_bins: usize,
+    pub mel_low_hz: f32,
+    pub mel_high_hz: f32,
+    pub preemph_coeff: f32,
+    /// float `[-1, 1]` -> int16 magnitude, the domain kaldi fbank operates in.
+    pub input_scale: f32,
+    /// mel-energy floor before the log.
+    pub log_energy_floor: f32,
+    pub window: KaldiWindowKind,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum KaldiFbankError {
+    #[error("kaldi fbank frontend requires finite audio")]
+    UnsupportedAudio,
+    #[error("kaldi fbank frontend produced no frames from {samples} samples")]
+    NoFrames { samples: usize },
+}
+
+/// Pre-CMVN log-mel features, row-major `[frame][mel]` (mel innermost).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct KaldiFbankFeatures {
+    pub data: Vec<f32>,
+    pub n_frames: usize,
+    pub n_mels: usize,
+}
+
+/// One triangular mel filter as a contiguous weight run over FFT power bins.
+struct MelFilter {
+    first_bin: usize,
+    weights: Vec<f32>,
+}
+
+pub(crate) struct KaldiFbankFrontend {
+    config: KaldiFbankConfig,
+    window: Vec<f32>,
+    filters: Vec<MelFilter>,
+    fft: Arc<dyn RealToComplex<f32>>,
+}
+
+impl std::fmt::Debug for KaldiFbankFrontend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KaldiFbankFrontend")
+            .field("n_mels", &self.filters.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl KaldiFbankFrontend {
+    pub(crate) fn new(config: KaldiFbankConfig) -> Self {
+        let window = build_window(config.window, config.frame_length);
+        let filters = build_mel_filters(&config);
+        let fft = RealFftPlanner::<f32>::new().plan_fft_forward(config.fft_size);
+        Self {
+            config,
+            window,
+            filters,
+            fft,
+        }
+    }
+
+    /// Compute pre-CMVN kaldi log-mel features for mono `samples` (float in
+    /// `[-1, 1]`). `snip_edges=true`: frame count is
+    /// `1 + (len - frame_length) / frame_shift`, frame `i` starts at
+    /// `i * frame_shift` with no edge reflection.
+    pub(crate) fn compute(&self, samples: &[f32]) -> Result<KaldiFbankFeatures, KaldiFbankError> {
+        let cfg = &self.config;
+        if samples.iter().any(|v| !v.is_finite()) {
+            return Err(KaldiFbankError::UnsupportedAudio);
+        }
+        if samples.len() < cfg.frame_length {
+            return Err(KaldiFbankError::NoFrames {
+                samples: samples.len(),
+            });
+        }
+        let n_frames = 1 + (samples.len() - cfg.frame_length) / cfg.frame_shift;
+        let r2c = &self.fft;
+        let mut fft_in = r2c.make_input_vec();
+        let mut fft_out = r2c.make_output_vec();
+        let mut scratch = r2c.make_scratch_vec();
+        let mut power = vec![0.0f32; cfg.fft_size / 2 + 1];
+
+        let mut feats = vec![0.0f32; n_frames * cfg.num_mel_bins];
+        let mut frame = vec![0.0f32; cfg.frame_length];
+        for fr in 0..n_frames {
+            let start = fr * cfg.frame_shift;
+            for (dst, src) in frame
+                .iter_mut()
+                .zip(&samples[start..start + cfg.frame_length])
+            {
+                *dst = *src * cfg.input_scale;
+            }
+            // remove_dc_offset: subtract the frame mean.
+            let mean = frame.iter().sum::<f32>() / cfg.frame_length as f32;
+            for v in &mut frame {
+                *v -= mean;
+            }
+            // pre-emphasis with replicate padding: x[i] -= coeff * x[i-1] (i>=1),
+            // x[0] -= coeff * x[0].
+            for i in (1..cfg.frame_length).rev() {
+                frame[i] -= cfg.preemph_coeff * frame[i - 1];
+            }
+            frame[0] -= cfg.preemph_coeff * frame[0];
+            // Window into the zero-padded FFT input.
+            fft_in.fill(0.0);
+            for (slot, (sample, w)) in fft_in.iter_mut().zip(frame.iter().zip(self.window.iter())) {
+                *slot = *sample * *w;
+            }
+            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
+                .expect("kaldi fbank rfft");
+            for (bin, value) in fft_out.iter().enumerate() {
+                power[bin] = value.re * value.re + value.im * value.im;
+            }
+            for (bin, filter) in self.filters.iter().enumerate() {
+                let mut energy = 0.0f32;
+                for (j, weight) in filter.weights.iter().enumerate() {
+                    energy += weight * power[filter.first_bin + j];
+                }
+                feats[fr * cfg.num_mel_bins + bin] = energy.max(cfg.log_energy_floor).ln();
+            }
+        }
+        Ok(KaldiFbankFeatures {
+            data: feats,
+            n_frames,
+            n_mels: cfg.num_mel_bins,
+        })
+    }
+}
+
+fn build_window(kind: KaldiWindowKind, frame_length: usize) -> Vec<f32> {
+    (0..frame_length)
+        .map(|n| match kind {
+            KaldiWindowKind::Povey => {
+                // Povey window: a Hann raised to 0.85 (kaldi/torchaudio default).
+                let hann = 0.5
+                    - 0.5
+                        * (2.0 * std::f32::consts::PI * n as f32 / (frame_length as f32 - 1.0))
+                            .cos();
+                hann.powf(0.85)
+            }
+            KaldiWindowKind::Hamming => {
+                0.54 - 0.46
+                    * (2.0 * std::f32::consts::PI * n as f32 / (frame_length as f32 - 1.0)).cos()
+            }
+        })
+        .collect()
+}
+
+fn mel_scale(freq: f32) -> f32 {
+    1127.0 * (1.0 + freq / 700.0).ln()
+}
+
+/// Kaldi triangular mel filterbank over `fft_size/2 + 1` power bins:
+/// `num_mel_bins` peak-normalized triangles spanning `[mel_low_hz, mel_high_hz]`
+/// on the HTK mel scale, gated to bins strictly inside the filter band.
+fn build_mel_filters(cfg: &KaldiFbankConfig) -> Vec<MelFilter> {
+    let n_fft_bins = cfg.fft_size / 2 + 1;
+    let fft_bin_width = cfg.sample_rate_hz as f32 / cfg.fft_size as f32;
+    let mel_low = mel_scale(cfg.mel_low_hz);
+    let mel_high = mel_scale(cfg.mel_high_hz);
+    let mel_delta = (mel_high - mel_low) / (cfg.num_mel_bins as f32 + 1.0);
+
+    let mut filters = Vec::with_capacity(cfg.num_mel_bins);
+    for bin in 0..cfg.num_mel_bins {
+        let left = mel_low + bin as f32 * mel_delta;
+        let center = mel_low + (bin as f32 + 1.0) * mel_delta;
+        let right = mel_low + (bin as f32 + 2.0) * mel_delta;
+        let mut first_bin = None;
+        let mut weights = Vec::new();
+        for k in 0..n_fft_bins {
+            let mel = mel_scale(fft_bin_width * k as f32);
+            if mel > left && mel < right {
+                let weight = if mel <= center {
+                    (mel - left) / (center - left)
+                } else {
+                    (right - mel) / (right - center)
+                };
+                if first_bin.is_none() {
+                    first_bin = Some(k);
+                }
+                weights.push(weight);
+            } else if first_bin.is_some() {
+                break;
+            }
+        }
+        filters.push(MelFilter {
+            first_bin: first_bin.unwrap_or(0),
+            weights,
+        });
+    }
+    filters
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn firered_style_config(window: KaldiWindowKind) -> KaldiFbankConfig {
+        KaldiFbankConfig {
+            sample_rate_hz: 16_000,
+            frame_length: 400,
+            frame_shift: 160,
+            fft_size: 512,
+            num_mel_bins: 80,
+            mel_low_hz: 20.0,
+            mel_high_hz: 8_000.0,
+            preemph_coeff: 0.97,
+            input_scale: 32_768.0,
+            log_energy_floor: 1.192_092_9e-7,
+            window,
+        }
+    }
+
+    #[test]
+    fn produces_80_bin_snip_edges_fbank_povey() {
+        let samples = vec![0.01f32; 38_080];
+        let features = KaldiFbankFrontend::new(firered_style_config(KaldiWindowKind::Povey))
+            .compute(&samples)
+            .expect("fbank");
+        assert_eq!(features.n_mels, 80);
+        assert_eq!(features.n_frames, 236);
+        assert_eq!(features.data.len(), 236 * 80);
+        assert!(features.data.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn produces_80_bin_snip_edges_fbank_hamming() {
+        let samples = vec![0.01f32; 38_080];
+        let features = KaldiFbankFrontend::new(firered_style_config(KaldiWindowKind::Hamming))
+            .compute(&samples)
+            .expect("fbank");
+        assert_eq!(features.n_mels, 80);
+        assert_eq!(features.n_frames, 236);
+        assert!(features.data.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn rejects_too_short_audio() {
+        let samples = vec![0.0f32; 200];
+        assert!(matches!(
+            KaldiFbankFrontend::new(firered_style_config(KaldiWindowKind::Povey)).compute(&samples),
+            Err(KaldiFbankError::NoFrames { samples: 200 })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_finite_audio() {
+        let samples = vec![f32::NAN; 500];
+        assert!(matches!(
+            KaldiFbankFrontend::new(firered_style_config(KaldiWindowKind::Povey)).compute(&samples),
+            Err(KaldiFbankError::UnsupportedAudio)
+        ));
+    }
+}

--- a/crates/openasr-core/src/models/sensevoice/frontend.rs
+++ b/crates/openasr-core/src/models/sensevoice/frontend.rs
@@ -12,35 +12,42 @@
 //!     -> CMVN normalization  (x + neg_mean) * inv_stddev     [560-dim am.mvn]
 //! ```
 //!
-//! The fbank stage is the same kaldi computation the Dolphin frontend uses
-//! (both derive from `torchaudio.compliance.kaldi.fbank`), differing only in
-//! the window function: SenseVoice's checkpoint pins `window: hamming` where
-//! WeNet/Dolphin uses the Povey default. What is *SenseVoice-specific* and
-//! owned here is the **LFR stacking** and the fact that CMVN is applied to the
-//! LFR-stacked 560-dim feature rather than the raw 80-dim mel. LFR geometry and
-//! the CMVN affine are unit-tested with hand-computed expectations; fbank+LFR
-//! numeric parity is measured against reference FunASR features (see the
-//! onboarding notes for the recorded max-abs-error).
+//! The fbank stage is the shared [`crate::models::kaldi_fbank`] engine, the
+//! same kaldi computation the firered_aed and dolphin (kaldi variant)
+//! frontends use (all derive from `torchaudio.compliance.kaldi.fbank`),
+//! differing only in the window function: SenseVoice's checkpoint pins
+//! `window: hamming` where WeNet/Dolphin uses the Povey default. What is
+//! *SenseVoice-specific* and owned here is the **LFR stacking** and the fact
+//! that CMVN is applied to the LFR-stacked 560-dim feature rather than the raw
+//! 80-dim mel. LFR geometry and the CMVN affine are unit-tested with
+//! hand-computed expectations; fbank+LFR numeric parity is measured against
+//! reference FunASR features (see the onboarding notes for the recorded
+//! max-abs-error).
 
 #![allow(dead_code)]
 
-use std::sync::Arc;
-
-use realfft::{RealFftPlanner, RealToComplex};
+use crate::models::kaldi_fbank::{
+    KaldiFbankConfig, KaldiFbankError, KaldiFbankFrontend, KaldiWindowKind,
+};
 
 /// 16 kHz, 25 ms window / 10 ms shift, 80 mel bins (FunASR `WavFrontend` fbank).
 pub(crate) const SAMPLE_RATE_HZ: u32 = 16_000;
-const FRAME_LENGTH: usize = 400; // 25 ms @ 16 kHz
-const FRAME_SHIFT: usize = 160; // 10 ms @ 16 kHz
-const FFT_SIZE: usize = 512; // next pow2 >= 400 (kaldi rounds the window up)
 pub(crate) const NUM_MEL_BINS: usize = 80;
-const MEL_LOW_HZ: f32 = 20.0;
-const MEL_HIGH_HZ: f32 = 8_000.0; // high_freq <= 0 in kaldi => Nyquist (8 kHz)
-const PREEMPH_COEFF: f32 = 0.97;
-/// float `[-1, 1]` -> int16 magnitude, the domain kaldi fbank operates in.
-const INPUT_SCALE: f32 = 32_768.0;
-/// kaldi/torchaudio mel-energy floor before the log (`torch.finfo(f32).eps`).
-const LOG_ENERGY_FLOOR: f32 = 1.192_092_9e-7;
+
+const FRONTEND_CONFIG: KaldiFbankConfig = KaldiFbankConfig {
+    sample_rate_hz: SAMPLE_RATE_HZ,
+    frame_length: 400, // 25 ms @ 16 kHz
+    frame_shift: 160,  // 10 ms @ 16 kHz
+    fft_size: 512,     // next pow2 >= 400 (kaldi rounds the window up)
+    num_mel_bins: NUM_MEL_BINS,
+    mel_low_hz: 20.0,
+    mel_high_hz: 8_000.0, // high_freq <= 0 in kaldi => Nyquist (8 kHz)
+    preemph_coeff: 0.97,
+    input_scale: 32_768.0, // float [-1, 1] -> int16 magnitude
+    log_energy_floor: 1.192_092_9e-7,
+    // Kaldi Hamming window (the checkpoint's `frontend_conf.window: hamming`).
+    window: KaldiWindowKind::Hamming,
+};
 
 /// LFR (low frame rate) stacking parameters for SenseVoiceSmall: stack `m = 7`
 /// consecutive fbank frames per output frame, advancing by `n = 6` frames.
@@ -71,13 +78,17 @@ pub(crate) enum SenseVoiceFrontendError {
     },
 }
 
-/// Pre-CMVN 80-mel fbank features, row-major `[frame][mel]` (mel innermost).
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct SenseVoiceFbankFeatures {
-    pub data: Vec<f32>,
-    pub n_frames: usize,
-    pub n_mels: usize,
+impl From<KaldiFbankError> for SenseVoiceFrontendError {
+    fn from(error: KaldiFbankError) -> Self {
+        match error {
+            KaldiFbankError::UnsupportedAudio => Self::UnsupportedAudio,
+            KaldiFbankError::NoFrames { samples } => Self::NoFrames { samples },
+        }
+    }
 }
+
+/// Pre-CMVN 80-mel fbank features, row-major `[frame][mel]` (mel innermost).
+pub(crate) type SenseVoiceFbankFeatures = crate::models::kaldi_fbank::KaldiFbankFeatures;
 
 /// LFR-stacked features, row-major `[lfr_frame][560]` (stacked mel innermost).
 /// This is the layout the SenseVoice encoder input projection consumes.
@@ -88,22 +99,13 @@ pub(crate) struct SenseVoiceLfrFeatures {
     pub feature_dim: usize,
 }
 
-/// One triangular mel filter as a contiguous weight run over FFT power bins.
-struct MelFilter {
-    first_bin: usize,
-    weights: Vec<f32>,
-}
-
 pub(crate) struct SenseVoiceFbankFrontend {
-    window: [f32; FRAME_LENGTH],
-    filters: Vec<MelFilter>,
-    fft: Arc<dyn RealToComplex<f32>>,
+    inner: KaldiFbankFrontend,
 }
 
 impl std::fmt::Debug for SenseVoiceFbankFrontend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SenseVoiceFbankFrontend")
-            .field("n_mels", &self.filters.len())
             .finish_non_exhaustive()
     }
 }
@@ -116,18 +118,8 @@ impl Default for SenseVoiceFbankFrontend {
 
 impl SenseVoiceFbankFrontend {
     pub(crate) fn new() -> Self {
-        let mut window = [0.0f32; FRAME_LENGTH];
-        for (n, w) in window.iter_mut().enumerate() {
-            // Kaldi Hamming window (the checkpoint's `frontend_conf.window:
-            // hamming`): 0.54 - 0.46 cos(2*pi*n / (N-1)).
-            *w = 0.54
-                - 0.46
-                    * (2.0 * std::f32::consts::PI * n as f32 / (FRAME_LENGTH as f32 - 1.0)).cos();
-        }
         Self {
-            window,
-            filters: build_mel_filters(),
-            fft: RealFftPlanner::<f32>::new().plan_fft_forward(FFT_SIZE),
+            inner: KaldiFbankFrontend::new(FRONTEND_CONFIG),
         }
     }
 
@@ -138,62 +130,7 @@ impl SenseVoiceFbankFrontend {
         &self,
         samples: &[f32],
     ) -> Result<SenseVoiceFbankFeatures, SenseVoiceFrontendError> {
-        if samples.iter().any(|v| !v.is_finite()) {
-            return Err(SenseVoiceFrontendError::UnsupportedAudio);
-        }
-        if samples.len() < FRAME_LENGTH {
-            return Err(SenseVoiceFrontendError::NoFrames {
-                samples: samples.len(),
-            });
-        }
-        let n_frames = 1 + (samples.len() - FRAME_LENGTH) / FRAME_SHIFT;
-        let r2c = &self.fft;
-        let mut fft_in = r2c.make_input_vec();
-        let mut fft_out = r2c.make_output_vec();
-        let mut scratch = r2c.make_scratch_vec();
-        let mut power = vec![0.0f32; FFT_SIZE / 2 + 1];
-
-        let mut feats = vec![0.0f32; n_frames * NUM_MEL_BINS];
-        let mut frame = [0.0f32; FRAME_LENGTH];
-        for fr in 0..n_frames {
-            let start = fr * FRAME_SHIFT;
-            for (dst, src) in frame.iter_mut().zip(&samples[start..start + FRAME_LENGTH]) {
-                *dst = *src * INPUT_SCALE;
-            }
-            // remove_dc_offset: subtract the frame mean.
-            let mean = frame.iter().sum::<f32>() / FRAME_LENGTH as f32;
-            for v in &mut frame {
-                *v -= mean;
-            }
-            // pre-emphasis with replicate padding: x[i] -= 0.97 x[i-1] (i>=1),
-            // x[0] -= 0.97 x[0].
-            for i in (1..FRAME_LENGTH).rev() {
-                frame[i] -= PREEMPH_COEFF * frame[i - 1];
-            }
-            frame[0] -= PREEMPH_COEFF * frame[0];
-            // Hamming window into the zero-padded FFT input.
-            fft_in.fill(0.0);
-            for (slot, (sample, w)) in fft_in.iter_mut().zip(frame.iter().zip(self.window.iter())) {
-                *slot = *sample * *w;
-            }
-            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
-                .expect("sensevoice fbank rfft");
-            for (bin, value) in fft_out.iter().enumerate() {
-                power[bin] = value.re * value.re + value.im * value.im;
-            }
-            for (bin, filter) in self.filters.iter().enumerate() {
-                let mut energy = 0.0f32;
-                for (j, weight) in filter.weights.iter().enumerate() {
-                    energy += weight * power[filter.first_bin + j];
-                }
-                feats[fr * NUM_MEL_BINS + bin] = energy.max(LOG_ENERGY_FLOOR).ln();
-            }
-        }
-        Ok(SenseVoiceFbankFeatures {
-            data: feats,
-            n_frames,
-            n_mels: NUM_MEL_BINS,
-        })
+        Ok(self.inner.compute(samples)?)
     }
 }
 
@@ -300,51 +237,6 @@ pub(crate) fn apply_cmvn(
         }
     }
     Ok(())
-}
-
-fn mel_scale(freq: f32) -> f32 {
-    1127.0 * (1.0 + freq / 700.0).ln()
-}
-
-/// Kaldi triangular mel filterbank over `FFT_SIZE/2 + 1` power bins: `NUM_MEL_BINS`
-/// filters spanning `[MEL_LOW_HZ, MEL_HIGH_HZ]` on the HTK mel scale, each a peak-
-/// normalized triangle gated to bins strictly inside the filter band.
-fn build_mel_filters() -> Vec<MelFilter> {
-    let n_fft_bins = FFT_SIZE / 2 + 1;
-    let fft_bin_width = SAMPLE_RATE_HZ as f32 / FFT_SIZE as f32;
-    let mel_low = mel_scale(MEL_LOW_HZ);
-    let mel_high = mel_scale(MEL_HIGH_HZ);
-    let mel_delta = (mel_high - mel_low) / (NUM_MEL_BINS as f32 + 1.0);
-
-    let mut filters = Vec::with_capacity(NUM_MEL_BINS);
-    for bin in 0..NUM_MEL_BINS {
-        let left = mel_low + bin as f32 * mel_delta;
-        let center = mel_low + (bin as f32 + 1.0) * mel_delta;
-        let right = mel_low + (bin as f32 + 2.0) * mel_delta;
-        let mut first_bin = None;
-        let mut weights = Vec::new();
-        for k in 0..n_fft_bins {
-            let mel = mel_scale(fft_bin_width * k as f32);
-            if mel > left && mel < right {
-                let weight = if mel <= center {
-                    (mel - left) / (center - left)
-                } else {
-                    (right - mel) / (right - center)
-                };
-                if first_bin.is_none() {
-                    first_bin = Some(k);
-                }
-                weights.push(weight);
-            } else if first_bin.is_some() {
-                break;
-            }
-        }
-        filters.push(MelFilter {
-            first_bin: first_bin.unwrap_or(0),
-            weights,
-        });
-    }
-    filters
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/xasr_zipformer/frontend.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/frontend.rs
@@ -3,6 +3,17 @@
 //! This is the production-side Rust frontend scaffold. The exact constants are
 //! intentionally local to X-ASR because sherpa/icefall fbank parity is part of
 //! this family contract, not a generic OpenASR mel frontend.
+//!
+//! Deliberately **not** built on the shared batch engine in
+//! [`crate::models::kaldi_fbank`] (which firered_aed/dolphin/sensevoice do
+//! share): this frontend runs `snip_edges=false` framing with incremental,
+//! cacheable frame-range computation (`features_for_frame_range_from`,
+//! `earliest_sample_needed_for_frame`) for O(1)-memory streaming, skips
+//! pre-emphasis/DC-removal/int16 rescale entirely, and stores mel filters
+//! densely with precomputed per-mel bin ranges for that range slicing --
+//! folding it into the shared engine would mean threading streaming-only
+//! control flow through a batch-oriented API, i.e. a shared-layer special
+//! case rather than a config difference.
 
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary

Extracts the kaldi-style fbank computation shared by firered_aed, dolphin's
kaldi frontend, and sensevoice into `crates/openasr-core/src/models/kaldi_fbank.rs`,
a single `pub(crate)` engine parameterized by a `KaldiFbankConfig`
(frame geometry, mel range, pre-emphasis, log floor, window kind).

## Why

The three families had byte-identical framing / DC-removal / pre-emphasis /
windowed-FFT / HTK triangular mel-filterbank / log-energy-floor code, differing
only in the analysis window (Povey vs Hamming). Any numeric fix to that math
had to be hand-applied three times, and the copies could silently drift.

## Changes

- New `models/kaldi_fbank.rs`: `KaldiFbankConfig`, `KaldiWindowKind`
  (Povey/Hamming), `KaldiFbankFrontend`, `KaldiFbankFeatures`, `KaldiFbankError`.
- `firered_aed`, `dolphin` (`DolphinFbankFrontend`, the kaldi-variant path
  only), and `sensevoice` now build a small family-local `KaldiFbankConfig`
  const and delegate `compute()` to the shared engine; each keeps its own
  error enum (mapped via `From<KaldiFbankError>`), CMVN affine (tensor names
  and sign conventions are checkpoint-specific), and any family-specific
  post-processing (dolphin's separate ESPnet frontend, sensevoice's LFR
  stacking) untouched.
- `xasr_zipformer`'s HTK-variant frontend is intentionally **not** folded in:
  it runs `snip_edges=false` incremental frame-range streaming (for O(1)-memory
  caching), skips pre-emphasis/DC-removal/int16 rescale, and stores mel filters
  densely for range slicing -- a materially different computation, not a
  config difference. Cross-referenced in both module docs.
- Pure move: no numeric behavior change in any family.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2309 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (byte-identical; the two firered_aed golden cases are ignored in this environment, same as on main, pending the private dev-only pack)
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

N/A (pure internal refactor, no user-facing surface changed).

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (N/A: no behavior change)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch `xasr_zipformer`'s frontend (see rationale above).
- Does not touch dolphin's ESPnet frontend (a different, non-kaldi pipeline).
- Does not change any CMVN/LFR semantics, error message text observed by
  callers (mapped 1:1 through `From<KaldiFbankError>`), or public model
  behavior.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI-assisted refactor (audit-directed extraction of shared frontend code); reviewed and verified against the full test suite by the human maintainer before submission.