### PR TITLE
fix(server): re-warm after idle unload; docs touch-ups

### DIFF
--- a/crates/openasr-server/src/idle_activity.rs
+++ b/crates/openasr-server/src/idle_activity.rs
@@ -14,7 +14,7 @@
 
 use std::sync::{
     Mutex, OnceLock,
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicU64, AtomicUsize, Ordering},
 };
 use std::time::{Duration, Instant};
 
@@ -65,6 +65,34 @@ static NATIVE_ACTIVITY: OnceLock<NativeActivityTracker> = OnceLock::new();
 
 fn native_activity() -> &'static NativeActivityTracker {
     NATIVE_ACTIVITY.get_or_init(NativeActivityTracker::new)
+}
+
+/// Process-wide count of successful `unload_idle_native_model_runtime_caches`
+/// calls, bumped once per eviction by [`bump_native_unload_generation`]
+/// (currently only [`spawn_idle_unload_reaper`]'s loop). A realtime-streaming
+/// decode worker's OS thread survives an `idle_unload` eviction -- it only
+/// tears down much later, at the separate hard-release threshold -- so its
+/// thread-local "have I warmed this thread" state cannot be a bare bool: that
+/// would keep reading "warmed" after the resident runtime it warmed has
+/// already been evicted, skipping re-warm and pushing the cold rebuild onto
+/// the first real decode of the next attach instead. The warm-up gate in
+/// `native_worker.rs` instead records the generation it warmed at and
+/// re-warms whenever the current generation has moved on.
+static NATIVE_UNLOAD_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// Current unload generation. `Relaxed` is sufficient: this is a coarse
+/// "has an unload happened since I last checked" signal, not a coordination
+/// primitive, and it is never combined with a specific unload's Ordering.
+pub(crate) fn native_unload_generation() -> u64 {
+    NATIVE_UNLOAD_GENERATION.load(Ordering::Relaxed)
+}
+
+/// Marks one `unload_idle_native_model_runtime_caches` eviction. Exposed
+/// beyond [`spawn_idle_unload_reaper`]'s own use so tests can simulate an
+/// idle-unload deterministically instead of waiting on the reaper's poll
+/// interval.
+pub(crate) fn bump_native_unload_generation() {
+    NATIVE_UNLOAD_GENERATION.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Marks one native request/session as started. Must be paired with a later
@@ -121,6 +149,7 @@ pub(crate) fn spawn_idle_unload_reaper(idle_for: Duration) {
             tokio::time::sleep(poll_interval).await;
             if native_activity_is_idle_for(Instant::now(), idle_for) {
                 openasr_core::unload_idle_native_model_runtime_caches();
+                bump_native_unload_generation();
             }
         }
     });

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -448,27 +448,40 @@ pub(crate) fn run_native_streaming_session_on_worker(
     // live on this worker thread and remain available to the next attachment.
 }
 
-/// Pays the cold runtime-build cost exactly once per worker thread (worker
-/// threads are keyed by backend+pack and persist across sessions). The old
-/// "warm only if idle for 5s" gate skipped warm-up the moment live audio
+/// Pays the cold runtime-build cost exactly once per worker thread *per
+/// resident runtime generation* (worker threads are keyed by backend+pack and
+/// persist across sessions, well past any `idle_unload` eviction of the
+/// runtime they built -- see `idle_activity::native_unload_generation`). The
+/// old "warm only if idle for 5s" gate skipped warm-up the moment live audio
 /// frames queued — which is exactly the case where the cold build then landed
 /// on the first real decode and delayed the first partial by many seconds.
 /// Warm-up is enqueued before any audio, so paying it immediately moves the
