### PR TITLE
fix(xasr): rebind streaming ggml runners across decode-worker threads

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -561,6 +561,11 @@ pub enum GgmlCpuGraphError {
     GraphBuildFailed { step: &'static str },
     #[error("ggml cpu graph backend buffer allocation failed")]
     BackendBufferAllocationFailed,
+    #[error(
+        "ggml cpu graph backend has no device (backend outlived the thread-local \
+         backend that owns it); refusing to allocate against a dangling backend"
+    )]
+    BackendDeviceUnavailable,
     #[error("ggml cpu graph could not create loaded weight context: {reason}")]
     LoadedWeightContextFailed { reason: String },
     #[error("ggml cpu graph loaded tensor '{tensor}' is missing from context")]
@@ -4903,6 +4908,26 @@ fn backend_set_n_threads(backend: NonNull<c_void>, n_threads: c_int) {
     }
 }
 
+/// True when `backend` still resolves to a device. A live ggml backend always
+/// has one; a null device means the backend is no longer usable -- e.g. a
+/// cached (`free_on_drop=false`) Metal/GPU backend whose owning thread-local
+/// `THREAD_BACKEND_CACHE_BY_KIND` entry was dropped when its thread exited,
+/// leaving a non-owning guard elsewhere pointing at freed memory.
+/// `ggml_backend_alloc_ctx_tensors` dereferences the device unconditionally and
+/// `GGML_ASSERT(device)`-aborts the whole daemon on null, so buffer allocation
+/// fails closed here (typed error, propagated up the graph builder) instead.
+fn backend_device_present(backend: NonNull<c_void>) -> bool {
+    !unsafe { ffi::ggml_backend_get_device(backend.as_ptr()) }.is_null()
+}
+
+fn ensure_backend_device_present(backend: NonNull<c_void>) -> Result<(), GgmlCpuGraphError> {
+    if backend_device_present(backend) {
+        Ok(())
+    } else {
+        Err(GgmlCpuGraphError::BackendDeviceUnavailable)
+    }
+}
+
 fn backend_name(backend: NonNull<c_void>) -> String {
     let raw_name = unsafe { ffi::ggml_backend_name(backend.as_ptr()) };
     cstr_lossy(raw_name)
@@ -4971,6 +4996,7 @@ impl GgmlBackendBufferGuard {
         context: NonNull<c_void>,
         backend: NonNull<c_void>,
     ) -> Result<Self, GgmlCpuGraphError> {
+        ensure_backend_device_present(backend)?;
         let raw =
             unsafe { ffi::ggml_backend_alloc_ctx_tensors(context.as_ptr(), backend.as_ptr()) };
         NonNull::new(raw)
@@ -4983,6 +5009,7 @@ impl GgmlBackendBufferGuard {
         backend: NonNull<c_void>,
         usage: c_int,
     ) -> Result<Self, GgmlCpuGraphError> {
+        ensure_backend_device_present(backend)?;
         let raw =
             unsafe { ffi::ggml_backend_alloc_ctx_tensors(context.as_ptr(), backend.as_ptr()) };
         let Some(raw) = NonNull::new(raw) else {
@@ -5149,6 +5176,19 @@ mod tests {
 
     fn softplus_reference(value: f32) -> f32 {
         value.max(0.0) + (-(value.abs())).exp().ln_1p()
+    }
+
+    #[test]
+    fn backend_device_present_holds_for_a_live_backend() {
+        // A live ggml backend always resolves to a device, so the fail-closed
+        // buffer-allocation guard must accept it. The null case it defends
+        // against -- a cached GPU-class backend whose owning thread exited,
+        // leaving a dangling non-owning guard -- is a use-after-free that cannot
+        // be forged safely here; this pins the positive path so the guard stays a
+        // safety net and never rejects a valid backend.
+        let backend = super::GgmlBackendGuard::cpu().expect("cpu backend");
+        assert!(super::backend_device_present(backend.raw));
+        assert!(super::ensure_backend_device_present(backend.raw).is_ok());
     }
 
     #[test]

--- a/crates/openasr-core/src/models/xasr_zipformer/encoder_graph.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/encoder_graph.rs
@@ -31,11 +31,30 @@ use crate::ggml_runtime::{
     GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor,
     GgmlPersistentGraphSession,
 };
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::OnceLock;
+use std::thread::ThreadId;
 use std::time::Instant;
 
 const XASR_PROFILE_ENV: &str = "OPENASR_XASR_PROFILE";
+
+/// Records the OS thread a set of thread-affine ggml runners was last built on
+/// and reports whether execution has since moved to a different thread.
+///
+/// The streaming runtimes are handed out from a process-global pool
+/// (`XASR_PROCESS_RUNTIME_POOL`) and therefore migrate between decode worker
+/// threads. Their GPU-class (Metal/GPU) backend guards are non-owning
+/// (`free_on_drop=false`) views into the *building* thread's thread-local
+/// backend cache; that cache -- and the backend it owns -- is freed when its
+/// thread exits (a native streaming worker is hard-released after 60s idle).
+/// Reusing such a runner from another thread would dereference a freed backend
+/// and `GGML_ASSERT(device)`-abort the daemon. Returning `true` here tells the
+/// caller to drop those runners so they rebuild against the current thread's
+/// backend. Returns `false` on the first bind (nothing built yet) and while the
+/// thread is unchanged.
+fn thread_moved_since_bind(bound: &Cell<Option<ThreadId>>, current: ThreadId) -> bool {
+    matches!(bound.replace(Some(current)), Some(previous) if previous != current)
+}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum XasrEncoderGraphError {
@@ -154,6 +173,11 @@ pub(crate) struct XasrZipformerEncoderGraph {
     // full-encoder persistent session's prepared (frozen) graph buffer between
     // chunk computes.
     embed_ggml_runner: RefCell<Option<GgmlCpuGraphRunner>>,
+    // The OS thread the ggml runners above were last built on. Their GPU-class
+    // backend guards are non-owning views into that thread's thread-local
+    // backend cache, so when a pooled runtime migrates to another decode worker
+    // thread the runners must be rebuilt before use. See `thread_moved_since_bind`.
+    bound_thread: Cell<Option<ThreadId>>,
 }
 
 impl std::fmt::Debug for XasrZipformerEncoderGraph {
@@ -181,6 +205,7 @@ impl XasrZipformerEncoderGraph {
             full_encoder_reuse: RefCell::new(None),
             ggml_runner: RefCell::new(None),
             embed_ggml_runner: RefCell::new(None),
+            bound_thread: Cell::new(None),
         })
     }
 
@@ -198,6 +223,7 @@ impl XasrZipformerEncoderGraph {
             full_encoder_reuse: RefCell::new(None),
             ggml_runner: RefCell::new(None),
             embed_ggml_runner: RefCell::new(None),
+            bound_thread: Cell::new(None),
         })
     }
 
@@ -215,6 +241,7 @@ impl XasrZipformerEncoderGraph {
             full_encoder_reuse: RefCell::new(None),
             ggml_runner: RefCell::new(None),
             embed_ggml_runner: RefCell::new(None),
+            bound_thread: Cell::new(None),
         })
     }
 
@@ -282,11 +309,31 @@ impl XasrZipformerEncoderGraph {
         self.encode_from_embed_rows(&embed.rows, embed.frames, embed.dim, input.frames)
     }
 
+    /// Drop the thread-affine ggml runners when streaming execution has moved to
+    /// a different OS thread than they were built on, so they rebuild against the
+    /// current thread's backend cache instead of dereferencing the previous
+    /// thread's (possibly already-freed) GPU-class backend. See
+    /// [`thread_moved_since_bind`] for the pooled-runtime migration this guards.
+    ///
+    /// Clears in field-declaration order: `full_encoder_reuse` holds raw backend
+    /// pointers into `ggml_runner`, so it is dropped first. The runners are pure
+    /// graph builders -- per-utterance encoder cache state lives in the caller's
+    /// `XasrEncoderChunkState`, not here -- so a rebuild only re-pays the graph
+    /// warm-up, never loses decode state.
+    fn rebind_ggml_runners_to_current_thread(&self) {
+        if thread_moved_since_bind(&self.bound_thread, std::thread::current().id()) {
+            *self.full_encoder_reuse.borrow_mut() = None;
+            *self.ggml_runner.borrow_mut() = None;
+            *self.embed_ggml_runner.borrow_mut() = None;
+        }
+    }
+
     pub(crate) fn encode_streaming_chunk_from_features(
         &self,
         input: &XasrEncoderFeatureInput,
         state: Option<&XasrEncoderChunkState>,
     ) -> Result<XasrEncoderChunkOutput, XasrEncoderGraphError> {
+        self.rebind_ggml_runners_to_current_thread();
         if self.backend != XasrEncoderGraphBackend::GgmlCpuFullEncoder {
             return Err(XasrEncoderGraphError::Shape {
                 reason: "streaming chunk execution requires GgmlCpuFullEncoder backend".to_string(),
@@ -5245,8 +5292,29 @@ mod tests {
     };
     use crate::models::xasr_zipformer::runtime_contract::parse_xasr_zipformer_execution_metadata;
     use crate::models::xasr_zipformer::weights::{NamedTensor, StoredLinear};
+    use std::cell::Cell;
     use std::fs;
     use std::path::Path;
+
+    #[test]
+    fn thread_moved_since_bind_reports_only_real_thread_changes() {
+        let bound: Cell<Option<std::thread::ThreadId>> = Cell::new(None);
+        let a = std::thread::current().id();
+        // First bind: nothing has been built yet, so no rebuild is requested.
+        assert!(!thread_moved_since_bind(&bound, a));
+        // Same thread on every later use: reuse the warm runners.
+        assert!(!thread_moved_since_bind(&bound, a));
+        // A pooled runtime migrating to another decode worker thread must force a
+        // rebuild so it never touches the previous thread's (freed) backend.
+        let b = std::thread::spawn(|| std::thread::current().id())
+            .join()
+            .expect("spawned thread id");
+        assert_ne!(a, b, "spawned thread must have a distinct id");
+        assert!(thread_moved_since_bind(&bound, b));
+        // Once rebound it stays put until the thread changes again.
+        assert!(!thread_moved_since_bind(&bound, b));
+        assert!(thread_moved_since_bind(&bound, a));
+    }
 
     fn metadata() -> XasrZipformerExecutionMetadata {
         XasrZipformerExecutionMetadata {


### PR DESCRIPTION
## Summary

Fix a `GGML_ASSERT(device) failed` abort that takes down the whole native
streaming daemon (0.1.12 blocker, P0). A warmed X-ASR streaming runtime,
handed out from a process-global pool, is reused on a decode worker thread
different from the one that built its ggml runners, after the original
thread (and the Metal/GPU backend it owned) was recycled -- a use-after-free
of the backend struct.

## Why

Real-machine repro: several dictations `closed-clean`, then one
`closed-abnormal`, then every session times out. Daemon backtrace:

```
ggml-backend.cpp: GGML_ASSERT(device) failed -> ggml_abort
 run_native_streaming_session_on_worker -> push_audio
 -> XasrZipformerEncoderGraph::encode_streaming_chunk_from_features
 -> GgmlCpuGraphBuilder::set_f32_slice -> ggml_backend_alloc_ctx_tensors
```

Root cause chain:

- X-ASR streaming runtimes live in a **process-global** pool
  (`XASR_PROCESS_RUNTIME_POOL`, moved via `unsafe impl Send`) and migrate
  between decode worker threads.
- Their encoder graph caches ggml runners (`embed_ggml_runner`,
  `ggml_runner`, `full_encoder_reuse`). On an accelerated (Metal/GPU)
  request the runner's `GgmlBackendGuard` is **non-owning**
  (`free_on_drop=false`) -- a view into the *building* thread's
  thread-local `THREAD_BACKEND_CACHE_BY_KIND`.
- A native streaming worker thread is hard-released after 60s idle
  (`NATIVE_STREAMING_WORKER_HARD_RELEASE_AFTER`, independent of the
  `idle_unload` runtime reaper -- so `idle_unload=never` does not prevent
  it). Thread exit runs the thread-local cache destructor ->
  `ggml_backend_free` -> the Metal backend struct is freed
  (`ggml_metal_free: deallocating` in the incident log).
- The pooled runtime survives with a **dangling** backend pointer. The next
  session runs on a fresh worker thread, reuses the cached runner, and
  `ggml_backend_alloc_ctx_tensors` dereferences the freed backend -> its
  device reads NULL -> `GGML_ASSERT(device)` aborts the process; every
  later session then times out. (Boot warm-up / PR #77 amplifies this by
  building and pooling runtimes and by churning worker threads, but the
  hazard is the pool/thread-local-backend ownership mismatch itself.)

## Changes

- **Correctness (`xasr/encoder_graph.rs`):** bind the encoder graph's ggml
  runners to the OS thread they were built on. When streaming execution
  enters on a different thread (a migrated pooled runtime), drop the
  runners first so they rebuild against the current thread's backend cache.
  The runners are pure graph builders -- per-utterance encoder cache state
  lives in the caller's `XasrEncoderChunkState` -- so a rebuild only
  re-pays the graph warm-up and never loses decode state or reuses a stale
  backend. Cleared in drop-safe field order (`full_encoder_reuse` holds raw
  pointers into `ggml_runner`).
- **Fail-closed net (`ggml_runtime/cpu_graph.rs`):**
  `GgmlBackendBufferGuard::allocate`/`allocate_with_usage` now verify the
  backend still resolves to a device before `ggml_backend_alloc_ctx_tensors`
  and return a typed `GgmlCpuGraphError::BackendDeviceUnavailable` when it
  does not. The error propagates up the graph builder, so a worker ends
  that one session with an error and keeps serving -- instead of the C-side
  `GGML_ASSERT` aborting the daemon (trust-boundary panic-free invariant).
- Regression tests: deterministic thread-change trigger for the rebind, and
  the live-backend positive path for the device guard.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (openasr-core)
- [x] `cargo nextest run` (openasr-core: 1909 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo test -p openasr-core golden_diff`
- [ ] `cargo deny check`

## Manual smoke checks

None on-device here (the abort path needs a recycled worker thread on an
accelerated Metal session); covered by the deterministic thread-migration
unit test plus the golden_diff decode-parity suite.

## Docs updated

- [x] No behavior/limitation docs need changes (internal lifetime fix).
- [x] No docs overclaim.

## Scope / non-goals

- Does not change the process-global pool design or the worker-thread reap
  policy; it makes runtime reuse across those boundaries safe.
- Other model families do not use this streaming pool; the ggml device
  guard additionally protects every ggml buffer allocation process-wide.

## Artifact confirmation

- [x] No model weights, binaries, generated artifacts, secrets, or private audio.
- [x] No vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] No unverified download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI assisted with root-cause investigation from the incident logs and drafting the fix and tests; the analysis and code were reviewed and are owned by me.