### PR TITLE
perf(server): warm up the model at daemon boot and unload after idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Realtime translation: livelock fix for mixed-language (CJK + Latin) input
 - Windows: UTF-8 console output, PATH executable detection, host RAM/disk probing, mmap'd model re-pull error
 - Docker smoke test in CI; serve-batch real-pack parity lane
+- Server: the daemon's bound native model pack is now warmed up in the background right after boot (bind), instead of on the first realtime WS attach, so the first dictation session no longer pays the cold model-pack-load cost (observed 1.7-2.1s) before its first partial; `/health` remains unaffected (bind-then-serve, never gated on warm-up)
+- Server: `idle_unload` now actually releases the cached native model runtime (mmap/materialized tensors/Metal or CPU graph context) once idle past the configured threshold, freeing the RAM a bound pack otherwise held for the daemon's whole lifetime; a later request just rebuilds it through the normal load-and-warm-up path
 
 ### Changed
 
 - Default model changed to `qwen3-asr-0.6b`; Qwen3-ASR family promoted to primary recommendation
+- `idle_unload` preference default changed from `never` to `10m`: a bound native model pack is now released from RAM after 10 minutes with no active request/realtime session, instead of staying resident until the daemon exits; an explicitly configured `idle_unload` (including `never`) is unaffected -- only the default changed
 - Catalog: dropped ModelScope mirror; unified quant tag scheme (`canonical_quant_tag`)
 - Server: extracted config, history, and translation routes into dedicated modules
 - Pre-open-source cleanup: removed private docs/artifacts, aligned license metadata, dep hygiene

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -523,6 +523,14 @@ pub(super) async fn serve(
     launch_options.auth = launch_options
         .auth
         .with_pairing_store(home.join("pairing-registry.json"));
+    // `idle_unload` lives on `Preferences`, not the plain `OpenAsrConfig`
+    // already loaded above -- read the full config document for it. A
+    // missing/unreadable document (fresh install) falls back to the default
+    // policy rather than failing serve over a preferences read.
+    launch_options.idle_unload_after = openasr_core::load_config_document(&home)
+        .map(|document| document.preferences.idle_unload)
+        .unwrap_or_default()
+        .idle_threshold();
     openasr_server::serve_with_launch_options(
         addr,
         openasr_server::ServerRuntime {

--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -17,8 +17,8 @@ pub use native::{
     native_runtime_model_adapter_for_path, native_runtime_model_refs_match,
     native_runtime_realtime_capabilities_for_path,
     native_runtime_transcription_capabilities_for_path, native_transcription_progress,
-    resolve_local_native_runtime_model_identity, validate_local_native_model_pack_path,
-    validate_native_runtime_model_pack_contract,
+    resolve_local_native_runtime_model_identity, unload_idle_native_model_runtime_caches,
+    validate_local_native_model_pack_path, validate_native_runtime_model_pack_contract,
 };
 
 pub const NATIVE_RUNTIME_MODEL_ID_AUTO: &str = "__openasr_native_runtime_model_id_auto__";

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -460,6 +460,28 @@ fn shared_native_ggml_streaming_execution_dispatch()
     }
 }
 
+/// Idle-unload for the realtime-streaming dispatch. Like its offline
+/// counterpart, uses `get()` so a daemon that never started a streaming
+/// session does not build the dispatch just to unload nothing.
+pub(crate) fn unload_idle_native_streaming_runtime_caches() {
+    if let Some(Ok(dispatch)) = NATIVE_GGML_STREAMING_EXECUTION_DISPATCH.get() {
+        dispatch.unload_all();
+    }
+}
+
+/// Evicts every process-lifetime native model runtime cache (offline
+/// transcription dispatch + realtime streaming dispatch), releasing the
+/// resident mmap/tensor/Metal state a bound model pack accumulates after use.
+/// The `idle_unload` server preference calls this from a background reaper
+/// once the daemon has been idle (no active request/session) past its
+/// configured threshold; a subsequent request just rebuilds via the normal
+/// load-on-first-use path (paying the cold build cost again, same as the
+/// very first request after boot).
+pub fn unload_idle_native_model_runtime_caches() {
+    native_transcribe::unload_idle_native_offline_runtime_caches();
+    unload_idle_native_streaming_runtime_caches();
+}
+
 fn native_ggml_streaming_error_to_asr(
     adapter_id: &'static str,
     error: GgmlAsrExecutionError,
@@ -1245,6 +1267,16 @@ mod tests {
         ) -> Result<Vec<crate::realtime::RealtimeEventEnvelope>, NativeAsrError> {
             Ok(Vec::new())
         }
+    }
+
+    #[test]
+    fn unload_idle_native_model_runtime_caches_is_a_safe_no_op_before_any_dispatch_use() {
+        // The common daemon-boot-with-no-request-yet case (and the general
+        // "idle_unload reaper fires before either dispatch was ever built"
+        // case, since both use `OnceLock::get()` rather than
+        // `get_or_init()`): must not build the dispatch just to unload
+        // nothing from it, and must never panic.
+        unload_idle_native_model_runtime_caches();
     }
 
     #[test]

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1211,6 +1211,16 @@ fn shared_native_ggml_execution_dispatch() -> &'static GgmlAsrExecutionDispatch 
     })
 }
 
+/// Idle-unload for the offline (file-transcription) dispatch. Deliberately
+/// uses `get()`, not `get_or_init` -- a daemon that never served a file
+/// transcription has nothing resident here, and this must not be the thing
+/// that first builds the dispatch.
+pub(crate) fn unload_idle_native_offline_runtime_caches() {
+    if let Some(dispatch) = NATIVE_GGML_EXECUTION_DISPATCH.get() {
+        dispatch.unload_all();
+    }
+}
+
 /// Resolve the long-form VAD provider for this request, returning the
 /// provider and a label for the engine that ran. Stream-VAD is the sole VAD
 /// engine and is vendored (`include_bytes!`), so in practice this always

