### PR TITLE
feat(server): persist self-signed TLS identity across daemon restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "time",
  "tokio",
  "tokio-rustls",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,11 @@ getrandom = "0.3"
 sha2 = "0.10"
 tempfile = "3.10"
 thiserror = "2.0"
+# rcgen's `CertificateParams::not_before`/`not_after` are `time::OffsetDateTime`;
+# depended on directly (not just transitively via rcgen) to set an explicit,
+# bounded validity window on generated self-signed TLS identities (see
+# `openasr-server`'s `generate_self_signed_tls_material`).
+time = "0.3"
 tokio = { version = "1.37", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-stream = "0.1"
 tokio-rustls = "0.26"

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -523,6 +523,12 @@ pub(super) async fn serve(
     launch_options.auth = launch_options
         .auth
         .with_pairing_store(home.join("pairing-registry.json"));
+    // Persist the self-signed TLS private key + certificate under OPENASR_HOME,
+    // alongside pairing-registry.json, so a --tls-self-signed daemon keeps the
+    // same certificate fingerprint (and therefore the same pairing safety code
+    // and every already-paired client's TOFU pin) across the restarts the
+    // desktop performs on every model switch. No-op when TLS is disabled.
+    launch_options.tls_identity_store = Some(home.join("tls-identity.json"));
     // `idle_unload` lives on `Preferences`, not the plain `OpenAsrConfig`
     // already loaded above -- read the full config document for it. A
     // missing/unreadable document (fresh install) falls back to the default

--- a/crates/openasr-core/src/atomic_file.rs
+++ b/crates/openasr-core/src/atomic_file.rs
@@ -17,7 +17,16 @@ pub(crate) fn write_file_atomically(path: &Path, contents: &[u8]) -> io::Result<
     )
 }
 
-pub(crate) fn write_owner_only_file_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
+/// Atomically writes `contents` to `path`, creating the temporary file with
+/// owner-only (0600) permissions from the moment it is created (not
+/// after-the-fact via a post-rename `chmod`), then re-asserting 0600 on the
+/// renamed target as a defense-in-depth belt-and-suspenders step. Callers
+/// with secret-bearing files (API key hashes, voiceprint enrollments, TLS
+/// private keys) use this instead of [`write_file_atomically`] so there is
+/// never a window where the file is readable by group/other, regardless of
+/// umask. Exposed crate-externally (via the crate-root re-export) for
+/// `openasr-server`'s TLS identity store, which holds a raw private key.
+pub fn write_owner_only_file_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
     write_owner_only_file_atomically_with(&RealAtomicFileSystem, path, contents)
 }
 
@@ -104,6 +113,14 @@ impl AtomicFileSystem for RealAtomicFileSystem {
         options.open(path)
     }
 
