### PR TITLE
refactor(core): extract shared STFT/mel DSP primitives, switch parakeet_ctc

### DIFF
--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -1,3 +1,4 @@
+pub(crate) mod audio_frontend;
 pub(crate) mod aux_pack_registry;
 pub(crate) mod builtin_execution_dispatch;
 pub mod cohere;

--- a/crates/openasr-core/src/models/audio_frontend/mel.rs
+++ b/crates/openasr-core/src/models/audio_frontend/mel.rs
@@ -1,0 +1,352 @@
+//! Triangular mel filterbank construction, shared across model families.
+//!
+//! Every family's mel filterbank is a set of triangular filters spanning
+//! `[fmin, fmax]` on *some* mel-like scale over the `n_fft / 2 + 1` power
+//! bins of an `n_fft`-point real FFT. Families differ along exactly two
+//! axes, both captured by [`MelScale`]:
+//!
+//! - the hz<->mel warping formula ([`hz_to_mel`] / [`mel_to_hz`]), and
+//! - whether filter edges are compared in the Hz domain (with the classic
+//!   librosa/`torchaudio` triangular-ramp construction, optionally
+//!   Slaney-area-normalized) or entirely in the mel domain (the
+//!   `kaldi`/`torchaudio.compliance.kaldi.fbank` construction, which never
+//!   converts filter edges back to Hz).
+//!
+//! [`filterbank`] returns a dense row-major `[n_mels, fft_bins]` matrix for
+//! every scale. `Kaldi`-scale callers that want the sparse
+//! first-nonzero-bin-plus-run representation
+//! [`crate::models::kaldi_fbank`] uses for its hot loop can derive it from
+//! this matrix (leading/trailing zeros per row); the numeric filter weights
+//! are identical either way.
+
+/// Which hz<->mel warping (and filter-construction convention) to use.
+///
+/// `Htk`/`Kaldi` are not yet consumed by any switched-over family (only
+/// `Slaney` is, via `parakeet_ctc`) -- they're declared now per this
+/// module's target API and covered by their own unit tests below, so the
+/// family PRs that migrate `xasr_zipformer` / `kaldi_fbank`'s consumers
+/// onto this module can wire them in directly instead of inventing the
+/// scale math a second time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum MelScale {
+    /// librosa `norm="slaney"`, `htk=False`: linear below 1 kHz, log above;
+    /// filter edges are converted back to Hz and the resulting triangle is
+    /// area-normalized (`2 / (right_hz - left_hz)`). Used by
+    /// `parakeet_ctc`/`parakeet_tdt` and `whisper`.
+    Slaney,
+    /// Classic HTK mel scale (`1127 * ln(1 + hz / 700)`); filter edges are
+    /// converted back to Hz, triangles are *not* area-normalized. Used by
+    /// `xasr_zipformer`.
+    Htk,
+    /// Same hz<->mel formula as [`MelScale::Htk`], but filter weights are
+    /// computed by mapping each FFT bin's *own* frequency to the mel domain
+    /// and comparing it against the (already mel-domain) filter edges --
+    /// never converting edges back to Hz. This is
+    /// `torchaudio.compliance.kaldi.fbank`'s construction, used by
+    /// [`crate::models::kaldi_fbank`] (`firered_aed`/`dolphin`/`sensevoice`).
+    Kaldi,
+}
+
+/// Geometry for [`filterbank`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FilterbankConfig {
+    pub scale: MelScale,
+    pub sample_rate_hz: f32,
+    pub n_fft: usize,
+    pub n_mels: usize,
+    pub fmin: f32,
+    pub fmax: f32,
+}
+
+/// `hz -> mel` for `scale`.
+pub(crate) fn hz_to_mel(scale: MelScale, hz: f32) -> f32 {
+    match scale {
+        MelScale::Slaney => hz_to_mel_slaney(hz),
+        MelScale::Htk | MelScale::Kaldi => hz_to_mel_htk(hz),
+    }
+}
+
+/// `mel -> hz` for `scale` (the inverse of [`hz_to_mel`]).
+pub(crate) fn mel_to_hz(scale: MelScale, mel: f32) -> f32 {
+    match scale {
+        MelScale::Slaney => mel_to_hz_slaney(mel),
+        MelScale::Htk | MelScale::Kaldi => mel_to_hz_htk(mel),
+    }
+}
+
+/// Dense row-major `[n_mels, n_fft/2+1]` triangular mel filterbank.
+pub(crate) fn filterbank(config: FilterbankConfig) -> Vec<f32> {
+    let fft_bins = config.n_fft / 2 + 1;
+    match config.scale {
+        MelScale::Slaney => hz_domain_filterbank(config, fft_bins, true),
+        MelScale::Htk => hz_domain_filterbank(config, fft_bins, false),
+        MelScale::Kaldi => mel_domain_filterbank(config, fft_bins),
+    }
+}
+
+fn hz_to_mel_slaney(hz: f32) -> f32 {
+    // librosa slaney: linear below 1000 Hz, log above.
+    const F_MIN: f32 = 0.0;
+    const F_SP: f32 = 200.0 / 3.0;
+    const MIN_LOG_HZ: f32 = 1000.0;
+    let min_log_mel = (MIN_LOG_HZ - F_MIN) / F_SP;
+    let logstep = (6.4f32).ln() / 27.0;
+    if hz >= MIN_LOG_HZ {
+        min_log_mel + (hz / MIN_LOG_HZ).ln() / logstep
+    } else {
+        (hz - F_MIN) / F_SP
+    }
+}
+
+fn mel_to_hz_slaney(mel: f32) -> f32 {
+    const F_MIN: f32 = 0.0;
+    const F_SP: f32 = 200.0 / 3.0;
+    const MIN_LOG_HZ: f32 = 1000.0;
+    let min_log_mel = (MIN_LOG_HZ - F_MIN) / F_SP;
+    let logstep = (6.4f32).ln() / 27.0;
+    if mel >= min_log_mel {
+        MIN_LOG_HZ * (logstep * (mel - min_log_mel)).exp()
+    } else {
+        F_MIN + F_SP * mel
+    }
+}
+
+fn hz_to_mel_htk(hz: f32) -> f32 {
+    1127.0 * (1.0 + hz / 700.0).ln()
+}
+
+fn mel_to_hz_htk(mel: f32) -> f32 {
+    700.0 * ((mel / 1127.0).exp() - 1.0)
+}
+
+/// librosa-style construction: `n_mels + 2` edges equally spaced in the mel
+/// domain, converted back to Hz, triangles built from Hz-domain distances to
+/// `(left, center, right)`; optionally Slaney-area-normalized
+/// (`2 / (right - left)`).
+fn hz_domain_filterbank(config: FilterbankConfig, fft_bins: usize, slaney_norm: bool) -> Vec<f32> {
+    let FilterbankConfig {
+        scale,
+        sample_rate_hz,
+        n_fft,
+        n_mels,
+        fmin,
+        fmax,
+    } = config;
+    let fft_freqs: Vec<f32> = (0..fft_bins)
+        .map(|i| i as f32 * sample_rate_hz / n_fft as f32)
+        .collect();
+    let mel_min = hz_to_mel(scale, fmin);
+    let mel_max = hz_to_mel(scale, fmax);
+    let mel_points: Vec<f32> = (0..n_mels + 2)
+        .map(|i| mel_min + (mel_max - mel_min) * i as f32 / (n_mels + 1) as f32)
+        .collect();
+    let hz_points: Vec<f32> = mel_points.iter().map(|&m| mel_to_hz(scale, m)).collect();
+
+    let mut filters = vec![0.0f32; n_mels * fft_bins];
+    for m in 0..n_mels {
+        let left = hz_points[m];
+        let center = hz_points[m + 1];
+        let right = hz_points[m + 2];
+        let enorm = if slaney_norm {
+            2.0 / (right - left)
+        } else {
+            1.0
+        };
+        for (bin, &f) in fft_freqs.iter().enumerate() {
+            let lower = (f - left) / (center - left);
+            let upper = (right - f) / (right - center);
+            let weight = lower.min(upper).max(0.0);
+            filters[m * fft_bins + bin] = weight * enorm;
+        }
+    }
+    filters
+}
+
+/// `torchaudio.compliance.kaldi.fbank` construction: `n_mels + 2` edges
+/// equally spaced in the mel domain (never converted back to Hz); each FFT
+/// bin's own frequency is mapped to the mel domain and compared against
+/// `(left, center, right)` there. Filters are zero outside a contiguous run
+/// of bins, but this returns the same dense `[n_mels, fft_bins]` shape as
+/// the Hz-domain construction -- callers that want the sparse
+/// first-bin-plus-run representation derive it from the zero runs.
+fn mel_domain_filterbank(config: FilterbankConfig, fft_bins: usize) -> Vec<f32> {
+    let FilterbankConfig {
+        scale,
+        sample_rate_hz,
+        n_fft,
+        n_mels,
+        fmin,
+        fmax,
+    } = config;
+    let fft_bin_width = sample_rate_hz / n_fft as f32;
+    let mel_low = hz_to_mel(scale, fmin);
+    let mel_high = hz_to_mel(scale, fmax);
+    let mel_delta = (mel_high - mel_low) / (n_mels as f32 + 1.0);
+
+    let mut filters = vec![0.0f32; n_mels * fft_bins];
+    for m in 0..n_mels {
+        let left = mel_low + m as f32 * mel_delta;
+        let center = mel_low + (m as f32 + 1.0) * mel_delta;
+        let right = mel_low + (m as f32 + 2.0) * mel_delta;
+        for k in 0..fft_bins {
+            let mel = hz_to_mel(scale, fft_bin_width * k as f32);
+            if mel > left && mel < right {
+                let weight = if mel <= center {
+                    (mel - left) / (center - left)
+                } else {
+                    (right - mel) / (right - center)
+                };
+                filters[m * fft_bins + k] = weight;
+            }
+        }
+    }
+    filters
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exact reimplementation of the pre-refactor
+    /// `parakeet_ctc::frontend::slaney_mel_filterbank`, kept only in this
+    /// test to pin `MelScale::Slaney` to the values the parakeet family
+    /// shipped before this module existed.
+    fn reference_parakeet_slaney_filterbank(
+        n_mels: usize,
+        n_fft: usize,
+        fft_bins: usize,
+    ) -> Vec<f32> {
+        const SAMPLE_RATE: f32 = 16_000.0;
+        const MEL_FMIN: f32 = 0.0;
+        const MEL_FMAX: f32 = 8_000.0;
+        let fft_freqs: Vec<f32> = (0..fft_bins)
+            .map(|i| i as f32 * SAMPLE_RATE / n_fft as f32)
+            .collect();
+        let mel_min = hz_to_mel_slaney(MEL_FMIN);
+        let mel_max = hz_to_mel_slaney(MEL_FMAX);
+        let mel_points: Vec<f32> = (0..n_mels + 2)
+            .map(|i| mel_min + (mel_max - mel_min) * i as f32 / (n_mels + 1) as f32)
+            .collect();
+        let hz_points: Vec<f32> = mel_points.iter().map(|&m| mel_to_hz_slaney(m)).collect();
+
+        let mut filters = vec![0.0f32; n_mels * fft_bins];
+        for m in 0..n_mels {
+            let left = hz_points[m];
+            let center = hz_points[m + 1];
+            let right = hz_points[m + 2];
+            let enorm = 2.0 / (right - left);
+            for (bin, &f) in fft_freqs.iter().enumerate() {
+                let lower = (f - left) / (center - left);
+                let upper = (right - f) / (right - center);
+                let weight = lower.min(upper).max(0.0);
+                filters[m * fft_bins + bin] = weight * enorm;
+            }
+        }
+        filters
+    }
+
+    #[test]
+    fn slaney_filterbank_is_byte_identical_to_pre_refactor_parakeet_impl() {
+        let (n_mels, n_fft, fft_bins) = (80, 512, 257);
+        let expected = reference_parakeet_slaney_filterbank(n_mels, n_fft, fft_bins);
+        let actual = filterbank(FilterbankConfig {
+            scale: MelScale::Slaney,
+            sample_rate_hz: 16_000.0,
+            n_fft,
+            n_mels,
+            fmin: 0.0,
+            fmax: 8_000.0,
+        });
+        assert_eq!(expected, actual);
+
+        let (n_mels128, _, _) = (128, 512, 257);
+        let expected128 = reference_parakeet_slaney_filterbank(n_mels128, n_fft, fft_bins);
+        let actual128 = filterbank(FilterbankConfig {
+            scale: MelScale::Slaney,
+            sample_rate_hz: 16_000.0,
+            n_fft,
+            n_mels: n_mels128,
+            fmin: 0.0,
+            fmax: 8_000.0,
+        });
+        assert_eq!(expected128, actual128);
+    }
+
+    #[test]
+    fn htk_filterbank_matches_xasr_zipformer_reference_points() {
+        // xasr_zipformer::frontend's htk_mel_filterbank uses the same
+        // hz-domain construction without area normalization; cross-check a
+        // couple of known htk hz<->mel round-trip points independently of
+        // any live family module.
+        for hz in [20.0f32, 300.0, 1000.0, 4000.0, 7600.0] {
+            let mel = hz_to_mel(MelScale::Htk, hz);
+            let back = mel_to_hz(MelScale::Htk, mel);
+            assert!((back - hz).abs() < 1e-2, "hz={hz} round-trip={back}");
+        }
+        let fb = filterbank(FilterbankConfig {
+            scale: MelScale::Htk,
+            sample_rate_hz: 16_000.0,
+            n_fft: 512,
+            n_mels: 80,
+            fmin: 20.0,
+            fmax: 7_600.0,
+        });
+        for m in 0..80 {
+            let row = &fb[m * 257..(m + 1) * 257];
+            assert!(row.iter().sum::<f32>() > 0.0, "row {m} empty");
+            assert!(row.iter().all(|w| w.is_finite() && *w >= 0.0));
+        }
+    }
+
+    #[test]
+    fn kaldi_scale_filterbank_matches_kaldi_fbank_module_shape() {
+        // Same mel-domain construction as crate::models::kaldi_fbank's
+        // build_mel_filters (HTK mel scale, weight computed in mel space):
+        // every row is a single contiguous nonzero run, peak-normalized
+        // triangles (peak weight 1.0 at the center bin), gated strictly
+        // inside (left, right).
+        let fb = filterbank(FilterbankConfig {
+            scale: MelScale::Kaldi,
+            sample_rate_hz: 16_000.0,
+            n_fft: 512,
+            n_mels: 80,
+            fmin: 20.0,
+            fmax: 8_000.0,
+        });
+        for m in 0..80 {
+            let row = &fb[m * 257..(m + 1) * 257];
+            let nonzero: Vec<usize> = row
+                .iter()
+                .enumerate()
+                .filter(|&(_, &w)| w > 0.0)
+                .map(|(i, _)| i)
+                .collect();
+            if nonzero.is_empty() {
+                continue;
+            }
+            let first = *nonzero.first().unwrap();
+            let last = *nonzero.last().unwrap();
+            assert_eq!(
+                nonzero.len(),
+                last - first + 1,
+                "row {m} weights are not one contiguous run"
+            );
+            assert!(row.iter().all(|w| w.is_finite() && *w >= 0.0 && *w <= 1.0));
+        }
+    }
+
+    #[test]
+    fn hz_to_mel_and_mel_to_hz_round_trip_for_every_scale() {
+        for scale in [MelScale::Slaney, MelScale::Htk, MelScale::Kaldi] {
+            for hz in [0.0f32, 20.0, 440.0, 1000.0, 4000.0, 8000.0] {
+                let mel = hz_to_mel(scale, hz);
+                let back = mel_to_hz(scale, mel);
+                assert!(
+                    (back - hz).abs() < 1e-2,
+                    "scale={scale:?} hz={hz} round_trip={back}"
+                );
+            }
+        }
+    }
+}

