### PR TITLE
refactor(core): share tokenizer metadata accessors and bound the logits-head cache

### DIFF
--- a/crates/openasr-core/src/models/cohere/tokenizer.rs
+++ b/crates/openasr-core/src/models/cohere/tokenizer.rs
@@ -3,14 +3,17 @@ use std::collections::BTreeMap;
 use crate::NativeAsrError;
 use crate::ggml_runtime::GgufMetadata;
 use crate::models::decode_policy_component_registry::BuiltinSeq2SeqDecodePolicyTokenSource;
+use crate::models::oasr_metadata::{
+    TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_TOKENS_KEY, required_metadata_string,
+    required_metadata_string_array,
+};
 use crate::models::phrase_bias_decode::{
     PhraseBiasTokenEncoder, encode_sentencepiece_phrase_bias_tokens,
 };
 use crate::models::spm_decoder::{SpmDecoderConfig, decode_spm_pieces};
 
-const TOKENIZER_GGML_MODEL_KEY: &str = "tokenizer.ggml.model";
+const COHERE_TOKENIZER_FAMILY: &str = "Cohere Transcribe";
 const TOKENIZER_GGML_MODEL_VALUE_LLAMA: &str = "llama";
-const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
 
 #[derive(Debug, Clone)]
 pub(crate) struct CohereTranscribeTokenizer {
@@ -28,7 +31,8 @@ impl BuiltinSeq2SeqDecodePolicyTokenSource for CohereTranscribeTokenizer {}
 
 impl CohereTranscribeTokenizer {
     pub(crate) fn from_gguf_metadata(metadata: &GgufMetadata) -> Result<Self, NativeAsrError> {
-        let tokenizer_model = required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY)?;
+        let tokenizer_model =
+            required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY, COHERE_TOKENIZER_FAMILY)?;
         if !tokenizer_model.eq_ignore_ascii_case(TOKENIZER_GGML_MODEL_VALUE_LLAMA) {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -37,7 +41,11 @@ impl CohereTranscribeTokenizer {
                 ),
             });
         }
-        let tokens = required_metadata_string_array(metadata, TOKENIZER_GGML_TOKENS_KEY)?;
+        let tokens = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_TOKENS_KEY,
+            COHERE_TOKENIZER_FAMILY,
+        )?;
         if tokens.is_empty() {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -98,37 +106,6 @@ impl CohereTranscribeTokenizer {
             SpmDecoderConfig::BYTE_FALLBACK_BPE,
         ))
     }
-}
-
-fn required_metadata_string<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a str, NativeAsrError> {
-    let value = metadata
-        .get_string(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Cohere Transcribe GGUF tokenizer is missing required key '{key}'"),
-        })?;
-    let normalized = value.trim();
-    if normalized.is_empty() {
-        return Err(NativeAsrError::UnsupportedModelPack {
-            reason: format!("Cohere Transcribe GGUF tokenizer key '{key}' cannot be empty"),
-        });
-    }
-    Ok(normalized)
-}
-
-fn required_metadata_string_array<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a [String], NativeAsrError> {
-    metadata
-        .get_string_array(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!(
-                "Cohere Transcribe GGUF tokenizer requires key '{key}' as array[string]"
-            ),
-        })
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/hymt2/tokenizer.rs
+++ b/crates/openasr-core/src/models/hymt2/tokenizer.rs
@@ -5,14 +5,16 @@ use crate::ggml_runtime::GgufMetadata;
 use crate::models::gpt2_bpe::{
     build_merge_rank, build_token_to_id, encode_byte_level_piece, token_to_bytes,
 };
+use crate::models::oasr_metadata::{
+    TOKENIZER_GGML_MERGES_KEY, TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_TOKENS_KEY,
+    required_metadata_string, required_metadata_string_array,
+};
 use unicode_general_category::{GeneralCategory, get_general_category};
 
-const TOKENIZER_GGML_MODEL_KEY: &str = "tokenizer.ggml.model";
+const HYMT2_TOKENIZER_FAMILY: &str = "Hy-MT2";
 const TOKENIZER_GGML_MODEL_VALUE_GPT2: &str = "gpt2";
 const TOKENIZER_GGML_PRE_KEY: &str = "tokenizer.ggml.pre";
 const TOKENIZER_GGML_PRE_VALUE_HUNYUAN_DENSE: &str = "hunyuan-dense";
-const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
-const TOKENIZER_GGML_MERGES_KEY: &str = "tokenizer.ggml.merges";
 
 pub(crate) const HYMT2_BOS_TOKEN_ID: u32 = 120_000;
 pub(crate) const HYMT2_PAD_TOKEN_ID: u32 = 120_002;
@@ -40,7 +42,8 @@ pub struct Hymt2Tokenizer {
 
 impl Hymt2Tokenizer {
     pub(crate) fn from_gguf_metadata(metadata: &GgufMetadata) -> Result<Self, NativeAsrError> {
-        let tokenizer_model = required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY)?;
+        let tokenizer_model =
+            required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY, HYMT2_TOKENIZER_FAMILY)?;
         if !tokenizer_model.eq_ignore_ascii_case(TOKENIZER_GGML_MODEL_VALUE_GPT2) {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -49,7 +52,8 @@ impl Hymt2Tokenizer {
                 ),
             });
         }
-        let tokenizer_pre = required_metadata_string(metadata, TOKENIZER_GGML_PRE_KEY)?;
+        let tokenizer_pre =
+            required_metadata_string(metadata, TOKENIZER_GGML_PRE_KEY, HYMT2_TOKENIZER_FAMILY)?;
         if !tokenizer_pre.eq_ignore_ascii_case(TOKENIZER_GGML_PRE_VALUE_HUNYUAN_DENSE) {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -59,8 +63,16 @@ impl Hymt2Tokenizer {
             });
         }
 