-/// cold build ahead of speech; on an already-warm thread it is a no-op.
+/// cold build ahead of speech; on an already-warm thread whose runtime is
+/// still resident it is a no-op.
+///
+/// The gate is keyed by unload generation, not a bare bool: under an opt-in
+/// `idle_unload` policy shorter than the worker thread's own hard-release
+/// threshold, the thread stays alive after its runtime has been evicted. A
+/// bare "warmed once" bool would keep reading true post-eviction and skip
+/// re-warm, silently pushing the cold rebuild back onto the first real decode
+/// of the next attach -- the exact first-frame-latency regression this gate
+/// exists to avoid.
 pub(crate) fn warm_up_native_streaming_session_once(
     session: &mut dyn NativeAsrSession,
 ) -> Result<(), openasr_core::NativeAsrError> {
     thread_local! {
-        static WARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+        static WARMED_AT_GENERATION: std::cell::Cell<Option<u64>> =
+            const { std::cell::Cell::new(None) };
     }
-    if WARMED.with(std::cell::Cell::get) {
+    let current_generation = crate::idle_activity::native_unload_generation();
+    if WARMED_AT_GENERATION.with(std::cell::Cell::get) == Some(current_generation) {
         return Ok(());
     }
     openasr_core::stage_timing::log_event("realtime_warmup", "stage=start");
     let warmup_started = Instant::now();
     session.warm_up()?;
     openasr_core::stage_timing::log_stage("realtime_warmup", "complete", warmup_started.elapsed());
-    WARMED.with(|warmed| warmed.set(true));
+    WARMED_AT_GENERATION.with(|warmed| warmed.set(Some(current_generation)));
     Ok(())
 }
 
@@ -492,9 +505,10 @@ pub(crate) fn warm_up_native_streaming_session_once(
 /// worker thread processes one attached session's commands at a time, so a
 /// real attach for the same key that arrives mid-warm-up queues behind this
 /// one instead of racing a second cold build. Whichever attach's `Warm`
-/// actually runs first pays the cost once (see the thread-local `WARMED` gate
-/// in `warm_up_native_streaming_session_once`); every later attach on that
-/// thread reuses the now-warm state.
+/// actually runs first pays the cost once (see the thread-local
+/// `WARMED_AT_GENERATION` gate in `warm_up_native_streaming_session_once`);
+/// every later attach on that thread reuses the now-warm state, until an
+/// `idle_unload` eviction bumps the generation and forces a re-warm.
 pub(crate) fn spawn_boot_native_warmup(runtime: ServerRuntime) {
     tokio::spawn(async move {
         warm_up_default_native_streaming_worker(runtime).await;

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -50,6 +50,20 @@ async fn speaker_embedder_env_lock() -> tokio::sync::MutexGuard<'static, ()> {
         .await
 }
 
+/// `idle_activity::NATIVE_UNLOAD_GENERATION` is a process-wide counter (it
+/// has to be: a real idle-unload evicts every worker thread's resident
+/// runtime, not just one). Only the two warm-up/generation tests below
+/// mutate it directly (via `bump_native_unload_generation`); this lock keeps
+/// those two from racing each other under `cargo test`'s default test-thread
+/// parallelism, the same way `speaker_embedder_env_lock` above serializes
+/// tests that share process-wide env state.
+async fn native_unload_generation_test_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await
+}
+
 fn test_native_streaming_worker_key(name: &str) -> NativeStreamingWorkerKey {
     NativeStreamingWorkerKey::new(
         PathBuf::from(format!("/test/native-streaming/{name}")),
@@ -1448,6 +1462,12 @@ async fn native_streaming_warm_up_does_not_block_audio_ingest() {
 
 #[tokio::test]
 async fn native_streaming_warm_up_runs_immediately_and_once_per_worker() {
+    // Two Warm commands with no idle-unload between them must still collapse
+    // to one real warm-up; take the shared generation lock so a concurrently
+    // running idle-unload-generation test cannot bump the process-wide
+    // counter mid-window and make this one flake (see
+    // `native_unload_generation_test_lock`'s doc comment).
+    let _generation_lock = native_unload_generation_test_lock().await;
     let (event_sender, _event_receiver) = mpsc::channel(8);
     let mut session = WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
     let warm_calls = Arc::new(AtomicUsize::new(0));
@@ -1570,8 +1590,15 @@ async fn health_answers_immediately_while_boot_warmup_is_artificially_slow() {
 async fn boot_native_warmup_leaves_the_worker_thread_warm_for_the_next_real_attach() {
     // Confirms warm-up dedup: a boot warm-up and a subsequent
     // real WS attach on the SAME worker key share the one thread-local
-    // `WARMED` gate (`warm_up_native_streaming_session_once`) -- the real
-    // session's own `Warm` command must be a no-op, not a second cold build.
+    // `WARMED_AT_GENERATION` gate (`warm_up_native_streaming_session_once`)
+    // -- the real session's own `Warm` command must be a no-op, not a second
+    // cold build, as long as no idle-unload has happened in between (see
+    // `native_streaming_warm_up_rewarms_after_idle_unload_bumps_the_generation`
+    // for that case). Takes the shared generation lock for the same reason as
+    // `native_streaming_warm_up_runs_immediately_and_once_per_worker`: this
+    // spans two attaches expecting one warm-up, so a concurrent generation
+    // bump from another test would otherwise flake it.
+    let _generation_lock = native_unload_generation_test_lock().await;
     let warm_calls = Arc::new(AtomicUsize::new(0));
     let key = test_native_streaming_worker_key("boot-warmup-reuse");
 
@@ -1614,6 +1641,156 @@ async fn boot_native_warmup_leaves_the_worker_thread_warm_for_the_next_real_atta
          worker thread -- warm_up() must not run a second time"
     );
     real_session.finish("client_closed", true).await.unwrap();
+}
+
+#[tokio::test]
+async fn native_streaming_warm_up_stays_once_across_reattach_without_an_idle_unload() {
+    // Companion to the generation-bump regression test below: two separate
+    // attaches on the SAME worker key, with no idle-unload in between, must
+    // still share the one warm-up -- the generation-keyed gate must not
+    // regress the plain reuse case `boot_native_warmup_leaves_the_worker_\
+    // thread_warm_for_the_next_real_attach` already covers for the
+    // boot-warmup/real-attach pairing.
+    let _generation_lock = native_unload_generation_test_lock().await;
+    let warm_calls = Arc::new(AtomicUsize::new(0));
+    let key = test_native_streaming_worker_key("warm-once-across-reattach-no-unload");
+
+    let (event_sender, _event_receiver) = mpsc::channel(8);
+    let mut first_session =
+        WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
+    first_session
+        .attach_native_streaming_session(
+            key.clone(),
+            Box::new(SlowWarmNativeSession {
+                inner: TestServerNativeSession::new(first_session.session_id.0.clone()),
+                warm_sleep: Duration::from_millis(1),
+                warm_calls: Arc::clone(&warm_calls),
+            }),
+        )
+        .await
+        .unwrap();
+    first_session
+        .send_native_streaming_command(NativeStreamingCommand::Warm)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    first_session
+        .drain_native_streaming_outcomes()
+        .await
+        .unwrap();
+    assert_eq!(warm_calls.load(Ordering::Acquire), 1);
+    first_session.finish("client_closed", true).await.unwrap();
+
+    let (event_sender, _event_receiver) = mpsc::channel(8);
+    let mut second_session =
+        WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
+    second_session
+        .attach_native_streaming_session(
+            key,
+            Box::new(SlowWarmNativeSession {
+                inner: TestServerNativeSession::new(second_session.session_id.0.clone()),
+                warm_sleep: Duration::from_millis(1),
+                warm_calls: Arc::clone(&warm_calls),
+            }),
+        )
+        .await
+        .unwrap();
+    second_session
+        .send_native_streaming_command(NativeStreamingCommand::Warm)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    second_session
+        .drain_native_streaming_outcomes()
+        .await
+        .unwrap();
+    assert_eq!(
+        warm_calls.load(Ordering::Acquire),
+        1,
+        "no idle-unload happened between the two attaches, so the second \
+         attach's Warm must still be a no-op on the reused worker thread"
+    );
+    second_session.finish("client_closed", true).await.unwrap();
+}
+
+#[tokio::test]
+async fn native_streaming_warm_up_rewarms_after_idle_unload_bumps_the_generation() {
+    // Regression test for the WARMED/idle-unload race: an opt-in
+    // `idle_unload` policy can evict the resident runtime well before the
+    // decode worker OS thread's own (much longer) hard-release threshold, so
+    // the worker thread stays alive with a stale "already warmed" bit while
+    // the runtime it warmed is gone. Simulates that by bumping the process-
+    // wide unload generation directly (what the real `idle_unload` reaper
+    // does right after calling `unload_idle_native_model_runtime_caches`)
+    // between two attaches on the same worker key, and asserts the second
+    // attach's `Warm` actually re-runs `warm_up()` instead of reading the
+    // stale flag.
+    let _generation_lock = native_unload_generation_test_lock().await;
+    let warm_calls = Arc::new(AtomicUsize::new(0));
+    let key = test_native_streaming_worker_key("rewarm-after-idle-unload-generation-bump");
+
+    let (event_sender, _event_receiver) = mpsc::channel(8);
+    let mut first_session =
+        WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
+    first_session
+        .attach_native_streaming_session(
+            key.clone(),
+            Box::new(SlowWarmNativeSession {
+                inner: TestServerNativeSession::new(first_session.session_id.0.clone()),
+                warm_sleep: Duration::from_millis(1),
+                warm_calls: Arc::clone(&warm_calls),
+            }),
+        )
+        .await
+        .unwrap();
+    first_session
+        .send_native_streaming_command(NativeStreamingCommand::Warm)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    first_session
+        .drain_native_streaming_outcomes()
+        .await
+        .unwrap();
+    assert_eq!(warm_calls.load(Ordering::Acquire), 1);
+    first_session.finish("client_closed", true).await.unwrap();
+
+    // Simulate an `idle_unload` firing between the two attaches: the worker
+    // OS thread for `key` is still alive (attach/detach never tears it
+    // down on its own), but the resident runtime it warmed is now gone.
+    crate::idle_activity::bump_native_unload_generation();
+
+    let (event_sender, _event_receiver) = mpsc::channel(8);
+    let mut second_session =
+        WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
+    second_session
+        .attach_native_streaming_session(
+            key,
+            Box::new(SlowWarmNativeSession {
+                inner: TestServerNativeSession::new(second_session.session_id.0.clone()),
+                warm_sleep: Duration::from_millis(1),
+                warm_calls: Arc::clone(&warm_calls),
+            }),
+        )
+        .await
+        .unwrap();
+    second_session
+        .send_native_streaming_command(NativeStreamingCommand::Warm)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    second_session
+        .drain_native_streaming_outcomes()
+        .await
+        .unwrap();
+    assert_eq!(
+        warm_calls.load(Ordering::Acquire),
+        2,
+        "a generation bump between attaches must force a real re-warm, not \
+         reuse a stale thread-local WARMED_AT_GENERATION flag from before \
+         the idle-unload evicted the resident runtime"
+    );
+    second_session.finish("client_closed", true).await.unwrap();
 }
 
 #[tokio::test]

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -100,6 +100,14 @@ installed on demand) to attribute anonymous `SPEAKER_NN` labels onto any model's
 transcript; without the required capability pack the request fails closed rather
 than fabricating speakers.
 
+## Does the server keep the model resident in RAM forever?
+
+No. By default the daemon releases the bound model's resident runtime (mmap,
+tensors, Metal state) after 10 minutes with no active transcription request or
+realtime session; the next request just reloads and re-warms it, paying the
+normal cold-build cost again. Adjust or disable this via the `idle_unload`
+preference (`never`, `now`, `2m`, `10m` (default), `1h`).
+
 ## Is OpenASR public/open source now?
 
 Yes. OpenASR is licensed under Apache-2.0 and maintained as the public open core.

--- a/skills/openasr/references/http-api.md
+++ b/skills/openasr/references/http-api.md
@@ -1,6 +1,6 @@
 # OpenASR local HTTP API reference
 
-Verified against `openasr serve` (core 0.1.11). Everything here is local:
+Verified against `openasr serve` (core 0.1.11+). Everything here is local:
 the server never downloads models, never phones home, and fails closed on
 anything it cannot execute.
 


### PR DESCRIPTION
## Summary

Fixes a timing gap between the realtime native-streaming warm-up gate and the opt-in `idle_unload` model-release policy, plus two small pre-tag doc touch-ups.

## Why

`warm_up_native_streaming_session_once` gated the cold runtime-build cost behind a thread-local `bool`, on the assumption that a worker OS thread only ever gets built once. But the `idle_unload` preference (`now`/`2m`, both shorter than the worker thread's own hard-release threshold) can evict the resident runtime while the worker thread stays alive. The stale `WARMED` bit then kept reading true, skipping re-warm and silently pushing the cold rebuild onto the first real decode of the next attach -- the exact first-frame-latency regression the warm-up gate exists to avoid.

## Changes

- `crates/openasr-server/src/idle_activity.rs`: process-wide `NATIVE_UNLOAD_GENERATION` counter (`Relaxed` atomic), bumped once per successful `unload_idle_native_model_runtime_caches()` call in the `idle_unload` reaper. Exposes `native_unload_generation()` (read) and `bump_native_unload_generation()` (write, also used by tests to simulate an eviction deterministically).
- `crates/openasr-server/src/realtime/native_worker.rs`: `warm_up_native_streaming_session_once`'s thread-local changed from `WARMED: Cell<bool>` to `WARMED_AT_GENERATION: Cell<Option<u64>>`, recording the generation warmed at and re-warming whenever the current generation has moved on. No new locks; default `idle_unload` (10m) behavior is unchanged since nothing bumps the generation until an eviction actually happens.
- `crates/openasr-server/src/realtime/tests.rs`: two new tests -- re-warm after a simulated idle-unload generation bump, and warm-once-across-reattach when no unload happens. Also added a shared `native_unload_generation_test_lock` and applied it to the two existing tests that assert "stays warm across two attaches", since the unload generation is genuinely process-wide and those tests would otherwise flake under `cargo test`'s multi-threaded default if run concurrently with the new generation-bumping test.
- `docs/FAQ.md`: new entry documenting the `idle_unload` default (10 minutes) and how to adjust/disable it.
- `skills/openasr/references/http-api.md`: "Verified against core 0.1.11" -> "0.1.11+" to reflect the current verified baseline without hard-coding an unreleased version.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2348 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

N/A (unit/integration tests exercise the real attach/warm/detach/reattach worker-thread lifecycle against a fake native session).

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not change the `idle_unload` default or add any new user-facing config surface; purely closes the re-warm coherence gap for the existing opt-in policy values.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance (Claude Code), reviewed and validated locally before submission.