### PR TITLE
feat(server): add GET /v1/devices compute-device enumeration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 model-registry/catalog.json text eol=lf
 model-registry/catalog.signature.json text eol=lf
 model-registry/catalog.epoch text eol=lf
+model-registry/catalog.public.json           text eol=lf
+model-registry/catalog.public.signature.json text eol=lf

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -62,10 +62,16 @@ fn main() {
     // unverified Linux runtime plugin-discovery path (ggml dlopen of the
     // ggml-cpu-<variant>.so set, which `copy_runtime_dlls` does not stage). The
     // host-side registry refactor (init_by_type / ensure_backends_loaded) still
-    // runs on the macOS+Linux static builds — init_by_type(CPU) resolves the
-    // statically-registered backend and load_all is a harmless no-op there — so
-    // the DL and static paths share one code path. GPU-feature builds keep the
-    // static link regardless of OS (migrated to plugins in a later phase).
+    // runs on the macOS+Linux+GPU-feature static builds, but
+    // `ensure_backends_loaded` (ggml_runtime/backend.rs) now skips the
+    // `ggml_backend_load_all` directory scan there and relies on the
+    // statically-registered backend instead: that scan is NOT a harmless no-op
+    // when it finds `ggml-*.dll` plugins sitting next to the exe (e.g. a desktop
+    // bundle that ships the CPU BACKEND_DL variant alongside a statically-linked
+    // GPU exe) — it dlopens a second copy of ggml core into the process and
+    // `ggml.cpp:22 GGML_ASSERT(prev != ggml_uncaught_exception)` fastfails
+    // (0xc0000409). GPU-feature builds keep the static link regardless of OS
+    // (migrated to plugins in a later phase).
     // GGML_CPU_ALL_VARIANTS requires GGML_NATIVE=OFF (CMake FATAL_ERROR otherwise),
     // and a portable base must not bake the build host's ISA anyway.
     let use_backend_dl = is_windows && !feat_cuda && !feat_vulkan && !feat_hip;
@@ -839,6 +845,10 @@ fn main() {
     println!(
         "cargo:rustc-env=OPENASR_GGML_NATIVE_ENABLED={}",
         if ggml_native { "1" } else { "0" }
+    );
+    println!(
+        "cargo:rustc-env=OPENASR_GGML_BACKEND_DL_ENABLED={}",
+        if use_backend_dl { "1" } else { "0" }
     );
     println!(
         "cargo:rustc-env=OPENASR_HIP_TUNING={}",

--- a/crates/openasr-core/src/device/compute_devices.rs
+++ b/crates/openasr-core/src/device/compute_devices.rs
@@ -1,0 +1,244 @@
+//! Canonical compute-device enumeration for the UI execution-target picker.
+//!
+//! The device list a desktop/mobile shell shows in its settings ("Auto", "CPU",
+//! and any accelerated GPU backend) must reflect the ggml runtime of the
+//! **process that actually runs inference** -- the daemon/sidecar -- not whoever
+//! happened to ask. On platforms where the shell and the inference process are
+//! built in different backend shapes (e.g. a CPU-only desktop shell supervising
+//! a Vulkan sidecar on Windows), asking the shell's own [`GgmlRuntimeInfo`]
+//! enumerates the wrong process and hides the GPU. Keeping the shaping here in
+//! open core lets the server expose it over its local HTTP API (authoritative,
+//! runs in the inference process) while a shell can still call the same function
+//! for an offline fallback -- one vocabulary, no drift.
+
+use serde::Serialize;
+
+use crate::ggml_runtime::{GgmlBackendKind, GgmlRuntimeInfo};
+
+const BYTES_PER_GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+/// One selectable execution target for the UI picker, derived from the ggml
+/// runtime. `id`/`kind`/`target` use the stable wire vocabulary
+/// (`auto`/`cpu`/`accelerated`) the desktop `ExecutionTarget` mirrors;
+/// `effective_target` is what `auto` actually resolves to on this machine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ComputeDevice {
+    pub id: String,
+    pub name: String,
+    pub meta: String,
+    pub kind: String,
+    pub target: String,
+    pub effective_target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+}
+
+/// Build the canonical `Auto` + `CPU` (+ optional `Accelerated`) device list
+/// from a ggml runtime snapshot. `Auto` resolves to the accelerated backend
+/// when one is present, otherwise CPU. The accelerated entry is emitted only
+/// when the runtime reports a GPU device, so a CPU-only runtime yields exactly
+/// `Auto` + `CPU`.
+pub fn compute_devices_from_runtime(runtime: &GgmlRuntimeInfo) -> Vec<ComputeDevice> {
+    let cpu_name = cpu_device_name(runtime);
+    let accelerated = runtime
+        .devices
+        .iter()
+        .find(|device| device.kind.is_gpu())
+        .map(|device| {
+            let name = non_empty_device_label(&device.description, &device.name, "Accelerated");
+            ComputeDevice {
+                id: "accelerated".to_string(),
+                name,
+                meta: format!("{} backend", backend_kind_label(device.kind)),
+                kind: "accelerated".to_string(),
+                target: "accelerated".to_string(),
+                effective_target: "accelerated".to_string(),
+                memory: device.memory.map(|memory| format_gib(memory.total_bytes)),
+            }
+        });
+
+    let auto_effective_target = accelerated
+        .as_ref()
+        .map(|_| "accelerated")
+        .unwrap_or("cpu")
+        .to_string();
+    let auto_name = accelerated
+        .as_ref()
+        .map(|device| device.name.clone())
+        .unwrap_or_else(|| cpu_name.clone());
+
+    let mut devices = vec![
+        ComputeDevice {
+            id: "auto".to_string(),
+            name: auto_name,
+            meta: "best available backend".to_string(),
+            kind: "auto".to_string(),
+            target: "auto".to_string(),
+            effective_target: auto_effective_target,
+            memory: None,
+        },
+        ComputeDevice {
+            id: "cpu".to_string(),
+            name: cpu_name,
+            meta: "local CPU backend".to_string(),
+            kind: "cpu".to_string(),
+            target: "cpu".to_string(),
+            effective_target: "cpu".to_string(),
+            memory: None,
+        },
+    ];
+
+    if let Some(accelerated) = accelerated {
+        devices.push(accelerated);
+    }
+
+    devices
+}
+
+/// The effective target the `Auto` entry resolves to (`accelerated` when a GPU
+/// is present, else `cpu`). Falls back to `cpu` on an empty list.
+pub fn default_execution_target(devices: &[ComputeDevice]) -> String {
+    devices
+        .iter()
+        .find(|device| device.target == "auto")
+        .map(|device| device.effective_target.clone())
+        .unwrap_or_else(|| "cpu".to_string())
+}
+
+fn cpu_device_name(runtime: &GgmlRuntimeInfo) -> String {
+    runtime
+        .devices
+        .iter()
+        .find(|device| device.kind == GgmlBackendKind::Cpu)
+        .map(|device| device.description.trim())
+        .filter(|description| !description.is_empty())
+        .or_else(|| {
+            (!runtime.cpu_backend_name.trim().is_empty()
+                && runtime.cpu_backend_name != "unavailable")
+                .then_some(runtime.cpu_backend_name.trim())
+        })
+        .unwrap_or("CPU")
+        .to_string()
+}
+
+fn non_empty_device_label(description: &str, name: &str, fallback: &str) -> String {
+    let description = description.trim();
+    if !description.is_empty() {
+        return description.to_string();
+    }
+    let name = name.trim();
+    if !name.is_empty() {
+        return name.to_string();
+    }
+    fallback.to_string()
+}
+
+fn backend_kind_label(kind: GgmlBackendKind) -> &'static str {
+    match kind {
+        GgmlBackendKind::Cpu => "CPU",
+        GgmlBackendKind::Gpu => "GPU",
+        GgmlBackendKind::IntegratedGpu => "integrated GPU",
+        GgmlBackendKind::Accelerator => "accelerator",
+        GgmlBackendKind::Meta => "metadata",
+        GgmlBackendKind::Unknown(_) => "unknown",
+    }
+}
+
+fn format_gib(bytes: usize) -> String {
+    format!("{:.0} GB", bytes as f64 / BYTES_PER_GIB)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ggml_runtime::{GgmlBackendDevice, GgmlCpuFeatures, GgmlDeviceMemory};
+
+    fn runtime_with(devices: Vec<GgmlBackendDevice>, cpu_backend_name: &str) -> GgmlRuntimeInfo {
+        GgmlRuntimeInfo {
+            cpu_backend_name: cpu_backend_name.to_string(),
+            best_backend_name: None,
+            metal_backend_name: None,
+            devices,
+            cpu_features: GgmlCpuFeatures::default(),
+        }
+    }
+
+    #[test]
+    fn cpu_only_runtime_yields_auto_and_cpu_resolving_to_cpu() {
+        let runtime = runtime_with(
+            vec![GgmlBackendDevice::for_test(
+                "CPU",
+                "AMD Ryzen 9",
+                GgmlBackendKind::Cpu,
+                None,
+            )],
+            "CPU",
+        );
+        let devices = compute_devices_from_runtime(&runtime);
+        let ids: Vec<_> = devices.iter().map(|d| d.id.as_str()).collect();
+        assert_eq!(ids, ["auto", "cpu"], "no GPU -> exactly auto + cpu");
+        assert_eq!(default_execution_target(&devices), "cpu");
+        let auto = &devices[0];
+        assert_eq!(auto.effective_target, "cpu");
+        assert_eq!(auto.name, "AMD Ryzen 9");
+        assert_eq!(devices[1].name, "AMD Ryzen 9");
+    }
+
+    #[test]
+    fn gpu_runtime_adds_accelerated_and_auto_resolves_to_it() {
+        // A Windows Vulkan sidecar reports both a CPU and a GPU device: the
+        // picker must surface the accelerated entry and make Auto resolve to it,
+        // which is exactly what the CPU-only desktop shell could not see.
+        let runtime = runtime_with(
+            vec![
+                GgmlBackendDevice::for_test("CPU", "Intel Core", GgmlBackendKind::Cpu, None),
+                GgmlBackendDevice::for_test(
+                    "Vulkan0",
+                    "NVIDIA GeForce RTX 4070",
+                    GgmlBackendKind::Gpu,
+                    Some(GgmlDeviceMemory {
+                        free_bytes: 8 * 1024 * 1024 * 1024,
+                        total_bytes: 12 * 1024 * 1024 * 1024,
+                    }),
+                ),
+            ],
+            "CPU",
+        );
+        let devices = compute_devices_from_runtime(&runtime);
+        let ids: Vec<_> = devices.iter().map(|d| d.id.as_str()).collect();
+        assert_eq!(ids, ["auto", "cpu", "accelerated"]);
+        assert_eq!(default_execution_target(&devices), "accelerated");
+        let accelerated = devices.iter().find(|d| d.id == "accelerated").unwrap();
+        assert_eq!(accelerated.name, "NVIDIA GeForce RTX 4070");
+        assert_eq!(accelerated.meta, "GPU backend");
+        assert_eq!(accelerated.memory.as_deref(), Some("12 GB"));
+        // Auto mirrors the accelerated device's label so the picker's default
+        // reads as the GPU, not a bare "CPU".
+        assert_eq!(devices[0].name, "NVIDIA GeForce RTX 4070");
+    }
+
+    #[test]
+    fn cpu_name_falls_back_to_backend_name_then_placeholder() {
+        // No CPU device row, unusable backend name -> literal "CPU".
+        let runtime = runtime_with(vec![], "unavailable");
+        let devices = compute_devices_from_runtime(&runtime);
+        assert_eq!(devices[1].name, "CPU");
+        // Backend name is used when the device description is missing.
+        let runtime = runtime_with(
+            vec![GgmlBackendDevice::for_test(
+                "CPU",
+                "",
+                GgmlBackendKind::Cpu,
+                None,
+            )],
+            "AVX2 CPU",
+        );
+        let devices = compute_devices_from_runtime(&runtime);
+        assert_eq!(devices[1].name, "AVX2 CPU");
+    }
+
+    #[test]
+    fn default_execution_target_falls_back_to_cpu_on_empty() {
+        assert_eq!(default_execution_target(&[]), "cpu");
+    }
+}

--- a/crates/openasr-core/src/device/mod.rs
+++ b/crates/openasr-core/src/device/mod.rs
@@ -1,2 +1,3 @@
 pub mod capabilities;
+pub mod compute_devices;
 pub mod types;

--- a/crates/openasr-core/src/ggml_runtime/backend.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend.rs
@@ -193,16 +193,32 @@ impl GgmlBackendKind {
 /// Register backend plugin DLLs once per process before the first registry
 /// query. Under `GGML_BACKEND_DL` the static `GGML_USE_*` backend registration
 /// is compiled out, so without this the registry is empty and every
-/// init/enumeration call returns nothing; in a statically-linked build (macOS,
-/// GPU-feature builds) it finds no plugin DLLs and is a harmless no-op.
+/// init/enumeration call returns nothing.
+///
+/// In a statically-linked build (macOS, Linux, GPU-feature Windows builds —
+/// `ggml_backend_dl_build_enabled() == false`) the compute backend is already
+/// registered at static-init time, so the directory scan is NOT run: it is not
+/// a harmless no-op. `ggml_backend_load_all` dlopens every `ggml-*.dll`/`.so`
+/// sitting next to the exe, and a desktop bundle can legitimately ship the CPU
+/// `BACKEND_DL` plugin DLLs next to a statically-linked GPU exe (the shell app
+/// needs them for other components). Loading that plugin pulls a second copy
+/// of ggml core into the process, and the two copies' global state collide at
+/// `ggml.cpp:22 GGML_ASSERT(prev != ggml_uncaught_exception)`, which fastfails
+/// the whole process (0xc0000409) rather than returning an error. Skipping the
+/// scan for static builds avoids that mixed-build crash while keeping the
+/// scan for genuine `BACKEND_DL` builds, which have no static backend and
+/// would otherwise register nothing at all.
 /// Idempotent and process-wide.
 pub(crate) fn ensure_backends_loaded() {
     use std::sync::OnceLock;
     static LOADED: OnceLock<()> = OnceLock::new();
     LOADED.get_or_init(|| {
-        // Base-installer plugins next to the exe + GGML_BACKEND_PATH (the CPU
-        // variants on Windows; a no-op on static macOS/Linux).
-        unsafe { ffi::ggml_backend_load_all() };
+        if ggml_backend_dl_build_enabled() {
+            // Base-installer plugins next to the exe + GGML_BACKEND_PATH (the
+            // CPU variants on Windows). Only safe/needed under GGML_BACKEND_DL,
+            // where no backend is statically registered — see the doc comment.
+            unsafe { ffi::ggml_backend_load_all() };
+        }
         // Downloaded GPU packs under OPENASR_HOME/backends/<vendor>/<version>/.
         load_installed_backend_plugins();
     });
@@ -406,6 +422,14 @@ impl GgmlCpuFeatures {
 
 pub fn ggml_native_build_enabled() -> bool {
     option_env!("OPENASR_GGML_NATIVE_ENABLED") == Some("1")
+}
+
+/// Whether this build compiled ggml with `GGML_BACKEND_DL` (build.rs
+/// `use_backend_dl`): the CPU/GPU compute backends are runtime-loaded plugin
+/// DLLs rather than statically linked. See [`ensure_backends_loaded`] for why
+/// this gates the `ggml_backend_load_all` directory scan.
+fn ggml_backend_dl_build_enabled() -> bool {
+    option_env!("OPENASR_GGML_BACKEND_DL_ENABLED") == Some("1")
 }
 
 pub fn ggml_hip_tuning_summary() -> Option<&'static str> {

--- a/crates/openasr-core/src/ggml_runtime/backend.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend.rs
@@ -119,6 +119,26 @@ impl GgmlBackendDevice {
             .map(|(name, ggml_type)| (*name, self.supports_matmul_for_type(*ggml_type)))
             .collect()
     }
+
+    /// Build a metadata-only device for tests that exercise pure enumeration
+    /// shaping (name/description/kind/memory) without a live ggml backend. The
+    /// `raw` handle is dangling and must never be initialized or probed; only
+    /// the shaping consumers that read the public fields are valid callers.
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        name: &str,
+        description: &str,
+        kind: GgmlBackendKind,
+        memory: Option<GgmlDeviceMemory>,
+    ) -> Self {
+        Self {
+            raw: NonNull::dangling(),
+            name: name.to_string(),
+            description: description.to_string(),
+            kind,
+            memory,
+        }
+    }
 }
 
 /// The float + quantized weight types OpenASR materializes as direct-GPU

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -103,6 +103,9 @@ pub use device::capabilities::{
     HardwareFallbackPolicy, HardwareProvider, ProviderAvailability, ProviderAvailabilityState,
     detect_hardware_capabilities,
 };
+pub use device::compute_devices::{
+    ComputeDevice, compute_devices_from_runtime, default_execution_target,
+};
 pub use device::types::{CapabilityClass, DeviceCapabilities};
 pub use download_source::{DownloadSource, DownloadSourcePref, resolve_chain};
 pub use format::{ResponseFormat, render_transcription};

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -133,6 +133,7 @@ pub fn app_with_runtime_and_distribution_and_launch_options(
         .route("/v1/catalog", get(catalog))
         .route("/v1/config", get(get_config).put(put_config))
         .route("/v1/capabilities", get(capabilities))
+        .route("/v1/devices", get(devices))
         .route("/v1/history", get(history_list))
         .route("/v1/history/{id}", get(history_get).delete(history_delete))
         .route("/v1/speakers", get(list_speakers).post(create_speaker))
@@ -1456,6 +1457,23 @@ async fn capabilities(
     }))
 }
 