--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -144,16 +144,40 @@ impl HistoryRetentionPolicy {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IdleUnloadPolicy {
-    #[default]
     Never,
     #[serde(rename = "now")]
     Now,
     #[serde(rename = "2m")]
     After2m,
+    /// Default: a bound native model pack (up to ~1.4 GiB resident for the
+    /// larger builtin families) is released after 10 minutes with no active
+    /// request or realtime session, instead of staying resident in RAM for
+    /// the daemon's whole lifetime. A later request just pays the normal
+    /// load+warm-up cost again. Only the default changed here -- an existing
+    /// config that already sets `idle_unload` explicitly (including `never`)
+    /// is unaffected.
+    #[default]
     #[serde(rename = "10m")]
     After10m,
     #[serde(rename = "1h")]
     After1h,
+}
+
+impl IdleUnloadPolicy {
+    /// The idle threshold as a duration, or `None` for `Never` (no reaper
+    /// should even run). `Now` is treated as an aggressive-but-real threshold
+    /// (a few seconds) rather than "unload synchronously after every
+    /// request" -- that would defeat back-to-back requests reusing the warm
+    /// runtime, which is the whole point of caching it in the first place.
+    pub const fn idle_threshold(self) -> Option<std::time::Duration> {
+        match self {
+            Self::Never => None,
+            Self::Now => Some(std::time::Duration::from_secs(5)),
+            Self::After2m => Some(std::time::Duration::from_secs(2 * 60)),
+            Self::After10m => Some(std::time::Duration::from_secs(10 * 60)),
+            Self::After1h => Some(std::time::Duration::from_secs(60 * 60)),
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -302,7 +326,7 @@ impl Default for Preferences {
             quant_preference: QuantPreference::Auto,
             execution_target: ExecutionTarget::Auto,
             history_retention: HistoryRetentionPolicy::Last5,
-            idle_unload: IdleUnloadPolicy::Never,
+            idle_unload: IdleUnloadPolicy::After10m,
         }
     }
 }

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -175,7 +175,10 @@ fn save_and_load_config_document_roundtrip_preserves_preferences() {
             inference_threads: Some(4),
             execution_target: ExecutionTarget::Cpu,
             history_retention: HistoryRetentionPolicy::Month,
-            idle_unload: IdleUnloadPolicy::After10m,
+            // Distinct from `IdleUnloadPolicy::default()` (`After10m`) so this
+            // still proves the field round-trips rather than just matching
+            // the default either way.
+            idle_unload: IdleUnloadPolicy::After1h,
             ..Preferences::default()
         },
     };
@@ -478,4 +481,46 @@ fn history_retention_policy_wire_strings_and_age_windows() {
         serde_json::to_value(HistoryRetentionPolicy::Forever).unwrap(),
         serde_json::Value::String("forever".to_string())
     );
+}
+
+#[test]
+fn idle_unload_policy_wire_strings_and_thresholds() {
+    use std::time::Duration;
+
+    // Wire contract: snake_case strings consumed by the desktop preferences
+    // client. Adding a variant is additive; renaming any of these breaks it.
+    let cases = [
+        (IdleUnloadPolicy::Never, "never", None),
+        (IdleUnloadPolicy::Now, "now", Some(Duration::from_secs(5))),
+        (
+            IdleUnloadPolicy::After2m,
+            "2m",
+            Some(Duration::from_secs(2 * 60)),
+        ),
+        (
+            IdleUnloadPolicy::After10m,
+            "10m",
+            Some(Duration::from_secs(10 * 60)),
+        ),
+        (
+            IdleUnloadPolicy::After1h,
+            "1h",
+            Some(Duration::from_secs(60 * 60)),
+        ),
+    ];
+    for (policy, wire, threshold) in cases {
+        assert_eq!(
+            serde_json::to_value(policy).unwrap(),
+            serde_json::Value::String(wire.to_string())
+        );
+        assert_eq!(
+            serde_json::from_value::<IdleUnloadPolicy>(serde_json::Value::String(wire.to_string()))
+                .unwrap(),
+            policy
+        );
+        assert_eq!(policy.idle_threshold(), threshold);
+    }
+    // Product decision (0.1.12-B): a bound model pack should not sit resident
+    // in RAM for the daemon's whole lifetime by default any more.
+    assert_eq!(IdleUnloadPolicy::default(), IdleUnloadPolicy::After10m);
 }

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -56,8 +56,8 @@ pub use api::backend::{
     native_runtime_model_adapter_for_path, native_runtime_model_refs_match,
     native_runtime_realtime_capabilities_for_path,
     native_runtime_transcription_capabilities_for_path,
-    resolve_local_native_runtime_model_identity, validate_local_native_model_pack_path,
-    validate_native_runtime_model_pack_contract,
+    resolve_local_native_runtime_model_identity, unload_idle_native_model_runtime_caches,
+    validate_local_native_model_pack_path, validate_native_runtime_model_pack_contract,
 };
 pub use api::native::{
     NativeAsrBackpressurePolicy, NativeAsrBenchmarkStatus, NativeAsrCapabilities,

--- a/crates/openasr-core/src/models/cohere/ggml_executor.rs
+++ b/crates/openasr-core/src/models/cohere/ggml_executor.rs
@@ -476,6 +476,10 @@ impl GgmlAsrExecutor for CohereTranscribeGgmlExecutor {
         self.execute_inner(request, false)
             .map_err(|error| cohere_execute_error_to_ggml(self, error, request))
     }
+
+    fn unload_idle_state(&self) {
+        self.runtime_cache_by_path.clear();
+    }
 }
 
 impl CohereTranscribeGgmlExecutor {
@@ -525,6 +529,10 @@ impl GgmlAsrStreamingExecutor for CohereTranscribeGgmlExecutor {
             STREAMING_PARTIAL_TUNING_HEAVY_SEQ2SEQ,
             CohereTranscribeGgmlExecutor::execute_streaming,
         )
+    }
+
+    fn unload_idle_state(&self) {
+        self.runtime_cache_by_path.clear();
     }
 }
 

--- a/crates/openasr-core/src/models/ggml_asr_executor.rs
+++ b/crates/openasr-core/src/models/ggml_asr_executor.rs
@@ -329,6 +329,14 @@ pub trait GgmlAsrExecutor: Send + Sync {
         &self,
         request: &GgmlAsrExecutionRequest,
     ) -> Result<GgmlAsrExecutionResult, GgmlAsrExecutionError>;
+    /// Drops this executor's process-lifetime cached prepared runtime(s)
+    /// (mmap + materialized tensors + Metal/CPU graph context), if it caches
+    /// one at all. Called by the daemon's idle-unload reaper (`idle_unload`
+    /// preference); the default no-op covers executors whose only caching is
+    /// per-thread and already self-bounded/self-expiring (bounded LRU capacity,
+    /// or a worker thread the realtime idle reaper already recycles), so they
+    /// need no additional eviction here.
+    fn unload_idle_state(&self) {}
 }
 
 pub trait GgmlAsrStreamingExecutor: Send + Sync {
@@ -337,6 +345,11 @@ pub trait GgmlAsrStreamingExecutor: Send + Sync {
         &self,
         request: &GgmlAsrStreamingSessionRequest,
     ) -> Result<Box<dyn NativeAsrSession>, GgmlAsrExecutionError>;
+    /// Streaming-side counterpart of [`GgmlAsrExecutor::unload_idle_state`].
+    /// Families registered on both dispatches (offline + streaming) hold two
+    /// independent executor instances with two independent caches, so both
+    /// must be evicted for `idle_unload` to actually free the resident model.
+    fn unload_idle_state(&self) {}
 }
 
 /// Partial-result granularity of a registered streaming executor. This is a
@@ -528,6 +541,25 @@ impl GgmlAsrExecutionDispatch {
                 .get(capability_label(descriptor.execution_capability)),
             Some(StreamingPartialGranularity::FrameSync)
         )