+    // TODO(windows): this is a no-op on Windows. An owner-only equivalent
+    // would mean building and applying a DACL (via
+    // Win32_Security_Authorization's SetNamedSecurityInfoW or similar) that
+    // grants access only to the current user's SID -- meaningfully more than
+    // a `windows-sys` feature-flag addition, so it is not done here. Secret
+    // stores written through `write_owner_only_file_atomically` (API keys,
+    // voiceprint enrollments, TLS private keys) rely on the Windows user
+    // profile directory's default ACL for protection on that platform.
     fn set_owner_only_permissions(&self, path: &Path) -> io::Result<()> {
         #[cfg(unix)]
         {
@@ -403,6 +420,33 @@ mod tests {
         assert_eq!(
             fs.state.owner_only_permission_paths.borrow().as_slice(),
             &[fs.temp_path()]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_only_temp_file_is_0600_from_the_moment_it_is_created() {
+        // Regression test for a write-then-chmod window: exercises the real
+        // (non-faked) `RealAtomicFileSystem::create_new` in `OwnerOnly` mode
+        // and stats the temp file immediately -- before any `write_all`,
+        // `rename`, or the later explicit `set_owner_only_permissions` call
+        // that `write_file_atomically_with` performs on the renamed target --
+        // to pin down that the file is 0600 from creation, not merely 0600 in
+        // steady state. A temp file created with a permissive default mode
+        // (0666 & ~umask, commonly 0644) and only tightened to 0600 after
+        // rename would leave a group/other-readable window during which a
+        // local user could read a raw private key off disk.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let temp_path = dir.path().join(".probe.tmp");
+        let file = RealAtomicFileSystem
+            .create_new(&temp_path, AtomicFileMode::OwnerOnly)
+            .unwrap();
+        let mode = file.metadata().unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "temp file must be 0600 the instant create_new returns, before any later chmod"
         );
     }
 }

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -66,6 +66,7 @@ pub use api::native::{
     NativeAsrRuntimeReadiness, NativeAsrSession, NativeAsrSessionContext,
     NativeAsrStreamingSessionConfig, NativeAsrTensorLayoutRef, load_native_wav_16khz_mono_f32_v0,
 };
+pub use atomic_file::write_owner_only_file_atomically;
 pub use audio::{
     AudioInputError, AudioInputInfo, AudioInputIssue, AudioPreparationError,
     AudioPreparationOptions, PreparedAudioInput, prepare_audio_input, probe_audio_input,

--- a/crates/openasr-server/Cargo.toml
+++ b/crates/openasr-server/Cargo.toml
@@ -32,6 +32,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
+time.workspace = true
 tokio.workspace = true
 tokio-rustls.workspace = true
 tokio-stream.workspace = true

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -62,10 +62,11 @@ use openasr_core::{
     resolve_installed_pack_reference, resolve_installed_pack_reference_with_catalog,
     resolve_launch_pack, runtime_registry, save_default_model_selection,
 };
-use rcgen::generate_simple_self_signed;
+use rcgen::{Certificate, CertificateParams};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::{Semaphore, watch},
@@ -290,7 +291,10 @@ pub async fn serve_with_launch_options(
         }
         ServerTlsConfig::SelfSigned { subject_alt_names } => {
             stage_started = Instant::now();
-            let identity = self_signed_tls_identity(subject_alt_names)?;
+            let identity = load_or_generate_self_signed_tls_identity(
+                subject_alt_names,
+                launch_options.tls_identity_store.as_deref(),
+            )?;
             openasr_core::stage_timing::log_stage(
                 "server_boot",
                 "tls_self_signed_identity",
@@ -328,6 +332,18 @@ pub async fn serve_with_launch_options(
     Ok(())
 }
 
+/// Validity window for a freshly generated self-signed TLS identity: long
+/// enough that "expired, regenerate" is a rare, load-bearing rotation rather
+/// than something routine daemon restarts would ever hit, short enough to
+/// still be a believable server certificate lifetime (this mirrors the
+/// ~397-day cap modern browsers/CAs enforce for publicly-trusted TLS server
+/// certs -- nothing here is publicly trusted, but there is no reason to mint
+/// something longer-lived).
+const TLS_IDENTITY_VALIDITY_DAYS: i64 = 397;
+/// Backdate `not_before` by this much so a client whose clock runs slightly
+/// behind the server's still sees an already-valid certificate.
+const TLS_IDENTITY_CLOCK_SKEW_BACKDATE_HOURS: i64 = 24;
+
 #[derive(Clone)]
 struct TlsIdentity {
     acceptor: TlsAcceptor,
@@ -337,12 +353,67 @@ struct TlsIdentity {
     certificate_der: CertificateDer<'static>,
 }
 
+/// On-disk shape of a persisted self-signed TLS identity: the private key +
+/// certificate DER, plus the metadata needed to decide whether it is still
+/// usable without re-parsing X.509 fields. Stored as plain JSON like
+/// `pairing-registry.json`; the private key field is the sensitive one,
+/// which is why `persist_tls_identity` writes the file with owner-only
+/// (0600) permissions, matching the pairing store and API key store's
+/// convention for secret-bearing files under OPENASR_HOME.
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedTlsIdentity {
+    subject_alt_names: Vec<String>,
+    certificate_der: Vec<u8>,
+    private_key_der: Vec<u8>,
+    not_before_unix_secs: u64,
+    not_after_unix_secs: u64,
+}
+
+/// Generates a brand new self-signed identity for `subject_alt_names` with no
+/// persistence -- every call mints a fresh keypair+certificate. Used directly
+/// by tests that want an ephemeral identity, and as the fallback inside
+/// `load_or_generate_self_signed_tls_identity` when no store path is given.
 fn self_signed_tls_identity(subject_alt_names: &[String]) -> anyhow::Result<TlsIdentity> {
-    let certified = generate_simple_self_signed(subject_alt_names.to_vec())?;
-    let certificate_der = CertificateDer::from(certified.serialize_der()?);
-    let private_key_der = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(
-        certified.serialize_private_key_der(),
-    ));
+    let (certificate_der, private_key_der, ..) =
+        generate_self_signed_tls_material(subject_alt_names)?;
+    tls_identity_from_der(certificate_der, private_key_der)
+}
+
+/// Generates a new self-signed keypair + certificate for `subject_alt_names`.
+/// Returns the raw DER encodings (so callers can persist them) alongside the
+/// validity window's Unix-epoch bounds (so callers can record expiry without
+/// re-parsing the certificate's X.509 fields later).
+fn generate_self_signed_tls_material(
+    subject_alt_names: &[String],
+) -> anyhow::Result<(Vec<u8>, Vec<u8>, u64, u64)> {
+    let mut params = CertificateParams::new(subject_alt_names.to_vec());
+    let now = OffsetDateTime::now_utc();
+    let not_before = now - time::Duration::hours(TLS_IDENTITY_CLOCK_SKEW_BACKDATE_HOURS);
+    let not_after = now + time::Duration::days(TLS_IDENTITY_VALIDITY_DAYS);
+    params.not_before = not_before;
+    params.not_after = not_after;
+    let certified = Certificate::from_params(params)?;
+    let certificate_der = certified.serialize_der()?;
+    let private_key_der = certified.serialize_private_key_der();
+    Ok((
+        certificate_der,
+        private_key_der,
+        not_before.unix_timestamp() as u64,
+        not_after.unix_timestamp() as u64,
+    ))
+}
+
+/// Builds a `TlsIdentity` (fingerprint, pairing safety code, rustls acceptor)
+/// from raw DER bytes, whether they were just generated or loaded back from
+/// `persist_tls_identity`'s store file. The single place that turns key
+/// material into a live rustls `ServerConfig`, so a persisted identity and a
+/// freshly generated one are wired up identically.
+fn tls_identity_from_der(
+    certificate_der: Vec<u8>,
+    private_key_der: Vec<u8>,
+) -> anyhow::Result<TlsIdentity> {
+    let certificate_der = CertificateDer::from(certificate_der);
+    let private_key_der = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(private_key_der));
     let certificate_sha256 = certificate_fingerprint_sha256(certificate_der.as_ref());
     let config = rustls::ServerConfig::builder_with_provider(
         rustls::crypto::ring::default_provider().into(),
@@ -357,6 +428,157 @@ fn self_signed_tls_identity(subject_alt_names: &[String]) -> anyhow::Result<TlsI
         #[cfg(test)]
         certificate_der,
     })
+}
+
+/// Loads a persisted self-signed TLS identity from `store_path` (if given)
+/// and reuses it when it is readable, was issued for the same
+/// `subject_alt_names`, and has not expired -- otherwise generates a fresh
+/// identity and persists it to `store_path` for next time. `store_path: None`
+/// keeps the previous always-generate-in-memory behavior (used by tests and
+/// any caller with no durable home to persist under).
+///
+/// This is what keeps a paired remote client's TOFU-pinned certificate
+/// fingerprint (and the human-readable pairing safety code derived from it,
+/// see `pairing_safety_code_for_certificate_fingerprint`) stable across the
+/// daemon restarts the desktop app performs on every model switch: before
+/// this, `serve_with_launch_options` minted a brand new keypair+certificate
+/// on *every* start, so every restart rotated the identity out from under
+/// already-paired clients and forced them to re-pair.
+///
+/// Fail-closed on a damaged store: a present-but-corrupt or
+/// permission-denied file is never silently treated as "no identity yet" --
+/// only a genuinely missing file is. Any other read/parse error falls
+/// through to generating (and re-persisting) a fresh identity, logging why,
+/// rather than risk serving with a partially-loaded or tampered keypair. A
+/// missing file, or an expired/SAN-mismatched identity, are ordinary
+/// rotation and are not logged as errors.
+fn load_or_generate_self_signed_tls_identity(
+    subject_alt_names: &[String],
+    store_path: Option<&Path>,
+) -> anyhow::Result<TlsIdentity> {
+    let Some(store_path) = store_path else {
+        return self_signed_tls_identity(subject_alt_names);
+    };
+    match load_persisted_tls_identity(store_path, subject_alt_names) {
+        Ok(Some((certificate_der, private_key_der))) => {
+            return tls_identity_from_der(certificate_der, private_key_der);
+        }
+        Ok(None) => {
+            // Missing, expired, or issued for different subject alt names:
+            // ordinary rotation, already logged (if interesting) by
+            // load_persisted_tls_identity. Fall through to regenerate.
+        }
+        Err(error) => {
+            eprintln!(
+                "openasr-server: could not load persisted TLS identity from {} ({error}); regenerating a new identity (paired remote clients will need to re-confirm the new fingerprint)",
+                store_path.display()
+            );
+        }
+    }
+    let (certificate_der, private_key_der, not_before_unix_secs, not_after_unix_secs) =
+        generate_self_signed_tls_material(subject_alt_names)?;
+    persist_tls_identity(
+        store_path,
+        subject_alt_names,
+        &certificate_der,
+        &private_key_der,
+        not_before_unix_secs,
+        not_after_unix_secs,
+    );
+    tls_identity_from_der(certificate_der, private_key_der)
+}
+
+/// Returns `Ok(Some(..))` when `store_path` holds a still-usable identity for
+/// `subject_alt_names`, `Ok(None)` when it is absent/expired/for different
+/// names (normal, not-logged-as-error rotation), and `Err` when the file is
+/// present but unreadable as a well-formed identity (corrupt JSON, empty key
+/// material) -- the caller treats `Err` as a louder "this should not happen"
+/// event distinct from routine rotation.
+fn load_persisted_tls_identity(
+    store_path: &Path,
+    subject_alt_names: &[String],
+) -> anyhow::Result<Option<(Vec<u8>, Vec<u8>)>> {
+    let bytes = match fs::read(store_path) {
+        Ok(bytes) => bytes,
+        // Absent file = legitimately no persisted identity yet (fresh
+        // install, or first ever --tls-self-signed run).
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        // Anything else (permission denied, I/O error) is NOT "no identity":
+        // returning Err keeps the caller from treating a locked-out file as
+        // license to silently mint (and overwrite) a new one without saying
+        // why.
+        Err(error) => return Err(error.into()),
+    };
+    let persisted: PersistedTlsIdentity = serde_json::from_slice(&bytes)?;
+    if persisted.certificate_der.is_empty() || persisted.private_key_der.is_empty() {
+        anyhow::bail!("persisted TLS identity has empty certificate or private key material");
+    }
+    if persisted.subject_alt_names != subject_alt_names {
+        eprintln!(
+            "openasr-server: persisted TLS identity at {} was issued for different subject alt names ({:?}, now requesting {:?}); rotating",
+            store_path.display(),
+            persisted.subject_alt_names,
+            subject_alt_names
+        );
+        return Ok(None);
+    }
+    if unix_now_secs() >= persisted.not_after_unix_secs {
+        eprintln!(
+            "openasr-server: persisted TLS identity at {} expired (not_after unix {}); rotating",
+            store_path.display(),
+            persisted.not_after_unix_secs
+        );
+        return Ok(None);
+    }
+    Ok(Some((persisted.certificate_der, persisted.private_key_der)))
+}
+
+/// Persists `certificate_der`/`private_key_der` (plus the metadata needed to
+/// validate reuse later) to `store_path`, atomically and with owner-only
+/// (0600) permissions -- this is the only place a self-signed TLS private key
+/// touches disk. Best-effort: a write failure is logged and otherwise
+/// swallowed (the freshly generated in-memory identity still serves this
+/// boot; it simply will not survive the next restart), matching
+/// `persist_pairing_credentials_locked`'s "never fail serve over a
+/// persistence hiccup" posture.
+fn persist_tls_identity(
+    store_path: &Path,
+    subject_alt_names: &[String],
+    certificate_der: &[u8],
+    private_key_der: &[u8],
+    not_before_unix_secs: u64,
+    not_after_unix_secs: u64,
+) {
+    let persisted = PersistedTlsIdentity {
+        subject_alt_names: subject_alt_names.to_vec(),
+        certificate_der: certificate_der.to_vec(),
+        private_key_der: private_key_der.to_vec(),
+        not_before_unix_secs,
+        not_after_unix_secs,
+    };
+    match serde_json::to_vec_pretty(&persisted) {
+        Ok(bytes) => {
+            if let Err(error) = write_bytes_atomically(store_path, &bytes) {
+                eprintln!(
+                    "openasr-server: could not persist TLS identity to {} (continuing without persistence; this identity will not survive a restart): {error}",
+                    store_path.display()
+                );
+            } else {
+                // Holds a private key: owner-only, like the pairing store and
+                // API key store.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ = fs::set_permissions(store_path, std::fs::Permissions::from_mode(0o600));
+                }
+            }
+        }
+        Err(error) => {
+            eprintln!(
+                "openasr-server: could not serialize TLS identity (continuing without persistence): {error}"
+            );
+        }
+    }
 }
 
 struct TlsListener {
@@ -453,6 +675,15 @@ pub struct ServerLaunchOptions {
     /// (the default, and what `never` resolves to) never spawns the reaper,
     /// matching every existing caller/test that does not set this.
     pub idle_unload_after: Option<Duration>,
+    /// Where to persist (and load back) the self-signed TLS private key +
+    /// certificate across restarts -- see
+    /// `load_or_generate_self_signed_tls_identity`. `None` keeps the
+    /// pre-persistence behavior of generating a brand new identity on every
+    /// `serve_with_launch_options` call; only a caller that sets this (the
+    /// CLI, to `OPENASR_HOME/tls-identity.json`, alongside
+    /// `pairing-registry.json`) gets an identity that survives a restart.
+    /// No-op when `tls` is `ServerTlsConfig::Disabled`.
+    pub tls_identity_store: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -358,8 +358,13 @@ struct TlsIdentity {
 /// usable without re-parsing X.509 fields. Stored as plain JSON like
 /// `pairing-registry.json`; the private key field is the sensitive one,
 /// which is why `persist_tls_identity` writes the file with owner-only
-/// (0600) permissions, matching the pairing store and API key store's
-/// convention for secret-bearing files under OPENASR_HOME.
+/// (0600) permissions from the moment it is created -- on unix, via
+/// `openasr_core::write_owner_only_file_atomically`, there is no
+/// group/other-readable window at any point, matching the pairing store and
+/// API key store's convention for secret-bearing files under OPENASR_HOME.
+/// Windows has no equivalent owner-only chmod here; the file relies on the
+/// user profile directory's default ACL (see `write_owner_only_file_atomically`'s
+/// unix-only permission step) -- tracked as a gap, not fixed by this PR.
 #[derive(Debug, Serialize, Deserialize)]
 struct PersistedTlsIdentity {
     subject_alt_names: Vec<String>,
@@ -447,10 +452,13 @@ fn tls_identity_from_der(
 ///
 /// Fail-closed on a damaged store: a present-but-corrupt or
 /// permission-denied file is never silently treated as "no identity yet" --
-/// only a genuinely missing file is. Any other read/parse error falls
+/// only a genuinely missing file is. Any other read/parse error, *and* a
+/// present-and-well-formed-JSON-but-unusable DER payload (truncated/bit-flipped
+/// key or certificate bytes that parse as JSON but fail to build into a
+/// rustls `ServerConfig` -- see the `tls_identity_from_der` call below), falls
 /// through to generating (and re-persisting) a fresh identity, logging why,
-/// rather than risk serving with a partially-loaded or tampered keypair. A
-/// missing file, or an expired/SAN-mismatched identity, are ordinary
+/// rather than risking a hard startup failure over a damaged on-disk keypair.
+/// A missing file, or an expired/SAN-mismatched identity, are ordinary
 /// rotation and are not logged as errors.
 fn load_or_generate_self_signed_tls_identity(
     subject_alt_names: &[String],
@@ -459,9 +467,25 @@ fn load_or_generate_self_signed_tls_identity(
     let Some(store_path) = store_path else {
         return self_signed_tls_identity(subject_alt_names);
     };
+    harden_tls_identity_store_dir_permissions(store_path);
     match load_persisted_tls_identity(store_path, subject_alt_names) {
         Ok(Some((certificate_der, private_key_der))) => {
-            return tls_identity_from_der(certificate_der, private_key_der);
+            match tls_identity_from_der(certificate_der, private_key_der) {
+                Ok(identity) => return Ok(identity),
+                Err(error) => {
+                    // Legitimate JSON envelope, but the DER payload inside it
+                    // does not parse/build into a usable rustls keypair
+                    // (truncated write, bit flip, hand-edited file). Treat
+                    // exactly like corrupt JSON: log and regenerate below,
+                    // rather than let the `?`-propagated error here fail
+                    // serve's startup outright and require manual deletion of
+                    // the store file to recover.
+                    eprintln!(
+                        "openasr-server: persisted TLS identity at {} did not load as a valid keypair/certificate ({error}); treating as corrupt and regenerating (paired remote clients will need to re-confirm the new fingerprint)",
+                        store_path.display()
+                    );
+                }
+            }
         }
         Ok(None) => {
             // Missing, expired, or issued for different subject alt names:
@@ -486,6 +510,40 @@ fn load_or_generate_self_signed_tls_identity(
         not_after_unix_secs,
     );
     tls_identity_from_der(certificate_der, private_key_der)
+}
+
+/// Best-effort owner-only (0700) hardening of the directory that will hold
+/// `store_path` (in practice `OPENASR_HOME`), applied unconditionally on
+/// every load/generate call -- not just the first time the directory is
+/// created -- so a directory that predates this PR (or was widened by some
+/// other tool) gets tightened back up on the next daemon start rather than
+/// staying at whatever mode `create_dir_all` + the process umask produced.
+/// Creates the directory if it does not exist yet (the TLS identity store,
+/// unlike the pairing/API-key stores, has no other writer upstream in the
+/// boot sequence that is guaranteed to have created `OPENASR_HOME` first).
+/// Never fails serve over this: a create or chmod failure is logged and
+/// swallowed, matching every other persistence step in this module.
+fn harden_tls_identity_store_dir_permissions(store_path: &Path) {
+    let Some(parent) = store_path.parent() else {
+        return;
+    };
+    if let Err(error) = fs::create_dir_all(parent) {
+        eprintln!(
+            "openasr-server: could not create {} to hold the TLS identity store ({error}); continuing (persistence may fail)",
+            parent.display()
+        );
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(error) = fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)) {
+            eprintln!(
+                "openasr-server: could not tighten {} to owner-only (0700) permissions ({error}); continuing",
+                parent.display()
+            );
+        }
+    }
 }
 
 /// Returns `Ok(Some(..))` when `store_path` holds a still-usable identity for
@@ -535,10 +593,15 @@ fn load_persisted_tls_identity(
 
 /// Persists `certificate_der`/`private_key_der` (plus the metadata needed to
 /// validate reuse later) to `store_path`, atomically and with owner-only
-/// (0600) permissions -- this is the only place a self-signed TLS private key
-/// touches disk. Best-effort: a write failure is logged and otherwise
-/// swallowed (the freshly generated in-memory identity still serves this
-/// boot; it simply will not survive the next restart), matching
+/// (0600) permissions applied from the moment the temporary file is
+/// created (on unix; see `openasr_core::write_owner_only_file_atomically`) --
+/// this is the only place a self-signed TLS private key touches disk. Unlike
+/// a plain atomic write followed by a post-rename `chmod`, there is no
+/// window where the renamed file (or its temp-file predecessor) is
+/// group/other readable: the raw PKCS8 key never sits on disk at a
+/// permissive mode, even transiently. Best-effort: a write failure is logged
+/// and otherwise swallowed (the freshly generated in-memory identity still
+/// serves this boot; it simply will not survive the next restart), matching
 /// `persist_pairing_credentials_locked`'s "never fail serve over a
 /// persistence hiccup" posture.
 fn persist_tls_identity(
@@ -558,19 +621,11 @@ fn persist_tls_identity(
     };
     match serde_json::to_vec_pretty(&persisted) {
         Ok(bytes) => {
-            if let Err(error) = write_bytes_atomically(store_path, &bytes) {
+            if let Err(error) = openasr_core::write_owner_only_file_atomically(store_path, &bytes) {
                 eprintln!(
                     "openasr-server: could not persist TLS identity to {} (continuing without persistence; this identity will not survive a restart): {error}",
                     store_path.display()
                 );
-            } else {
-                // Holds a private key: owner-only, like the pairing store and
-                // API key store.
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let _ = fs::set_permissions(store_path, std::fs::Permissions::from_mode(0o600));
-                }
             }
         }
         Err(error) => {
@@ -619,6 +674,22 @@ impl Listener for TlsListener {
     }
 }
 
+/// Generates a brand-new, wholly ephemeral self-signed identity for
+/// `subject_alt_names` and returns its certificate fingerprint. **Not** a
+/// preview of, or in any way tied to, the identity a real
+/// `--tls-self-signed` daemon actually serves: it calls
+/// `self_signed_tls_identity` directly (bypassing
+/// `load_or_generate_self_signed_tls_identity` and any `tls_identity_store`),
+/// so every call mints a fresh keypair+certificate with its own fingerprint,
+/// independent of whatever a running daemon has persisted to
+/// `OPENASR_HOME/tls-identity.json`. Do not use this to predict or display
+/// "the" server fingerprint for a paired/persisted identity -- read that from
+/// a live server's `/health` or pairing response instead. Kept as-is
+/// (unchanged by the TLS-identity-persistence work) because nothing in this
+/// codebase currently calls it for that purpose; if a future caller wants a
+/// persistence-aware preview, it should call
+/// `load_or_generate_self_signed_tls_identity` (or a thin wrapper around it)
+/// instead of this function.
 pub fn server_certificate_fingerprint_for_subject_alt_names(
     subject_alt_names: impl IntoIterator<Item = impl Into<String>>,
 ) -> anyhow::Result<String> {

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -732,6 +732,207 @@ fn load_or_generate_self_signed_tls_identity_regenerates_on_expired_certificate(
     assert!(persisted.not_after_unix_secs > unix_now_secs());
 }
 
+#[cfg(unix)]
+#[test]
+fn load_or_generate_self_signed_tls_identity_hardens_openasr_home_to_0700() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("openasr-home");
+    // Simulate an OPENASR_HOME that predates this PR (or was widened by some
+    // other tool/umask): world-traversable 0755, the `create_dir_all`
+    // default under a typical 022 umask.
+    fs::create_dir_all(&home).unwrap();
+    fs::set_permissions(&home, fs::Permissions::from_mode(0o755)).unwrap();
+    let store_path = home.join("tls-identity.json");
+    let sans = vec!["localhost".to_string()];
+
+    load_or_generate_self_signed_tls_identity(&sans, Some(&store_path)).unwrap();
+
+    let mode = fs::metadata(&home).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o700,
+        "OPENASR_HOME must be tightened to owner-only even when it already existed wider"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn load_or_generate_self_signed_tls_identity_creates_and_hardens_missing_openasr_home() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    // Deliberately does not exist yet -- the TLS identity store has no other
+    // writer upstream (unlike apikeys.json/pairing-registry.json) guaranteed
+    // to have created OPENASR_HOME first.
+    let home = temp.path().join("openasr-home");
+    let store_path = home.join("tls-identity.json");
+    let sans = vec!["localhost".to_string()];
+    assert!(!home.exists());
+
+    load_or_generate_self_signed_tls_identity(&sans, Some(&store_path)).unwrap();
+
+    let mode = fs::metadata(&home).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o700);
+}
+
+#[test]
+fn load_or_generate_self_signed_tls_identity_regenerates_on_corrupt_der_inside_valid_json() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("tls-identity.json");
+    let sans = vec!["localhost".to_string()];
+
+    // The JSON envelope itself is well-formed (unlike
+    // `..._regenerates_on_corrupt_store`, which corrupts the JSON layer) --
+    // only the DER payloads inside it are garbage, simulating a truncated
+    // write or a bit-flipped disk that still leaves valid-looking JSON
+    // structure. `load_persisted_tls_identity` only checks the DER fields are
+    // non-empty, so this reaches `tls_identity_from_der` and must be handled
+    // there (this is the regression test for S1: before the fix, the `?`
+    // inside `tls_identity_from_der`'s rustls `with_single_cert` call
+    // propagated straight out of `load_or_generate_self_signed_tls_identity`,
+    // failing serve's startup instead of rotating).
+    let corrupt = PersistedTlsIdentity {
+        subject_alt_names: sans.clone(),
+        certificate_der: vec![1, 2, 3, 4, 5, 6, 7, 8],
+        private_key_der: vec![8, 7, 6, 5, 4, 3, 2, 1],
+        not_before_unix_secs: unix_now_secs().saturating_sub(3600),
+        not_after_unix_secs: unix_now_secs() + 3600,
+    };
+    fs::write(&store_path, serde_json::to_vec_pretty(&corrupt).unwrap()).unwrap();
+
+    let identity = load_or_generate_self_signed_tls_identity(&sans, Some(&store_path))
+        .expect("a DER-corrupt-but-JSON-valid store must regenerate, not fail startup");
+
+    assert_eq!(identity.certificate_sha256.len(), 64);
+    // The corrupt DER must have been overwritten with a freshly generated,
+    // internally-consistent identity, not left in place for the next boot to
+    // trip over again.
+    let persisted: PersistedTlsIdentity =
+        serde_json::from_slice(&fs::read(&store_path).unwrap()).unwrap();
+    assert_eq!(
+        certificate_fingerprint_sha256(&persisted.certificate_der),
+        identity.certificate_sha256
+    );
+    // The regenerated identity must actually build into a usable rustls
+    // config, i.e. round-trips through `tls_identity_from_der` cleanly.
+    tls_identity_from_der(persisted.certificate_der, persisted.private_key_der)
+        .expect("regenerated identity must itself load back as a valid keypair/certificate");
+}
+
+#[test]
+fn load_or_generate_self_signed_tls_identity_regenerates_on_key_cert_mismatch() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("tls-identity.json");
+    let sans = vec!["localhost".to_string()];
+
+    // Each half is individually well-formed DER, but the private key does
+    // not correspond to the certificate's public key -- rustls's
+    // `with_single_cert` documents that it fails in exactly this case ("if
+    // the SubjectPublicKeyInfo from the private key does not match the
+    // public key for the end-entity certificate"). Simulates one field of a
+    // persisted identity being replaced/corrupted independently of the
+    // other.
+    let (certificate_der, _matching_key_der, ..) =
+        generate_self_signed_tls_material(&sans).unwrap();
+    let (_other_certificate_der, mismatched_key_der, ..) =
+        generate_self_signed_tls_material(&sans).unwrap();
+    let mismatched = PersistedTlsIdentity {
+        subject_alt_names: sans.clone(),
+        certificate_der,
+        private_key_der: mismatched_key_der,
+        not_before_unix_secs: unix_now_secs().saturating_sub(3600),
+        not_after_unix_secs: unix_now_secs() + 3600,
+    };
+    fs::write(&store_path, serde_json::to_vec_pretty(&mismatched).unwrap()).unwrap();
+
+    let identity = load_or_generate_self_signed_tls_identity(&sans, Some(&store_path))
+        .expect("a key/cert mismatch must regenerate, not fail startup");
+
+    let persisted: PersistedTlsIdentity =
+        serde_json::from_slice(&fs::read(&store_path).unwrap()).unwrap();
+    assert_eq!(
+        certificate_fingerprint_sha256(&persisted.certificate_der),
+        identity.certificate_sha256
+    );
+    tls_identity_from_der(persisted.certificate_der, persisted.private_key_der)
+        .expect("regenerated identity must have a matching key and certificate");
+}
+
+/// `write_bytes_atomically`'s rename is atomic, but there is no cross-process
+/// file lock around "read store, decide to (re)generate, write store" -- the
+/// TLS identity store has the same gap the review flagged for
+/// `persist_pairing_credentials_locked` (whose `_locked` suffix is an
+/// in-process `Mutex`, not an `flock`). Two daemons racing their first
+/// `--tls-self-signed` start against the same `OPENASR_HOME` can each
+/// generate their own identity and each call `persist_tls_identity`; the
+/// atomic rename means the loser's write is fully overwritten (never a
+/// torn/partial file), but the two in-memory server processes end up serving
+/// *different* certificates for one boot cycle, and only one of the two
+/// generated identities survives on disk.
+///
+/// This is a known, documented gap (see `load_or_generate_self_signed_tls_identity`'s
+/// module-level discussion and the PR description) rather than something this
+/// test suite adds cross-process locking for. What *is* guaranteed, and what
+/// this test pins down, is that the loser's overwrite never corrupts the
+/// store into something unusable: whichever identity's `persist_tls_identity`
+/// call won the race is a complete, well-formed, self-consistent identity,
+/// and the next daemon start (no race this time) loads it back rather than
+/// tripping the corrupt-store regeneration path.
+#[test]
+fn concurrent_first_boot_race_self_heals_to_the_last_writer_on_next_start() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("tls-identity.json");
+    let sans = vec!["localhost".to_string()];
+
+    // Two "processes" independently generate an identity before either has
+    // written anything -- the miss-then-generate race window.
+    let (first_cert, first_key, first_not_before, first_not_after) =
+        generate_self_signed_tls_material(&sans).unwrap();
+    let (second_cert, second_key, second_not_before, second_not_after) =
+        generate_self_signed_tls_material(&sans).unwrap();
+    let first_fingerprint = certificate_fingerprint_sha256(&first_cert);
+    let second_fingerprint = certificate_fingerprint_sha256(&second_cert);
+    assert_ne!(
+        first_fingerprint, second_fingerprint,
+        "two independent generations must not coincidentally collide"
+    );
+
+    // Both persist, "first" then "second" -- last-writer-wins via atomic
+    // rename (see `write_bytes_atomically` / `openasr_core::write_owner_only_file_atomically`).
+    persist_tls_identity(
+        &store_path,
+        &sans,
+        &first_cert,
+        &first_key,
+        first_not_before,
+        first_not_after,
+    );
+    persist_tls_identity(
+        &store_path,
+        &sans,
+        &second_cert,
+        &second_key,
+        second_not_before,
+        second_not_after,
+    );
+
+    // Next daemon start (no concurrent writer this time) must load the
+    // survivor back cleanly -- not trip the corrupt-store/DER-mismatch
+    // regeneration path added for S1, and not silently keep serving the
+    // loser's in-memory identity forever.
+    let loaded = load_or_generate_self_signed_tls_identity(&sans, Some(&store_path)).unwrap();
+    assert_eq!(loaded.certificate_sha256, second_fingerprint);
+    assert_ne!(loaded.certificate_sha256, first_fingerprint);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(&store_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}
+
 #[tokio::test]
 async fn loopback_tls_pairing_device_transcription_skips_server_history() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -630,6 +630,108 @@ fn self_signed_tls_defaults_to_localhost_and_reports_certificate_fingerprint() {
     assert_eq!(identity.pairing_safety_code.len(), "ABCD-1234".len());
 }
 
+#[test]
+fn load_or_generate_self_signed_tls_identity_loads_persisted_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("tls-identity.json");
+    let sans = vec!["127.0.0.1".to_string()];
+
+    let first = load_or_generate_self_signed_tls_identity(&sans, Some(&store_path)).unwrap();
+    // A second call against the same store must load the persisted keypair +
+    // certificate back rather than minting a new one -- this is the crux of
+    // "restart does not rotate the pairing fingerprint".
+    let second = load_or_generate_self_signed_tls_identity(&sans, Some(&store_path)).unwrap();
+
+    assert_eq!(first.certificate_sha256, second.certificate_sha256);
+    assert_eq!(first.certificate_der, second.certificate_der);
+    assert_eq!(first.pairing_safety_code, second.pairing_safety_code);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(&store_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "persisted TLS identity file must be owner-only"
+        );
+    }
+}
+
+#[test]
+fn load_or_generate_self_signed_tls_identity_generates_and_persists_when_store_missing() {
+    let temp = tempfile::tempdir().unwrap();
+    // Deliberately does not exist yet -- a fresh install / first ever
+    // --tls-self-signed run.
+    let store_path = temp.path().join("tls-identity.json");
+    let sans = vec!["localhost".to_string()];
+    assert!(!store_path.exists());
+
+    let identity = load_or_generate_self_signed_tls_identity(&sans, Some(&store_path)).unwrap();
+
+    assert!(store_path.exists());
+    let persisted: PersistedTlsIdentity =
+        serde_json::from_slice(&fs::read(&store_path).unwrap()).unwrap();
+    assert_eq!(persisted.subject_alt_names, sans);
+    assert_eq!(
+        certificate_fingerprint_sha256(&persisted.certificate_der),
+        identity.certificate_sha256
+    );
+    assert!(persisted.not_after_unix_secs > unix_now_secs());
+}
+
+#[test]
+fn load_or_generate_self_signed_tls_identity_regenerates_on_corrupt_store() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("tls-identity.json");
+    // Present but not valid JSON at all -- simulates disk corruption /
+    // truncation, distinct from "file does not exist".
+    fs::write(&store_path, b"not valid json { at all").unwrap();
+    let sans = vec!["localhost".to_string()];
+
+    // Must fail closed by regenerating rather than propagating the parse
+    // error or, worse, serving with unusable key material.
+    let identity = load_or_generate_self_signed_tls_identity(&sans, Some(&store_path)).unwrap();
+
+    assert_eq!(identity.certificate_sha256.len(), 64);
+    // The corrupt file must have been overwritten with a freshly generated,
+    // well-formed identity -- not left corrupt for the next boot to trip over
+    // again.
+    let persisted: PersistedTlsIdentity =
+        serde_json::from_slice(&fs::read(&store_path).unwrap()).unwrap();
+    assert_eq!(
+        certificate_fingerprint_sha256(&persisted.certificate_der),
+        identity.certificate_sha256
+    );
+}
+
+#[test]
+fn load_or_generate_self_signed_tls_identity_regenerates_on_expired_certificate() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("tls-identity.json");
+    let sans = vec!["localhost".to_string()];
+
+    let (certificate_der, private_key_der, ..) = generate_self_signed_tls_material(&sans).unwrap();
+    let expired_fingerprint = certificate_fingerprint_sha256(&certificate_der);
+    let expired = PersistedTlsIdentity {
+        subject_alt_names: sans.clone(),
+        certificate_der,
+        private_key_der,
+        // Both bounds safely in the past: an already-expired identity, not
+        // merely "expiring soon".
+        not_before_unix_secs: unix_now_secs().saturating_sub(3600),
+        not_after_unix_secs: unix_now_secs().saturating_sub(60),
+    };
+    fs::write(&store_path, serde_json::to_vec_pretty(&expired).unwrap()).unwrap();
+
+    let identity = load_or_generate_self_signed_tls_identity(&sans, Some(&store_path)).unwrap();
+
+    // A genuinely new identity was minted, not the expired one reused.
+    assert_ne!(identity.certificate_sha256, expired_fingerprint);
+    let persisted: PersistedTlsIdentity =
+        serde_json::from_slice(&fs::read(&store_path).unwrap()).unwrap();
+    assert!(persisted.not_after_unix_secs > unix_now_secs());
+}
+
 #[tokio::test]
 async fn loopback_tls_pairing_device_transcription_skips_server_history() {
     let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

`serve_with_launch_options` minted a brand new self-signed keypair + certificate
on every start. This PR persists the identity to `OPENASR_HOME/tls-identity.json`
(alongside `pairing-registry.json`) and loads it back on the next start instead
of always regenerating.

## Why

The certificate fingerprint is what everything else hangs off of: the pairing
safety code shown during device pairing is derived from it
(`pairing_safety_code_for_certificate_fingerprint`), and paired remote clients
pin it via TOFU (`openasr-client`'s `TofuServerVerifier`). Because
`self_signed_tls_identity` regenerated the keypair on every `serve` call, every
daemon restart -- including the ones the desktop app performs on every model
switch -- rotated the fingerprint out from under already-paired clients,
forcing them to notice a "TLS fingerprint changed" rejection and re-pair. It
also paid a fresh RSA/EC keygen + self-sign on every boot for no reason.

Confirmed by tracing the fingerprint derivation chain
(`certificate_fingerprint_sha256` -> `pairing_safety_code_for_certificate_fingerprint`
-> `TofuServerVerifier::verify_server_cert`) and, empirically, by starting
`serve --tls-self-signed` twice against the same `OPENASR_HOME` before this
change: two different `certificate sha256:` values and pairing codes printed
on stdout each time.

## Changes

- `crates/openasr-server/src/lib.rs`:
  - `generate_self_signed_tls_material` now sets an explicit ~397-day validity
    window (previously effectively unbounded, "expired" was unreachable) and
    returns the Unix-epoch validity bounds alongside the DER bytes.
  - New `load_or_generate_self_signed_tls_identity(subject_alt_names, store_path)`:
    loads a persisted identity when it is readable, matches the requested SANs,
    and has not expired; otherwise generates a fresh one and persists it.
    `store_path: None` keeps the old always-regenerate behavior (used by
    existing tests/callers that pass no path).
  - `load_persisted_tls_identity` fails closed: a genuinely missing file is
    `Ok(None)` (ordinary "nothing persisted yet"); a present-but-corrupt or
    permission-denied file is `Err`, which the caller logs loudly and treats as
    "regenerate", never as license to silently keep going with unreadable key
    material. An expired identity or one issued for different subject alt
    names is `Ok(None)` too (ordinary rotation, not an error).
  - `persist_tls_identity` writes the private key + certificate atomically with
    owner-only (0600) permissions from the moment the temp file is created (see
    Review fixes / B1 below).
  - `ServerLaunchOptions` gains `tls_identity_store: Option<PathBuf>` (mirrors
    `ServerAuth::with_pairing_store`); a no-op when TLS is disabled.
- `crates/openasr-cli/src/native_segment_cli.rs`: `serve` now sets
  `launch_options.tls_identity_store = Some(home.join("tls-identity.json"))`,
  right next to the existing `pairing-registry.json` wiring.
- `Cargo.toml` / `crates/openasr-server/Cargo.toml`: added a direct `time`
  dependency (already pulled in transitively by `rcgen`) to set the explicit
  validity window on `CertificateParams`.

## Review fixes

This PR went through an adversarial review pass (1 blocker, 3 should-fix) before
merge. All four are addressed in this revision:

- **B1 (blocker) -- write-then-chmod window on the raw private key.**
  `persist_tls_identity` previously wrote the file via a generic atomic-write
  helper (temp file created with the process's default mode, commonly 0644
  under umask 022) and only `chmod`'d it to 0600 *after* the rename -- a real
  window where a local group/other user could read the raw PKCS8 key off disk.
  Fixed by reusing `openasr-core`'s existing `write_owner_only_file_atomically`
  (already used for the API key store and voiceprint enrollments), which
  creates the temp file with `OpenOptions::mode(0o600)` from the very first
  `open()` call -- there is no readable-window state at any point, on the temp
  file or the renamed target. Exposed it from `openasr-core`'s crate-root
  re-exports (`pub use atomic_file::write_owner_only_file_atomically;`) so
  `openasr-server` can call it without duplicating the atomic-write-with-mode
  logic. `write_bytes_atomically` (still used for pull-job snapshots, which are
  not secrets) is untouched.

  Also hardens `OPENASR_HOME` itself: `load_or_generate_self_signed_tls_identity`
  now calls a new `harden_tls_identity_store_dir_permissions` that
  `create_dir_all`s the TLS store's parent directory and `chmod`s it to 0700 on
  every load/generate call -- not just on first creation -- so a directory that
  predates this PR (or was widened by some other tool/umask) gets tightened on
  the next daemon start. Best-effort: a create/chmod failure is logged and
  swallowed, never fails serve.

  Corrected the doc comment on `PersistedTlsIdentity` (previously overstated
  "written with owner-only (0600) permissions" without mentioning the window)
  to describe the actual create-time guarantee and its Windows scope.

- **S1 (should-fix) -- DER-layer corruption failed serve's startup instead of
  regenerating.** `load_persisted_tls_identity` only validated that the JSON
  envelope parsed and the DER fields were non-empty; a legally-JSON file with
  truncated/bit-flipped DER bytes passed that check, then failed inside
  `tls_identity_from_der`'s `rustls::ServerConfig::with_single_cert` call --
  and that `Err` propagated straight out of
  `load_or_generate_self_signed_tls_identity`, hard-failing daemon startup
  (worse than the intended "corrupt -> rotate" contract; needed manual file
  deletion to recover). Fixed: the loaded-identity branch now matches on
  `tls_identity_from_der`'s result; on `Err` it logs and falls through to the
  same generate-and-persist path used for corrupt JSON / expired / SAN-mismatch,
  so every "damaged store" shape ends up regenerating rather than only the
  JSON-parse-error shape.

- **S2 (test gap) -- DER corruption / key-cert mismatch / concurrent first-boot
  race were untested.** Added:
  - `load_or_generate_self_signed_tls_identity_regenerates_on_corrupt_der_inside_valid_json`
    -- pins down the S1 fix (well-formed JSON, garbage DER bytes).
  - `load_or_generate_self_signed_tls_identity_regenerates_on_key_cert_mismatch`
    -- constructs a persisted identity whose certificate and private key come
    from two different generated keypairs (rustls's `with_single_cert`
    documents that it fails when the key's public key does not match the
    cert's); confirms this also regenerates rather than hard-failing.
  - `concurrent_first_boot_race_self_heals_to_the_last_writer_on_next_start`
    -- there is no cross-process file lock around read-decide-write (same
    known gap as `persist_pairing_credentials_locked`'s in-process-only
    `Mutex`); this PR does not add one. The test instead pins down what *is*
    guaranteed: simulating two racing first-boot generations both calling
    `persist_tls_identity` against the same store, the atomic rename means
    last-writer-wins cleanly (never a torn file), and the *next* daemon start
    (no race) loads the survivor back rather than tripping the corrupt-store
    regeneration path. Documented as a known, not-fixed-here gap in the
    function's doc comment and in Scope/non-goals below.
  - Two directory-hardening tests
    (`..._hardens_openasr_home_to_0700`, `..._creates_and_hardens_missing_openasr_home`)
    for the B1 `OPENASR_HOME` tightening.
  - A real-filesystem regression test in `openasr-core`'s `atomic_file.rs`
    (`owner_only_temp_file_is_0600_from_the_moment_it_is_created`) that calls
    the real (non-faked) `create_new` in owner-only mode and stats the file
    immediately -- before any write/rename/chmod -- to pin the create-time
    0600 guarantee at the unit responsible for it, not just observed in
    steady state after the fact.

- **S3 (should-fix) -- no Windows owner-only equivalent.** Confirmed
  `write_owner_only_file_atomically`'s permission step is unix-only (as it was
  before this PR). A real Windows equivalent means constructing and applying a
  DACL granting only the current user's SID (e.g. via
  `Win32_Security_Authorization::SetNamedSecurityInfoW`), which is materially
  more than a `windows-sys` feature-flag addition -- not done here per the
  review's "don't force it if it's not low-cost" guidance. Documented instead:
  a `TODO(windows)` comment on `set_owner_only_permissions` in
  `atomic_file.rs`, and a note on `PersistedTlsIdentity`'s doc comment, both
  stating that Windows relies on the user profile directory's default ACL for
  this file (same as the pairing store and API key store already did,
  pre-existing gap, not introduced by this PR).

- **NOTE -- doc warning on the ephemeral preview function.** Added a doc
  comment to `server_certificate_fingerprint_for_subject_alt_names` making
  explicit that it is wholly unrelated to persistence: every call mints a
  fresh keypair (bypassing `load_or_generate_self_signed_tls_identity` and
  `tls_identity_store` entirely), so its fingerprint is independent of, and
  will not match, whatever a running daemon has actually persisted. Confirmed
  the desktop app does not call this function for fingerprint preview -- it
  reads `certificate_fingerprint` from a live server's `/health`/pairing
  response instead, so no real bug today; the doc warning is to stop a future
  caller from assuming this function previews a persisted identity's
  fingerprint.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2386 passed, 0 failed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (pre-existing duplicate-version warning only, unrelated to this change; advisories/bans/licenses/sources all ok)

New/updated unit tests in `crates/openasr-server/src/tests.rs`:

- `load_or_generate_self_signed_tls_identity_loads_persisted_identity`
- `load_or_generate_self_signed_tls_identity_generates_and_persists_when_store_missing`
- `load_or_generate_self_signed_tls_identity_regenerates_on_corrupt_store`
- `load_or_generate_self_signed_tls_identity_regenerates_on_expired_certificate`
- `load_or_generate_self_signed_tls_identity_regenerates_on_corrupt_der_inside_valid_json` (new, S1/S2)
- `load_or_generate_self_signed_tls_identity_regenerates_on_key_cert_mismatch` (new, S2)
- `concurrent_first_boot_race_self_heals_to_the_last_writer_on_next_start` (new, S2)
- `load_or_generate_self_signed_tls_identity_hardens_openasr_home_to_0700` (new, B1)
- `load_or_generate_self_signed_tls_identity_creates_and_hardens_missing_openasr_home` (new, B1)

New unit test in `crates/openasr-core/src/atomic_file.rs`:

- `owner_only_temp_file_is_0600_from_the_moment_it_is_created` (new, B1)

## Manual smoke checks

Started `openasr serve --addr 127.0.0.1:58732 --tls-self-signed --tls-san
127.0.0.1` twice in a row against a scratch `OPENASR_HOME`, killing the process
cleanly between runs (self-managed pid, no system daemon touched):

```
run 1: certificate sha256:3c1217794dbca5849b1aae450d04ac657850075f244ac2e0da6f3c45c56e1ccf, pairing code 2533-083D  (tls_self_signed_identity stage: 19.4ms -- keygen)
run 2: certificate sha256:3c1217794dbca5849b1aae450d04ac657850075f244ac2e0da6f3c45c56e1ccf, pairing code 2533-083D  (tls_self_signed_identity stage: 0.8ms  -- load)
```

Identical fingerprint and pairing code across the restart. Verified permissions
after the first run: `OPENASR_HOME` is `drwx------` (0700, tightened from the
freshly-`mkdir`'d 0755) and `tls-identity.json` is `-rw-------` (0600).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

No user-facing docs describe self-signed TLS identity lifetime today, so
nothing needed updating.

## Scope / non-goals

- Does not change the pairing protocol, TOFU pinning logic, or the desktop
  app's supervisor/restart behavior -- purely makes the server-side identity
  survive a restart.
- Does not add identity rotation/renewal tooling beyond "expired -> regenerate
  on next start"; there is no background renewal before expiry.
- Does not add cross-process file locking around the TLS identity store's
  read-decide-write sequence; a race between two processes on their first boot
  against the same `OPENASR_HOME` resolves via atomic-rename last-writer-wins
  (never a corrupt file), and the loser's process serves a different
  in-memory fingerprint than what ends up on disk for that one boot. Same
  category of gap as `persist_pairing_credentials_locked`'s in-process-only
  lock; see `concurrent_first_boot_race_self_heals_to_the_last_writer_on_next_start`.
- Does not add a Windows owner-only ACL equivalent for the TLS identity file;
  relies on the Windows user profile directory's default ACL, same as the
  pre-existing pairing store and API key store. Tracked as a `TODO(windows)`
  in `atomic_file.rs`.
- Leaves `server_certificate_fingerprint_for_subject_alt_names` (unused in
  this repo) ephemeral/non-persisting; now has a doc warning against future
  misuse as a persisted-identity preview.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI (Claude Code) assistance under human direction; human reviewed the diff, ran/read all test output, performed an adversarial review pass before merge, and performed the manual restart smoke checks.