-        let tokens = required_metadata_string_array(metadata, TOKENIZER_GGML_TOKENS_KEY)?;
-        let merges = required_metadata_string_array(metadata, TOKENIZER_GGML_MERGES_KEY)?;
+        let tokens = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_TOKENS_KEY,
+            HYMT2_TOKENIZER_FAMILY,
+        )?;
+        let merges = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_MERGES_KEY,
+            HYMT2_TOKENIZER_FAMILY,
+        )?;
         if tokens.is_empty() || merges.is_empty() {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: "Hy-MT2 GGUF tokenizer tokens and merges must be non-empty".to_string(),
@@ -508,35 +520,6 @@ fn validate_token_id_in_range(
             id_to_token.len()
         ),
     })
-}
-
-fn required_metadata_string<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a str, NativeAsrError> {
-    let value = metadata
-        .get_string(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Hy-MT2 GGUF tokenizer is missing required key '{key}'"),
-        })?;
-    let normalized = value.trim();
-    if normalized.is_empty() {
-        return Err(NativeAsrError::UnsupportedModelPack {
-            reason: format!("Hy-MT2 GGUF tokenizer key '{key}' cannot be empty"),
-        });
-    }
-    Ok(normalized)
-}
-
-fn required_metadata_string_array<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a [String], NativeAsrError> {
-    metadata
-        .get_string_array(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Hy-MT2 GGUF tokenizer is missing required key '{key}'"),
-        })
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/moonshine/tokenizer.rs
+++ b/crates/openasr-core/src/models/moonshine/tokenizer.rs
@@ -2,14 +2,17 @@ use std::collections::BTreeMap;
 
 use crate::NativeAsrError;
 use crate::ggml_runtime::GgufMetadata;
+use crate::models::oasr_metadata::{
+    TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_TOKENS_KEY, required_metadata_string,
+    required_metadata_string_array,
+};
 use crate::models::phrase_bias_decode::{
     PhraseBiasTokenEncoder, encode_sentencepiece_phrase_bias_tokens,
 };
 use crate::models::spm_decoder::{SpmDecoderConfig, decode_spm_pieces};
 
-const TOKENIZER_GGML_MODEL_KEY: &str = "tokenizer.ggml.model";
+const MOONSHINE_TOKENIZER_FAMILY: &str = "Moonshine";
 const TOKENIZER_GGML_MODEL_VALUE_LLAMA: &str = "llama";
-const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
 
 /// SentencePiece-style ▁/byte-fallback BPE tokenizer used by Moonshine.
 ///
@@ -30,7 +33,11 @@ impl PhraseBiasTokenEncoder for MoonshineTokenizer {
 
 impl MoonshineTokenizer {
     pub(crate) fn from_gguf_metadata(metadata: &GgufMetadata) -> Result<Self, NativeAsrError> {
-        let tokenizer_model = required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY)?;
+        let tokenizer_model = required_metadata_string(
+            metadata,
+            TOKENIZER_GGML_MODEL_KEY,
+            MOONSHINE_TOKENIZER_FAMILY,
+        )?;
         if !tokenizer_model.eq_ignore_ascii_case(TOKENIZER_GGML_MODEL_VALUE_LLAMA) {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -38,7 +45,11 @@ impl MoonshineTokenizer {
                 ),
             });
         }
-        let tokens = required_metadata_string_array(metadata, TOKENIZER_GGML_TOKENS_KEY)?;
+        let tokens = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_TOKENS_KEY,
+            MOONSHINE_TOKENIZER_FAMILY,
+        )?;
         if tokens.is_empty() {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -83,26 +94,4 @@ impl MoonshineTokenizer {
             SpmDecoderConfig::BYTE_FALLBACK_BPE,
         ))
     }
-}
-
-fn required_metadata_string<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a str, NativeAsrError> {
-    metadata
-        .get_string(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Moonshine GGUF metadata is missing required key '{key}'"),
-        })
-}
-
-fn required_metadata_string_array<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a [String], NativeAsrError> {
-    metadata
-        .get_string_array(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Moonshine GGUF metadata is missing required string array '{key}'"),
-        })
 }

--- a/crates/openasr-core/src/models/oasr_metadata.rs
+++ b/crates/openasr-core/src/models/oasr_metadata.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
-use crate::ggml_runtime::GgufWriteValue;
+use crate::NativeAsrError;
+use crate::ggml_runtime::{GgufMetadata, GgufWriteValue};
 
 pub const OASR_METADATA_KEY_PACKAGE_VERSION: &str = "openasr.package.version";
 pub const OASR_METADATA_KEY_MODEL_FAMILY: &str = "openasr.model.family";
@@ -11,6 +12,16 @@ pub const OASR_METADATA_KEY_FEATURE_DIARIZATION: &str = "openasr.features.diariz
 
 pub const OASR_PACKAGE_VERSION_V1: &str = "1";
 pub const OASR_FEATURE_DIARIZATION_COHERE_TOKEN_STREAM_V1: &str = "cohere-token-stream-v1";
+
+/// Shared `tokenizer.ggml.*` GGUF key names. Every builtin tokenizer family
+/// (cohere, hymt2, moonshine, whisper, qwen) reads/writes the same three keys
+/// under these exact names; only the accepted `tokenizer.ggml.model` *value*
+/// differs per family (llama/SentencePiece vs gpt2/BPE) and stays declared
+/// locally in each family, since merging the values would collapse a real
+/// distinction into a false one.
+pub(crate) const TOKENIZER_GGML_MODEL_KEY: &str = "tokenizer.ggml.model";
+pub(crate) const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
+pub(crate) const TOKENIZER_GGML_MERGES_KEY: &str = "tokenizer.ggml.merges";
 
 /// Insert a string-valued GGUF metadata entry. Shared by every family's
 /// `*_runtime_gguf_metadata` builder in place of a per-file copy of the same
