### PR TITLE
perf(core): share executor instance across offline and streaming dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Server: `/health` now reports `model_resident`, whether the bound model's native runtime is currently loaded in memory versus idle-unloaded (or not yet loaded this boot) -- lets clients (e.g. the desktop status indicator) distinguish "ready, instant transcription" from "bound but will pay a cold rebuild on the next request" without guessing from the `idle_unload` timer. Additive; `model_installed` is unchanged.
 
+### Changed
+
+- Core: the offline and realtime-streaming dispatch stacks now share one process-wide executor instance for qwen, cohere, whisper, and moonshine (the families that host-materialize a prepared runtime instead of relying purely on the pack's own mmap), instead of each stack holding its own independent instance and cache. A model warmed on both stacks no longer pays for its resident weights twice: measured on `qwen3-asr-0.6b` q4_k, warming both stacks on the same pack now costs ~1x instead of ~2x (2965 MiB -> 2197 MiB physical footprint in a same-process repro). AED/CTC/transducer families keep zero-copy mmap-shared weights already and are unaffected.
+
 ## [0.1.12] - 2026-07-11
 
 ### Added

--- a/crates/openasr-core/src/models/builtin_execution_dispatch.rs
+++ b/crates/openasr-core/src/models/builtin_execution_dispatch.rs
@@ -6,21 +6,19 @@ use crate::GgmlAsrExecutionDispatch;
 use crate::StreamingPartialGranularity;
 use crate::arch::{OpenAsrArchitectureRegistry, OpenAsrArchitectureRegistryError};
 
-use super::cohere::CohereTranscribeGgmlExecutor;
 use super::dolphin::executor::DolphinGgmlExecutor;
 use super::executor_component_registry::{
     BuiltinExecutorComponentRegistryError, materialize_builtin_executors_by_model_architecture,
+    shared_cohere_transcribe_executor, shared_moonshine_executor, shared_qwen3_asr_executor,
+    shared_whisper_executor,
 };
 use super::firered_aed::executor::FireRedAedGgmlExecutor;
 use super::ggml_composed_executor::ComposedGgmlAsrExecutor;
 use super::ggml_family_adapter::GgmlExecutionCapability;
-use super::moonshine::MoonshineGgmlExecutor;
 use super::parakeet_ctc::executor::ParakeetCtcGgmlExecutor;
 use super::parakeet_tdt::executor::ParakeetTdtGgmlExecutor;
-use super::qwen::Qwen3AsrGgmlExecutor;
 use super::sensevoice::executor::SenseVoiceGgmlExecutor;
 use super::wav2vec2_ctc::executor::Wav2Vec2CtcGgmlExecutor;
-use super::whisper::WhisperGgmlExecutor;
 use super::xasr_zipformer::executor::XasrZipformerGgmlExecutor;
 
 #[derive(Debug, Error, Clone, PartialEq)]
@@ -111,7 +109,7 @@ pub(crate) fn build_builtin_ggml_streaming_execution_dispatch()
     let dispatch = GgmlAsrExecutionDispatch::default()
         .with_streaming_executor_for_adapter(
             crate::QWEN3_ASR_GGML_ADAPTER_ID,
-            Arc::new(Qwen3AsrGgmlExecutor::default()),
+            shared_qwen3_asr_executor(),
         )
         .with_streaming_partial_granularity_for_adapter(
             crate::QWEN3_ASR_GGML_ADAPTER_ID,
@@ -119,7 +117,7 @@ pub(crate) fn build_builtin_ggml_streaming_execution_dispatch()
         )
         .with_streaming_executor_for_adapter(
             crate::WHISPER_GGML_ADAPTER_ID,
-            Arc::new(WhisperGgmlExecutor::default()),
+            shared_whisper_executor(),
         )
         .with_streaming_partial_granularity_for_adapter(
             crate::WHISPER_GGML_ADAPTER_ID,
@@ -127,7 +125,7 @@ pub(crate) fn build_builtin_ggml_streaming_execution_dispatch()
         )
         .with_streaming_executor_for_adapter(
             crate::COHERE_TRANSCRIBE_GGML_ADAPTER_ID,
-            Arc::new(CohereTranscribeGgmlExecutor::default()),
+            shared_cohere_transcribe_executor(),
         )
         .with_streaming_partial_granularity_for_adapter(
             crate::COHERE_TRANSCRIBE_GGML_ADAPTER_ID,
@@ -135,7 +133,7 @@ pub(crate) fn build_builtin_ggml_streaming_execution_dispatch()
         )
         .with_streaming_executor_for_adapter(
             crate::MOONSHINE_GGML_ADAPTER_ID,
-            Arc::new(MoonshineGgmlExecutor::default()),
+            shared_moonshine_executor(),
         )
         .with_streaming_partial_granularity_for_adapter(
             crate::MOONSHINE_GGML_ADAPTER_ID,

--- a/crates/openasr-core/src/models/cohere/ggml_executor.rs
+++ b/crates/openasr-core/src/models/cohere/ggml_executor.rs
@@ -145,7 +145,7 @@ impl CohereTranscribeGgmlExecutor {
                 request.selected_family.model_architecture,
                 preflight.as_ref(),
                 map_prepared_runtime_registry_error,
-                cohere_runtime_cache_poisoned,
+                cohere_runtime_cache_slot_unavailable,
                 || CohereTranscribeGgmlExecutorError::PreparedRuntimeFailed {
                     reason: format!(
                         "prepared runtime registry returned non-cohere runtime for architecture '{}'",
@@ -377,9 +377,16 @@ impl CohereTranscribeGgmlExecutor {
     }
 }
 
-fn cohere_runtime_cache_poisoned() -> CohereTranscribeGgmlExecutorError {
+// Covers both a genuinely poisoned slot mutex and a build attempt that
+// panicked and was caught (mutex stays unpoisoned, slot stays empty,
+// retryable) -- see `PreparedRuntimeCache::get_or_try_insert_with`. Either way
+// the cache could not deliver a prepared runtime for this attempt; the
+// caller's next request retries clean.
+fn cohere_runtime_cache_slot_unavailable() -> CohereTranscribeGgmlExecutorError {
     CohereTranscribeGgmlExecutorError::PreparedRuntimeFailed {
-        reason: "cohere runtime cache mutex is poisoned".to_string(),
+        reason:
+            "cohere runtime cache slot unavailable (poisoned lock or a caught build panic); retry"
+                .to_string(),
     }
 }
 
@@ -954,7 +961,7 @@ mod tests {
                 request.selected_family.model_architecture,
                 &preflight,
                 map_prepared_runtime_registry_error,
-                cohere_runtime_cache_poisoned,
+                cohere_runtime_cache_slot_unavailable,
             )
             .expect("prepared runtime should build");
         let runtime_b = executor
@@ -963,10 +970,86 @@ mod tests {
                 request.selected_family.model_architecture,
                 &preflight,
                 map_prepared_runtime_registry_error,
-                cohere_runtime_cache_poisoned,
+                cohere_runtime_cache_slot_unavailable,
             )
             .expect("prepared runtime should reuse cache");
         assert!(Arc::ptr_eq(&runtime_a, &runtime_b));
+    }
+
+    /// Core-layer regression coverage for the shared-executor change (PR
+    /// #96): `shared_cohere_transcribe_executor()` is the literal process-wide
+    /// singleton that BOTH `build_builtin_ggml_execution_dispatch` (offline)
+    /// and `build_builtin_ggml_streaming_execution_dispatch` (streaming)
+    /// register into their respective dispatch tables (see
+    /// `executor_component_registry.rs`) -- this test drives that same
+    /// singleton through its two real entry points (`execute`, the offline
+    /// path, and `execute_streaming`, exactly what
+    /// `GgmlAsrStreamingExecutor::start_streaming_session` calls per chunk)
+    /// and asserts they resolve to the *same* `Arc<CoherePreparedRuntime>`,
+    /// not just that both happen to succeed. A regression that reintroduced
+    /// a second executor instance (or a second `runtime_cache_by_path`) would
+    /// still let both calls decode successfully -- the host-materialized
+    /// weights would just be duplicated in memory -- so pointer identity is
+    /// the assertion that actually catches it.
+    #[test]
+    fn cohere_offline_and_streaming_entries_share_the_same_prepared_runtime() {
+        with_forced_cpu_backend_for_test(|| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let runtime_path = temp.path().join("cohere-runtime.gguf");
+            let spec = TinyGgufFixtureSpec::cohere_oasr_v1_runtime_ready("cohere-runtime-fixture");
+            write_tiny_gguf_runtime_source(&runtime_path, &spec).expect("write fixture");
+
+            let shared =
+                crate::models::executor_component_registry::shared_cohere_transcribe_executor();
+            let request = runtime_ready_request(runtime_path);
+            let preflight = request
+                .resolve_runtime_source_preflight()
+                .expect("preflight should resolve")
+                .into_owned();
+
+            // Cold fetch through the exact call `execute_inner` makes
+            // internally for the offline path (`with_cohere_transcribe_runtime_for_preflight`
+            // -> `prepared_runtime_for_preflight`), captured directly so its
+            // Arc identity is observable (`execute`'s return type does not
+            // expose it).
+            let runtime_via_offline_style_lookup = shared
+                .runtime_cache_by_path
+                .prepared_runtime_for_preflight(
+                    request.selected_family.model_architecture,
+                    &preflight,
+                    map_prepared_runtime_registry_error,
+                    cohere_runtime_cache_slot_unavailable,
+                )
+                .expect("offline-style lookup should build the prepared runtime");
+
+            // Real streaming entry, real decode, through the same shared
+            // singleton -- not a stand-in.
+            shared
+                .execute_streaming(&request)
+                .expect("streaming entry should decode using the shared singleton's cache");
+
+            // Now a pure cache hit if (and only if) `execute_streaming` above
+            // reused `runtime_cache_by_path` rather than materializing its
+            // own separate prepared runtime.
+            let runtime_after_streaming_entry = shared
+                .runtime_cache_by_path
+                .prepared_runtime_for_preflight(
+                    request.selected_family.model_architecture,
+                    &preflight,
+                    map_prepared_runtime_registry_error,
+                    cohere_runtime_cache_slot_unavailable,
+                )
+                .expect("post-streaming lookup should still be cached");
+
+            assert!(
+                Arc::ptr_eq(
+                    &runtime_via_offline_style_lookup,
+                    &runtime_after_streaming_entry
+                ),
+                "offline and streaming entry points on the shared executor singleton must \
+                 resolve the same prepared-runtime Arc, proving the cache is actually shared"
+            );
+        });
     }
 
     #[test]

--- a/crates/openasr-core/src/models/executor_component_registry.rs
+++ b/crates/openasr-core/src/models/executor_component_registry.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, OnceLock},
+};
 
 use thiserror::Error;
 
@@ -67,20 +70,69 @@ fn materialize_builtin_executor_component(
 ) -> Option<Arc<dyn GgmlAsrExecutor>> {
     match executor_component_id {
         COHERE_TRANSCRIBE_EXECUTOR_COMPONENT_ID => {
-            Some(Arc::new(CohereTranscribeGgmlExecutor::default()))
+            Some(shared_cohere_transcribe_executor() as Arc<dyn GgmlAsrExecutor>)
         }
-        WHISPER_EXECUTOR_COMPONENT_ID => Some(Arc::new(WhisperGgmlExecutor::default())),
-        QWEN3_ASR_EXECUTOR_COMPONENT_ID => Some(Arc::new(Qwen3AsrGgmlExecutor::default())),
+        WHISPER_EXECUTOR_COMPONENT_ID => {
+            Some(shared_whisper_executor() as Arc<dyn GgmlAsrExecutor>)
+        }
+        QWEN3_ASR_EXECUTOR_COMPONENT_ID => {
+            Some(shared_qwen3_asr_executor() as Arc<dyn GgmlAsrExecutor>)
+        }
         PARAKEET_CTC_EXECUTOR_COMPONENT_ID => Some(Arc::new(ParakeetCtcGgmlExecutor)),
         PARAKEET_TDT_EXECUTOR_COMPONENT_ID => Some(Arc::new(ParakeetTdtGgmlExecutor)),
         WAV2VEC2_CTC_EXECUTOR_COMPONENT_ID => Some(Arc::new(Wav2Vec2CtcGgmlExecutor)),
-        MOONSHINE_EXECUTOR_COMPONENT_ID => Some(Arc::new(MoonshineGgmlExecutor::default())),
+        MOONSHINE_EXECUTOR_COMPONENT_ID => {
+            Some(shared_moonshine_executor() as Arc<dyn GgmlAsrExecutor>)
+        }
         XASR_ZIPFORMER_EXECUTOR_COMPONENT_ID => Some(Arc::new(XasrZipformerGgmlExecutor)),
         DOLPHIN_EXECUTOR_COMPONENT_ID => Some(Arc::new(DolphinGgmlExecutor)),
         SENSEVOICE_EXECUTOR_COMPONENT_ID => Some(Arc::new(SenseVoiceGgmlExecutor)),
         FIRERED_AED_EXECUTOR_COMPONENT_ID => Some(Arc::new(FireRedAedGgmlExecutor)),
         _ => None,
     }
+}
+
+// Process-wide single instances for the "has-state, host-materializes-weights"
+// families (qwen / cohere / whisper / moonshine). Each family's builtin
+// executor struct implements *both* `GgmlAsrExecutor` (offline dispatch) and
+// `GgmlAsrStreamingExecutor` (streaming dispatch) already; historically the two
+// dispatch builders each called `<Family>Executor::default()` independently,
+// so the offline and streaming stacks held two separate instances with two
+// separate `runtime_cache_by_path` caches -- meaning a model warmed on both
+// stacks paid for its host-materialized prepared runtime (weights) twice.
+//
+// These accessors hand out one `Arc<ConcreteExecutor>` per family per process,
+// unsized-coerced independently into each dispatch's own trait-object map
+// (`Arc<dyn GgmlAsrExecutor>` here, `Arc<dyn GgmlAsrStreamingExecutor>` at the
+// streaming registration site in `builtin_execution_dispatch.rs`). Both
+// coercions point at the same heap allocation, so both dispatches share the
+// same `runtime_cache_by_path`: a cold load on either stack populates the one
+// cache the other stack will also hit, and `unload_idle_state()` called from
+// either dispatch's `unload_all()` clears the same cache (the other stack's
+// subsequent `unload_all()` call just clears an already-empty cache, a no-op).
+static SHARED_QWEN3_ASR_EXECUTOR: OnceLock<Arc<Qwen3AsrGgmlExecutor>> = OnceLock::new();
+static SHARED_COHERE_TRANSCRIBE_EXECUTOR: OnceLock<Arc<CohereTranscribeGgmlExecutor>> =
+    OnceLock::new();
+static SHARED_WHISPER_EXECUTOR: OnceLock<Arc<WhisperGgmlExecutor>> = OnceLock::new();
+static SHARED_MOONSHINE_EXECUTOR: OnceLock<Arc<MoonshineGgmlExecutor>> = OnceLock::new();
+
+pub(crate) fn shared_qwen3_asr_executor() -> Arc<Qwen3AsrGgmlExecutor> {
+    Arc::clone(SHARED_QWEN3_ASR_EXECUTOR.get_or_init(|| Arc::new(Qwen3AsrGgmlExecutor::default())))
+}
+
+pub(crate) fn shared_cohere_transcribe_executor() -> Arc<CohereTranscribeGgmlExecutor> {
+    Arc::clone(
+        SHARED_COHERE_TRANSCRIBE_EXECUTOR
+            .get_or_init(|| Arc::new(CohereTranscribeGgmlExecutor::default())),
+    )
+}
+
+pub(crate) fn shared_whisper_executor() -> Arc<WhisperGgmlExecutor> {
+    Arc::clone(SHARED_WHISPER_EXECUTOR.get_or_init(|| Arc::new(WhisperGgmlExecutor::default())))
+}
+
+pub(crate) fn shared_moonshine_executor() -> Arc<MoonshineGgmlExecutor> {
+    Arc::clone(SHARED_MOONSHINE_EXECUTOR.get_or_init(|| Arc::new(MoonshineGgmlExecutor::default())))
 }
 
 #[cfg(test)]
@@ -211,5 +263,71 @@ mod tests {
             seen_families, expected_families,
             "phrase-bias expectation table must not contain stale builtin families"
         );
+    }
+
+    // Phase 1 shared-executor regression coverage: qwen / cohere / whisper /
+    // moonshine each hand out one process-wide `Arc<ConcreteExecutor>` so the
+    // offline and streaming dispatches -- built independently, possibly on
+    // different threads -- register the *same* instance (and therefore the
+    // same `runtime_cache_by_path`) instead of two instances with two
+    // independent caches. These tests share process-global `OnceLock`
+    // statics with every other test in this binary, so they only assert
+    // "repeated calls agree with each other", never a specific identity.
+
+    #[test]
+    fn shared_stateful_family_executors_are_process_wide_singletons() {
+        assert!(Arc::ptr_eq(
+            &shared_qwen3_asr_executor(),
+            &shared_qwen3_asr_executor()
+        ));
+        assert!(Arc::ptr_eq(
+            &shared_cohere_transcribe_executor(),
+            &shared_cohere_transcribe_executor()
+        ));
+        assert!(Arc::ptr_eq(
+            &shared_whisper_executor(),
+            &shared_whisper_executor()
+        ));
+        assert!(Arc::ptr_eq(
+            &shared_moonshine_executor(),
+            &shared_moonshine_executor()
+        ));
+    }
+
+    #[test]
+    fn offline_executor_map_registers_the_same_instance_as_the_shared_accessor() {
+        // `materialize_builtin_executor_component` must route these four
+        // architectures through the shared accessors, not through a fresh
+        // `Default::default()`. If a future edit reverts one of them to a
+        // bare `Arc::new(...)`, this test catches it: the offline map's Arc
+        // would stop being pointer-equal to the shared singleton the
+        // streaming dispatch also draws from, silently reintroducing a
+        // second resident copy of that family's host-materialized weights.
+        let executors =
+            materialize_builtin_executors_by_model_architecture().expect("executor map");
+
+        let qwen_offline = executors
+            .get(crate::QWEN3_ASR_GGML_ARCHITECTURE_ID)
+            .expect("qwen executor");
+        let qwen_shared: Arc<dyn GgmlAsrExecutor> = shared_qwen3_asr_executor();
+        assert!(Arc::ptr_eq(qwen_offline, &qwen_shared));
+
+        let cohere_offline = executors
+            .get(crate::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID)
+            .expect("cohere executor");
+        let cohere_shared: Arc<dyn GgmlAsrExecutor> = shared_cohere_transcribe_executor();
+        assert!(Arc::ptr_eq(cohere_offline, &cohere_shared));
+
+        let whisper_offline = executors
+            .get(crate::WHISPER_GGML_ARCHITECTURE_ID)
+            .expect("whisper executor");
+        let whisper_shared: Arc<dyn GgmlAsrExecutor> = shared_whisper_executor();
+        assert!(Arc::ptr_eq(whisper_offline, &whisper_shared));
+
+        let moonshine_offline = executors
+            .get(crate::arch::MOONSHINE_GGML_ARCHITECTURE_ID)
+            .expect("moonshine executor");
+        let moonshine_shared: Arc<dyn GgmlAsrExecutor> = shared_moonshine_executor();
+        assert!(Arc::ptr_eq(moonshine_offline, &moonshine_shared));
     }
 }

