### PR TITLE
feat(server): expose model_resident in /health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Server: `/health` now reports `model_resident`, whether the bound model's native runtime is currently loaded in memory versus idle-unloaded (or not yet loaded this boot) -- lets clients (e.g. the desktop status indicator) distinguish "ready, instant transcription" from "bound but will pay a cold rebuild on the next request" without guessing from the `idle_unload` timer. Additive; `model_installed` is unchanged.
+
 ## [0.1.12] - 2026-07-11
 
 ### Added

--- a/crates/openasr-server/src/idle_activity.rs
+++ b/crates/openasr-server/src/idle_activity.rs
@@ -95,6 +95,80 @@ pub(crate) fn bump_native_unload_generation() {
     NATIVE_UNLOAD_GENERATION.fetch_add(1, Ordering::Relaxed);
 }
 
+/// Process-wide unload generation as of the most recent successful native
+/// model warm state transition (an offline decode or a realtime streaming
+/// warm-up that actually built or reused the resident runtime). Compared
+/// against [`native_unload_generation`], this is the source of truth for
+/// `/health`'s `model_resident` field: the two read equal only when no
+/// `idle_unload` eviction has happened since that last successful load.
+///
+/// `u64::MAX` is the "never warmed yet" sentinel -- unreachable via the
+/// generation counter's own increments in a running process -- so a fresh
+/// boot reads as not-resident until the first successful load completes,
+/// same as after a real eviction.
+static LAST_WARM_GENERATION: AtomicU64 = AtomicU64::new(u64::MAX);
+
+/// Records that the native model runtime is resident as of right now, at the
+/// current unload generation. Call sites: [`crate::realtime::native_worker`]'s
+/// streaming warm-up gate and the offline-decode path in
+/// `routes::transcription`, both right after their respective build/decode
+/// succeeds.
+///
+/// Safe against a racing `idle_unload` eviction: the reaper only unloads
+/// while [`native_activity_is_idle_for`] reads true, i.e. while the active
+/// count is zero, and every call site runs from inside an active
+/// [`NativeActivityGuard`] (or an attached streaming session's equivalent
+/// window) -- so the generation read here cannot be bumped out from under an
+/// in-flight caller before its request finishes.
+pub(crate) fn mark_native_model_warm() {
+    LAST_WARM_GENERATION.store(native_unload_generation(), Ordering::Relaxed);
+}
+
+/// Whether the bound native model runtime is resident right now: warmed, and
+/// not evicted by an `idle_unload` sweep since. Reads `false` before the
+/// first successful load of the process's lifetime, and `false` again after
+/// any eviction until the next successful load.
+pub(crate) fn native_model_is_resident() -> bool {
+    LAST_WARM_GENERATION.load(Ordering::Relaxed) == native_unload_generation()
+}
+
+/// Single shared lock serializing every test in this crate that mutates
+/// `NATIVE_UNLOAD_GENERATION` (via [`bump_native_unload_generation`]) or
+/// `LAST_WARM_GENERATION` (via [`mark_native_model_warm`], including
+/// indirectly by exercising a real `warm_up_native_streaming_session_once`
+/// success path with a fake session) against each other -- without it, a
+/// bump or mark from one test could land between another test's own bump and
+/// check under `cargo test`'s default same-process test-thread parallelism.
+/// `cargo nextest` isolates each test in its own process and would not need
+/// this at all.
+///
+/// `tokio::sync::Mutex` (not `std::sync::Mutex`) because some holders are
+/// async tests that keep the guard alive across an `.await` (e.g. awaiting
+/// `attach_and_run_boot_warmup`) -- a `std::sync::MutexGuard` is not `Send`,
+/// so it cannot survive an await point on a multi-threaded runtime.
+/// [`native_unload_generation_test_lock_blocking`] is the sync-test
+/// counterpart, for callers (like this module's own `#[test]`s) that never
+/// hold the guard across an await point.
+#[cfg(test)]
+fn native_unload_generation_test_lock_mutex() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+#[cfg(test)]
+pub(crate) async fn native_unload_generation_test_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    native_unload_generation_test_lock_mutex().lock().await
+}
+
+/// Blocking counterpart of [`native_unload_generation_test_lock`] for plain
+/// (non-`tokio::test`) `#[test]`s, which never run inside an async executor
+/// -- `Mutex::blocking_lock` would panic if called from one.
+#[cfg(test)]
+pub(crate) fn native_unload_generation_test_lock_blocking() -> tokio::sync::MutexGuard<'static, ()>
+{
+    native_unload_generation_test_lock_mutex().blocking_lock()
+}
+
 /// Marks one native request/session as started. Must be paired with a later
 /// [`native_activity_exit`] -- prefer [`NativeActivityGuard`] over calling
 /// this directly when the activity's lifetime is a single lexical scope.