@@ -95,4 +106,109 @@ impl OasrMetadataBuilder {
     pub(crate) fn build(self) -> BTreeMap<String, GgufWriteValue> {
         self.metadata
     }
+}
+
+// --- Read-side accessors -------------------------------------------------
+//
+// Every builtin tokenizer family's `from_gguf_metadata` loader (cohere,
+// hymt2, moonshine, whisper, qwen) parsed its GGUF metadata through a
+// byte-for-byte copy of these helpers, differing only in the family name
+// spliced into the error text. Centralizing them here (mirroring the
+// write-side `insert_metadata*` helpers above) means a metadata-parsing fix
+// lands once instead of five times.
+
+/// Read a required string-valued GGUF metadata key, trimmed and rejected if
+/// empty after trimming.
+pub(crate) fn required_metadata_string<'a>(
+    metadata: &'a GgufMetadata,
+    key: &'static str,
+    family: &str,
+) -> Result<&'a str, NativeAsrError> {
+    let value = metadata
+        .get_string(key)
+        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
+            reason: format!("{family} GGUF tokenizer is missing required key '{key}'"),
+        })?;
+    let normalized = value.trim();
+    if normalized.is_empty() {
+        return Err(NativeAsrError::UnsupportedModelPack {
+            reason: format!("{family} GGUF tokenizer key '{key}' cannot be empty"),
+        });
+    }
+    Ok(normalized)
+}
+
+/// Read a required `array[string]`-valued GGUF metadata key.
+pub(crate) fn required_metadata_string_array<'a>(
+    metadata: &'a GgufMetadata,
+    key: &'static str,
+    family: &str,
+) -> Result<&'a [String], NativeAsrError> {
+    metadata
+        .get_string_array(key)
+        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
+            reason: format!("{family} GGUF tokenizer requires key '{key}' as array[string]"),
+        })
+}
+
+/// Read a required `array[uint32]`-valued GGUF metadata key.
+pub(crate) fn required_metadata_u32_array<'a>(
+    metadata: &'a GgufMetadata,
+    key: &'static str,
+    family: &str,
+) -> Result<&'a [u32], NativeAsrError> {
+    metadata
+        .get_u32_array(key)
+        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
+            reason: format!("{family} GGUF tokenizer requires key '{key}' as array[uint32]"),
+        })
+}
+
+/// Read an optional `u32`-valued GGUF metadata key, accepting a native u32, a
+/// native u64 that fits u32, or a numeric string (some importers write ints
+/// as strings). Returns `None` when the key is absent.
+pub(crate) fn optional_metadata_u32(
+    metadata: &GgufMetadata,
+    key: &'static str,
+    family: &str,
+) -> Result<Option<u32>, NativeAsrError> {
+    if let Some(value) = metadata.get_u32(key) {
+        return Ok(Some(value));
+    }
+    if let Some(value) = metadata.get_u64(key) {
+        return u32::try_from(value)
+            .map(Some)
+            .map_err(|_| NativeAsrError::UnsupportedModelPack {
+                reason: format!(
+                    "{family} GGUF tokenizer key '{key}' value {value} does not fit u32"
+                ),
+            });
+    }
+    if let Some(value) = metadata.get_string(key) {
+        let parsed =
+            value
+                .trim()
+                .parse::<u32>()
+                .map_err(|error| NativeAsrError::UnsupportedModelPack {
+                    reason: format!(
+                        "{family} GGUF tokenizer key '{key}' cannot parse '{value}' as u32: {error}"
+                    ),
+                })?;
+        return Ok(Some(parsed));
+    }
+    Ok(None)
+}
+
+/// Read a required `u32`-valued GGUF metadata key (see [`optional_metadata_u32`]
+/// for the accepted encodings).
+pub(crate) fn required_metadata_u32(
+    metadata: &GgufMetadata,
+    key: &'static str,
+    family: &str,
+) -> Result<u32, NativeAsrError> {
+    optional_metadata_u32(metadata, key, family)?.ok_or_else(|| {
+        NativeAsrError::UnsupportedModelPack {
+            reason: format!("{family} GGUF tokenizer is missing required key '{key}'"),
+        }
+    })
 }

--- a/crates/openasr-core/src/models/qwen/logits_head.rs
+++ b/crates/openasr-core/src/models/qwen/logits_head.rs
@@ -1,15 +1,14 @@
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    fmt,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::{cell::RefCell, fmt, path::PathBuf};
 
 use thiserror::Error;
 
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlStaticTensor,
     GgmlStaticTensorArena, GgufTensorDataReadError, GgufTensorDataReader, env_toggle_with_raw,
+};
+use crate::models::thread_local_runtime_cache::{
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
 };
 
 use super::graph_config::qwen_runtime_graph_config;
@@ -22,6 +21,12 @@ const DEFAULT_RMS_NORM_EPSILON: f32 = 1e-6;
 const QWEN3_LLM_LOGITS_GRAPH_CONTEXT_BYTES: usize = 16 * 1024 * 1024;
 const OPENASR_QWEN3_LLM_LOGITS_GGML_ENV: &str = "OPENASR_QWEN3_LLM_LOGITS_GGML";
 
