### PR TITLE
refactor(core): move relative positional encoding primitives to shared nn layer

### DIFF
--- a/crates/openasr-core/src/models/cohere/encoder_graph.rs
+++ b/crates/openasr-core/src/models/cohere/encoder_graph.rs
@@ -11,6 +11,7 @@ use crate::nn::conv::{
     Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation,
     apply_conv_2d_depthwise_bias_activation, reshape_bias_4d as nn_reshape_bias_4d,
 };
+use crate::nn::encoder::build_relative_positional_encoding;
 use crate::nn::half::f32_to_f16_bits;
 
 use super::encoder_weights::{CohereEncoderLayerWeights, CohereTranscribeEncoderWeights};
@@ -581,8 +582,11 @@ impl CohereTranscribeEncoderGraphRuntime {
         let subsampled_frames = conv_out_dim(mel_features.n_frames, 3, 2, 1)?;
         let subsampled_frames = conv_out_dim(subsampled_frames, 3, 2, 1)?;
         let subsampled_frames = conv_out_dim(subsampled_frames, 3, 2, 1)?;
-        let positional =
-            build_relative_positional_encoding(metadata.encoder_d_model, subsampled_frames)?;
+        let positional = build_relative_positional_encoding(
+            metadata.encoder_d_model,
+            subsampled_frames,
+            || CohereTranscribeEncoderError::ShapeOverflow,
+        )?;
 
         let mut graph = self.runner.start_graph();
         let mel = graph
@@ -1286,36 +1290,6 @@ fn validate_mel_features(
         });
     }
     Ok(())
