### PR TITLE
fix(ggml): keep Windows checkouts and static builds safe from stray backend DLLs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 model-registry/catalog.json text eol=lf
 model-registry/catalog.signature.json text eol=lf
 model-registry/catalog.epoch text eol=lf
+model-registry/catalog.public.json           text eol=lf
+model-registry/catalog.public.signature.json text eol=lf

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -62,10 +62,16 @@ fn main() {
     // unverified Linux runtime plugin-discovery path (ggml dlopen of the
     // ggml-cpu-<variant>.so set, which `copy_runtime_dlls` does not stage). The
     // host-side registry refactor (init_by_type / ensure_backends_loaded) still
-    // runs on the macOS+Linux static builds — init_by_type(CPU) resolves the
-    // statically-registered backend and load_all is a harmless no-op there — so
-    // the DL and static paths share one code path. GPU-feature builds keep the
-    // static link regardless of OS (migrated to plugins in a later phase).
+    // runs on the macOS+Linux+GPU-feature static builds, but
+    // `ensure_backends_loaded` (ggml_runtime/backend.rs) now skips the
+    // `ggml_backend_load_all` directory scan there and relies on the
+    // statically-registered backend instead: that scan is NOT a harmless no-op
+    // when it finds `ggml-*.dll` plugins sitting next to the exe (e.g. a desktop
+    // bundle that ships the CPU BACKEND_DL variant alongside a statically-linked
+    // GPU exe) — it dlopens a second copy of ggml core into the process and
+    // `ggml.cpp:22 GGML_ASSERT(prev != ggml_uncaught_exception)` fastfails
+    // (0xc0000409). GPU-feature builds keep the static link regardless of OS
+    // (migrated to plugins in a later phase).
     // GGML_CPU_ALL_VARIANTS requires GGML_NATIVE=OFF (CMake FATAL_ERROR otherwise),
     // and a portable base must not bake the build host's ISA anyway.
     let use_backend_dl = is_windows && !feat_cuda && !feat_vulkan && !feat_hip;
@@ -839,6 +845,10 @@ fn main() {
     println!(
         "cargo:rustc-env=OPENASR_GGML_NATIVE_ENABLED={}",
         if ggml_native { "1" } else { "0" }
+    );
+    println!(
+        "cargo:rustc-env=OPENASR_GGML_BACKEND_DL_ENABLED={}",
+        if use_backend_dl { "1" } else { "0" }
     );
     println!(
         "cargo:rustc-env=OPENASR_HIP_TUNING={}",

--- a/crates/openasr-core/src/ggml_runtime/backend.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend.rs
@@ -193,16 +193,32 @@ impl GgmlBackendKind {
 /// Register backend plugin DLLs once per process before the first registry
 /// query. Under `GGML_BACKEND_DL` the static `GGML_USE_*` backend registration
 /// is compiled out, so without this the registry is empty and every
-/// init/enumeration call returns nothing; in a statically-linked build (macOS,
-/// GPU-feature builds) it finds no plugin DLLs and is a harmless no-op.
+/// init/enumeration call returns nothing.
+///
+/// In a statically-linked build (macOS, Linux, GPU-feature Windows builds —
+/// `ggml_backend_dl_build_enabled() == false`) the compute backend is already
+/// registered at static-init time, so the directory scan is NOT run: it is not
+/// a harmless no-op. `ggml_backend_load_all` dlopens every `ggml-*.dll`/`.so`
+/// sitting next to the exe, and a desktop bundle can legitimately ship the CPU
+/// `BACKEND_DL` plugin DLLs next to a statically-linked GPU exe (the shell app
+/// needs them for other components). Loading that plugin pulls a second copy
+/// of ggml core into the process, and the two copies' global state collide at
+/// `ggml.cpp:22 GGML_ASSERT(prev != ggml_uncaught_exception)`, which fastfails
+/// the whole process (0xc0000409) rather than returning an error. Skipping the
+/// scan for static builds avoids that mixed-build crash while keeping the
+/// scan for genuine `BACKEND_DL` builds, which have no static backend and
+/// would otherwise register nothing at all.
 /// Idempotent and process-wide.
 pub(crate) fn ensure_backends_loaded() {
     use std::sync::OnceLock;
     static LOADED: OnceLock<()> = OnceLock::new();
     LOADED.get_or_init(|| {
-        // Base-installer plugins next to the exe + GGML_BACKEND_PATH (the CPU
-        // variants on Windows; a no-op on static macOS/Linux).
-        unsafe { ffi::ggml_backend_load_all() };
+        if ggml_backend_dl_build_enabled() {
+            // Base-installer plugins next to the exe + GGML_BACKEND_PATH (the
+            // CPU variants on Windows). Only safe/needed under GGML_BACKEND_DL,
+            // where no backend is statically registered — see the doc comment.
+            unsafe { ffi::ggml_backend_load_all() };
+        }
         // Downloaded GPU packs under OPENASR_HOME/backends/<vendor>/<version>/.
         load_installed_backend_plugins();
     });
@@ -406,6 +422,14 @@ impl GgmlCpuFeatures {
 
 pub fn ggml_native_build_enabled() -> bool {
     option_env!("OPENASR_GGML_NATIVE_ENABLED") == Some("1")
+}
+
+/// Whether this build compiled ggml with `GGML_BACKEND_DL` (build.rs
+/// `use_backend_dl`): the CPU/GPU compute backends are runtime-loaded plugin
+/// DLLs rather than statically linked. See [`ensure_backends_loaded`] for why
+/// this gates the `ggml_backend_load_all` directory scan.
+fn ggml_backend_dl_build_enabled() -> bool {
+    option_env!("OPENASR_GGML_BACKEND_DL_ENABLED") == Some("1")
 }
 
 pub fn ggml_hip_tuning_summary() -> Option<&'static str> {


### PR DESCRIPTION
## Summary

Two small Windows-safety fixes, stacked because the second depends on the
first for a clean rebase base:

1. `.gitattributes` now forces `eol=lf` on the two public catalog projection
   files (`model-registry/catalog.public.json`,
   `model-registry/catalog.public.signature.json`), matching the rule already
   in place for the private catalog files.
2. `ensure_backends_loaded()` now skips the `ggml_backend_load_all` plugin
   directory scan on statically-linked builds instead of always running it.

## Why

**Catalog EOL**: the public catalog projection files were missing from the
`eol=lf` rules that already cover `model-registry/catalog.json` and
`model-registry/catalog.signature.json`. On a Windows checkout with Git's
default `core.autocrlf`, that gap lets Git normalize their line endings to
CRLF on checkout, which silently mangles the signed JSON payload relative to
what was actually signed.

**Static-build DLL scan**: `ensure_backends_loaded()` called
`ggml_backend_load_all()` unconditionally. That function `dlopen()`s every
`ggml-*.dll` sitting next to the executable. On a statically-linked build
(macOS, Linux, and Windows GPU-feature builds, where `use_backend_dl` is
false) the compute backend is already registered at static-init time, so the
scan is not just unnecessary -- it is actively dangerous when the exe
directory also contains the CPU `BACKEND_DL` plugin DLLs, which a desktop
bundle can legitimately ship alongside a statically-linked GPU exe for other
components. Loading that plugin pulls a second copy of ggml core into the
process; the two copies' global state collide at
`ggml.cpp:22 GGML_ASSERT(prev != ggml_uncaught_exception)`, which fastfails
the whole process with `0xc0000409` instead of returning an error. This was
reproduced on a real mixed install (statically-linked GPU exe next to shipped
CPU `BACKEND_DL` DLLs) and confirmed fixed after gating the scan.

## Changes

- `.gitattributes`: add `eol=lf` for `catalog.public.json` and
  `catalog.public.signature.json`.
- `crates/openasr-core/build.rs`: emit
  `OPENASR_GGML_BACKEND_DL_ENABLED` (mirrors the existing
  `OPENASR_GGML_NATIVE_ENABLED` pattern) so the compiled `use_backend_dl`
  build.rs decision is visible to the Rust side at runtime; update the
  adjacent comment that previously (incorrectly) called the scan a
  "harmless no-op" on static builds.
- `crates/openasr-core/src/ggml_runtime/backend.rs`: add
  `ggml_backend_dl_build_enabled()` and gate the
  `ffi::ggml_backend_load_all()` call in `ensure_backends_loaded()` on it.
  Genuine `GGML_BACKEND_DL` builds are unaffected: no backend is statically
  registered there, so the scan still runs and is still required.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (scoped to `-p openasr-core -p openasr-server`, the crates in this stack; 3 pre-existing `#[cfg(unix)]`-only warnings elsewhere in `openasr-core` are unrelated to this change and reproduce identically on a clean `main` checkout on this Windows host -- they don't surface on the Linux/macOS CI matrix)
- [x] `cargo nextest run --workspace` (2358 tests: 2356 passed, 2 pre-existing failures verified present on a clean `main` worktree before this change -- `pull::tests::pull_lock_blocks_second_writer` (Windows PID-liveness semantics) and `transcriptions_large_upload_memory_stays_bounded` (depends on Unix `ps -o rss=`); neither touches code in this PR)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

This rebase re-ran the full validation suite above against the new `main`
(v0.1.12) base; it did not change or need to re-run the real-machine repro
below, which predates the rebase.

## Manual smoke checks

As documented in the `fix(ggml)` commit's own rationale (established when
this fix was originally authored, ahead of this rebase): reproduced the
`0xc0000409` fastfail with a statically-linked GPU exe placed next to the
shipped CPU `BACKEND_DL` DLLs before the fix, then confirmed clean startup
with the same mixed layout after the fix; also checked a plain CPU flavor
build (no DLLs to skip -- scan gate is a no-op there) for regressions.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

(No user-facing docs changed -- both fixes are internal robustness/safety
fixes with no CLI/API surface change.)

## Scope / non-goals

Does not touch the plugin-DLL migration itself (GPU-feature builds keep the
static link regardless of OS, as before); that migration stays a later
phase per the existing build.rs comment. Does not add new catalog files or
change catalog schema -- only fixes the checkout line-ending rule for files
that already exist.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI assisted with rebase mechanics and running/summarizing the validation commands in this PR.