+/// (canonical pack path, backend): identifies the resident fused logits-head
+/// graph executor for a loaded pack, mirroring the `(PathBuf,
+/// GgmlCpuGraphBackend)` key convention used by the qwen audio-encoder and
+/// firered-aed encoder/decoder runtime caches.
+type QwenLogitsHeadExecutorCacheKey = (PathBuf, GgmlCpuGraphBackend);
+
 #[derive(Debug, Clone)]
 pub(crate) struct Qwen3AsrLlmLogitsHead {
     d_model: usize,
@@ -32,7 +37,7 @@ pub(crate) struct Qwen3AsrLlmLogitsHead {
     output_weight_values: Option<Vec<f32>>,
     output_weight_layout: OutputWeightLayout,
     ggml_output_weight: Option<OwnedGgmlLogitsWeight>,
-    ggml_executor_id: Option<u64>,
+    ggml_executor_cache_key: Option<QwenLogitsHeadExecutorCacheKey>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -116,11 +121,12 @@ impl Qwen3AsrLlmLogitsHead {
             return Err(Qwen3AsrLlmLogitsHeadError::NonFiniteInputs);
         }
 
-        if let (Some(executor_id), Some(output_weight)) =
-            (self.ggml_executor_id, self.ggml_output_weight.as_ref())
-        {
+        if let (Some(cache_key), Some(output_weight)) = (
+            self.ggml_executor_cache_key.as_ref(),
+            self.ggml_output_weight.as_ref(),
+        ) {
             return with_thread_local_logits_head_executor(
-                executor_id,
+                cache_key.clone(),
                 self.d_model,
                 self.vocab_size,
                 self.rms_norm_epsilon,
@@ -185,11 +191,12 @@ impl Qwen3AsrLlmLogitsHead {
             return Err(Qwen3AsrLlmLogitsHeadError::NonFiniteInputs);
         }
 
-        if let (Some(executor_id), Some(output_weight)) =
-            (self.ggml_executor_id, self.ggml_output_weight.as_ref())
-        {
+        if let (Some(cache_key), Some(output_weight)) = (
+            self.ggml_executor_cache_key.as_ref(),
+            self.ggml_output_weight.as_ref(),
+        ) {
             let token_id = with_thread_local_logits_head_executor(
-                executor_id,
+                cache_key.clone(),
                 self.d_model,
                 self.vocab_size,
                 self.rms_norm_epsilon,
@@ -300,9 +307,12 @@ pub(crate) fn load_qwen3_llm_logits_head_from_reader_with_output_tensor(
         output_weight_tensor_name,
         output_weight_values,
         output_weight_layout,
-        ggml_executor_id: raw_output_weight
-            .as_ref()
-            .map(|_| next_qwen_logits_head_executor_id()),
+        ggml_executor_cache_key: raw_output_weight.as_ref().map(|_| {
+            (
+                canonical_runtime_cache_path(reader.tensor_index().path()),
+                qwen_runtime_graph_config().backend,
+            )
+        }),
         ggml_output_weight: raw_output_weight,
     })
 }
@@ -342,18 +352,25 @@ struct Qwen3AsrLlmLogitsHeadGraphExecutor {
 }
 
 thread_local! {
-    static QWEN_LLM_LOGITS_HEAD_EXECUTOR_BY_ID: RefCell<HashMap<u64, Qwen3AsrLlmLogitsHeadGraphExecutor>> =
-        RefCell::new(HashMap::new());
-}
-
-static NEXT_QWEN_LLM_LOGITS_HEAD_EXECUTOR_ID: AtomicU64 = AtomicU64::new(1);
-
-fn next_qwen_logits_head_executor_id() -> u64 {
-    NEXT_QWEN_LLM_LOGITS_HEAD_EXECUTOR_ID.fetch_add(1, Ordering::Relaxed)
+    // Bounded LRU (not a plain `HashMap`): each entry owns a resident ggml
+    // static-tensor arena holding the full vocab x d_model output-weight
+    // matrix. The previous design keyed this cache on a thread-local
+    // monotonic id minted once per model *load* and never evicted or
+    // reused, so every load of a qwen pack left one more multi-hundred-MB
+    // entry permanently resident per thread for the life of the process --
+    // the same "memory roller coaster" root cause already fixed for the
+    // other per-pack runtime caches (see
+    // `thread_local_runtime_cache::DEFAULT_RUNTIME_CACHE_CAPACITY`). Keying
+    // on `(canonical pack path, backend)` instead lets repeated loads of the
+    // same pack reuse one entry and bounds the worst case to
+    // `DEFAULT_RUNTIME_CACHE_CAPACITY` resident executors per thread.
+    static QWEN_LLM_LOGITS_HEAD_EXECUTOR_BY_KEY: RefCell<
+        BoundedRuntimeCache<QwenLogitsHeadExecutorCacheKey, Qwen3AsrLlmLogitsHeadGraphExecutor>,
+    > = RefCell::new(BoundedRuntimeCache::new());
 }
 
 fn with_thread_local_logits_head_executor<R>(
-    executor_id: u64,
+    cache_key: QwenLogitsHeadExecutorCacheKey,
     d_model: usize,
     vocab_size: usize,
     rms_norm_epsilon: f32,
@@ -361,23 +378,21 @@ fn with_thread_local_logits_head_executor<R>(
     output_weight: &OwnedGgmlLogitsWeight,
     use_executor: impl FnOnce(&mut Qwen3AsrLlmLogitsHeadGraphExecutor) -> Result<R, GgmlCpuGraphError>,
 ) -> Result<R, GgmlCpuGraphError> {
-    QWEN_LLM_LOGITS_HEAD_EXECUTOR_BY_ID.with(|cache| {
-        let mut cache = cache.borrow_mut();
-        if let std::collections::hash_map::Entry::Vacant(e) = cache.entry(executor_id) {
-            let executor = Qwen3AsrLlmLogitsHeadGraphExecutor::new(
+    with_thread_local_cached_mut_by_key(
+        &QWEN_LLM_LOGITS_HEAD_EXECUTOR_BY_KEY,
+        cache_key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
+        || {
+            Qwen3AsrLlmLogitsHeadGraphExecutor::new(
                 d_model,
                 vocab_size,
                 rms_norm_epsilon,
                 output_norm_weight,
                 output_weight,
-            )?;
-            e.insert(executor);
-        }
-        let executor = cache
-            .get_mut(&executor_id)
-            .expect("qwen logits-head executor cache must contain inserted entry");
-        use_executor(executor)
-    })
+            )
+        },
+        use_executor,
+    )
 }
 
 impl fmt::Debug for Qwen3AsrLlmLogitsHeadGraphExecutor {
@@ -662,7 +677,7 @@ mod tests {
             ]),
             output_weight_layout: OutputWeightLayout::HiddenVocab,
             ggml_output_weight: None,
-            ggml_executor_id: None,
+            ggml_executor_cache_key: None,
         };
         let logits = head
             .compute_logits_for_last_hidden(&[1.0, 2.0])
@@ -682,7 +697,7 @@ mod tests {
             output_weight_values: Some(vec![0.0; 32]),
             output_weight_layout: OutputWeightLayout::HiddenVocab,
             ggml_output_weight: None,
-            ggml_executor_id: None,
+            ggml_executor_cache_key: None,
         };
         let error = head
             .compute_logits_for_last_hidden(&[0.0; 3])
@@ -752,5 +767,80 @@ mod tests {
     fn logits_head_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<Qwen3AsrLlmLogitsHead>();
+    }
+
+    fn ggml_logits_head_with_cache_key(
+        cache_key: QwenLogitsHeadExecutorCacheKey,
+        output_norm_weight: Vec<f32>,
+    ) -> Qwen3AsrLlmLogitsHead {
+        // A valid rank-2 [d_model x vocab_size] f32 weight for d_model=2,
+        // vocab_size=3, matching the fused-logits fixture in
+        // `llm_transformer::tests::fused_logits_top1_selects_first_token_on_equal_logit_tie`.
+        let output_weight_values: [f32; 6] = [
+            0.1, 0.0, //
+            0.3, 0.0, //
+            0.3, 0.0,
+        ];
+        Qwen3AsrLlmLogitsHead {
+            d_model: 2,
+            vocab_size: 3,
+            rms_norm_epsilon: DEFAULT_RMS_NORM_EPSILON,
+            output_norm_weight,
+            output_weight_tensor_name: OUTPUT_WEIGHT_TENSOR_NAME,
+            output_weight_values: None,
+            output_weight_layout: OutputWeightLayout::HiddenVocab,
+            ggml_output_weight: Some(OwnedGgmlLogitsWeight {
+                ggml_type: crate::ggml_runtime::GGML_TYPE_F32,
+                dims: vec![2, 3],
+                bytes: output_weight_values
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect(),
+            }),
+            ggml_executor_cache_key: Some(cache_key),
+        }
+    }
+
+    fn ggml_logits_head_test_cache_key(id: usize) -> QwenLogitsHeadExecutorCacheKey {
+        (
+            PathBuf::from(format!("/tmp/openasr-test-logits-head-cache-{id}.gguf")),
+            GgmlCpuGraphBackend::Cpu,
+        )
+    }
+
+    #[test]
+    fn ggml_logits_head_executor_cache_reuses_same_key_without_rebuilding() {
+        let key = ggml_logits_head_test_cache_key(9_000_001);
+        let first = ggml_logits_head_with_cache_key(key.clone(), vec![1.0, 1.0]);
+        first
+            .compute_top1_token_for_last_hidden(&[1.0, 2.0])
+            .expect("first compute builds and caches the executor");
+
+        // Same cache key, but a norm-weight width that would fail
+        // `Qwen3AsrLlmLogitsHeadGraphExecutor::new`'s shape validation if it
+        // were actually rebuilt. Success here proves the cached executor
+        // from `first` was reused and this (invalid) weight was never used
+        // to build a new one.
+        let second = ggml_logits_head_with_cache_key(key, vec![1.0, 1.0, 1.0]);
+        second
+            .compute_top1_token_for_last_hidden(&[1.0, 2.0])
+            .expect("second compute must reuse the cached executor, not rebuild from bad input");
+    }
+
+    #[test]
+    fn ggml_logits_head_executor_cache_evicts_beyond_capacity() {
+        let base_id = 9_100_000;
+        for offset in 0..(DEFAULT_RUNTIME_CACHE_CAPACITY + 3) {
+            let key = ggml_logits_head_test_cache_key(base_id + offset);
+            let head = ggml_logits_head_with_cache_key(key, vec![1.0, 1.0]);
+            head.compute_top1_token_for_last_hidden(&[1.0, 2.0])
+                .unwrap_or_else(|error| panic!("compute for distinct key {offset}: {error}"));
+
+            let len = QWEN_LLM_LOGITS_HEAD_EXECUTOR_BY_KEY.with(|cache| cache.borrow().len());
+            assert!(
+                len <= DEFAULT_RUNTIME_CACHE_CAPACITY,
+                "cache must never exceed the configured capacity (cap={DEFAULT_RUNTIME_CACHE_CAPACITY}), got {len}"
+            );
+        }
     }
 }

--- a/crates/openasr-core/src/models/qwen/tokenizer.rs
+++ b/crates/openasr-core/src/models/qwen/tokenizer.rs
@@ -6,6 +6,10 @@ use crate::models::decode_policy_component_registry::BuiltinSeq2SeqDecodePolicyT
 use crate::models::gpt2_bpe::{
     build_merge_rank, build_token_to_id, encode_prompt_text, token_to_bytes,
 };
+use crate::models::oasr_metadata::{
+    TOKENIZER_GGML_MERGES_KEY, TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_TOKENS_KEY,
+    required_metadata_string, required_metadata_string_array, required_metadata_u32,
+};
 use crate::models::phrase_bias_decode::{PhraseBiasTokenEncoder, encode_bpe_phrase_bias_variants};
 
 use super::runtime_contract::{
@@ -13,10 +17,8 @@ use super::runtime_contract::{
     QWEN3_EOS_TOKEN_ID_KEY, QWEN3_LLM_VOCAB_SIZE_KEY, QWEN3_PAD_TOKEN_ID_KEY,
 };
 
-const TOKENIZER_GGML_MODEL_KEY: &str = "tokenizer.ggml.model";
+const QWEN3_TOKENIZER_FAMILY: &str = "Qwen3-ASR";
 const TOKENIZER_GGML_MODEL_VALUE_GPT2: &str = "gpt2";
-const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
-const TOKENIZER_GGML_MERGES_KEY: &str = "tokenizer.ggml.merges";
 
 #[derive(Debug, Clone)]
 pub(crate) struct Qwen3AsrTokenizer {
@@ -32,7 +34,8 @@ pub(crate) struct Qwen3AsrTokenizer {
 
 impl Qwen3AsrTokenizer {
     pub fn from_gguf_metadata(metadata: &GgufMetadata) -> Result<Self, NativeAsrError> {
-        let tokenizer_model = required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY)?;
+        let tokenizer_model =
+            required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY, QWEN3_TOKENIZER_FAMILY)?;
         if !tokenizer_model.eq_ignore_ascii_case(TOKENIZER_GGML_MODEL_VALUE_GPT2) {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -42,7 +45,11 @@ impl Qwen3AsrTokenizer {
             });
         }
 
-        let tokens = required_metadata_string_array(metadata, TOKENIZER_GGML_TOKENS_KEY)?;
+        let tokens = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_TOKENS_KEY,
+            QWEN3_TOKENIZER_FAMILY,
+        )?;
         if tokens.is_empty() {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -51,7 +58,11 @@ impl Qwen3AsrTokenizer {
                 ),
             });
         }
-        let merges = required_metadata_string_array(metadata, TOKENIZER_GGML_MERGES_KEY)?;
+        let merges = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_MERGES_KEY,
+            QWEN3_TOKENIZER_FAMILY,
+        )?;
         if merges.is_empty() {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -61,7 +72,8 @@ impl Qwen3AsrTokenizer {
             });
         }
 
-        let vocab_size = required_metadata_u32(metadata, QWEN3_LLM_VOCAB_SIZE_KEY)?;
+        let vocab_size =
+            required_metadata_u32(metadata, QWEN3_LLM_VOCAB_SIZE_KEY, QWEN3_TOKENIZER_FAMILY)?;
         let token_count =
             u32::try_from(tokens.len()).map_err(|_| NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -78,11 +90,25 @@ impl Qwen3AsrTokenizer {
             });
         }
 
-        let audio_start_token_id = required_metadata_u32(metadata, QWEN3_AUDIO_START_TOKEN_ID_KEY)?;
-        let audio_end_token_id = required_metadata_u32(metadata, QWEN3_AUDIO_END_TOKEN_ID_KEY)?;
-        let audio_pad_token_id = required_metadata_u32(metadata, QWEN3_AUDIO_PAD_TOKEN_ID_KEY)?;
-        let eos_token_id = required_metadata_u32(metadata, QWEN3_EOS_TOKEN_ID_KEY)?;
-        let pad_token_id = required_metadata_u32(metadata, QWEN3_PAD_TOKEN_ID_KEY)?;
+        let audio_start_token_id = required_metadata_u32(
+            metadata,
+            QWEN3_AUDIO_START_TOKEN_ID_KEY,
+            QWEN3_TOKENIZER_FAMILY,
+        )?;
+        let audio_end_token_id = required_metadata_u32(
+            metadata,
+            QWEN3_AUDIO_END_TOKEN_ID_KEY,
+            QWEN3_TOKENIZER_FAMILY,
+        )?;
+        let audio_pad_token_id = required_metadata_u32(
+            metadata,
+            QWEN3_AUDIO_PAD_TOKEN_ID_KEY,
+            QWEN3_TOKENIZER_FAMILY,
+        )?;
+        let eos_token_id =
+            required_metadata_u32(metadata, QWEN3_EOS_TOKEN_ID_KEY, QWEN3_TOKENIZER_FAMILY)?;
+        let pad_token_id =
+            required_metadata_u32(metadata, QWEN3_PAD_TOKEN_ID_KEY, QWEN3_TOKENIZER_FAMILY)?;
 
         let mut id_to_token = tokens
             .iter()
@@ -226,62 +252,6 @@ fn validate_token_id_in_range(
             id_to_token.len()
         ),
     })