--- a/crates/openasr-core/src/models/moonshine/ggml_executor.rs
+++ b/crates/openasr-core/src/models/moonshine/ggml_executor.rs
@@ -208,8 +208,14 @@ impl MoonshineGgmlExecutor {
         self.runtime_cache_by_path.get_or_try_insert_with(
             preflight.runtime_source.path(),
             || build_moonshine_prepared_runtime(preflight).map_err(map_prepared_runtime_error),
+            // Covers both a genuinely poisoned slot mutex and a build attempt
+            // that panicked and was caught (mutex stays unpoisoned, slot
+            // stays empty, retryable) -- see
+            // `PreparedRuntimeCache::get_or_try_insert_with`. Either way the
+            // cache could not deliver a prepared runtime for this attempt;
+            // the caller's next request retries clean.
             || MoonshineGgmlExecutorError::PreparedRuntimeFailed {
-                reason: "moonshine runtime cache mutex is poisoned".to_string(),
+                reason: "moonshine runtime cache slot unavailable (poisoned lock or a caught build panic); retry".to_string(),
             },
         )
     }

--- a/crates/openasr-core/src/models/prepared_runtime_cache.rs
+++ b/crates/openasr-core/src/models/prepared_runtime_cache.rs
@@ -1,4 +1,6 @@
+use std::any::Any;
 use std::collections::HashMap;