@@ -241,5 +315,62 @@ mod tests {
         // absolute or relative count, which would be flaky under contention.
         let _guard = NativeActivityGuard::enter();
         drop(_guard);
+    }
+
+    #[test]
+    fn native_model_is_not_resident_before_any_warm_mark() {
+        // Regression guard for the `u64::MAX` sentinel: a generation counter
+        // that starts at 0 must never accidentally equal it, or a fresh boot
+        // (before the first successful load) would misreport resident.
+        let _generation_guard = native_unload_generation_test_lock_blocking();
+        assert_ne!(
+            native_unload_generation(),
+            u64::MAX,
+            "a real process-wide generation must never coincide with the never-warmed sentinel"
+        );
+    }
+
+    #[test]
+    fn marking_warm_makes_native_model_read_resident() {
+        let _generation_guard = native_unload_generation_test_lock_blocking();
+        bump_native_unload_generation();
+        assert!(
+            !native_model_is_resident(),
+            "a fresh bump with no matching mark must read as not resident"
+        );
+
+        mark_native_model_warm();
+        assert!(
+            native_model_is_resident(),
+            "marking warm at the current generation must read as resident"
+        );
+    }
+
+    #[test]
+    fn idle_unload_eviction_flips_resident_back_to_false() {
+        // Exercises the exact flip this field exists for: reload (mark warm)
+        // makes it true, and a subsequent idle-unload eviction (bump the
+        // generation, as `spawn_idle_unload_reaper` does) makes it false
+        // again without any further mark -- the reader never has to poll a
+        // second signal to notice the eviction.
+        let _generation_guard = native_unload_generation_test_lock_blocking();
+        bump_native_unload_generation();
+        mark_native_model_warm();
+        assert!(
+            native_model_is_resident(),
+            "just-marked warm at the current generation must read as resident"
+        );
+
+        bump_native_unload_generation();
+        assert!(
+            !native_model_is_resident(),
+            "an idle-unload eviction must flip resident back to false until the next mark"
+        );
+
+        mark_native_model_warm();
+        assert!(
+            native_model_is_resident(),
+            "a reload after the eviction (mark at the new generation) must flip resident back to true"
+        );
     }
 }

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -911,6 +911,23 @@ impl ServerRuntime {
             BackendKind::Native => self.model_pack_path.is_some(),
         }
     }
+
+    /// Whether the bound model's runtime is resident right now (surfaced by
+    /// `/health` as `model_resident`, gated on `has_model_bound` -- see the
+    /// call site) so clients can tell "loaded, ready to transcribe
+    /// instantly" apart from "bound but idle-unloaded, the next request pays
+    /// a cold rebuild". `mock` has no runtime to unload -- it is resident
+    /// whenever it is bound. `native`'s residency is the real, process-wide
+    /// idle-unload signal in `idle_activity`, not a guess: it reads `true`
+    /// only after a successful load/decode, and flips back to `false` the
+    /// moment the `idle_unload` reaper evicts the cached runtime, without
+    /// this method reaching into any per-thread cache itself.
+    fn model_is_resident(&self) -> bool {
+        match self.backend {
+            BackendKind::Mock => true,
+            BackendKind::Native => idle_activity::native_model_is_resident(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1386,6 +1403,7 @@ async fn health(
         pid: identity.pid,
         instance_token: identity.instance_token.clone(),
         model_installed: runtime.has_model_bound(),
+        model_resident: runtime.has_model_bound() && runtime.model_is_resident(),
     })
 }
 
@@ -1518,6 +1536,18 @@ struct HealthResponse {
     /// yet. Clients should treat this as "go install a model", not "daemon
     /// unreachable".
     model_installed: bool,
+    /// Whether the bound model's runtime is currently resident in memory,
+    /// i.e. ready to transcribe instantly with no cold-load latency. Added in
+    /// 0.1.13 alongside the `idle_unload` reaper actually releasing the
+    /// runtime after an idle period: `model_installed: true,
+    /// model_resident: false` means a model is bound but its runtime has been
+    /// unloaded (idle past the configured `idle_unload` threshold, or never
+    /// loaded yet this boot) -- the next transcription request pays a cold
+    /// rebuild before it can run, but is not itself an error. Always `false`
+    /// when `model_installed` is `false` (nothing to be resident). Additive:
+    /// absent in the pre-0.1.13 contract, so an older client that only reads
+    /// `model_installed` keeps working unchanged.
+    model_resident: bool,
 }
 
 #[derive(Serialize)]

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -482,6 +482,10 @@ pub(crate) fn warm_up_native_streaming_session_once(
     session.warm_up()?;
     openasr_core::stage_timing::log_stage("realtime_warmup", "complete", warmup_started.elapsed());
     WARMED_AT_GENERATION.with(|warmed| warmed.set(Some(current_generation)));
+    // Process-wide counterpart of the thread-local gate above, so `/health`
+    // can answer "is the model resident" without reaching into any worker
+    // thread's TLS -- see `idle_activity::native_model_is_resident`.
+    crate::idle_activity::mark_native_model_warm();
     Ok(())
 }
 

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -50,20 +50,6 @@ async fn speaker_embedder_env_lock() -> tokio::sync::MutexGuard<'static, ()> {
         .await
 }
 