-}
-
-fn required_metadata_string<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a str, NativeAsrError> {
-    let value = metadata
-        .get_string(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Qwen3-ASR GGUF tokenizer is missing required key '{key}'"),
-        })?;
-    let normalized = value.trim();
-    if normalized.is_empty() {
-        return Err(NativeAsrError::UnsupportedModelPack {
-            reason: format!("Qwen3-ASR GGUF tokenizer key '{key}' cannot be empty"),
-        });
-    }
-    Ok(normalized)
-}
-
-fn required_metadata_u32(
-    metadata: &GgufMetadata,
-    key: &'static str,
-) -> Result<u32, NativeAsrError> {
-    if let Some(value) = metadata.get_u32(key) {
-        return Ok(value);
-    }
-    if let Some(value) = metadata.get_u64(key) {
-        return u32::try_from(value).map_err(|_| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Qwen3-ASR GGUF tokenizer key '{key}' value {value} does not fit u32"),
-        });
-    }
-    if let Some(value) = metadata.get_string(key) {
-        let parsed = value.trim().parse::<u32>().map_err(|error| {
-            NativeAsrError::UnsupportedModelPack {
-                reason: format!(
-                    "Qwen3-ASR GGUF tokenizer key '{key}' cannot parse '{value}' as u32: {error}"
-                ),
-            }
-        })?;
-        return Ok(parsed);
-    }
-    Err(NativeAsrError::UnsupportedModelPack {
-        reason: format!("Qwen3-ASR GGUF tokenizer is missing required key '{key}'"),
-    })
-}
-
-fn required_metadata_string_array<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a [String], NativeAsrError> {
-    metadata
-        .get_string_array(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Qwen3-ASR GGUF tokenizer requires key '{key}' as array[string]"),
-        })
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/whisper/tokenizer.rs
+++ b/crates/openasr-core/src/models/whisper/tokenizer.rs
@@ -17,8 +17,20 @@ use crate::models::gpt2_bpe::{
     build_merge_rank, build_token_to_id, encode_prompt_text, token_to_bytes,
 };
 use crate::models::language::{language_control_token, normalize_language};
