### PR TITLE
fix(qwen): invalidate the thread-local decoder cache across idle unloads

### DIFF
--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -480,6 +480,14 @@ pub(crate) fn unload_idle_native_streaming_runtime_caches() {
 pub fn unload_idle_native_model_runtime_caches() {
     native_transcribe::unload_idle_native_offline_runtime_caches();
     unload_idle_native_streaming_runtime_caches();
+    // The per-family *thread-local* runtime caches (device-resident decoder /
+    // encoder sessions living in reused spawn_blocking worker TLS) cannot be
+    // dropped from this thread. Bumping the unload generation makes each
+    // owning thread discard its pre-unload runtimes on next use instead of
+    // handing them back out as cache hits -- without it, a worker thread that
+    // tokio keeps alive pins those weights (e.g. the qwen whole-decoder's
+    // device-uploaded LLM layers) across the unload indefinitely.
+    crate::models::thread_local_runtime_cache::bump_unload_generation();
 }
 
 fn native_ggml_streaming_error_to_asr(
@@ -1276,7 +1284,27 @@ mod tests {
         // case, since both use `OnceLock::get()` rather than
         // `get_or_init()`): must not build the dispatch just to unload
         // nothing from it, and must never panic.
+        let _generation_guard =
+            crate::models::thread_local_runtime_cache::unload_generation_test_lock();
         unload_idle_native_model_runtime_caches();
+    }
+
+    #[test]
+    fn unload_idle_native_model_runtime_caches_advances_the_thread_local_unload_generation() {
+        // The thread-local per-family runtime caches (e.g. the qwen
+        // whole-decoder's device-uploaded weights in a spawn_blocking
+        // thread's TLS) are unreachable from the reaper thread; the unload
+        // generation bump is the only signal that makes their owning threads
+        // discard them, so an unload sweep that does not advance it would
+        // silently reintroduce the post-unload residency leak.
+        let _generation_guard =
+            crate::models::thread_local_runtime_cache::unload_generation_test_lock();
+        let before = crate::models::thread_local_runtime_cache::current_unload_generation();
+        unload_idle_native_model_runtime_caches();
+        assert!(
+            crate::models::thread_local_runtime_cache::current_unload_generation() > before,
+            "idle unload must advance the thread-local cache unload generation"
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/models/ggml_asr_executor.rs
+++ b/crates/openasr-core/src/models/ggml_asr_executor.rs
@@ -333,9 +333,11 @@ pub trait GgmlAsrExecutor: Send + Sync {
     /// (mmap + materialized tensors + Metal/CPU graph context), if it caches
     /// one at all. Called by the daemon's idle-unload reaper (`idle_unload`
     /// preference); the default no-op covers executors whose only caching is
-    /// per-thread and already self-bounded/self-expiring (bounded LRU capacity,
-    /// or a worker thread the realtime idle reaper already recycles), so they
-    /// need no additional eviction here.
+    /// per-thread. Per-thread caches are not reachable from the reaper's
+    /// thread at all -- they are instead invalidated lazily through the
+    /// unload generation (`thread_local_runtime_cache::bump_unload_generation`,
+    /// bumped by `unload_idle_native_model_runtime_caches` after the dispatch
+    /// sweep that calls this method), so they need no eviction here either.
     fn unload_idle_state(&self) {}
 }
 

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -56,7 +56,7 @@ use crate::models::seq2seq_greedy_decode::{
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::thread_local_runtime_cache::{
     BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    current_unload_generation, take_generation_tagged, with_thread_local_cached_mut_by_key,
 };
 use crate::{
     GgmlAsrExecutionError, GgmlAsrExecutionRequest, GgmlAsrExecutionResult, GgmlAsrExecutor,
@@ -88,8 +88,13 @@ thread_local! {
     // (pack path, backend, adapter fingerprint), which does not explode
     // per audio chunk the way a frame-count-keyed cache does -- one entry is
     // built and reused across the whole longform run for a given pack, so
-    // there is no unbounded-growth hazard to bound here.
-    static QWEN_WHOLE_DECODER_BY_KEY: RefCell<HashMap<WholeDecoderCacheKey, Qwen3AsrLlmWholeDecoderGraphExecutor>> =
+    // there is no unbounded-growth hazard to bound here. Entries are tagged
+    // with the idle-unload generation they were built under: this cache holds
+    // the device-uploaded LLM layer weights (hundreds of MB) in the TLS of a
+    // reused spawn_blocking thread, where the idle-unload reaper cannot drop
+    // them, so `take_cached_whole_decoder` discards any decoder built before
+    // the last unload instead of handing it back out.
+    static QWEN_WHOLE_DECODER_BY_KEY: RefCell<HashMap<WholeDecoderCacheKey, (u64, Qwen3AsrLlmWholeDecoderGraphExecutor)>> =
         RefCell::new(HashMap::new());
     static QWEN_AUDIO_ENCODER_BY_KEY: RefCell<BoundedRuntimeCache<AudioEncoderCacheKey, Qwen3AsrAudioEncoderRuntime>> =
         RefCell::new(BoundedRuntimeCache::new());
@@ -97,16 +102,19 @@ thread_local! {
 
 fn take_cached_whole_decoder(
     key: &WholeDecoderCacheKey,
+    unload_generation: u64,
 ) -> Option<Qwen3AsrLlmWholeDecoderGraphExecutor> {
-    QWEN_WHOLE_DECODER_BY_KEY.with(|cache| cache.borrow_mut().remove(key))
+    QWEN_WHOLE_DECODER_BY_KEY
+        .with(|cache| take_generation_tagged(&mut cache.borrow_mut(), key, unload_generation))
 }
 
 fn store_cached_whole_decoder(
     key: WholeDecoderCacheKey,
+    unload_generation: u64,
     decoder: Qwen3AsrLlmWholeDecoderGraphExecutor,
 ) {
     QWEN_WHOLE_DECODER_BY_KEY.with(|cache| {
-        cache.borrow_mut().insert(key, decoder);
+        cache.borrow_mut().insert(key, (unload_generation, decoder));
     });
 }
 
@@ -503,7 +511,13 @@ impl Qwen3AsrGgmlExecutor {
             adapter_fingerprint,
         );
         let whole_decoder_started_at = qwen_decode_profile_start();
-        let whole_decoder = match take_cached_whole_decoder(&decoder_cache_key) {
+        // Sampled before the cache take and reused for the store-back below:
+        // if the idle-unload reaper bumps the generation while this decode is
+        // in flight, the decoder goes back tagged with the pre-unload
+        // generation and the *next* take discards it, so an unload can never
+        // be lost to an overlapping decode.
+        let unload_generation = current_unload_generation();
+        let whole_decoder = match take_cached_whole_decoder(&decoder_cache_key, unload_generation) {
             // Resident hit: layer weights already uploaded to the device and the
             // reuse graph already built — skip the per-chunk rebuild + re-upload.
             Some(decoder) => {
@@ -580,7 +594,11 @@ impl Qwen3AsrGgmlExecutor {
         // Return the resident whole-decoder to the cache for the next chunk /
         // execute(); its weights + reuse graph stay valid regardless of outcome.
         let store_decoder_started_at = qwen_decode_profile_start();
-        store_cached_whole_decoder(decoder_cache_key, step_executor.whole_decoder);
+        store_cached_whole_decoder(
+            decoder_cache_key,
+            unload_generation,
+            step_executor.whole_decoder,
+        );
         qwen_decode_profile_log_opt("store_cached_whole_decoder", store_decoder_started_at);
         // Hitting the token budget without EOT degrades to the generated prefix
         // (mirrors cohere/moonshine) rather than failing the call — so a no-EOT

--- a/crates/openasr-core/src/models/thread_local_runtime_cache.rs
+++ b/crates/openasr-core/src/models/thread_local_runtime_cache.rs
@@ -2,10 +2,58 @@ use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::LocalKey;
 
 pub(crate) fn canonical_runtime_cache_path(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Process-wide generation of native idle-unload sweeps, bumped once per
+/// successful `unload_idle_native_model_runtime_caches` call.
+///
+/// The thread-local runtime caches in this module (and the per-family caches
+/// built on it) live in the TLS of whatever worker thread ran the model --
+/// typically a reused `spawn_blocking` thread -- so the idle-unload reaper,
+/// which runs on a different thread, cannot drop them directly. Instead each
+/// cache records the generation it was last synced at and discards its
+/// resident runtimes the next time its owning thread touches it after the
+/// generation has moved on. Release is therefore *lazy*: a runtime pinned in
+/// a thread that never runs that model family again stays resident until the
+/// thread itself exits (for tokio's blocking pool, after its keep-alive
+/// expiry) -- but it can never be handed out as a cache hit again.
+static RUNTIME_CACHE_UNLOAD_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// Current idle-unload generation. `Relaxed` is sufficient: this is a coarse
+/// "has an unload happened since this cache was filled" signal, not a
+/// synchronization primitive.
+pub(crate) fn current_unload_generation() -> u64 {
+    RUNTIME_CACHE_UNLOAD_GENERATION.load(Ordering::Relaxed)
+}
+
+/// Marks one idle-unload sweep. Called by
+/// `unload_idle_native_model_runtime_caches` after the process-lifetime
+/// dispatch caches have been dropped, so the thread-local caches follow suit
+/// on their owning threads' next use.
+pub(crate) fn bump_unload_generation() {
+    RUNTIME_CACHE_UNLOAD_GENERATION.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Removes and returns the entry for `key` from a map of
+/// `(unload generation, runtime)` pairs, discarding every entry (the
+/// requested one included) whose recorded generation predates
+/// `current_generation`. Stale runtimes are dropped in place -- on the thread
+/// that owns them, which is the only thread that safely can -- including
+/// stale entries under *other* keys, so a decoder cached for one pack does
+/// not stay resident just because only a different pack is requested after an
+/// idle unload.
+pub(crate) fn take_generation_tagged<K: Eq + Hash, V>(
+    entries: &mut HashMap<K, (u64, V)>,
+    key: &K,
+    current_generation: u64,
+) -> Option<V> {
+    entries.retain(|_, (generation, _)| *generation == current_generation);
+    entries.remove(key).map(|(_, value)| value)
 }
 
 /// Default per-key entry cap for the model runtime caches keyed by
@@ -32,6 +80,9 @@ pub(crate) const DEFAULT_RUNTIME_CACHE_CAPACITY: usize = 4;
 pub(crate) struct BoundedRuntimeCache<K, T> {
     entries: HashMap<K, T>,
     order: VecDeque<K>,
+    /// The unload generation this cache was last synced at; see
+    /// [`BoundedRuntimeCache::sync_to_unload_generation`].
+    unload_generation: u64,
 }
 
 impl<K, T> BoundedRuntimeCache<K, T> {
@@ -39,6 +90,19 @@ impl<K, T> BoundedRuntimeCache<K, T> {
         Self {
             entries: HashMap::new(),
             order: VecDeque::new(),
+            unload_generation: current_unload_generation(),
+        }
+    }
+
+    /// Drops every cached runtime if an idle unload happened since the last
+    /// access on this thread. The idle-unload reaper cannot reach another
+    /// thread's TLS, so this lazy check on the owning thread is where the
+    /// thread-local share of an `idle_unload` eviction actually happens.
+    fn sync_to_unload_generation(&mut self, current_generation: u64) {
+        if self.unload_generation != current_generation {
+            self.entries.clear();
+            self.order.clear();
+            self.unload_generation = current_generation;
         }
     }
 
@@ -49,6 +113,44 @@ impl<K, T> BoundedRuntimeCache<K, T> {
 }
 
 impl<K, T> Default for BoundedRuntimeCache<K, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wraps a thread-local cache payload (a map of resident runtimes/sessions)
+/// with the unload generation it was last synced at. [`Self::synced`] resets
+/// the payload to its default (dropping every resident entry, on the owning
+/// thread) when an idle unload has happened since the previous access, then
+/// hands out the payload -- callers do all their map operations through it so
+/// no access path can see pre-unload entries.
+pub(crate) struct UnloadGenerationGated<T> {
+    unload_generation: u64,
+    payload: T,
+}
+
+impl<T: Default> UnloadGenerationGated<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            unload_generation: current_unload_generation(),
+            payload: T::default(),
+        }
+    }
+
+    pub(crate) fn synced(&mut self) -> &mut T {
+        self.sync_to(current_unload_generation())
+    }
+
+    fn sync_to(&mut self, current_generation: u64) -> &mut T {
+        if self.unload_generation != current_generation {
+            self.payload = T::default();
+            self.unload_generation = current_generation;
+        }
+        &mut self.payload
+    }
+}
+
+impl<T: Default> Default for UnloadGenerationGated<T> {
     fn default() -> Self {
         Self::new()
     }
@@ -84,6 +186,7 @@ where
     let max_entries = max_entries.max(1);
     cache.with(|cache| -> Result<R, E> {
         let mut cache = cache.borrow_mut();
+        cache.sync_to_unload_generation(current_unload_generation());
         if !cache.entries.contains_key(&key) {
             if cache.entries.len() >= max_entries {
                 // Evict the single least-recently-used entry. This runs
@@ -110,6 +213,18 @@ where
     })
 }
 
+/// Serializes tests that bump the process-wide unload generation against
+/// tests that assert cache persistence across consecutive calls. Without it,
+/// a bump landing between another test's two cache accesses would spuriously
+/// clear that test's thread-local cache when the whole test binary runs in
+/// one process (plain `cargo test`; `cargo nextest` isolates per process).
+#[cfg(test)]
+pub(crate) fn unload_generation_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,6 +241,7 @@ mod tests {
 
     #[test]
     fn reuses_thread_local_mut_runtime() {
+        let _generation_guard = unload_generation_test_lock();
         let path = Path::new("/tmp/thread-local-mut.gguf");
         let first = with_thread_local_cached_mut_by_key(
             &STUB_MUT_CACHE,
@@ -156,6 +272,7 @@ mod tests {
 
     #[test]
     fn separates_thread_local_mut_runtime_by_custom_key() {
+        let _generation_guard = unload_generation_test_lock();
         let path = Path::new("/tmp/thread-local-mut-key.gguf");
         let cpu = with_thread_local_cached_mut_by_key(
             &STUB_MUT_CACHE_BY_KEY,
@@ -212,6 +329,7 @@ mod tests {
 
     #[test]
     fn bounded_cache_evicts_least_recently_used_entry_and_drops_it() {
+        let _generation_guard = unload_generation_test_lock();
         let counter = std::rc::Rc::new(std::cell::Cell::new(0usize));
         let cap = 2usize;
 
@@ -262,6 +380,7 @@ mod tests {
 
     #[test]
     fn bounded_cache_promotes_recently_used_entry_ahead_of_eviction() {
+        let _generation_guard = unload_generation_test_lock();
         let counter = std::rc::Rc::new(std::cell::Cell::new(0usize));
         let cap = 2usize;
         thread_local! {
@@ -318,5 +437,131 @@ mod tests {
             );
             assert!(cache.entries.contains_key(&2usize));
         });
+    }
+
+    #[test]
+    fn take_generation_tagged_returns_entry_built_under_the_same_generation() {
+        let mut entries: HashMap<&str, (u64, u32)> = HashMap::new();
+        entries.insert("pack-a", (7, 41));
+
+        assert_eq!(take_generation_tagged(&mut entries, &"pack-a", 7), Some(41));
+        assert!(
+            entries.is_empty(),
+            "take removes the returned entry from the map"
+        );
+    }
+
+    #[test]
+    fn take_generation_tagged_discards_entries_built_before_the_current_generation() {
+        let counter = std::rc::Rc::new(std::cell::Cell::new(0usize));
+        let mut entries: HashMap<&str, (u64, DropRecorder)> = HashMap::new();
+        entries.insert("pack-a", (7, DropRecorder::new(counter.clone())));
+        // A stale entry under a *different* key must be swept too: without
+        // the sweep it would stay resident until its own pack is requested
+        // again on this thread, which may never happen.
+        entries.insert("pack-b", (7, DropRecorder::new(counter.clone())));
+        assert_eq!(counter.get(), 2);
+
+        assert!(
+            take_generation_tagged(&mut entries, &"pack-a", 8).is_none(),
+            "an entry built before the current unload generation must not be a hit"
+        );
+        assert_eq!(
+            counter.get(),
+            0,
+            "both stale entries are dropped on the owning thread during the take"
+        );
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn bounded_cache_sync_drops_all_entries_when_the_generation_moves_on() {
+        let counter = std::rc::Rc::new(std::cell::Cell::new(0usize));
+        let mut cache: BoundedRuntimeCache<usize, DropRecorder> = BoundedRuntimeCache::new();
+        cache.unload_generation = 3;
+        cache.entries.insert(0, DropRecorder::new(counter.clone()));
+        cache.entries.insert(1, DropRecorder::new(counter.clone()));
+        cache.order.push_back(0);
+        cache.order.push_back(1);
+        assert_eq!(counter.get(), 2);
+
+        cache.sync_to_unload_generation(3);
+        assert_eq!(counter.get(), 2, "same generation keeps entries resident");
+
+        cache.sync_to_unload_generation(4);
+        assert_eq!(counter.get(), 0, "newer generation drops every entry");
+        assert!(cache.entries.is_empty());
+        assert!(cache.order.is_empty());
+        assert_eq!(cache.unload_generation, 4);
+    }
+
+    #[test]
+    fn unload_generation_gated_payload_resets_when_the_generation_moves_on() {
+        let mut gated: UnloadGenerationGated<Vec<u32>> = UnloadGenerationGated::new();
+        gated.unload_generation = 3;
+        gated.sync_to(3).push(41);
+        assert_eq!(gated.sync_to(3).as_slice(), &[41]);
+
+        assert!(
+            gated.sync_to(4).is_empty(),
+            "newer generation resets the payload to its default"
+        );
+        assert_eq!(gated.unload_generation, 4);
+    }
+
+    #[test]
+    fn shared_helper_rebuilds_after_an_unload_generation_bump() {
+        let _generation_guard = unload_generation_test_lock();
+        thread_local! {
+            static BUMP_CACHE: RefCell<BoundedRuntimeCache<usize, DropRecorder>> =
+                RefCell::new(BoundedRuntimeCache::new());
+        }
+        let counter = std::rc::Rc::new(std::cell::Cell::new(0usize));
+
+        let build_calls = std::cell::Cell::new(0usize);
+        let touch = |key: usize| {
+            let counter = counter.clone();
+            let build_calls = &build_calls;
+            with_thread_local_cached_mut_by_key(
+                &BUMP_CACHE,
+                key,
+                DEFAULT_RUNTIME_CACHE_CAPACITY,
+                move || {
+                    build_calls.set(build_calls.get() + 1);
+                    Ok::<_, &'static str>(DropRecorder::new(counter))
+                },
+                |_recorder| Ok::<_, &'static str>(()),
+            )
+            .expect("cache access");
+        };
+
+        touch(0);
+        touch(0);
+        assert_eq!(build_calls.get(), 1, "same generation reuses the entry");
+        assert_eq!(counter.get(), 1);
+
+        bump_unload_generation();
+        touch(0);
+        assert_eq!(
+            build_calls.get(),
+            2,
+            "a bump makes the next access rebuild instead of reusing"
+        );
+        assert_eq!(
+            counter.get(),
+            1,
+            "the pre-bump entry was dropped, not retained alongside the rebuild"
+        );
+    }
+
+    #[test]
+    fn bump_unload_generation_advances_the_current_generation() {
+        let _generation_guard = unload_generation_test_lock();
+        let before = current_unload_generation();
+        bump_unload_generation();
+        assert!(
+            current_unload_generation() > before,
+            "bump must move the process-wide unload generation forward"
+        );
     }
 }

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -37,7 +37,9 @@ use crate::models::incremental_streaming_driver::{
 };
 use crate::models::prepared_runtime_cache::PreparedRuntimeCache;
 use crate::models::runtime_contract::MetadataContractError;
-use crate::models::thread_local_runtime_cache::canonical_runtime_cache_path;
+use crate::models::thread_local_runtime_cache::{
+    UnloadGenerationGated, canonical_runtime_cache_path,
+};
 use crate::models::tokenizer_component_registry::materialize_builtin_tokenizer_for_architecture;
 use crate::nn::attn::{
     AttentionHeadLayout, AttentionReshapeSteps, AttentionValueMergeSteps,
@@ -347,12 +349,17 @@ type WhisperEncoderPersistentSessionKey = (PathBuf, GgmlCpuGraphBackend);
 type WhisperDecoderPersistentSessionKey = (PathBuf, GgmlCpuGraphBackend);
 
 thread_local! {
+    // Gated on the idle-unload generation: these sessions pin the resident
+    // encoder/decoder weight caches in the TLS of a reused spawn_blocking
+    // thread, where the idle-unload reaper cannot drop them, so every access
+    // goes through `synced()` and discards pre-unload sessions on the owning
+    // thread instead of reusing them.
     static WHISPER_ENCODER_PERSISTENT_SESSION_BY_KEY:
-        RefCell<HashMap<WhisperEncoderPersistentSessionKey, WhisperEncoderPersistentStaticSession>> =
-            RefCell::new(HashMap::new());
+        RefCell<UnloadGenerationGated<HashMap<WhisperEncoderPersistentSessionKey, WhisperEncoderPersistentStaticSession>>> =
+            RefCell::new(UnloadGenerationGated::new());
     static WHISPER_DECODER_PERSISTENT_SESSION_BY_KEY:
-        RefCell<HashMap<WhisperDecoderPersistentSessionKey, Vec<WhisperDecoderPersistentStaticSession>>> =
-            RefCell::new(HashMap::new());
+        RefCell<UnloadGenerationGated<HashMap<WhisperDecoderPersistentSessionKey, Vec<WhisperDecoderPersistentStaticSession>>>> =
+            RefCell::new(UnloadGenerationGated::new());
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3380,6 +3387,7 @@ fn take_whisper_encoder_persistent_static_session(
     WHISPER_ENCODER_PERSISTENT_SESSION_BY_KEY.with(|sessions| {
         sessions
             .borrow_mut()
+            .synced()
             .remove(&(canonical_runtime_cache_path(runtime_path), backend))
     })
 }
@@ -3393,7 +3401,7 @@ fn store_whisper_encoder_persistent_static_session(
             canonical_runtime_cache_path(runtime_path),
             session.graph_config.backend,
         );
-        sessions.borrow_mut().insert(key, session);
+        sessions.borrow_mut().synced().insert(key, session);
     });
 }
 
@@ -3568,6 +3576,7 @@ fn take_or_build_whisper_decoder_persistent_static_session(
     );
     WHISPER_DECODER_PERSISTENT_SESSION_BY_KEY.with(|sessions| {
         let mut sessions = sessions.borrow_mut();
+        let sessions = sessions.synced();
         if let Some(pool) = sessions.get_mut(&key)
             && let Some(index) = pool.iter().position(|session| {
                 decoder_persistent_session_matches_runtime(
@@ -3601,6 +3610,7 @@ fn store_whisper_decoder_persistent_static_session(
 ) {
     WHISPER_DECODER_PERSISTENT_SESSION_BY_KEY.with(|sessions| {
         let mut sessions = sessions.borrow_mut();
+        let sessions = sessions.synced();
         let key = (
             canonical_runtime_cache_path(runtime_path),
             session.graph_config.backend,


### PR DESCRIPTION
## Summary

`idle_unload` now actually reaches the per-thread runtime caches. The qwen whole-decoder cache (device-uploaded LLM layer weights, ~630 MB for the 0.6b pack) lives in the TLS of a reused `spawn_blocking` worker thread, where the idle-unload reaper cannot drop it; after an unload the stale decoder was handed back out as a cache hit and the promised footprint drop never materialized (nondeterministically, depending on thread reuse). A process-wide unload generation in the core now invalidates every thread-local runtime cache lazily, on its owning thread.

## Why

PR #83 fixed the dispatch-level unload chain, but a follow-up footprint investigation showed ~630 MB of nondeterministic post-unload residency traced to `QWEN_WHOLE_DECODER_BY_KEY` (thread-local, unreachable from the reaper). This also covered the "switch model, old model's decoder stays pinned" case. 0.1.12 memory cleanup.

## Changes

- `models/thread_local_runtime_cache.rs`: process-level `AtomicU64` unload generation (`current_unload_generation` / `bump_unload_generation`; core-owned, independent of the server's warm-up generation) + `take_generation_tagged` (per-entry tags, sweeps stale entries under other keys too) + `UnloadGenerationGated<T>` (map-level gate) + `BoundedRuntimeCache::sync_to_unload_generation` wired into `with_thread_local_cached_mut_by_key` (covers cohere/moonshine/firered/parakeet-ctc/tdt/sensevoice/wav2vec2/xasr/qwen audio encoder + logits head with one check).
- `api/backend/native.rs`: `unload_idle_native_model_runtime_caches()` bumps the generation after the dispatch sweep.
- `models/qwen/ggml_executor.rs`: whole-decoder entries tagged with the generation sampled before the take; a take under a newer generation drops all stale entries on the owning thread and rebuilds (an unload landing mid-decode is caught on the next take).
- `models/whisper/ggml_executor.rs`: the two persistent-session maps (resident encoder/decoder weight caches, same plain-HashMap-in-TLS pattern) go through `UnloadGenerationGated::synced()` (same-family sweep; found while auditing the other families).
- `models/ggml_asr_executor.rs`: trait doc updated (per-thread caches are generation-invalidated, not "self-expiring").
- Unit tests: same-generation reuse, post-bump rebuild + drop, stale-sibling sweep, gated-map reset, generation bump on unload; a test-only lock keeps generation-bumping tests from racing cache-persistence tests under plain in-process `cargo test` (nextest isolates per process).

Release semantics (documented in code): eviction of a thread-local runtime is lazy -- it happens on the owning thread's next cache access after the bump, or when the thread itself exits (tokio blocking keep-alive, realtime worker hard-release), whichever comes first. A stale runtime can never be *reused* past an unload; a thread that never touches that family again holds the memory only until the thread dies.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2356 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources ok)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

Release build, isolated `OPENASR_HOME`, `idle_unload: "now"`, qwen3-asr-0.6b q4_k, `phys_footprint` via macOS `footprint` (not RSS), `OPENASR_QWEN_DECODE_PROFILE=1` as the cache hit/miss counter:

- Boot warmup -> idle: 1047 MB while the realtime worker TLS is still live, 36 MB floor after its 60 s hard-release.
- Request A (cold): `whole_decoder_cache_miss_init`, 1828 MB. Request B immediately after (control): `whole_decoder_cache_hit` in 6 us -- proves same-thread cache reuse within one generation.
- 8 s idle (unload fires) -> request C on the same reused thread: `whole_decoder_cache_miss_init` -- the stale decoder was discarded by the generation check, exactly where the pre-fix behavior returned a hit. Post-C footprint 1809 MB (~= post-A 1828 MB; the discarded decoder was dropped, not retained alongside the rebuild).
- Idle floors across cycles: 36 / 179 / 127 / 125 MB -- second and later idle cycles return to the same order of magnitude with no ~630 MB residue and no round-over-round creep.
- Switch-model: qwen -> dolphin-base x4 (threads kept warm) -> idle unload -> re-request qwen logs `whole_decoder_cache_miss_init` (old cache is guaranteed dropped on switch-back); footprint settles back to the floor. Transient post-unload readings (e.g. 1106 MB at idle+8 s, 890 MB in one cycle) are the documented lazy window: TLS memory returns at the owning thread's next access or thread exit, and drained to 125-147 MB in every cycle.
- Transcription output unchanged (JFK fixture byte-identical text across all runs; the generation only gates cache lifetime, never decode inputs).

## Docs updated

- [x] No user-facing behavior contract changed; in-code docs updated (`unload_idle_state` trait doc, cache module docs). No docs overclaim current capabilities.

## Scope / non-goals

- No eager cross-thread eviction (TLS cannot be safely dropped from the reaper thread); release stays lazy as documented.
- `THREAD_BACKEND_CACHE_BY_KIND` (per-thread ggml backend guards) is intentionally untouched: backend handles, not model weights.
- No change to the server-side warm-up generation (`idle_activity.rs`); the two counters stay independent by design.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented and verified with AI assistance under maintainer direction and review.