+use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -9,13 +11,34 @@ fn prepared_runtime_cache_key(runtime_path: &Path) -> PathBuf {
     std::fs::canonicalize(runtime_path).unwrap_or_else(|_| runtime_path.to_path_buf())
 }
 
-// One slot per canonicalized runtime path. `None` means "not built yet, or a
-// previous build attempt failed and left nothing cached" (matching the
-// original retry-on-failure contract: a failed build never poisons the path
-// for future callers). The slot's own `Mutex` is held across `build()`, which
-// gives single-flight semantics *scoped to this one path* -- see
-// `get_or_try_insert_with` for why that scoping matters.
+// One slot per canonicalized runtime path. `None` means "not built yet, a
+// previous build attempt returned `Err` and left nothing cached, or a
+// previous build attempt *panicked*" -- all three are retryable and leave the
+// slot's `Mutex` unpoisoned (matching the original retry-on-failure contract:
+// no failed build, whether by typed error or panic, poisons the path for
+// future callers). `get_or_try_insert_with` is what makes the panic case
+// retryable too: it runs `build()` behind `catch_unwind` so a panic never
+// unwinds through the held `MutexGuard` (which is what would poison the
+// `Mutex`), and never writes anything into the slot. The slot's own `Mutex`
+// is held across `build()`, which gives single-flight semantics *scoped to
+// this one path* -- see `get_or_try_insert_with` for why that scoping matters.
 type PreparedRuntimeSlot<T> = Arc<Mutex<Option<Arc<T>>>>;
