### PR TITLE
perf(core): skip full-vocab softmax on blank frames in CTC greedy decode

### DIFF
--- a/crates/openasr-core/src/models/ctc_greedy_decode.rs
+++ b/crates/openasr-core/src/models/ctc_greedy_decode.rs
@@ -115,8 +115,15 @@ impl IncrementalCtcGreedyDecoder {
         // set and its output stays byte-identical to the un-biased decode.
         let argmax = self.argmax_frame(row, frame)?;
         // Confidence of this frame's pick; a token's probability is the mean over
-        // its argmax run.
-        let probability = token_softmax_probability(row, argmax as usize);
+        // its argmax run. Blank runs are dropped whole in `push_ctc_token_run`
+        // before their probability is ever read, so skip the full-vocab softmax
+        // scan for blank frames -- this is the hottest path in blank-dominated
+        // audio (most frames between spoken tokens).
+        let probability = if argmax == self.config.blank_token_id {
+            0.0
+        } else {
+            token_softmax_probability(row, argmax as usize)
+        };
         match self.prev_argmax {
             None => {
                 self.prev_argmax = Some(argmax);


### PR DESCRIPTION
## Summary

CTC greedy decode skips the full-vocab softmax confidence computation
(`token_softmax_probability`) for frames whose argmax is the blank token.

## Why

`push_ctc_token_run` drops every blank-collapsed run whole (`if token_id ==
blank_token_id { return; }`) before its accumulated probability is ever read.
So for every blank-argmax frame, `IncrementalCtcGreedyDecoder::append_frame`
was still paying for a full two-pass, `exp()`-heavy softmax scan over the
entire vocabulary just to compute a number that gets thrown away a few lines
later. Blank frames dominate CTC output (most frames between spoken tokens),
so this is the hottest path in the CTC greedy decoder.

## Changes

- `crates/openasr-core/src/models/ctc_greedy_decode.rs`: gate the
  `token_softmax_probability` call behind `argmax == self.config.blank_token_id`;
  default the (discarded) probability to `0.0` on the blank branch instead.
  No other logic changes -- non-blank frames are unaffected, and blank runs
  still never contribute a token or a span.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2376 passed, 0 failed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (byte-identical: 2 passed, 2 ignored -- private packs unavailable in this environment)
- [x] `cargo test -p openasr-core ctc_greedy_decode` (all 14 unit tests green, including blank-collapse and incremental-vs-batch parity tests)

## Manual smoke checks

Synthetic microbenchmark (throwaway `#[ignore]` test, removed before commit,
not part of this diff): 3000 synthetic frames at 90% blank -- matching typical
CTC output -- decoded 3x per config in a `--release` build, median reported.
Measured by toggling the change out (temporarily reverting to the
unconditional `token_softmax_probability` call) and back in, same binary,
same machine (Apple M1):

| vocab (family)              | before  | after   | speedup |
|------------------------------|---------|---------|---------|
| 1025 (parakeet-ctc-0.6b)      | 15.9 ms | 4.7 ms  | ~3.4x   |
| 25055 (sensevoice)            | 1038 ms | 206 ms  | ~5.0x   |

The speedup scales with vocab size because `token_softmax_probability` is two
full-vocab passes with `exp()` per element, versus the single-pass `argmax`
scan that still runs on every frame regardless.

No `.oasr` packs are available in this dev environment (no silent downloads),
so this is a targeted microbenchmark isolating exactly the changed code path
rather than a full end-to-end audio timing; the golden-diff byte-identity
check above is what actually proves the decode output does not change.

## Docs updated

- [x] No behavior or user-facing limitation changed; no docs update needed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch the CTC prefix-beam (hotword) decode path -- unaffected.
- Does not change token span probabilities for non-blank tokens.
- No attempt at a full end-to-end audio-file timing harness; see microbenchmark
  caveat above.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI coding agent drafted the change and this PR under human direction; logic and evidence were independently reviewed before submission.