+// Re-exported at this path (rather than imported privately) because
+// `whisper::package_import` and `whisper::batched_decode` reach these three
+// shared keys via `super::tokenizer::TOKENIZER_GGML_*`, matching how they
+// already pull `TOKENIZER_GGML_MODEL_VALUE_GPT2` from this module.
+pub(crate) use crate::models::oasr_metadata::{
+    TOKENIZER_GGML_MERGES_KEY, TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_TOKENS_KEY,
+};
+use crate::models::oasr_metadata::{
+    optional_metadata_u32, required_metadata_string, required_metadata_string_array,
+    required_metadata_u32, required_metadata_u32_array,
+};
 use crate::models::phrase_bias_decode::{PhraseBiasTokenEncoder, encode_bpe_phrase_bias_variants};
 
+const WHISPER_TOKENIZER_FAMILY: &str = "Whisper";
 const SOURCE_TOKENIZER_JSON: &str = "tokenizer.json";
 const SOURCE_VOCAB_JSON: &str = "vocab.json";
 const SOURCE_MERGES_TXT: &str = "merges.txt";
@@ -29,9 +41,7 @@ const END_OF_TEXT_TOKEN: &str = "<|endoftext|>";
 const TRANSCRIBE_TOKEN: &str = "<|transcribe|>";
 const TRANSLATE_TOKEN: &str = "<|translate|>";
 const ENGLISH_LANGUAGE_TOKEN: &str = "<|en|>";