+
+/// Best-effort human-readable panic message for logging. `std::panic` payloads
+/// are `Box<dyn Any + Send>`; the standard library's own default panic hook
+/// only special-cases `&str` and `String`, so that is what is worth matching
+/// here too -- anything else (a custom payload type) just gets a placeholder,
+/// which is fine since this is diagnostic-only and never part of the typed
+/// error returned to callers.
+fn describe_panic_payload(payload: &(dyn Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct PreparedRuntimeCache<T> {
@@ -77,18 +100,63 @@ impl<T> PreparedRuntimeCache<T> {
         // family that goes through this cache, so it is the single place to
         // time "how long did loading this pack take" without instrumenting
         // each family's build function separately.
+        //
+        // `build()` runs behind `catch_unwind` rather than being called
+        // directly: this slot's `MutexGuard` (`slot_guard`) is held across the
+        // call, and a `Mutex` is poisoned when a guard is dropped *while the
+        // thread is unwinding from a panic*. Left uncaught, a single panicking
+        // build would permanently wedge this one runtime path -- every future
+        // caller would get a poisoned-lock error instead of a clean retry,
+        // which is a strictly worse failure mode than the pre-single-flight
+        // behavior (where `build()` ran outside any lock, so a panic there
+        // never poisoned anything). `catch_unwind` fully absorbs the panic
+        // before this function returns, so by the time `slot_guard` actually
+        // drops the thread is no longer unwinding and the `Mutex` stays
+        // unpoisoned -- restoring the original "a failed build attempt never
+        // poisons the path for future callers" contract for panics, not just
+        // typed `Err`s. `AssertUnwindSafe` is sound here because `build()` is
+        // a pure host materialization closure that never touches this cache's
+        // own state (no callback into `slots_by_path`, `slot`, or any other
+        // shared mutable state reachable from here) -- if it panics partway,
+        // whatever partial state existed lived entirely on `build()`'s own
+        // stack and is simply dropped with it; nothing left reachable through
+        // `self` or `slot_guard` can observe a half-built value.
         let load_started = Instant::now();
-        let prepared = Arc::new(build()?);
-        stage_timing::log_event(
-            "model_pack_load",
-            format_args!(
-                "path={} duration_ms={:.3}",
-                runtime_path.display(),
-                load_started.elapsed().as_secs_f64() * 1000.0
-            ),
-        );
-        *slot_guard = Some(Arc::clone(&prepared));
-        Ok(prepared)
+        match panic::catch_unwind(AssertUnwindSafe(build)) {
+            Ok(result) => {
+                let prepared = Arc::new(result?);
+                stage_timing::log_event(
+                    "model_pack_load",
+                    format_args!(
+                        "path={} duration_ms={:.3}",
+                        runtime_path.display(),
+                        load_started.elapsed().as_secs_f64() * 1000.0
+                    ),
+                );
+                *slot_guard = Some(Arc::clone(&prepared));
+                Ok(prepared)
+            }
+            Err(panic_payload) => {
+                // Deliberately do not write to `*slot_guard` (it stays
+                // `None`, so the next caller for this path retries a clean
+                // build) and do not resume the unwind (that would just move
+                // the "which thread crashes" problem around -- for the
+                // offline path that thread is a `spawn_blocking` worker,
+                // which tokio would report via a `JoinError` on the awaiting
+                // task, not crash the process, but callers of this cache
+                // expect a typed `Result`, not a propagated panic).
+                stage_timing::log_event(
+                    "model_pack_load_panicked",
+                    format_args!(
+                        "path={} duration_ms={:.3} message={}",
+                        runtime_path.display(),
+                        load_started.elapsed().as_secs_f64() * 1000.0,
+                        describe_panic_payload(panic_payload.as_ref())
+                    ),
+                );
+                Err(map_poisoned_lock())
+            }
+        }
     }
 
     /// Drops every cached prepared runtime, releasing the `Arc<T>` this cache
@@ -265,5 +333,142 @@ mod tests {
             "single-flight must build exactly once for a concurrent same-path miss"
         );
         assert!(Arc::ptr_eq(&runtime_a, &runtime_b));
+    }
+
+    /// Proves the SF-1 fix (see `get_or_try_insert_with`'s panic-handling
+    /// comment above `catch_unwind`): before that fix, a `build()` panic
+    /// unwound through the held slot `MutexGuard` and poisoned its `Mutex`,
+    /// wedging this path so every future caller failed the same way until
+    /// `clear()` ran (or forever, under `idle_unload=never`). Against the
+    /// pre-fix code (`Arc::new(build()?)` with no `catch_unwind`) this panic
+    /// propagates straight out of `get_or_try_insert_with` and aborts the
+    /// test on the first call; against the fixed code both calls below
+    /// succeed as documented.
+    #[test]
+    fn build_panic_does_not_poison_the_slot_for_the_next_caller() {
+        let cache = PreparedRuntimeCache::<StubRuntime>::default();
+        let path = Path::new("/tmp/test-runtime-panic.gguf");
+
+        // The panic below is deliberate and is caught internally by
+        // `get_or_try_insert_with`'s own `catch_unwind` (that catch is
+        // exactly what this test proves happens); silence the default panic
+        // hook's stderr noise for it so the test binary's output does not
+        // read like a real crash, then restore the previous hook so other
+        // tests keep normal panic reporting.
+        let previous_hook = panic::take_hook();
+        panic::set_hook(Box::new(|_| {}));
+        let first_result = cache.get_or_try_insert_with(
+            path,
+            || -> Result<StubRuntime, &'static str> { panic!("simulated build panic") },
+            || "poisoned",
+        );
+        panic::set_hook(previous_hook);
+
+        assert_eq!(
+            first_result,
+            Err("poisoned"),
+            "a build() panic must be caught and mapped through map_poisoned_lock, not left \
+             to unwind out of get_or_try_insert_with"
+        );
+
+        // The real assertion: the slot must not be poisoned by the panic
+        // above, so the very next call for the SAME path builds cleanly
+        // instead of inheriting a permanent poisoned-lock failure.
+        let second_result = cache
+            .get_or_try_insert_with(
+                path,
+                || Ok::<_, &'static str>(StubRuntime { value: 42 }),
+                || "poisoned",
+            )
+            .expect("build must succeed cleanly on retry after a prior build panic");
+        assert_eq!(second_result.value, 42);
+    }
+
+    /// Proves `clear()` cannot be "undone" by a build that was already in
+    /// flight when it ran (see `clear()`'s doc comment on this exact
+    /// scenario): the in-flight winner still completes normally -- a
+    /// concurrent `clear()` must not corrupt or block it -- but its result is
+    /// orphaned once `clear()` removes the slot from the map, so the next
+    /// request for the same path rebuilds from scratch rather than somehow
+    /// resurrecting the orphaned build. Production is never actually exposed
+    /// to this race (the activity-gate reaper cannot call `clear()` while a
+    /// request is still in flight, see the shared-executor review), but the
+    /// cache itself should be correct independent of that caller-side
+    /// guarantee.
+    #[test]
+    fn clear_during_in_flight_build_does_not_resurrect_the_evicted_slot() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::thread;
+
+        let cache = Arc::new(PreparedRuntimeCache::<StubRuntime>::default());
+        let path = Path::new("/tmp/test-runtime-clear-in-flight.gguf");
+        let build_count = Arc::new(AtomicUsize::new(0));
+        // Synchronizes "the builder thread is inside build(), holding the
+        // slot lock" with "the main thread's clear() call", so the race this
+        // test targets (clear() concurrent with an in-flight build for the
+        // same path) is reliably exercised rather than left to chance thread
+        // scheduling.
+        let builder_in_build = Arc::new(Barrier::new(2));
+
+        let builder = {
+            let cache = Arc::clone(&cache);
+            let build_count = Arc::clone(&build_count);
+            let barrier = Arc::clone(&builder_in_build);
+            thread::spawn(move || {
+                cache
+                    .get_or_try_insert_with(
+                        path,
+                        || {
+                            build_count.fetch_add(1, Ordering::SeqCst);
+                            barrier.wait();
+                            thread::sleep(std::time::Duration::from_millis(50));
+                            Ok::<_, &'static str>(StubRuntime { value: 1 })
+                        },
+                        || "poisoned",
+                    )
+                    .expect(
+                        "in-flight build must still complete normally despite a concurrent clear()",
+                    )
+            })
+        };
+
+        builder_in_build.wait();
+        // The builder is now inside build(), holding only the slot's own
+        // lock (see get_or_try_insert_with's step 1/2 split -- the outer map
+        // lock is never held across build()), so this clear() proceeds
+        // immediately instead of blocking on the in-flight build.
+        cache.clear();
+
+        let winner_runtime = builder.join().expect("builder thread joined");
+        assert_eq!(build_count.load(Ordering::SeqCst), 1);
+
+        // clear() already dropped the map's only reference to the winner's
+        // slot before the winner finished, so the cache has no path back to
+        // that Arc anymore. A fresh request for the same path must rebuild
+        // from scratch (new slot, new Arc, no double-write into a stale
+        // slot) rather than somehow observing the orphaned in-flight build.
+        let rebuilt_runtime = cache
+            .get_or_try_insert_with(
+                path,
+                || {
+                    build_count.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, &'static str>(StubRuntime { value: 2 })
+                },
+                || "poisoned",
+            )
+            .expect("rebuild after clear must succeed");
+
+        assert_eq!(
+            build_count.load(Ordering::SeqCst),
+            2,
+            "clear() during an in-flight build must force the next caller to rebuild, not \
+             reuse the orphaned slot"
+        );
+        assert!(
+            !Arc::ptr_eq(&winner_runtime, &rebuilt_runtime),
+            "the post-clear rebuild must be a distinct Arc from the orphaned in-flight build's result"
+        );
+        assert_eq!(rebuilt_runtime.value, 2);
     }
 }