--- a/crates/openasr-core/src/models/audio_frontend/mod.rs
+++ b/crates/openasr-core/src/models/audio_frontend/mod.rs
@@ -1,0 +1,317 @@
+//! Model-agnostic STFT/mel DSP primitives, shared across ASR frontend
+//! modules.
+//!
+//! This is the base layer [`crate::models::kaldi_fbank`] already carved out
+//! for the batch kaldi-fbank engine (`firered_aed`/`dolphin`/`sensevoice`);
+//! this module holds the lower-level primitives that engine -- and every
+//! other family's frontend -- is built from: framing + windowing + FFT
+//! ([`StftFramer`]), mel filterbank construction ([`mel`]), and per-feature
+//! (mean/std) normalization ([`per_feature_normalize`]).
+//!
+//! Each family still owns its own frontend module, error type, and any
+//! family-specific pre/post-processing (pre-emphasis, DC removal, log-guard
+//! style, LFR stacking, CMVN affine, ...); this module intentionally stops
+//! at the shared numeric primitives so a config difference between families
+//! stays a config difference instead of a second copy of the math. See
+//! `parakeet_ctc/frontend.rs` for the first family built directly on these
+//! primitives; other families migrate in their own follow-up changes (each
+//! independently golden-verified) rather than all at once here.
+//!
+//! Numeric behavior is carried over byte-for-byte from the pre-refactor
+//! per-family copies -- nothing here is a "cleanup" of the math itself, only
+//! of where it lives.
+
+pub(crate) mod mel;
+
+use std::sync::Arc;
+
+use realfft::{RealFftPlanner, RealToComplex};
+
+/// How a [`StftFramer`] turns raw samples into fixed-length frames before
+/// windowing + FFT. Each variant fixes both the boundary-padding behavior
+/// *and* the window-buffer alignment convention real frontends pair it
+/// with; see the field docs on [`StftFramer::new`] for why those two are
+/// coupled per engine rather than independent axes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PadMode {
+    /// `torch.stft(center=True, pad_mode="reflect")`: reflect-pad `n_fft/2`
+    /// samples on both ends (no edge repeat) before framing at `hop`
+    /// stride, i.e. `n_frames = (padded_len - n_fft) / hop + 1`. Used by
+    /// `parakeet_ctc`/`parakeet_tdt`, `whisper`, `cohere`, `qwen`.
+    ReflectCenter,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum StftError {
+    #[error("stft framer produced no frames from {samples} samples")]
+    TooShort { samples: usize },
+}
+
+/// Power spectrogram, row-major `[frame][fft_bin]` (bin innermost).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PowerSpectrogram {
+    pub data: Vec<f32>,
+    pub n_frames: usize,
+    pub n_fft_bins: usize,
+}
+
+/// Frames raw audio, applies an analysis window, and runs a real FFT to
+/// produce a power spectrogram. Owns the FFT plan (built once per instance)
+/// since planning dominates the per-call cost for short frames.
+pub(crate) struct StftFramer {
+    n_fft: usize,
+    /// Analysis window length before any `n_fft` zero-pad (documentation +
+    /// `Debug` only; alignment is baked into `window` by the caller).
+    win: usize,
+    hop: usize,
+    pad_mode: PadMode,
+    /// Pre-built analysis window, already embedded in an `n_fft`-length
+    /// buffer at whatever alignment the caller's family needs (e.g.
+    /// [`hann_window_centered`] centers a `win < n_fft` window; a future
+    /// left-aligned builder for the kaldi/snip-edges convention would zero
+    /// the trailing `n_fft - win` samples instead). `StftFramer` itself is
+    /// agnostic to that choice -- it only ever indexes `window[0..n_fft]`.
+    window: Vec<f32>,
+    fft: Arc<dyn RealToComplex<f32>>,
+}
+
+impl std::fmt::Debug for StftFramer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StftFramer")
+            .field("n_fft", &self.n_fft)
+            .field("win", &self.win)
+            .field("hop", &self.hop)
+            .field("pad_mode", &self.pad_mode)
+            .finish_non_exhaustive()
+    }
+}
+
+impl StftFramer {
+    /// `window` must have length `n_fft` (see the field doc above for why
+    /// alignment is the caller's responsibility).
+    pub(crate) fn new(
+        n_fft: usize,
+        win: usize,
+        hop: usize,
+        pad_mode: PadMode,
+        window: Vec<f32>,
+    ) -> Self {
+        debug_assert_eq!(window.len(), n_fft, "StftFramer window must be n_fft long");
+        Self {
+            n_fft,
+            win,
+            hop,
+            pad_mode,
+            window,
+            fft: RealFftPlanner::<f32>::new().plan_fft_forward(n_fft),
+        }
+    }
+
+    pub(crate) fn n_fft_bins(&self) -> usize {
+        self.n_fft / 2 + 1
+    }
+
+    /// Compute the power spectrogram for mono `samples` (float, any scale --
+    /// scaling to the engine's native domain, e.g. int16 magnitude, is the
+    /// caller's job before calling this).
+    pub(crate) fn power_spectrogram(&self, samples: &[f32]) -> Result<PowerSpectrogram, StftError> {
+        match self.pad_mode {
+            PadMode::ReflectCenter => self.power_spectrogram_reflect_center(samples),
+        }
+    }
+
+    fn power_spectrogram_reflect_center(
+        &self,
+        samples: &[f32],
+    ) -> Result<PowerSpectrogram, StftError> {
+        let pad = self.n_fft / 2;
+        let padded = reflect_pad(samples, pad);
+        if padded.len() < self.n_fft {
+            return Err(StftError::TooShort {
+                samples: samples.len(),
+            });
+        }
+        let n_frames = (padded.len() - self.n_fft) / self.hop + 1;
+        let fft_bins = self.n_fft_bins();
+
+        let r2c = &self.fft;
+        let mut fft_in = r2c.make_input_vec();
+        let mut fft_out = r2c.make_output_vec();
+        let mut scratch = r2c.make_scratch_vec();
+
+        let mut data = vec![0.0f32; n_frames * fft_bins];
+        for frame_idx in 0..n_frames {
+            let start = frame_idx * self.hop;
+            for i in 0..self.n_fft {
+                fft_in[i] = padded[start + i] * self.window[i];
+            }
+            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
+                .expect("stft framer rfft");
+            let row = &mut data[frame_idx * fft_bins..(frame_idx + 1) * fft_bins];
+            for (bin, c) in fft_out.iter().enumerate() {
+                row[bin] = c.norm_sqr();
+            }
+        }
+        Ok(PowerSpectrogram {
+            data,
+            n_frames,
+            n_fft_bins: fft_bins,
+        })
+    }
+}
+
+/// Periodic Hann window of `win_length`, zero-padded symmetrically into a
+/// buffer of `n_fft` (`torch.stft` pads a shorter `win_length` to `n_fft`,
+/// centered).
+pub(crate) fn hann_window_centered(win_length: usize, n_fft: usize) -> Vec<f32> {
+    let mut window = vec![0.0f32; n_fft];
+    let offset = (n_fft - win_length) / 2;
+    for i in 0..win_length {
+        let w = 0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / win_length as f32).cos();
+        window[offset + i] = w;
+    }
+    window
+}
+
+/// numpy/`torch.stft`-style reflect padding (no edge repeat): pads `pad`
+/// samples of mirrored signal onto both ends of `samples`.
+fn reflect_pad(samples: &[f32], pad: usize) -> Vec<f32> {
+    let n = samples.len();
+    let mut out = Vec::with_capacity(n + 2 * pad);
+    for i in 0..pad {
+        out.push(samples[(pad - i).min(n.saturating_sub(1))]);
+    }
+    out.extend_from_slice(samples);
+    for i in 0..pad {
+        let idx = n.saturating_sub(2 + i);
+        out.push(samples[idx.min(n.saturating_sub(1))]);
+    }
+    out
+}
+
+/// Per-feature (column) mean/std normalization of a row-major
+/// `[n_frames, n_features]` matrix (feature innermost), in place.
+///
+/// `ddof` is the variance denominator's delta degrees of freedom
+/// (`denom = max(n_frames - ddof, 1)`; `ddof = 0.0` is the population
+/// variance every current family uses). `eps` is added to the standard
+/// deviation *after* the square root (not inside it), matching every
+/// current family's normalization epsilon placement.
+pub(crate) fn per_feature_normalize(
+    data: &mut [f32],
+    n_frames: usize,
+    n_features: usize,
+    eps: f32,
+    ddof: f64,
+) {
+    debug_assert_eq!(data.len(), n_frames * n_features);
+    let mean_denom = n_frames.max(1) as f64;
+    for feat in 0..n_features {
+        let mut mean = 0.0f64;
+        for fr in 0..n_frames {
+            mean += data[fr * n_features + feat] as f64;
+        }
+        mean /= mean_denom;
+
+        let mut var = 0.0f64;
+        for fr in 0..n_frames {
+            let d = data[fr * n_features + feat] as f64 - mean;
+            var += d * d;
+        }
+        let var_denom = (n_frames as f64 - ddof).max(1.0);
+        var /= var_denom;
+        let std = (var.sqrt() as f32) + eps;
+
+        for fr in 0..n_frames {
+            let v = &mut data[fr * n_features + feat];
+            *v = (*v - mean as f32) / std;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parakeet_style_framer() -> StftFramer {
+        StftFramer::new(
+            512,
+            400,
+            160,
+            PadMode::ReflectCenter,
+            hann_window_centered(400, 512),
+        )
+    }
+
+    #[test]
+    fn reflect_center_frame_count_matches_torch_stft_formula() {
+        let framer = parakeet_style_framer();
+        // 1 s @ 16 kHz -> padded len = 16000 + 512, n_frames = (padded -
+        // 512) / 160 + 1.
+        let samples = vec![0.01f32; 16_000];
+        let spectrogram = framer.power_spectrogram(&samples).expect("spectrogram");
+        let expected_frames = (16_000 + 512 - 512) / 160 + 1;
+        assert_eq!(spectrogram.n_frames, expected_frames);
+        assert_eq!(spectrogram.n_fft_bins, 257);
+        assert_eq!(
+            spectrogram.data.len(),
+            spectrogram.n_frames * spectrogram.n_fft_bins
+        );
+        assert!(spectrogram.data.iter().all(|v| v.is_finite() && *v >= 0.0));
+    }
+
+    #[test]
+    fn reflect_center_handles_audio_shorter_than_n_fft_without_panicking() {
+        // padded len = samples.len() + n_fft always >= n_fft for nonempty
+        // input, so `ReflectCenter` never actually returns `TooShort` for
+        // this pad amount (n_fft/2 both sides) -- it's a defensive variant
+        // carried over from the pre-refactor per-family error type, kept
+        // for parity. What must hold is: short-but-nonempty audio still
+        // produces one valid (finite) frame, not a panic.
+        let framer = parakeet_style_framer();
+        let samples = vec![0.01f32; 4];
+        let spectrogram = framer.power_spectrogram(&samples).expect("spectrogram");
+        assert_eq!(spectrogram.n_frames, 1);
+        assert!(spectrogram.data.iter().all(|v| v.is_finite() && *v >= 0.0));
+    }
+
+    #[test]
+    fn hann_window_centered_is_zero_padded_symmetrically() {
+        let window = hann_window_centered(400, 512);
+        assert_eq!(window.len(), 512);
+        let offset = (512 - 400) / 2;
+        assert!(window[..offset].iter().all(|&v| v == 0.0));
+        assert!(window[offset + 400..].iter().all(|&v| v == 0.0));
+        // periodic Hann starts and (nearly) ends at 0, peaks at the center.
+        assert_eq!(window[offset], 0.0);
+        assert!(window[offset + 200] > 0.99);
+    }
+
+    #[test]
+    fn per_feature_normalize_ddof_zero_matches_population_stats() {
+        // 3 frames, 2 features: feature 0 = [1,2,3], feature 1 = [10,10,10].
+        let mut data = vec![1.0, 10.0, 2.0, 10.0, 3.0, 10.0];
+        per_feature_normalize(&mut data, 3, 2, 1.0e-5, 0.0);
+        // feature 1 has zero variance: normalized to (x - mean) / (0 + eps).
+        for fr in 0..3 {
+            assert!((data[fr * 2 + 1]).abs() < 1.0e-3);
+        }
+        // feature 0: mean=2, population var=2/3, std=sqrt(2/3).
+        let std = (2.0f64 / 3.0).sqrt() as f32 + 1.0e-5;
+        assert!((data[0] - (1.0 - 2.0) / std).abs() < 1.0e-5);
+        assert!((data[2] - (2.0 - 2.0) / std).abs() < 1.0e-5);
+        assert!((data[4] - (3.0 - 2.0) / std).abs() < 1.0e-5);
+    }
+
+    #[test]
+    fn per_feature_normalize_ddof_one_uses_sample_variance() {
+        let mut ddof0 = vec![1.0f32, 2.0, 3.0];
+        let mut ddof1 = ddof0.clone();
+        per_feature_normalize(&mut ddof0, 3, 1, 0.0, 0.0);
+        per_feature_normalize(&mut ddof1, 3, 1, 0.0, 1.0);
+        // sample variance (ddof=1) is larger than population variance
+        // (ddof=0), so the ddof=1 std is larger and its normalized
+        // magnitudes are smaller.
+        assert!(ddof1[0].abs() < ddof0[0].abs());
+    }
+}

--- a/crates/openasr-core/src/models/parakeet_ctc/frontend.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/frontend.rs
@@ -8,13 +8,21 @@
 //! 80-mel (slaney, fmin 0, fmax 8000) → log(x + 2⁻²⁴) → per-feature
 //! (per-mel-bin) mean/std normalization over the utterance. Output is the
 //! `[n_mels, n_frames]` (mel-fastest) layout the encoder's mel input expects.
+//!
+//! Framing/windowing/FFT, the slaney mel filterbank, and the per-feature
+//! mean/std normalization are the shared [`crate::models::audio_frontend`]
+//! primitives (this is the first family built directly on them); only the
+//! preemphasis and the NeMo `log_zero_guard_type="add"` log-guard style stay
+//! here since they differ per family.
 
 #![allow(dead_code)]
 
-use realfft::RealFftPlanner;
-
 use super::encoder_graph::ParakeetMelFeatures;
 use super::runtime_contract::ParakeetCtcExecutionMetadata;
+use crate::models::audio_frontend::mel::{FilterbankConfig, MelScale};
+use crate::models::audio_frontend::{
+    PadMode, StftError, StftFramer, hann_window_centered, per_feature_normalize,
+};
 
 const PREEMPHASIS: f32 = 0.97;
 const N_FFT: usize = 512;
@@ -38,10 +46,17 @@ pub(crate) enum ParakeetFrontendError {
     TooShort { samples: usize },
 }
 
+impl From<StftError> for ParakeetFrontendError {
+    fn from(error: StftError) -> Self {
+        match error {
+            StftError::TooShort { samples } => Self::TooShort { samples },
+        }
+    }
+}
+
 pub(crate) struct ParakeetFrontend {
     n_mels: usize,
-    /// Hann window of `WIN_LENGTH`, zero-centered into `N_FFT`.
-    window: Vec<f32>,
+    framer: StftFramer,
     /// Row-major `[n_mels][fft_bins]` slaney mel filterbank.
     mel_filters: Vec<f32>,
     fft_bins: usize,
@@ -58,10 +73,25 @@ impl ParakeetFrontend {
     /// identical across the parakeet family).
     pub(crate) fn with_n_mels(n_mels: usize) -> Self {
         let fft_bins = N_FFT / 2 + 1;
+        let framer = StftFramer::new(
+            N_FFT,
+            WIN_LENGTH,
+            HOP_LENGTH,
+            PadMode::ReflectCenter,
+            hann_window_centered(WIN_LENGTH, N_FFT),
+        );
+        let mel_filters = crate::models::audio_frontend::mel::filterbank(FilterbankConfig {
+            scale: MelScale::Slaney,
+            sample_rate_hz: SAMPLE_RATE,
+            n_fft: N_FFT,
+            n_mels,
+            fmin: MEL_FMIN,
+            fmax: MEL_FMAX,
+        });
         Self {
             n_mels,
-            window: centered_hann_window(WIN_LENGTH, N_FFT),
-            mel_filters: slaney_mel_filterbank(n_mels, N_FFT, fft_bins),
+            framer,
+            mel_filters,
             fft_bins,
         }
     }
@@ -79,35 +109,14 @@ impl ParakeetFrontend {
             emphasized.push(if i == 0 { x } else { x - PREEMPHASIS * prev });
             prev = x;
         }
-        // reflect center-pad n_fft/2 (torch.stft center=True).
-        let pad = N_FFT / 2;
-        let padded = reflect_pad(&emphasized, pad);
-        if padded.len() < N_FFT {
-            return Err(ParakeetFrontendError::TooShort {
-                samples: samples.len(),
-            });
-        }
-        let n_frames = (padded.len() - N_FFT) / HOP_LENGTH + 1;
-
-        let mut planner = RealFftPlanner::<f32>::new();
-        let r2c = planner.plan_fft_forward(N_FFT);
-        let mut fft_in = r2c.make_input_vec();
-        let mut fft_out = r2c.make_output_vec();
-        let mut scratch = r2c.make_scratch_vec();
+        let spectrogram = self.framer.power_spectrogram(&emphasized)?;
+        let n_frames = spectrogram.n_frames;
 
         // Output [n_frames][n_mels] then we emit mel-fastest [mel, frame].
         let mut mel = vec![0.0f32; n_frames * self.n_mels];
-        let mut power = vec![0.0f32; self.fft_bins];
         for frame_idx in 0..n_frames {
-            let start = frame_idx * HOP_LENGTH;
-            for i in 0..N_FFT {
-                fft_in[i] = padded[start + i] * self.window[i];
-            }
-            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
-                .expect("rfft");
-            for (bin, c) in fft_out.iter().enumerate() {
-                power[bin] = c.norm_sqr();
-            }
+            let power =
+                &spectrogram.data[frame_idx * self.fft_bins..(frame_idx + 1) * self.fft_bins];
             for m in 0..self.n_mels {
                 let row = &self.mel_filters[m * self.fft_bins..(m + 1) * self.fft_bins];
                 let mut acc = 0.0f32;
@@ -119,24 +128,7 @@ impl ParakeetFrontend {
         }
 
         // per-feature (per mel bin) normalization over the time axis.
-        for m in 0..self.n_mels {
-            let mut mean = 0.0f64;
-            for f in 0..n_frames {
-                mean += mel[f * self.n_mels + m] as f64;
-            }
-            mean /= n_frames.max(1) as f64;
-            let mut var = 0.0f64;
-            for f in 0..n_frames {
-                let d = mel[f * self.n_mels + m] as f64 - mean;
-                var += d * d;
-            }
-            var /= n_frames.max(1) as f64;
-            let std = (var.sqrt() as f32) + NORM_EPS;
-            for f in 0..n_frames {
-                let v = &mut mel[f * self.n_mels + m];
-                *v = (*v - mean as f32) / std;
-            }
-        }
+        per_feature_normalize(&mut mel, n_frames, self.n_mels, NORM_EPS, 0.0);
 
         Ok(ParakeetMelFeatures {
             data: mel,
@@ -144,94 +136,6 @@ impl ParakeetFrontend {
             n_mels: self.n_mels,
         })
     }
-}
-
-/// Periodic Hann window of `win_length`, zero-padded symmetrically into `n_fft`
-/// (torch.stft pads a shorter `win_length` to `n_fft`, centered).
-fn centered_hann_window(win_length: usize, n_fft: usize) -> Vec<f32> {
-    let mut window = vec![0.0f32; n_fft];
-    let offset = (n_fft - win_length) / 2;
-    for i in 0..win_length {
-        // periodic Hann: 0.5 - 0.5 cos(2πi / win_length).
-        let w = 0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / win_length as f32).cos();
-        window[offset + i] = w;
-    }
-    window
-}
-
-fn reflect_pad(samples: &[f32], pad: usize) -> Vec<f32> {
-    let n = samples.len();
-    let mut out = Vec::with_capacity(n + 2 * pad);
-    for i in 0..pad {
-        // reflect without repeating the edge sample (numpy 'reflect').
-        out.push(samples[(pad - i).min(n.saturating_sub(1))]);
-    }
-    out.extend_from_slice(samples);
-    for i in 0..pad {
-        let idx = n.saturating_sub(2 + i);
-        out.push(samples[idx.min(n.saturating_sub(1))]);
-    }
-    out
-}
-
-fn hz_to_mel_slaney(hz: f32) -> f32 {
-    // librosa slaney: linear below 1000 Hz, log above.
-    const F_MIN: f32 = 0.0;
-    const F_SP: f32 = 200.0 / 3.0;
-    const MIN_LOG_HZ: f32 = 1000.0;
-    let min_log_mel = (MIN_LOG_HZ - F_MIN) / F_SP;
-    let logstep = (6.4f32).ln() / 27.0;
-    if hz >= MIN_LOG_HZ {
-        min_log_mel + (hz / MIN_LOG_HZ).ln() / logstep
-    } else {
-        (hz - F_MIN) / F_SP
-    }
-}
-
-fn mel_to_hz_slaney(mel: f32) -> f32 {
-    const F_MIN: f32 = 0.0;
-    const F_SP: f32 = 200.0 / 3.0;
-    const MIN_LOG_HZ: f32 = 1000.0;
-    let min_log_mel = (MIN_LOG_HZ - F_MIN) / F_SP;
-    let logstep = (6.4f32).ln() / 27.0;
-    if mel >= min_log_mel {
-        MIN_LOG_HZ * (logstep * (mel - min_log_mel)).exp()
-    } else {
-        F_MIN + F_SP * mel
-    }
-}
-
-/// librosa.filters.mel(sr=16000, n_fft, n_mels, fmin=0, fmax=8000, htk=False,
-/// norm='slaney'): triangular filters with slaney area normalization. Row-major
-/// `[n_mels][fft_bins]`.
-fn slaney_mel_filterbank(n_mels: usize, n_fft: usize, fft_bins: usize) -> Vec<f32> {
-    // fft bin center frequencies.
-    let fft_freqs: Vec<f32> = (0..fft_bins)
-        .map(|i| i as f32 * SAMPLE_RATE / n_fft as f32)
-        .collect();
-    // n_mels + 2 mel points equally spaced in mel between fmin..fmax.
-    let mel_min = hz_to_mel_slaney(MEL_FMIN);
-    let mel_max = hz_to_mel_slaney(MEL_FMAX);
-    let mel_points: Vec<f32> = (0..n_mels + 2)
-        .map(|i| mel_min + (mel_max - mel_min) * i as f32 / (n_mels + 1) as f32)
-        .collect();
-    let hz_points: Vec<f32> = mel_points.iter().map(|&m| mel_to_hz_slaney(m)).collect();
-
-    let mut filters = vec![0.0f32; n_mels * fft_bins];
-    for m in 0..n_mels {
-        let left = hz_points[m];
-        let center = hz_points[m + 1];
-        let right = hz_points[m + 2];
-        // slaney area normalization: 2 / (right - left).
-        let enorm = 2.0 / (right - left);
-        for (bin, &f) in fft_freqs.iter().enumerate() {
-            let lower = (f - left) / (center - left);
-            let upper = (right - f) / (right - center);
-            let weight = lower.min(upper).max(0.0);
-            filters[m * fft_bins + bin] = weight * enorm;
-        }
-    }
-    filters
 }
 
 #[cfg(test)]
@@ -275,12 +179,33 @@ mod tests {
 
     #[test]
     fn mel_filterbank_rows_are_normalized_and_localized() {
-        let fb = slaney_mel_filterbank(80, 512, 257);
+        let fb = crate::models::audio_frontend::mel::filterbank(FilterbankConfig {
+            scale: MelScale::Slaney,
+            sample_rate_hz: SAMPLE_RATE,
+            n_fft: 512,
+            n_mels: 80,
+            fmin: MEL_FMIN,
+            fmax: MEL_FMAX,
+        });
         // every row has positive mass, bounded weights.
         for m in 0..80 {
             let row = &fb[m * 257..(m + 1) * 257];
             assert!(row.iter().sum::<f32>() > 0.0, "row {m} empty");
             assert!(row.iter().all(|w| w.is_finite() && *w >= 0.0));
         }
+    }
+
+    #[test]
+    fn handles_audio_shorter_than_one_stft_frame_without_panicking() {
+        // See `audio_frontend`'s equivalent test: reflect-center padding
+        // (n_fft/2 both sides) means `TooShort` never actually triggers for
+        // nonempty input at this frontend's fixed n_fft; what must hold is
+        // that short-but-nonempty audio still produces finite features.
+        let frontend = ParakeetFrontend::new(&metadata());
+        let samples = vec![0.01f32; 4];
+        let feats = frontend.features_from_samples(&samples).expect("features");
+        assert_eq!(feats.n_frames, 1);
+        assert_eq!(feats.n_mels, 80);
+        assert!(feats.data.iter().all(|v| v.is_finite()));
     }
 }


### PR DESCRIPTION
## Summary

Stage 1 of the shared audio-frontend DSP extraction (roadmap item C3): adds a
model-agnostic `audio_frontend` module holding the STFT/mel primitives every
frontend is built from, and switches `parakeet_ctc` onto it (byte-identical
output). `parakeet_tdt` rides along for free since it already calls
`parakeet_ctc`'s `ParakeetFrontend` at `n_mels=128` -- no changes needed there.

Every other family's frontend (`whisper`, `cohere`, `qwen`, `xasr_zipformer`,
`dolphin`, plus `kaldi_fbank.rs`'s existing `firered_aed`/`dolphin`/`sensevoice`
consumers, plus the two diarize copies and the pack-build side) is
**intentionally untouched** in this PR. Section "DSP copy inventory" below is
the road map for the follow-up, family-by-family PRs.

## Why

`kaldi_fbank.rs` already carved a shared batch fbank engine out of 3 families'
byte-identical FFT/mel math. The same duplication exists one level lower and
across more families: roughly 8 independent STFT (frame+window+FFT) copies and
7 independent mel-filterbank builders (3 different scale/construction
conventions), including 3 pack-build-side copies that bake filter tensors at
publish time. Each copy is a place a numeric detail (window shape, padding,
log-guard, area-normalization) can silently drift per family. This PR builds
the shared primitives and proves the pattern on one family before touching the
rest.

## Changes

- `crates/openasr-core/src/models/audio_frontend/mod.rs` (new): `StftFramer`
  (`n_fft`/`win`/`hop`/`pad_mode`/`window` -> power spectrogram; owns the FFT
  plan), `hann_window_centered`, `per_feature_normalize` (mean/std,
  configurable `ddof`, eps added after the sqrt). `PadMode` currently has one
  variant, `ReflectCenter` (`torch.stft(center=True, pad_mode="reflect")`,
  used by `parakeet_ctc`/`parakeet_tdt`/`whisper`/`cohere`/`qwen`); further
  variants (kaldi `snip_edges=true`, xasr's incremental reflect framing) land
  with the PR that migrates that family, verified against that family's own
  golden.
- `crates/openasr-core/src/models/audio_frontend/mel.rs` (new): `MelScale`
  (`Slaney`/`Htk`/`Kaldi`) + single `hz_to_mel`/`mel_to_hz` per scale, and
  `filterbank(FilterbankConfig)` returning a dense `[n_mels, fft_bins]` matrix
  for all three. `Slaney` is wired to `parakeet_ctc` this PR and pinned with an
  exact-equality (`assert_eq!`, not epsilon) unit test against a frozen copy of
  the pre-refactor `parakeet_ctc::frontend::slaney_mel_filterbank`. `Htk`/
  `Kaldi` are implemented and unit-tested now (declared per this module's
  target API) but not yet consumed by any switched-over family.
- `crates/openasr-core/src/models/parakeet_ctc/frontend.rs`: `ParakeetFrontend`
  now builds a `StftFramer` + calls `audio_frontend::mel::filterbank` instead
  of its own reflect-pad/centered-Hann/FFT loop and its own
  `slaney_mel_filterbank`; `features_from_samples` calls
  `audio_frontend::per_feature_normalize` instead of its own mean/std loop.
  Preemphasis and the NeMo `log_zero_guard_type="add"` log-guard stay local
  (family-specific). The reflect-pad, window-building, FFT loop, and
  normalize loop are moved **verbatim** (same arithmetic, same order) -- this
  is a relocation, not a rewrite of the math.
- `crates/openasr-core/src/models.rs`: registers `audio_frontend`.

## DSP copy inventory (road map for follow-up PRs, not touched here)

STFT (frame + window + FFT) implementations:

| Family / site | File | Status |
|---|---|---|
| `kaldi_fbank` shared engine | `models/kaldi_fbank.rs` | shared (firered_aed, dolphin's kaldi variant, sensevoice) |
| parakeet_ctc/tdt | `models/parakeet_ctc/frontend.rs` | **switched this PR** |
| cohere | `models/cohere/frontend.rs:143` | own copy |
| qwen | `models/qwen/frontend.rs:143` | own copy |
| xasr_zipformer | `models/xasr_zipformer/frontend.rs:103` | own copy (deliberately not shared -- streaming O(1) framing) |
| whisper | `models/whisper/mel.rs` | own copy |
| dolphin espnet variant | `models/dolphin/frontend.rs:246` | own copy (separate from its kaldi-variant path in the same file) |
| diarize speaker embedder | `diarize/embed/fbank.rs:73` | own copy |
| diarize VAD | `diarize/vad/firered_stream/frontend.rs:68` | own copy |

Mel filterbank builders (by scale/construction convention):

| Family / site | File | Scale | Status |
|---|---|---|---|
| `kaldi_fbank` shared engine | `models/kaldi_fbank.rs:205` | Kaldi (mel-domain) | shared |
| parakeet_ctc/tdt | `models/parakeet_ctc/frontend.rs` | Slaney | **switched this PR** |
| whisper | `models/whisper/mel.rs:320` | Slaney | own copy |
| dolphin espnet variant | `models/dolphin/frontend.rs:353` | Slaney | own copy |
| xasr_zipformer | `models/xasr_zipformer/frontend.rs:281` | Htk | own copy |
| diarize speaker embedder | `diarize/embed/fbank.rs:143` | Kaldi | own copy |
| diarize VAD | `diarize/vad/firered_stream/frontend.rs:155` | Kaldi | own copy |
| pack-build: dolphin | `models/dolphin/package_import.rs:782` | Kaldi/Htk | bakes `dolphin.mel_filters` tensor |
| pack-build: firered_aed | `models/firered_aed/package_import.rs:816` | Kaldi/Htk | bakes `firered.mel_filters` tensor |
| pack-build: qwen | `models/qwen/package_import.rs:838` | Slaney | bakes `audio.mel_filters` tensor consumed by `qwen/frontend.rs` at runtime |
| cohere | `models/cohere/frontend.rs` | -- | mel filters come from the source checkpoint (baked through, not regenerated by our importer) |

`Kaldi` and `Htk` mel scale math is identical
(`1127 * ln(1 + hz/700)`); what differs between the `Kaldi` shared engine and
the `Htk`/`Slaney` construction is whether filter weights are computed in the
mel domain (kaldi_fbank.rs, sparse first-bin+run) or the Hz domain (dense,
optionally area-normalized). `mel::filterbank` already implements both
constructions so the family PRs that migrate onto it don't need to invent
either one.

## Golden / gate evidence

- `cargo fmt --check`: clean.
- `cargo clippy --all-targets -- -D warnings` (workspace): clean.
- `cargo test -p openasr-core golden_diff -- --nocapture`: 2 passed, 2 ignored
  (firered_aed's golden tests require a private dev-only pack not present in
  CI/this environment -- pre-existing, unrelated to this change), 0 failed.
- `cargo nextest run --workspace`: **2386 passed** (1 slow), 122 skipped
  (private-fixture-gated tests, pre-existing), 0 failed.
- `cargo test --workspace --doc`: clean (0 doctests, as before).
- `tooling/publish-model/scripts/regenerate_all.sh --check`: catalog + prose
  locale drift check passed for all 27 models -- pack-build side unaffected.
- `cargo deny check`: advisories/bans/licenses/sources ok.
- New DSP-module unit tests (9, all passing): `mel::filterbank` Slaney output
  pinned bit-exact (`assert_eq!`) against a frozen copy of the pre-refactor
  `parakeet_ctc` filterbank for both `n_mels=80` and `n_mels=128`; `Htk`/
  `Kaldi` scale round-trip + filter-shape invariants; `StftFramer` frame-count
  formula and short-audio boundary behavior; `per_feature_normalize` ddof=0
  vs ddof=1 variance.
- `parakeet_ctc`'s own end-to-end regression
  (`parakeet_ctc_transcribes_librispeech_clip_when_present`) requires a
  private `.oasr` pack + LibriSpeech clip under `tmp/models/` /
  `tmp/audio/librispeech/` that are not present in this environment (same
  gate pattern as `firered_aed`'s ignored golden tests above), so it wasn't
  exercised here; the STFT framing, windowing, and normalize loops are moved
  verbatim (same floating-point operations in the same order, not
  reimplemented), so byte-identical output is a property of the relocation,
  not something this specific test would newly confirm.

## Manual smoke checks

N/A (DSP-internals refactor; behavior verified via the unit/regression tests
above, not manual CLI/API smoke checks).

## Docs updated

- [x] No behavior or limitations changed; no README/docs updates needed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does **not** migrate any family other than `parakeet_ctc` (`parakeet_tdt`
  rides along via existing reuse, no code change).
- Does **not** touch `kaldi_fbank.rs`, `xasr_zipformer`, `whisper`, `cohere`,
  `qwen`, `dolphin`, the two diarize DSP copies, or any pack-build importer.
- Does **not** add a `PadMode` variant for kaldi's `snip_edges=true` framing or
  xasr's incremental streaming framing; those land with the PR that migrates
  that family.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts,
      secrets, or private audio.
- [x] I did not add vendored runtime sources outside
      `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage
      policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI
      assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI-assisted implementation of the shared DSP
  module extraction and the parakeet_ctc switch-over, under direct human
  direction and review.
