### PR TITLE
refactor(core): extract the shared ggml static-arena weight pipeline

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/arena_weight_pipeline.rs
+++ b/crates/openasr-core/src/ggml_runtime/arena_weight_pipeline.rs
@@ -1,0 +1,159 @@
+//! Generic ggml static-tensor-arena weight-residency plumbing.
+//!
+//! `models/{parakeet_ctc,parakeet_tdt,sensevoice,wav2vec2_ctc}/encoder_graph.rs`
+//! each independently reimplemented the identical
+//! alloc(rank-dispatched)/upload(f32,f16)/bind-zero-copy skeleton for their
+//! per-layer weights, differing only in (a) their own local graph-build error
+//! enum and (b) whether rank-4 tensors are supported (subsampling convs need
+//! it; FSMN/conv kernels in other families do not). This module owns exactly
+//! that shared plumbing and nothing else: it never sees a model-specific
+//! tensor name, block-wiring decision, or math op, so it stays usable by any
+//! future family with the same "zero-copy bind from the mmap'd pack, else
+//! f32/f16 arena upload" shape without encoding that family's semantics here
+//! (see AGENTS.md: keep infrastructure model-agnostic).
+//!
+//! Each family keeps a thin same-named wrapper (`alloc_static`,
+//! `upload_static`, `bind_loaded`, ...) around these functions that maps
+//! `ArenaAllocError` / the `bind_loaded` error string into its own error enum,
+//! so every existing call site in those files is unchanged -- only the
+//! function *bodies* moved here.
+//!
+//! `models/parakeet_tdt/encoder_graph.rs` has no legacy no-pack arena
+//! fallback, so it never constructs `WeightSlot::Arena` (see that module for
+//! why); the type stays shared regardless since the fallback variant existing
+//! but unused is exactly the same "kept for parity" convention already used
+//! by `models/moonshine`.
+
+use super::{
+    GGML_TYPE_F16, GGML_TYPE_F32, GgmlCpuGraphError, GgmlCpuTensor, GgmlLoadedTensor,
+    GgmlLoadedWeightContext, GgmlStaticTensor, GgmlStaticTensorArena,
+};
+
+/// A 2-D linear weight: either an arena tensor (f32-uploaded -- legacy / no
+/// runtime pack) or a zero-copy leaf bound to the mmap'd pack (native
+/// q4_K/f16/f32, no host copy + no arena upload).
+#[derive(Clone, Copy)]
+pub(crate) enum WeightSlot {
+    // No current family constructs this variant (every bindable weight's
+    // host payload is dropped, or never materialized, at load, so binding
+    // failure always fails closed rather than falling back) -- kept for
+    // parity with a possible future non-mmap fallback, same rationale
+    // `models::moonshine` already documents for its own (now-replaced) copy.
+    #[allow(dead_code)]
+    Arena(GgmlStaticTensor),
+    Loaded(GgmlLoadedTensor),
+}
+
+impl WeightSlot {
+    pub(crate) fn graph<'a>(self, arena: &GgmlStaticTensorArena) -> GgmlCpuTensor<'a> {
+        match self {
+            Self::Arena(handle) => arena.graph_tensor(handle),
+            Self::Loaded(tensor) => tensor.as_graph_tensor(),
+        }
+    }
+}
+
+/// Bind a 2-D linear zero-copy from the mmap'd pack (`loaded`) by its on-disk
+/// name. Returns `Err(reason)` -- a formatted message, not a family error type
+/// -- if the loaded context is absent or the tensor is missing; the caller
+/// wraps `reason` in its own "Shape"-style error variant and the returned
+/// tensor in its own `WeightSlot`-shaped type (this never constructs `Arena`
+/// -- some families' `WeightSlot` has no such variant at all -- so callers
+/// that want the shared enum wrap it themselves: `.map(WeightSlot::Loaded)`).
+/// FAILS CLOSED: the host f32 values for bound weights are dropped (or never
+/// materialized) at load in every current caller of this pipeline, so there
+/// is no arena fallback here -- uploading an empty buffer would silently
+/// corrupt the graph.
+pub(crate) fn bind_loaded(
+    loaded: Option<&GgmlLoadedWeightContext>,
+    name: &str,
+) -> Result<GgmlLoadedTensor, String> {
+    match loaded.and_then(|ctx| ctx.tensor(name)) {
+        Some(tensor) => Ok(tensor),
+        None => Err(format!(
+            "2-D linear '{name}' could not be bound zero-copy from the runtime pack \
+             (loaded weight context missing or tensor absent); host payload was dropped"
+        )),
+    }
+}
+
+/// A rank-dispatch failure: `dims` didn't match any rank this pipeline
+/// allocates for the caller's `support_rank4` setting. Carried as owned data
+/// (not a family error type) so this module stays error-enum-agnostic; wrap
+/// `GgmlCpuGraphError` transparently via `?` and format `UnsupportedRank`
+/// yourself (the message text differs slightly per family: "unsupported
+/// rank" vs. "f16 depthwise" vs. "f16 fsmn kernel", etc.).
+pub(crate) enum ArenaAllocError {
+    Graph(GgmlCpuGraphError),
+    UnsupportedRank(Vec<usize>),
+}
+
+impl From<GgmlCpuGraphError> for ArenaAllocError {
+    fn from(source: GgmlCpuGraphError) -> Self {
+        Self::Graph(source)
+    }
+}
+
+/// Allocate a static arena tensor matching a host weight's stored dims,
+/// f32-typed. `support_rank4` gates the 4-D case some families' subsampling
+/// convs need and others never emit -- the only thing that varies
+/// family-to-family in this allocation shape.
+pub(crate) fn alloc_static_f32(
+    arena: &GgmlStaticTensorArena,
+    dims: &[usize],
+    values_len: usize,
+    step: &'static str,
+    support_rank4: bool,
+) -> Result<GgmlStaticTensor, ArenaAllocError> {
+    match dims {
+        [] | [_] => Ok(arena.new_tensor_1d_f32(values_len, step)?),
+        [ne0, ne1] => Ok(arena.new_tensor_2d_f32(*ne0, *ne1, step)?),
+        [ne0, ne1, ne2] => Ok(arena.new_tensor_3d_f32(*ne0, *ne1, *ne2, step)?),
+        [ne0, ne1, ne2, ne3] if support_rank4 => {
+            Ok(arena.new_tensor_4d_typed(*ne0, *ne1, *ne2, *ne3, GGML_TYPE_F32, step)?)
+        }
+        _ => Err(ArenaAllocError::UnsupportedRank(dims.to_vec())),
+    }
+}
+
+/// Allocate an f16 arena tensor (ggml `conv_2d_dw` requires an f16 kernel;
+/// also used for FSMN kernels). `support_rank4` mirrors `alloc_static_f32`.
+pub(crate) fn alloc_static_f16(
+    arena: &GgmlStaticTensorArena,
+    dims: &[usize],
+    step: &'static str,
+    support_rank4: bool,
+) -> Result<GgmlStaticTensor, ArenaAllocError> {
+    match dims {
+        [ne0, ne1, ne2] => Ok(arena.new_tensor_3d_typed(*ne0, *ne1, *ne2, GGML_TYPE_F16, step)?),
+        [ne0, ne1, ne2, ne3] if support_rank4 => {
+            Ok(arena.new_tensor_4d_typed(*ne0, *ne1, *ne2, *ne3, GGML_TYPE_F16, step)?)
+        }
+        _ => Err(ArenaAllocError::UnsupportedRank(dims.to_vec())),
+    }
+}
+
+/// Upload f32 host values into an already-allocated arena tensor.
+pub(crate) fn upload_static_f32(
+    arena: &mut GgmlStaticTensorArena,
+    tensor: GgmlStaticTensor,
+    values: &[f32],
+    step: &'static str,
+) -> Result<(), GgmlCpuGraphError> {
+    arena.set_f32_slice(tensor, values, step)
+}
+
+/// Convert f32 host values to f16 bits and upload into an already-allocated
+/// f16 arena tensor. `f32_to_f16_bits` is threaded through by the caller
+/// (rather than imported here) so this module stays free of any dependency on
+/// `models::*` -- every current family already has the conversion in scope.
+pub(crate) fn upload_static_f16(
+    arena: &mut GgmlStaticTensorArena,
+    tensor: GgmlStaticTensor,
+    values: &[f32],
+    step: &'static str,
+    f32_to_f16_bits: impl Fn(f32) -> u16,
+) -> Result<(), GgmlCpuGraphError> {
+    let bits: Vec<u16> = values.iter().copied().map(f32_to_f16_bits).collect();
+    arena.set_f16_bits_slice(tensor, &bits, step)
+}

