### PR TITLE
perf(core): native adapter/capability caching + preference-aware boot warm-up

### DIFF
--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -567,10 +567,14 @@ pub fn resolve_local_native_runtime_model_identity(
 pub fn native_runtime_transcription_capabilities_for_path(
     path: &Path,
 ) -> TranscriptionBackendCapabilities {
+    // Build the adapter once and derive every facet (phrase_bias,
+    // diarization, language) from it, instead of re-reading and re-parsing
+    // the pack's GGUF metadata/tensor index once per facet.
+    let adapter = native_runtime_model_adapter_for_path(path);
     let mut capabilities = TranscriptionBackendCapabilities::for_backend_kind(BackendKind::Native);
-    capabilities.phrase_bias = native_phrase_bias_capability_for_path(path);
-    capabilities.diarization = native_diarization_capability_for_path(path);
-    if let Some(adapter) = native_runtime_model_adapter_for_path(path) {
+    capabilities.phrase_bias = native_phrase_bias_capability_for_adapter(adapter.as_ref());
+    capabilities.diarization = native_diarization_capability_for_adapter(adapter.as_ref());
+    if let Some(adapter) = adapter.as_ref() {
         capabilities.language = super::LanguageCapability::from(adapter.language_mode());
     }
     capabilities
@@ -578,10 +582,10 @@ pub fn native_runtime_transcription_capabilities_for_path(
 
 pub(crate) const NATIVE_PHRASE_BIAS_UNAVAILABLE_REASON: &str = "Phrase bias / hotword boosting is not implemented for this native model; requests with phrase_bias or hotword fields are rejected.";
 
-fn native_phrase_bias_capability_for_path(path: &Path) -> BackendFeatureCapability {
-    if native_runtime_model_adapter_for_path(path)
-        .is_some_and(|adapter| adapter.capabilities().supports_phrase_bias)
-    {
+fn native_phrase_bias_capability_for_adapter(
+    adapter: Option<&NativeRuntimeModelAdapter>,
+) -> BackendFeatureCapability {
+    if adapter.is_some_and(|adapter| adapter.capabilities().supports_phrase_bias) {
         BackendFeatureCapability::supported()
     } else {
         BackendFeatureCapability::reject_request(NATIVE_PHRASE_BIAS_UNAVAILABLE_REASON)
@@ -595,8 +599,11 @@ pub(crate) const NATIVE_DIARIZATION_UNAVAILABLE_REASON: &str = "Diarization need
 /// Diarization capability for a runtime pack: supported when the model
 /// self-diarizes (e.g. the cohere token-stream) or the model-agnostic
 /// VAD + active speaker-embedder path is installed for this process.
-fn native_diarization_capability_for_path(path: &Path) -> BackendFeatureCapability {
-    if native_runtime_path_supports_diarization(path) || crate::diarize::vad_diarization_available()
+fn native_diarization_capability_for_adapter(
+    adapter: Option<&NativeRuntimeModelAdapter>,
+) -> BackendFeatureCapability {
+    if native_runtime_adapter_supports_diarization(adapter)
+        || crate::diarize::vad_diarization_available()
     {
         BackendFeatureCapability::supported()
     } else {
@@ -605,13 +612,20 @@ fn native_diarization_capability_for_path(path: &Path) -> BackendFeatureCapabili
 }
 
 pub fn native_runtime_realtime_capabilities_for_path(path: &Path) -> RealtimeBackendCapabilities {
-    RealtimeBackendCapabilities::from_native_capabilities(
-        &native_runtime_asr_capabilities_for_path(path),
-    )
+    // Same single-build discipline as the transcription facets above: one
+    // adapter build serves the one realtime facet derived from it today, and
+    // keeps this entry point structurally consistent if more facets are
+    // added later.
+    let adapter = native_runtime_model_adapter_for_path(path);
+    RealtimeBackendCapabilities::from_native_capabilities(&native_runtime_capabilities_for_adapter(
+        adapter.as_ref(),
+    ))
 }
 
-fn native_runtime_asr_capabilities_for_path(path: &Path) -> NativeAsrCapabilities {
-    native_runtime_model_adapter_for_path(path)
+fn native_runtime_capabilities_for_adapter(
+    adapter: Option<&NativeRuntimeModelAdapter>,
+) -> NativeAsrCapabilities {
+    adapter
         .map(|adapter| adapter.capabilities())
         .unwrap_or_else(NativeAsrCapabilities::unsupported)
 }
@@ -803,9 +817,10 @@ pub fn validate_native_runtime_model_pack_contract(path: &Path) -> Result<(), St
 /// have written, not that the file is corrupt.
 const RUNTIME_CONTRACT_OUTDATED_PACK_HINT: &str = "this pack was likely produced by an outdated or incompatible conversion pipeline; re-convert or re-pull the model pack";
 
-pub(crate) fn native_runtime_path_supports_diarization(path: &Path) -> bool {
-    native_runtime_model_adapter_for_path(path)
-        .is_some_and(|adapter| adapter.capabilities().supports_diarization)
+fn native_runtime_adapter_supports_diarization(
+    adapter: Option<&NativeRuntimeModelAdapter>,
+) -> bool {
+    adapter.is_some_and(|adapter| adapter.capabilities().supports_diarization)
 }
 
 /// Diarization support for a runtime pack: the family must be capable of

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -1,4 +1,8 @@
-use std::{path::Path, sync::OnceLock};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
 
 use super::{
     BackendError, BackendFeatureCapability, BackendKind, Transcription, TranscriptionBackend,
@@ -477,6 +481,15 @@ pub(crate) fn unload_idle_native_streaming_runtime_caches() {
 /// configured threshold; a subsequent request just rebuilds via the normal
 /// load-on-first-use path (paying the cold build cost again, same as the
 /// very first request after boot).
+///
+/// This deliberately does not touch the process-lifetime GGUF
+/// metadata/adapter/identity caches (`NATIVE_RUNTIME_MODEL_ADAPTER_CACHE`,
+/// `NATIVE_RUNTIME_MODEL_IDENTITY_CACHE`): those hold small parsed metadata,
+/// not resident weights/device state, and idle-unload's contract is "release
+/// what the model actually costs memory/device-residency for", not "forget
+/// what we know about an installed pack's identity/capabilities". Re-deriving
+/// them is also unconditionally safe (installed-pack content immutability),
+/// so there is no correctness reason to evict them here either.
 pub fn unload_idle_native_model_runtime_caches() {
     native_transcribe::unload_idle_native_offline_runtime_caches();
     unload_idle_native_streaming_runtime_caches();
@@ -554,14 +567,59 @@ pub fn validate_local_native_model_pack_path(
     native_path::validate_local_native_model_pack_path(path)
 }
 
+/// Process-lifetime cache key for the caches below: an installed pack is
+/// content-immutable for the life of the daemon (see the doc comment on
+/// [`native_runtime_model_adapter_for_path`]), but the same on-disk pack can
+/// be reached through different (relative, symlinked, `..`-containing) path
+/// spellings across callers, so cache on the canonicalized path rather than
+/// the raw one. Canonicalization can fail (path race, permissions); fall back
+/// to the given path rather than panicking or refusing to cache -- worst case
+/// two spellings of the same pack each get their own entry, same as before
+/// this cache existed.
+fn native_runtime_cache_key_for_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+type NativeRuntimeIdentityCacheKey = (PathBuf, Option<String>);
+type NativeRuntimeIdentityCacheValue =
+    Result<NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError>;
+
+static NATIVE_RUNTIME_MODEL_IDENTITY_CACHE: OnceLock<
+    Mutex<HashMap<NativeRuntimeIdentityCacheKey, NativeRuntimeIdentityCacheValue>>,
+> = OnceLock::new();
+
+/// Cached wrapper over [`native_model_id::resolve_local_native_runtime_model_identity`].
+///
+/// Keyed on `(canonicalized path, explicit_model_id_fallback)`, not path
+/// alone: `explicit_model_id_fallback` is a per-request value (e.g. the
+/// server forwards the client's requested model string on every transcription
+/// request as the fallback), and it only changes the resolved identity when
+/// the pack's own GGUF metadata does not already carry a usable id -- so two
+/// calls for the same pack with different fallbacks must not share a cache
+/// entry. Errors are cached too (a pack that fails to resolve now will keep
+/// failing the same way for the rest of the process's life).
 pub fn resolve_local_native_runtime_model_identity(
     runtime_path: &Path,
     explicit_model_id_fallback: Option<&str>,
 ) -> Result<NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError> {
-    native_model_id::resolve_local_native_runtime_model_identity(
+    let cache = NATIVE_RUNTIME_MODEL_IDENTITY_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let cache_key = (
+        native_runtime_cache_key_for_path(runtime_path),
+        explicit_model_id_fallback.map(str::to_string),
+    );
+    if let Ok(cache) = cache.lock()
+        && let Some(cached) = cache.get(&cache_key)
+    {
+        return cached.clone();
+    }
+    let resolved = native_model_id::resolve_local_native_runtime_model_identity(
         runtime_path,
         explicit_model_id_fallback,
-    )
+    );
+    if let Ok(mut cache) = cache.lock() {
+        cache.insert(cache_key, resolved.clone());
+    }
+    resolved
 }
 
 pub fn native_runtime_transcription_capabilities_for_path(
@@ -630,7 +688,46 @@ fn native_runtime_capabilities_for_adapter(
         .unwrap_or_else(NativeAsrCapabilities::unsupported)
 }
 
+static NATIVE_RUNTIME_MODEL_ADAPTER_CACHE: OnceLock<
+    Mutex<HashMap<PathBuf, Option<NativeRuntimeModelAdapter>>>,
+> = OnceLock::new();
+
+/// Resolves (and process-lifetime caches) the runtime adapter for an
+/// installed native model pack: GGUF metadata + tensor-index parse, family
+/// registry selection, and the derived capability/language facets.
+///
+/// Caching is safe under the same invariant the realtime capabilities cache
+/// in `openasr-server` already relies on
+/// (`cached_native_realtime_capabilities_for_path`): an installed pack's
+/// content is immutable for the life of the process. A model switch rebinds
+/// the server to a new `--model-pack` path (a restart), and the operator-only
+/// pull API installs new/updated packs under their own path rather than
+/// overwriting the path of an already-bound, in-use pack -- so there is no
+/// live path where a cached entry's underlying bytes change out from under
+/// it. `None` results (path fails to validate, or does not match any builtin
+/// family) are cached too, since a fixed input path deterministically
+/// produces the same non-adapter answer.
+///
+/// This function used to re-open and re-parse the pack's GGUF metadata (and,
+/// best-effort, its tensor index) on every call; every capability probe,
+/// preflight check, and CLI capability summary for the same pack now shares
+/// one parse for the process's lifetime instead of paying it again per call.
 pub fn native_runtime_model_adapter_for_path(path: &Path) -> Option<NativeRuntimeModelAdapter> {
+    let cache = NATIVE_RUNTIME_MODEL_ADAPTER_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let cache_key = native_runtime_cache_key_for_path(path);
+    if let Ok(cache) = cache.lock()
+        && let Some(cached) = cache.get(&cache_key)
+    {
+        return cached.clone();
+    }
+    let adapter = build_native_runtime_model_adapter_for_path(path);
+    if let Ok(mut cache) = cache.lock() {
+        cache.insert(cache_key, adapter.clone());
+    }
+    adapter
+}
+
+fn build_native_runtime_model_adapter_for_path(path: &Path) -> Option<NativeRuntimeModelAdapter> {
     let runtime_source = native_path::validate_local_native_runtime_source(path).ok()?;
     let metadata = read_gguf_metadata_from_runtime_source(&runtime_source).ok()?;
     let selection_metadata = selection_metadata_from_gguf(&metadata);

--- a/crates/openasr-core/src/api/backend/native_model_id.rs
+++ b/crates/openasr-core/src/api/backend/native_model_id.rs
@@ -24,7 +24,7 @@ pub struct NativeRuntimeModelIdentity {
     pub source: NativeRuntimeModelIdSource,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum NativeRuntimeModelIdentityError {
     #[error("could not validate GGUF-backed runtime source '{path}': {reason}")]
     RuntimeSourceValidation { path: String, reason: String },

--- a/crates/openasr-server/src/realtime/mod.rs
+++ b/crates/openasr-server/src/realtime/mod.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     convert::Infallible,
     io::{self, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Arc, Mutex, OnceLock,
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
@@ -650,17 +650,22 @@ fn seconds_to_millis(value: f32) -> u64 {
     (value as f64 * 1000.0).round() as u64
 }
 
-fn realtime_inference_threads_preference(distribution: &DistributionContext) -> Option<u16> {
-    let home = distribution.openasr_home().ok()?;
+/// Reads the user's saved `inference_threads` preference from `home`'s config
+/// document. Takes a resolved home directory rather than a
+/// [`DistributionContext`] so it can be shared by both a real WS attach
+/// (which already has one) and the boot warm-up (which runs before the
+/// per-request `DistributionContext` exists) -- see
+/// `warm_up_default_native_streaming_worker` in `native_worker.rs`.
+fn realtime_inference_threads_preference(home: &Path) -> Option<u16> {
     openasr_core::config::load_config_document(home)
         .ok()
         .and_then(|document| document.preferences.inference_threads)
 }
 
-fn realtime_execution_target_preference(
-    distribution: &DistributionContext,
-) -> Option<openasr_core::ExecutionTarget> {
-    let home = distribution.openasr_home().ok()?;
+/// Reads the user's saved `execution_target` preference from `home`'s config
+/// document. See [`realtime_inference_threads_preference`] for why this takes
+/// a resolved home directory instead of a [`DistributionContext`].
+fn realtime_execution_target_preference(home: &Path) -> Option<openasr_core::ExecutionTarget> {
     openasr_core::config::load_config_document(home)
         .ok()
         .map(|document| document.preferences.execution_target)

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -496,11 +496,19 @@ pub(crate) fn warm_up_native_streaming_session_once(
 /// partial. Fire-and-forget: never blocks bind/serve/health, and any failure
 /// here (bad pack, no adapter, ...) is swallowed silently -- a real request
 /// still fails closed with a proper error through the normal request path.
-/// The existing WS-attach `Warm` command (see `start_native_streaming_session`
-/// in `ws_session.rs`) remains the fallback for whatever this boot warm-up
-/// does not cover: no pack bound yet at boot, an explicit
-/// `inference_threads`/`execution_target` that does not match the default
-/// worker key used here, or the bound pack having changed since boot.
+/// Derives its `hardware_target`/`inference_threads` from the user's saved
+/// preferences the same way a real WS attach without an explicit per-session
+/// override does (see `realtime_execution_target_preference` /
+/// `realtime_inference_threads_preference`), so a user who changed their
+/// default execution target or thread count still lands this warm-up on the
+/// same [`NativeStreamingWorkerKey`] their next real attach will use -- a
+/// worker warmed under the *bare* default key would otherwise sit unused
+/// while the real attach pays the cold-build cost on a different key. The
+/// existing WS-attach `Warm` command (see `start_native_streaming_session` in
+/// `ws_session.rs`) remains the fallback for whatever this boot warm-up does
+/// not cover: no pack bound yet at boot, an explicit per-session
+/// `inference_threads`/`execution_target` override that differs from the
+/// saved preference, or the bound pack having changed since boot.
 ///
 /// Dedup with a concurrent real attach is structural, not a flag: this
 /// attaches its own short-lived "session" to the same
@@ -535,15 +543,27 @@ async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
     let model_pack =
         NativeAsrModelPackRef::new("native-default", adapter.model_family(), model_pack_path);
     let context = NativeAsrSessionContext::new("boot-warmup");
-    let options = NativeAsrRequestOptions::new();
+    // Same saved-preferences fallback a real WS attach applies when a session
+    // does not set an explicit `execution_target`/`inference_threads`
+    // override (`realtime_execution_target_preference` /
+    // `realtime_inference_threads_preference` in `realtime/mod.rs`), so a
+    // user who changed their default hardware target or thread count still
+    // gets a worker warmed at the key their next attach will actually use.
+    // `openasr_home()` resolution failing here (unreadable env, race) just
+    // means "no preference found" -- same graceful fallback to defaults the
+    // request-time paths use.
+    let preferences_home = openasr_core::openasr_home().ok();
+    let inference_threads = preferences_home
+        .as_deref()
+        .and_then(realtime_inference_threads_preference);
+    let execution_target_preference = preferences_home
+        .as_deref()
+        .and_then(realtime_execution_target_preference);
+    let options = NativeAsrRequestOptions::new().with_inference_threads(inference_threads);
     let session_config = NativeAsrStreamingSessionConfig::new()
         .with_audio_format(RealtimeAudioFormat::pcm16_mono_16khz());
     let executor = NativeBackendExecutor;
-    // Matches the hardware target / thread count a WS session defaults to
-    // when the client does not override them (`execution_target` /
-    // `inference_threads` both unset) -- the common case, and exactly the
-    // worker key this warm-up needs to land on to actually help.
-    let hardware_target = native_hardware_target_from_execution_target(None);
+    let hardware_target = native_hardware_target_from_execution_target(execution_target_preference);
     let session = match NativeAsrExecutor::start_streaming_session(
         &executor,
         &adapter,
@@ -556,7 +576,8 @@ async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
         Ok(session) => session,
         Err(_) => return,
     };
-    let key = NativeStreamingWorkerKey::new(model_pack.root.clone(), hardware_target, None);
+    let key =
+        NativeStreamingWorkerKey::new(model_pack.root.clone(), hardware_target, inference_threads);
     attach_and_run_boot_warmup(key, session).await;
 }
 

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -1109,17 +1109,24 @@ impl WsSession {
         self.phrase_bias = phrase_bias;
         self.inference_threads =
             match validate_realtime_inference_threads(session.inference_threads) {
-                Ok(inference_threads) => inference_threads
-                    .or_else(|| realtime_inference_threads_preference(&self.distribution)),
+                Ok(inference_threads) => inference_threads.or_else(|| {
+                    self.distribution
+                        .openasr_home()
+                        .ok()
+                        .and_then(|home| realtime_inference_threads_preference(&home))
+                }),
                 Err(message) => {
                     self.emit_error(RealtimeErrorCode::StartupConfigError, &message, false)
                         .await?;
                     return Err(());
                 }
             };
-        self.execution_target = session
-            .execution_target
-            .or_else(|| realtime_execution_target_preference(&self.distribution));
+        self.execution_target = session.execution_target.or_else(|| {
+            self.distribution
+                .openasr_home()
+                .ok()
+                .and_then(|home| realtime_execution_target_preference(&home))
+        });
         self.word_timestamps = word_timestamps;
         self.source_name = source_name;
         self.translation = translation;


### PR DESCRIPTION
## Summary

Three independent startup/hot-path fixes for native capability probing and streaming warm-up:

1. Build the native runtime adapter once per capability probe (was up to 3x per call).
2. Add a process-lifetime cache for the GGUF metadata/adapter/identity resolution behind it.
3. Have boot warm-up read the user's saved execution_target/inference_threads preferences so it warms the worker key a real attach will actually use.

## Why

`native_runtime_transcription_capabilities_for_path` re-opened and re-parsed a pack's GGUF metadata/tensor index once per capability facet (phrase_bias, diarization, language), and every one of these probes re-parsed from disk on every call with no cross-call memoization, even though an installed pack is content-immutable for the life of the daemon process. This directly costs the desktop cold-start handshake (capabilities + models calls against the same bound pack) and any repeated CLI capability summary.

Separately, `warm_up_default_native_streaming_worker` always warmed the *default* `NativeStreamingWorkerKey` (Auto hardware target, no thread override), ignoring the user's saved preferences that a real WS attach without an explicit per-session override falls back to. A user who changed their default execution target or thread count got a warm-up that landed on the wrong worker key and still paid the cold model-pack-load cost (observed 1.7-2.1s) on their first real dictation session.

## Changes

- `crates/openasr-core/src/api/backend/native.rs`:
  - `native_runtime_transcription_capabilities_for_path` builds the adapter once; `native_phrase_bias_capability_for_adapter` / `native_diarization_capability_for_adapter` now take `Option<&NativeRuntimeModelAdapter>` instead of `&Path`, so a repeat build is impossible by construction. `native_runtime_realtime_capabilities_for_path` follows the same shape.
  - `native_runtime_model_adapter_for_path` and `resolve_local_native_runtime_model_identity` are now backed by canonicalized-path-keyed process caches (`OnceLock<Mutex<HashMap<..>>>`). The identity cache keys additionally on `explicit_model_id_fallback` (a per-request value) so two calls for the same pack with different fallbacks never share an entry. `idle_unload` deliberately does not evict either cache -- they hold parsed metadata, not resident weights/device state.
- `crates/openasr-core/src/api/backend/native_model_id.rs`: `NativeRuntimeModelIdentityError` derives `Clone` so the identity cache can store/return `Result` values directly.
- `crates/openasr-server/src/realtime/mod.rs`: `realtime_execution_target_preference` / `realtime_inference_threads_preference` now take a resolved home `&Path` instead of `&DistributionContext`, so boot warm-up (which runs before the per-request `DistributionContext` exists) can share the same preference-reading logic as a real WS attach.
- `crates/openasr-server/src/realtime/native_worker.rs`: `warm_up_default_native_streaming_worker` resolves `openasr_home()`, reads the saved preferences, and builds its `NativeAsrRequestOptions` / `NativeStreamingWorkerKey` from them instead of hardcoded defaults.
- `crates/openasr-server/src/realtime/ws_session.rs`: updated the two preference-lookup call sites for the new `&Path`-based signature (no behavior change there).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2376 passed, 0 failed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (2 passed, 2 ignored -- private dev-only packs unavailable in this environment)
- [x] `cargo deny check` (advisories/bans/licenses/sources ok)

## Manual smoke checks

Isolated before/after benchmark (release build, `--ignored` test calling `native_runtime_transcription_capabilities_for_path` / `native_runtime_realtime_capabilities_for_path` / `resolve_local_native_runtime_model_identity` / `native_runtime_model_adapter_for_path` 200x against an installed `whisper-tiny` q8_0 pack on this machine):

- Before (origin/main): ~286 ms/iter
- After (this branch): ~0.66 ms/iter

An end-to-end `openasr serve --model-pack ...` -> `/health` ready timing comparison showed no measurable difference (bind/`/health` was already fire-and-forget w.r.t. boot warm-up and unaffected by this cache), and a first pass at benchmarking repeated `/v1/capabilities` HTTP calls end-to-end was dominated by an unrelated, uncached per-call Hy-MT2 translation-pack lookup in `translation_capability_for_distribution` (a much larger pack on this machine) -- that lookup is out of scope for this PR but is a good target for a follow-up.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch `native_transcribe.rs`'s offline transcription runtime cache or the realtime streaming execution dispatch cache -- those already have their own established caching/idle-unload story.
- Does not cache `validate_native_runtime_model_pack_contract` (install/import-time pack validation) -- that path can legitimately be called against a pack mid-authoring/retry before it is considered "installed," so caching it would violate the content-immutability invariant this PR otherwise relies on.
- Does not address the uncached Hy-MT2 translation-capability lookup noted above.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance (Claude Code); all changes reviewed and validated by the submitter.