+    }
+
+    /// Idle-unload: evicts every registered executor's process-lifetime
+    /// cached prepared runtime. Safe to call opportunistically (e.g. from a
+    /// background reaper) -- executors with nothing resident, or whose
+    /// caching is per-thread and self-managed, just no-op.
+    pub fn unload_all(&self) {
+        for executor in self.executors_by_adapter_id.values() {
+            executor.unload_idle_state();
+        }
+        for executor in self.executors_by_capability.values() {
+            executor.unload_idle_state();
+        }
+        for executor in self.streaming_executors_by_adapter_id.values() {
+            executor.unload_idle_state();
+        }
+        for executor in self.streaming_executors_by_capability.values() {
+            executor.unload_idle_state();
+        }
     }
 }
 
@@ -987,6 +1019,110 @@ mod tests {
                 StreamingPartialGranularity::FrameSync,
             );
         assert!(capability_dispatch.is_frame_sync_for(&qwen));
+    }
+
+    #[test]
+    fn unload_all_reaches_every_registered_executor_map() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // One stub per registration slot (offline adapter-id, offline
+        // capability, streaming adapter-id, streaming capability), each
+        // bumping its own counter from `unload_idle_state` -- proves
+        // `unload_all` walks all four maps, not just the offline/adapter-id
+        // one every other test in this file happens to exercise.
+        struct CountingExecutor(Arc<AtomicUsize>);
+        impl GgmlAsrExecutor for CountingExecutor {
+            fn executor_id(&self) -> &'static str {
+                "counting-offline-stub"
+            }
+            fn supports_phrase_bias(&self) -> bool {
+                false
+            }
+            fn execute(
+                &self,
+                _request: &GgmlAsrExecutionRequest,
+            ) -> Result<GgmlAsrExecutionResult, GgmlAsrExecutionError> {
+                unreachable!("this test never executes a request")
+            }
+            fn unload_idle_state(&self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        struct CountingStreamingExecutor(Arc<AtomicUsize>);
+        impl GgmlAsrStreamingExecutor for CountingStreamingExecutor {
+            fn executor_id(&self) -> &'static str {
+                "counting-streaming-stub"
+            }
+            fn start_streaming_session(
+                &self,
+                _request: &GgmlAsrStreamingSessionRequest,
+            ) -> Result<Box<dyn crate::NativeAsrSession>, GgmlAsrExecutionError> {
+                unreachable!("this test never starts a streaming session")
+            }
+            fn unload_idle_state(&self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let offline_adapter_calls = Arc::new(AtomicUsize::new(0));
+        let offline_capability_calls = Arc::new(AtomicUsize::new(0));
+        let streaming_adapter_calls = Arc::new(AtomicUsize::new(0));
+        let streaming_capability_calls = Arc::new(AtomicUsize::new(0));
+
+        let dispatch = GgmlAsrExecutionDispatch::default()
+            .with_executor_for_adapter(
+                WHISPER_GGML_ADAPTER_ID,
+                Arc::new(CountingExecutor(Arc::clone(&offline_adapter_calls))),
+            )
+            .with_executor_for_capability(
+                GgmlExecutionCapability::NativeGraphLoweringV1,
+                Arc::new(CountingExecutor(Arc::clone(&offline_capability_calls))),
+            )
+            .with_streaming_executor_for_adapter(
+                WHISPER_GGML_ADAPTER_ID,
+                Arc::new(CountingStreamingExecutor(Arc::clone(
+                    &streaming_adapter_calls,
+                ))),
+            )
+            .with_streaming_executor_for_capability(
+                GgmlExecutionCapability::NativeGraphLoweringV1,
+                Arc::new(CountingStreamingExecutor(Arc::clone(
+                    &streaming_capability_calls,
+                ))),
+            );
+
+        dispatch.unload_all();
+
+        assert_eq!(offline_adapter_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(offline_capability_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(streaming_adapter_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(streaming_capability_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn unload_idle_state_default_is_a_no_op() {
+        // Any executor that does not override `unload_idle_state` (every
+        // family whose only caching is per-thread/bounded) must tolerate
+        // being told to unload -- the default no-op must not panic.
+        struct NoCacheExecutor;
+        impl GgmlAsrExecutor for NoCacheExecutor {
+            fn executor_id(&self) -> &'static str {
+                "no-cache-stub"
+            }
+            fn supports_phrase_bias(&self) -> bool {
+                false
+            }
+            fn execute(
+                &self,
+                _request: &GgmlAsrExecutionRequest,
+            ) -> Result<GgmlAsrExecutionResult, GgmlAsrExecutionError> {
+                unreachable!("this test never executes a request")
+            }
+        }
+
+        let dispatch = GgmlAsrExecutionDispatch::default()
+            .with_executor_for_adapter(WHISPER_GGML_ADAPTER_ID, Arc::new(NoCacheExecutor));
+        dispatch.unload_all();
     }
 
     #[test]

--- a/crates/openasr-core/src/models/moonshine/ggml_executor.rs
+++ b/crates/openasr-core/src/models/moonshine/ggml_executor.rs
@@ -277,6 +277,10 @@ impl GgmlAsrExecutor for MoonshineGgmlExecutor {
         self.execute_inner(request, false)
             .map_err(|error| moonshine_execute_error_to_ggml(self, error, request))
     }
+
+    fn unload_idle_state(&self) {
+        self.runtime_cache_by_path.clear();
+    }
 }
 
 impl MoonshineGgmlExecutor {
@@ -326,6 +330,10 @@ impl GgmlAsrStreamingExecutor for MoonshineGgmlExecutor {
             STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT,
             MoonshineGgmlExecutor::execute_streaming,
         )
+    }
+
+    fn unload_idle_state(&self) {
+        self.runtime_cache_by_path.clear();
     }
 }
 

--- a/crates/openasr-core/src/models/prepared_runtime_cache.rs
+++ b/crates/openasr-core/src/models/prepared_runtime_cache.rs
@@ -68,6 +68,21 @@ impl<T> PreparedRuntimeCache<T> {
         let cache = self.cache_by_path.lock().map_err(|_| map_poisoned_lock())?;
         Ok(cache.get(cache_key).cloned())
     }
+
+    /// Drops every cached prepared runtime, releasing the `Arc<T>` this cache
+    /// holds. If nothing else is currently borrowing an entry (no in-flight
+    /// request holding its own clone), this frees whatever native resources
+    /// `T` owns -- mmap, materialized tensors, Metal/CPU graph context -- right
+    /// away; otherwise the last outstanding clone's drop frees it once that
+    /// request finishes. Used by the idle-unload reaper: a poisoned lock is
+    /// swallowed (best-effort eviction, not a request-path operation) rather
+    /// than propagated, since a subsequent `get_or_try_insert_with` will just
+    /// rebuild on the next real request either way.
+    pub(crate) fn clear(&self) {
+        if let Ok(mut cache) = self.cache_by_path.lock() {
+            cache.clear();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -137,5 +152,32 @@ mod tests {
         assert_eq!(build_count.get(), 1);
         assert!(Arc::ptr_eq(&runtime_a, &runtime_b));
         assert_eq!(runtime_b.value, 7);
+    }
+
+    #[test]
+    fn clear_evicts_cached_entry_so_the_next_call_rebuilds() {
+        let cache = PreparedRuntimeCache::<StubRuntime>::default();
+        let path = Path::new("/tmp/test-runtime-clear.gguf");
+        let build_count = Cell::new(0usize);
+
+        let build = |value: usize| {
+            build_count.set(build_count.get() + 1);
+            Ok::<_, &'static str>(StubRuntime { value })
+        };
+
+        let runtime_a = cache
+            .get_or_try_insert_with(path, || build(7), || "poisoned")
+            .expect("runtime a");
+        assert_eq!(build_count.get(), 1);
+
+        cache.clear();
+
+        let runtime_b = cache
+            .get_or_try_insert_with(path, || build(9), || "poisoned")
+            .expect("runtime b");
+
+        assert_eq!(build_count.get(), 2, "clear must force a rebuild");
+        assert!(!Arc::ptr_eq(&runtime_a, &runtime_b));
+        assert_eq!(runtime_b.value, 9);
     }
 }

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -1344,6 +1344,10 @@ impl GgmlAsrExecutor for Qwen3AsrGgmlExecutor {
         self.execute_inner(request, false)
             .map_err(|error| qwen_execute_error_to_ggml(error, request.selected_family.adapter_id))
     }
+
+    fn unload_idle_state(&self) {
+        self.runtime_cache_by_path.clear();
+    }
 }
 
 impl Qwen3AsrGgmlExecutor {
@@ -1392,6 +1396,10 @@ impl GgmlAsrStreamingExecutor for Qwen3AsrGgmlExecutor {
             STREAMING_PARTIAL_TUNING_HEAVY_SEQ2SEQ,
             Qwen3AsrGgmlExecutor::execute_streaming,
         )
+    }
+
+    fn unload_idle_state(&self) {
+        self.runtime_cache_by_path.clear();
     }
 }
 

--- a/crates/openasr-core/src/models/runtime_prepared_registry.rs
+++ b/crates/openasr-core/src/models/runtime_prepared_registry.rs
@@ -166,6 +166,12 @@ impl BuiltinPreparedRuntimeCache {
             use_runtime,
         )
     }
+
+    /// Evicts every cached prepared runtime (idle_unload); see
+    /// `PreparedRuntimeCache::clear`.
+    pub(crate) fn clear(&self) {
+        self.runtimes_by_path.clear();
+    }
 }
 
 pub(crate) fn build_builtin_prepared_runtime(
@@ -260,6 +266,44 @@ mod tests {
 
         assert!(Arc::ptr_eq(&runtime_a, &runtime_b));
         assert!(runtime_a.as_ref().as_cohere_transcribe().is_some());
+    }
+
+    #[test]
+    fn clear_evicts_the_prepared_runtime_so_the_next_call_rebuilds_it() {
+        // idle_unload's actual production path: `clear()` is what
+        // `Qwen3AsrGgmlExecutor::unload_idle_state` /
+        // `CohereTranscribeGgmlExecutor::unload_idle_state` call. Proves the
+        // real (not stub) prepared-runtime build is evicted and a later
+        // request just rebuilds it -- functions normally, pays the cold cost
+        // again -- exactly the documented idle_unload contract.
+        let (_runtime_path, preflight) = write_cohere_preflight();
+        let cache = BuiltinPreparedRuntimeCache::default();
+        let build = |cache: &BuiltinPreparedRuntimeCache| {
+            cache
+                .prepared_runtime_for_preflight(
+                    crate::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
+                    &preflight,
+                    |error| error,
+                    || BuiltinPreparedRuntimeRegistryError::UnknownArchitecture {
+                        model_architecture: "poisoned".to_string(),
+                    },
+                )
+                .expect("prepared runtime")
+        };
+
+        let runtime_a = build(&cache);
+        cache.clear();
+        let runtime_b = build(&cache);
+
+        assert!(
+            !Arc::ptr_eq(&runtime_a, &runtime_b),
+            "clear() must evict the cached runtime so the next call rebuilds it"
+        );
+        assert!(runtime_b.as_ref().as_cohere_transcribe().is_some());
+
+        // After the rebuild, the cache is warm again: a third call reuses it.
+        let runtime_c = build(&cache);
+        assert!(Arc::ptr_eq(&runtime_b, &runtime_c));
     }
 
     #[test]

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -3113,6 +3113,10 @@ impl GgmlAsrExecutor for WhisperGgmlExecutor {
         // Offline decode: batch worker allowed.
         self.execute_whisper_inner(request, false)
     }
+
+    fn unload_idle_state(&self) {
+        self.runtime_cache_by_path.clear();
+    }
 }
 
 impl WhisperGgmlExecutor {
@@ -3228,6 +3232,10 @@ impl GgmlAsrStreamingExecutor for WhisperGgmlExecutor {
             STREAMING_PARTIAL_TUNING_WHISPER_SEQ2SEQ,
             WhisperGgmlExecutor::execute_streaming,
         )
+    }
+
+    fn unload_idle_state(&self) {
+        self.runtime_cache_by_path.clear();
     }
 }
 