-/// `idle_activity::NATIVE_UNLOAD_GENERATION` is a process-wide counter (it
-/// has to be: a real idle-unload evicts every worker thread's resident
-/// runtime, not just one). Only the two warm-up/generation tests below
-/// mutate it directly (via `bump_native_unload_generation`); this lock keeps
-/// those two from racing each other under `cargo test`'s default test-thread
-/// parallelism, the same way `speaker_embedder_env_lock` above serializes
-/// tests that share process-wide env state.
-async fn native_unload_generation_test_lock() -> tokio::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
-        .lock()
-        .await
-}
-
 fn test_native_streaming_worker_key(name: &str) -> NativeStreamingWorkerKey {
     NativeStreamingWorkerKey::new(
         PathBuf::from(format!("/test/native-streaming/{name}")),
@@ -1467,7 +1453,7 @@ async fn native_streaming_warm_up_runs_immediately_and_once_per_worker() {
     // running idle-unload-generation test cannot bump the process-wide
     // counter mid-window and make this one flake (see
     // `native_unload_generation_test_lock`'s doc comment).
-    let _generation_lock = native_unload_generation_test_lock().await;
+    let _generation_lock = crate::idle_activity::native_unload_generation_test_lock().await;
     let (event_sender, _event_receiver) = mpsc::channel(8);
     let mut session = WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
     let warm_calls = Arc::new(AtomicUsize::new(0));
@@ -1598,7 +1584,7 @@ async fn boot_native_warmup_leaves_the_worker_thread_warm_for_the_next_real_atta
     // `native_streaming_warm_up_runs_immediately_and_once_per_worker`: this
     // spans two attaches expecting one warm-up, so a concurrent generation
     // bump from another test would otherwise flake it.
-    let _generation_lock = native_unload_generation_test_lock().await;
+    let _generation_lock = crate::idle_activity::native_unload_generation_test_lock().await;
     let warm_calls = Arc::new(AtomicUsize::new(0));
     let key = test_native_streaming_worker_key("boot-warmup-reuse");
 
@@ -1651,7 +1637,7 @@ async fn native_streaming_warm_up_stays_once_across_reattach_without_an_idle_unl
     // regress the plain reuse case `boot_native_warmup_leaves_the_worker_\
     // thread_warm_for_the_next_real_attach` already covers for the
     // boot-warmup/real-attach pairing.
-    let _generation_lock = native_unload_generation_test_lock().await;
+    let _generation_lock = crate::idle_activity::native_unload_generation_test_lock().await;
     let warm_calls = Arc::new(AtomicUsize::new(0));
     let key = test_native_streaming_worker_key("warm-once-across-reattach-no-unload");
 
@@ -1725,7 +1711,7 @@ async fn native_streaming_warm_up_rewarms_after_idle_unload_bumps_the_generation
     // between two attaches on the same worker key, and asserts the second
     // attach's `Warm` actually re-runs `warm_up()` instead of reading the
     // stale flag.
-    let _generation_lock = native_unload_generation_test_lock().await;
+    let _generation_lock = crate::idle_activity::native_unload_generation_test_lock().await;
     let warm_calls = Arc::new(AtomicUsize::new(0));
     let key = test_native_streaming_worker_key("rewarm-after-idle-unload-generation-bump");
 

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1378,6 +1378,11 @@ pub(crate) async fn transcribe_with_runtime(
             )
             .map_err(native_asr_error_to_backend)
             .map_err(TranscriptionRuntimeError::Backend)?;
+            // The decode above only returns `Ok` after the model runtime is
+            // built (or reused) and actually ran, so this is the resident
+            // signal `/health`'s `model_resident` field reads -- see
+            // `idle_activity::native_model_is_resident`.
+            crate::idle_activity::mark_native_model_warm();
             if word_timestamps {
                 add_segment_word_timestamps(&mut transcription);
             }

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -1091,6 +1091,48 @@ async fn daemon_starts_and_reports_ready_with_zero_models_installed() {
         parsed["model_installed"], false,
         "health must honestly report no model bound instead of just being unreachable"
     );
+    assert_eq!(
+        parsed["model_resident"], false,
+        "nothing can be resident when no model is bound at all"
+    );
+}
+
+#[tokio::test]
+async fn health_reports_model_bound_but_not_resident_before_any_load() {
+    // A native pack can be bound (`model_installed: true`) at boot without
+    // its runtime ever having been loaded yet -- the boot warm-up runs in
+    // the background and this test never triggers it or any transcription.
+    // `/health` must not conflate "bound" with "resident": a client polling
+    // right after daemon start must see `model_resident: false` until an
+    // actual load (warm-up or first request) completes.
+    let temp = tempfile::tempdir().unwrap();
+    let pack_root = temp.path().join("native-pack.oasr");
+    write_mock_gguf_runtime_source(&pack_root, None);
+    let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
+        backend: openasr_core::BackendKind::Native,
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: Some(pack_root),
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    let parsed: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(parsed["model_installed"], true, "a model pack is bound");
+    assert_eq!(
+        parsed["model_resident"], false,
+        "a bound pack whose runtime has never been loaded this boot must not read resident"
+    );
 }
 
 #[tokio::test]
@@ -2334,7 +2376,11 @@ async fn health_returns_identity_json_without_instance_token() {
     );
     assert_eq!(parsed["pid"], serde_json::json!(std::process::id()));
     assert!(parsed["instance_token"].is_null());
-    assert_eq!(parsed.as_object().expect("health response object").len(), 5);
+    assert_eq!(
+        parsed["model_resident"], true,
+        "the mock backend has no runtime to unload, so it reads resident whenever bound"
+    );
+    assert_eq!(parsed.as_object().expect("health response object").len(), 6);
 }
 
 #[tokio::test]
@@ -2366,7 +2412,7 @@ async fn health_echoes_launch_instance_token_without_env() {
         parsed["instance_token"],
         serde_json::json!("launch-health-token")
     );
-    assert_eq!(parsed.as_object().expect("health response object").len(), 5);
+    assert_eq!(parsed.as_object().expect("health response object").len(), 6);
 }
 
 #[tokio::test]
