### PR TITLE
fix(core): forward unload_idle_state through the composed executor

### DIFF
--- a/crates/openasr-core/src/models/ggml_composed_executor.rs
+++ b/crates/openasr-core/src/models/ggml_composed_executor.rs
@@ -63,6 +63,18 @@ impl GgmlAsrExecutor for ComposedGgmlAsrExecutor {
         };
         executor.execute(request)
     }
+
+    fn unload_idle_state(&self) {
+        // The composed executor is itself registered in the dispatch maps
+        // (see `builtin_execution_dispatch.rs`), so the reaper only ever
+        // calls unload on this wrapper -- without forwarding, every
+        // architecture behind it (e.g. qwen3-asr's NativeGraphLoweringV1
+        // executor) never sees `unload_idle_state` and its cached prepared
+        // runtime lives forever.
+        for executor in self.executors_by_model_architecture.values() {
+            executor.unload_idle_state();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -149,5 +161,44 @@ mod tests {
                 capability: "model-architecture-executor",
             }
         ));
+    }
+
+    #[test]
+    fn unload_idle_state_forwards_to_every_wrapped_architecture_executor() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Reproduces the qwen3-asr idle-unload bug: the composed executor is
+        // what the daemon's reaper actually holds a handle to (registered by
+        // model-architecture executor set), so if it does not forward
+        // `unload_idle_state` to the wrapped per-architecture executors, the
+        // inner executor's cached prepared runtime is never evicted.
+        struct CountingExecutor(Arc<AtomicUsize>);
+        impl GgmlAsrExecutor for CountingExecutor {
+            fn executor_id(&self) -> &'static str {
+                "counting-architecture-stub"
+            }
+            fn supports_phrase_bias(&self) -> bool {
+                true
+            }
+            fn execute(
+                &self,
+                _request: &GgmlAsrExecutionRequest,
+            ) -> Result<GgmlAsrExecutionResult, GgmlAsrExecutionError> {
+                unreachable!("this test never executes a request")
+            }
+            fn unload_idle_state(&self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let unload_calls = Arc::new(AtomicUsize::new(0));
+        let executor = ComposedGgmlAsrExecutor::default().with_architecture_executor(
+            crate::QWEN3_ASR_GGML_ARCHITECTURE_ID,
+            Arc::new(CountingExecutor(Arc::clone(&unload_calls))),
+        );
+
+        executor.unload_idle_state();
+
+        assert_eq!(unload_calls.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## Summary

`idle_unload` never actually unloaded qwen3-asr: the composed executor that wraps every `NativeGraphLoweringV1` family inherited the trait's no-op default for `unload_idle_state`, so the reaper's `unload_all` stopped at the wrapper and the inner `Qwen3AsrGgmlExecutor`'s cached prepared runtime stayed resident for the daemon's whole lifetime. This forwards `unload_idle_state` through the wrapper to every wrapped per-architecture executor.

## Why

qwen3-asr is the only builtin family registered by capability (`NativeGraphLoweringV1`) behind `ComposedGgmlAsrExecutor` instead of directly by adapter id, so it was the only family the idle-unload reaper could not reach on the offline dispatch (the streaming dispatch registers qwen directly and was unaffected). A daemon serving qwen kept the full offline runtime resident forever regardless of the `idle_unload` preference. Blocks the 0.1.12 tag.

## Changes

- `crates/openasr-core/src/models/ggml_composed_executor.rs`: add the missing `unload_idle_state` override on `ComposedGgmlAsrExecutor`, forwarding to every entry in `executors_by_model_architecture` (same traversal shape as `supports_phrase_bias`).
- New test `unload_idle_state_forwards_to_every_wrapped_architecture_executor`: a counting stub wrapped by the composed executor asserts the unload call reaches the inner executor -- the blind spot `unload_all_reaches_every_registered_executor_map` left open (it only covers directly-registered executors).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2349 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

Release build, `idle_unload = "now"`, qwen3-asr-0.6b q4_k (Metal, M1), `openasr serve` + offline REST requests against `/v1/audio/transcriptions`, tracking `footprint <pid>` (phys_footprint) and `model_pack_load` log lines:

- Boot warm-up: `model_pack_load` #1 (streaming dispatch), 1047 MB resident.
- First offline request: `model_pack_load` #2 (offline dispatch), 2063 MB warm.
- Idle > threshold: footprint fell 2063 MB -> 124 MB (~1.9 GB released).
- Next request: `model_pack_load` #3 -- the offline prepared runtime was really evicted and rebuilt (before this fix the cache entry survived forever, so no reload could occur).
- Second idle/request cycle: `model_pack_load` #4; footprint 1640 MB -> 758 MB stable.

The 758 MB residual in cycle 2 is the known separate hazard: the device-uploaded whole-decoder cache is a thread-local (`QWEN_WHOLE_DECODER_BY_KEY`) on whichever tokio blocking thread ran the decode, and it is only freed if that thread happens to die (10s blocking-pool keep-alive) before being reused, which is why cycle 1 dropped all the way to 124 MB and cycle 2 did not. Left out of scope here; see non-goals.

## Docs updated

- [x] No docs change needed: this restores the already-documented `idle_unload` behavior (docs/FAQ.md) for the one family it silently missed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch the thread-local whole-decoder residency above; that needs a design decision (e.g. a core-side unload generation checked at decoder-cache access) and is tracked separately.
- No change to streaming dispatch unload (already correct) or to reaper scheduling.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI-assisted diagnosis, fix, tests, and verification under maintainer direction and review.