-}
-
-/// Conformer Transformer-XL relative-position sinusoidal table. Shared with the
-/// parakeet-ctc encoder (S3c) — same conformer rel-pos that `conformer_block`'s
-/// rel_shift consumes; exposed `pub(crate)` for reuse (additive, no behavior
-/// change to cohere).
-pub(crate) fn build_relative_positional_encoding(
-    d_model: usize,
-    frame_count: usize,
-) -> Result<Vec<f32>, CohereTranscribeEncoderError> {
-    let n_positions = frame_count
-        .checked_mul(2)
-        .and_then(|value| value.checked_sub(1))
-        .ok_or(CohereTranscribeEncoderError::ShapeOverflow)?;
-    let total = n_positions
-        .checked_mul(d_model)
-        .ok_or(CohereTranscribeEncoderError::ShapeOverflow)?;
-    let mut values = vec![0.0_f32; total];
-    for position_idx in 0..n_positions {
-        let pos = (frame_count - 1) as f32 - position_idx as f32;
-        for j in 0..(d_model / 2) {
-            let div = 10000.0_f32.powf((2.0 * j as f32) / d_model as f32);
-            let base = position_idx * d_model + 2 * j;
-            values[base] = (pos / div).sin();
-            if base + 1 < values.len() {
-                values[base + 1] = (pos / div).cos();
-            }
-        }
-    }
-    Ok(values)
 }
 
 fn emit_cohere_debug_encoder_stage_preview(

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -17,8 +17,9 @@
 //! dolphin/sensevoice/xasr precedent: hand-written, `block_stack: None`,
 //! built from the lower-level `nn::attn` / `nn::norm` / `nn::conv` primitives.
 //! The relative-position table math IS bit-identical to cohere/parakeet-ctc's
-//! shared Transformer-XL formula (same ESPnet/WeNet lineage), so that helper
-//! is reused directly instead of re-derived.
+//! shared Transformer-XL formula (same ESPnet/WeNet lineage), so the shared
+//! `nn::encoder::build_relative_positional_encoding` helper is reused directly
+//! instead of re-derived.
 
 #![allow(dead_code)]
 
@@ -27,7 +28,6 @@ use std::path::Path;
 use thiserror::Error;
 
 use crate::ggml_runtime::{GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlLoadedWeightContext};
-use crate::models::cohere::encoder_graph::build_relative_positional_encoding;
 use crate::nn::attn::{
     AttentionHeadLayout, AttentionReshapeSteps, AttentionValueMergeSteps,
     STANDARD_HEAD_PERMUTE_AXES, attention_context_from_probs,
@@ -36,6 +36,7 @@ use crate::nn::attn::{
 use crate::nn::conv::{
     Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation, reshape_bias_4d,
 };
+use crate::nn::encoder::build_relative_positional_encoding;
 use crate::nn::ffn::{
     FeedForwardActivation, FeedForwardResidualSteps, apply_feed_forward_residual,
 };
@@ -189,8 +190,10 @@ fn encode_firered_aed_audio_embeddings(
         .set_input(mel)
         .map_err(|source| map_err("ggml_set_input(mel)", source))?;
 
-    let positional_values = build_relative_positional_encoding(metadata.d_model, frame_count)
-        .map_err(|_| FireRedEncoderError::ShapeOverflow)?;
+    let positional_values =
+        build_relative_positional_encoding(metadata.d_model, frame_count, || {
+            FireRedEncoderError::ShapeOverflow
+        })?;
     let pos_enc = graph
         .new_tensor_2d_f32(metadata.d_model, 2 * frame_count - 1, "firered_enc_rel_pos")
         .map_err(|source| map_err("ggml_new_tensor_2d(pos_enc)", source))?;

--- a/crates/openasr-core/src/models/parakeet_ctc/encoder_graph.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/encoder_graph.rs
@@ -6,7 +6,7 @@
 //! NeMo dw_striding: regular conv0+ReLU, depthwise conv2, pointwise conv3+ReLU,
 //! depthwise conv5, pointwise conv6+ReLU), so the #1 frame-count risk is borrowed
 //! from a proven impl. The conformer layers reuse `nn::encoder::conformer_block`
-//! and the rel-pos table reuses cohere's `build_relative_positional_encoding`.
+//! and the rel-pos table reuses the shared `nn::encoder::build_relative_positional_encoding`.
 
 #![allow(dead_code)]
 
@@ -19,14 +19,16 @@ use crate::ggml_runtime::{
     bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
     upload_static_f32 as arena_upload_static_f32,
 };
-use crate::models::cohere::encoder_graph::build_relative_positional_encoding;
 use crate::models::parakeet_ctc::graph_config::parakeet_ctc_encoder_graph_config;
 
 use crate::nn::conv::{
     Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation,
     apply_conv_2d_depthwise_bias_activation, reshape_bias_4d,
 };
-use crate::nn::encoder::{ConformerBlockConfig, ConformerBlockWeights, conformer_block};
+use crate::nn::encoder::{
+    ConformerBlockConfig, ConformerBlockWeights, build_relative_positional_encoding,
+    conformer_block,
+};
 use crate::nn::half::f32_to_f16_bits;
 
 use super::encoder_weights::{NamedTensor, ParakeetEncoderLayerWeights, ParakeetEncoderWeights};
@@ -395,12 +397,11 @@ impl ParakeetCtcEncoderGraph {
         let d_model = metadata.hidden_size;
         let subsampled_frames = conv_out_dim(conv_out_dim(conv_out_dim(mel.n_frames)));
         let subsampled_freq = conv_out_dim(conv_out_dim(conv_out_dim(mel.n_mels)));
-        let positional =
-            build_relative_positional_encoding(d_model, subsampled_frames).map_err(|e| {
-                ParakeetEncoderError::Shape {
-                    reason: e.to_string(),
-                }
-            })?;
+        let positional = build_relative_positional_encoding(d_model, subsampled_frames, || {
+            ParakeetEncoderError::Shape {
+                reason: "relative positional encoding shape overflow".to_string(),
+            }
+        })?;
 
         let mut graph = self.runner.start_graph();
 

--- a/crates/openasr-core/src/models/parakeet_tdt/encoder_graph.rs
+++ b/crates/openasr-core/src/models/parakeet_tdt/encoder_graph.rs
@@ -14,14 +14,16 @@ use crate::ggml_runtime::{
     bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
     upload_static_f32 as arena_upload_static_f32,
 };
-use crate::models::cohere::encoder_graph::build_relative_positional_encoding;
 use crate::models::parakeet_tdt::graph_config::parakeet_tdt_encoder_graph_config;
 
 use crate::nn::conv::{
     Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation,
     apply_conv_2d_depthwise_bias_activation, reshape_bias_4d,
 };
-use crate::nn::encoder::{ConformerBlockConfig, ConformerBlockWeights, conformer_block};
+use crate::nn::encoder::{
+    ConformerBlockConfig, ConformerBlockWeights, build_relative_positional_encoding,
+    conformer_block,
+};
 use crate::nn::half::f32_to_f16_bits;
 
 use super::encoder_weights::{
@@ -368,12 +370,11 @@ impl ParakeetTdtEncoderGraph {
         let d_model = metadata.hidden_size;
         let subsampled_frames = conv_out_dim(conv_out_dim(conv_out_dim(mel.n_frames)));
         let subsampled_freq = conv_out_dim(conv_out_dim(conv_out_dim(mel.n_mels)));
-        let positional =
-            build_relative_positional_encoding(d_model, subsampled_frames).map_err(|e| {
-                ParakeetTdtEncoderError::Shape {
-                    reason: e.to_string(),
-                }
-            })?;
+        let positional = build_relative_positional_encoding(d_model, subsampled_frames, || {
+            ParakeetTdtEncoderError::Shape {
+                reason: "relative positional encoding shape overflow".to_string(),
+            }
+        })?;
 
         let mut graph = self.runner.start_graph();
 

--- a/crates/openasr-core/src/nn/encoder.rs
+++ b/crates/openasr-core/src/nn/encoder.rs
@@ -547,6 +547,36 @@ where
     })
 }
 
+/// Conformer Transformer-XL relative-position sinusoidal table: the per-frame
+/// `[2*frame_count-1, d_model]` sin/cos table that `conformer_block`'s
+/// `rel_shift` view consumes. Pure math, no model-specific state -- generic
+/// over the caller's error `E` (via `overflow_err`) like every other `nn/`
+/// builder, so no family's error type leaks into another's.
+pub(crate) fn build_relative_positional_encoding<E>(
+    d_model: usize,
+    frame_count: usize,
+    overflow_err: impl Fn() -> E,
+) -> Result<Vec<f32>, E> {
+    let n_positions = frame_count
+        .checked_mul(2)
+        .and_then(|value| value.checked_sub(1))
+        .ok_or_else(&overflow_err)?;
+    let total = n_positions.checked_mul(d_model).ok_or_else(overflow_err)?;
+    let mut values = vec![0.0_f32; total];
+    for position_idx in 0..n_positions {
+        let pos = (frame_count - 1) as f32 - position_idx as f32;
+        for j in 0..(d_model / 2) {
+            let div = 10000.0_f32.powf((2.0 * j as f32) / d_model as f32);
+            let base = position_idx * d_model + 2 * j;
+            values[base] = (pos / div).sin();
+            if base + 1 < values.len() {
+                values[base + 1] = (pos / div).cos();
+            }
+        }
+    }
+    Ok(values)
+}
+
 /// Scalar/shape knobs for one standard pre-norm Transformer encoder block
 /// (masked scaled-dot self-attention + a single biased FFN — the Whisper /
 /// Qwen-audio encoder shape).


### PR DESCRIPTION
## Summary

- Move `build_relative_positional_encoding` (the pure sinusoidal Transformer-XL
  rel-pos table) from `models/cohere/encoder_graph.rs` into `nn/encoder.rs`,
  next to `conformer_block` (the shared IR-boundary module it already fed).
- Neutralize its error type: it's now generic over the caller's `E` via an
  `overflow_err` closure, the same convention every other `nn/` builder in this
  file already follows (`conformer_block`, `transformer_layer`,
  `sanm_fsmn_encoder_layer`).

## Why

The function has no cohere-private state -- it's pure math (frame_count,
d_model) -> sin/cos table -- but lived under `models/cohere/`, so
`firered_aed`, `parakeet_ctc`, and `parakeet_tdt` all reached across family
boundaries with `use crate::models::cohere::encoder_graph::...` and had to
`.map_err(...)` cohere's `CohereTranscribeEncoderError` into their own error
enum at every call site. That's a real reverse dependency of three families on
cohere's internals for something that isn't cohere-specific at all.

Reverse-dependency audit (`rg -n "cohere::" .../firered_aed .../parakeet_ctc .../parakeet_tdt`):

- `firered_aed/encoder_graph.rs:30` (import) + `:192` (call site)
- `parakeet_ctc/encoder_graph.rs:22` (import) + `:399` (call site)
- `parakeet_tdt/encoder_graph.rs:17` (import) + `:372` (call site)

Only `build_relative_positional_encoding` was actually imported cross-family
(no separate shared "rel-shift helper" function exists -- the `rel_shift_nb1
/nb2/offset` byte-stride arithmetic is intentionally duplicated inline per
family per `nn/encoder.rs`'s existing doc comment: "the caller keeps its
overflow-checked arithmetic", so `conformer_block` stays free of fallible
pre-math. That part needs no change.)

## Changes

- `crates/openasr-core/src/nn/encoder.rs`: add
  `build_relative_positional_encoding<E>(d_model, frame_count, overflow_err:
  impl Fn() -> E) -> Result<Vec<f32>, E>` (verbatim body, no arithmetic
  changed).
- `crates/openasr-core/src/models/cohere/encoder_graph.rs`: delete the
  function; import the shared one; its one call site now supplies
  `|| CohereTranscribeEncoderError::ShapeOverflow`.
- `crates/openasr-core/src/models/firered_aed/encoder_graph.rs`,
  `parakeet_ctc/encoder_graph.rs`, `parakeet_tdt/encoder_graph.rs`: drop the
  `use crate::models::cohere::...` import, import from `nn::encoder` instead,
  and pass each family's own error variant directly to `overflow_err` (no more
  `.map_err(|e| ... e.to_string() ...)` translation through cohere's error
  `Display`).
- Updated the doc comments in `parakeet_ctc` / `firered_aed` that referenced
  "cohere's `build_relative_positional_encoding`" to point at the shared
  `nn::encoder` location.

No numeric logic changed anywhere.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2376 passed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources ok; pre-existing
      duplicate-crate warnings only, unrelated to this change)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (2 passed: whisper)
- [x] `cargo test -p openasr-core golden_diff -- --ignored --nocapture` with
      the private dev-only `firered-aed-l-fp16.oasr` pack present: both
      `golden_diff_end_to_end_transcribe_matches_reference_pytorch_decode_on_{jfk,zh_sample}_wav`
      pass (byte-exact match against the reference PyTorch decode text).

## Manual smoke checks

`cohere`, `parakeet_ctc`, and `parakeet_tdt` have no golden-diff-named tests in
this repo, so I built release binaries for this branch and for `main` (HEAD
`2dad2af`, identical on every touched file) and ran real installed `.oasr`
packs end-to-end through `transcribe --model-pack ... --format verbose_json`
on `fixtures/jfk.wav`, then `diff`'d the two JSON outputs byte-for-byte:

- `cohere-transcribe-03-2026` (q4_k): **zero diff**
- `parakeet-ctc-0.6b` (q4_k): **zero diff**
- `parakeet-tdt-0.6b-v3` (q4_k): **zero diff**
- `firered-aed-l-v2` (q4_k): **zero diff**

`verbose_json` includes per-word timestamps/confidences derived from the full
encoder + decoder pipeline, so this is a stronger check than comparing the
rel-pos table alone -- it confirms the whole encoder graph for all four
touched families is unaffected.

## Docs updated

- [x] No README or docs.md capability claims changed; only in-code doc
      comments describing where the shared helper now lives.

## Scope / non-goals

- Does not touch the `rel_shift_nb1/nb2/offset` inline byte-stride arithmetic
  (by design, per `nn/encoder.rs`'s existing doc comment -- that's caller-owned
  overflow-checked math feeding `ConformerBlockConfig`, not a shared function).
- Does not touch `ctc_greedy_decode.rs`, `api/backend/native.rs`, or
  `realtime/native_worker.rs`.
- Does not attempt the FastConformer encoder dedup between `parakeet_ctc` and
  `parakeet_tdt` (separate, larger follow-up).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI-assisted refactor (function move + generic error signature), reverse-dependency audit, and verification (real-pack end-to-end diff, golden_diff tests, full workspace gate suite).