@@ -2400,7 +2446,7 @@ async fn health_prefers_env_instance_token_over_launch_option() {
         parsed["instance_token"],
         serde_json::json!("env-health-token")
     );
-    assert_eq!(parsed.as_object().expect("health response object").len(), 5);
+    assert_eq!(parsed.as_object().expect("health response object").len(), 6);
 }
 
 #[tokio::test]

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -117,7 +117,10 @@ remote-serving flow.
 
 ### Endpoints an agent typically needs
 
-- `GET /health` -- liveness + server identity, unauthenticated.
+- `GET /health` -- liveness + server identity, unauthenticated. Includes
+  `model_installed` (a pack is bound) and `model_resident` (0.1.13+: that
+  pack's runtime is currently loaded in memory, vs. idle-unloaded or not yet
+  loaded this boot).
 - `GET /v1/models` -- installed packs.
 - `POST /v1/audio/transcriptions` -- OpenAI-compatible transcription
   (multipart `file` + `model`; `response_format` of `json`, `text`, `srt`,

--- a/skills/openasr/references/http-api.md
+++ b/skills/openasr/references/http-api.md
@@ -33,6 +33,12 @@ pack that is being served.
 ## Endpoints
 
 - `GET /health` -- liveness + server identity; never requires auth.
+  `{"status","server_version","pid","instance_token","model_installed",
+  "model_resident"}`. `model_installed` is whether a pack is bound at all;
+  `model_resident` (0.1.13+) is whether that pack's runtime is currently
+  loaded in memory -- `false` means the next transcription request pays a
+  cold rebuild (idle-unloaded past the `idle_unload` threshold, or not yet
+  loaded this boot), not an error.
 - `GET /v1/models` -- OpenAI-style list of the served pack
   (`{"object":"list","data":[{"id","object":"model","owned_by":"openasr"}]}`;
   no `created` field).


### PR DESCRIPTION
## Summary

Add `model_resident` to `GET /health`: whether the bound native model's runtime is currently loaded in memory, versus idle-unloaded (or not yet loaded this boot). Supports the desktop three-state status indicator (ready / idle-unloaded / startup-failed).

## Why

`model_installed` only reports whether a pack is *bound*, not whether its runtime is currently resident. Since 0.1.12's `idle_unload` reaper actually evicts the cached runtime after an idle period (default 10m), a bound pack can be cold at any time, and the next transcription request then pays a full cold-rebuild before it can run. Desktop needs to tell these apart to show something other than a plain "ready" light.

## Changes

- `crates/openasr-server/src/idle_activity.rs`: new `LAST_WARM_GENERATION` process-wide marker, `mark_native_model_warm()` / `native_model_is_resident()`. Reuses the existing `native_unload_generation()` signal (the same one the realtime warm-up gate's thread-local `WARMED_AT_GENERATION` already compares against) -- no new source of truth, no per-thread cache probing from a different thread.
- `crates/openasr-server/src/realtime/native_worker.rs`: `warm_up_native_streaming_session_once` marks warm (process-wide) right alongside its existing thread-local mark, after `session.warm_up()` succeeds.
- `crates/openasr-server/src/routes/transcription.rs`: the native offline-decode path marks warm right after `NativeAsrExecutor::transcribe` succeeds.
- `crates/openasr-server/src/lib.rs`: `ServerRuntime::model_is_resident()` (mock is always resident when bound; native defers to `idle_activity`); `/health` now returns `model_resident`, gated on `model_installed`; doc comment on the new field states the 0.1.13+ contract and backward compatibility.
- Test-lock consolidation: `idle_activity.rs` and `realtime/tests.rs` each had their own private lock serializing tests that mutate the shared unload-generation counter under plain `cargo test`. Since the new marker shares that same counter, I merged both into one `idle_activity::native_unload_generation_test_lock()` (async, for tests awaiting across the lock) plus a `_blocking()` variant (for the new plain `#[test]`s), instead of adding a second, uncoordinated lock.
- `CHANGELOG.md`, `docs/AGENT_INTEGRATION.md`, `skills/openasr/references/http-api.md`: document the new field and its 0.1.13+ contract.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2370 passed, 122 skipped -- the skipped ones need real model-pack env vars)
- [x] `cargo test --workspace --doc`

New/updated tests:
- `idle_activity::tests`: `marking_warm_makes_native_model_read_resident`, `idle_unload_eviction_flips_resident_back_to_false` (the unload -> false, reload -> true flip this field exists for), `native_model_is_not_resident_before_any_warm_mark`.
- `openasr-server::api`: `health_reports_model_bound_but_not_resident_before_any_load` (bound pack, never loaded -> `model_resident: false`); updated the three existing `/health` shape tests for the new field count and the mock-backend-is-always-resident case; `daemon_starts_and_reports_ready_with_zero_models_installed` now also asserts `model_resident: false`.

## Manual smoke checks

None beyond the automated tests above -- exercising a real idle-unload -> reload cycle end to end requires a real model pack (no weights are committed to this repo), so the unit tests directly exercise the generation-comparison mechanism instead.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not add a fourth "startup failed" health state; that's a separate concern from residency and not covered by this field.
- Does not attempt to reflect residency for individual worker-thread-local caches (e.g. per-family bounded LRU caches) -- those already self-expire independently and are orthogonal to the process-lifetime runtime cache this field tracks.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance (Claude Code); reviewed and understood in full before submission.