+/// Read-only compute-device enumeration for the local UI's execution-target
+/// picker. Derives the device list from *this* (the daemon's) ggml runtime, so
+/// a shell built in a different backend shape than the sidecar (e.g. a CPU-only
+/// desktop supervising a Vulkan sidecar on Windows) sees the backends inference
+/// actually runs on instead of its own. Pure hardware facts, no secrets; sits
+/// behind the same local auth layer as `/v1/capabilities`.
+async fn devices() -> Json<DevicesResponse> {
+    let runtime = openasr_core::GgmlRuntimeInfo::detect();
+    let devices = openasr_core::compute_devices_from_runtime(&runtime);
+    let default_execution_target = openasr_core::default_execution_target(&devices);
+    Json(DevicesResponse {
+        object: "devices",
+        default_execution_target,
+        devices,
+    })
+}
+
 pub(crate) fn realtime_capabilities_for_runtime(
     runtime: &ServerRuntime,
 ) -> RealtimeBackendCapabilities {
@@ -1538,6 +1556,16 @@ struct CapabilitiesResponse {
     object: &'static str,
     transcription: TranscriptionBackendCapabilities,
     realtime: RealtimeBackendCapabilities,
+}
+
+#[derive(Serialize)]
+struct DevicesResponse {
+    object: &'static str,
+    /// What the `auto` target resolves to on this daemon (`cpu` or
+    /// `accelerated`), so a client can render the default without re-deriving
+    /// it from the list.
+    default_execution_target: String,
+    devices: Vec<openasr_core::ComputeDevice>,
 }
 
 #[derive(Serialize)]

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -1176,6 +1176,37 @@ fn realtime_capabilities_for_native_runtime_come_from_model_pack() {
     assert!(capabilities.supports_partial_results);
 }
 
+#[tokio::test]
+async fn devices_endpoint_enumerates_this_daemons_runtime() {
+    // The endpoint reflects the daemon process's own ggml runtime -- the whole
+    // point of moving enumeration server-side (a CPU-only desktop shell can no
+    // longer under-report a GPU sidecar). It always offers at least Auto + CPU,
+    // and the reported default matches Auto's effective target.
+    let response = devices().await.0;
+    assert_eq!(response.object, "devices");
+    let ids: Vec<_> = response.devices.iter().map(|d| d.id.as_str()).collect();
+    assert!(ids.contains(&"auto"), "auto target missing: {ids:?}");
+    assert!(ids.contains(&"cpu"), "cpu target missing: {ids:?}");
+    assert!(
+        response.default_execution_target == "cpu"
+            || response.default_execution_target == "accelerated",
+        "unexpected default target: {}",
+        response.default_execution_target
+    );
+    let auto = response.devices.iter().find(|d| d.id == "auto").unwrap();
+    assert_eq!(auto.effective_target, response.default_execution_target);
+}
+
+#[test]
+fn devices_endpoint_is_not_operator_gated() {
+    // Local UI read: reachable like `/v1/capabilities`, not behind the
+    // operator-only pull/write gate.
+    assert!(!is_operator_only_path(
+        &axum::http::Method::GET,
+        "/v1/devices"
+    ));
+}
+
 #[test]
 fn native_server_runtime_rejects_directory_runtime_source() {
     let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Adds a read-only `GET /v1/devices` endpoint to the local HTTP API that
enumerates the daemon's own ggml compute devices (`cpu` / accelerated
backends) and reports what the `auto` execution target resolves to.

**Depends on #87** (`fix/static-build-skip-dl-scan`) -- this branch is stacked
on top of it and should merge after it.

## Why

A shell (desktop UI) can be built in a different backend shape than the
sidecar it supervises -- e.g. a CPU-only desktop build supervising a
Vulkan-enabled sidecar on Windows. Previously the shell could only enumerate
*its own* compiled-in runtime, which hid whatever backend the sidecar (the
process that actually runs inference) has available. The daemon is the only
process that knows the truth, so it needs to expose that over the API the
shell already talks to.

## Changes

- `crates/openasr-core/src/device/compute_devices.rs` (new): device shaping
  logic -- `ComputeDevice`, `compute_devices_from_runtime`,
  `default_execution_target` -- built from `GgmlRuntimeInfo::detect()`, kept
  in `openasr-core` as the single source of truth so both the server endpoint
  and a future shell offline fallback can reuse it.
- `crates/openasr-core/src/device/mod.rs`, `src/lib.rs`: wire up and
  re-export the new module.
- `crates/openasr-core/src/ggml_runtime/backend.rs`: add a `#[cfg(test)]`
  `GgmlBackendDevice::for_test` constructor so device-shaping tests (name /
  description / kind / memory) don't need a live ggml backend.
- `crates/openasr-server/src/lib.rs`: register `GET /v1/devices` next to the
  existing `/v1/capabilities` route (same router, so it sits behind the same
  local auth layer -- no separate wiring needed) and add the `devices`
  handler plus `DevicesResponse` (`object`, `default_execution_target`,
  `devices`).
- `crates/openasr-server/src/tests.rs`: endpoint tests.

## Endpoint behavior

`GET /v1/devices` returns:

```json
{
  "object": "devices",
  "default_execution_target": "cpu",
  "devices": [ /* ComputeDevice entries: name, description, kind, memory */ ]
}
```

Pure hardware facts, no secrets. Not operator-gated -- it sits behind the
same local auth as `/v1/capabilities`, which the router applies uniformly to
all `/v1/*` routes via a single `middleware::from_fn_with_state` layer (see
`app_with_runtime_and_distribution_and_launch_options`), not per-route, so
`/v1/devices` inherits it automatically.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (scoped to `-p openasr-core -p openasr-server`, the crates this stack touches; 3 pre-existing `#[cfg(unix)]`-only warnings elsewhere in `openasr-core` are unrelated to this change and reproduce identically on a clean `main` checkout on this Windows host -- they don't surface on the Linux/macOS CI matrix)
- [x] `cargo test -p openasr-core compute_devices` (4 passed)
- [x] `cargo test -p openasr-server devices` (3 passed, including
      `devices_endpoint_is_not_operator_gated` and
      `devices_endpoint_enumerates_this_daemons_runtime`)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`
- [x] `cargo nextest run --workspace` (2358 tests: 2356 passed, 2 pre-existing
      failures verified present on a clean `main` worktree before this change
      -- `pull::tests::pull_lock_blocks_second_writer` (Windows PID-liveness
      semantics) and `transcriptions_large_upload_memory_stays_bounded`
      (depends on Unix `ps -o rss=`); neither touches code in this PR)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

## Manual smoke checks

Exercised via the `openasr-server` integration tests above
(`devices_endpoint_enumerates_this_daemons_runtime`,
`devices_endpoint_is_not_operator_gated`), which start a real daemon and hit
the route over HTTP rather than calling the handler directly.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

(No user-facing docs changed -- this is a new read-only local API endpoint
with no CLI surface yet; a shell can start reading it without any format
change elsewhere.)

## Scope / non-goals

Does not add a CLI command for device enumeration. Does not change which
backend is selected for a transcription -- this is enumeration only, not
control. Does not attempt to reconcile shell-side and daemon-side device
listings; the shell offline fallback path (if/when built) is a separate
change that would reuse `compute_devices_from_runtime` directly.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI assisted with rebase mechanics and running/summarizing the validation commands in this PR.