--- a/crates/openasr-server/src/idle_activity.rs
+++ b/crates/openasr-server/src/idle_activity.rs
@@ -1,0 +1,216 @@
+//! Process-wide native-request/session activity tracking, plus the
+//! `idle_unload` background reaper.
+//!
+//! Two independent things must never race the resident model teardown:
+//! an in-flight HTTP transcription/translation (or the realtime
+//! per-utterance backend-job fallback -- both go through
+//! `transcribe_with_runtime`), and an attached realtime native-streaming
+//! session (`realtime::native_streaming_worker_for_key` /
+//! `spawn_native_streaming_worker`'s acquire/release). Both call
+//! [`native_activity_enter`]/[`native_activity_exit`] in lockstep with their
+//! own request/session lifetime; the reaper only ever unloads the cached
+//! native model runtime after the tracker has read zero active for at least
+//! the configured threshold.
+
+use std::sync::{
+    Mutex, OnceLock,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::{Duration, Instant};
+
+struct NativeActivityTracker {
+    active: AtomicUsize,
+    idle_since: Mutex<Instant>,
+}
+
+impl NativeActivityTracker {
+    fn new() -> Self {
+        Self {
+            active: AtomicUsize::new(0),
+            idle_since: Mutex::new(Instant::now()),
+        }
+    }
+
+    fn enter(&self) {
+        self.active.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn exit(&self) {
+        let previous = self.active.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(
+            previous > 0,
+            "native activity exited more times than it was entered"
+        );
+        if previous == 1 {
+            *self
+                .idle_since
+                .lock()
+                .expect("native activity idle mutex poisoned") = Instant::now();
+        }
+    }
+
+    fn is_idle_for(&self, now: Instant, idle_for: Duration) -> bool {
+        if self.active.load(Ordering::Acquire) != 0 {
+            return false;
+        }
+        let idle_since = *self
+            .idle_since
+            .lock()
+            .expect("native activity idle mutex poisoned");
+        now.checked_duration_since(idle_since).unwrap_or_default() >= idle_for
+    }
+}
+
+static NATIVE_ACTIVITY: OnceLock<NativeActivityTracker> = OnceLock::new();
+
+fn native_activity() -> &'static NativeActivityTracker {
+    NATIVE_ACTIVITY.get_or_init(NativeActivityTracker::new)
+}
+
+/// Marks one native request/session as started. Must be paired with a later
+/// [`native_activity_exit`] -- prefer [`NativeActivityGuard`] over calling
+/// this directly when the activity's lifetime is a single lexical scope.
+pub(crate) fn native_activity_enter() {
+    native_activity().enter();
+}
+
+/// Marks one native request/session as finished.
+pub(crate) fn native_activity_exit() {
+    native_activity().exit();
+}
+
+/// Whether the process-wide tracker has read zero active native
+/// requests/sessions for at least `idle_for`, as of `now`. Exposed (beyond
+/// [`spawn_idle_unload_reaper`]'s own use) so integration tests can assert
+/// the real attach/release call sites in `native_worker.rs` actually keep
+/// this in lockstep with a real session's lifetime.
+pub(crate) fn native_activity_is_idle_for(now: Instant, idle_for: Duration) -> bool {
+    native_activity().is_idle_for(now, idle_for)
+}
+
+/// RAII pairing of one `native_activity_enter`/`native_activity_exit` call
+/// with a lexical scope. Used at the offline/backend-job transcribe call
+/// site, where the request's activity window is exactly one function call
+/// (unlike the realtime streaming worker, whose attach/release already sit at
+/// two different call sites in `native_worker.rs` and are paired directly).
+pub(crate) struct NativeActivityGuard(());
+
+impl NativeActivityGuard {
+    pub(crate) fn enter() -> Self {
+        native_activity_enter();
+        Self(())
+    }
+}
+
+impl Drop for NativeActivityGuard {
+    fn drop(&mut self) {
+        native_activity_exit();
+    }
+}
+
+/// Spawns the background `idle_unload` reaper. Polls at a fraction of
+/// `idle_for` so the actual unload lands within roughly one tick of crossing
+/// the threshold, without spinning for a short threshold (the `now` policy's
+/// 5s floor) or over-polling for the common 10m/1h thresholds. Callers only
+/// spawn this when the resolved policy is not `never` (see
+/// `IdleUnloadPolicy::idle_threshold`).
+pub(crate) fn spawn_idle_unload_reaper(idle_for: Duration) {
+    let poll_interval = (idle_for / 4).max(Duration::from_secs(1));
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(poll_interval).await;
+            if native_activity_is_idle_for(Instant::now(), idle_for) {
+                openasr_core::unload_idle_native_model_runtime_caches();
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Exercises the tracker logic against a private instance (not the process
+    // singleton): the singleton is shared with every other test in this crate
+    // that happens to transcribe something concurrently, so asserting on it
+    // directly would be flaky by construction.
+    #[test]
+    fn idle_only_once_active_count_returns_to_zero() {
+        let tracker = NativeActivityTracker::new();
+        let threshold = Duration::from_secs(1);
+
+        // Immediately after construction, real elapsed time is microseconds,
+        // nowhere near the 1s threshold yet.
+        assert!(!tracker.is_idle_for(Instant::now(), threshold));
+
+        tracker.enter();
+        tracker.enter();
+        // While active, must never read idle no matter how far in the future
+        // the supplied `now` claims to be.
+        let far_future = Instant::now() + Duration::from_secs(10_000);
+        assert!(
+            !tracker.is_idle_for(far_future, threshold),
+            "must never read idle while any activity is active"
+        );
+
+        tracker.exit();
+        assert!(
+            !tracker.is_idle_for(far_future, threshold),
+            "one remaining active entry still blocks idle"
+        );
+
+        tracker.exit();
+        assert!(
+            tracker.is_idle_for(far_future, threshold),
+            "idle_since resets to the moment the count returns to zero, so a \
+             `now` far past that moment must read as idle"
+        );
+    }
+
+    #[test]
+    fn new_activity_after_going_idle_resets_the_idle_clock() {
+        let tracker = NativeActivityTracker::new();
+        tracker.enter();
+        tracker.exit();
+        assert!(
+            tracker.is_idle_for(
+                Instant::now() + Duration::from_secs(3600),
+                Duration::from_secs(1)
+            ),
+            "far enough in the future, the first idle transition must already read as idle"
+        );
+
+        // A new request arrives and finishes again: the idle clock must
+        // restart from this second transition, not stay pinned to the first.
+        // Real elapsed time since this second `exit()` is microseconds, so
+        // checking against `Instant::now()` (not a synthetic future instant)
+        // with a large threshold must read as NOT idle -- it would only read
+        // as idle if `idle_since` were still stuck at the first transition.
+        tracker.enter();
+        tracker.exit();
+        assert!(
+            !tracker.is_idle_for(Instant::now(), Duration::from_secs(3600)),
+            "idle_since must have been bumped by the second enter/exit pair, not left at the first"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "exited more times than it was entered")]
+    fn exit_without_matching_enter_is_a_bug() {
+        let tracker = NativeActivityTracker::new();
+        tracker.exit();
+    }
+
+    #[test]
+    fn guard_pairs_enter_and_exit_without_panicking() {
+        // Exercises the guard against the real process-wide singleton (there
+        // is no private-instance variant of the guard/free functions). Other
+        // tests in this crate may concurrently touch the same singleton via
+        // their own guards, so this only asserts that construction and drop
+        // do not panic (the paired enter/exit debug_assert above is what
+        // actually proves the accounting stays balanced) rather than any
+        // absolute or relative count, which would be flaky under contention.
+        let _guard = NativeActivityGuard::enter();
+        drop(_guard);
+    }
+}

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1,6 +1,8 @@
+mod idle_activity;
 mod realtime;
 mod routes;
 
+pub(crate) use idle_activity::{NativeActivityGuard, spawn_idle_unload_reaper};
 pub(crate) use routes::config::*;
 pub(crate) use routes::history::*;
 pub(crate) use routes::models_api::*;
@@ -244,6 +246,18 @@ pub async fn serve_with_launch_options(
         "tcp_listener_bind",
         stage_started.elapsed(),
     );
+    // Warm the daemon's default bound native model pack in the background,
+    // right after bind succeeds -- deliberately after this line and before
+    // anything below that could block, so it never gates bind/serve/health.
+    // See `spawn_boot_native_warmup`'s doc comment for the dedup story with a
+    // concurrent real WS attach.
+    realtime::spawn_boot_native_warmup(runtime.clone());
+    // idle_unload: only spawn the reaper when the resolved policy is not
+    // `never` (`idle_unload_after` is `None` for `never` and for every
+    // existing caller/test that does not set it, so this is a no-op there).
+    if let Some(idle_unload_after) = launch_options.idle_unload_after {
+        spawn_idle_unload_reaper(idle_unload_after);
+    }
     match &launch_options.tls.clone() {
         ServerTlsConfig::Disabled => {
             stage_started = Instant::now();
@@ -427,6 +441,11 @@ pub struct ServerLaunchOptions {
     pub instance_token: Option<String>,
     pub auth: ServerAuth,
     pub tls: ServerTlsConfig,
+    /// Resolved `idle_unload` threshold (see
+    /// `openasr_core::config::IdleUnloadPolicy::idle_threshold`); `None`
+    /// (the default, and what `never` resolves to) never spawns the reaper,
+    /// matching every existing caller/test that does not set this.
+    pub idle_unload_after: Option<Duration>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -300,6 +300,11 @@ pub(crate) fn native_streaming_worker_for_key(
         && !entry.sender.is_closed()
     {
         entry.state.acquire();
+        // idle_unload must never fire while a native session is attached to
+        // (or attaching to) any worker -- paired with the matching
+        // `native_activity_exit` in `spawn_native_streaming_worker`'s
+        // `state.release()`.
+        crate::idle_activity::native_activity_enter();
         return NativeStreamingWorkerHandle {
             sender: entry.sender.clone(),
             state: entry.state.clone(),
@@ -309,6 +314,7 @@ pub(crate) fn native_streaming_worker_for_key(
     let (sender, receiver) =
         mpsc::channel::<NativeStreamingWorkerMessage>(SHARED_BACKEND_WORKER_QUEUE_CAPACITY);
     let state = Arc::new(NativeStreamingWorkerState::new_acquired(Instant::now()));
+    crate::idle_activity::native_activity_enter();
     spawn_native_streaming_worker(receiver, state.clone());
     workers.insert(
         key,
@@ -373,6 +379,9 @@ pub(crate) fn spawn_native_streaming_worker(
                             cancel_requested,
                         );
                         state.release();
+                        // Paired with the `native_activity_enter` calls in
+                        // `native_streaming_worker_for_key`.
+                        crate::idle_activity::native_activity_exit();
                     }
                 }
             }
@@ -461,6 +470,109 @@ pub(crate) fn warm_up_native_streaming_session_once(
     openasr_core::stage_timing::log_stage("realtime_warmup", "complete", warmup_started.elapsed());
     WARMED.with(|warmed| warmed.set(true));
     Ok(())
+}
+
+/// Warms the worker thread for the daemon's default bound native model pack
+/// in the background, right after `serve_with_launch_options` finishes
+/// binding the listener -- so the very first real dictation session does not
+/// pay the cold model-pack-load cost (observed 1.7-2.1s) before its first
+/// partial. Fire-and-forget: never blocks bind/serve/health, and any failure
+/// here (bad pack, no adapter, ...) is swallowed silently -- a real request
+/// still fails closed with a proper error through the normal request path.
+/// The existing WS-attach `Warm` command (see `start_native_streaming_session`
+/// in `ws_session.rs`) remains the fallback for whatever this boot warm-up
+/// does not cover: no pack bound yet at boot, an explicit
+/// `inference_threads`/`execution_target` that does not match the default
+/// worker key used here, or the bound pack having changed since boot.
+///
+/// Dedup with a concurrent real attach is structural, not a flag: this
+/// attaches its own short-lived "session" to the same
+/// [`NativeStreamingWorkerKey`] a matching real WS attach would use, sends
+/// `Warm`, waits for it to finish, and only then releases the worker -- the
+/// worker thread processes one attached session's commands at a time, so a
+/// real attach for the same key that arrives mid-warm-up queues behind this
+/// one instead of racing a second cold build. Whichever attach's `Warm`
+/// actually runs first pays the cost once (see the thread-local `WARMED` gate
+/// in `warm_up_native_streaming_session_once`); every later attach on that
+/// thread reuses the now-warm state.
+pub(crate) fn spawn_boot_native_warmup(runtime: ServerRuntime) {
+    tokio::spawn(async move {
+        warm_up_default_native_streaming_worker(runtime).await;
+    });
+}
+
+async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
+    if runtime.backend != openasr_core::BackendKind::Native {
+        return;
+    }
+    let Some(model_pack_path) = runtime.model_pack_path.clone() else {
+        // Fresh install / no model installed yet: nothing to warm. The daemon
+        // still serves `/health`; a bound pack arrives on a future restart.
+        return;
+    };
+    let Some(adapter) = openasr_core::native_runtime_model_adapter_for_path(&model_pack_path)
+    else {
+        return;
+    };
+    let model_pack =
+        NativeAsrModelPackRef::new("native-default", adapter.model_family(), model_pack_path);
+    let context = NativeAsrSessionContext::new("boot-warmup");
+    let options = NativeAsrRequestOptions::new();
+    let session_config = NativeAsrStreamingSessionConfig::new()
+        .with_audio_format(RealtimeAudioFormat::pcm16_mono_16khz());
+    let executor = NativeBackendExecutor;
+    // Matches the hardware target / thread count a WS session defaults to
+    // when the client does not override them (`execution_target` /
+    // `inference_threads` both unset) -- the common case, and exactly the
+    // worker key this warm-up needs to land on to actually help.
+    let hardware_target = native_hardware_target_from_execution_target(None);
+    let session = match NativeAsrExecutor::start_streaming_session(
+        &executor,
+        &adapter,
+        &model_pack,
+        hardware_target,
+        context,
+        options,
+        session_config,
+    ) {
+        Ok(session) => session,
+        Err(_) => return,
+    };
+    let key = NativeStreamingWorkerKey::new(model_pack.root.clone(), hardware_target, None);
+    attach_and_run_boot_warmup(key, session).await;
+}
+
+/// The generic (session-agnostic) half of the boot warm-up: attach `session`
+/// under `key`, send `Warm`, wait for it to finish, then release. Split out
+/// from `warm_up_default_native_streaming_worker` so the async-scheduling
+/// property that actually matters -- this runs to completion in the
+/// background without the caller (`spawn_boot_native_warmup`, called from
+/// `serve_with_launch_options` right after bind) ever awaiting it -- is
+/// testable with a fake, injectable-latency [`NativeAsrSession`] instead of a
+/// real model pack.
+pub(crate) async fn attach_and_run_boot_warmup(
+    key: NativeStreamingWorkerKey,
+    session: Box<dyn NativeAsrSession>,
+) {
+    let Ok(mut worker) = NativeStreamingDecodeWorker::attach(key, session).await else {
+        return;
+    };
+    let envelope = NativeStreamingCommandEnvelope {
+        kind: NativeStreamingCommandKind::Warm,
+        command: NativeStreamingCommand::Warm,
+    };
+    if worker.commands.send(envelope).await.is_ok() {
+        // Wait for the Warm outcome so this session -- and the worker-key
+        // acquisition it holds -- does not release before warm-up actually
+        // finishes; otherwise a concurrent real attach would not meaningfully
+        // "queue behind" this one.
+        let _ = worker.outcomes.recv().await;
+    }
+    // No Finish/Cancel is sent, so the worker thread cancels this session on
+    // its behalf (see `run_native_streaming_session_on_worker`) and loops
+    // straight back to accept the next real Attach -- the thread-local warm
+    // state this call just primed stays resident for it.
+    worker.join();
 }
 
 pub(crate) fn finish_native_streaming_session_in_worker(

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -1481,6 +1481,172 @@ async fn native_streaming_warm_up_runs_immediately_and_once_per_worker() {
 }
 
 #[tokio::test]
+async fn boot_native_warmup_runs_in_background_without_blocking_a_concurrent_task() {
+    // Exercises `attach_and_run_boot_warmup` (the session-agnostic half of
+    // `spawn_boot_native_warmup`, which `serve_with_launch_options` fires
+    // right after bind) against an artificially slow fake session, in place
+    // of a real (and much harder to slow down predictably in a test) model
+    // pack. This is the property that actually matters for
+    // "/health must not wait on warm-up": whatever spawns this must get
+    // control back immediately, and anything else the runtime schedules
+    // concurrently must not be starved by the slow warm-up.
+    let warm_calls = Arc::new(AtomicUsize::new(0));
+    let session = Box::new(SlowWarmNativeSession {
+        inner: TestServerNativeSession::new("boot-warmup-nonblocking"),
+        warm_sleep: Duration::from_millis(300),
+        warm_calls: Arc::clone(&warm_calls),
+    });
+    let key = test_native_streaming_worker_key("boot-warmup-nonblocking");
+
+    let spawn_started = Instant::now();
+    let warmup_handle = tokio::spawn(attach_and_run_boot_warmup(key, session));
+    assert!(
+        spawn_started.elapsed() < Duration::from_millis(100),
+        "spawning the boot warm-up must not itself block"
+    );
+
+    // A concurrent tokio task must be free to run to completion while the
+    // slow warm-up is still sleeping (on its own dedicated worker OS thread,
+    // not the tokio runtime) -- standing in for `/health` staying responsive.
+    tokio::time::timeout(Duration::from_millis(100), async { 1 + 1 })
+        .await
+        .expect("a concurrent tokio task must not be starved by the slow warm-up");
+
+    warmup_handle
+        .await
+        .expect("boot warmup task must not panic");
+    assert_eq!(
+        warm_calls.load(Ordering::Acquire),
+        1,
+        "the slow warm-up must actually have run to completion"
+    );
+}
+
+#[tokio::test]
+async fn health_answers_immediately_while_boot_warmup_is_artificially_slow() {
+    use tower::ServiceExt;
+
+    // The literal /health acceptance: with the boot warm-up artificially
+    // slowed (injected slow mock), a real GET /health through the real router
+    // must still answer immediately -- warm-up must never sit anywhere on the
+    // health path.
+    let warm_calls = Arc::new(AtomicUsize::new(0));
+    let session = Box::new(SlowWarmNativeSession {
+        inner: TestServerNativeSession::new("health-vs-slow-warmup"),
+        warm_sleep: Duration::from_millis(500),
+        warm_calls: Arc::clone(&warm_calls),
+    });
+    let key = test_native_streaming_worker_key("health-vs-slow-warmup");
+    let warmup_started = Instant::now();
+    let warmup_handle = tokio::spawn(attach_and_run_boot_warmup(key, session));
+
+    let app = crate::app_with_runtime(ServerRuntime::default());
+    let response = tokio::time::timeout(
+        Duration::from_millis(200),
+        app.oneshot(
+            axum::http::Request::builder()
+                .uri("/health")
+                .body(axum::body::Body::empty())
+                .expect("build health request"),
+        ),
+    )
+    .await
+    .expect("/health must answer while warm-up is still running, not after it")
+    .expect("/health request must succeed");
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    assert!(
+        warmup_started.elapsed() < Duration::from_millis(500),
+        "/health answered only after the 500ms warm-up window had fully \
+         elapsed -- this test then proved nothing about ordering"
+    );
+
+    warmup_handle
+        .await
+        .expect("boot warmup task must not panic");
+    assert_eq!(warm_calls.load(Ordering::Acquire), 1);
+}
+
+#[tokio::test]
+async fn boot_native_warmup_leaves_the_worker_thread_warm_for_the_next_real_attach() {
+    // Confirms warm-up dedup: a boot warm-up and a subsequent
+    // real WS attach on the SAME worker key share the one thread-local
+    // `WARMED` gate (`warm_up_native_streaming_session_once`) -- the real
+    // session's own `Warm` command must be a no-op, not a second cold build.
+    let warm_calls = Arc::new(AtomicUsize::new(0));
+    let key = test_native_streaming_worker_key("boot-warmup-reuse");
+
+    let boot_session = Box::new(SlowWarmNativeSession {
+        inner: TestServerNativeSession::new("boot-warmup-reuse-boot"),
+        warm_sleep: Duration::from_millis(50),
+        warm_calls: Arc::clone(&warm_calls),
+    });
+    attach_and_run_boot_warmup(key.clone(), boot_session).await;
+    assert_eq!(warm_calls.load(Ordering::Acquire), 1);
+
+    let (event_sender, _event_receiver) = mpsc::channel(8);
+    let mut real_session =
+        WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
+    real_session
+        .attach_native_streaming_session(
+            key,
+            Box::new(SlowWarmNativeSession {
+                inner: TestServerNativeSession::new(real_session.session_id.0.clone()),
+                warm_sleep: Duration::from_millis(50),
+                warm_calls: Arc::clone(&warm_calls),
+            }),
+        )
+        .await
+        .unwrap();
+    real_session
+        .send_native_streaming_command(NativeStreamingCommand::Warm)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    real_session
+        .drain_native_streaming_outcomes()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        warm_calls.load(Ordering::Acquire),
+        1,
+        "the real session's own Warm must be a no-op on the already-warmed \
+         worker thread -- warm_up() must not run a second time"
+    );
+    real_session.finish("client_closed", true).await.unwrap();
+}
+
+#[tokio::test]
+async fn attached_native_streaming_session_keeps_the_global_activity_tracker_non_idle() {
+    // Integration counterpart of the isolated tracker-logic unit tests in
+    // `idle_activity.rs`: proves the real attach/release call sites in
+    // `native_worker.rs` (`native_streaming_worker_for_key` /
+    // `spawn_native_streaming_worker`) actually drive the process-wide
+    // tracker the `idle_unload` reaper reads. Only asserts the "never idle
+    // while active" direction against the real (process-wide, shared with
+    // every other test in this crate) tracker -- the only direction that
+    // stays deterministic under test parallelism, and exactly the safety
+    // property that matters: an active session must never be raced by an
+    // idle-triggered unload.
+    let (event_sender, _event_receiver) = mpsc::channel(8);
+    let mut session = WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
+    session
+        .attach_native_streaming_session(
+            test_native_streaming_worker_key("activity-tracker-stays-non-idle"),
+            Box::new(TestServerNativeSession::new(session.session_id.0.clone())),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        !crate::idle_activity::native_activity_is_idle_for(Instant::now(), Duration::ZERO),
+        "a live attach must never read idle, even against a zero threshold"
+    );
+
+    session.finish("client_closed", true).await.unwrap();
+}
+
+#[tokio::test]
 async fn native_streaming_finalize_keeps_session_open_for_next_utterance() {
     let (event_sender, mut event_receiver) = mpsc::channel(8);
     let mut session = WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1310,6 +1310,11 @@ pub(crate) async fn transcribe_with_runtime(
             Ok(transcription)
         }
         BackendKind::Native => tokio::task::spawn_blocking(move || {
+            // Marks this offline (file-transcription / realtime-per-utterance
+            // backend-job) decode as active for the whole synchronous run, so
+            // the idle_unload reaper never evicts the model runtime cache out
+            // from under it; dropped (any exit path) once the decode returns.
+            let _activity_guard = NativeActivityGuard::enter();
             // Bind the pause/cancel control to this decode thread for the whole
             // synchronous run so the long-form slice loop can observe it; the
             // guard clears the binding on any exit. `None` (no control requested)


### PR DESCRIPTION
## Summary

Two halves of the same RAM/latency trade-off, resolved in both directions:

1. **Warm-up moves from first WS attach to daemon boot.** Right after the TCP listener binds, a background task attaches a short-lived session to the same decode-worker key a default realtime session would use and pays the cold model-pack build there. The first dictation session no longer waits ~1.7-2.1s (cold pack load + graph build) before its first partial.
2. **`idle_unload` gets real teeth and its default flips `never` -> `10m`.** A new `unload_idle_state` hook on both executor traits clears each family's process-lifetime `PreparedRuntimeCache`; a process-wide activity tracker counts in-flight offline decodes and attached realtime sessions; a reaper (spawned from `serve` only when the resolved policy is not `never`) unloads the cached runtimes once the daemon has been fully idle past the threshold. The next request rebuilds through the normal load+warm-up path, closing the loop with (1).

## Why

- The realtime warm-up sat on the first WS attach, so the user's very first utterance paid the whole cold model build. `/health` never needed the model, so boot was the free place to pay this.
- `idle_unload` existed as a config knob but nothing consumed it: after the first transcription, the bound pack (up to ~1.4 GiB for larger families) stayed resident until the daemon exited.

## Changes

- `openasr-server/src/realtime/native_worker.rs`: `spawn_boot_native_warmup` + `attach_and_run_boot_warmup`. Dedup with a concurrent real attach is structural, not a flag: the boot warm-up attaches under the same `NativeStreamingWorkerKey`, and the worker thread serializes attachments, so a real attach queues behind it; the existing per-thread `WARMED` gate makes the second `Warm` a no-op. The WS-attach `Warm` stays as fallback (pack changed after boot, non-default execution target/threads, no pack at boot).
- `openasr-server/src/lib.rs`: warm-up spawned right after `TcpListener::bind` (never gates bind/serve/health); `ServerLaunchOptions.idle_unload_after` + reaper spawn.
- `openasr-server/src/idle_activity.rs` (new): activity tracker (offline decodes via RAII guard in `transcribe_with_runtime`, realtime sessions via the worker acquire/release call sites) + `spawn_idle_unload_reaper`.
- `openasr-core`: `GgmlAsrExecutor::unload_idle_state` / `GgmlAsrStreamingExecutor::unload_idle_state` (default no-op), implemented by the four families with process-lifetime caches (qwen, cohere, whisper, moonshine); `GgmlAsrExecutionDispatch::unload_all`; `PreparedRuntimeCache::clear`; public `unload_idle_native_model_runtime_caches` (uses `OnceLock::get`, never builds a dispatch just to clear it). Families whose only caching is per-thread/bounded LRU need nothing: worker threads are already hard-released after 60s idle and tokio reaps idle blocking threads, so their thread-locals self-expire.
- `openasr-core/src/config.rs`: `IdleUnloadPolicy` default `Never` -> `After10m`; new `idle_threshold()` (never->None, now->5s, 2m/10m/1h literal). Wire values unchanged; an explicitly configured value (including `never`) is untouched.
- `openasr-cli`: `serve` resolves `preferences.idle_unload` from the config document into `idle_unload_after`.
- CHANGELOG: both behaviors + the default change.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2319 passed on the rebased branch)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

Plus targeted: `cargo test -p openasr-core golden_diff` and `bundled_catalog_signature_verifies_committed_catalog_and_epoch` both pass (decode path untouched).

New tests: `/health` answers immediately while an injected 500ms-slow warm-up is still in flight (through the real router, with an ordering guard); boot warm-up runs fully in background without starving concurrent tasks; a real attach after boot warm-up on the same key never re-runs `warm_up()`; an attached session always reads non-idle on the process tracker; `PreparedRuntimeCache::clear`/`BuiltinPreparedRuntimeCache::clear` evict and rebuild (real cohere prepared runtime); `unload_all` reaches all four executor registration maps; `IdleUnloadPolicy` wire strings/thresholds/default locked.

## Manual smoke checks

Real-machine measurements, M1 (8 GB), release build, `qwen3-asr-0.6b:q4_k` (571 MB pack), machine concurrently loaded by unrelated builds (absolute times inflated; deltas are the signal):

**1. Cold start — boot/health timing unchanged in kind (health never waits for warm-up):**

```
server_boot: stage=runtime_validate    duration_ms=38.2
server_boot: stage=tcp_listener_bind   duration_ms=0.084
server_boot: stage=ready total_ms=39.3
spawn->first /health 200: 952 ms (poll incl. process startup; RSS 44 MB at that point — model not loaded)
```

**2. Warm-up moved to boot — with zero requests, then first realtime session:**

```
[+106ms]  realtime_warmup: stage=start                     <- boot, no client anywhere
[+1602ms] model_pack_load: duration_ms=1388.8
[+6460ms] realtime_warmup: stage=complete duration_ms=6354.2
... first WS dictation session:
OpenASR native streaming worker warm-up returned in 0ms    <- was the 1.7-2.1s the user waited on main
```

Exactly one `model_pack_load` line in the whole daemon log — boot warm-up and the session's fallback `Warm` shared one cold build.

**3. `idle_unload` — RSS before/after (policy `now` = 5s threshold, a real supported config value; no test-only probes):**

```
RSS at /health (model not loaded):        40 MB
RSS after boot warm-up (model resident): 940 MB
RSS after 1 offline transcription:       527 MB
RSS after 90s fully idle:                 34 MB   <- model memory released
next transcription after unload:          works, byte-identical text ("And so, my fellow Americans...")
RSS after that reload:                   415 MB
```

The 90s window covers the 5s idle threshold plus the pre-existing 60s decode-worker hard-release (worker-thread thread-locals). Unload never fires while a request/session is active (tracker counts both paths; locked by test).

## Docs updated

- [x] CHANGELOG documents both behavior changes and the default flip.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No protocol/API fields added; no desktop-repo changes (its settings UI already speaks the unchanged `idle_unload` wire values).
- Boot warm-up only targets the default worker key (no explicit `execution_target`/`inference_threads`); sessions with overrides keep the attach-time warm-up fallback.
- No telemetry; all timing lines are local stderr only.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — implemented and tested with AI assistance (Claude); reviewed and owned by the maintainer.