--- a/crates/openasr-core/src/ggml_runtime/mod.rs
+++ b/crates/openasr-core/src/ggml_runtime/mod.rs
@@ -1,3 +1,4 @@
+mod arena_weight_pipeline;
 mod backend;
 mod cpu_graph;
 mod env_flags;
@@ -10,6 +11,10 @@ mod gguf_write;
 mod package_probe;
 mod runtime_source;
 
+pub(crate) use arena_weight_pipeline::{
+    ArenaAllocError, WeightSlot, alloc_static_f16, alloc_static_f32, bind_loaded,
+    upload_static_f16, upload_static_f32,
+};
 pub(crate) use backend::ensure_backends_loaded;
 pub use backend::{
     GgmlBackend, GgmlBackendDevice, GgmlBackendKind, GgmlCpuFeatures, GgmlDeviceMemory,

--- a/crates/openasr-core/src/models/parakeet_ctc/encoder_graph.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/encoder_graph.rs
@@ -13,13 +13,15 @@
 use std::path::Path;
 
 use crate::ggml_runtime::{
-    GGML_TYPE_F32, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor,
-    GgmlLoadedWeightContext, GgmlStaticTensor, GgmlStaticTensorArena,
+    ArenaAllocError, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedWeightContext,
+    GgmlStaticTensor, GgmlStaticTensorArena, WeightSlot,
+    alloc_static_f16 as arena_alloc_static_f16, alloc_static_f32 as arena_alloc_static_f32,
+    bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
+    upload_static_f32 as arena_upload_static_f32,
 };
 use crate::models::cohere::encoder_graph::{build_relative_positional_encoding, f32_to_f16_bits};
 use crate::models::parakeet_ctc::graph_config::parakeet_ctc_encoder_graph_config;
 
-const GGML_TYPE_F16: i32 = 1;
 use crate::nn::conv::{
     Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation,
     apply_conv_2d_depthwise_bias_activation, reshape_bias_4d,
@@ -71,29 +73,19 @@ fn bf(step: &'static str) -> impl Fn(GgmlCpuGraphError) -> ParakeetEncoderError 
     move |source| ParakeetEncoderError::GraphBuildFailed { step, source }
 }
 
-/// A 2-D linear weight: either an arena tensor (f32-uploaded — legacy / no
-/// runtime pack) or a zero-copy leaf bound to the mmap'd pack (native
-/// q4_K/f16/f32, no host copy + no arena upload). Goals 7+8 lever: parakeet's
-/// packer reverses every rank>=2 `.weight` to ggml `[in,out]` at PACK time, so
-/// the on-disk linears (`ff*`, `attn.{q,k,v,out,pos}`, `conv.pw{1,2}`, ctc head)
-/// are directly `mul_mat`-consumable and safe to bind — mirroring cohere's
-/// `loaded_or_static_tensor` + qwen's `bind_or_arena_llm`. NOT bound: the
-/// BN-folded depthwise conv (its host values are mutated at load), 1-D
-/// norms/biases, the rank-3/4 subsampling convs, and `attn.pos_bias_u/v`.
-#[derive(Clone, Copy)]
-enum WeightSlot {
-    Arena(GgmlStaticTensor),
-    Loaded(GgmlLoadedTensor),
-}
-
-impl WeightSlot {
-    fn graph<'a>(self, arena: &GgmlStaticTensorArena) -> GgmlCpuTensor<'a> {
-        match self {
-            Self::Arena(handle) => arena.graph_tensor(handle),
-            Self::Loaded(tensor) => tensor.as_graph_tensor(),
-        }
-    }
-}
+// `WeightSlot` (imported above from `ggml_runtime`): either an arena tensor
+// (f32-uploaded — legacy / no runtime pack) or a zero-copy leaf bound to the
+// mmap'd pack (native q4_K/f16/f32, no host copy + no arena upload). Goals
+// 7+8 lever: parakeet's packer reverses every rank>=2 `.weight` to ggml
+// `[in,out]` at PACK time, so the on-disk linears (`ff*`,
+// `attn.{q,k,v,out,pos}`, `conv.pw{1,2}`, ctc head) are directly
+// `mul_mat`-consumable and safe to bind — mirroring cohere's
+// `loaded_or_static_tensor` + qwen's `bind_or_arena_llm`. NOT bound: the
+// BN-folded depthwise conv (its host values are mutated at load), 1-D
+// norms/biases, the rank-3/4 subsampling convs, and `attn.pos_bias_u/v`. The
+// type itself is shared with parakeet-tdt/sensevoice/wav2vec2-ctc — see
+// `ggml_runtime::arena_weight_pipeline` — since it is pure residency
+// plumbing with no parakeet-specific semantics.
 
 /// Bind a 2-D linear zero-copy from the mmap'd pack (`loaded`) by its on-disk
 /// name. FAILS CLOSED if the loaded context is absent or the tensor is missing:
@@ -103,15 +95,9 @@ fn bind_loaded(
     loaded: Option<&GgmlLoadedWeightContext>,
     name: &str,
 ) -> Result<WeightSlot, ParakeetEncoderError> {
-    match loaded.and_then(|ctx| ctx.tensor(name)) {
-        Some(tensor) => Ok(WeightSlot::Loaded(tensor)),
-        None => Err(ParakeetEncoderError::Shape {
-            reason: format!(
-                "2-D linear '{name}' could not be bound zero-copy from the runtime pack \
-                 (loaded weight context missing or tensor absent); host payload was dropped"
-            ),
-        }),
-    }
+    arena_bind_loaded(loaded, name)
+        .map(WeightSlot::Loaded)
+        .map_err(|reason| ParakeetEncoderError::Shape { reason })
 }
 
 fn conv_out_dim(input: usize) -> usize {
@@ -126,23 +112,16 @@ fn alloc_static(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<GgmlStaticTensor, ParakeetEncoderError> {
-    let map = |source| ParakeetEncoderError::GraphBuildFailed { step, source };
-    match weight.dims.as_slice() {
-        [] | [_] => arena
-            .new_tensor_1d_f32(weight.values.len(), step)
-            .map_err(map),
-        [ne0, ne1] => arena.new_tensor_2d_f32(*ne0, *ne1, step).map_err(map),
-        [ne0, ne1, ne2] => arena.new_tensor_3d_f32(*ne0, *ne1, *ne2, step).map_err(map),
-        [ne0, ne1, ne2, ne3] => arena
-            .new_tensor_4d_typed(*ne0, *ne1, *ne2, *ne3, GGML_TYPE_F32, step)
-            .map_err(map),
-        _ => Err(ParakeetEncoderError::Shape {
-            reason: format!(
-                "tensor '{}' has unsupported rank {:?}",
-                weight.name, weight.dims
-            ),
-        }),
-    }
+    arena_alloc_static_f32(arena, &weight.dims, weight.values.len(), step, true).map_err(
+        |e| match e {
+            ArenaAllocError::Graph(source) => {
+                ParakeetEncoderError::GraphBuildFailed { step, source }
+            }
+            ArenaAllocError::UnsupportedRank(dims) => ParakeetEncoderError::Shape {
+                reason: format!("tensor '{}' has unsupported rank {:?}", weight.name, dims),
+            },
+        },
+    )
 }
 
 fn upload_static(
@@ -151,8 +130,7 @@ fn upload_static(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<(), ParakeetEncoderError> {
-    arena
-        .set_f32_slice(tensor, &weight.values, step)
+    arena_upload_static_f32(arena, tensor, &weight.values, step)
         .map_err(|source| ParakeetEncoderError::GraphBuildFailed { step, source })
 }
 
@@ -163,18 +141,12 @@ fn alloc_static_f16(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<GgmlStaticTensor, ParakeetEncoderError> {
-    let map = |source| ParakeetEncoderError::GraphBuildFailed { step, source };
-    match weight.dims.as_slice() {
-        [ne0, ne1, ne2] => arena
-            .new_tensor_3d_typed(*ne0, *ne1, *ne2, GGML_TYPE_F16, step)
-            .map_err(map),
-        [ne0, ne1, ne2, ne3] => arena
-            .new_tensor_4d_typed(*ne0, *ne1, *ne2, *ne3, GGML_TYPE_F16, step)
-            .map_err(map),
-        _ => Err(ParakeetEncoderError::Shape {
-            reason: format!("f16 depthwise '{}' rank {:?}", weight.name, weight.dims),
-        }),
-    }
+    arena_alloc_static_f16(arena, &weight.dims, step, true).map_err(|e| match e {
+        ArenaAllocError::Graph(source) => ParakeetEncoderError::GraphBuildFailed { step, source },
+        ArenaAllocError::UnsupportedRank(dims) => ParakeetEncoderError::Shape {
+            reason: format!("f16 depthwise '{}' rank {:?}", weight.name, dims),
+        },
+    })
 }
 
 fn upload_static_f16(
@@ -183,9 +155,7 @@ fn upload_static_f16(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<(), ParakeetEncoderError> {
-    let bits: Vec<u16> = weight.values.iter().copied().map(f32_to_f16_bits).collect();
-    arena
-        .set_f16_bits_slice(tensor, &bits, step)
+    arena_upload_static_f16(arena, tensor, &weight.values, step, f32_to_f16_bits)
         .map_err(|source| ParakeetEncoderError::GraphBuildFailed { step, source })
 }
 

--- a/crates/openasr-core/src/models/parakeet_tdt/encoder_graph.rs
+++ b/crates/openasr-core/src/models/parakeet_tdt/encoder_graph.rs
@@ -8,13 +8,15 @@
 use std::path::Path;
 
 use crate::ggml_runtime::{
-    GGML_TYPE_F32, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor,
+    ArenaAllocError, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor,
     GgmlLoadedWeightContext, GgmlStaticTensor, GgmlStaticTensorArena,
+    alloc_static_f16 as arena_alloc_static_f16, alloc_static_f32 as arena_alloc_static_f32,
+    bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
+    upload_static_f32 as arena_upload_static_f32,
 };
 use crate::models::cohere::encoder_graph::{build_relative_positional_encoding, f32_to_f16_bits};
 use crate::models::parakeet_tdt::graph_config::parakeet_tdt_encoder_graph_config;
 
-const GGML_TYPE_F16: i32 = 1;
 use crate::nn::conv::{
     Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation,
     apply_conv_2d_depthwise_bias_activation, reshape_bias_4d,
@@ -88,15 +90,9 @@ fn bind_loaded(
     loaded: Option<&GgmlLoadedWeightContext>,
     name: &str,
 ) -> Result<WeightSlot, ParakeetTdtEncoderError> {
-    match loaded.and_then(|ctx| ctx.tensor(name)) {
-        Some(tensor) => Ok(WeightSlot(tensor)),
-        None => Err(ParakeetTdtEncoderError::Shape {
-            reason: format!(
-                "2-D linear '{name}' could not be bound zero-copy from the runtime pack \
-                 (loaded weight context missing or tensor absent); host payload was dropped"
-            ),
-        }),
-    }
+    arena_bind_loaded(loaded, name)
+        .map(WeightSlot)
+        .map_err(|reason| ParakeetTdtEncoderError::Shape { reason })
 }
 
 fn conv_out_dim(input: usize) -> usize {
@@ -108,23 +104,16 @@ fn alloc_static(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<GgmlStaticTensor, ParakeetTdtEncoderError> {
-    let map = |source| ParakeetTdtEncoderError::GraphBuildFailed { step, source };
-    match weight.dims.as_slice() {
-        [] | [_] => arena
-            .new_tensor_1d_f32(weight.values.len(), step)
-            .map_err(map),
-        [ne0, ne1] => arena.new_tensor_2d_f32(*ne0, *ne1, step).map_err(map),
-        [ne0, ne1, ne2] => arena.new_tensor_3d_f32(*ne0, *ne1, *ne2, step).map_err(map),
-        [ne0, ne1, ne2, ne3] => arena
-            .new_tensor_4d_typed(*ne0, *ne1, *ne2, *ne3, GGML_TYPE_F32, step)
-            .map_err(map),
-        _ => Err(ParakeetTdtEncoderError::Shape {
-            reason: format!(
-                "tensor '{}' has unsupported rank {:?}",
-                weight.name, weight.dims
-            ),
-        }),
-    }
+    arena_alloc_static_f32(arena, &weight.dims, weight.values.len(), step, true).map_err(
+        |e| match e {
+            ArenaAllocError::Graph(source) => {
+                ParakeetTdtEncoderError::GraphBuildFailed { step, source }
+            }
+            ArenaAllocError::UnsupportedRank(dims) => ParakeetTdtEncoderError::Shape {
+                reason: format!("tensor '{}' has unsupported rank {:?}", weight.name, dims),
+            },
+        },
+    )
 }
 
 fn upload_static(
@@ -133,8 +122,7 @@ fn upload_static(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<(), ParakeetTdtEncoderError> {
-    arena
-        .set_f32_slice(tensor, &weight.values, step)
+    arena_upload_static_f32(arena, tensor, &weight.values, step)
         .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed { step, source })
 }
 
@@ -143,18 +131,14 @@ fn alloc_static_f16(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<GgmlStaticTensor, ParakeetTdtEncoderError> {
-    let map = |source| ParakeetTdtEncoderError::GraphBuildFailed { step, source };
-    match weight.dims.as_slice() {
-        [ne0, ne1, ne2] => arena
-            .new_tensor_3d_typed(*ne0, *ne1, *ne2, GGML_TYPE_F16, step)
-            .map_err(map),
-        [ne0, ne1, ne2, ne3] => arena
-            .new_tensor_4d_typed(*ne0, *ne1, *ne2, *ne3, GGML_TYPE_F16, step)
-            .map_err(map),
-        _ => Err(ParakeetTdtEncoderError::Shape {
-            reason: format!("f16 depthwise '{}' rank {:?}", weight.name, weight.dims),
-        }),
-    }
+    arena_alloc_static_f16(arena, &weight.dims, step, true).map_err(|e| match e {
+        ArenaAllocError::Graph(source) => {
+            ParakeetTdtEncoderError::GraphBuildFailed { step, source }
+        }
+        ArenaAllocError::UnsupportedRank(dims) => ParakeetTdtEncoderError::Shape {
+            reason: format!("f16 depthwise '{}' rank {:?}", weight.name, dims),
+        },
+    })
 }
 
 fn upload_static_f16(
@@ -163,9 +147,7 @@ fn upload_static_f16(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<(), ParakeetTdtEncoderError> {
-    let bits: Vec<u16> = weight.values.iter().copied().map(f32_to_f16_bits).collect();
-    arena
-        .set_f16_bits_slice(tensor, &bits, step)
+    arena_upload_static_f16(arena, tensor, &weight.values, step, f32_to_f16_bits)
         .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed { step, source })
 }
 

--- a/crates/openasr-core/src/models/sensevoice/encoder_graph.rs
+++ b/crates/openasr-core/src/models/sensevoice/encoder_graph.rs
@@ -12,8 +12,11 @@
 use std::path::Path;
 
 use crate::ggml_runtime::{
-    GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor,
-    GgmlLoadedWeightContext, GgmlStaticTensor, GgmlStaticTensorArena,
+    ArenaAllocError, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlLoadedWeightContext,
+    GgmlStaticTensor, GgmlStaticTensorArena, WeightSlot,
+    alloc_static_f16 as arena_alloc_static_f16, alloc_static_f32 as arena_alloc_static_f32,
+    bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
+    upload_static_f32 as arena_upload_static_f32,
 };
 use crate::models::cohere::encoder_graph::f32_to_f16_bits;
 use crate::nn::encoder::{SanMFsmnBlockConfig, SanMFsmnBlockWeights, sanm_fsmn_encoder_layer};
@@ -26,7 +29,6 @@ use super::runtime_contract::SenseVoiceExecutionMetadata;
 const SENSEVOICE_ENCODER_GRAPH_CONTEXT_BYTES: usize = 768 * 1024 * 1024;
 /// FunASR LayerNorm epsilon (torch LayerNorm eps=1e-12 in EncoderLayerSANM).
 const ENCODER_LAYER_NORM_EPSILON: f32 = 1.0e-12;
-const GGML_TYPE_F16: i32 = 1;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SenseVoiceEncoderError {
@@ -63,36 +65,19 @@ pub(crate) struct SenseVoiceEncoderOutput {
     pub logits: Vec<f32>,
 }
 
-/// A 2-D linear weight: arena tensor or zero-copy bound to the mmap'd pack
-/// (native f16/q8_0/q4_k — the keep-quantized seam).
-#[derive(Clone, Copy)]
-enum WeightSlot {
-    Arena(GgmlStaticTensor),
-    Loaded(GgmlLoadedTensor),
-}
-
-impl WeightSlot {
-    fn graph<'a>(self, arena: &GgmlStaticTensorArena) -> GgmlCpuTensor<'a> {
-        match self {
-            Self::Arena(handle) => arena.graph_tensor(handle),
-            Self::Loaded(tensor) => tensor.as_graph_tensor(),
-        }
-    }
-}
+// `WeightSlot` (imported above from `ggml_runtime`): arena tensor or
+// zero-copy bound to the mmap'd pack (native f16/q8_0/q4_k — the
+// keep-quantized seam). Shared with parakeet-ctc/parakeet-tdt/wav2vec2-ctc —
+// see `ggml_runtime::arena_weight_pipeline` — since it is pure residency
+// plumbing with no sensevoice-specific semantics.
 
 fn bind_loaded(
     loaded: Option<&GgmlLoadedWeightContext>,
     name: &str,
 ) -> Result<WeightSlot, SenseVoiceEncoderError> {
-    match loaded.and_then(|ctx| ctx.tensor(name)) {
-        Some(tensor) => Ok(WeightSlot::Loaded(tensor)),
-        None => Err(SenseVoiceEncoderError::Shape {
-            reason: format!(
-                "2-D linear '{name}' could not be bound zero-copy from the runtime pack \
-                 (loaded weight context missing or tensor absent); host payload was dropped"
-            ),
-        }),
-    }
+    arena_bind_loaded(loaded, name)
+        .map(WeightSlot::Loaded)
+        .map_err(|reason| SenseVoiceEncoderError::Shape { reason })
 }
 
 fn alloc_static(
@@ -100,20 +85,16 @@ fn alloc_static(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<GgmlStaticTensor, SenseVoiceEncoderError> {
-    let map = |source| SenseVoiceEncoderError::GraphBuildFailed { step, source };
-    match weight.dims.as_slice() {
-        [] | [_] => arena
-            .new_tensor_1d_f32(weight.values.len(), step)
-            .map_err(map),
-        [ne0, ne1] => arena.new_tensor_2d_f32(*ne0, *ne1, step).map_err(map),
-        [ne0, ne1, ne2] => arena.new_tensor_3d_f32(*ne0, *ne1, *ne2, step).map_err(map),
-        _ => Err(SenseVoiceEncoderError::Shape {
-            reason: format!(
-                "tensor '{}' has unsupported rank {:?}",
-                weight.name, weight.dims
-            ),
-        }),
-    }
+    arena_alloc_static_f32(arena, &weight.dims, weight.values.len(), step, false).map_err(|e| {
+        match e {
+            ArenaAllocError::Graph(source) => {
+                SenseVoiceEncoderError::GraphBuildFailed { step, source }
+            }
+            ArenaAllocError::UnsupportedRank(dims) => SenseVoiceEncoderError::Shape {
+                reason: format!("tensor '{}' has unsupported rank {:?}", weight.name, dims),
+            },
+        }
+    })
 }
 
 fn alloc_static_f16(
@@ -121,15 +102,12 @@ fn alloc_static_f16(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<GgmlStaticTensor, SenseVoiceEncoderError> {
-    let map = |source| SenseVoiceEncoderError::GraphBuildFailed { step, source };
-    match weight.dims.as_slice() {
-        [ne0, ne1, ne2] => arena
-            .new_tensor_3d_typed(*ne0, *ne1, *ne2, GGML_TYPE_F16, step)
-            .map_err(map),
-        _ => Err(SenseVoiceEncoderError::Shape {
-            reason: format!("f16 fsmn kernel '{}' rank {:?}", weight.name, weight.dims),
-        }),
-    }
+    arena_alloc_static_f16(arena, &weight.dims, step, false).map_err(|e| match e {
+        ArenaAllocError::Graph(source) => SenseVoiceEncoderError::GraphBuildFailed { step, source },
+        ArenaAllocError::UnsupportedRank(dims) => SenseVoiceEncoderError::Shape {
+            reason: format!("f16 fsmn kernel '{}' rank {:?}", weight.name, dims),
+        },
+    })
 }
 
 fn upload_static(
@@ -138,8 +116,7 @@ fn upload_static(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<(), SenseVoiceEncoderError> {
-    arena
-        .set_f32_slice(tensor, &weight.values, step)
+    arena_upload_static_f32(arena, tensor, &weight.values, step)
         .map_err(|source| SenseVoiceEncoderError::GraphBuildFailed { step, source })
 }
 
@@ -149,9 +126,7 @@ fn upload_static_f16(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<(), SenseVoiceEncoderError> {
-    let bits: Vec<u16> = weight.values.iter().copied().map(f32_to_f16_bits).collect();
-    arena
-        .set_f16_bits_slice(tensor, &bits, step)
+    arena_upload_static_f16(arena, tensor, &weight.values, step, f32_to_f16_bits)
         .map_err(|source| SenseVoiceEncoderError::GraphBuildFailed { step, source })
 }
 

--- a/crates/openasr-core/src/models/wav2vec2_ctc/encoder_graph.rs
+++ b/crates/openasr-core/src/models/wav2vec2_ctc/encoder_graph.rs
@@ -12,8 +12,11 @@
 use std::path::Path;
 
 use crate::ggml_runtime::{
-    GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor,
-    GgmlLoadedWeightContext, GgmlStaticTensor, GgmlStaticTensorArena,
+    ArenaAllocError, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedWeightContext,
+    GgmlStaticTensor, GgmlStaticTensorArena, WeightSlot,
+    alloc_static_f16 as arena_alloc_static_f16, alloc_static_f32 as arena_alloc_static_f32,
+    bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
+    upload_static_f32 as arena_upload_static_f32,
 };
 use crate::models::wav2vec2_ctc::graph_config::wav2vec2_ctc_encoder_graph_config;
 use crate::nn::norm::{AffineLayerNormSteps, apply_affine_layer_norm};
@@ -30,7 +33,6 @@ use super::runtime_contract::{
     Wav2Vec2CtcExecutionMetadata,
 };
 
-const GGML_TYPE_F16: i32 = 1;
 /// Base context budget; scaled up for the larger 24-layer / 1024-hidden variants
 /// (hubert/lv60/data2vec) so the arena + graph fit.
 const WAV2VEC2_ENCODER_GRAPH_CONTEXT_BYTES: usize = 1536 * 1024 * 1024;
@@ -67,36 +69,19 @@ fn bf2(step: &'static str, source: GgmlCpuGraphError) -> Wav2Vec2EncoderError {
     Wav2Vec2EncoderError::GraphBuildFailed { step, source }
 }
 
-/// A 2-D linear weight: arena (f32-uploaded) or zero-copy leaf bound to the
-/// mmap'd pack (native q4_K/f16/f32).
-#[derive(Clone, Copy)]
-enum WeightSlot {
-    Arena(GgmlStaticTensor),
-    Loaded(GgmlLoadedTensor),
-}
-
-impl WeightSlot {
-    fn graph<'a>(self, arena: &GgmlStaticTensorArena) -> GgmlCpuTensor<'a> {
-        match self {
-            Self::Arena(handle) => arena.graph_tensor(handle),
-            Self::Loaded(tensor) => tensor.as_graph_tensor(),
-        }
-    }
-}
+// `WeightSlot` (imported above from `ggml_runtime`): arena (f32-uploaded) or
+// zero-copy leaf bound to the mmap'd pack (native q4_K/f16/f32). Shared with
+// parakeet-ctc/parakeet-tdt/sensevoice — see
+// `ggml_runtime::arena_weight_pipeline` — since it is pure residency
+// plumbing with no wav2vec2-specific semantics.
 
 fn bind_loaded(
     loaded: Option<&GgmlLoadedWeightContext>,
     name: &str,
 ) -> Result<WeightSlot, Wav2Vec2EncoderError> {
-    match loaded.and_then(|ctx| ctx.tensor(name)) {
-        Some(tensor) => Ok(WeightSlot::Loaded(tensor)),
-        None => Err(Wav2Vec2EncoderError::Shape {
-            reason: format!(
-                "2-D linear '{name}' could not be bound zero-copy from the runtime pack \
-                 (loaded weight context missing or tensor absent); host payload was dropped"
-            ),
-        }),
-    }
+    arena_bind_loaded(loaded, name)
+        .map(WeightSlot::Loaded)
+        .map_err(|reason| Wav2Vec2EncoderError::Shape { reason })
 }
 
 fn alloc_static_f32(
@@ -104,20 +89,16 @@ fn alloc_static_f32(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<GgmlStaticTensor, Wav2Vec2EncoderError> {
-    let map = |source| Wav2Vec2EncoderError::GraphBuildFailed { step, source };
-    match weight.dims.as_slice() {
-        [] | [_] => arena
-            .new_tensor_1d_f32(weight.values.len(), step)
-            .map_err(map),
-        [ne0, ne1] => arena.new_tensor_2d_f32(*ne0, *ne1, step).map_err(map),
-        [ne0, ne1, ne2] => arena.new_tensor_3d_f32(*ne0, *ne1, *ne2, step).map_err(map),
-        _ => Err(Wav2Vec2EncoderError::Shape {
-            reason: format!(
-                "tensor '{}' has unsupported rank {:?}",
-                weight.name, weight.dims
-            ),
-        }),
-    }
+    arena_alloc_static_f32(arena, &weight.dims, weight.values.len(), step, false).map_err(|e| {
+        match e {
+            ArenaAllocError::Graph(source) => {
+                Wav2Vec2EncoderError::GraphBuildFailed { step, source }
+            }
+            ArenaAllocError::UnsupportedRank(dims) => Wav2Vec2EncoderError::Shape {
+                reason: format!("tensor '{}' has unsupported rank {:?}", weight.name, dims),
+            },
+        }
+    })
 }
 
 fn alloc_static_f16(
@@ -125,15 +106,12 @@ fn alloc_static_f16(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<GgmlStaticTensor, Wav2Vec2EncoderError> {
-    let map = |source| Wav2Vec2EncoderError::GraphBuildFailed { step, source };
-    match weight.dims.as_slice() {
-        [ne0, ne1, ne2] => arena
-            .new_tensor_3d_typed(*ne0, *ne1, *ne2, GGML_TYPE_F16, step)
-            .map_err(map),
-        _ => Err(Wav2Vec2EncoderError::Shape {
-            reason: format!("f16 conv '{}' rank {:?}", weight.name, weight.dims),
-        }),
-    }
+    arena_alloc_static_f16(arena, &weight.dims, step, false).map_err(|e| match e {
+        ArenaAllocError::Graph(source) => Wav2Vec2EncoderError::GraphBuildFailed { step, source },
+        ArenaAllocError::UnsupportedRank(dims) => Wav2Vec2EncoderError::Shape {
+            reason: format!("f16 conv '{}' rank {:?}", weight.name, dims),
+        },
+    })
 }
 
 fn upload_static(
@@ -142,8 +120,7 @@ fn upload_static(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<(), Wav2Vec2EncoderError> {
-    arena
-        .set_f32_slice(tensor, &weight.values, step)
+    arena_upload_static_f32(arena, tensor, &weight.values, step)
         .map_err(|source| Wav2Vec2EncoderError::GraphBuildFailed { step, source })
 }
 
@@ -153,9 +130,7 @@ fn upload_static_f16(
     weight: &NamedTensor,
     step: &'static str,
 ) -> Result<(), Wav2Vec2EncoderError> {
-    let bits: Vec<u16> = weight.values.iter().copied().map(f32_to_f16_bits).collect();
-    arena
-        .set_f16_bits_slice(tensor, &bits, step)
+    arena_upload_static_f16(arena, tensor, &weight.values, step, f32_to_f16_bits)
         .map_err(|source| Wav2Vec2EncoderError::GraphBuildFailed { step, source })
 }
 


### PR DESCRIPTION
## Summary

Extract the byte-for-byte duplicated ggml static-tensor-arena weight-residency
skeleton (alloc rank-dispatch / f32+f16 upload / bind-zero-copy-from-pack) that
`parakeet_ctc`, `parakeet_tdt`, `sensevoice`, and `wav2vec2_ctc`
`encoder_graph.rs` each reimplemented independently, into a new
`ggml_runtime::arena_weight_pipeline` module.

## Why

Audited for duplication across every `LayerArena`/`bind_loaded`/static-tensor
family. `parakeet_ctc::encoder_graph::alloc_static`/`alloc_static_f16`/
`upload_static`/`upload_static_f16`/`bind_loaded` + the `WeightSlot` enum were
copied nearly verbatim into `parakeet_tdt`, `sensevoice`, and `wav2vec2_ctc`
(same rank-dispatch branches, same `bind_loaded` fail-closed message text,
same f16-bits upload logic), differing only in each family's own graph-build
error enum and in whether 4-D tensors are supported. This is pure ggml arena
plumbing with zero model-family semantics, so it belongs in shared
infrastructure per AGENTS.md ("Keep infrastructure model-agnostic").

Deliberately **not** touched, to avoid pushing family semantics into shared
code:
- `moonshine` (encoder + decoder): ad-hoc per-tensor allocation + LoRA slot
  wiring, no generic `alloc_static` equivalent to fold in.
- `firered_punc`: no `bind_loaded`/`WeightSlot` at all (pure arena, explicit
  `ne0`/`ne1` allocation signature).
- `cohere` / `qwen`: already diverged into a richer 8-function upload API
  (`upload_static_f16_from_f32`, row-major matrix helpers, expected-type
  checks) that doesn't match this skeleton.

## Changes

- New `crates/openasr-core/src/ggml_runtime/arena_weight_pipeline.rs`: shared
  `WeightSlot`, `bind_loaded`, `ArenaAllocError`, `alloc_static_f32`,
  `alloc_static_f16`, `upload_static_f32`, `upload_static_f16`.
- `parakeet_ctc`, `parakeet_tdt`, `sensevoice`, `wav2vec2_ctc`
  `encoder_graph.rs`: each keeps its own thin same-named wrapper function that
  maps the shared error type into its own error enum, so every existing call
  site (dozens per file) is unchanged -- only the function *bodies* moved.
  `parakeet_tdt` keeps its own no-arena-fallback `WeightSlot` newtype (it has
  no legacy no-pack path) built from the shared `bind_loaded`'s
  `GgmlLoadedTensor` result.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2309 passed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

N/A -- pure refactor of internal weight-residency plumbing, no behavior
change; covered by the existing parakeet-ctc/parakeet-tdt encoder graph smoke
tests (skip cleanly when the dev-only packs are absent, same as before) plus
the full nextest run above.

## Docs updated

- [x] No behavior or limitations changed; no docs needed updating.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch `moonshine`, `firered_punc`, `cohere`, or `qwen` (see Why).
- Does not change `WeightSlot`/`bind_loaded` semantics or error messages for
  any family; golden_diff coverage confirms output is unchanged.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- Claude Code audited the duplication across the 4 encoder-graph families, designed and implemented the shared `arena_weight_pipeline` module, and ran the full validation suite under my direction.