-pub(crate) const TOKENIZER_GGML_MODEL_KEY: &str = "tokenizer.ggml.model";
 pub(crate) const TOKENIZER_GGML_MODEL_VALUE_GPT2: &str = "gpt2";
-pub(crate) const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
 
 /// True when a Whisper pack carries the multilingual language-token block, using
 /// the same `vocab_size > WHISPER_ENGLISH_ONLY_MAX_VOCAB_SIZE` rule the decoder
@@ -39,12 +49,15 @@ pub(crate) const TOKENIZER_GGML_TOKENS_KEY: &str = "tokenizer.ggml.tokens";
 /// decoder still validates the explicit `<|lang|>` token before use, so this only
 /// affects whether an English-only pack rejects a foreign-language hint.
 pub(crate) fn whisper_metadata_is_multilingual(metadata: &GgufMetadata) -> bool {
-    match required_metadata_string_array(metadata, TOKENIZER_GGML_TOKENS_KEY) {
+    match required_metadata_string_array(
+        metadata,
+        TOKENIZER_GGML_TOKENS_KEY,
+        WHISPER_TOKENIZER_FAMILY,
+    ) {
         Ok(tokens) => tokens.len() > super::ggml_executor::WHISPER_ENGLISH_ONLY_MAX_VOCAB_SIZE,
         Err(_) => true,
     }
 }
-pub(crate) const TOKENIZER_GGML_MERGES_KEY: &str = "tokenizer.ggml.merges";
 pub(crate) const TOKENIZER_GGML_SPECIAL_TOKEN_IDS_KEY: &str = "tokenizer.ggml.special_token_ids";
 pub(crate) const TOKENIZER_GGML_SOT_TOKEN_ID_KEY: &str = "tokenizer.ggml.sot_token_id";
 pub(crate) const TOKENIZER_GGML_EOT_TOKEN_ID_KEY: &str = "tokenizer.ggml.eot_token_id";
@@ -129,7 +142,8 @@ impl WhisperTokenizer {
     }
 
     pub(crate) fn from_gguf_metadata(metadata: &GgufMetadata) -> Result<Self, NativeAsrError> {
-        let tokenizer_model = required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY)?;
+        let tokenizer_model =
+            required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY, WHISPER_TOKENIZER_FAMILY)?;
         if !tokenizer_model.eq_ignore_ascii_case(TOKENIZER_GGML_MODEL_VALUE_GPT2) {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -139,7 +153,11 @@ impl WhisperTokenizer {
             });
         }
 
-        let tokens = required_metadata_string_array(metadata, TOKENIZER_GGML_TOKENS_KEY)?;
+        let tokens = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_TOKENS_KEY,
+            WHISPER_TOKENIZER_FAMILY,
+        )?;
         if tokens.is_empty() {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -148,7 +166,11 @@ impl WhisperTokenizer {
                 ),
             });
         }
-        let merges = required_metadata_string_array(metadata, TOKENIZER_GGML_MERGES_KEY)?;
+        let merges = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_MERGES_KEY,
+            WHISPER_TOKENIZER_FAMILY,
+        )?;
         if merges.is_empty() {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -157,8 +179,11 @@ impl WhisperTokenizer {
                 ),
             });
         }
