### PR TITLE
refactor(hymt2): route greedy decode through the shared driver

### DIFF
--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -152,6 +152,15 @@ pub(crate) const FIRERED_AED_DECODE_POLICY_ID: &str = "firered-aed.greedy.seq2se
 pub(crate) const FIRERED_AED_RUNTIME_TENSOR_CONTRACT_ID: &str = "firered-aed.runtime-tensors.v0";
 pub(crate) const FIRERED_AED_EXECUTOR_COMPONENT_ID: &str = "firered-aed.ggml-executor.v0";
 
+// hymt2 (Tencent Hunyuan-MT2 subtitle translation, hunyuan-dense decoder-only
+// LLM). An auxiliary text-to-text family, NOT an ASR architecture: it is
+// dispatched through `models::aux_pack_registry` / the translation routes, so
+// it declares no architecture descriptor here. Its decode policy id still
+// lives in this file (the single home for policy ids) and resolves directly
+// through `models::decode_policy_component_registry`, keeping its greedy loop
+// on the one shared decode driver.
+pub(crate) const HYMT2_DECODE_POLICY_ID: &str = "hymt2.greedy.seq2seq.v0";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OpenAsrComponentKind {
     AudioFrontend,

--- a/crates/openasr-core/src/models/decode_policy_component_registry.rs
+++ b/crates/openasr-core/src/models/decode_policy_component_registry.rs
@@ -37,6 +37,9 @@ pub(crate) enum BuiltinDecodePolicyExecutionKind {
 pub(crate) enum BuiltinDecodePolicySeq2SeqTextPostprocessKind {
     Identity,
     Qwen3AsrStripControlPrefixV0,
+    /// Trim leading/trailing whitespace around the decoded text (hymt2:
+    /// chat-format completions lead with a space after the assistant marker).
+    TrimWhitespaceV0,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,6 +52,10 @@ pub(crate) enum BuiltinDecodePolicySeq2SeqTraceKind {
 pub(crate) enum BuiltinDecodePolicySeq2SeqStopTokenKind {
     None,
     Qwen3AsrAudioBoundaryV0,
+    /// hymt2 chat-boundary markers (EOT + BOS + role markers) on top of the
+    /// EOS eot token: a decoder-only chat LLM must stop when it starts a new
+    /// turn, not only on EOS.
+    Hymt2ChatBoundaryV0,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -120,6 +127,15 @@ pub(crate) enum BuiltinDecodePolicyComponentRegistryError {
 /// own joint-decode loop. Those ride dedicated executors and never reach
 /// `resolve_builtin_decode_policy`.
 ///
+/// Hy-MT2 (`models/hymt2`) IS registered here even though it is not an ASR
+/// architecture: it is an auxiliary translation family invoked directly by
+/// the CLI/server (`Hymt2Runtime::translate_clause*` / `decode_prompt_tokens`)
+/// rather than dispatched through the `OpenAsrArchitectureRegistry`, so its
+/// runtime resolves the policy by id (`resolve_builtin_decode_policy`) instead
+/// of by `model_architecture`. Its decode steps ride the fused device top-1
+/// logits head, surfacing tokens through `greedy_token_hint` with no host
+/// logit row (the driver's hint-only step shape).
+///
 /// The `all_seq2seq_greedy_arch_decode_policies_resolve` regression test enforces
 /// that every `*.greedy.seq2seq.*` policy IS registered, so a new seq2seq family
 /// cannot half-connect (constant present, execution descriptor missing).
@@ -186,6 +202,23 @@ const BUILTIN_DECODE_POLICY_COMPONENTS: &[BuiltinDecodePolicyComponentDescriptor
         // structural fix for its long-audio repetition (issue #60).
         longform_prompt_carry_mode: BuiltinDecodePolicyLongformPromptCarryMode::TokenHistory,
         longform_profile: BuiltinDecodePolicyLongformProfile::ConservativeSeq2SeqV1,
+        ctc_blank_token_id: None,
+    },
+    BuiltinDecodePolicyComponentDescriptor {
+        // hymt2 is an auxiliary translation family (no arch-registry entry, no
+        // crate-root re-export); its runtime resolves this descriptor directly
+        // by policy id. Source of truth for the id is `crate::arch`.
+        decode_policy_id: crate::arch::HYMT2_DECODE_POLICY_ID,
+        execution_kind: BuiltinDecodePolicyExecutionKind::Seq2SeqGreedyV0,
+        seq2seq_text_postprocess_kind:
+            BuiltinDecodePolicySeq2SeqTextPostprocessKind::TrimWhitespaceV0,
+        seq2seq_trace_kind: BuiltinDecodePolicySeq2SeqTraceKind::None,
+        seq2seq_stop_token_kind: BuiltinDecodePolicySeq2SeqStopTokenKind::Hymt2ChatBoundaryV0,
+        seq2seq_suppression_kind: BuiltinDecodePolicySeq2SeqSuppressionKind::None,
+        // Longform fields are inert for hymt2: translation decodes one clause
+        // per request and never enters the longform transcription orchestrator.
+        longform_prompt_carry_mode: BuiltinDecodePolicyLongformPromptCarryMode::Text,
+        longform_profile: BuiltinDecodePolicyLongformProfile::Default,
         ctc_blank_token_id: None,
     },
     BuiltinDecodePolicyComponentDescriptor {
@@ -419,6 +452,25 @@ pub(crate) fn build_builtin_seq2seq_decode_policy_config(
                 token_source.audio_end_token_id(),
             )?,
         ],
+        BuiltinDecodePolicySeq2SeqStopTokenKind::Hymt2ChatBoundaryV0 => {
+            use crate::models::hymt2::tokenizer::{
+                HYMT2_ASSISTANT_TOKEN, HYMT2_BOS_TOKEN, HYMT2_EOT_TOKEN, HYMT2_USER_TOKEN,
+            };
+            let mut stop_token_ids = Vec::with_capacity(4);
+            for marker in [
+                HYMT2_EOT_TOKEN,
+                HYMT2_BOS_TOKEN,
+                HYMT2_USER_TOKEN,
+                HYMT2_ASSISTANT_TOKEN,
+            ] {
+                stop_token_ids.push(require_special_token(
+                    descriptor,
+                    marker,
+                    token_source.token_id_by_content(marker),
+                )?);
+            }
+            stop_token_ids
+        }
     };
 
     let (suppress_first_step_token_ids, suppress_token_ids) =
@@ -546,6 +598,9 @@ pub(crate) fn apply_seq2seq_text_postprocess(
             [seq2seq_transcript_byte_start(kind, decoded)..]
             .trim()
             .to_string(),
+        BuiltinDecodePolicySeq2SeqTextPostprocessKind::TrimWhitespaceV0 => {
+            decoded.trim().to_string()
+        }
     }
 }
 
@@ -558,7 +613,8 @@ pub(crate) fn seq2seq_transcript_byte_start(
     decoded: &str,
 ) -> usize {
     match kind {
-        BuiltinDecodePolicySeq2SeqTextPostprocessKind::Identity => 0,
+        BuiltinDecodePolicySeq2SeqTextPostprocessKind::Identity
+        | BuiltinDecodePolicySeq2SeqTextPostprocessKind::TrimWhitespaceV0 => 0,
         BuiltinDecodePolicySeq2SeqTextPostprocessKind::Qwen3AsrStripControlPrefixV0 => decoded
             .find(QWEN3_ASR_TEXT_MARKER)
             .map(|index| index + QWEN3_ASR_TEXT_MARKER.len())
@@ -661,6 +717,96 @@ mod tests {
         assert_eq!(
             qwen.seq2seq_text_postprocess_kind,
             BuiltinDecodePolicySeq2SeqTextPostprocessKind::Qwen3AsrStripControlPrefixV0
+        );
+    }
+
+    #[test]
+    fn hymt2_decode_policy_resolves_as_seq2seq_greedy_with_chat_boundary_stops() {
+        // hymt2 has no arch-registry entry (auxiliary translation family), so
+        // the arch-driven completeness test cannot cover it; this pins its
+        // registration and stop-token wiring directly by policy id.
+        let descriptor = resolve_builtin_decode_policy(crate::arch::HYMT2_DECODE_POLICY_ID)
+            .expect("hymt2 decode policy");
+        assert_eq!(
+            descriptor.execution_kind,
+            BuiltinDecodePolicyExecutionKind::Seq2SeqGreedyV0
+        );
+        assert_eq!(
+            descriptor.seq2seq_text_postprocess_kind,
+            BuiltinDecodePolicySeq2SeqTextPostprocessKind::TrimWhitespaceV0
+        );
+        assert_eq!(
+            descriptor.seq2seq_stop_token_kind,
+            BuiltinDecodePolicySeq2SeqStopTokenKind::Hymt2ChatBoundaryV0
+        );
+
+        use crate::models::hymt2::tokenizer::{
+            HYMT2_ASSISTANT_TOKEN, HYMT2_BOS_TOKEN, HYMT2_EOT_TOKEN, HYMT2_USER_TOKEN,
+        };
+        let token_source = SyntheticTokenSource {
+            audio_end_token_id: None,
+            audio_pad_token_id: None,
+            start_of_transcript_token_id: None,
+            transcribe_token_id: None,
+            no_timestamps_token_id: None,
+            token_ids_by_content: BTreeMap::from([
+                (HYMT2_EOT_TOKEN, 11),
+                (HYMT2_BOS_TOKEN, 12),
+                (HYMT2_USER_TOKEN, 13),
+                (HYMT2_ASSISTANT_TOKEN, 14),
+            ]),
+        };
+        let config = build_builtin_seq2seq_decode_policy_config(
+            descriptor,
+            &BuiltinSeq2SeqDecodePolicyConfigInput {
+                initial_prompt_tokens: vec![1, 2],
+                eot_token_id: 7,
+                vocab_size: 32,
+                max_generated_tokens: 16,
+            },
+            &token_source,
+            None,
+        )
+        .expect("hymt2 config");
+        assert_eq!(config.eot_token_id, 7);
+        assert_eq!(config.stop_token_ids, vec![11, 12, 13, 14]);
+        assert!(config.suppress_token_ids.is_empty());
+        assert!(config.suppress_first_step_token_ids.is_empty());
+
+        // Fail closed when a chat-boundary marker cannot be resolved.
+        let error = build_builtin_seq2seq_decode_policy_config(
+            descriptor,
+            &BuiltinSeq2SeqDecodePolicyConfigInput {
+                initial_prompt_tokens: vec![1],
+                eot_token_id: 7,
+                vocab_size: 32,
+                max_generated_tokens: 16,
+            },
+            &(),
+            None,
+        )
+        .expect_err("missing hymt2 chat markers must fail closed");
+        assert!(matches!(
+            error,
+            BuiltinDecodePolicyComponentRegistryError::MissingRequiredSpecialToken { .. }
+        ));
+    }
+
+    #[test]
+    fn trim_whitespace_postprocess_trims_and_keeps_transcript_start() {
+        assert_eq!(
+            apply_seq2seq_text_postprocess(
+                BuiltinDecodePolicySeq2SeqTextPostprocessKind::TrimWhitespaceV0,
+                " translated clause \n",
+            ),
+            "translated clause"
+        );
+        assert_eq!(
+            seq2seq_transcript_byte_start(
+                BuiltinDecodePolicySeq2SeqTextPostprocessKind::TrimWhitespaceV0,
+                " translated clause",
+            ),
+            0
         );
     }
 

--- a/crates/openasr-core/src/models/hymt2/runtime.rs
+++ b/crates/openasr-core/src/models/hymt2/runtime.rs
@@ -4,14 +4,20 @@ use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
+use crate::arch::HYMT2_DECODE_POLICY_ID;
 use crate::ggml_runtime::{
     GgmlCpuGraphError, GgufMetadataReadError, GgufTensorDataReadError, GgufTensorDataReader,
     GgufTensorIndexReadError,
+};
+use crate::models::decode_policy_component_registry::{
+    BuiltinDecodePolicyComponentRegistryError, BuiltinSeq2SeqDecodePolicyConfigInput,
+    BuiltinSeq2SeqDecodePolicyTokenSource, run_builtin_seq2seq_decode_policy,
 };
 use crate::models::hymt2::prompt::{
     build_hymt2_subtitle_prompt_token_parts, build_hymt2_user_chat_prompt_tokens,
     build_subtitle_translation_prompt, max_output_tokens_for_source_tokens,
 };
+use crate::models::phrase_bias_decode::PhraseBiasTokenEncoder;
 use crate::models::qwen::{
     Qwen3AsrLayerKvCacheState, Qwen3AsrLlmFusedLogitsHeadSpec, Qwen3AsrLlmLayerAttentionProjection,
     Qwen3AsrLlmLogitsHead, Qwen3AsrLlmWholeDecoderGraphExecutor, Qwen3AsrLlmWholeStepOutput,
@@ -19,6 +25,10 @@ use crate::models::qwen::{
     load_qwen3_llm_attention_projections_from_reader_with_materialized_qkv,
     load_qwen3_llm_logits_head_from_reader_with_output_tensor,
     load_qwen3_token_embedding_table_from_reader,
+};
+use crate::models::seq2seq_greedy_decode::{
+    Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeStepExecutor, Seq2SeqGreedyDecodeStepInput,
+    Seq2SeqGreedyDecodeStepLogitsOutput,
 };
 use crate::{
     GgmlRuntimeSourcePathError, NativeAsrError, read_gguf_metadata_from_runtime_source,
@@ -30,7 +40,11 @@ use super::config::{
     validate_hymt2_runtime_tensors_with_index,
 };
 use super::tensor_names::TOKEN_EMBD_WEIGHT;
-use super::tokenizer::Hymt2Tokenizer;
+use super::tokenizer::{
+    HYMT2_ASSISTANT_TOKEN, HYMT2_ASSISTANT_TOKEN_ID, HYMT2_BOS_TOKEN, HYMT2_BOS_TOKEN_ID,
+    HYMT2_EOS_TOKEN_ID, HYMT2_EOT_TOKEN, HYMT2_EOT_TOKEN_ID, HYMT2_USER_TOKEN, HYMT2_USER_TOKEN_ID,
+    Hymt2Tokenizer,
+};
 
 const HYMT2_PROFILE_ENV: &str = "OPENASR_HYMT2_PROFILE";
 const HYMT2_PREFILL_CHUNK_TOKENS_ENV: &str = "OPENASR_HYMT2_PREFILL_CHUNK_TOKENS";
@@ -453,8 +467,7 @@ impl Hymt2Runtime {
             .ok_or_else(|| Hymt2RuntimeError::Decode {
                 reason: "Hy-MT2 cached prefill token count overflowed".to_string(),
             })?;
-        let stop_token_ids = self.tokenizer.stop_token_ids();
-        let (first_step_logits, generated_tokens, prefill, decode) = {
+        let (first_step_logits, generated_tokens, text, prefill, decode) = {
             let session_started_at = hymt2_profile_start();
             let mut session = self.session.lock().map_err(|_| Hymt2RuntimeError::Decode {
                 reason: "Hy-MT2 runtime session lock poisoned".to_string(),
@@ -482,28 +495,18 @@ impl Hymt2Runtime {
             let prefill = prefill_started_at.elapsed();
             let first_step_logits = logits.clone();
 
-            let mut generated_tokens = Vec::with_capacity(max_output_tokens);
             let decode_started_at = Instant::now();
-            let mut token_id = greedy_argmax(&logits)?;
-            for _ in 0..max_output_tokens {
-                if stop_token_ids.contains(&token_id) {
-                    break;
-                }
-                generated_tokens.push(token_id);
-                if generated_tokens.len() == max_output_tokens {
-                    break;
-                }
-                token_id = stepper.decode_next_token_id(&generated_tokens)?;
-            }
+            let (generated_tokens, text) = run_hymt2_shared_greedy_decode(
+                logits,
+                &mut |generated| stepper.decode_next_token_id(generated),
+                &|token_ids| self.tokenizer.decode_text_token_ids(token_ids),
+                &parts.prompt_tokens,
+                self.metadata.vocab_size,
+                max_output_tokens,
+            )?;
             let decode = decode_started_at.elapsed();
-            (first_step_logits, generated_tokens, prefill, decode)
+            (first_step_logits, generated_tokens, text, prefill, decode)
         };
-        let text = self
-            .tokenizer
-            .decode_text_token_ids(&generated_tokens)
-            .map_err(|source| Hymt2RuntimeError::Tokenizer { source })?
-            .trim()
-            .to_string();
         let generated_token_count = generated_tokens.len();
         if finalized {
             cache.invalidate();
@@ -627,27 +630,16 @@ impl Hymt2Runtime {
         let logits = stepper.prefill_prompt_and_compute_last_logits(&prompt_embeddings)?;
         let prefill = prefill_started_at.elapsed();
         let first_step_logits = logits.clone();
-        let stop_token_ids = self.tokenizer.stop_token_ids();
-        let mut generated_tokens = Vec::with_capacity(max_output_tokens);
         let decode_started_at = Instant::now();
-        let mut token_id = greedy_argmax(&logits)?;
-        for _ in 0..max_output_tokens {
-            if stop_token_ids.contains(&token_id) {
-                break;
-            }
-            generated_tokens.push(token_id);
-            if generated_tokens.len() == max_output_tokens {
-                break;
-            }
-            token_id = stepper.decode_next_token_id(&generated_tokens)?;
-        }
+        let (generated_tokens, text) = run_hymt2_shared_greedy_decode(
+            logits,
+            &mut |generated| stepper.decode_next_token_id(generated),
+            &|token_ids| self.tokenizer.decode_text_token_ids(token_ids),
+            &prompt_tokens,
+            self.metadata.vocab_size,
+            max_output_tokens,
+        )?;
         let decode = decode_started_at.elapsed();
-        let text = self
-            .tokenizer
-            .decode_text_token_ids(&generated_tokens)
-            .map_err(|source| Hymt2RuntimeError::Tokenizer { source })?
-            .trim()
-            .to_string();
         let generated_token_count = generated_tokens.len();
         Ok(Hymt2DecodeResult {
             prompt_tokens: prompt_tokens.clone(),
@@ -1541,28 +1533,166 @@ impl Hymt2GreedyStepper<'_> {
     }
 }
 
-fn greedy_argmax(logits: &[f32]) -> Result<u32, Hymt2RuntimeError> {
-    if logits.is_empty() {
-        return Err(Hymt2RuntimeError::Decode {
-            reason: "Hy-MT2 decode step produced empty logits".to_string(),
-        });
+/// Token source for the hymt2 decode-policy descriptor: resolves the chat
+/// boundary markers (`Hymt2ChatBoundaryV0` stop tokens) by content. The ids
+/// are the compile-time tokenizer constants, so the registry stays declarative
+/// while the id/content pairing lives with the tokenizer.
+struct Hymt2DecodePolicyTokenSource;
+
+impl PhraseBiasTokenEncoder for Hymt2DecodePolicyTokenSource {
+    fn encode_phrase_bias_tokens(&self, _phrase: &str) -> Result<Option<Vec<u32>>, String> {
+        // Phrase bias is an ASR-transcription feature; hymt2 never requests it
+        // (the shared path passes `phrase_bias: None`), so encoding is
+        // declared unsupported rather than half-implemented.
+        Ok(None)
     }
-    let mut best_index = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (index, value) in logits.iter().copied().enumerate() {
-        if !value.is_finite() {
-            return Err(Hymt2RuntimeError::Decode {
-                reason: format!("Hy-MT2 decode logits contain non-finite value at {index}"),
+}
+
+impl BuiltinSeq2SeqDecodePolicyTokenSource for Hymt2DecodePolicyTokenSource {
+    fn token_id_by_content(&self, content: &str) -> Option<u32> {
+        match content {
+            HYMT2_EOT_TOKEN => Some(HYMT2_EOT_TOKEN_ID),
+            HYMT2_BOS_TOKEN => Some(HYMT2_BOS_TOKEN_ID),
+            HYMT2_USER_TOKEN => Some(HYMT2_USER_TOKEN_ID),
+            HYMT2_ASSISTANT_TOKEN => Some(HYMT2_ASSISTANT_TOKEN_ID),
+            _ => None,
+        }
+    }
+}
+
+/// hymt2's step executor for the shared greedy decode driver. Step 0 replays
+/// the full logit row the prefill already computed (the driver's host argmax
+/// selects from it, byte-identical to the previous in-module argmax);
+/// subsequent steps run the fused device top-1 decode and surface the selected
+/// token through `greedy_token_hint` with an empty logits row -- the driver's
+/// hint-only step shape -- so the fused kernel never has to materialize a
+/// full-vocab row per step.
+struct Hymt2SharedGreedyStepExecutor<'a> {
+    pending_first_step_logits: Option<Vec<f32>>,
+    next_token_id: &'a mut dyn FnMut(&[u32]) -> Result<u32, Hymt2RuntimeError>,
+}
+
+impl Seq2SeqGreedyDecodeStepExecutor for Hymt2SharedGreedyStepExecutor<'_> {
+    fn decode_step_logits(
+        &mut self,
+        input: Seq2SeqGreedyDecodeStepInput<'_>,
+    ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyDecodeError> {
+        if input.step_index == 0 {
+            let logits = self.pending_first_step_logits.take().ok_or_else(|| {
+                Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                    reason: "Hy-MT2 first-step logits were already consumed".to_string(),
+                }
+            })?;
+            return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits,
+                greedy_token_hint: None,
             });
         }
-        if value > best {
-            best = value;
-            best_index = index;
-        }
+        let token_id = (self.next_token_id)(input.generated_tokens).map_err(|error| {
+            Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                reason: error.to_string(),
+            }
+        })?;
+        Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+            logits: Vec::new(),
+            greedy_token_hint: Some(token_id),
+        })
     }
-    u32::try_from(best_index).map_err(|_| Hymt2RuntimeError::Decode {
-        reason: format!("Hy-MT2 greedy token index {best_index} does not fit u32"),
+}
+
+/// Family-side error for the shared-driver run: `Truncated` is hymt2's normal
+/// outcome when the decode reaches its output budget
+/// (`max_output_tokens_for_source_tokens`) before a stop token -- the caller
+/// degrades to the generated prefix instead of failing the clause.
+enum Hymt2SharedDecodeError {
+    Truncated { generated_tokens: Vec<u32> },
+    Runtime(Hymt2RuntimeError),
+}
+
+fn map_hymt2_family_error_to_shared(error: Hymt2SharedDecodeError) -> Seq2SeqGreedyDecodeError {
+    Seq2SeqGreedyDecodeError::TokenizerDecodeFailed {
+        reason: match error {
+            Hymt2SharedDecodeError::Runtime(error) => error.to_string(),
+            // Unreachable: the token-decoder closure only fails with Runtime.
+            Hymt2SharedDecodeError::Truncated { .. } => {
+                "Hy-MT2 token decoder reported truncation".to_string()
+            }
+        },
+    }
+}
+
+fn map_shared_error_to_hymt2(error: Seq2SeqGreedyDecodeError) -> Hymt2SharedDecodeError {
+    match error {
+        Seq2SeqGreedyDecodeError::EotNotReachedBeforeMaxTokens {
+            generated_tokens, ..
+        } => Hymt2SharedDecodeError::Truncated { generated_tokens },
+        other => Hymt2SharedDecodeError::Runtime(Hymt2RuntimeError::Decode {
+            reason: other.to_string(),
+        }),
+    }
+}
+
+fn map_registry_error_to_hymt2(
+    error: BuiltinDecodePolicyComponentRegistryError,
+) -> Hymt2SharedDecodeError {
+    Hymt2SharedDecodeError::Runtime(Hymt2RuntimeError::Decode {
+        reason: error.to_string(),
     })
+}
+
+/// Route one hymt2 greedy decode through the shared seq2seq driver (the repo
+/// AGENTS.md "One greedy decode driver" invariant). The registry descriptor
+/// for [`HYMT2_DECODE_POLICY_ID`] declares the chat-boundary stop tokens and
+/// whitespace-trim postprocess; the driver owns argmax, stop handling, and the
+/// degenerate-loop guard. Reaching `max_output_tokens` before a stop token is
+/// hymt2's expected truncation outcome, so the driver's no-EOT error is
+/// degraded to the generated prefix here instead of failing the clause.
+fn run_hymt2_shared_greedy_decode(
+    first_step_logits: Vec<f32>,
+    next_token_id: &mut dyn FnMut(&[u32]) -> Result<u32, Hymt2RuntimeError>,
+    decode_text_token_ids: &dyn Fn(&[u32]) -> Result<String, NativeAsrError>,
+    prompt_tokens: &[u32],
+    vocab_size: usize,
+    max_output_tokens: usize,
+) -> Result<(Vec<u32>, String), Hymt2RuntimeError> {
+    let mut step_executor = Hymt2SharedGreedyStepExecutor {
+        pending_first_step_logits: Some(first_step_logits),
+        next_token_id,
+    };
+    let config_input = BuiltinSeq2SeqDecodePolicyConfigInput {
+        initial_prompt_tokens: prompt_tokens.to_vec(),
+        eot_token_id: HYMT2_EOS_TOKEN_ID,
+        vocab_size,
+        max_generated_tokens: max_output_tokens,
+    };
+    let decode_text = |token_ids: &[u32]| {
+        decode_text_token_ids(token_ids).map_err(|source| {
+            Hymt2SharedDecodeError::Runtime(Hymt2RuntimeError::Tokenizer { source })
+        })
+    };
+    match run_builtin_seq2seq_decode_policy(
+        HYMT2_DECODE_POLICY_ID,
+        &config_input,
+        &Hymt2DecodePolicyTokenSource,
+        None,
+        &mut step_executor,
+        &decode_text,
+        map_hymt2_family_error_to_shared,
+        map_shared_error_to_hymt2,
+        map_registry_error_to_hymt2,
+    ) {
+        Ok(result) => Ok((result.generated_tokens, result.text)),
+        Err(Hymt2SharedDecodeError::Truncated { generated_tokens }) => {
+            // Mirror the driver's TrimWhitespaceV0 postprocess on the degraded
+            // prefix so both exits produce identically normalized text.
+            let text = decode_text_token_ids(&generated_tokens)
+                .map_err(|source| Hymt2RuntimeError::Tokenizer { source })?
+                .trim()
+                .to_string();
+            Ok((generated_tokens, text))
+        }
+        Err(Hymt2SharedDecodeError::Runtime(error)) => Err(error),
+    }
 }
 
 fn tokens_per_second(tokens: usize, elapsed: Duration) -> f64 {
@@ -1749,9 +1879,127 @@ mod tests {
         }
     }
 
+    /// Vocab wide enough to contain the real hymt2 special-token ids, so the
+    /// shared-decode tests exercise the actual stop set (EOS + chat markers).
+    const SHARED_DECODE_TEST_VOCAB: usize = 120_021;
+
+    fn shared_decode_first_step_logits(token_id: u32) -> Vec<f32> {
+        let mut logits = vec![0.0_f32; SHARED_DECODE_TEST_VOCAB];
+        logits[token_id as usize] = 1.0;
+        logits
+    }
+
+    fn shared_decode_text(token_ids: &[u32]) -> Result<String, NativeAsrError> {
+        Ok(token_ids
+            .iter()
+            .map(|token_id| format!(" t{token_id}"))
+            .collect::<String>())
+    }
+
     #[test]
-    fn greedy_argmax_selects_first_max() {
-        assert_eq!(greedy_argmax(&[0.1, 0.3, 0.3]).expect("argmax"), 1);
+    fn shared_greedy_decode_selects_prefill_argmax_then_hint_tokens_until_eos() {
+        let mut scripted = vec![6_u32, HYMT2_EOS_TOKEN_ID].into_iter();
+        let mut next_token_id = |generated: &[u32]| {
+            assert!(!generated.is_empty(), "hint steps follow the first token");
+            Ok(scripted.next().expect("scripted token"))
+        };
+
+        let (generated_tokens, text) = run_hymt2_shared_greedy_decode(
+            shared_decode_first_step_logits(5),
+            &mut next_token_id,
+            &shared_decode_text,
+            &[42, 43],
+            SHARED_DECODE_TEST_VOCAB,
+            8,
+        )
+        .expect("shared decode");
+
+        assert_eq!(generated_tokens, vec![5, 6]);
+        // TrimWhitespaceV0: the leading space from detokenization is trimmed.
+        assert_eq!(text, "t5 t6");
+    }
+
+    #[test]
+    fn shared_greedy_decode_stops_on_chat_boundary_marker() {
+        let mut next_token_id = |_: &[u32]| Ok(HYMT2_USER_TOKEN_ID);
+
+        let (generated_tokens, text) = run_hymt2_shared_greedy_decode(
+            shared_decode_first_step_logits(5),
+            &mut next_token_id,
+            &shared_decode_text,
+            &[42],
+            SHARED_DECODE_TEST_VOCAB,
+            8,
+        )
+        .expect("shared decode");
+
+        assert_eq!(generated_tokens, vec![5]);
+        assert_eq!(text, "t5");
+    }
+
+    #[test]
+    fn shared_greedy_decode_degrades_to_prefix_at_output_budget() {
+        // Distinct tokens (no degenerate cycle) that never reach a stop token:
+        // the driver's no-EOT error must degrade to the generated prefix, the
+        // pre-driver truncation contract of `max_output_tokens_for_source_tokens`.
+        let mut scripted = vec![6_u32, 7, 8].into_iter();
+        let mut next_token_id = |_: &[u32]| Ok(scripted.next().expect("scripted token"));
+
+        let (generated_tokens, text) = run_hymt2_shared_greedy_decode(
+            shared_decode_first_step_logits(5),
+            &mut next_token_id,
+            &shared_decode_text,
+            &[42],
+            SHARED_DECODE_TEST_VOCAB,
+            3,
+        )
+        .expect("shared decode");
+
+        assert_eq!(generated_tokens, vec![5, 6, 7]);
+        assert_eq!(text, "t5 t6 t7");
+    }
+
+    #[test]
+    fn shared_greedy_decode_truncates_degenerate_repeat_loop() {
+        // A stuck greedy loop (same token forever) now trips the driver's
+        // shared degenerate n-gram guard instead of spinning to the cap.
+        let mut next_token_id = |_: &[u32]| Ok(5_u32);
+
+        let (generated_tokens, _) = run_hymt2_shared_greedy_decode(
+            shared_decode_first_step_logits(5),
+            &mut next_token_id,
+            &shared_decode_text,
+            &[42],
+            SHARED_DECODE_TEST_VOCAB,
+            10,
+        )
+        .expect("shared decode");
+
+        assert_eq!(generated_tokens, vec![5]);
+    }
+
+    #[test]
+    fn shared_greedy_decode_surfaces_decoder_step_failures() {
+        let mut next_token_id = |_: &[u32]| {
+            Err(Hymt2RuntimeError::Decode {
+                reason: "synthetic step failure".to_string(),
+            })
+        };
+
+        let error = run_hymt2_shared_greedy_decode(
+            shared_decode_first_step_logits(5),
+            &mut next_token_id,
+            &shared_decode_text,
+            &[42],
+            SHARED_DECODE_TEST_VOCAB,
+            8,
+        )
+        .expect_err("step failure must surface");
+
+        assert!(matches!(
+            error,
+            Hymt2RuntimeError::Decode { reason } if reason.contains("synthetic step failure")
+        ));
     }
 
     #[test]

--- a/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
+++ b/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
@@ -262,6 +262,29 @@ pub(crate) fn select_seq2seq_greedy_step_token(
     on_topk: &mut dyn FnMut(usize, &[f32]),
 ) -> Result<Seq2SeqGreedyStepSelection, Seq2SeqGreedyDecodeError> {
     if step_logits.logits.is_empty() {
+        // Hint-only step: executors whose decode step ends in a fused
+        // device-side argmax (e.g. hymt2's fused top1 logits head) never
+        // materialize a host logit row, and forcing one per step would regress
+        // the very kernel that fusion exists for. Honor the hint when nothing
+        // about this step needs the row (no phrase bias, hint not suppressed);
+        // otherwise fail closed on the existing empty-logits error, because a
+        // suppressed hint has no row to fall back to.
+        if config.phrase_biases.is_empty()
+            && let Some(next_token) = step_logits.greedy_token_hint
+        {
+            validate_selected_token(step_index, next_token, config.vocab_size)?;
+            let is_suppressed = config.suppress_token_ids.contains(&next_token)
+                || (step_index == 0 && config.suppress_first_step_token_ids.contains(&next_token));
+            if !is_suppressed {
+                return Ok(Seq2SeqGreedyStepSelection {
+                    token_id: next_token,
+                    reached_eot: is_stop_token(next_token, stop_token_ids),
+                    // No host row to score against: report zero probability
+                    // (hint-only families do not consume per-token scores).
+                    probability: 0.0,
+                });
+            }
+        }
         return Err(Seq2SeqGreedyDecodeError::EmptyStepLogits { step_index });
     }
     if step_logits.logits.len() != config.vocab_size {
@@ -586,6 +609,155 @@ mod tests {
             }
         );
         assert_eq!(topk_calls, 0);
+    }
+
+    #[test]
+    fn seq2seq_step_selection_accepts_hint_only_step_without_logits() {
+        let config = Seq2SeqGreedyDecodeConfig {
+            initial_prompt_tokens: vec![42],
+            eot_token_id: 7,
+            stop_token_ids: Vec::new(),
+            vocab_size: 16,
+            max_generated_tokens: 8,
+            suppress_first_step_token_ids: Vec::new(),
+            suppress_token_ids: Vec::new(),
+            phrase_biases: Vec::new(),
+        };
+        let stop = build_seq2seq_greedy_stop_token_ids(&config);
+        let mut on_topk = |_: usize, _: &[f32]| panic!("hint-only step must not emit topk");
+
+        let selection = select_seq2seq_greedy_step_token(
+            &config,
+            &[],
+            1,
+            Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: Some(3),
+            },
+            &stop,
+            &mut on_topk,
+        )
+        .expect("hint-only step should select");
+
+        assert_eq!(
+            selection,
+            Seq2SeqGreedyStepSelection {
+                token_id: 3,
+                reached_eot: false,
+                probability: 0.0,
+            }
+        );
+
+        let eot_selection = select_seq2seq_greedy_step_token(
+            &config,
+            &[3],
+            2,
+            Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: Some(7),
+            },
+            &stop,
+            &mut on_topk,
+        )
+        .expect("hint-only eot should select");
+        assert!(eot_selection.reached_eot);
+    }
+
+    #[test]
+    fn seq2seq_step_selection_hint_only_fails_closed_without_a_fallback_row() {
+        let biased_config = Seq2SeqGreedyDecodeConfig {
+            initial_prompt_tokens: vec![42],
+            eot_token_id: 7,
+            stop_token_ids: Vec::new(),
+            vocab_size: 16,
+            max_generated_tokens: 8,
+            suppress_first_step_token_ids: Vec::new(),
+            suppress_token_ids: Vec::new(),
+            phrase_biases: vec![TokenPhraseBias::new(vec![vec![1, 2]], 0.2).unwrap()],
+        };
+        let suppressed_config = Seq2SeqGreedyDecodeConfig {
+            suppress_token_ids: vec![3],
+            phrase_biases: Vec::new(),
+            ..biased_config.clone()
+        };
+        let no_hint_config = Seq2SeqGreedyDecodeConfig {
+            suppress_token_ids: Vec::new(),
+            ..suppressed_config.clone()
+        };
+        let out_of_vocab_config = no_hint_config.clone();
+        let mut on_topk = |_: usize, _: &[f32]| {};
+
+        // Phrase bias needs the logit row: empty logits must fail closed.
+        let biased = select_seq2seq_greedy_step_token(
+            &biased_config,
+            &[],
+            0,
+            Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: Some(3),
+            },
+            &build_seq2seq_greedy_stop_token_ids(&biased_config),
+            &mut on_topk,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            biased,
+            Seq2SeqGreedyDecodeError::EmptyStepLogits { step_index: 0 }
+        ));
+
+        // A suppressed hint has no row to fall back to: fail closed.
+        let suppressed = select_seq2seq_greedy_step_token(
+            &suppressed_config,
+            &[],
+            0,
+            Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: Some(3),
+            },
+            &build_seq2seq_greedy_stop_token_ids(&suppressed_config),
+            &mut on_topk,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            suppressed,
+            Seq2SeqGreedyDecodeError::EmptyStepLogits { step_index: 0 }
+        ));
+
+        // Empty logits without a hint keeps the pre-existing error.
+        let no_hint = select_seq2seq_greedy_step_token(
+            &no_hint_config,
+            &[],
+            0,
+            Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: None,
+            },
+            &build_seq2seq_greedy_stop_token_ids(&no_hint_config),
+            &mut on_topk,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            no_hint,
+            Seq2SeqGreedyDecodeError::EmptyStepLogits { step_index: 0 }
+        ));
+
+        // A hint outside the declared vocab is rejected, not trusted.
+        let out_of_vocab = select_seq2seq_greedy_step_token(
+            &out_of_vocab_config,
+            &[],
+            0,
+            Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: Some(16),
+            },
+            &build_seq2seq_greedy_stop_token_ids(&out_of_vocab_config),
+            &mut on_topk,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            out_of_vocab,
+            Seq2SeqGreedyDecodeError::SelectedTokenOutOfVocab { token_id: 16, .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hy-MT2 (the subtitle translation family) was the last autoregressive seq2seq family decoding through hand-written greedy argmax loops (two copies in `models/hymt2/runtime.rs`) instead of the shared greedy decode driver. This PR routes both Hy-MT2 decode paths through `run_builtin_seq2seq_decode_policy`, registering `hymt2.greedy.seq2seq.v0` in the decode-policy component registry, and teaches the shared driver a hint-only step shape so fused device top-1 executors can join it without materializing a full-vocab host logits row per step.

## Why

The "One greedy decode driver" invariant (AGENTS.md) exists because hand-rolled loops miss the shared degenerate-loop guard and drift argmax / stop-token semantics (the hand-rolled firered loop caused the long-audio repetition, #60). Hy-MT2's loops had exactly that exposure: an NMT phrase loop was bounded only by `max_output_tokens`, and its stop/argmax semantics lived outside the centralized driver.

## Changes

- `models/seq2seq_greedy_decode.rs`: `select_seq2seq_greedy_step_token` accepts a hint-only step (empty logits row + `greedy_token_hint`) when nothing about the step needs the row; fails closed when it does (phrase bias configured, hint suppressed, no hint, out-of-vocab hint). Non-empty-row behavior is untouched.
- `models/decode_policy_component_registry.rs`: new descriptor `hymt2.greedy.seq2seq.v0` (resolved directly by policy id; hymt2 is an auxiliary translation family with no arch-registry entry), new `Hymt2ChatBoundaryV0` stop-token kind (EOT + BOS + role markers on top of EOS, fail-closed via `require_special_token`) and `TrimWhitespaceV0` postprocess kind.
- `models/hymt2/runtime.rs`: both `decode_prompt_tokens` and `translate_clause_with_cache` decode through the shared driver via `Hymt2SharedGreedyStepExecutor` -- step 0 replays the prefill logits row (host argmax, same first-max tie-breaking as before), later steps surface the fused top-1 token as a hint. Reaching the output budget degrades to the generated prefix, preserving the existing truncation contract. The KV prefix-reuse prefill logic is untouched.
- `arch/mod.rs`: `HYMT2_DECODE_POLICY_ID` constant (policy ids keep a single home).
- Tests: driver hint-only selection + fail-closed cases; hymt2 registry resolution / stop-token config / missing-marker fail-closed; hymt2 shared-decode happy path, chat-boundary stop, budget truncation, degenerate-loop truncation, step-failure surfacing.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

Also: `cargo test -p openasr-core golden_diff -- --nocapture` and `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture` pass.

## Manual smoke checks

None beyond the test suite; the llama.cpp parity harness (`hymt2_real_pack_matches_llama_cpp_greedy_tokens`) remains available for real-pack verification and its token-sequence contract is unchanged by construction (same argmax, same stop set, same step order).

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (No behavior change on healthy decodes; registry doc comments updated in place.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No change to Hy-MT2 prompt building, KV prefix-reuse planning, or the fused top-1 kernels.
- Degenerate short-cycle repetition is now truncated by the shared guard instead of spinning to the token cap; healthy decode outputs are byte-identical.
- No arch-registry (transcription dispatch) entry for hymt2: it stays an auxiliary translation family.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implementation and tests developed with AI assistance under maintainer direction and review.