--- a/crates/openasr-core/src/models/prepared_runtime_cache.rs
+++ b/crates/openasr-core/src/models/prepared_runtime_cache.rs
@@ -9,15 +9,23 @@ fn prepared_runtime_cache_key(runtime_path: &Path) -> PathBuf {
     std::fs::canonicalize(runtime_path).unwrap_or_else(|_| runtime_path.to_path_buf())
 }
 
+// One slot per canonicalized runtime path. `None` means "not built yet, or a
+// previous build attempt failed and left nothing cached" (matching the
+// original retry-on-failure contract: a failed build never poisons the path
+// for future callers). The slot's own `Mutex` is held across `build()`, which
+// gives single-flight semantics *scoped to this one path* -- see
+// `get_or_try_insert_with` for why that scoping matters.
+type PreparedRuntimeSlot<T> = Arc<Mutex<Option<Arc<T>>>>;
+
 #[derive(Debug, Clone)]
 pub(crate) struct PreparedRuntimeCache<T> {
-    cache_by_path: Arc<Mutex<HashMap<PathBuf, Arc<T>>>>,
+    slots_by_path: Arc<Mutex<HashMap<PathBuf, PreparedRuntimeSlot<T>>>>,
 }
 
 impl<T> Default for PreparedRuntimeCache<T> {
     fn default() -> Self {
         Self {
-            cache_by_path: Arc::new(Mutex::new(HashMap::new())),
+            slots_by_path: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -34,9 +42,34 @@ impl<T> PreparedRuntimeCache<T> {
         M: Fn() -> E,
     {
         let cache_key = prepared_runtime_cache_key(runtime_path);
-        if let Some(runtime) = self.get_by_key(&cache_key, &map_poisoned_lock)? {
-            return Ok(runtime);
+        // Step 1: fetch (or create) this path's slot. The outer map lock is
+        // only ever held for this cheap lookup/insert -- never across a build
+        // -- so a slow cold load for one runtime path never blocks lookups or
+        // builds for a different path sharing this cache (e.g. two families
+        // that both route through `BuiltinPreparedRuntimeCache`, or two
+        // distinct model packs of the same family).
+        let slot = {
+            let mut slots = self.slots_by_path.lock().map_err(|_| map_poisoned_lock())?;
+            Arc::clone(
+                slots
+                    .entry(cache_key)
+                    .or_insert_with(|| Arc::new(Mutex::new(None))),
+            )
+        };
+
+        // Step 2: single-flight on this path's slot. Holding the slot's lock
+        // across `build()` means a concurrent cold-miss for the *same* path
+        // (e.g. the offline and streaming dispatch stacks racing to warm the
+        // same shared executor instance's cache on first use) blocks on this
+        // lock instead of independently materializing its own duplicate
+        // prepared runtime; the loser just observes the winner's result once
+        // it acquires the lock, so a distinct-path model pack load never gets
+        // built twice, not even transiently.
+        let mut slot_guard = slot.lock().map_err(|_| map_poisoned_lock())?;
+        if let Some(runtime) = slot_guard.as_ref() {
+            return Ok(Arc::clone(runtime));
         }
+
         // Model pack loading (mmap + tensor materialization + context/graph
         // construction, up to inference-ready) happens exactly here, exactly
         // once per distinct runtime path per process (subsequent calls hit the
@@ -54,19 +87,8 @@ impl<T> PreparedRuntimeCache<T> {
                 load_started.elapsed().as_secs_f64() * 1000.0
             ),
         );
-        let mut cache = self.cache_by_path.lock().map_err(|_| map_poisoned_lock())?;
-        let entry = cache
-            .entry(cache_key)
-            .or_insert_with(|| Arc::clone(&prepared));
-        Ok(Arc::clone(entry))
-    }
-
-    fn get_by_key<E, M>(&self, cache_key: &Path, map_poisoned_lock: M) -> Result<Option<Arc<T>>, E>
-    where
-        M: Fn() -> E,
-    {
-        let cache = self.cache_by_path.lock().map_err(|_| map_poisoned_lock())?;
-        Ok(cache.get(cache_key).cloned())
+        *slot_guard = Some(Arc::clone(&prepared));
+        Ok(prepared)
     }
 
     /// Drops every cached prepared runtime, releasing the `Arc<T>` this cache
@@ -78,9 +100,18 @@ impl<T> PreparedRuntimeCache<T> {
     /// swallowed (best-effort eviction, not a request-path operation) rather
     /// than propagated, since a subsequent `get_or_try_insert_with` will just
     /// rebuild on the next real request either way.
+    ///
+    /// This drops the per-path slots wholesale rather than resetting each
+    /// slot's inner `Option` to `None`: any build that is still in flight for
+    /// a slot at the moment `clear()` runs holds its own `Arc` clone of that
+    /// slot (taken before `clear()` could remove it from the map), so it
+    /// still completes and populates the slot it is holding -- that slot is
+    /// just no longer reachable from the map, so the next `get_or_try_insert_with`
+    /// call for that path creates a fresh slot and rebuilds, which is the same
+    /// "pay the cold cost again" contract `clear()` has always documented.
     pub(crate) fn clear(&self) {
-        if let Ok(mut cache) = self.cache_by_path.lock() {
-            cache.clear();
+        if let Ok(mut slots) = self.slots_by_path.lock() {
+            slots.clear();
         }
     }
 }
@@ -179,5 +210,60 @@ mod tests {
         assert_eq!(build_count.get(), 2, "clear must force a rebuild");
         assert!(!Arc::ptr_eq(&runtime_a, &runtime_b));
         assert_eq!(runtime_b.value, 9);
+    }
+
+    /// Proves the single-flight fix (see `get_or_try_insert_with`): two
+    /// threads racing a cold miss on the *same* path must not both run
+    /// `build()` -- the second thread has to block on the first thread's
+    /// slot lock and observe its result, not materialize its own copy. This
+    /// is exactly the "offline dispatch and streaming dispatch both warm the
+    /// same shared executor's cache at once" race the shared-executor Phase 1
+    /// change makes newly reachable (previously each dispatch had its own
+    /// separate cache, so there was no shared slot to race on).
+    #[test]
+    fn concurrent_cold_miss_on_the_same_path_builds_exactly_once() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        let cache = Arc::new(PreparedRuntimeCache::<StubRuntime>::default());
+        let path = Path::new("/tmp/test-runtime-concurrent.gguf");
+        let build_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(2));
+
+        let spawn_racer = |value: usize| {
+            let cache = Arc::clone(&cache);
+            let build_count = Arc::clone(&build_count);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                cache
+                    .get_or_try_insert_with(
+                        path,
+                        || {
+                            build_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                            // Give the other thread a chance to reach the slot
+                            // lock while this build is "in flight" -- if the
+                            // fix regressed to build-outside-lock, it would
+                            // race in here concurrently instead of blocking.
+                            thread::sleep(std::time::Duration::from_millis(20));
+                            Ok::<_, &'static str>(StubRuntime { value })
+                        },
+                        || "poisoned",
+                    )
+                    .expect("runtime")
+            })
+        };
+
+        let racer_a = spawn_racer(1);
+        let racer_b = spawn_racer(2);
+        let runtime_a = racer_a.join().expect("racer a joined");
+        let runtime_b = racer_b.join().expect("racer b joined");
+
+        assert_eq!(
+            build_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "single-flight must build exactly once for a concurrent same-path miss"
+        );
+        assert!(Arc::ptr_eq(&runtime_a, &runtime_b));
     }
 }

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -260,7 +260,7 @@ impl Qwen3AsrGgmlExecutor {
                 request.selected_family.model_architecture,
                 preflight.as_ref(),
                 map_prepared_runtime_registry_error,
-                qwen_runtime_cache_poisoned,
+                qwen_runtime_cache_slot_unavailable,
                 || Qwen3AsrGgmlExecutorError::RuntimeContractViolation {
                     reason: format!(
                         "prepared runtime registry returned non-qwen runtime for architecture '{}'",
@@ -766,9 +766,16 @@ impl Qwen3AsrGgmlExecutor {
     }
 }
 
-fn qwen_runtime_cache_poisoned() -> Qwen3AsrGgmlExecutorError {
+// Covers both a genuinely poisoned slot mutex and a build attempt that
+// panicked and was caught (mutex stays unpoisoned, slot stays empty,
+// retryable) -- see `PreparedRuntimeCache::get_or_try_insert_with`. Either way
+// the cache could not deliver a prepared runtime for this attempt; the
+// caller's next request retries clean.
+fn qwen_runtime_cache_slot_unavailable() -> Qwen3AsrGgmlExecutorError {
     Qwen3AsrGgmlExecutorError::RuntimeMetadataReadFailed {
-        reason: "qwen runtime cache mutex is poisoned".to_string(),
+        reason:
+            "qwen runtime cache slot unavailable (poisoned lock or a caught build panic); retry"
+                .to_string(),
     }
 }
 

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -3050,14 +3050,21 @@ impl WhisperGgmlExecutor {
                     self.tokenizer_provider.as_ref(),
                 )
             },
-            whisper_runtime_cache_poisoned,
+            whisper_runtime_cache_slot_unavailable,
         )
     }
 }
 