-        let special_token_ids =
-            required_metadata_u32_array(metadata, TOKENIZER_GGML_SPECIAL_TOKEN_IDS_KEY)?;
+        let special_token_ids = required_metadata_u32_array(
+            metadata,
+            TOKENIZER_GGML_SPECIAL_TOKEN_IDS_KEY,
+            WHISPER_TOKENIZER_FAMILY,
+        )?;
         if special_token_ids.is_empty() {
             return Err(NativeAsrError::UnsupportedModelPack {
                 reason: format!(
@@ -168,7 +193,9 @@ impl WhisperTokenizer {
             });
         }
 
-        if let Some(vocab_size) = optional_metadata_u32(metadata, WHISPER_VOCAB_SIZE_KEY)? {
+        if let Some(vocab_size) =
+            optional_metadata_u32(metadata, WHISPER_VOCAB_SIZE_KEY, WHISPER_TOKENIZER_FAMILY)?
+        {
             let token_count =
                 u32::try_from(tokens.len()).map_err(|_| NativeAsrError::UnsupportedModelPack {
                     reason: format!(
@@ -186,12 +213,26 @@ impl WhisperTokenizer {
             }
         }
 
-        let sot_token_id = required_metadata_u32(metadata, TOKENIZER_GGML_SOT_TOKEN_ID_KEY)?;
-        let eot_token_id = required_metadata_u32(metadata, TOKENIZER_GGML_EOT_TOKEN_ID_KEY)?;
-        let transcribe_token_id =
-            required_metadata_u32(metadata, TOKENIZER_GGML_TRANSCRIBE_TOKEN_ID_KEY)?;
-        let no_timestamps_token_id =
-            required_metadata_u32(metadata, TOKENIZER_GGML_NO_TIMESTAMPS_TOKEN_ID_KEY)?;
+        let sot_token_id = required_metadata_u32(
+            metadata,
+            TOKENIZER_GGML_SOT_TOKEN_ID_KEY,
+            WHISPER_TOKENIZER_FAMILY,
+        )?;
+        let eot_token_id = required_metadata_u32(
+            metadata,
+            TOKENIZER_GGML_EOT_TOKEN_ID_KEY,
+            WHISPER_TOKENIZER_FAMILY,
+        )?;
+        let transcribe_token_id = required_metadata_u32(
+            metadata,
+            TOKENIZER_GGML_TRANSCRIBE_TOKEN_ID_KEY,
+            WHISPER_TOKENIZER_FAMILY,
+        )?;
+        let no_timestamps_token_id = required_metadata_u32(
+            metadata,
+            TOKENIZER_GGML_NO_TIMESTAMPS_TOKEN_ID_KEY,
+            WHISPER_TOKENIZER_FAMILY,
+        )?;
 
         let id_to_token = tokens
             .iter()
@@ -660,77 +701,6 @@ impl PhraseBiasTokenEncoder for WhisperTokenizer {
         // mid-sentence, not just the standalone tokenization.
         encode_bpe_phrase_bias_variants(phrase, |text| self.encode_prompt_text(text)).map(Some)
     }
-}
-
-fn required_metadata_string<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a str, NativeAsrError> {
-    let value = metadata
-        .get_string(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Whisper GGUF tokenizer is missing required key '{key}'"),
-        })?;
-    let normalized = value.trim();
-    if normalized.is_empty() {
-        return Err(NativeAsrError::UnsupportedModelPack {
-            reason: format!("Whisper GGUF tokenizer key '{key}' cannot be empty"),
-        });
-    }
-    Ok(normalized)
-}
-
-fn required_metadata_u32(
-    metadata: &GgufMetadata,
-    key: &'static str,
-) -> Result<u32, NativeAsrError> {
-    optional_metadata_u32(metadata, key)?.ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-        reason: format!("Whisper GGUF tokenizer is missing required key '{key}'"),
-    })
-}
-
-fn optional_metadata_u32(
-    metadata: &GgufMetadata,
-    key: &'static str,
-) -> Result<Option<u32>, NativeAsrError> {
-    if let Some(value) = metadata.get_u32(key) {
-        return Ok(Some(value));
-    }
-    if let Some(value) = metadata.get_string(key) {
-        let parsed =
-            value
-                .trim()
-                .parse::<u32>()
-                .map_err(|error| NativeAsrError::UnsupportedModelPack {
-                    reason: format!(
-                        "Whisper GGUF tokenizer key '{key}' cannot parse '{value}' as u32: {error}"
-                    ),
-                })?;
-        return Ok(Some(parsed));
-    }
-    Ok(None)
-}
-
-fn required_metadata_string_array<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a [String], NativeAsrError> {
-    metadata
-        .get_string_array(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Whisper GGUF tokenizer requires key '{key}' as array[string]"),
-        })
-}
-
-fn required_metadata_u32_array<'a>(
-    metadata: &'a GgufMetadata,
-    key: &'static str,
-) -> Result<&'a [u32], NativeAsrError> {
-    metadata
-        .get_u32_array(key)
-        .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
-            reason: format!("Whisper GGUF tokenizer requires key '{key}' as array[uint32]"),
-        })
 }
 
 fn read_json_file<T: for<'de> Deserialize<'de>>(


### PR DESCRIPTION
## Summary

- Move the GGUF metadata read accessors duplicated across five builtin tokenizer families into `models/oasr_metadata.rs`, parameterized by family.
- Bound the qwen fused logits-head executor thread-local cache instead of leaking one resident executor per model load forever.

## Why

`cohere/tokenizer.rs`, `hymt2/tokenizer.rs`, `moonshine/tokenizer.rs`, `whisper/tokenizer.rs`, and `qwen/tokenizer.rs` each carried a private, byte-for-byte copy of `required_metadata_string`, `required_metadata_string_array`, `required_metadata_u32[_array]`, and `optional_metadata_u32`, differing only in the family name spliced into the error text (plus minor incidental wording drift, e.g. moonshine skipped the trim/empty check the other four had). Each family also redeclared the same `tokenizer.ggml.model` / `tokenizer.ggml.tokens` / `tokenizer.ggml.merges` GGUF key strings locally.

Separately, `qwen/logits_head.rs`'s fused logits-head executor cache used a thread-local `HashMap<u64, _>` keyed by a monotonically increasing id minted once per model load and never evicted. Every load of a qwen pack left one more resident vocab x d_model output-weight executor per thread for the life of the process -- the same unbounded-cache "memory roller coaster" pattern already fixed for the qwen audio encoder and firered-aed encoder/decoder runtime caches, but missed here.

## Changes

- `models/oasr_metadata.rs`: add `required_metadata_string`, `required_metadata_string_array`, `required_metadata_u32`, `required_metadata_u32_array`, `optional_metadata_u32` (each taking a `family: &str` for the error text), plus the three shared `TOKENIZER_GGML_{MODEL,TOKENS,MERGES}_KEY` constants.
- `models/{cohere,hymt2,moonshine,whisper,qwen}/tokenizer.rs`: delete the five local accessor copies and the duplicated key constants, call the shared versions. The `tokenizer.ggml.model` *value* constants (`llama` vs `gpt2`) stay declared locally per family since they are genuinely different, not incidental duplication.
  - Normalized moonshine's accessor to the trim + empty-check behavior the other four families already had (previously it silently skipped both).
  - Normalized whisper's `optional_metadata_u32`/`required_metadata_u32` to also accept a native `u64` value (matching qwen's existing behavior), a strict superset that only helps a previously-rejected encoding.
  - `whisper/tokenizer.rs` re-exports the three shared key constants at their original path since `whisper::package_import` and `whisper::batched_decode` reach them via `super::tokenizer::TOKENIZER_GGML_*`.
- `models/qwen/logits_head.rs`: replace the unbounded `HashMap<u64, _>` + `AtomicU64` id generator with the existing `thread_local_runtime_cache::with_thread_local_cached_mut_by_key` bounded LRU (cap = `DEFAULT_RUNTIME_CACHE_CAPACITY` = 4), keyed on `(canonical pack path, backend)` -- the same key shape already used by the qwen audio-encoder and firered-aed encoder/decoder caches. Added `ggml_logits_head_executor_cache_reuses_same_key_without_rebuilding` and `ggml_logits_head_executor_cache_evicts_beyond_capacity`.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2307 passed, 1 slow, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

N/A -- pure internal refactor of metadata parsing and a cache key scheme; no CLI/API-visible behavior change (aside from the two accessor-behavior normalizations noted above, which only affect previously-rejected/previously-silent edge cases).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed. (No user-facing behavior or limitations changed.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch the independently-duplicated `tokenizer.ggml.*` constant literals in `package_import.rs` / `forced_aligner_import.rs` / `forced_aligner_runtime.rs` / `hymt2/config.rs` -- those are a distinct, wider duplication not covered by this audit finding and are left for a separate pass.
- Does not merge the `tokenizer.ggml.model` *value* constants (`llama` vs `gpt2`) across families -- these are genuinely different per family.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- an AI coding agent implemented this refactor end-to-end (audit-driven duplication removal and cache bounding) under human direction; changes were reviewed against the repo's existing shared-cache and metadata-accessor conventions before submission.