### PR TITLE
chore(core,server,cli): audit maintenance batch (install-dispatch coverage, dead code, trust-boundary hygiene)

### DIFF
--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -909,18 +909,11 @@ fn serve_native_accepts_quant_pinned_model_ref_for_bare_local_runtime_source() {
 // that boundary.
 #[allow(clippy::zombie_processes)]
 fn spawn_serve_and_wait_until_listening(home: &Path) -> (std::process::Child, String) {
-    // `serve` prints back the `--addr` it was given verbatim rather than the
-    // listener's actual bound address, so `--addr 127.0.0.1:0` would echo the
-    // unusable "port 0". Reserve a real ephemeral port ourselves, release it,
-    // and pass that through -- a race in principle, but a released loopback
-    // port is not reused within a single test's tiny window in practice.
-    let reserved = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port");
-    let addr = reserved
-        .local_addr()
-        .expect("reserved listener addr")
-        .to_string();
-    drop(reserved);
-
+    // `--addr 127.0.0.1:0` asks the OS for an ephemeral port; `serve` reports
+    // back the listener's actual bound address (not the `:0` it was given
+    // verbatim), so the real port is parsed straight from that banner line
+    // instead of pre-reserving one ourselves (which was also a race, in
+    // principle, against the reserved port being reused before `serve` binds).
     let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_openasr"));
     command
         .env("OPENASR_HOME", home)
@@ -928,7 +921,7 @@ fn spawn_serve_and_wait_until_listening(home: &Path) -> (std::process::Child, St
         .env_remove("OPENASR_ADDR")
         .env_remove("OPENASR_ASSUME_YES")
         .env_remove("OPENASR_OFFLINE")
-        .args(["serve", "--backend", "native", "--addr", &addr])
+        .args(["serve", "--backend", "native", "--addr", "127.0.0.1:0"])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
     let mut child = command.spawn().expect("spawn openasr serve");
@@ -951,11 +944,15 @@ fn spawn_serve_and_wait_until_listening(home: &Path) -> (std::process::Child, St
                 "openasr serve exited before reporting it was listening (status: {status:?}, stderr: {stderr})"
             );
         }
-        if line
-            .trim_end()
-            .starts_with("OpenASR server listening on http://")
-        {
-            return (child, addr);
+        let trimmed = line.trim_end();
+        if let Some(addr) = trimmed.strip_prefix("OpenASR server listening on http://") {
+            assert_ne!(
+                addr, "127.0.0.1:0",
+                "serve must report the listener's real bound port, not the \
+                 requested wildcard address, or every caller of this helper \
+                 would try to connect to the unusable port 0"
+            );
+            return (child, addr.to_string());
         }
         if std::time::Instant::now() > deadline {
             let _ = child.kill();

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -2201,6 +2201,74 @@ mod tests {
         );
     }
 
+    /// `validate_native_runtime_model_pack_contract`'s per-family dispatch
+    /// (the `match descriptor.model_architecture { ... }` above) has a
+    /// catch-all `_ => Ok(())` arm for architectures with no dedicated
+    /// required-metadata parser (yet). That arm must never silently swallow
+    /// an architecture that *should* have fail-closed validation wired up.
+    ///
+    /// Mirrors the sibling completeness tests in `builtin_execution_dispatch`
+    /// (`builtins_cover_all_dedicated_runtime_architectures` /
+    /// `..._native_graph_lowering_architectures`), but black-box: rather than
+    /// checking a lookup table contains a key, it feeds every builtin
+    /// architecture a pack that carries only the bare adapter-selection
+    /// metadata (family/architecture/audio-frontend/decode-policy) and
+    /// nothing else, and asserts install-time validation rejects it. Every
+    /// architecture wired up today (via a dedicated `runtime_contract`
+    /// parser, or via the qwen3/cohere tensor-contract check, or via the
+    /// aux-pack table) fails closed on such a bare-bones pack, so if a
+    /// future architecture's dispatch arm is missing (or someone widens the
+    /// `_` arm's reach), it would fall through to `Ok(())` here and this
+    /// test would catch it.
+    #[test]
+    fn install_time_family_metadata_validation_covers_every_builtin_architecture() {
+        use crate::arch::OpenAsrArchitectureRegistry;
+        use crate::models::oasr_metadata::{
+            OASR_METADATA_KEY_AUDIO_FRONTEND, OASR_METADATA_KEY_DECODE_POLICY,
+            OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
+            OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
+        };
+        use std::collections::BTreeMap;
+
+        for descriptor in OpenAsrArchitectureRegistry::with_builtins().descriptors() {
+            let mut metadata = BTreeMap::new();
+            metadata.insert(
+                OASR_METADATA_KEY_PACKAGE_VERSION.to_string(),
+                OASR_PACKAGE_VERSION_V1.to_string(),
+            );
+            metadata.insert(
+                OASR_METADATA_KEY_MODEL_FAMILY.to_string(),
+                descriptor.model_family.to_string(),
+            );
+            metadata.insert(
+                OASR_METADATA_KEY_MODEL_ARCHITECTURE.to_string(),
+                descriptor.model_architecture.to_string(),
+            );
+            metadata.insert(
+                OASR_METADATA_KEY_AUDIO_FRONTEND.to_string(),
+                descriptor.audio_frontend_id.to_string(),
+            );
+            metadata.insert(
+                OASR_METADATA_KEY_DECODE_POLICY.to_string(),
+                descriptor.decode_policy_id.to_string(),
+            );
+            let spec = TinyGgufFixtureSpec::new(metadata);
+            let temp = tempfile::tempdir().unwrap();
+            let pack_path = temp.path().join("fixture.gguf");
+            write_tiny_gguf_runtime_source(&pack_path, &spec).unwrap();
+
+            let result = validate_native_runtime_model_pack_contract(&pack_path);
+            assert!(
+                result.is_err(),
+                "{} accepted an install-time pack that carries only bare \
+                 adapter-selection metadata; every builtin architecture must fail \
+                 closed on missing family-specific runtime metadata (a silent \
+                 `_ => Ok(())` dispatch arm would let this through)",
+                descriptor.model_architecture,
+            );
+        }
+    }
+
     #[test]
     fn native_backend_rejects_speakers_hint_without_diarize() {
         with_forced_cpu_backend_for_test(|| {

--- a/crates/openasr-core/src/models/qwen/kv_cache.rs
+++ b/crates/openasr-core/src/models/qwen/kv_cache.rs
@@ -1,62 +1,4 @@
-use crate::ggml_runtime::{
-    GgmlCpuGraphBuilder, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlStaticTensor,
-    GgmlStaticTensorArena,
-};
-
-use super::graph_config::qwen_runtime_graph_config;
-use super::runtime_contract::Qwen3AsrExecutionMetadata;
-
-#[allow(dead_code)]
-const QWEN3_LLM_KV_CACHE_ARENA_CONTEXT_BYTES: usize = 16 * 1024 * 1024;
-
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct Qwen3AsrKvCacheLayout {
-    pub head_dim: usize,
-    pub kv_heads: usize,
-    pub max_positions: usize,
-    pub layers: usize,
-    pub key_width: usize,
-    pub value_width: usize,
-}
-
-#[allow(dead_code)]
-impl Qwen3AsrKvCacheLayout {
-    pub(crate) fn from_metadata(
-        metadata: Qwen3AsrExecutionMetadata,
-    ) -> Result<Self, GgmlCpuGraphError> {
-        let key_width = metadata
-            .llm_kv_heads
-            .checked_mul(metadata.llm_head_dim)
-            .ok_or(GgmlCpuGraphError::UnsupportedInputs {
-                reason: "qwen kv key width overflow",
-            })?;
-        let value_width = key_width;
-        Ok(Self {
-            head_dim: metadata.llm_head_dim,
-            kv_heads: metadata.llm_kv_heads,
-            max_positions: metadata.llm_max_positions,
-            layers: metadata.llm_layers,
-            key_width,
-            value_width,
-        })
-    }
-}
-
-#[allow(dead_code)]
-pub(crate) struct Qwen3AsrPersistentKvCache {
-    layout: Qwen3AsrKvCacheLayout,
-    arena: GgmlStaticTensorArena,
-    layers: Vec<Qwen3AsrPersistentKvLayer>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct Qwen3AsrPersistentKvLayer {
-    #[allow(dead_code)]
-    pub key: GgmlStaticTensor,
-    #[allow(dead_code)]
-    pub value: GgmlStaticTensor,
-}
+use crate::ggml_runtime::{GgmlCpuGraphBuilder, GgmlCpuGraphError, GgmlCpuTensor};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Qwen3AsrLayerKvCacheState {
@@ -83,55 +25,6 @@ pub(crate) struct Qwen3AsrLayerKvCacheHistory<'a> {
     pub written_positions: usize,
     pub keys: &'a [f32],
     pub values: &'a [f32],
-}
-
-#[allow(dead_code)]
-impl Qwen3AsrPersistentKvCache {
-    pub(crate) fn allocate(metadata: Qwen3AsrExecutionMetadata) -> Result<Self, GgmlCpuGraphError> {
-        let layout = Qwen3AsrKvCacheLayout::from_metadata(metadata)?;
-        let mut config = qwen_runtime_graph_config();
-        config.context_bytes = QWEN3_LLM_KV_CACHE_ARENA_CONTEXT_BYTES;
-        let runner = GgmlCpuGraphRunner::new(config)?;
-        let mut arena = runner.start_static_tensor_arena(config.context_bytes)?;
-        let mut layers = Vec::with_capacity(layout.layers);
-        for layer_idx in 0..layout.layers {
-            let key_name =
-                Box::leak(format!("qwen_llm_kv_cache_key_layer_{layer_idx}").into_boxed_str());
-            let value_name =
-                Box::leak(format!("qwen_llm_kv_cache_value_layer_{layer_idx}").into_boxed_str());
-            let key = arena.new_tensor_3d_f32(
-                layout.head_dim,
-                layout.max_positions,
-                layout.kv_heads,
-                key_name,
-            )?;
-            let value = arena.new_tensor_3d_f32(
-                layout.head_dim,
-                layout.max_positions,
-                layout.kv_heads,
-                value_name,
-            )?;
-            layers.push(Qwen3AsrPersistentKvLayer { key, value });
-        }
-        arena.allocate_backend_buffer()?;
-        Ok(Self {
-            layout,
-            arena,
-            layers,
-        })
-    }
-
-    pub(crate) fn layout(&self) -> Qwen3AsrKvCacheLayout {
-        self.layout
-    }
-
-    pub(crate) fn layer(&self, layer_idx: usize) -> Option<Qwen3AsrPersistentKvLayer> {
-        self.layers.get(layer_idx).copied()
-    }
-
-    pub(crate) fn arena(&self) -> &GgmlStaticTensorArena {
-        &self.arena
-    }
 }
 
 impl Qwen3AsrLayerKvCacheState {
@@ -605,31 +498,6 @@ impl Qwen3AsrLayerKvCacheState {
 mod tests {
     use super::*;
 
-    fn tiny_metadata() -> Qwen3AsrExecutionMetadata {
-        Qwen3AsrExecutionMetadata {
-            sample_rate_hz: 16_000,
-            n_mels: 8,
-            n_fft: 400,
-            win_length: 400,
-            hop_length: 160,
-            audio_layers: 2,
-            audio_d_model: 16,
-            audio_heads: 2,
-            llm_layers: 3,
-            llm_d_model: 16,
-            llm_heads: 2,
-            llm_kv_heads: 2,
-            llm_head_dim: 8,
-            vocab_size: 32,
-            llm_max_positions: 64,
-            audio_start_token_id: 2,
-            audio_end_token_id: 3,
-            audio_pad_token_id: 4,
-            eos_token_id: 0,
-            pad_token_id: 6,
-        }
-    }
-
     #[test]
     fn host_kv_cache_tracks_written_prefix() {
         let mut cache = Qwen3AsrLayerKvCacheState::new(8, 1, 2);
@@ -710,22 +578,5 @@ mod tests {
         cache.truncate_written_positions(1).expect("truncate");
         assert_eq!(cache.written_positions(), 1);
         assert!(cache.truncate_written_positions(2).is_err());
-    }
-
-    #[test]
-    fn persistent_kv_cache_allocates_all_layers() {
-        let cache =
-            Qwen3AsrPersistentKvCache::allocate(tiny_metadata()).expect("allocate kv cache");
-        let layout = cache.layout();
-
-        assert_eq!(layout.layers, 3);
-        assert_eq!(layout.head_dim, 8);
-        assert_eq!(layout.kv_heads, 2);
-        assert_eq!(layout.max_positions, 64);
-        assert!(cache.layer(0).is_some());
-        assert!(cache.layer(2).is_some());
-        assert!(cache.layer(3).is_none());
-
-        let _ = cache.arena();
     }
 }

--- a/crates/openasr-core/src/nn/encoder.rs
+++ b/crates/openasr-core/src/nn/encoder.rs
@@ -1325,4 +1325,237 @@ mod tests {
             );
         }
     }
+
+    // ----- SAN-M (SenseVoice/Paraformer) `input_dim == d_model` vs `!=` -----
+    //
+    // The only real caller (`models::sensevoice::encoder_graph`) exercises the
+    // `input_dim != d_model` branch (the 560-dim LFR+prompt feature feeding
+    // `enc.blk.0`) only through a bring-up test gated on
+    // `#[ignore = "requires SENSEVOICE_BRINGUP_DIR + SENSEVOICE_PACK ..."]`,
+    // which needs a local oracle pack and never runs in CI. These tiny
+    // synthetic-tensor tests exercise both sides of the residual-skip
+    // conditional (`config.input_dim == d_model` above) directly, independent
+    // of any real pack.
+
+    const SANM_D_MODEL: usize = HIDDEN;
+    const SANM_MISMATCHED_INPUT_DIM: usize = 6;
+    const SANM_FSMN_KERNEL: usize = 1;
+
+    /// Build a tiny `sanm_fsmn_encoder_layer` graph with every weight/bias
+    /// zeroed except the two LayerNorm scale vectors (kept at 1 so the norm
+    /// itself stays well-defined). Every affine transform downstream of the
+    /// norms (QKV, attention-out, the FSMN depthwise conv, the FFN) then
+    /// multiplies by zero, so the whole attention+FFN contribution collapses
+    /// to exactly zero and the block's output reduces to plain `state`: the
+    /// original `input` when the residual add fires (`input_dim == d_model`),
+    /// or exactly the zero vector when it is skipped (`input_dim !=
+    /// d_model`, so `state = attn_out = 0`). That makes both branches of the
+    /// conditional hand-verifiable without needing a full identity-attention
+    /// reference implementation.
+    fn run_sanm_fsmn_encoder_layer_zeroed(input_dim: usize, input_values: &[f32]) -> Vec<f32> {
+        assert_eq!(input_values.len(), input_dim * TOKENS);
+        let config = GgmlCpuGraphConfig {
+            backend: GgmlCpuGraphBackend::Cpu,
+            ..GgmlCpuGraphConfig::conservative_default()
+        };
+        let mut runner = GgmlCpuGraphRunner::new(config).expect("cpu graph runner should init");
+        let mut graph = runner.start_graph();
+
+        let input = graph
+            .new_tensor_2d_f32(input_dim, TOKENS, "sanm_input")
+            .expect("input tensor");
+        let attn_norm_weight = graph
+            .new_tensor_1d_f32(input_dim, "sanm_attn_norm_weight")
+            .expect("attn_norm_weight");
+        let attn_norm_bias = graph
+            .new_tensor_1d_f32(input_dim, "sanm_attn_norm_bias")
+            .expect("attn_norm_bias");
+        let attn_qkv_weight = graph
+            .new_tensor_2d_f32(input_dim, 3 * SANM_D_MODEL, "sanm_qkv_weight")
+            .expect("attn_qkv_weight");
+        let attn_qkv_bias = graph
+            .new_tensor_1d_f32(3 * SANM_D_MODEL, "sanm_qkv_bias")
+            .expect("attn_qkv_bias");
+        let attn_out_weight = graph
+            .new_tensor_2d_f32(SANM_D_MODEL, SANM_D_MODEL, "sanm_out_weight")
+            .expect("attn_out_weight");
+        let attn_out_bias = graph
+            .new_tensor_1d_f32(SANM_D_MODEL, "sanm_out_bias")
+            .expect("attn_out_bias");
+        let attn_fsmn_weight = graph
+            .new_tensor_3d_f16(SANM_FSMN_KERNEL, 1, SANM_D_MODEL, "sanm_fsmn_weight")
+            .expect("attn_fsmn_weight");
+        let ffn_norm_weight = graph
+            .new_tensor_1d_f32(SANM_D_MODEL, "sanm_ffn_norm_weight")
+            .expect("ffn_norm_weight");
+        let ffn_norm_bias = graph
+            .new_tensor_1d_f32(SANM_D_MODEL, "sanm_ffn_norm_bias")
+            .expect("ffn_norm_bias");
+        let ffn_up_weight = graph
+            .new_tensor_2d_f32(SANM_D_MODEL, SANM_D_MODEL, "sanm_ffn_up_weight")
+            .expect("ffn_up_weight");
+        let ffn_up_bias = graph
+            .new_tensor_1d_f32(SANM_D_MODEL, "sanm_ffn_up_bias")
+            .expect("ffn_up_bias");
+        let ffn_down_weight = graph
+            .new_tensor_2d_f32(SANM_D_MODEL, SANM_D_MODEL, "sanm_ffn_down_weight")
+            .expect("ffn_down_weight");
+        let ffn_down_bias = graph
+            .new_tensor_1d_f32(SANM_D_MODEL, "sanm_ffn_down_bias")
+            .expect("ffn_down_bias");
+
+        for tensor in [
+            input,
+            attn_norm_weight,
+            attn_norm_bias,
+            attn_qkv_weight,
+            attn_qkv_bias,
+            attn_out_weight,
+            attn_out_bias,
+            attn_fsmn_weight,
+            ffn_norm_weight,
+            ffn_norm_bias,
+            ffn_up_weight,
+            ffn_up_bias,
+            ffn_down_weight,
+            ffn_down_bias,
+        ] {
+            graph.set_input(tensor).expect("tensor should be an input");
+        }
+
+        let output = sanm_fsmn_encoder_layer(
+            &mut graph,
+            input,
+            SanMFsmnBlockConfig {
+                d_model: SANM_D_MODEL,
+                input_dim,
+                attention_heads: HEADS,
+                head_dim: HEAD_DIM,
+                frame_count: TOKENS,
+                fsmn_kernel: SANM_FSMN_KERNEL,
+                layer_norm_epsilon: 1.0e-5,
+            },
+            SanMFsmnBlockWeights {
+                attn_norm_weight,
+                attn_norm_bias,
+                attn_qkv_weight,
+                attn_qkv_bias,
+                attn_out_weight,
+                attn_out_bias,
+                attn_fsmn_weight,
+                ffn_norm_weight,
+                ffn_norm_bias,
+                ffn_up_weight,
+                ffn_up_bias,
+                ffn_down_weight,
+                ffn_down_bias,
+            },
+            identity_map_err,
+        )
+        .expect("sanm_fsmn_encoder_layer should build");
+        graph.set_output(output).expect("output should be settable");
+
+        graph
+            .set_f32_slice(input, input_values, "sanm_input")
+            .expect("input upload");
+        graph
+            .set_f32_slice(
+                attn_norm_weight,
+                &vec![1.0f32; input_dim],
+                "sanm_attn_norm_weight",
+            )
+            .expect("attn_norm_weight upload");
+        graph
+            .set_f32_slice(
+                attn_norm_bias,
+                &vec![0.0f32; input_dim],
+                "sanm_attn_norm_bias",
+            )
+            .expect("attn_norm_bias upload");
+        graph
+            .set_f32_slice(
+                attn_qkv_weight,
+                &vec![0.0f32; input_dim * 3 * SANM_D_MODEL],
+                "sanm_qkv_weight",
+            )
+            .expect("attn_qkv_weight upload");
+        graph
+            .set_f32_slice(attn_qkv_bias, &[0.0f32; 3 * SANM_D_MODEL], "sanm_qkv_bias")
+            .expect("attn_qkv_bias upload");
+        graph
+            .set_f32_slice(attn_out_weight, &ZERO_4X4, "sanm_out_weight")
+            .expect("attn_out_weight upload");
+        graph
+            .set_f32_slice(attn_out_bias, &ZERO_1D, "sanm_out_bias")
+            .expect("attn_out_bias upload");
+        graph
+            .set_f16_bits_slice(
+                attn_fsmn_weight,
+                &[0u16; SANM_FSMN_KERNEL * SANM_D_MODEL],
+                "sanm_fsmn_weight",
+            )
+            .expect("attn_fsmn_weight upload");
+        graph
+            .set_f32_slice(ffn_norm_weight, &NORM_WEIGHT, "sanm_ffn_norm_weight")
+            .expect("ffn_norm_weight upload");
+        graph
+            .set_f32_slice(ffn_norm_bias, &ZERO_1D, "sanm_ffn_norm_bias")
+            .expect("ffn_norm_bias upload");
+        graph
+            .set_f32_slice(ffn_up_weight, &ZERO_4X4, "sanm_ffn_up_weight")
+            .expect("ffn_up_weight upload");
+        graph
+            .set_f32_slice(ffn_up_bias, &ZERO_1D, "sanm_ffn_up_bias")
+            .expect("ffn_up_bias upload");
+        graph
+            .set_f32_slice(ffn_down_weight, &ZERO_4X4, "sanm_ffn_down_weight")
+            .expect("ffn_down_weight upload");
+        graph
+            .set_f32_slice(ffn_down_bias, &ZERO_1D, "sanm_ffn_down_bias")
+            .expect("ffn_down_bias upload");
+
+        graph
+            .compute_output_f32(output, SANM_D_MODEL * TOKENS)
+            .expect("sanm_fsmn_encoder_layer graph should compute")
+    }
+
+    #[test]
+    fn sanm_residual_adds_input_when_input_dim_matches_d_model() {
+        let input = [
+            0.4, -0.3, 0.2, 0.1, //
+            -0.1, 0.5, -0.2, 0.3, //
+            0.2, 0.1, 0.4, -0.4,
+        ];
+        let output = run_sanm_fsmn_encoder_layer_zeroed(SANM_D_MODEL, &input);
+        assert_eq!(output.len(), input.len());
+        for (index, (actual, expected)) in output.iter().zip(input.iter()).enumerate() {
+            assert!(
+                (actual - expected).abs() <= 1.0e-5,
+                "element {index}: with attention/FFN weights zeroed, the residual add \
+                 must pass `input` through unchanged when input_dim == d_model, got \
+                 {actual} expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn sanm_residual_is_skipped_when_input_dim_differs_from_d_model() {
+        // A wider first-layer input (SenseVoice's real shape feeds a 560-dim
+        // LFR+prompt feature into a 512-dim d_model); the specific values
+        // don't matter here since every weight downstream is zeroed -- only
+        // that input_dim != d_model.
+        let input: Vec<f32> = (0..(SANM_MISMATCHED_INPUT_DIM * TOKENS))
+            .map(|i| 0.1 * (i as f32 + 1.0))
+            .collect();
+        let output = run_sanm_fsmn_encoder_layer_zeroed(SANM_MISMATCHED_INPUT_DIM, &input);
+        assert_eq!(output.len(), SANM_D_MODEL * TOKENS);
+        for (index, actual) in output.iter().enumerate() {
+            assert!(
+                actual.abs() <= 1.0e-5,
+                "element {index}: with attention/FFN weights zeroed, the residual add \
+                 must be SKIPPED when input_dim != d_model, so the block output should \
+                 reduce to exactly zero, got {actual}"
+            );
+        }
+    }
 }

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -1973,6 +1973,11 @@ fn verify_partial_and_install(
     })?;
     atomic_file::sync_parent_dir_best_effort(&paths.final_path);
     let _ = fs::remove_file(&paths.partial_meta_path);
+    // A resume can switch from the chunked/parallel path (which persists
+    // `partial_segments_meta_path`) to this single-stream success path once
+    // the remaining bytes drop below the parallel-eligibility threshold; clean
+    // it up here too so it cannot outlive the `.partial` file it describes.
+    let _ = fs::remove_file(&paths.partial_segments_meta_path);
     let pack = write_installed_record(target, paths)?;
     progress(PullProgress::Installed {
         path: pack.path.clone(),

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -1234,6 +1234,46 @@ fn pull_rejects_size_mismatch_and_removes_partial_metadata() {
 }
 
 #[test]
+fn verify_partial_and_install_removes_stale_segments_meta_on_single_stream_success() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let (target, paths) = write_complete_partial(temp.path(), &resolved, &bytes);
+
+    // Simulate a resume that began as a chunked/parallel download (which
+    // persists `partial_segments_meta_path`) but finished through this
+    // single-stream success path once the remaining bytes dropped below the
+    // parallel-eligibility threshold, leaving a stale segments bitmap behind
+    // that this success path must also clean up (it previously only removed
+    // `partial_meta_path`).
+    let meta = SegmentedPartialMeta {
+        format: PARALLEL_META_FORMAT.to_string(),
+        model_id: target.model_id.clone(),
+        quant: target.quant.clone(),
+        filename: target.filename.clone(),
+        hf_revision: target.hf_revision.clone(),
+        sha256: target.sha256.clone(),
+        size_bytes: target.size_bytes,
+        segment_bytes: bytes.len() as u64,
+        etag: Some("etag-a".to_string()),
+        segments_done: vec![true],
+        updated_at_unix_seconds: 0,
+    };
+    write_partial_segments_meta(&paths.partial_segments_meta_path, &meta).unwrap();
+    assert!(paths.partial_segments_meta_path.exists());
+
+    verify_partial_and_install(&target, &paths, None, &|| false, |_| {}).unwrap();
+
+    assert!(paths.final_path.exists());
+    assert!(!paths.partial_meta_path.exists());
+    assert!(
+        !paths.partial_segments_meta_path.exists(),
+        "single-stream success must also clean up a stale segments bitmap left \
+         over from an earlier chunked/parallel attempt"
+    );
+}
+
+#[test]
 fn download_response_rejects_fresh_content_length_mismatch_before_reading() {
     let bytes = tiny_pack_bytes();
     let resolved = resolved_for(&bytes);

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -241,6 +241,12 @@ pub async fn serve_with_launch_options(
     );
     stage_started = Instant::now();
     let listener = TcpListener::bind(addr).await?;
+    // Shadow the requested `addr` (which may be an OS-assigned wildcard like
+    // `:0`) with the listener's actual bound address so everything below --
+    // the "listening on" banners and the stage-timing "ready" event -- reports
+    // the real, connectable port instead of echoing the CLI's `--addr` input
+    // back verbatim.
+    let addr = listener.local_addr()?;
     openasr_core::stage_timing::log_stage(
         "server_boot",
         "tcp_listener_bind",

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1501,12 +1501,12 @@ fn safe_extension_suffix(file_name: &str) -> Option<String> {
         .and_then(std::path::Path::extension)
         .and_then(std::ffi::OsStr::to_str)?
         .to_ascii_lowercase();
-    match extension.as_str() {
-        "wav" | "mp3" | "m4a" | "mp4" | "webm" | "flac" | "ogg" | "qta" => {
-            Some(format!(".{extension}"))
-        }
-        _ => None,
-    }
+    // Single source of truth for the recognized-audio-extension whitelist
+    // (was a second hand-kept copy of the list in `openasr_core::audio::types`,
+    // which could silently drift from it).
+    openasr_core::recognized_audio_extensions()
+        .contains(&extension.as_str())
+        .then(|| format!(".{extension}"))
 }
 
 #[cfg(test)]

--- a/crates/openasr-server/src/routes/translation.rs
+++ b/crates/openasr-server/src/routes/translation.rs
@@ -3,7 +3,7 @@
 //! via `use crate::*`, translation/pack types from `openasr_core`.
 
 use std::{
-    env, fs,
+    env,
     path::{Path, PathBuf},
 };
 
@@ -103,34 +103,17 @@ fn find_installed_hymt2_translation_pack(
     home: &Path,
     requested_model: Option<&str>,
 ) -> Option<InstalledPack> {
-    let root = home.join("models");
-    let model_dirs = fs::read_dir(root).ok()?;
-    let mut candidates = Vec::new();
-    for model_dir in model_dirs.flatten() {
-        let Ok(quant_dirs) = fs::read_dir(model_dir.path()) else {
-            continue;
-        };
-        for quant_dir in quant_dirs.flatten() {
-            let metadata_path = quant_dir.path().join("installed.json");
-            let Ok(contents) = fs::read_to_string(metadata_path) else {
-                continue;
-            };
-            let Ok(pack) = serde_json::from_str::<InstalledPack>(&contents) else {
-                continue;
-            };
-            if !translation_installed_pack_matches(&pack, requested_model) {
-                continue;
-            }
-            if fs::symlink_metadata(&pack.path)
-                .ok()
-                .is_some_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink())
-            {
-                candidates.push(pack);
-            }
-        }
-    }
-    candidates.sort_by(|left, right| left.pull.cmp(&right.pull));
-    candidates.into_iter().next()
+    // Reuse `list_installed_packs`'s trust-boundary validation (safe
+    // relative model_id/quant/filename components, no path traversal, the
+    // record's declared `path` must literally be `quant_dir/filename`, and
+    // the file must be a real non-symlink regular file) instead of a
+    // hand-rolled directory scan that trusted `installed.json`'s `path`
+    // field outright. Already sorted by `pull`, so `.find()` preserves the
+    // same "first by pull order" tie-break the old manual scan applied.
+    let packs = openasr_core::list_installed_packs(home).ok()?;
+    packs
+        .into_iter()
+        .find(|pack| translation_installed_pack_matches(pack, requested_model))
 }
 
 fn translation_installed_pack_matches(pack: &InstalledPack, requested_model: Option<&str>) -> bool {
@@ -171,4 +154,64 @@ fn validate_hymt2_translation_pack(path: &Path) -> Result<(), String> {
                 error
             )
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn stub_installed_pack(path: PathBuf, filename: &str) -> InstalledPack {
+        InstalledPack {
+            model_id: HYMT2_TRANSLATION_MODEL_ID.to_string(),
+            display_name: "Hy-MT2 1.8B".to_string(),
+            quant: "q4_k_m".to_string(),
+            suffix: "q4_k_m".to_string(),
+            pull: HYMT2_TRANSLATION_MODEL_ID.to_string(),
+            filename: filename.to_string(),
+            path,
+            url: "https://example.invalid/model.oasr".to_string(),
+            hf_revision: "a".repeat(40),
+            sha256: "b".repeat(64),
+            size_bytes: 0,
+            installed_at_unix_seconds: 0,
+            source: None,
+        }
+    }
+
+    /// Aligns `find_installed_hymt2_translation_pack` with the trust
+    /// boundary `list_installed_packs` already enforces: an `installed.json`
+    /// record whose declared `path` does not resolve to
+    /// `<quant_dir>/<filename>` must be rejected outright, not trusted just
+    /// because the path happens to exist and isn't a symlink. The
+    /// hand-rolled directory scan this replaced only checked the latter, so
+    /// a record like this would previously have been accepted.
+    #[test]
+    fn rejects_installed_record_whose_declared_path_escapes_its_quant_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let quant_dir = home
+            .path()
+            .join("models")
+            .join(HYMT2_TRANSLATION_MODEL_ID)
+            .join("q4_k_m");
+        fs::create_dir_all(&quant_dir).unwrap();
+
+        // A real, non-symlink file elsewhere under `home` -- the crafted
+        // record points `path` at this instead of `quant_dir/model.oasr`.
+        let escaped_path = home.path().join("escaped.oasr");
+        fs::write(&escaped_path, b"not a real pack, just needs to exist").unwrap();
+
+        let pack = stub_installed_pack(escaped_path, "model.oasr");
+        fs::write(
+            quant_dir.join("installed.json"),
+            serde_json::to_string(&pack).unwrap(),
+        )
+        .unwrap();
+
+        assert!(
+            find_installed_hymt2_translation_pack(home.path(), None).is_none(),
+            "an installed.json record whose declared path escapes its own quant \
+             directory must be rejected, not silently trusted"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Six small audited maintenance items across openasr-core/openasr-server/openasr-cli, plus one bonus fix found while validating the batch:

1. Add a black-box completeness test proving every builtin architecture fails closed in `validate_native_runtime_model_pack_contract`'s per-family metadata dispatch, so a future architecture can't silently fall through the `_ => Ok(())` catch-all arm.
2. Add tiny synthetic-tensor tests for `sanm_fsmn_encoder_layer`'s residual-skip branch (`input_dim == d_model` vs `!=`), previously exercised only by an `#[ignore]`d SenseVoice bring-up test that never runs in CI.
3. Remove dead `Qwen3AsrKvCacheLayout`/`Qwen3AsrPersistentKvCache`/`Qwen3AsrPersistentKvLayer` scaffolding (zero references outside their own module/tests; the host-side cache actually in use, `Qwen3AsrLayerKvCacheState`, is untouched).
4. Route `find_installed_hymt2_translation_pack` through `openasr_core::list_installed_packs` instead of a hand-rolled directory scan that trusted each `installed.json` record's declared `path` outright.
5. Read `safe_extension_suffix`'s audio-extension whitelist from `openasr_core::recognized_audio_extensions()` instead of a second hand-kept copy.
6. Clean up an orphaned `.partial.segments.json` bitmap on the pull single-stream success path (a resume can switch from chunked/parallel to single-stream once remaining bytes drop below the parallel threshold, leaking the old bitmap).
7. (Bonus) `serve`'s startup banner echoed the requested `--addr` verbatim instead of the listener's actual bound address, so `--addr 127.0.0.1:0` reported the unusable "port 0"; fixed by shadowing `addr` with `listener.local_addr()`.

## Why

Backlog of small audit findings (completeness/coverage gaps, dead code, and a couple of low-severity trust-boundary/hygiene issues) batched into one PR since each is independently small.

## Changes

- `crates/openasr-core/src/api/backend/native.rs`: completeness test for install-time dispatch.
- `crates/openasr-core/src/nn/encoder.rs`: SAN-M residual-skip tests.
- `crates/openasr-core/src/models/qwen/kv_cache.rs`: dead-code removal.
- `crates/openasr-server/src/routes/translation.rs`: hy-mt2 pack lookup + regression test.
- `crates/openasr-server/src/routes/transcription.rs`: dedupe audio-extension whitelist.
- `crates/openasr-core/src/pull.rs`, `pull_tests.rs`: segments-bitmap cleanup + test.
- `crates/openasr-server/src/lib.rs`, `crates/openasr-cli/tests/cli.rs`: real bound-address banner fix + simplified test helper.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2329 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch`
- [x] `cargo test -p openasr-cli --test cli` (all 70 integration tests, including the two exercising the serve banner fix)

Each new/changed test was verified to actually fail when the corresponding fix/behavior was reverted, before being restored.

## Manual smoke checks

N/A (unit/integration test coverage only, no user-facing behavior change beyond the two bug fixes described above).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not touch the similar (but out-of-scope) restart/mismatch branch in `download_response` that also only cleans up `.partial.meta.json` and not the segments bitmap; only the single-stream success path called out in the audit was in scope.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — implemented with AI assistance (Claude Code) under human review and direction.