-fn whisper_runtime_cache_poisoned() -> WhisperGgmlExecutorError {
+// Covers both a genuinely poisoned slot mutex (a prior caller panicked while
+// holding it -- extremely unlikely, see `PreparedRuntimeCache::get_or_try_insert_with`)
+// and a build attempt that panicked and was caught (mutex stays unpoisoned,
+// slot stays empty, retryable). Either way the cache could not deliver a
+// prepared runtime for this attempt; the caller's next request retries clean.
+fn whisper_runtime_cache_slot_unavailable() -> WhisperGgmlExecutorError {
     WhisperGgmlExecutorError::TensorMaterializationFailed {
-        reason: "whisper runtime cache mutex is poisoned".to_string(),
+        reason:
+            "whisper runtime cache slot unavailable (poisoned lock or a caught build panic); retry"
+                .to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary

Share one executor instance between the offline (file-transcription) dispatch and the realtime-streaming dispatch for the four families that host-materialize a prepared runtime (qwen, cohere, whisper, moonshine), and make the prepared-runtime cache single-flight per path. A model warmed on both stacks no longer keeps two host-materialized copies of its weights resident.

This is Phase 1 (candidate B) of the shared-prepared-runtime design (v2, measurement-arbitrated): axis 1 (host prepared cache) is collapsed across dispatches; axis 2 (thread-local whole-decoder arenas) is explicitly out of scope, and AED/CTC/transducer families are excluded because their weights are zero-copy mmap-bound and already physically shared by the kernel page cache across stacks.

## Why

`materialize_builtin_executor_component` (offline) and `build_builtin_ggml_streaming_execution_dispatch` (streaming) each called `<Family>Executor::default()`, so each stack held an independent `runtime_cache_by_path`. Warming the same pack on both stacks doubled resident memory for the stateful families; qwen's owned f16 `token_embedding` alone is ~594 MiB, and the measured dual-stack qwen q4_k footprint was ~2x a single stack.

## Changes

- `models/executor_component_registry.rs`: process-wide `shared_qwen3_asr_executor()` / `shared_cohere_transcribe_executor()` / `shared_whisper_executor()` / `shared_moonshine_executor()` accessors (`OnceLock<Arc<ConcreteExecutor>>`). The offline map now draws these four from the accessors; the other seven families are unchanged.
- `models/builtin_execution_dispatch.rs`: the streaming registration sites for the same four families use the shared accessors instead of `Arc::new(::default())`. The same `Arc` is unsized-coerced to `Arc<dyn GgmlAsrExecutor>` on one side and `Arc<dyn GgmlAsrStreamingExecutor>` on the other -- one heap allocation, one shared cache.
- `models/prepared_runtime_cache.rs`: single-flight builds. Previously `build()` ran outside the map lock and `or_insert` collapsed duplicates after the fact, so two threads cold-missing the same path (now reachable: both dispatch stacks warming the same shared cache at once) would each transiently materialize a full prepared runtime. The cache now keeps one slot (`Arc<Mutex<Option<Arc<T>>>>`) per canonicalized path and holds the slot lock across `build()`: the loser blocks and observes the winner's result, so a given pack is never built twice, not even transiently. The outer map lock still only guards slot lookup/insert, so a slow load for one pack never blocks a different pack.
- Idle-unload semantics are untouched: the reaper still sweeps both dispatches with `unload_all()`; both sweeps now hit the same executor instance, whose `unload_idle_state()` -> `clear()` is idempotent (the second sweep clears an already-empty cache). The core unload functions, their call order in the server reaper, and the unload-generation signal are not modified. `clear()` drops slots wholesale, so an in-flight build completes against its own slot Arc and the next request pays the cold rebuild -- the documented contract.
- Regression tests: singleton identity per accessor; offline executor map hands out pointer-identical instances to the shared accessors; two-thread barrier test proving a concurrent same-path cold miss builds exactly once.
- CHANGELOG entry under Unreleased/Changed.

## Review fixes

A prior review flagged one SHOULD-FIX and asked for corresponding test coverage; both are addressed in a follow-up commit:

- **Singleflight slot panic-safety.** `get_or_try_insert_with` held the per-path slot's `MutexGuard` across `build()`. A `build()` panic unwound through that guard and poisoned the `Mutex`, wedging the path so every future caller for it failed the same way until the idle-unload reaper's `clear()` ran (or forever under `idle_unload=never`) -- a regression versus the pre-single-flight code, where `build()` ran outside any lock and a panic there never poisoned anything. Fixed by running `build()` behind `std::panic::catch_unwind` (`AssertUnwindSafe` is sound here: `build()` is a pure host-materialization closure that never touches the cache's own state, so a partial panic only discards `build()`'s own stack, nothing reachable through the cache). A caught panic now leaves the slot `None` and the `Mutex` unpoisoned, so the next request for that path retries cleanly -- restoring the original "a failed build never poisons the path" contract for panics, not just typed `Err`s. Updated the four family-level "poisoned" error reasons (whisper/cohere/qwen/moonshine) to describe both cases they now cover, and log the caught panic message for diagnostics. Also corrected the slot-type doc comment, which previously conflated a typed `Err` (already retryable pre-fix) with a panic (was not).
- **New tests**, per the review's ask:
  - A panic-injection singleflight test (`build_panic_does_not_poison_the_slot_for_the_next_caller`) that fails against the pre-fix code (a build panic propagates straight out of `get_or_try_insert_with` and aborts the test) and passes against the fix.
  - A `clear()`-during-in-flight-build test (`clear_during_in_flight_build_does_not_resurrect_the_evicted_slot`) proving the in-flight winner still completes normally, its result is orphaned once `clear()` removes the slot from the map, and the next request for that path rebuilds from scratch rather than reusing the orphaned slot.
  - A core-layer integration test (`cohere_offline_and_streaming_entries_share_the_same_prepared_runtime`) that drives the real offline (`execute`) and streaming (`execute_streaming`) entry points on the process-wide shared executor singleton and asserts they resolve the same `Arc<CoherePreparedRuntime>` -- proving the cache sharing this PR introduces is actually exercised by both entry points, not just structurally present.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2402 passed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (byte-identical; 2 passed, 2 skipped needing the private firered dev pack, as on main)
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

Dual-stack behavior regression with the real `qwen3-asr-0.6b` q4_k pack (scratch harness, not committed): offline transcribe and a streaming session alternated twice, then ran concurrently from two threads on the shared instance. No deadlock; offline and streaming transcripts byte-identical across all rounds (offline: the full JFK sentence; streaming: identical partial-window final in every round).

Memory (same-process `footprint` physical footprint, M1 16 GiB; reference values, machine had concurrent load):

| scenario (qwen3-asr-0.6b q4_k) | before | after |
|---|---|---|
| offline only | - | 2214 MiB |
| streaming only | - | 1189 MiB |
| offline + streaming warm ("both") | 2965 MiB | 2197 MiB |

"Both" drops from ~2x to ~1x offline: the after-both footprint sits at the offline-only level.

## Docs updated

- [x] CHANGELOG updated; no docs overclaim (the entry scopes the saving to dual-stack warm and names the excluded mmap families).

## Scope / non-goals

- No change to public API, HTTP surface, unload semantics, or any ZST/AED family (parakeet, wav2vec2, sensevoice, dolphin, firered, xasr).
- Axis 2 (qwen's thread-local whole-decoder arena) is deliberately not pooled here; per the v2 design it stays a separate, data-driven decision.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implementation and tests developed with AI assistance under maintainer direction and review.
