### PR TITLE
refactor(core): extract shared FastConformer encoder core (parakeet-ctc/tdt)

### DIFF
--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -10,6 +10,7 @@ pub(crate) mod decode_token_history;
 pub(crate) mod diarize_pack_import;
 pub(crate) mod dolphin;
 pub(crate) mod executor_component_registry;
+pub(crate) mod fastconformer;
 pub(crate) mod firered_aed;
 pub(crate) mod firered_punc;
 pub(crate) mod frame_sync_streaming_driver;

--- a/crates/openasr-core/src/models/fastconformer/graph.rs
+++ b/crates/openasr-core/src/models/fastconformer/graph.rs
@@ -1,0 +1,728 @@
+//! Shared FastConformer encoder graph: arena alloc/upload/bind plumbing, the
+//! dw-striding subsampling prelude, and the conformer layer loop, carried
+//! over byte-for-byte from `parakeet_ctc::encoder_graph` /
+//! `parakeet_tdt::encoder_graph` (which built the identical graph shape).
+//!
+//! What is intentionally NOT here: the tail (CTC head vs. joint encoder
+//! projection matmul + output), the family's mel/output struct names, and
+//! the family's own error type. [`FastConformerEncoderCore::build`] takes
+//! the tail as a pair of declare/upload closures so the "declare every arena
+//! tensor, THEN upload every value" ordering the arena requires (the first
+//! `set_*_slice` call freezes further `new_tensor_*` allocation) stays
+//! intact across the family-specific tail tensors too.
+
+use std::path::Path;
+
+use crate::ggml_runtime::{
+    ArenaAllocError, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError,
+    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedWeightContext, GgmlStaticTensor,
+    GgmlStaticTensorArena, WeightSlot, alloc_static_f16 as arena_alloc_static_f16,
+    alloc_static_f32 as arena_alloc_static_f32, bind_loaded as arena_bind_loaded,
+    upload_static_f16 as arena_upload_static_f16, upload_static_f32 as arena_upload_static_f32,
+};
+use crate::nn::conv::{
+    Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation,
+    apply_conv_2d_depthwise_bias_activation, reshape_bias_4d,
+};
+use crate::nn::encoder::{
+    ConformerBlockConfig, ConformerBlockWeights, build_relative_positional_encoding,
+    conformer_block,
+};
+use crate::nn::half::f32_to_f16_bits;
+
+use super::FastConformerGraphError;
+use super::weights::{FastConformerLayerWeights, NamedTensor};
+
+const ENCODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
+const CONFORMER_MACARON_SCALE: f32 = 0.5;
+const SUBSAMPLING_KERNEL: usize = 3;
+const SUBSAMPLING_STRIDE: usize = 2;
+const SUBSAMPLING_PADDING: usize = 1;
+
+pub(crate) fn conv_out_dim(input: usize) -> usize {
+    (input + 2 * SUBSAMPLING_PADDING - SUBSAMPLING_KERNEL) / SUBSAMPLING_STRIDE + 1
+}
+
+fn bf<E: FastConformerGraphError>(step: &'static str) -> impl Fn(GgmlCpuGraphError) -> E {
+    move |source| E::graph_build_failed(step, source)
+}
+
+/// Bind a 2-D linear zero-copy from the mmap'd pack (`loaded`) by its on-disk
+/// name. FAILS CLOSED if the loaded context is absent or the tensor is
+/// missing: the host f32 `values` for bound weights are dropped at load, so
+/// there is no arena fallback -- uploading an empty buffer would silently
+/// corrupt the graph.
+pub(crate) fn bind_loaded<E: FastConformerGraphError>(
+    loaded: Option<&GgmlLoadedWeightContext>,
+    name: &str,
+) -> Result<WeightSlot, E> {
+    arena_bind_loaded(loaded, name)
+        .map(WeightSlot::Loaded)
+        .map_err(E::shape)
+}
+
+/// Allocate a static arena tensor matching a host weight's stored dims (the
+/// same layout the importer wrote, so `conformer_block` consumes it
+/// identically).
+pub(crate) fn alloc_static<E: FastConformerGraphError>(
+    arena: &GgmlStaticTensorArena,
+    weight: &NamedTensor,
+    step: &'static str,
+) -> Result<GgmlStaticTensor, E> {
+    arena_alloc_static_f32(arena, &weight.dims, weight.values.len(), step, true).map_err(
+        |e| match e {
+            ArenaAllocError::Graph(source) => E::graph_build_failed(step, source),
+            ArenaAllocError::UnsupportedRank(dims) => E::shape(format!(
+                "tensor '{}' has unsupported rank {:?}",
+                weight.name, dims
+            )),
+        },
+    )
+}
+
+pub(crate) fn upload_static<E: FastConformerGraphError>(
+    arena: &mut GgmlStaticTensorArena,
+    tensor: GgmlStaticTensor,
+    weight: &NamedTensor,
+    step: &'static str,
+) -> Result<(), E> {
+    arena_upload_static_f32(arena, tensor, &weight.values, step).map_err(bf(step))
+}
+
+/// Allocate an f16 arena tensor for a depthwise conv kernel (ggml
+/// `conv_2d_dw` requires an f16 kernel; regular `conv_2d` accepts f32).
+pub(crate) fn alloc_static_f16<E: FastConformerGraphError>(
+    arena: &GgmlStaticTensorArena,
+    weight: &NamedTensor,
+    step: &'static str,
+) -> Result<GgmlStaticTensor, E> {
+    arena_alloc_static_f16(arena, &weight.dims, step, true).map_err(|e| match e {
+        ArenaAllocError::Graph(source) => E::graph_build_failed(step, source),
+        ArenaAllocError::UnsupportedRank(dims) => {
+            E::shape(format!("f16 depthwise '{}' rank {:?}", weight.name, dims))
+        }
+    })
+}
+
+pub(crate) fn upload_static_f16<E: FastConformerGraphError>(
+    arena: &mut GgmlStaticTensorArena,
+    tensor: GgmlStaticTensor,
+    weight: &NamedTensor,
+    step: &'static str,
+) -> Result<(), E> {
+    arena_upload_static_f16(arena, tensor, &weight.values, step, f32_to_f16_bits).map_err(bf(step))
+}
+
+pub(crate) fn upload_graph_f32<'a, E: FastConformerGraphError>(
+    graph: &mut GgmlCpuGraphBuilder<'a>,
+    tensor: GgmlCpuTensor<'a>,
+    values: &[f32],
+    step: &'static str,
+) -> Result<(), E> {
+    graph.set_f32_slice(tensor, values, step).map_err(bf(step))
+}
+
+fn find_sub<'a, E: FastConformerGraphError>(
+    subsampling: &'a [NamedTensor],
+    name: &str,
+) -> Result<&'a NamedTensor, E> {
+    subsampling
+        .iter()
+        .find(|t| t.name == name)
+        .ok_or_else(|| E::shape(format!("missing subsampling tensor '{name}'")))
+}
+
+/// Per-layer handles for the conformer block weights. The 2-D linears
+/// (`ff*.{up,down}`, `attn.{q,k,v,out,pos}`, `conv.pw{1,2}`) are `WeightSlot`
+/// (bound zero-copy from the pack when a runtime path is supplied); norms,
+/// biases, and the BN-folded depthwise conv stay plain arena tensors.
+pub(crate) struct LayerArena {
+    ff1_norm_weight: GgmlStaticTensor,
+    ff1_norm_bias: GgmlStaticTensor,
+    ff1_up_weight: WeightSlot,
+    ff1_up_bias: GgmlStaticTensor,
+    ff1_down_weight: WeightSlot,
+    ff1_down_bias: GgmlStaticTensor,
+    attn_norm_weight: GgmlStaticTensor,
+    attn_norm_bias: GgmlStaticTensor,
+    attn_q_weight: WeightSlot,
+    attn_q_bias: GgmlStaticTensor,
+    attn_k_weight: WeightSlot,
+    attn_k_bias: GgmlStaticTensor,
+    attn_v_weight: WeightSlot,
+    attn_v_bias: GgmlStaticTensor,
+    attn_out_weight: WeightSlot,
+    attn_out_bias: GgmlStaticTensor,
+    attn_pos_weight: WeightSlot,
+    attn_pos_bias_u: GgmlStaticTensor,
+    attn_pos_bias_v: GgmlStaticTensor,
+    conv_norm_weight: GgmlStaticTensor,
+    conv_norm_bias: GgmlStaticTensor,
+    conv_pw1_weight: WeightSlot,
+    conv_pw1_bias: GgmlStaticTensor,
+    conv_dw_weight: GgmlStaticTensor,
+    conv_dw_bias: GgmlStaticTensor,
+    conv_pw2_weight: WeightSlot,
+    conv_pw2_bias: GgmlStaticTensor,
+    ff2_norm_weight: GgmlStaticTensor,
+    ff2_norm_bias: GgmlStaticTensor,
+    ff2_up_weight: WeightSlot,
+    ff2_up_bias: GgmlStaticTensor,
+    ff2_down_weight: WeightSlot,
+    ff2_down_bias: GgmlStaticTensor,
+    out_norm_weight: GgmlStaticTensor,
+    out_norm_bias: GgmlStaticTensor,
+}
+
+pub(crate) struct SubsamplingArena {
+    conv0_w: GgmlStaticTensor,
+    conv0_b: GgmlStaticTensor,
+    conv2_w: GgmlStaticTensor,
+    conv2_b: GgmlStaticTensor,
+    conv3_w: GgmlStaticTensor,
+    conv3_b: GgmlStaticTensor,
+    conv5_w: GgmlStaticTensor,
+    conv5_b: GgmlStaticTensor,
+    conv6_w: GgmlStaticTensor,
+    conv6_b: GgmlStaticTensor,
+    linear_w: WeightSlot,
+    linear_b: GgmlStaticTensor,
+    conv6_channels: usize,
+}
+
+/// Allocate one conformer layer's arena tensors + bind its 2-D linears
+/// zero-copy from the mmap'd pack. Fails closed (`bind_loaded`) when a bound
+/// weight is absent -- its host payload was dropped at load.
+pub(crate) fn alloc_layer<E: FastConformerGraphError>(
+    arena: &GgmlStaticTensorArena,
+    loaded: Option<&GgmlLoadedWeightContext>,
+    layer: &FastConformerLayerWeights,
+) -> Result<LayerArena, E> {
+    Ok(LayerArena {
+        ff1_norm_weight: alloc_static(arena, &layer.ff1_norm_weight, "ff1_norm_w")?,
+        ff1_norm_bias: alloc_static(arena, &layer.ff1_norm_bias, "ff1_norm_b")?,
+        ff1_up_weight: bind_loaded(loaded, &layer.ff1_up_weight.name)?,
+        ff1_up_bias: alloc_static(arena, &layer.ff1_up_bias, "ff1_up_b")?,
+        ff1_down_weight: bind_loaded(loaded, &layer.ff1_down_weight.name)?,
+        ff1_down_bias: alloc_static(arena, &layer.ff1_down_bias, "ff1_down_b")?,
+        attn_norm_weight: alloc_static(arena, &layer.attn_norm_weight, "attn_norm_w")?,
+        attn_norm_bias: alloc_static(arena, &layer.attn_norm_bias, "attn_norm_b")?,
+        attn_q_weight: bind_loaded(loaded, &layer.attn_q_weight.name)?,
+        attn_q_bias: alloc_static(arena, &layer.attn_q_bias, "attn_q_b")?,
+        attn_k_weight: bind_loaded(loaded, &layer.attn_k_weight.name)?,
+        attn_k_bias: alloc_static(arena, &layer.attn_k_bias, "attn_k_b")?,
+        attn_v_weight: bind_loaded(loaded, &layer.attn_v_weight.name)?,
+        attn_v_bias: alloc_static(arena, &layer.attn_v_bias, "attn_v_b")?,
+        attn_out_weight: bind_loaded(loaded, &layer.attn_out_weight.name)?,
+        attn_out_bias: alloc_static(arena, &layer.attn_out_bias, "attn_out_b")?,
+        attn_pos_weight: bind_loaded(loaded, &layer.attn_pos_weight.name)?,
+        attn_pos_bias_u: alloc_static(arena, &layer.attn_pos_bias_u, "attn_pos_u")?,
+        attn_pos_bias_v: alloc_static(arena, &layer.attn_pos_bias_v, "attn_pos_v")?,
+        conv_norm_weight: alloc_static(arena, &layer.conv_norm_weight, "conv_norm_w")?,
+        conv_norm_bias: alloc_static(arena, &layer.conv_norm_bias, "conv_norm_b")?,
+        conv_pw1_weight: bind_loaded(loaded, &layer.conv_pw1_weight.name)?,
+        conv_pw1_bias: alloc_static(arena, &layer.conv_pw1_bias, "conv_pw1_b")?,
+        conv_dw_weight: alloc_static_f16(arena, &layer.conv_dw_weight, "conv_dw_w")?,
+        conv_dw_bias: alloc_static(arena, &layer.conv_dw_bias, "conv_dw_b")?,
+        conv_pw2_weight: bind_loaded(loaded, &layer.conv_pw2_weight.name)?,
+        conv_pw2_bias: alloc_static(arena, &layer.conv_pw2_bias, "conv_pw2_b")?,
+        ff2_norm_weight: alloc_static(arena, &layer.ff2_norm_weight, "ff2_norm_w")?,
+        ff2_norm_bias: alloc_static(arena, &layer.ff2_norm_bias, "ff2_norm_b")?,
+        ff2_up_weight: bind_loaded(loaded, &layer.ff2_up_weight.name)?,
+        ff2_up_bias: alloc_static(arena, &layer.ff2_up_bias, "ff2_up_b")?,
+        ff2_down_weight: bind_loaded(loaded, &layer.ff2_down_weight.name)?,
+        ff2_down_bias: alloc_static(arena, &layer.ff2_down_bias, "ff2_down_b")?,
+        out_norm_weight: alloc_static(arena, &layer.out_norm_weight, "out_norm_w")?,
+        out_norm_bias: alloc_static(arena, &layer.out_norm_bias, "out_norm_b")?,
+    })
+}
+
+/// Upload one layer's ARENA tensors (norms, biases, BN-folded depthwise
+/// conv). The 2-D linears are bound zero-copy in `alloc_layer`, so they are
+/// absent here (their host f32 `values` were dropped at load).
+pub(crate) fn upload_layer<E: FastConformerGraphError>(
+    arena: &mut GgmlStaticTensorArena,
+    layer: &FastConformerLayerWeights,
+    h: &LayerArena,
+) -> Result<(), E> {
+    upload_static_f16(arena, h.conv_dw_weight, &layer.conv_dw_weight, "conv_dw_w")?;
+    let pairs: [(GgmlStaticTensor, &NamedTensor); 23] = [
+        (h.ff1_norm_weight, &layer.ff1_norm_weight),
+        (h.ff1_norm_bias, &layer.ff1_norm_bias),
+        (h.ff1_up_bias, &layer.ff1_up_bias),
+        (h.ff1_down_bias, &layer.ff1_down_bias),
+        (h.attn_norm_weight, &layer.attn_norm_weight),
+        (h.attn_norm_bias, &layer.attn_norm_bias),
+        (h.attn_q_bias, &layer.attn_q_bias),
+        (h.attn_k_bias, &layer.attn_k_bias),
+        (h.attn_v_bias, &layer.attn_v_bias),
+        (h.attn_out_bias, &layer.attn_out_bias),
+        (h.attn_pos_bias_u, &layer.attn_pos_bias_u),
+        (h.attn_pos_bias_v, &layer.attn_pos_bias_v),
+        (h.conv_norm_weight, &layer.conv_norm_weight),
+        (h.conv_norm_bias, &layer.conv_norm_bias),
+        (h.conv_pw1_bias, &layer.conv_pw1_bias),
+        (h.conv_dw_bias, &layer.conv_dw_bias),
+        (h.conv_pw2_bias, &layer.conv_pw2_bias),
+        (h.ff2_norm_weight, &layer.ff2_norm_weight),
+        (h.ff2_norm_bias, &layer.ff2_norm_bias),
+        (h.ff2_up_bias, &layer.ff2_up_bias),
+        (h.ff2_down_bias, &layer.ff2_down_bias),
+        (h.out_norm_weight, &layer.out_norm_weight),
+        (h.out_norm_bias, &layer.out_norm_bias),
+    ];
+    for (tensor, weight) in pairs {
+        upload_static(arena, tensor, weight, "layer_weight")?;
+    }
+    Ok(())
+}
+
+pub(crate) fn conformer_weights<'a>(
+    arena: &'a GgmlStaticTensorArena,
+    h: &LayerArena,
+) -> ConformerBlockWeights<'a> {
+    let g = |t: GgmlStaticTensor| arena.graph_tensor(t);
+    // Bound 2-D linears resolve to their mmap'd leaf via the `WeightSlot`
+    // handle; everything else is a plain arena tensor.
+    let b = |slot: WeightSlot| slot.graph(arena);
+    ConformerBlockWeights {
+        ff1_norm_weight: g(h.ff1_norm_weight),
+        ff1_norm_bias: g(h.ff1_norm_bias),
+        ff1_up_weight: b(h.ff1_up_weight),
+        ff1_up_bias: g(h.ff1_up_bias),
+        ff1_down_weight: b(h.ff1_down_weight),
+        ff1_down_bias: g(h.ff1_down_bias),
+        attn_norm_weight: g(h.attn_norm_weight),
+        attn_norm_bias: g(h.attn_norm_bias),
+        attn_q_weight: b(h.attn_q_weight),
+        attn_q_bias: g(h.attn_q_bias),
+        attn_k_weight: b(h.attn_k_weight),
+        attn_k_bias: g(h.attn_k_bias),
+        attn_v_weight: b(h.attn_v_weight),
+        attn_v_bias: g(h.attn_v_bias),
+        attn_out_weight: b(h.attn_out_weight),
+        attn_out_bias: g(h.attn_out_bias),
+        attn_pos_weight: b(h.attn_pos_weight),
+        attn_pos_bias_u: g(h.attn_pos_bias_u),
+        attn_pos_bias_v: g(h.attn_pos_bias_v),
+        conv_norm_weight: g(h.conv_norm_weight),
+        conv_norm_bias: g(h.conv_norm_bias),
+        conv_pw1_weight: b(h.conv_pw1_weight),
+        conv_pw1_bias: g(h.conv_pw1_bias),
+        conv_dw_weight: g(h.conv_dw_weight),
+        conv_dw_bias: g(h.conv_dw_bias),
+        conv_pw2_weight: b(h.conv_pw2_weight),
+        conv_pw2_bias: g(h.conv_pw2_bias),
+        ff2_norm_weight: g(h.ff2_norm_weight),
+        ff2_norm_bias: g(h.ff2_norm_bias),
+        ff2_up_weight: b(h.ff2_up_weight),
+        ff2_up_bias: g(h.ff2_up_bias),
+        ff2_down_weight: b(h.ff2_down_weight),
+        ff2_down_bias: g(h.ff2_down_bias),
+        out_norm_weight: g(h.out_norm_weight),
+        out_norm_bias: g(h.out_norm_bias),
+    }
+}
+
+/// The shared FastConformer encoder residency: the graph runner, the
+/// mmap-backed loaded-weight context the bound slots alias, the static
+/// tensor arena, and every subsampling/conformer-layer handle. A family's
+/// own `EncoderGraph` embeds this plus its own tail handles (CTC head or
+/// joint encoder projection).
+pub(crate) struct FastConformerEncoderCore {
+    pub(crate) runner: GgmlCpuGraphRunner,
+    // Owns the mmap-backed buffer the `Loaded` weight slots above alias.
+    // Rust drops struct fields in declaration order (first-declared drops
+    // first), so declaring it here does NOT make it outlive `arena`;
+    // soundness relies on neither `arena` nor `runner` dereferencing weight
+    // memory on drop. Never read directly -- it exists to keep the mapping
+    // alive.
+    #[allow(dead_code)]
+    pub(crate) loaded_weights: Option<GgmlLoadedWeightContext>,
+    pub(crate) arena: GgmlStaticTensorArena,
+    pub(crate) sub: SubsamplingArena,
+    pub(crate) layers: Vec<LayerArena>,
+}
+
+impl FastConformerEncoderCore {
+    /// Build the runner + arena + every subsampling/conformer-layer tensor,
+    /// threading the family's own tail (CTC head weight+bias, or joint
+    /// encoder projection weight+bias) through as a declare/upload closure
+    /// pair so it participates in the arena's single "declare everything,
+    /// then upload everything" pass (the first upload call freezes further
+    /// tensor allocation).
+    pub(crate) fn build<E, T>(
+        mut graph_config: GgmlCpuGraphConfig,
+        context_bytes: usize,
+        runtime_path: Option<&Path>,
+        subsampling: &[NamedTensor],
+        layers: &[FastConformerLayerWeights],
+        declare_tail: impl FnOnce(
+            &GgmlStaticTensorArena,
+            Option<&GgmlLoadedWeightContext>,
+        ) -> Result<T, E>,
+        upload_tail: impl FnOnce(&mut GgmlStaticTensorArena, &T) -> Result<(), E>,
+    ) -> Result<(Self, T), E>
+    where
+        E: FastConformerGraphError,
+    {
+        graph_config.context_bytes = context_bytes;
+        // FastConformer-XL builds more graph nodes than the default 4096-node
+        // cap, tripping `GGML_ASSERT(cgraph->n_nodes < cgraph->size)`. Size
+        // the cgraph to the actual (data-driven) layer count with generous
+        // per-layer headroom. This is capacity only -- the built graph and
+        // its op order are unchanged, so a model within the default cap
+        // stays byte-for-byte identical.
+        graph_config.graph_size = graph_config.graph_size.max(layers.len() * 256 + 2048);
+        let runner = GgmlCpuGraphRunner::new(graph_config)
+            .map_err(|source| E::graph_build_failed("runner_init", source))?;
+        // Bind the 2-D linears zero-copy from the mmap'd pack (no f32
+        // dequantize-to-host, no arena upload). Fails closed below if the
+        // load failed but a bindable weight's host payload was dropped.
+        let loaded_weights =
+            runtime_path.and_then(|path| runner.load_gguf_weight_context(path).ok());
+        let loaded = loaded_weights.as_ref();
+        let mut arena = runner
+            .start_static_tensor_arena(context_bytes)
+            .map_err(|source| E::graph_build_failed("static_tensor_arena", source))?;
+
+        // ----- declare (allocate) all arena tensors first (first upload freezes) -----
+        let s = |n: &str| find_sub::<E>(subsampling, n);
+        let conv0_w_t = alloc_static(&arena, s("enc.sub.layers.0.weight")?, "sub0_w")?;
+        let conv0_b_t = alloc_static(&arena, s("enc.sub.layers.0.bias")?, "sub0_b")?;
+        let conv2_w_t = alloc_static_f16(&arena, s("enc.sub.layers.2.weight")?, "sub2_w")?;
+        let conv2_b_t = alloc_static(&arena, s("enc.sub.layers.2.bias")?, "sub2_b")?;
+        let conv3_w_t = alloc_static(&arena, s("enc.sub.layers.3.weight")?, "sub3_w")?;
+        let conv3_b_t = alloc_static(&arena, s("enc.sub.layers.3.bias")?, "sub3_b")?;
+        let conv5_w_t = alloc_static_f16(&arena, s("enc.sub.layers.5.weight")?, "sub5_w")?;
+        let conv5_b_t = alloc_static(&arena, s("enc.sub.layers.5.bias")?, "sub5_b")?;
+        let conv6_w_t = alloc_static(&arena, s("enc.sub.layers.6.weight")?, "sub6_w")?;
+        let conv6_b_t = alloc_static(&arena, s("enc.sub.layers.6.bias")?, "sub6_b")?;
+        let linear_w_slot = bind_loaded(loaded, "enc.sub.linear.weight")?;
+        let linear_b_t = alloc_static(&arena, s("enc.sub.linear.bias")?, "sub_lin_b")?;
+        let conv6_channels = s("enc.sub.layers.6.bias")?.values.len();
+
+        let mut layer_arenas = Vec::with_capacity(layers.len());
+        for layer in layers {
+            layer_arenas.push(alloc_layer(&arena, loaded, layer)?);
+        }
+
+        let tail = declare_tail(&arena, loaded)?;
+
+        // ----- upload all values (arena now freezes on first set) -----
+        upload_static(
+            &mut arena,
+            conv0_w_t,
+            s("enc.sub.layers.0.weight")?,
+            "sub0_w",
+        )?;
+        upload_static(&mut arena, conv0_b_t, s("enc.sub.layers.0.bias")?, "sub0_b")?;
+        upload_static_f16(
+            &mut arena,
+            conv2_w_t,
+            s("enc.sub.layers.2.weight")?,
+            "sub2_w",
+        )?;
+        upload_static(&mut arena, conv2_b_t, s("enc.sub.layers.2.bias")?, "sub2_b")?;
+        upload_static(
+            &mut arena,
+            conv3_w_t,
+            s("enc.sub.layers.3.weight")?,
+            "sub3_w",
+        )?;
+        upload_static(&mut arena, conv3_b_t, s("enc.sub.layers.3.bias")?, "sub3_b")?;
+        upload_static_f16(
+            &mut arena,
+            conv5_w_t,
+            s("enc.sub.layers.5.weight")?,
+            "sub5_w",
+        )?;
+        upload_static(&mut arena, conv5_b_t, s("enc.sub.layers.5.bias")?, "sub5_b")?;
+        upload_static(
+            &mut arena,
+            conv6_w_t,
+            s("enc.sub.layers.6.weight")?,
+            "sub6_w",
+        )?;
+        upload_static(&mut arena, conv6_b_t, s("enc.sub.layers.6.bias")?, "sub6_b")?;
+        // `enc.sub.linear.weight` is bound zero-copy; only its bias is arena-uploaded.
+        upload_static(
+            &mut arena,
+            linear_b_t,
+            s("enc.sub.linear.bias")?,
+            "sub_lin_b",
+        )?;
+        for (layer, handles) in layers.iter().zip(&layer_arenas) {
+            upload_layer(&mut arena, layer, handles)?;
+        }
+        upload_tail(&mut arena, &tail)?;
+
+        Ok((
+            Self {
+                runner,
+                loaded_weights,
+                arena,
+                sub: SubsamplingArena {
+                    conv0_w: conv0_w_t,
+                    conv0_b: conv0_b_t,
+                    conv2_w: conv2_w_t,
+                    conv2_b: conv2_b_t,
+                    conv3_w: conv3_w_t,
+                    conv3_b: conv3_b_t,
+                    conv5_w: conv5_w_t,
+                    conv5_b: conv5_b_t,
+                    conv6_w: conv6_w_t,
+                    conv6_b: conv6_b_t,
+                    linear_w: linear_w_slot,
+                    linear_b: linear_b_t,
+                    conv6_channels,
+                },
+                layers: layer_arenas,
+            },
+            tail,
+        ))
+    }
+}
+
+/// Scalar knobs the shared subsampling + conformer stack needs, mapped from
+/// each family's own execution-metadata struct. `scale_input` is the one
+/// checkpoint-dependent knob: parakeet-ctc's HF conversion always scales
+/// (`true`); parakeet-tdt-0.6b-v3's does not (metadata-driven).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FastConformerStackConfig {
+    pub hidden_size: usize,
+    pub n_heads: usize,
+    pub head_dim: usize,
+    pub conv_kernel: usize,
+    pub subsampling_channels: usize,
+    pub scale_input: bool,
+}
+
+/// Output of the shared subsampling + conformer stack: the last block's
+/// output tensor (`state`, pre-tail), the mel/positional input tensors (for
+/// the caller to upload after building its own tail), and the frame count.
+pub(crate) struct FastConformerStackOutput<'a> {
+    pub state: GgmlCpuTensor<'a>,
+    pub mel_t: GgmlCpuTensor<'a>,
+    pub pos_t: GgmlCpuTensor<'a>,
+    pub positional: Vec<f32>,
+    pub subsampled_frames: usize,
+}
+
+/// Build the dw-striding subsampling prelude (verbatim cohere FastConformer
+/// clone: conv0+ReLU, dw conv2, pw conv3+ReLU, dw conv5, pw conv6+ReLU) +
+/// linear + optional `scale_input` + the conformer layer loop (the shared
+/// `nn::encoder::conformer_block`). The caller builds its own tail from
+/// `state`, then must call `graph.set_output`, `prepare_outputs_for_upload`,
+/// and upload `mel_t`/`pos_t` (via [`upload_graph_f32`] with
+/// `output.positional`) before computing -- mirroring the ordering the two
+/// families' `encode()` used before this was shared.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_conformer_stack<'a, E: FastConformerGraphError>(
+    graph: &mut GgmlCpuGraphBuilder<'a>,
+    arena: &'a GgmlStaticTensorArena,
+    sub: &SubsamplingArena,
+    layers: &[LayerArena],
+    config: FastConformerStackConfig,
+    n_mels: usize,
+    n_frames: usize,
+    mel_tensor_name: &'static str,
+    pos_tensor_name: &'static str,
+) -> Result<FastConformerStackOutput<'a>, E> {
+    let d_model = config.hidden_size;
+    let subsampled_frames = conv_out_dim(conv_out_dim(conv_out_dim(n_frames)));
+    let subsampled_freq = conv_out_dim(conv_out_dim(conv_out_dim(n_mels)));
+    let positional = build_relative_positional_encoding(d_model, subsampled_frames, || {
+        E::shape("relative positional encoding shape overflow".to_string())
+    })?;
+
+    let mel_t = graph
+        .new_tensor_2d_f32(n_mels, n_frames, mel_tensor_name)
+        .map_err(bf("new_mel"))?;
+    let pos_t = graph
+        .new_tensor_2d_f32(d_model, positional.len() / d_model, pos_tensor_name)
+        .map_err(bf("new_pos"))?;
+    graph.set_input(mel_t).map_err(bf("set_input_mel"))?;
+    graph.set_input(pos_t).map_err(bf("set_input_pos"))?;
+
+    let conv_map = |step, source| E::graph_build_failed(step, source);
+    let stride2 = Conv2dParams {
+        stride_x: 2,
+        stride_y: 2,
+        padding_x: 1,
+        padding_y: 1,
+        dilation_x: 1,
+        dilation_y: 1,
+    };
+    let pointwise = Conv2dParams {
+        stride_x: 1,
+        stride_y: 1,
+        padding_x: 0,
+        padding_y: 0,
+        dilation_x: 1,
+        dilation_y: 1,
+    };
+    let bias4d = |g: &_, t: GgmlStaticTensor, len: usize, step| {
+        reshape_bias_4d(g, arena.graph_tensor(t), len, step, conv_map)
+    };
+
+    // ----- dw-striding subsampling (verbatim cohere FastConformer prelude) -----
+    let mut state_4d = graph
+        .reshape_4d(mel_t, n_mels, n_frames, 1, 1)
+        .map_err(bf("reshape_mel_4d"))?;
+    let conv0_b = bias4d(
+        &*graph,
+        sub.conv0_b,
+        config.subsampling_channels,
+        "sub0_bias4d",
+    )?;
+    state_4d = apply_conv_2d_bias_activation(
+        &*graph,
+        arena.graph_tensor(sub.conv0_w),
+        state_4d,
+        conv0_b,
+        stride2,
+        ConvActivation::Relu,
+        ConvBlockSteps {
+            conv: "conv0",
+            bias: "conv0_bias",
+            activation: "conv0_relu",
+        },
+        conv_map,
+    )?;
+    let conv2_b = bias4d(
+        &*graph,
+        sub.conv2_b,
+        config.subsampling_channels,
+        "sub2_bias4d",
+    )?;
+    state_4d = apply_conv_2d_depthwise_bias_activation(
+        &*graph,
+        arena.graph_tensor(sub.conv2_w),
+        state_4d,
+        conv2_b,
+        stride2,
+        None,
+        ConvBlockSteps {
+            conv: "conv2_dw",
+            bias: "conv2_bias",
+            activation: "conv2_noact",
+        },
+        conv_map,
+    )?;
+    let conv3_b = bias4d(
+        &*graph,
+        sub.conv3_b,
+        config.subsampling_channels,
+        "sub3_bias4d",
+    )?;
+    state_4d = apply_conv_2d_bias_activation(
+        &*graph,
+        arena.graph_tensor(sub.conv3_w),
+        state_4d,
+        conv3_b,
+        pointwise,
+        ConvActivation::Relu,
+        ConvBlockSteps {
+            conv: "conv3_pw",
+            bias: "conv3_bias",
+            activation: "conv3_relu",
+        },
+        conv_map,
+    )?;
+    let conv5_b = bias4d(
+        &*graph,
+        sub.conv5_b,
+        config.subsampling_channels,
+        "sub5_bias4d",
+    )?;
+    state_4d = apply_conv_2d_depthwise_bias_activation(
+        &*graph,
+        arena.graph_tensor(sub.conv5_w),
+        state_4d,
+        conv5_b,
+        stride2,
+        None,
+        ConvBlockSteps {
+            conv: "conv5_dw",
+            bias: "conv5_bias",
+            activation: "conv5_noact",
+        },
+        conv_map,
+    )?;
+    let conv6_b = bias4d(
+        &*graph,
+        sub.conv6_b,
+        config.subsampling_channels,
+        "sub6_bias4d",
+    )?;
+    state_4d = apply_conv_2d_bias_activation(
+        &*graph,
+        arena.graph_tensor(sub.conv6_w),
+        state_4d,
+        conv6_b,
+        pointwise,
+        ConvActivation::Relu,
+        ConvBlockSteps {
+            conv: "conv6_pw",
+            bias: "conv6_bias",
+            activation: "conv6_relu",
+        },
+        conv_map,
+    )?;
+
+    // flatten [channels, freq] per frame -> [channels*freq, frames] -> linear -> d_model.
+    let flattened = sub
+        .conv6_channels
+        .checked_mul(subsampled_freq)
+        .ok_or_else(|| E::shape("flatten overflow".into()))?;
+    let mut state = graph
+        .permute(state_4d, 0, 2, 1, 3)
+        .map_err(bf("permute_flatten"))?;
+    state = graph.cont(state).map_err(bf("cont_flatten"))?;
+    state = graph
+        .reshape_2d(state, flattened, subsampled_frames)
+        .map_err(bf("reshape_flatten"))?;
+    state = graph
+        .mul_mat(sub.linear_w.graph(arena), state)
+        .map_err(bf("sub_linear"))?;
+    state = graph
+        .add(state, arena.graph_tensor(sub.linear_b))
+        .map_err(bf("sub_linear_bias"))?;
+    // scale_input: x *= sqrt(d_model) (NeMo FastConformer), metadata-driven.
+    if config.scale_input {
+        state = graph
+            .scale(state, (d_model as f32).sqrt())
+            .map_err(bf("scale_input"))?;
+    }
+
+    // ----- conformer layers (shared nn/ block) -----
+    let element = std::mem::size_of::<f32>();
+    let frame = subsampled_frames;
+    let block_config = ConformerBlockConfig {
+        d_model,
+        attention_heads: config.n_heads,
+        head_dim: config.head_dim,
+        frame_count: frame,
+        conv_kernel: config.conv_kernel,
+        layer_norm_epsilon: ENCODER_LAYER_NORM_EPSILON,
+        macaron_scale: CONFORMER_MACARON_SCALE,
+        rel_shift_nb1: (2 * frame - 2) * element,
+        rel_shift_nb2: (2 * frame - 1) * frame * element,
+        rel_shift_offset: (frame - 1) * element,
+    };
+    let pos_enc = pos_t;
+    for handles in layers {
+        let weights = conformer_weights(arena, handles);
+        let block = conformer_block(graph, state, pos_enc, block_config, weights, conv_map)?;
+        state = block.output;
+    }
+
+    Ok(FastConformerStackOutput {
+        state,
+        mel_t,
+        pos_t,
+        positional,
+        subsampled_frames,
+    })
+}

--- a/crates/openasr-core/src/models/fastconformer/mod.rs
+++ b/crates/openasr-core/src/models/fastconformer/mod.rs
@@ -1,0 +1,51 @@
+//! Shared FastConformer encoder infrastructure: the dw-striding subsampling
+//! prelude + `nn::encoder::conformer_block` stack that `parakeet_ctc` and
+//! `parakeet_tdt` both build byte-for-byte identically (the TDT checkpoint
+//! honors `scale_input`/no-bias metadata the CTC checkpoint does not, but
+//! the graph shape and math are the same builder either way).
+//!
+//! This module owns the weight-loading (BatchNorm fold, zero-bias synthesis
+//! for bias-free checkpoints) and graph-building (arena alloc/upload/bind,
+//! subsampling conv chain, conformer layer loop) skeleton and nothing else:
+//! it never picks a tail (CTC head vs. joint encoder projection) or owns a
+//! family error type. Each family keeps its own `encoder_weights.rs` /
+//! `encoder_graph.rs` with its own public types (`Parakeet*EncoderGraph`,
+//! `Parakeet*MelFeatures`, ...) and error enum; those enums implement
+//! [`FastConformerGraphError`] / [`FastConformerWeightsError`] (a handful of
+//! one-line constructors) so the shared builders stay generic over `E`,
+//! mirroring the `map_err` pattern `nn::encoder::conformer_block` already
+//! uses (see AGENTS.md: keep infrastructure model-agnostic).
+//!
+//! Numeric behavior is carried over byte-for-byte from the pre-refactor
+//! per-family copies -- nothing here changes the math, only where it lives.
+
+pub(crate) mod graph;
+pub(crate) mod weights;
+
+pub(crate) use graph::{
+    FastConformerEncoderCore, FastConformerStackConfig, alloc_static, bind_loaded,
+    build_conformer_stack, upload_graph_f32, upload_static,
+};
+pub(crate) use weights::{
+    FastConformerLayerWeights, NamedTensor, load_fastconformer_layer,
+    load_fastconformer_subsampling, load_named,
+};
+
+use crate::ggml_runtime::{GgmlCpuGraphError, GgufTensorDataReadError};
+
+/// Error hook the shared graph builders need. Each family's own graph-build
+/// error enum implements this with two one-line constructors mapping onto
+/// its existing variants, so the shared code never owns (or has to spell)
+/// a model-specific error type.
+pub(crate) trait FastConformerGraphError: Sized {
+    fn graph_build_failed(step: &'static str, source: GgmlCpuGraphError) -> Self;
+    fn shape(reason: String) -> Self;
+}
+
+/// Error hook the shared weight loaders need. `From<GgufTensorDataReadError>`
+/// lets `?` keep working at every GGUF read call site exactly as it did in
+/// each family's own (now-shared) loader -- both existing error enums
+/// already derive this via `#[error(...)] Read(#[from] GgufTensorDataReadError)`.
+pub(crate) trait FastConformerWeightsError: Sized + From<GgufTensorDataReadError> {
+    fn batchnorm_fold(reason: String) -> Self;
+}

--- a/crates/openasr-core/src/models/fastconformer/weights.rs
+++ b/crates/openasr-core/src/models/fastconformer/weights.rs
@@ -1,0 +1,348 @@
+//! Shared FastConformer encoder weight loading: generic GGUF tensor reads,
+//! the conv BatchNorm1d fold, zero-bias synthesis for bias-free checkpoints,
+//! and the bound-linear payload drops that keep peak RSS down. Carried over
+//! byte-for-byte from `parakeet_ctc::encoder_weights` /
+//! `parakeet_tdt::encoder_weights` (which were identical modulo TDT's
+//! zero-bias synthesis and error-type names).
+
+use crate::ggml_runtime::{GgufTensorDataReadError, GgufTensorDataReader};
+
+use super::FastConformerWeightsError;
+
+const CONV_BN_EPSILON: f32 = 1.0e-5;
+
+/// A host weight: its stored dims (from the GGUF index) + dequantized f32
+/// values. Bias slots a bias-free checkpoint does not ship are synthesized
+/// as zeros (see [`zero_bias`]); shape validators read `dims`, not `values`.
+#[derive(Debug, Clone)]
+pub(crate) struct NamedTensor {
+    pub name: String,
+    pub dims: Vec<usize>,
+    pub values: Vec<f32>,
+}
+
+impl NamedTensor {
+    pub(crate) fn element_count(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Drop the resident f32 host `values` (keeping name + dims) for a weight
+    /// the encoder graph binds zero-copy from the mmap'd pack. The
+    /// dequantized f32 copy is dead weight for a bound tensor (its bytes come
+    /// straight from the pack at `mul_mat`), and is the dominant peak-RSS
+    /// term for a q4_K parakeet pack. The encoder's `alloc_layer` binds these
+    /// by name only, so the empty `values` is never observed. `pub(crate)`
+    /// so each family can drop its own tail tensor's payload (CTC head /
+    /// joint encoder projection) the same way.
+    pub(crate) fn drop_bound_payload(&mut self) {
+        self.values = Vec::new();
+    }
+}
+
+/// Per-layer FastConformer weights: the same field set both parakeet-ctc and
+/// parakeet-tdt load, mirroring `nn::encoder::ConformerBlockWeights`. Norms,
+/// biases, and the BN-folded depthwise conv stay plain arena tensors in the
+/// graph; the 2-D linears (`ff*.{up,down}`, `attn.{q,k,v,out,pos}`,
+/// `conv.pw{1,2}`) are bound zero-copy from the mmap'd pack.
+#[derive(Debug, Clone)]
+pub(crate) struct FastConformerLayerWeights {
+    pub ff1_norm_weight: NamedTensor,
+    pub ff1_norm_bias: NamedTensor,
+    pub ff1_up_weight: NamedTensor,
+    pub ff1_up_bias: NamedTensor,
+    pub ff1_down_weight: NamedTensor,
+    pub ff1_down_bias: NamedTensor,
+    pub attn_norm_weight: NamedTensor,
+    pub attn_norm_bias: NamedTensor,
+    pub attn_q_weight: NamedTensor,
+    pub attn_q_bias: NamedTensor,
+    pub attn_k_weight: NamedTensor,
+    pub attn_k_bias: NamedTensor,
+    pub attn_v_weight: NamedTensor,
+    pub attn_v_bias: NamedTensor,
+    pub attn_out_weight: NamedTensor,
+    pub attn_out_bias: NamedTensor,
+    pub attn_pos_weight: NamedTensor,
+    pub attn_pos_bias_u: NamedTensor,
+    pub attn_pos_bias_v: NamedTensor,
+    pub conv_norm_weight: NamedTensor,
+    pub conv_norm_bias: NamedTensor,
+    pub conv_pw1_weight: NamedTensor,
+    pub conv_pw1_bias: NamedTensor,
+    /// BatchNorm folded into these two at load (so the graph sees a plain dw conv).
+    pub conv_dw_weight: NamedTensor,
+    pub conv_dw_bias: NamedTensor,
+    pub conv_pw2_weight: NamedTensor,
+    pub conv_pw2_bias: NamedTensor,
+    pub ff2_norm_weight: NamedTensor,
+    pub ff2_norm_bias: NamedTensor,
+    pub ff2_up_weight: NamedTensor,
+    pub ff2_up_bias: NamedTensor,
+    pub ff2_down_weight: NamedTensor,
+    pub ff2_down_bias: NamedTensor,
+    pub out_norm_weight: NamedTensor,
+    pub out_norm_bias: NamedTensor,
+}
+
+pub(crate) fn load_named<E: FastConformerWeightsError>(
+    reader: &GgufTensorDataReader,
+    name: &str,
+) -> Result<NamedTensor, E> {
+    let tensor = reader.tensor_index().get(name).ok_or_else(|| {
+        E::from(GgufTensorDataReadError::TensorNotFound {
+            path: reader.tensor_index().path().to_path_buf(),
+            tensor_name: name.to_string(),
+        })
+    })?;
+    let dims: Vec<usize> = tensor.dims.iter().map(|&d| d as usize).collect();
+    let shape_u64: Vec<u64> = tensor.dims.clone();
+    let values = reader.host_tensor_f32_copy_dequantized_by_name(name, &shape_u64)?;
+    Ok(NamedTensor {
+        name: name.to_string(),
+        dims,
+        values,
+    })
+}
+
+/// Zero bias for a projection a bias-free checkpoint does not ship (NeMo/HF
+/// `attention_bias`/`convolution_bias`/FFN-bias all false, e.g.
+/// parakeet-tdt-0.6b-v3). The shared conformer block is bias-shaped; a zero
+/// bias is the mathematical identity, nothing model-specific is fabricated.
+fn zero_bias(name: String, len: usize) -> NamedTensor {
+    NamedTensor {
+        name,
+        dims: vec![len],
+        values: vec![0.0; len],
+    }
+}
+
+/// Load one FastConformer conformer-block layer's weights + fold its conv
+/// BatchNorm. `bias_present` is the family's "does the checkpoint ship
+/// attention/conv/FFN biases" knob: `true` loads every bias tensor from the
+/// pack (parakeet-ctc); `false` synthesizes zero biases of the right width
+/// (parakeet-tdt-0.6b-v3, whose HF conversion has no bias tensors at all).
+pub(crate) fn load_fastconformer_layer<E: FastConformerWeightsError>(
+    reader: &GgufTensorDataReader,
+    layer: usize,
+    d_model: usize,
+    ffn_dim: usize,
+    bias_present: bool,
+) -> Result<FastConformerLayerWeights, E> {
+    let n = |suffix: &str| format!("enc.blk.{layer}.{suffix}");
+    let bias = |suffix: &str, len: usize| -> Result<NamedTensor, E> {
+        if bias_present {
+            load_named::<E>(reader, &n(suffix))
+        } else {
+            Ok(zero_bias(n(suffix), len))
+        }
+    };
+    let mut weights = FastConformerLayerWeights {
+        ff1_norm_weight: load_named::<E>(reader, &n("ff1.norm.weight"))?,
+        ff1_norm_bias: load_named::<E>(reader, &n("ff1.norm.bias"))?,
+        ff1_up_weight: load_named::<E>(reader, &n("ff1.up.weight"))?,
+        ff1_up_bias: bias("ff1.up.bias", ffn_dim)?,
+        ff1_down_weight: load_named::<E>(reader, &n("ff1.down.weight"))?,
+        ff1_down_bias: bias("ff1.down.bias", d_model)?,
+        attn_norm_weight: load_named::<E>(reader, &n("attn.norm.weight"))?,
+        attn_norm_bias: load_named::<E>(reader, &n("attn.norm.bias"))?,
+        attn_q_weight: load_named::<E>(reader, &n("attn.q.weight"))?,
+        attn_q_bias: bias("attn.q.bias", d_model)?,
+        attn_k_weight: load_named::<E>(reader, &n("attn.k.weight"))?,
+        attn_k_bias: bias("attn.k.bias", d_model)?,
+        attn_v_weight: load_named::<E>(reader, &n("attn.v.weight"))?,
+        attn_v_bias: bias("attn.v.bias", d_model)?,
+        attn_out_weight: load_named::<E>(reader, &n("attn.out.weight"))?,
+        attn_out_bias: bias("attn.out.bias", d_model)?,
+        attn_pos_weight: load_named::<E>(reader, &n("attn.pos.weight"))?,
+        attn_pos_bias_u: load_named::<E>(reader, &n("attn.pos_bias_u"))?,
+        attn_pos_bias_v: load_named::<E>(reader, &n("attn.pos_bias_v"))?,
+        conv_norm_weight: load_named::<E>(reader, &n("conv.norm.weight"))?,
+        conv_norm_bias: load_named::<E>(reader, &n("conv.norm.bias"))?,
+        conv_pw1_weight: load_named::<E>(reader, &n("conv.pw1.weight"))?,
+        conv_pw1_bias: bias("conv.pw1.bias", 2 * d_model)?,
+        conv_dw_weight: load_named::<E>(reader, &n("conv.dw.weight"))?,
+        conv_dw_bias: bias("conv.dw.bias", d_model)?,
+        conv_pw2_weight: load_named::<E>(reader, &n("conv.pw2.weight"))?,
+        conv_pw2_bias: bias("conv.pw2.bias", d_model)?,
+        ff2_norm_weight: load_named::<E>(reader, &n("ff2.norm.weight"))?,
+        ff2_norm_bias: load_named::<E>(reader, &n("ff2.norm.bias"))?,
+        ff2_up_weight: load_named::<E>(reader, &n("ff2.up.weight"))?,
+        ff2_up_bias: bias("ff2.up.bias", ffn_dim)?,
+        ff2_down_weight: load_named::<E>(reader, &n("ff2.down.weight"))?,
+        ff2_down_bias: bias("ff2.down.bias", d_model)?,
+        out_norm_weight: load_named::<E>(reader, &n("out.norm.weight"))?,
+        out_norm_bias: load_named::<E>(reader, &n("out.norm.bias"))?,
+    };
+    fold_batchnorm_into_depthwise::<E>(reader, layer, &mut weights)?;
+    drop_bound_layer_linear_payloads(&mut weights);
+    Ok(weights)
+}
+
+/// Fold the conv BatchNorm1d (`conv.bn.{weight,bias,mean,var}`) into the
+/// depthwise weight + bias so the graph runs a plain depthwise conv.
+/// Channel-major layout (the depthwise weight is `[channels, 1, kernel]`
+/// C-order = `channel*kernel + k`).
+pub(crate) fn fold_batchnorm_into_depthwise<E: FastConformerWeightsError>(
+    reader: &GgufTensorDataReader,
+    layer: usize,
+    weights: &mut FastConformerLayerWeights,
+) -> Result<(), E> {
+    let n = |suffix: &str| format!("enc.blk.{layer}.{suffix}");
+    let gamma: NamedTensor = load_named::<E>(reader, &n("conv.bn.weight"))?;
+    let beta: NamedTensor = load_named::<E>(reader, &n("conv.bn.bias"))?;
+    let mean: NamedTensor = load_named::<E>(reader, &n("conv.bn.mean"))?;
+    let var: NamedTensor = load_named::<E>(reader, &n("conv.bn.var"))?;
+
+    let channels = weights.conv_dw_bias.element_count();
+    if gamma.element_count() != channels
+        || beta.element_count() != channels
+        || mean.element_count() != channels
+        || var.element_count() != channels
+    {
+        return Err(E::batchnorm_fold(format!(
+            "per-channel sizes disagree: dw_bias={channels} gamma={} beta={} mean={} var={}",
+            gamma.element_count(),
+            beta.element_count(),
+            mean.element_count(),
+            var.element_count()
+        )));
+    }
+    let dw_elems = weights.conv_dw_weight.element_count();
+    if !dw_elems.is_multiple_of(channels) {
+        return Err(E::batchnorm_fold(format!(
+            "depthwise weight {dw_elems} not divisible by channels {channels}"
+        )));
+    }
+    let kernel = dw_elems / channels;
+    let scale: Vec<f32> = (0..channels)
+        .map(|c| gamma.values[c] / (var.values[c] + CONV_BN_EPSILON).sqrt())
+        .collect();
+    // `c` indexes several parallel per-channel arrays (scale, beta/mean, the dw
+    // kernel rows + the dw bias), so a range loop is clearest here.
+    #[allow(clippy::needless_range_loop)]
+    for c in 0..channels {
+        for k in 0..kernel {
+            weights.conv_dw_weight.values[c * kernel + k] *= scale[c];
+        }
+        weights.conv_dw_bias.values[c] =
+            beta.values[c] + (weights.conv_dw_bias.values[c] - mean.values[c]) * scale[c];
+    }
+    Ok(())
+}
+
+/// Drop the f32 host payload of the 2-D linears the encoder graph binds
+/// zero-copy (the q4_K/f32 `ff*`, `attn.{q,k,v,out,pos}`, `conv.pw{1,2}`
+/// projections). Their `dims` are retained for the binder + validators; only
+/// the dequantized values are freed. Norms, biases, and the BN-folded
+/// depthwise conv are NOT dropped (the graph still arena-uploads them).
+pub(crate) fn drop_bound_layer_linear_payloads(layer: &mut FastConformerLayerWeights) {
+    for w in [
+        &mut layer.ff1_up_weight,
+        &mut layer.ff1_down_weight,
+        &mut layer.attn_q_weight,
+        &mut layer.attn_k_weight,
+        &mut layer.attn_v_weight,
+        &mut layer.attn_out_weight,
+        &mut layer.attn_pos_weight,
+        &mut layer.conv_pw1_weight,
+        &mut layer.conv_pw2_weight,
+        &mut layer.ff2_up_weight,
+        &mut layer.ff2_down_weight,
+    ] {
+        w.drop_bound_payload();
+    }
+}
+
+pub(crate) fn drop_bound_subsampling_payloads(subsampling: &mut [NamedTensor]) {
+    for weight in subsampling {
+        if weight.name == "enc.sub.linear.weight" {
+            weight.drop_bound_payload();
+        }
+    }
+}
+
+/// Load the dw-striding subsampling prelude tensors: `enc.sub.layers.{0,2,3,5,6}.{weight,bias}`
+/// (whichever are present) plus `enc.sub.linear.{weight,bias}`, then drop the
+/// linear weight's f32 host payload (bound zero-copy from the mmap'd pack).
+pub(crate) fn load_fastconformer_subsampling<E: FastConformerWeightsError>(
+    reader: &GgufTensorDataReader,
+) -> Result<Vec<NamedTensor>, E> {
+    let mut subsampling = Vec::new();
+    for sub_layer in [0usize, 2, 3, 5, 6] {
+        for kind in ["weight", "bias"] {
+            let name = format!("enc.sub.layers.{sub_layer}.{kind}");
+            if reader.tensor_index().get(&name).is_some() {
+                subsampling.push(load_named::<E>(reader, &name)?);
+            }
+        }
+    }
+    subsampling.push(load_named::<E>(reader, "enc.sub.linear.weight")?);
+    subsampling.push(load_named::<E>(reader, "enc.sub.linear.bias")?);
+    drop_bound_subsampling_payloads(&mut subsampling);
+    Ok(subsampling)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, thiserror::Error)]
+    enum TestError {
+        #[error("read: {0}")]
+        Read(#[from] GgufTensorDataReadError),
+        #[error("batchnorm fold: {0}")]
+        BatchNormFold(String),
+    }
+
+    impl FastConformerWeightsError for TestError {
+        fn batchnorm_fold(reason: String) -> Self {
+            Self::BatchNormFold(reason)
+        }
+    }
+
+    #[test]
+    fn drops_subsampling_linear_payload_only() {
+        let mut subsampling = vec![
+            NamedTensor {
+                name: "enc.sub.linear.weight".to_string(),
+                dims: vec![2, 3],
+                values: vec![1.0; 6],
+            },
+            NamedTensor {
+                name: "enc.sub.linear.bias".to_string(),
+                dims: vec![3],
+                values: vec![1.0; 3],
+            },
+            NamedTensor {
+                name: "enc.sub.layers.0.weight".to_string(),
+                dims: vec![3, 3, 1, 256],
+                values: vec![1.0; 9],
+            },
+        ];
+
+        drop_bound_subsampling_payloads(&mut subsampling);
+
+        assert!(subsampling[0].values.is_empty());
+        assert_eq!(subsampling[1].values.len(), 3);
+        assert_eq!(subsampling[2].values.len(), 9);
+    }
+
+    #[test]
+    fn zero_bias_is_correct_width_and_zeroed() {
+        let t = zero_bias("x".to_string(), 5);
+        assert_eq!(t.dims, vec![5]);
+        assert_eq!(t.values, vec![0.0; 5]);
+    }
+
+    // Compile-only check that the generic loaders are usable with a
+    // family-shaped error type (the real integration coverage -- BN fold
+    // correctness against a real pack -- stays in each family's own test
+    // module, which already asserts on real tensor values).
+    #[allow(dead_code)]
+    fn _generic_signatures_compile(reader: &GgufTensorDataReader) {
+        let _: Result<NamedTensor, TestError> = load_named(reader, "x");
+        let _: Result<Vec<NamedTensor>, TestError> = load_fastconformer_subsampling(reader);
+        let _: Result<FastConformerLayerWeights, TestError> =
+            load_fastconformer_layer(reader, 0, 1024, 4096, true);
+    }
+}

--- a/crates/openasr-core/src/models/parakeet_ctc/encoder_graph.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/encoder_graph.rs
@@ -1,45 +1,30 @@
-//! parakeet-ctc encoder graph (goal-1 S3c): dw-striding subsampling (cloned from
-//! cohere's proven FastConformer prelude) → `conformer_block` × N (the shared
-//! nn/ block) → final LayerNorm → CTC head → `[vocab, frames]` logits.
+//! parakeet-ctc encoder graph (goal-1 S3c): the shared FastConformer
+//! subsampling + conformer stack (`models::fastconformer`) with a CTC-head
+//! tail, producing `[vocab, frames]` logits.
 //!
 //! The subsampling op sequence is a verbatim clone of cohere `encode()` (same
 //! NeMo dw_striding: regular conv0+ReLU, depthwise conv2, pointwise conv3+ReLU,
 //! depthwise conv5, pointwise conv6+ReLU), so the #1 frame-count risk is borrowed
 //! from a proven impl. The conformer layers reuse `nn::encoder::conformer_block`
-//! and the rel-pos table reuses the shared `nn::encoder::build_relative_positional_encoding`.
+//! and the rel-pos table reuses `nn::encoder::build_relative_positional_encoding`;
+//! the shared arena/subsampling/conformer-loop skeleton is
+//! `models::fastconformer`, which `parakeet_tdt` builds on identically save
+//! for its tail (joint encoder projection instead of a CTC head).
 
 #![allow(dead_code)]
 
 use std::path::Path;
 
-use crate::ggml_runtime::{
-    ArenaAllocError, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedWeightContext,
-    GgmlStaticTensor, GgmlStaticTensorArena, WeightSlot,
-    alloc_static_f16 as arena_alloc_static_f16, alloc_static_f32 as arena_alloc_static_f32,
-    bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
-    upload_static_f32 as arena_upload_static_f32,
+use crate::ggml_runtime::{GgmlCpuGraphError, GgmlStaticTensor, WeightSlot};
+use crate::models::fastconformer::{
+    self, FastConformerEncoderCore, FastConformerGraphError, FastConformerStackConfig,
 };
 use crate::models::parakeet_ctc::graph_config::parakeet_ctc_encoder_graph_config;
 
-use crate::nn::conv::{
-    Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation,
-    apply_conv_2d_depthwise_bias_activation, reshape_bias_4d,
-};
-use crate::nn::encoder::{
-    ConformerBlockConfig, ConformerBlockWeights, build_relative_positional_encoding,
-    conformer_block,
-};
-use crate::nn::half::f32_to_f16_bits;
-
-use super::encoder_weights::{NamedTensor, ParakeetEncoderLayerWeights, ParakeetEncoderWeights};
+use super::encoder_weights::ParakeetEncoderWeights;
 use super::runtime_contract::ParakeetCtcExecutionMetadata;
 
 const PARAKEET_ENCODER_GRAPH_CONTEXT_BYTES: usize = 768 * 1024 * 1024;
-const ENCODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const CONFORMER_MACARON_SCALE: f32 = 0.5;
-const SUBSAMPLING_KERNEL: usize = 3;
-const SUBSAMPLING_STRIDE: usize = 2;
-const SUBSAMPLING_PADDING: usize = 1;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ParakeetEncoderError {
@@ -52,6 +37,15 @@ pub(crate) enum ParakeetEncoderError {
     GraphExecutionFailed { reason: String },
     #[error("parakeet-ctc encoder shape error: {reason}")]
     Shape { reason: String },
+}
+
+impl FastConformerGraphError for ParakeetEncoderError {
+    fn graph_build_failed(step: &'static str, source: GgmlCpuGraphError) -> Self {
+        Self::GraphBuildFailed { step, source }
+    }
+    fn shape(reason: String) -> Self {
+        Self::Shape { reason }
+    }
 }
 
 /// 80-bin log-mel features for one (single-chunk) utterance: `data` is row-major
@@ -72,181 +66,11 @@ pub(crate) struct ParakeetCtcEncoderOutput {
     pub logits: Vec<f32>,
 }
 
-fn bf(step: &'static str) -> impl Fn(GgmlCpuGraphError) -> ParakeetEncoderError {
-    move |source| ParakeetEncoderError::GraphBuildFailed { step, source }
-}
-
-// `WeightSlot` (imported above from `ggml_runtime`): either an arena tensor
-// (f32-uploaded — legacy / no runtime pack) or a zero-copy leaf bound to the
-// mmap'd pack (native q4_K/f16/f32, no host copy + no arena upload). Goals
-// 7+8 lever: parakeet's packer reverses every rank>=2 `.weight` to ggml
-// `[in,out]` at PACK time, so the on-disk linears (`ff*`,
-// `attn.{q,k,v,out,pos}`, `conv.pw{1,2}`, ctc head) are directly
-// `mul_mat`-consumable and safe to bind — mirroring cohere's
-// `loaded_or_static_tensor` + qwen's `bind_or_arena_llm`. NOT bound: the
-// BN-folded depthwise conv (its host values are mutated at load), 1-D
-// norms/biases, the rank-3/4 subsampling convs, and `attn.pos_bias_u/v`. The
-// type itself is shared with parakeet-tdt/sensevoice/wav2vec2-ctc — see
-// `ggml_runtime::arena_weight_pipeline` — since it is pure residency
-// plumbing with no parakeet-specific semantics.
-
-/// Bind a 2-D linear zero-copy from the mmap'd pack (`loaded`) by its on-disk
-/// name. FAILS CLOSED if the loaded context is absent or the tensor is missing:
-/// the host f32 `values` for bound weights are dropped at load, so there is no
-/// arena fallback — uploading an empty buffer would silently corrupt the graph.
-fn bind_loaded(
-    loaded: Option<&GgmlLoadedWeightContext>,
-    name: &str,
-) -> Result<WeightSlot, ParakeetEncoderError> {
-    arena_bind_loaded(loaded, name)
-        .map(WeightSlot::Loaded)
-        .map_err(|reason| ParakeetEncoderError::Shape { reason })
-}
-
-fn conv_out_dim(input: usize) -> usize {
-    (input + 2 * SUBSAMPLING_PADDING - SUBSAMPLING_KERNEL) / SUBSAMPLING_STRIDE + 1
-}
-
-/// Allocate a static arena tensor matching a host weight's stored dims (the same
-/// layout the importer wrote + cohere's loader uses, so `conformer_block`
-/// consumes it identically).
-fn alloc_static(
-    arena: &GgmlStaticTensorArena,
-    weight: &NamedTensor,
-    step: &'static str,
-) -> Result<GgmlStaticTensor, ParakeetEncoderError> {
-    arena_alloc_static_f32(arena, &weight.dims, weight.values.len(), step, true).map_err(
-        |e| match e {
-            ArenaAllocError::Graph(source) => {
-                ParakeetEncoderError::GraphBuildFailed { step, source }
-            }
-            ArenaAllocError::UnsupportedRank(dims) => ParakeetEncoderError::Shape {
-                reason: format!("tensor '{}' has unsupported rank {:?}", weight.name, dims),
-            },
-        },
-    )
-}
-
-fn upload_static(
-    arena: &mut GgmlStaticTensorArena,
-    tensor: GgmlStaticTensor,
-    weight: &NamedTensor,
-    step: &'static str,
-) -> Result<(), ParakeetEncoderError> {
-    arena_upload_static_f32(arena, tensor, &weight.values, step)
-        .map_err(|source| ParakeetEncoderError::GraphBuildFailed { step, source })
-}
-
-/// Allocate an f16 arena tensor for a depthwise conv kernel (ggml `conv_2d_dw`
-/// requires an f16 kernel; regular `conv_2d` accepts f32).
-fn alloc_static_f16(
-    arena: &GgmlStaticTensorArena,
-    weight: &NamedTensor,
-    step: &'static str,
-) -> Result<GgmlStaticTensor, ParakeetEncoderError> {
-    arena_alloc_static_f16(arena, &weight.dims, step, true).map_err(|e| match e {
-        ArenaAllocError::Graph(source) => ParakeetEncoderError::GraphBuildFailed { step, source },
-        ArenaAllocError::UnsupportedRank(dims) => ParakeetEncoderError::Shape {
-            reason: format!("f16 depthwise '{}' rank {:?}", weight.name, dims),
-        },
-    })
-}
-
-fn upload_static_f16(
-    arena: &mut GgmlStaticTensorArena,
-    tensor: GgmlStaticTensor,
-    weight: &NamedTensor,
-    step: &'static str,
-) -> Result<(), ParakeetEncoderError> {
-    arena_upload_static_f16(arena, tensor, &weight.values, step, f32_to_f16_bits)
-        .map_err(|source| ParakeetEncoderError::GraphBuildFailed { step, source })
-}
-
-/// Per-layer handles for the conformer block weights. The 2-D linears
-/// (`ff*.{up,down}`, `attn.{q,k,v,out,pos}`, `conv.pw{1,2}`) are `WeightSlot`
-/// (bound zero-copy from the pack when a runtime path is supplied; else arena);
-/// norms, biases, and the BN-folded depthwise conv stay plain arena tensors.
-struct LayerArena {
-    ff1_norm_weight: GgmlStaticTensor,
-    ff1_norm_bias: GgmlStaticTensor,
-    ff1_up_weight: WeightSlot,
-    ff1_up_bias: GgmlStaticTensor,
-    ff1_down_weight: WeightSlot,
-    ff1_down_bias: GgmlStaticTensor,
-    attn_norm_weight: GgmlStaticTensor,
-    attn_norm_bias: GgmlStaticTensor,
-    attn_q_weight: WeightSlot,
-    attn_q_bias: GgmlStaticTensor,
-    attn_k_weight: WeightSlot,
-    attn_k_bias: GgmlStaticTensor,
-    attn_v_weight: WeightSlot,
-    attn_v_bias: GgmlStaticTensor,
-    attn_out_weight: WeightSlot,
-    attn_out_bias: GgmlStaticTensor,
-    attn_pos_weight: WeightSlot,
-    attn_pos_bias_u: GgmlStaticTensor,
-    attn_pos_bias_v: GgmlStaticTensor,
-    conv_norm_weight: GgmlStaticTensor,
-    conv_norm_bias: GgmlStaticTensor,
-    conv_pw1_weight: WeightSlot,
-    conv_pw1_bias: GgmlStaticTensor,
-    conv_dw_weight: GgmlStaticTensor,
-    conv_dw_bias: GgmlStaticTensor,
-    conv_pw2_weight: WeightSlot,
-    conv_pw2_bias: GgmlStaticTensor,
-    ff2_norm_weight: GgmlStaticTensor,
-    ff2_norm_bias: GgmlStaticTensor,
-    ff2_up_weight: WeightSlot,
-    ff2_up_bias: GgmlStaticTensor,
-    ff2_down_weight: WeightSlot,
-    ff2_down_bias: GgmlStaticTensor,
-    out_norm_weight: GgmlStaticTensor,
-    out_norm_bias: GgmlStaticTensor,
-}
-
-struct SubArena {
-    conv0_w: GgmlStaticTensor,
-    conv0_b: GgmlStaticTensor,
-    conv2_w: GgmlStaticTensor,
-    conv2_b: GgmlStaticTensor,
-    conv3_w: GgmlStaticTensor,
-    conv3_b: GgmlStaticTensor,
-    conv5_w: GgmlStaticTensor,
-    conv5_b: GgmlStaticTensor,
-    conv6_w: GgmlStaticTensor,
-    conv6_b: GgmlStaticTensor,
-    linear_w: WeightSlot,
-    linear_b: GgmlStaticTensor,
-    conv6_channels: usize,
-}
-
 pub(crate) struct ParakeetCtcEncoderGraph {
     metadata: ParakeetCtcExecutionMetadata,
-    runner: GgmlCpuGraphRunner,
-    // `loaded_weights` owns the mmap-backed buffer that the `Loaded` weight slots
-    // below alias. Rust drops struct fields in declaration order (first-declared
-    // drops first), so declaring it here does NOT make it outlive `arena`;
-    // soundness relies on neither `arena` nor `runner` dereferencing weight memory
-    // on drop. Field order mirrors cohere/qwen for consistency.
-    loaded_weights: Option<GgmlLoadedWeightContext>,
-    arena: GgmlStaticTensorArena,
-    sub: SubArena,
-    layers: Vec<LayerArena>,
+    core: FastConformerEncoderCore,
     ctc_head_weight: WeightSlot,
     ctc_head_bias: GgmlStaticTensor,
-}
-
-fn find_sub<'a>(
-    weights: &'a ParakeetEncoderWeights,
-    name: &str,
-) -> Result<&'a NamedTensor, ParakeetEncoderError> {
-    weights
-        .subsampling
-        .iter()
-        .find(|t| t.name == name)
-        .ok_or_else(|| ParakeetEncoderError::Shape {
-            reason: format!("missing subsampling tensor '{name}'"),
-        })
 }
 
 impl ParakeetCtcEncoderGraph {
@@ -255,137 +79,35 @@ impl ParakeetCtcEncoderGraph {
         metadata: ParakeetCtcExecutionMetadata,
         runtime_path: Option<&Path>,
     ) -> Result<Self, ParakeetEncoderError> {
-        let mut config = parakeet_ctc_encoder_graph_config();
-        config.context_bytes = PARAKEET_ENCODER_GRAPH_CONTEXT_BYTES;
-        // FastConformer-XL (parakeet-ctc-1.1b, ~42 conformer layers) builds more
-        // graph nodes than the default 4096-node cap, tripping
-        // `GGML_ASSERT(cgraph->n_nodes < cgraph->size)`. Size the cgraph to the
-        // actual (data-driven) layer count with generous per-layer headroom. This
-        // is capacity only — the built graph and its op order are identical, so
-        // the 24-layer 0.6b model's output stays byte-for-byte unchanged.
-        config.graph_size = config.graph_size.max(weights.layers.len() * 256 + 2048);
-        let runner = GgmlCpuGraphRunner::new(config).map_err(|source| {
-            ParakeetEncoderError::GraphBuildFailed {
-                step: "runner_init",
-                source,
-            }
-        })?;
-        // Goals 7+8 lever: bind the 2-D linears zero-copy from the mmap'd pack
-        // (no f32 dequantize-to-host, no arena upload). Fails closed below if the
-        // load failed but a bindable weight's host payload was dropped at load.
-        let loaded_weights =
-            runtime_path.and_then(|path| runner.load_gguf_weight_context(path).ok());
-        let loaded = loaded_weights.as_ref();
-        let mut arena = runner
-            .start_static_tensor_arena(PARAKEET_ENCODER_GRAPH_CONTEXT_BYTES)
-            .map_err(|source| ParakeetEncoderError::GraphBuildFailed {
-                step: "static_tensor_arena",
-                source,
-            })?;
-
-        // ----- declare (allocate) all arena tensors first (first upload freezes) -----
-        let s = |n: &str| find_sub(weights, n);
-        let conv0_w_t = alloc_static(&arena, s("enc.sub.layers.0.weight")?, "sub0_w")?;
-        let conv0_b_t = alloc_static(&arena, s("enc.sub.layers.0.bias")?, "sub0_b")?;
-        let conv2_w_t = alloc_static_f16(&arena, s("enc.sub.layers.2.weight")?, "sub2_w")?;
-        let conv2_b_t = alloc_static(&arena, s("enc.sub.layers.2.bias")?, "sub2_b")?;
-        let conv3_w_t = alloc_static(&arena, s("enc.sub.layers.3.weight")?, "sub3_w")?;
-        let conv3_b_t = alloc_static(&arena, s("enc.sub.layers.3.bias")?, "sub3_b")?;
-        let conv5_w_t = alloc_static_f16(&arena, s("enc.sub.layers.5.weight")?, "sub5_w")?;
-        let conv5_b_t = alloc_static(&arena, s("enc.sub.layers.5.bias")?, "sub5_b")?;
-        let conv6_w_t = alloc_static(&arena, s("enc.sub.layers.6.weight")?, "sub6_w")?;
-        let conv6_b_t = alloc_static(&arena, s("enc.sub.layers.6.bias")?, "sub6_b")?;
-        let linear_w_slot = bind_loaded(loaded, "enc.sub.linear.weight")?;
-        let linear_b_t = alloc_static(&arena, s("enc.sub.linear.bias")?, "sub_lin_b")?;
-        let conv6_channels = s("enc.sub.layers.6.bias")?.values.len();
-
-        let mut layer_arenas = Vec::with_capacity(weights.layers.len());
-        for (layer_idx, layer) in weights.layers.iter().enumerate() {
-            layer_arenas.push(alloc_layer(&arena, loaded, layer_idx, layer)?);
-        }
+        let config = parakeet_ctc_encoder_graph_config();
         // CTC head: `ctc.head.weight` is f16 `[1, d_model, vocab]` on disk (the
-        // packer's reversed-dims convention) — bound zero-copy + reshaped to
-        // `[d_model, vocab]` for the head matmul. Its bias stays arena (1-D f32).
-        let ctc_head_weight_slot = bind_loaded(loaded, &weights.ctc_head_weight.name)?;
-        let ctc_head_bias_t = alloc_static(&arena, &weights.ctc_head_bias, "ctc_head_b")?;
-
-        // ----- upload all values (arena now freezes on first set) -----
-        upload_static(
-            &mut arena,
-            conv0_w_t,
-            s("enc.sub.layers.0.weight")?,
-            "sub0_w",
-        )?;
-        upload_static(&mut arena, conv0_b_t, s("enc.sub.layers.0.bias")?, "sub0_b")?;
-        upload_static_f16(
-            &mut arena,
-            conv2_w_t,
-            s("enc.sub.layers.2.weight")?,
-            "sub2_w",
-        )?;
-        upload_static(&mut arena, conv2_b_t, s("enc.sub.layers.2.bias")?, "sub2_b")?;
-        upload_static(
-            &mut arena,
-            conv3_w_t,
-            s("enc.sub.layers.3.weight")?,
-            "sub3_w",
-        )?;
-        upload_static(&mut arena, conv3_b_t, s("enc.sub.layers.3.bias")?, "sub3_b")?;
-        upload_static_f16(
-            &mut arena,
-            conv5_w_t,
-            s("enc.sub.layers.5.weight")?,
-            "sub5_w",
-        )?;
-        upload_static(&mut arena, conv5_b_t, s("enc.sub.layers.5.bias")?, "sub5_b")?;
-        upload_static(
-            &mut arena,
-            conv6_w_t,
-            s("enc.sub.layers.6.weight")?,
-            "sub6_w",
-        )?;
-        upload_static(&mut arena, conv6_b_t, s("enc.sub.layers.6.bias")?, "sub6_b")?;
-        // `enc.sub.linear.weight` is bound zero-copy; only its bias is arena-uploaded.
-        upload_static(
-            &mut arena,
-            linear_b_t,
-            s("enc.sub.linear.bias")?,
-            "sub_lin_b",
-        )?;
-        for (layer, handles) in weights.layers.iter().zip(&layer_arenas) {
-            upload_layer(&mut arena, layer, handles)?;
-        }
-        // ctc head weight is bound zero-copy (no upload); only its bias is arena.
-        upload_static(
-            &mut arena,
-            ctc_head_bias_t,
-            &weights.ctc_head_bias,
-            "ctc_head_b",
+        // packer's reversed-dims convention) -- bound zero-copy + reshaped to
+        // `[d_model, vocab]` for the head matmul in `encode`. Its bias stays
+        // arena (1-D f32). Declared/uploaded through `build`'s tail closures so
+        // it participates in the shared "declare everything, then upload
+        // everything" arena pass alongside the subsampling + conformer layers.
+        let (core, (ctc_head_weight, ctc_head_bias)) = FastConformerEncoderCore::build(
+            config,
+            PARAKEET_ENCODER_GRAPH_CONTEXT_BYTES,
+            runtime_path,
+            &weights.subsampling,
+            &weights.layers,
+            |arena, loaded| {
+                let weight = fastconformer::bind_loaded(loaded, &weights.ctc_head_weight.name)?;
+                let bias =
+                    fastconformer::alloc_static(arena, &weights.ctc_head_bias, "ctc_head_b")?;
+                Ok((weight, bias))
+            },
+            |arena, &(_, bias)| {
+                fastconformer::upload_static(arena, bias, &weights.ctc_head_bias, "ctc_head_b")
+            },
         )?;
 
         Ok(Self {
             metadata,
-            runner,
-            loaded_weights,
-            arena,
-            sub: SubArena {
-                conv0_w: conv0_w_t,
-                conv0_b: conv0_b_t,
-                conv2_w: conv2_w_t,
-                conv2_b: conv2_b_t,
-                conv3_w: conv3_w_t,
-                conv3_b: conv3_b_t,
-                conv5_w: conv5_w_t,
-                conv5_b: conv5_b_t,
-                conv6_w: conv6_w_t,
-                conv6_b: conv6_b_t,
-                linear_w: linear_w_slot,
-                linear_b: linear_b_t,
-                conv6_channels,
-            },
-            layers: layer_arenas,
-            ctc_head_weight: ctc_head_weight_slot,
-            ctc_head_bias: ctc_head_bias_t,
+            core,
+            ctc_head_weight,
+            ctc_head_bias,
         })
     }
 
@@ -395,215 +117,58 @@ impl ParakeetCtcEncoderGraph {
     ) -> Result<ParakeetCtcEncoderOutput, ParakeetEncoderError> {
         let metadata = self.metadata;
         let d_model = metadata.hidden_size;
-        let subsampled_frames = conv_out_dim(conv_out_dim(conv_out_dim(mel.n_frames)));
-        let subsampled_freq = conv_out_dim(conv_out_dim(conv_out_dim(mel.n_mels)));
-        let positional = build_relative_positional_encoding(d_model, subsampled_frames, || {
-            ParakeetEncoderError::Shape {
-                reason: "relative positional encoding shape overflow".to_string(),
-            }
-        })?;
-
-        let mut graph = self.runner.start_graph();
-
-        let mel_t = graph
-            .new_tensor_2d_f32(mel.n_mels, mel.n_frames, "parakeet_mel")
-            .map_err(bf("new_mel"))?;
-        let pos_t = graph
-            .new_tensor_2d_f32(d_model, positional.len() / d_model, "parakeet_rel_pos")
-            .map_err(bf("new_pos"))?;
-        graph.set_input(mel_t).map_err(bf("set_input_mel"))?;
-        graph.set_input(pos_t).map_err(bf("set_input_pos"))?;
-
-        let conv_map = |step, source| ParakeetEncoderError::GraphBuildFailed { step, source };
-        let stride2 = Conv2dParams {
-            stride_x: 2,
-            stride_y: 2,
-            padding_x: 1,
-            padding_y: 1,
-            dilation_x: 1,
-            dilation_y: 1,
-        };
-        let pointwise = Conv2dParams {
-            stride_x: 1,
-            stride_y: 1,
-            padding_x: 0,
-            padding_y: 0,
-            dilation_x: 1,
-            dilation_y: 1,
-        };
-        let bias4d = |g: &_, t: GgmlStaticTensor, len: usize, step| {
-            reshape_bias_4d(g, self.arena.graph_tensor(t), len, step, conv_map)
-        };
-
-        // ----- dw-striding subsampling (verbatim cohere FastConformer prelude) -----
-        let mut state_4d = graph
-            .reshape_4d(mel_t, mel.n_mels, mel.n_frames, 1, 1)
-            .map_err(bf("reshape_mel_4d"))?;
-        let conv0_b = bias4d(
-            &graph,
-            self.sub.conv0_b,
-            metadata.subsampling_channels,
-            "sub0_bias4d",
-        )?;
-        state_4d = apply_conv_2d_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv0_w),
-            state_4d,
-            conv0_b,
-            stride2,
-            ConvActivation::Relu,
-            ConvBlockSteps {
-                conv: "conv0",
-                bias: "conv0_bias",
-                activation: "conv0_relu",
+        let mut graph = self.core.runner.start_graph();
+        let stack = fastconformer::build_conformer_stack::<ParakeetEncoderError>(
+            &mut graph,
+            &self.core.arena,
+            &self.core.sub,
+            &self.core.layers,
+            FastConformerStackConfig {
+                hidden_size: d_model,
+                n_heads: metadata.n_heads,
+                head_dim: metadata.head_dim,
+                conv_kernel: metadata.conv_kernel,
+                subsampling_channels: metadata.subsampling_channels,
+                scale_input: true,
             },
-            conv_map,
+            mel.n_mels,
+            mel.n_frames,
+            "parakeet_mel",
+            "parakeet_rel_pos",
         )?;
-        let conv2_b = bias4d(
-            &graph,
-            self.sub.conv2_b,
-            metadata.subsampling_channels,
-            "sub2_bias4d",
-        )?;
-        state_4d = apply_conv_2d_depthwise_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv2_w),
-            state_4d,
-            conv2_b,
-            stride2,
-            None,
-            ConvBlockSteps {
-                conv: "conv2_dw",
-                bias: "conv2_bias",
-                activation: "conv2_noact",
-            },
-            conv_map,
-        )?;
-        let conv3_b = bias4d(
-            &graph,
-            self.sub.conv3_b,
-            metadata.subsampling_channels,
-            "sub3_bias4d",
-        )?;
-        state_4d = apply_conv_2d_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv3_w),
-            state_4d,
-            conv3_b,
-            pointwise,
-            ConvActivation::Relu,
-            ConvBlockSteps {
-                conv: "conv3_pw",
-                bias: "conv3_bias",
-                activation: "conv3_relu",
-            },
-            conv_map,
-        )?;
-        let conv5_b = bias4d(
-            &graph,
-            self.sub.conv5_b,
-            metadata.subsampling_channels,
-            "sub5_bias4d",
-        )?;
-        state_4d = apply_conv_2d_depthwise_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv5_w),
-            state_4d,
-            conv5_b,
-            stride2,
-            None,
-            ConvBlockSteps {
-                conv: "conv5_dw",
-                bias: "conv5_bias",
-                activation: "conv5_noact",
-            },
-            conv_map,
-        )?;
-        let conv6_b = bias4d(
-            &graph,
-            self.sub.conv6_b,
-            metadata.subsampling_channels,
-            "sub6_bias4d",
-        )?;
-        state_4d = apply_conv_2d_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv6_w),
-            state_4d,
-            conv6_b,
-            pointwise,
-            ConvActivation::Relu,
-            ConvBlockSteps {
-                conv: "conv6_pw",
-                bias: "conv6_bias",
-                activation: "conv6_relu",
-            },
-            conv_map,
-        )?;
-
-        // flatten [channels, freq] per frame -> [channels*freq, frames] -> linear -> d_model.
-        let flattened = self
-            .sub
-            .conv6_channels
-            .checked_mul(subsampled_freq)
-            .ok_or_else(|| ParakeetEncoderError::Shape {
-                reason: "flatten overflow".into(),
-            })?;
-        let mut state = graph
-            .permute(state_4d, 0, 2, 1, 3)
-            .map_err(bf("permute_flatten"))?;
-        state = graph.cont(state).map_err(bf("cont_flatten"))?;
-        state = graph
-            .reshape_2d(state, flattened, subsampled_frames)
-            .map_err(bf("reshape_flatten"))?;
-        state = graph
-            .mul_mat(self.sub.linear_w.graph(&self.arena), state)
-            .map_err(bf("sub_linear"))?;
-        state = graph
-            .add(state, self.arena.graph_tensor(self.sub.linear_b))
-            .map_err(bf("sub_linear_bias"))?;
-        // scale_input: x *= sqrt(d_model)  (NeMo FastConformer).
-        state = graph
-            .scale(state, (d_model as f32).sqrt())
-            .map_err(bf("scale_input"))?;
-
-        // ----- conformer layers (shared nn/ block) -----
-        let element = std::mem::size_of::<f32>();
-        let frame = subsampled_frames;
-        let config = ConformerBlockConfig {
-            d_model,
-            attention_heads: metadata.n_heads,
-            head_dim: metadata.head_dim,
-            frame_count: frame,
-            conv_kernel: metadata.conv_kernel,
-            layer_norm_epsilon: ENCODER_LAYER_NORM_EPSILON,
-            macaron_scale: CONFORMER_MACARON_SCALE,
-            rel_shift_nb1: (2 * frame - 2) * element,
-            rel_shift_nb2: (2 * frame - 1) * frame * element,
-            rel_shift_offset: (frame - 1) * element,
-        };
-        let pos_enc = pos_t;
-        for handles in &self.layers {
-            let weights = conformer_weights(&self.arena, handles);
-            let block = conformer_block(&mut graph, state, pos_enc, config, weights, conv_map)?;
-            state = block.output;
-        }
 
         // ----- CTC head -----
         // No extra final norm: conformer_block already applies its per-layer
         // out_norm as its last step, and parakeet has no separate encoder-level
-        // final-norm tensor — the CTC head consumes the last block's output.
+        // final-norm tensor -- the CTC head consumes the last block's output.
         let head = graph
             .reshape_2d(
-                self.ctc_head_weight.graph(&self.arena),
+                self.ctc_head_weight.graph(&self.core.arena),
                 d_model,
                 metadata.vocab_size,
             )
-            .map_err(bf("ctc_head_reshape"))?;
-        let mut logits = graph.mul_mat(head, state).map_err(bf("ctc_head_matmul"))?;
+            .map_err(|source| ParakeetEncoderError::GraphBuildFailed {
+                step: "ctc_head_reshape",
+                source,
+            })?;
+        let mut logits = graph.mul_mat(head, stack.state).map_err(|source| {
+            ParakeetEncoderError::GraphBuildFailed {
+                step: "ctc_head_matmul",
+                source,
+            }
+        })?;
         logits = graph
-            .add(logits, self.arena.graph_tensor(self.ctc_head_bias))
-            .map_err(bf("ctc_head_bias"))?;
-        graph.set_output(logits).map_err(bf("set_output_logits"))?;
+            .add(logits, self.core.arena.graph_tensor(self.ctc_head_bias))
+            .map_err(|source| ParakeetEncoderError::GraphBuildFailed {
+                step: "ctc_head_bias",
+                source,
+            })?;
+        graph
+            .set_output(logits)
+            .map_err(|source| ParakeetEncoderError::GraphBuildFailed {
+                step: "set_output_logits",
+                source,
+            })?;
 
         // Peak-RSS lever: allocate the compute graph via the scheduler's gallocr
         // (liveness-based buffer REUSE) before uploading inputs, instead of the
@@ -611,13 +176,16 @@ impl ParakeetCtcEncoderGraph {
         // (RSS = sum over conformer layers). Collapses peak RSS to the working set.
         graph
             .prepare_outputs_for_upload(&[logits])
-            .map_err(bf("prepare_outputs"))?;
-        upload_graph_f32(&mut graph, mel_t, &mel.data, "upload_mel")?;
-        upload_graph_f32(&mut graph, pos_t, &positional, "upload_pos")?;
+            .map_err(|source| ParakeetEncoderError::GraphBuildFailed {
+                step: "prepare_outputs",
+                source,
+            })?;
+        fastconformer::upload_graph_f32(&mut graph, stack.mel_t, &mel.data, "upload_mel")?;
+        fastconformer::upload_graph_f32(&mut graph, stack.pos_t, &stack.positional, "upload_pos")?;
 
         let want = metadata
             .vocab_size
-            .checked_mul(subsampled_frames)
+            .checked_mul(stack.subsampled_frames)
             .ok_or_else(|| ParakeetEncoderError::Shape {
                 reason: "logits overflow".into(),
             })?;
@@ -627,161 +195,10 @@ impl ParakeetCtcEncoderGraph {
             }
         })?;
         Ok(ParakeetCtcEncoderOutput {
-            frame_count: subsampled_frames,
+            frame_count: stack.subsampled_frames,
             vocab_size: metadata.vocab_size,
             logits,
         })
-    }
-}
-
-fn upload_graph_f32<'a>(
-    graph: &mut crate::ggml_runtime::GgmlCpuGraphBuilder<'a>,
-    tensor: GgmlCpuTensor<'a>,
-    values: &[f32],
-    step: &'static str,
-) -> Result<(), ParakeetEncoderError> {
-    graph
-        .set_f32_slice(tensor, values, step)
-        .map_err(|source| ParakeetEncoderError::GraphBuildFailed { step, source })
-}
-
-/// Allocate one conformer layer's arena tensors + bind its 2-D linears zero-copy
-/// from the mmap'd pack. The bound set (`ff*.{up,down}`, `attn.{q,k,v,out,pos}`,
-/// `conv.pw{1,2}`) skips its `alloc_static`+`upload_static`: each is `[in,out]`
-/// native on disk (the packer reversed dims) so it is bound + drawn straight from
-/// the pack at `mul_mat`. Fails closed (`bind_loaded`) when a bound weight is
-/// absent — its host payload was dropped at load. `layer_idx` is unused for
-/// binding (weights carry their own `enc.blk.{i}.*` names) but threaded for
-/// parity with the qwen/cohere mirrors.
-fn alloc_layer(
-    arena: &GgmlStaticTensorArena,
-    loaded: Option<&GgmlLoadedWeightContext>,
-    _layer_idx: usize,
-    layer: &ParakeetEncoderLayerWeights,
-) -> Result<LayerArena, ParakeetEncoderError> {
-    Ok(LayerArena {
-        ff1_norm_weight: alloc_static(arena, &layer.ff1_norm_weight, "ff1_norm_w")?,
-        ff1_norm_bias: alloc_static(arena, &layer.ff1_norm_bias, "ff1_norm_b")?,
-        ff1_up_weight: bind_loaded(loaded, &layer.ff1_up_weight.name)?,
-        ff1_up_bias: alloc_static(arena, &layer.ff1_up_bias, "ff1_up_b")?,
-        ff1_down_weight: bind_loaded(loaded, &layer.ff1_down_weight.name)?,
-        ff1_down_bias: alloc_static(arena, &layer.ff1_down_bias, "ff1_down_b")?,
-        attn_norm_weight: alloc_static(arena, &layer.attn_norm_weight, "attn_norm_w")?,
-        attn_norm_bias: alloc_static(arena, &layer.attn_norm_bias, "attn_norm_b")?,
-        attn_q_weight: bind_loaded(loaded, &layer.attn_q_weight.name)?,
-        attn_q_bias: alloc_static(arena, &layer.attn_q_bias, "attn_q_b")?,
-        attn_k_weight: bind_loaded(loaded, &layer.attn_k_weight.name)?,
-        attn_k_bias: alloc_static(arena, &layer.attn_k_bias, "attn_k_b")?,
-        attn_v_weight: bind_loaded(loaded, &layer.attn_v_weight.name)?,
-        attn_v_bias: alloc_static(arena, &layer.attn_v_bias, "attn_v_b")?,
-        attn_out_weight: bind_loaded(loaded, &layer.attn_out_weight.name)?,
-        attn_out_bias: alloc_static(arena, &layer.attn_out_bias, "attn_out_b")?,
-        attn_pos_weight: bind_loaded(loaded, &layer.attn_pos_weight.name)?,
-        attn_pos_bias_u: alloc_static(arena, &layer.attn_pos_bias_u, "attn_pos_u")?,
-        attn_pos_bias_v: alloc_static(arena, &layer.attn_pos_bias_v, "attn_pos_v")?,
-        conv_norm_weight: alloc_static(arena, &layer.conv_norm_weight, "conv_norm_w")?,
-        conv_norm_bias: alloc_static(arena, &layer.conv_norm_bias, "conv_norm_b")?,
-        conv_pw1_weight: bind_loaded(loaded, &layer.conv_pw1_weight.name)?,
-        conv_pw1_bias: alloc_static(arena, &layer.conv_pw1_bias, "conv_pw1_b")?,
-        conv_dw_weight: alloc_static_f16(arena, &layer.conv_dw_weight, "conv_dw_w")?,
-        conv_dw_bias: alloc_static(arena, &layer.conv_dw_bias, "conv_dw_b")?,
-        conv_pw2_weight: bind_loaded(loaded, &layer.conv_pw2_weight.name)?,
-        conv_pw2_bias: alloc_static(arena, &layer.conv_pw2_bias, "conv_pw2_b")?,
-        ff2_norm_weight: alloc_static(arena, &layer.ff2_norm_weight, "ff2_norm_w")?,
-        ff2_norm_bias: alloc_static(arena, &layer.ff2_norm_bias, "ff2_norm_b")?,
-        ff2_up_weight: bind_loaded(loaded, &layer.ff2_up_weight.name)?,
-        ff2_up_bias: alloc_static(arena, &layer.ff2_up_bias, "ff2_up_b")?,
-        ff2_down_weight: bind_loaded(loaded, &layer.ff2_down_weight.name)?,
-        ff2_down_bias: alloc_static(arena, &layer.ff2_down_bias, "ff2_down_b")?,
-        out_norm_weight: alloc_static(arena, &layer.out_norm_weight, "out_norm_w")?,
-        out_norm_bias: alloc_static(arena, &layer.out_norm_bias, "out_norm_b")?,
-    })
-}
-
-/// Upload one layer's ARENA tensors (norms, biases, BN-folded depthwise conv).
-/// The 2-D linears are bound zero-copy in `alloc_layer`, so they are absent here
-/// (their host f32 `values` were dropped at load — see `encoder_weights`).
-fn upload_layer(
-    arena: &mut GgmlStaticTensorArena,
-    layer: &ParakeetEncoderLayerWeights,
-    h: &LayerArena,
-) -> Result<(), ParakeetEncoderError> {
-    upload_static_f16(arena, h.conv_dw_weight, &layer.conv_dw_weight, "conv_dw_w")?;
-    let pairs: [(GgmlStaticTensor, &NamedTensor); 23] = [
-        (h.ff1_norm_weight, &layer.ff1_norm_weight),
-        (h.ff1_norm_bias, &layer.ff1_norm_bias),
-        (h.ff1_up_bias, &layer.ff1_up_bias),
-        (h.ff1_down_bias, &layer.ff1_down_bias),
-        (h.attn_norm_weight, &layer.attn_norm_weight),
-        (h.attn_norm_bias, &layer.attn_norm_bias),
-        (h.attn_q_bias, &layer.attn_q_bias),
-        (h.attn_k_bias, &layer.attn_k_bias),
-        (h.attn_v_bias, &layer.attn_v_bias),
-        (h.attn_out_bias, &layer.attn_out_bias),
-        (h.attn_pos_bias_u, &layer.attn_pos_bias_u),
-        (h.attn_pos_bias_v, &layer.attn_pos_bias_v),
-        (h.conv_norm_weight, &layer.conv_norm_weight),
-        (h.conv_norm_bias, &layer.conv_norm_bias),
-        (h.conv_pw1_bias, &layer.conv_pw1_bias),
-        (h.conv_dw_bias, &layer.conv_dw_bias),
-        (h.conv_pw2_bias, &layer.conv_pw2_bias),
-        (h.ff2_norm_weight, &layer.ff2_norm_weight),
-        (h.ff2_norm_bias, &layer.ff2_norm_bias),
-        (h.ff2_up_bias, &layer.ff2_up_bias),
-        (h.ff2_down_bias, &layer.ff2_down_bias),
-        (h.out_norm_weight, &layer.out_norm_weight),
-        (h.out_norm_bias, &layer.out_norm_bias),
-    ];
-    for (tensor, weight) in pairs {
-        upload_static(arena, tensor, weight, "layer_weight")?;
-    }
-    Ok(())
-}
-
-fn conformer_weights<'a>(
-    arena: &'a GgmlStaticTensorArena,
-    h: &LayerArena,
-) -> ConformerBlockWeights<'a> {
-    let g = |t: GgmlStaticTensor| arena.graph_tensor(t);
-    // Bound 2-D linears resolve to their mmap'd leaf (or arena fallback) via the
-    // `WeightSlot` handle; everything else is a plain arena tensor.
-    let b = |slot: WeightSlot| slot.graph(arena);
-    ConformerBlockWeights {
-        ff1_norm_weight: g(h.ff1_norm_weight),
-        ff1_norm_bias: g(h.ff1_norm_bias),
-        ff1_up_weight: b(h.ff1_up_weight),
-        ff1_up_bias: g(h.ff1_up_bias),
-        ff1_down_weight: b(h.ff1_down_weight),
-        ff1_down_bias: g(h.ff1_down_bias),
-        attn_norm_weight: g(h.attn_norm_weight),
-        attn_norm_bias: g(h.attn_norm_bias),
-        attn_q_weight: b(h.attn_q_weight),
-        attn_q_bias: g(h.attn_q_bias),
-        attn_k_weight: b(h.attn_k_weight),
-        attn_k_bias: g(h.attn_k_bias),
-        attn_v_weight: b(h.attn_v_weight),
-        attn_v_bias: g(h.attn_v_bias),
-        attn_out_weight: b(h.attn_out_weight),
-        attn_out_bias: g(h.attn_out_bias),
-        attn_pos_weight: b(h.attn_pos_weight),
-        attn_pos_bias_u: g(h.attn_pos_bias_u),
-        attn_pos_bias_v: g(h.attn_pos_bias_v),
-        conv_norm_weight: g(h.conv_norm_weight),
-        conv_norm_bias: g(h.conv_norm_bias),
-        conv_pw1_weight: b(h.conv_pw1_weight),
-        conv_pw1_bias: g(h.conv_pw1_bias),
-        conv_dw_weight: g(h.conv_dw_weight),
-        conv_dw_bias: g(h.conv_dw_bias),
-        conv_pw2_weight: b(h.conv_pw2_weight),
-        conv_pw2_bias: g(h.conv_pw2_bias),
-        ff2_norm_weight: g(h.ff2_norm_weight),
-        ff2_norm_bias: g(h.ff2_norm_bias),
-        ff2_up_weight: b(h.ff2_up_weight),
-        ff2_up_bias: g(h.ff2_up_bias),
-        ff2_down_weight: b(h.ff2_down_weight),
-        ff2_down_bias: g(h.ff2_down_bias),
-        out_norm_weight: g(h.out_norm_weight),
-        out_norm_bias: g(h.out_norm_bias),
     }
 }
 
@@ -789,6 +206,7 @@ fn conformer_weights<'a>(
 mod tests {
     use super::*;
     use crate::ggml_runtime::GgufTensorDataReader;
+    use crate::models::fastconformer::graph::conv_out_dim;
     use crate::models::parakeet_ctc::encoder_weights::load_parakeet_ctc_encoder_weights;
     use crate::models::parakeet_ctc::runtime_contract::parse_parakeet_ctc_execution_metadata;
     use std::path::Path;

--- a/crates/openasr-core/src/models/parakeet_ctc/encoder_weights.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/encoder_weights.rs
@@ -3,19 +3,23 @@
 //! Every tensor is read generically (dims from the GGUF index, values
 //! dequantized to f32) so we never hand-guess the stored dim convention — the
 //! encoder graph (S3) reshapes each weight to what `nn::encoder::conformer_block`
-//! expects from its element layout. The per-layer set mirrors `ConformerBlockWeights`
-//! plus the dw-striding subsampling prelude + the CTC head; the BatchNorm1d
-//! tensors are folded into the depthwise weight/bias at load (eps 1e-5, same as
-//! cohere / HF default).
+//! expects from its element layout. The dw-striding subsampling + per-layer
+//! conformer weights (mirroring `ConformerBlockWeights`) + BatchNorm fold are
+//! the shared `models::fastconformer::weights` skeleton parakeet-tdt also
+//! uses; this module adds only the CTC-head tail, which parakeet-tdt has no
+//! equivalent of.
 
 // Consumed by the encoder graph + executor wired in S3c/S4; tested meanwhile.
 #![allow(dead_code)]
 
 use crate::ggml_runtime::{GgufTensorDataReadError, GgufTensorDataReader};
+use crate::models::fastconformer::{self, FastConformerLayerWeights, FastConformerWeightsError};
+// Re-exported so other parakeet-ctc modules can keep referring to it as
+// `encoder_weights::NamedTensor`, unchanged by the type's move into the
+// shared `fastconformer` module.
+pub(crate) use crate::models::fastconformer::NamedTensor;
 
 use super::runtime_contract::ParakeetCtcExecutionMetadata;
-
-const CONV_BN_EPSILON: f32 = 1.0e-5;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ParakeetEncoderWeightsError {
@@ -31,70 +35,15 @@ pub(crate) enum ParakeetEncoderWeightsError {
     BatchNormFold { reason: String },
 }
 
-/// A host weight: its stored dims (from the GGUF index) + dequantized f32 values.
-#[derive(Debug, Clone)]
-pub(crate) struct NamedTensor {
-    pub name: String,
-    pub dims: Vec<usize>,
-    pub values: Vec<f32>,
-}
-
-impl NamedTensor {
-    fn element_count(&self) -> usize {
-        self.values.len()
-    }
-
-    /// Drop the resident f32 host `values` (keeping name + dims) for a weight the
-    /// encoder graph binds zero-copy from the mmap'd pack. Mirrors qwen's
-    /// `dropped_projection_payload`: the dequantized f32 copy is dead weight for a
-    /// bound tensor (its bytes come straight from the pack at `mul_mat`), and is
-    /// the dominant peak-RSS term for the q4_K parakeet pack. Shape validators
-    /// read `dims`, not `values`, and the encoder's `alloc_layer` binds these by
-    /// name only — so the empty `values` is never observed.
-    fn drop_bound_payload(&mut self) {
-        self.values = Vec::new();
+impl FastConformerWeightsError for ParakeetEncoderWeightsError {
+    fn batchnorm_fold(reason: String) -> Self {
+        Self::BatchNormFold { reason }
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct ParakeetEncoderLayerWeights {
-    pub ff1_norm_weight: NamedTensor,
-    pub ff1_norm_bias: NamedTensor,
-    pub ff1_up_weight: NamedTensor,
-    pub ff1_up_bias: NamedTensor,
-    pub ff1_down_weight: NamedTensor,
-    pub ff1_down_bias: NamedTensor,
-    pub attn_norm_weight: NamedTensor,
-    pub attn_norm_bias: NamedTensor,
-    pub attn_q_weight: NamedTensor,
-    pub attn_q_bias: NamedTensor,
-    pub attn_k_weight: NamedTensor,
-    pub attn_k_bias: NamedTensor,
-    pub attn_v_weight: NamedTensor,
-    pub attn_v_bias: NamedTensor,
-    pub attn_out_weight: NamedTensor,
-    pub attn_out_bias: NamedTensor,
-    pub attn_pos_weight: NamedTensor,
-    pub attn_pos_bias_u: NamedTensor,
-    pub attn_pos_bias_v: NamedTensor,
-    pub conv_norm_weight: NamedTensor,
-    pub conv_norm_bias: NamedTensor,
-    pub conv_pw1_weight: NamedTensor,
-    pub conv_pw1_bias: NamedTensor,
-    /// BatchNorm folded into these two at load (so the graph sees a plain dw conv).
-    pub conv_dw_weight: NamedTensor,
-    pub conv_dw_bias: NamedTensor,
-    pub conv_pw2_weight: NamedTensor,
-    pub conv_pw2_bias: NamedTensor,
-    pub ff2_norm_weight: NamedTensor,
-    pub ff2_norm_bias: NamedTensor,
-    pub ff2_up_weight: NamedTensor,
-    pub ff2_up_bias: NamedTensor,
-    pub ff2_down_weight: NamedTensor,
-    pub ff2_down_bias: NamedTensor,
-    pub out_norm_weight: NamedTensor,
-    pub out_norm_bias: NamedTensor,
-}
+/// The parakeet-ctc checkpoint ships every conformer bias tensor (no
+/// bias-free NeMo/HF conversion, unlike parakeet-tdt-0.6b-v3).
+pub(crate) type ParakeetEncoderLayerWeights = FastConformerLayerWeights;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ParakeetEncoderWeights {
@@ -106,188 +55,31 @@ pub(crate) struct ParakeetEncoderWeights {
     pub ctc_head_bias: NamedTensor,
 }
 
-fn load_named(
-    reader: &GgufTensorDataReader,
-    name: &str,
-) -> Result<NamedTensor, ParakeetEncoderWeightsError> {
-    let tensor = reader.tensor_index().get(name).ok_or_else(|| {
-        ParakeetEncoderWeightsError::Read(GgufTensorDataReadError::TensorNotFound {
-            path: reader.tensor_index().path().to_path_buf(),
-            tensor_name: name.to_string(),
-        })
-    })?;
-    let dims: Vec<usize> = tensor.dims.iter().map(|&d| d as usize).collect();
-    let shape_u64: Vec<u64> = tensor.dims.clone();
-    let values = reader.host_tensor_f32_copy_dequantized_by_name(name, &shape_u64)?;
-    Ok(NamedTensor {
-        name: name.to_string(),
-        dims,
-        values,
-    })
-}
-
-fn load_layer(
-    reader: &GgufTensorDataReader,
-    layer: usize,
-) -> Result<ParakeetEncoderLayerWeights, ParakeetEncoderWeightsError> {
-    let n = |suffix: &str| format!("enc.blk.{layer}.{suffix}");
-    let mut weights = ParakeetEncoderLayerWeights {
-        ff1_norm_weight: load_named(reader, &n("ff1.norm.weight"))?,
-        ff1_norm_bias: load_named(reader, &n("ff1.norm.bias"))?,
-        ff1_up_weight: load_named(reader, &n("ff1.up.weight"))?,
-        ff1_up_bias: load_named(reader, &n("ff1.up.bias"))?,
-        ff1_down_weight: load_named(reader, &n("ff1.down.weight"))?,
-        ff1_down_bias: load_named(reader, &n("ff1.down.bias"))?,
-        attn_norm_weight: load_named(reader, &n("attn.norm.weight"))?,
-        attn_norm_bias: load_named(reader, &n("attn.norm.bias"))?,
-        attn_q_weight: load_named(reader, &n("attn.q.weight"))?,
-        attn_q_bias: load_named(reader, &n("attn.q.bias"))?,
-        attn_k_weight: load_named(reader, &n("attn.k.weight"))?,
-        attn_k_bias: load_named(reader, &n("attn.k.bias"))?,
-        attn_v_weight: load_named(reader, &n("attn.v.weight"))?,
-        attn_v_bias: load_named(reader, &n("attn.v.bias"))?,
-        attn_out_weight: load_named(reader, &n("attn.out.weight"))?,
-        attn_out_bias: load_named(reader, &n("attn.out.bias"))?,
-        attn_pos_weight: load_named(reader, &n("attn.pos.weight"))?,
-        attn_pos_bias_u: load_named(reader, &n("attn.pos_bias_u"))?,
-        attn_pos_bias_v: load_named(reader, &n("attn.pos_bias_v"))?,
-        conv_norm_weight: load_named(reader, &n("conv.norm.weight"))?,
-        conv_norm_bias: load_named(reader, &n("conv.norm.bias"))?,
-        conv_pw1_weight: load_named(reader, &n("conv.pw1.weight"))?,
-        conv_pw1_bias: load_named(reader, &n("conv.pw1.bias"))?,
-        conv_dw_weight: load_named(reader, &n("conv.dw.weight"))?,
-        conv_dw_bias: load_named(reader, &n("conv.dw.bias"))?,
-        conv_pw2_weight: load_named(reader, &n("conv.pw2.weight"))?,
-        conv_pw2_bias: load_named(reader, &n("conv.pw2.bias"))?,
-        ff2_norm_weight: load_named(reader, &n("ff2.norm.weight"))?,
-        ff2_norm_bias: load_named(reader, &n("ff2.norm.bias"))?,
-        ff2_up_weight: load_named(reader, &n("ff2.up.weight"))?,
-        ff2_up_bias: load_named(reader, &n("ff2.up.bias"))?,
-        ff2_down_weight: load_named(reader, &n("ff2.down.weight"))?,
-        ff2_down_bias: load_named(reader, &n("ff2.down.bias"))?,
-        out_norm_weight: load_named(reader, &n("out.norm.weight"))?,
-        out_norm_bias: load_named(reader, &n("out.norm.bias"))?,
-    };
-    fold_batchnorm_into_depthwise(reader, layer, &mut weights)?;
-    Ok(weights)
-}
-
-/// Fold the conv BatchNorm1d (`conv.bn.{weight,bias,mean,var}`) into the depthwise
-/// weight + bias so the graph runs a plain depthwise conv. Channel-major layout
-/// (the depthwise weight is `[channels, 1, kernel]` C-order = `channel*kernel + k`).
-fn fold_batchnorm_into_depthwise(
-    reader: &GgufTensorDataReader,
-    layer: usize,
-    weights: &mut ParakeetEncoderLayerWeights,
-) -> Result<(), ParakeetEncoderWeightsError> {
-    let n = |suffix: &str| format!("enc.blk.{layer}.{suffix}");
-    let gamma = load_named(reader, &n("conv.bn.weight"))?;
-    let beta = load_named(reader, &n("conv.bn.bias"))?;
-    let mean = load_named(reader, &n("conv.bn.mean"))?;
-    let var = load_named(reader, &n("conv.bn.var"))?;
-
-    let channels = weights.conv_dw_bias.element_count();
-    if gamma.element_count() != channels
-        || beta.element_count() != channels
-        || mean.element_count() != channels
-        || var.element_count() != channels
-    {
-        return Err(ParakeetEncoderWeightsError::BatchNormFold {
-            reason: format!(
-                "per-channel sizes disagree: dw_bias={channels} gamma={} beta={} mean={} var={}",
-                gamma.element_count(),
-                beta.element_count(),
-                mean.element_count(),
-                var.element_count()
-            ),
-        });
-    }
-    let dw_elems = weights.conv_dw_weight.element_count();
-    if !dw_elems.is_multiple_of(channels) {
-        return Err(ParakeetEncoderWeightsError::BatchNormFold {
-            reason: format!("depthwise weight {dw_elems} not divisible by channels {channels}"),
-        });
-    }
-    let kernel = dw_elems / channels;
-    let scale: Vec<f32> = (0..channels)
-        .map(|c| gamma.values[c] / (var.values[c] + CONV_BN_EPSILON).sqrt())
-        .collect();
-    // `c` indexes several parallel per-channel arrays (scale, beta/mean, the dw
-    // kernel rows + the dw bias), so a range loop is clearest here.
-    #[allow(clippy::needless_range_loop)]
-    for c in 0..channels {
-        for k in 0..kernel {
-            weights.conv_dw_weight.values[c * kernel + k] *= scale[c];
-        }
-        weights.conv_dw_bias.values[c] =
-            beta.values[c] + (weights.conv_dw_bias.values[c] - mean.values[c]) * scale[c];
-    }
-    Ok(())
-}
-
-/// Drop the f32 host payload of the 2-D linears the encoder graph binds zero-copy
-/// (the q4_K/f32 `ff*`, `attn.{q,k,v,out,pos}`, `conv.pw{1,2}` projections). Their
-/// `dims` are retained for the binder + validators; only the dequantized values
-/// are freed. Norms, biases, and the BN-folded depthwise conv are NOT dropped
-/// (the graph still arena-uploads them from these `values`).
-fn drop_bound_linear_payloads(layer: &mut ParakeetEncoderLayerWeights) {
-    for w in [
-        &mut layer.ff1_up_weight,
-        &mut layer.ff1_down_weight,
-        &mut layer.attn_q_weight,
-        &mut layer.attn_k_weight,
-        &mut layer.attn_v_weight,
-        &mut layer.attn_out_weight,
-        &mut layer.attn_pos_weight,
-        &mut layer.conv_pw1_weight,
-        &mut layer.conv_pw2_weight,
-        &mut layer.ff2_up_weight,
-        &mut layer.ff2_down_weight,
-    ] {
-        w.drop_bound_payload();
-    }
-}
-
-fn drop_bound_subsampling_payloads(subsampling: &mut [NamedTensor]) {
-    for weight in subsampling {
-        if weight.name == "enc.sub.linear.weight" {
-            weight.drop_bound_payload();
-        }
-    }
-}
-
 pub(crate) fn load_parakeet_ctc_encoder_weights(
     reader: &GgufTensorDataReader,
     metadata: &ParakeetCtcExecutionMetadata,
 ) -> Result<ParakeetEncoderWeights, ParakeetEncoderWeightsError> {
-    // dw-striding subsampling tensors: enc.sub.layers.{0,2,3,5,6}.{weight,bias}
-    // + enc.sub.linear.{weight,bias}. Load whichever of these are present.
-    let mut subsampling = Vec::new();
-    for sub_layer in [0usize, 2, 3, 5, 6] {
-        for kind in ["weight", "bias"] {
-            let name = format!("enc.sub.layers.{sub_layer}.{kind}");
-            if reader.tensor_index().get(&name).is_some() {
-                subsampling.push(load_named(reader, &name)?);
-            }
-        }
-    }
-    subsampling.push(load_named(reader, "enc.sub.linear.weight")?);
-    subsampling.push(load_named(reader, "enc.sub.linear.bias")?);
-    drop_bound_subsampling_payloads(&mut subsampling);
+    let subsampling =
+        fastconformer::load_fastconformer_subsampling::<ParakeetEncoderWeightsError>(reader)?;
 
     let mut layers = Vec::with_capacity(metadata.n_layers);
     for layer in 0..metadata.n_layers {
-        let mut layer_weights = load_layer(reader, layer)?;
-        // The encoder graph binds these 2-D linears zero-copy from the mmap'd
-        // pack (the packer stored them `[in,out]`-native), so drop their f32 host
-        // copy — the dominant peak-RSS term. Norms/biases + the BN-folded
-        // depthwise conv keep their `values` (still arena-uploaded).
-        drop_bound_linear_payloads(&mut layer_weights);
-        layers.push(layer_weights);
+        // bias_present = true: every attn/conv/FFN bias tensor is on disk.
+        layers.push(fastconformer::load_fastconformer_layer::<
+            ParakeetEncoderWeightsError,
+        >(
+            reader,
+            layer,
+            metadata.hidden_size,
+            metadata.ffn_dim,
+            true,
+        )?);
     }
 
-    let mut ctc_head_weight = load_named(reader, "ctc.head.weight")?;
-    let ctc_head_bias = load_named(reader, "ctc.head.bias")?;
+    let mut ctc_head_weight: NamedTensor =
+        fastconformer::load_named::<ParakeetEncoderWeightsError>(reader, "ctc.head.weight")?;
+    let ctc_head_bias: NamedTensor =
+        fastconformer::load_named::<ParakeetEncoderWeightsError>(reader, "ctc.head.bias")?;
     let expected_head = metadata.vocab_size * metadata.hidden_size;
     if ctc_head_weight.element_count() != expected_head {
         return Err(ParakeetEncoderWeightsError::ElementCount {
@@ -373,32 +165,5 @@ mod tests {
             .find(|t| t.name == "enc.sub.linear.weight")
             .expect("subsampling linear");
         assert!(sub_linear.values.is_empty());
-    }
-
-    #[test]
-    fn drops_subsampling_linear_payload_only() {
-        let mut subsampling = vec![
-            NamedTensor {
-                name: "enc.sub.linear.weight".to_string(),
-                dims: vec![2, 3],
-                values: vec![1.0; 6],
-            },
-            NamedTensor {
-                name: "enc.sub.linear.bias".to_string(),
-                dims: vec![3],
-                values: vec![1.0; 3],
-            },
-            NamedTensor {
-                name: "enc.sub.layers.0.weight".to_string(),
-                dims: vec![3, 3, 1, 256],
-                values: vec![1.0; 9],
-            },
-        ];
-
-        drop_bound_subsampling_payloads(&mut subsampling);
-
-        assert!(subsampling[0].values.is_empty());
-        assert_eq!(subsampling[1].values.len(), 3);
-        assert_eq!(subsampling[2].values.len(), 9);
     }
 }

--- a/crates/openasr-core/src/models/parakeet_tdt/encoder_graph.rs
+++ b/crates/openasr-core/src/models/parakeet_tdt/encoder_graph.rs
@@ -1,5 +1,5 @@
-//! parakeet-tdt encoder graph: the parakeet-ctc FastConformer encoder
-//! (dw-striding subsampling prelude + shared `nn::encoder::conformer_block`)
+//! parakeet-tdt encoder graph: the shared FastConformer subsampling +
+//! conformer stack (`models::fastconformer`, also used by `parakeet_ctc`)
 //! with the TDT differences: `scale_input` honored from pack metadata (false
 //! for v3) and the joint ENCODER PROJECTION (`enc.proj`, d_model -> joint
 //! hidden) applied in-graph instead of a CTC head. Output is the per-frame
@@ -7,36 +7,16 @@
 
 use std::path::Path;
 
-use crate::ggml_runtime::{
-    ArenaAllocError, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor,
-    GgmlLoadedWeightContext, GgmlStaticTensor, GgmlStaticTensorArena,
-    alloc_static_f16 as arena_alloc_static_f16, alloc_static_f32 as arena_alloc_static_f32,
-    bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
-    upload_static_f32 as arena_upload_static_f32,
+use crate::ggml_runtime::{GgmlCpuGraphError, GgmlStaticTensor, WeightSlot};
+use crate::models::fastconformer::{
+    self, FastConformerEncoderCore, FastConformerGraphError, FastConformerStackConfig,
 };
 use crate::models::parakeet_tdt::graph_config::parakeet_tdt_encoder_graph_config;
 
-use crate::nn::conv::{
-    Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation,
-    apply_conv_2d_depthwise_bias_activation, reshape_bias_4d,
-};
-use crate::nn::encoder::{
-    ConformerBlockConfig, ConformerBlockWeights, build_relative_positional_encoding,
-    conformer_block,
-};
-use crate::nn::half::f32_to_f16_bits;
-
-use super::encoder_weights::{
-    NamedTensor, ParakeetTdtEncoderLayerWeights, ParakeetTdtEncoderWeights,
-};
+use super::encoder_weights::ParakeetTdtEncoderWeights;
 use super::runtime_contract::ParakeetTdtExecutionMetadata;
 
 const PARAKEET_TDT_ENCODER_GRAPH_CONTEXT_BYTES: usize = 768 * 1024 * 1024;
-const ENCODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const CONFORMER_MACARON_SCALE: f32 = 0.5;
-const SUBSAMPLING_KERNEL: usize = 3;
-const SUBSAMPLING_STRIDE: usize = 2;
-const SUBSAMPLING_PADDING: usize = 1;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ParakeetTdtEncoderError {
@@ -49,6 +29,15 @@ pub(crate) enum ParakeetTdtEncoderError {
     GraphExecutionFailed { reason: String },
     #[error("parakeet-tdt encoder shape error: {reason}")]
     Shape { reason: String },
+}
+
+impl FastConformerGraphError for ParakeetTdtEncoderError {
+    fn graph_build_failed(step: &'static str, source: GgmlCpuGraphError) -> Self {
+        Self::GraphBuildFailed { step, source }
+    }
+    fn shape(reason: String) -> Self {
+        Self::Shape { reason }
+    }
 }
 
 /// 128-bin log-mel features for one utterance: `data` is row-major
@@ -69,171 +58,11 @@ pub(crate) struct ParakeetTdtEncoderOutput {
     pub features: Vec<f32>,
 }
 
-fn bf(step: &'static str) -> impl Fn(GgmlCpuGraphError) -> ParakeetTdtEncoderError {
-    move |source| ParakeetTdtEncoderError::GraphBuildFailed { step, source }
-}
-
-/// A 2-D linear bound zero-copy to the mmap'd pack (native q4_K/f16/f32).
-/// Unlike parakeet-ctc there is no arena fallback variant: every bindable
-/// linear's host payload is dropped at load, so binding failure fails closed
-/// in `bind_loaded`.
-#[derive(Clone, Copy)]
-struct WeightSlot(GgmlLoadedTensor);
-
-impl WeightSlot {
-    fn graph<'a>(self, _arena: &GgmlStaticTensorArena) -> GgmlCpuTensor<'a> {
-        self.0.as_graph_tensor()
-    }
-}
-
-/// Bind a 2-D linear zero-copy from the mmap'd pack. FAILS CLOSED when absent:
-/// the host f32 payload for bound weights was dropped at load, so there is no
-/// arena fallback.
-fn bind_loaded(
-    loaded: Option<&GgmlLoadedWeightContext>,
-    name: &str,
-) -> Result<WeightSlot, ParakeetTdtEncoderError> {
-    arena_bind_loaded(loaded, name)
-        .map(WeightSlot)
-        .map_err(|reason| ParakeetTdtEncoderError::Shape { reason })
-}
-
-fn conv_out_dim(input: usize) -> usize {
-    (input + 2 * SUBSAMPLING_PADDING - SUBSAMPLING_KERNEL) / SUBSAMPLING_STRIDE + 1
-}
-
-fn alloc_static(
-    arena: &GgmlStaticTensorArena,
-    weight: &NamedTensor,
-    step: &'static str,
-) -> Result<GgmlStaticTensor, ParakeetTdtEncoderError> {
-    arena_alloc_static_f32(arena, &weight.dims, weight.values.len(), step, true).map_err(
-        |e| match e {
-            ArenaAllocError::Graph(source) => {
-                ParakeetTdtEncoderError::GraphBuildFailed { step, source }
-            }
-            ArenaAllocError::UnsupportedRank(dims) => ParakeetTdtEncoderError::Shape {
-                reason: format!("tensor '{}' has unsupported rank {:?}", weight.name, dims),
-            },
-        },
-    )
-}
-
-fn upload_static(
-    arena: &mut GgmlStaticTensorArena,
-    tensor: GgmlStaticTensor,
-    weight: &NamedTensor,
-    step: &'static str,
-) -> Result<(), ParakeetTdtEncoderError> {
-    arena_upload_static_f32(arena, tensor, &weight.values, step)
-        .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed { step, source })
-}
-
-fn alloc_static_f16(
-    arena: &GgmlStaticTensorArena,
-    weight: &NamedTensor,
-    step: &'static str,
-) -> Result<GgmlStaticTensor, ParakeetTdtEncoderError> {
-    arena_alloc_static_f16(arena, &weight.dims, step, true).map_err(|e| match e {
-        ArenaAllocError::Graph(source) => {
-            ParakeetTdtEncoderError::GraphBuildFailed { step, source }
-        }
-        ArenaAllocError::UnsupportedRank(dims) => ParakeetTdtEncoderError::Shape {
-            reason: format!("f16 depthwise '{}' rank {:?}", weight.name, dims),
-        },
-    })
-}
-
-fn upload_static_f16(
-    arena: &mut GgmlStaticTensorArena,
-    tensor: GgmlStaticTensor,
-    weight: &NamedTensor,
-    step: &'static str,
-) -> Result<(), ParakeetTdtEncoderError> {
-    arena_upload_static_f16(arena, tensor, &weight.values, step, f32_to_f16_bits)
-        .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed { step, source })
-}
-
-struct LayerArena {
-    ff1_norm_weight: GgmlStaticTensor,
-    ff1_norm_bias: GgmlStaticTensor,
-    ff1_up_weight: WeightSlot,
-    ff1_up_bias: GgmlStaticTensor,
-    ff1_down_weight: WeightSlot,
-    ff1_down_bias: GgmlStaticTensor,
-    attn_norm_weight: GgmlStaticTensor,
-    attn_norm_bias: GgmlStaticTensor,
-    attn_q_weight: WeightSlot,
-    attn_q_bias: GgmlStaticTensor,
-    attn_k_weight: WeightSlot,
-    attn_k_bias: GgmlStaticTensor,
-    attn_v_weight: WeightSlot,
-    attn_v_bias: GgmlStaticTensor,
-    attn_out_weight: WeightSlot,
-    attn_out_bias: GgmlStaticTensor,
-    attn_pos_weight: WeightSlot,
-    attn_pos_bias_u: GgmlStaticTensor,
-    attn_pos_bias_v: GgmlStaticTensor,
-    conv_norm_weight: GgmlStaticTensor,
-    conv_norm_bias: GgmlStaticTensor,
-    conv_pw1_weight: WeightSlot,
-    conv_pw1_bias: GgmlStaticTensor,
-    conv_dw_weight: GgmlStaticTensor,
-    conv_dw_bias: GgmlStaticTensor,
-    conv_pw2_weight: WeightSlot,
-    conv_pw2_bias: GgmlStaticTensor,
-    ff2_norm_weight: GgmlStaticTensor,
-    ff2_norm_bias: GgmlStaticTensor,
-    ff2_up_weight: WeightSlot,
-    ff2_up_bias: GgmlStaticTensor,
-    ff2_down_weight: WeightSlot,
-    ff2_down_bias: GgmlStaticTensor,
-    out_norm_weight: GgmlStaticTensor,
-    out_norm_bias: GgmlStaticTensor,
-}
-
-struct SubArena {
-    conv0_w: GgmlStaticTensor,
-    conv0_b: GgmlStaticTensor,
-    conv2_w: GgmlStaticTensor,
-    conv2_b: GgmlStaticTensor,
-    conv3_w: GgmlStaticTensor,
-    conv3_b: GgmlStaticTensor,
-    conv5_w: GgmlStaticTensor,
-    conv5_b: GgmlStaticTensor,
-    conv6_w: GgmlStaticTensor,
-    conv6_b: GgmlStaticTensor,
-    linear_w: WeightSlot,
-    linear_b: GgmlStaticTensor,
-    conv6_channels: usize,
-}
-
 pub(crate) struct ParakeetTdtEncoderGraph {
     metadata: ParakeetTdtExecutionMetadata,
-    runner: GgmlCpuGraphRunner,
-    // `loaded_weights` owns the mmap-backed buffer the bound slots alias;
-    // field order mirrors parakeet_ctc/cohere (see the soundness note there).
-    // Never read directly -- it exists to keep the mapping alive.
-    #[allow(dead_code)]
-    loaded_weights: Option<GgmlLoadedWeightContext>,
-    arena: GgmlStaticTensorArena,
-    sub: SubArena,
-    layers: Vec<LayerArena>,
+    core: FastConformerEncoderCore,
     enc_proj_weight: WeightSlot,
     enc_proj_bias: GgmlStaticTensor,
-}
-
-fn find_sub<'a>(
-    weights: &'a ParakeetTdtEncoderWeights,
-    name: &str,
-) -> Result<&'a NamedTensor, ParakeetTdtEncoderError> {
-    weights
-        .subsampling
-        .iter()
-        .find(|t| t.name == name)
-        .ok_or_else(|| ParakeetTdtEncoderError::Shape {
-            reason: format!("missing subsampling tensor '{name}'"),
-        })
 }
 
 impl ParakeetTdtEncoderGraph {
@@ -242,123 +71,29 @@ impl ParakeetTdtEncoderGraph {
         metadata: ParakeetTdtExecutionMetadata,
         runtime_path: Option<&Path>,
     ) -> Result<Self, ParakeetTdtEncoderError> {
-        let mut config = parakeet_tdt_encoder_graph_config();
-        config.context_bytes = PARAKEET_TDT_ENCODER_GRAPH_CONTEXT_BYTES;
-        config.graph_size = config.graph_size.max(weights.layers.len() * 256 + 2048);
-        let runner = GgmlCpuGraphRunner::new(config).map_err(|source| {
-            ParakeetTdtEncoderError::GraphBuildFailed {
-                step: "runner_init",
-                source,
-            }
-        })?;
-        let loaded_weights =
-            runtime_path.and_then(|path| runner.load_gguf_weight_context(path).ok());
-        let loaded = loaded_weights.as_ref();
-        let mut arena = runner
-            .start_static_tensor_arena(PARAKEET_TDT_ENCODER_GRAPH_CONTEXT_BYTES)
-            .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed {
-                step: "static_tensor_arena",
-                source,
-            })?;
-
-        // ----- declare (allocate) all arena tensors first (first upload freezes) -----
-        let s = |n: &str| find_sub(weights, n);
-        let conv0_w_t = alloc_static(&arena, s("enc.sub.layers.0.weight")?, "sub0_w")?;
-        let conv0_b_t = alloc_static(&arena, s("enc.sub.layers.0.bias")?, "sub0_b")?;
-        let conv2_w_t = alloc_static_f16(&arena, s("enc.sub.layers.2.weight")?, "sub2_w")?;
-        let conv2_b_t = alloc_static(&arena, s("enc.sub.layers.2.bias")?, "sub2_b")?;
-        let conv3_w_t = alloc_static(&arena, s("enc.sub.layers.3.weight")?, "sub3_w")?;
-        let conv3_b_t = alloc_static(&arena, s("enc.sub.layers.3.bias")?, "sub3_b")?;
-        let conv5_w_t = alloc_static_f16(&arena, s("enc.sub.layers.5.weight")?, "sub5_w")?;
-        let conv5_b_t = alloc_static(&arena, s("enc.sub.layers.5.bias")?, "sub5_b")?;
-        let conv6_w_t = alloc_static(&arena, s("enc.sub.layers.6.weight")?, "sub6_w")?;
-        let conv6_b_t = alloc_static(&arena, s("enc.sub.layers.6.bias")?, "sub6_b")?;
-        let linear_w_slot = bind_loaded(loaded, "enc.sub.linear.weight")?;
-        let linear_b_t = alloc_static(&arena, s("enc.sub.linear.bias")?, "sub_lin_b")?;
-        let conv6_channels = s("enc.sub.layers.6.bias")?.values.len();
-
-        let mut layer_arenas = Vec::with_capacity(weights.layers.len());
-        for layer in weights.layers.iter() {
-            layer_arenas.push(alloc_layer(&arena, loaded, layer)?);
-        }
-        let enc_proj_weight_slot = bind_loaded(loaded, &weights.enc_proj_weight.name)?;
-        let enc_proj_bias_t = alloc_static(&arena, &weights.enc_proj_bias, "enc_proj_b")?;
-
-        // ----- upload all values -----
-        upload_static(
-            &mut arena,
-            conv0_w_t,
-            s("enc.sub.layers.0.weight")?,
-            "sub0_w",
-        )?;
-        upload_static(&mut arena, conv0_b_t, s("enc.sub.layers.0.bias")?, "sub0_b")?;
-        upload_static_f16(
-            &mut arena,
-            conv2_w_t,
-            s("enc.sub.layers.2.weight")?,
-            "sub2_w",
-        )?;
-        upload_static(&mut arena, conv2_b_t, s("enc.sub.layers.2.bias")?, "sub2_b")?;
-        upload_static(
-            &mut arena,
-            conv3_w_t,
-            s("enc.sub.layers.3.weight")?,
-            "sub3_w",
-        )?;
-        upload_static(&mut arena, conv3_b_t, s("enc.sub.layers.3.bias")?, "sub3_b")?;
-        upload_static_f16(
-            &mut arena,
-            conv5_w_t,
-            s("enc.sub.layers.5.weight")?,
-            "sub5_w",
-        )?;
-        upload_static(&mut arena, conv5_b_t, s("enc.sub.layers.5.bias")?, "sub5_b")?;
-        upload_static(
-            &mut arena,
-            conv6_w_t,
-            s("enc.sub.layers.6.weight")?,
-            "sub6_w",
-        )?;
-        upload_static(&mut arena, conv6_b_t, s("enc.sub.layers.6.bias")?, "sub6_b")?;
-        upload_static(
-            &mut arena,
-            linear_b_t,
-            s("enc.sub.linear.bias")?,
-            "sub_lin_b",
-        )?;
-        for (layer, handles) in weights.layers.iter().zip(&layer_arenas) {
-            upload_layer(&mut arena, layer, handles)?;
-        }
-        upload_static(
-            &mut arena,
-            enc_proj_bias_t,
-            &weights.enc_proj_bias,
-            "enc_proj_b",
+        let config = parakeet_tdt_encoder_graph_config();
+        let (core, (enc_proj_weight, enc_proj_bias)) = FastConformerEncoderCore::build(
+            config,
+            PARAKEET_TDT_ENCODER_GRAPH_CONTEXT_BYTES,
+            runtime_path,
+            &weights.subsampling,
+            &weights.layers,
+            |arena, loaded| {
+                let weight = fastconformer::bind_loaded(loaded, &weights.enc_proj_weight.name)?;
+                let bias =
+                    fastconformer::alloc_static(arena, &weights.enc_proj_bias, "enc_proj_b")?;
+                Ok((weight, bias))
+            },
+            |arena, &(_, bias)| {
+                fastconformer::upload_static(arena, bias, &weights.enc_proj_bias, "enc_proj_b")
+            },
         )?;
 
         Ok(Self {
             metadata,
-            runner,
-            loaded_weights,
-            arena,
-            sub: SubArena {
-                conv0_w: conv0_w_t,
-                conv0_b: conv0_b_t,
-                conv2_w: conv2_w_t,
-                conv2_b: conv2_b_t,
-                conv3_w: conv3_w_t,
-                conv3_b: conv3_b_t,
-                conv5_w: conv5_w_t,
-                conv5_b: conv5_b_t,
-                conv6_w: conv6_w_t,
-                conv6_b: conv6_b_t,
-                linear_w: linear_w_slot,
-                linear_b: linear_b_t,
-                conv6_channels,
-            },
-            layers: layer_arenas,
-            enc_proj_weight: enc_proj_weight_slot,
-            enc_proj_bias: enc_proj_bias_t,
+            core,
+            enc_proj_weight,
+            enc_proj_bias,
         })
     }
 
@@ -368,202 +103,27 @@ impl ParakeetTdtEncoderGraph {
     ) -> Result<ParakeetTdtEncoderOutput, ParakeetTdtEncoderError> {
         let metadata = self.metadata;
         let d_model = metadata.hidden_size;
-        let subsampled_frames = conv_out_dim(conv_out_dim(conv_out_dim(mel.n_frames)));
-        let subsampled_freq = conv_out_dim(conv_out_dim(conv_out_dim(mel.n_mels)));
-        let positional = build_relative_positional_encoding(d_model, subsampled_frames, || {
-            ParakeetTdtEncoderError::Shape {
-                reason: "relative positional encoding shape overflow".to_string(),
-            }
-        })?;
-
-        let mut graph = self.runner.start_graph();
-
-        let mel_t = graph
-            .new_tensor_2d_f32(mel.n_mels, mel.n_frames, "parakeet_tdt_mel")
-            .map_err(bf("new_mel"))?;
-        let pos_t = graph
-            .new_tensor_2d_f32(d_model, positional.len() / d_model, "parakeet_tdt_rel_pos")
-            .map_err(bf("new_pos"))?;
-        graph.set_input(mel_t).map_err(bf("set_input_mel"))?;
-        graph.set_input(pos_t).map_err(bf("set_input_pos"))?;
-
-        let conv_map = |step, source| ParakeetTdtEncoderError::GraphBuildFailed { step, source };
-        let stride2 = Conv2dParams {
-            stride_x: 2,
-            stride_y: 2,
-            padding_x: 1,
-            padding_y: 1,
-            dilation_x: 1,
-            dilation_y: 1,
-        };
-        let pointwise = Conv2dParams {
-            stride_x: 1,
-            stride_y: 1,
-            padding_x: 0,
-            padding_y: 0,
-            dilation_x: 1,
-            dilation_y: 1,
-        };
-        let bias4d = |g: &_, t: GgmlStaticTensor, len: usize, step| {
-            reshape_bias_4d(g, self.arena.graph_tensor(t), len, step, conv_map)
-        };
-
-        // ----- dw-striding subsampling (verbatim parakeet-ctc/cohere prelude) -----
-        let mut state_4d = graph
-            .reshape_4d(mel_t, mel.n_mels, mel.n_frames, 1, 1)
-            .map_err(bf("reshape_mel_4d"))?;
-        let conv0_b = bias4d(
-            &graph,
-            self.sub.conv0_b,
-            metadata.subsampling_channels,
-            "sub0_bias4d",
-        )?;
-        state_4d = apply_conv_2d_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv0_w),
-            state_4d,
-            conv0_b,
-            stride2,
-            ConvActivation::Relu,
-            ConvBlockSteps {
-                conv: "conv0",
-                bias: "conv0_bias",
-                activation: "conv0_relu",
+        let mut graph = self.core.runner.start_graph();
+        let stack = fastconformer::build_conformer_stack::<ParakeetTdtEncoderError>(
+            &mut graph,
+            &self.core.arena,
+            &self.core.sub,
+            &self.core.layers,
+            FastConformerStackConfig {
+                hidden_size: d_model,
+                n_heads: metadata.n_heads,
+                head_dim: metadata.head_dim,
+                conv_kernel: metadata.conv_kernel,
+                subsampling_channels: metadata.subsampling_channels,
+                // Metadata-driven: parakeet-ctc's HF checkpoint scales, v3's
+                // does NOT (the HF conversion folded NeMo's xscaling away).
+                scale_input: metadata.scale_input,
             },
-            conv_map,
+            mel.n_mels,
+            mel.n_frames,
+            "parakeet_tdt_mel",
+            "parakeet_tdt_rel_pos",
         )?;
-        let conv2_b = bias4d(
-            &graph,
-            self.sub.conv2_b,
-            metadata.subsampling_channels,
-            "sub2_bias4d",
-        )?;
-        state_4d = apply_conv_2d_depthwise_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv2_w),
-            state_4d,
-            conv2_b,
-            stride2,
-            None,
-            ConvBlockSteps {
-                conv: "conv2_dw",
-                bias: "conv2_bias",
-                activation: "conv2_noact",
-            },
-            conv_map,
-        )?;
-        let conv3_b = bias4d(
-            &graph,
-            self.sub.conv3_b,
-            metadata.subsampling_channels,
-            "sub3_bias4d",
-        )?;
-        state_4d = apply_conv_2d_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv3_w),
-            state_4d,
-            conv3_b,
-            pointwise,
-            ConvActivation::Relu,
-            ConvBlockSteps {
-                conv: "conv3_pw",
-                bias: "conv3_bias",
-                activation: "conv3_relu",
-            },
-            conv_map,
-        )?;
-        let conv5_b = bias4d(
-            &graph,
-            self.sub.conv5_b,
-            metadata.subsampling_channels,
-            "sub5_bias4d",
-        )?;
-        state_4d = apply_conv_2d_depthwise_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv5_w),
-            state_4d,
-            conv5_b,
-            stride2,
-            None,
-            ConvBlockSteps {
-                conv: "conv5_dw",
-                bias: "conv5_bias",
-                activation: "conv5_noact",
-            },
-            conv_map,
-        )?;
-        let conv6_b = bias4d(
-            &graph,
-            self.sub.conv6_b,
-            metadata.subsampling_channels,
-            "sub6_bias4d",
-        )?;
-        state_4d = apply_conv_2d_bias_activation(
-            &graph,
-            self.arena.graph_tensor(self.sub.conv6_w),
-            state_4d,
-            conv6_b,
-            pointwise,
-            ConvActivation::Relu,
-            ConvBlockSteps {
-                conv: "conv6_pw",
-                bias: "conv6_bias",
-                activation: "conv6_relu",
-            },
-            conv_map,
-        )?;
-
-        // flatten [channels, freq] per frame -> [channels*freq, frames] -> linear.
-        let flattened = self
-            .sub
-            .conv6_channels
-            .checked_mul(subsampled_freq)
-            .ok_or_else(|| ParakeetTdtEncoderError::Shape {
-                reason: "flatten overflow".into(),
-            })?;
-        let mut state = graph
-            .permute(state_4d, 0, 2, 1, 3)
-            .map_err(bf("permute_flatten"))?;
-        state = graph.cont(state).map_err(bf("cont_flatten"))?;
-        state = graph
-            .reshape_2d(state, flattened, subsampled_frames)
-            .map_err(bf("reshape_flatten"))?;
-        state = graph
-            .mul_mat(self.sub.linear_w.graph(&self.arena), state)
-            .map_err(bf("sub_linear"))?;
-        state = graph
-            .add(state, self.arena.graph_tensor(self.sub.linear_b))
-            .map_err(bf("sub_linear_bias"))?;
-        // scale_input: x *= sqrt(d_model). Metadata-driven: parakeet-ctc's HF
-        // checkpoint scales, parakeet-tdt-0.6b-v3's does NOT (scale_input
-        // false; the HF conversion folded NeMo's xscaling away).
-        if metadata.scale_input {
-            state = graph
-                .scale(state, (d_model as f32).sqrt())
-                .map_err(bf("scale_input"))?;
-        }
-
-        // ----- conformer layers (shared nn/ block) -----
-        let element = std::mem::size_of::<f32>();
-        let frame = subsampled_frames;
-        let config = ConformerBlockConfig {
-            d_model,
-            attention_heads: metadata.n_heads,
-            head_dim: metadata.head_dim,
-            frame_count: frame,
-            conv_kernel: metadata.conv_kernel,
-            layer_norm_epsilon: ENCODER_LAYER_NORM_EPSILON,
-            macaron_scale: CONFORMER_MACARON_SCALE,
-            rel_shift_nb1: (2 * frame - 2) * element,
-            rel_shift_nb2: (2 * frame - 1) * frame * element,
-            rel_shift_offset: (frame - 1) * element,
-        };
-        let pos_enc = pos_t;
-        for handles in &self.layers {
-            let weights = conformer_weights(&self.arena, handles);
-            let block = conformer_block(&mut graph, state, pos_enc, config, weights, conv_map)?;
-            state = block.output;
-        }
 
         // ----- joint encoder projection: d_model -> joint_hidden -----
         // (In place of parakeet-ctc's CTC head; the last conformer block
@@ -571,28 +131,45 @@ impl ParakeetTdtEncoderGraph {
         // final norm in the checkpoint.)
         let proj = graph
             .reshape_2d(
-                self.enc_proj_weight.graph(&self.arena),
+                self.enc_proj_weight.graph(&self.core.arena),
                 d_model,
                 metadata.joint_hidden,
             )
-            .map_err(bf("enc_proj_reshape"))?;
-        let mut features = graph.mul_mat(proj, state).map_err(bf("enc_proj_matmul"))?;
+            .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed {
+                step: "enc_proj_reshape",
+                source,
+            })?;
+        let mut features = graph.mul_mat(proj, stack.state).map_err(|source| {
+            ParakeetTdtEncoderError::GraphBuildFailed {
+                step: "enc_proj_matmul",
+                source,
+            }
+        })?;
         features = graph
-            .add(features, self.arena.graph_tensor(self.enc_proj_bias))
-            .map_err(bf("enc_proj_bias"))?;
+            .add(features, self.core.arena.graph_tensor(self.enc_proj_bias))
+            .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed {
+                step: "enc_proj_bias",
+                source,
+            })?;
         graph
             .set_output(features)
-            .map_err(bf("set_output_features"))?;
+            .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed {
+                step: "set_output_features",
+                source,
+            })?;
 
         graph
             .prepare_outputs_for_upload(&[features])
-            .map_err(bf("prepare_outputs"))?;
-        upload_graph_f32(&mut graph, mel_t, &mel.data, "upload_mel")?;
-        upload_graph_f32(&mut graph, pos_t, &positional, "upload_pos")?;
+            .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed {
+                step: "prepare_outputs",
+                source,
+            })?;
+        fastconformer::upload_graph_f32(&mut graph, stack.mel_t, &mel.data, "upload_mel")?;
+        fastconformer::upload_graph_f32(&mut graph, stack.pos_t, &stack.positional, "upload_pos")?;
 
         let want = metadata
             .joint_hidden
-            .checked_mul(subsampled_frames)
+            .checked_mul(stack.subsampled_frames)
             .ok_or_else(|| ParakeetTdtEncoderError::Shape {
                 reason: "features overflow".into(),
             })?;
@@ -602,147 +179,10 @@ impl ParakeetTdtEncoderGraph {
             }
         })?;
         Ok(ParakeetTdtEncoderOutput {
-            frame_count: subsampled_frames,
+            frame_count: stack.subsampled_frames,
             joint_hidden: metadata.joint_hidden,
             features,
         })
-    }
-}
-
-fn upload_graph_f32<'a>(
-    graph: &mut crate::ggml_runtime::GgmlCpuGraphBuilder<'a>,
-    tensor: GgmlCpuTensor<'a>,
-    values: &[f32],
-    step: &'static str,
-) -> Result<(), ParakeetTdtEncoderError> {
-    graph
-        .set_f32_slice(tensor, values, step)
-        .map_err(|source| ParakeetTdtEncoderError::GraphBuildFailed { step, source })
-}
-
-fn alloc_layer(
-    arena: &GgmlStaticTensorArena,
-    loaded: Option<&GgmlLoadedWeightContext>,
-    layer: &ParakeetTdtEncoderLayerWeights,
-) -> Result<LayerArena, ParakeetTdtEncoderError> {
-    Ok(LayerArena {
-        ff1_norm_weight: alloc_static(arena, &layer.ff1_norm_weight, "ff1_norm_w")?,
-        ff1_norm_bias: alloc_static(arena, &layer.ff1_norm_bias, "ff1_norm_b")?,
-        ff1_up_weight: bind_loaded(loaded, &layer.ff1_up_weight.name)?,
-        ff1_up_bias: alloc_static(arena, &layer.ff1_up_bias, "ff1_up_b")?,
-        ff1_down_weight: bind_loaded(loaded, &layer.ff1_down_weight.name)?,
-        ff1_down_bias: alloc_static(arena, &layer.ff1_down_bias, "ff1_down_b")?,
-        attn_norm_weight: alloc_static(arena, &layer.attn_norm_weight, "attn_norm_w")?,
-        attn_norm_bias: alloc_static(arena, &layer.attn_norm_bias, "attn_norm_b")?,
-        attn_q_weight: bind_loaded(loaded, &layer.attn_q_weight.name)?,
-        attn_q_bias: alloc_static(arena, &layer.attn_q_bias, "attn_q_b")?,
-        attn_k_weight: bind_loaded(loaded, &layer.attn_k_weight.name)?,
-        attn_k_bias: alloc_static(arena, &layer.attn_k_bias, "attn_k_b")?,
-        attn_v_weight: bind_loaded(loaded, &layer.attn_v_weight.name)?,
-        attn_v_bias: alloc_static(arena, &layer.attn_v_bias, "attn_v_b")?,
-        attn_out_weight: bind_loaded(loaded, &layer.attn_out_weight.name)?,
-        attn_out_bias: alloc_static(arena, &layer.attn_out_bias, "attn_out_b")?,
-        attn_pos_weight: bind_loaded(loaded, &layer.attn_pos_weight.name)?,
-        attn_pos_bias_u: alloc_static(arena, &layer.attn_pos_bias_u, "attn_pos_u")?,
-        attn_pos_bias_v: alloc_static(arena, &layer.attn_pos_bias_v, "attn_pos_v")?,
-        conv_norm_weight: alloc_static(arena, &layer.conv_norm_weight, "conv_norm_w")?,
-        conv_norm_bias: alloc_static(arena, &layer.conv_norm_bias, "conv_norm_b")?,
-        conv_pw1_weight: bind_loaded(loaded, &layer.conv_pw1_weight.name)?,
-        conv_pw1_bias: alloc_static(arena, &layer.conv_pw1_bias, "conv_pw1_b")?,
-        conv_dw_weight: alloc_static_f16(arena, &layer.conv_dw_weight, "conv_dw_w")?,
-        conv_dw_bias: alloc_static(arena, &layer.conv_dw_bias, "conv_dw_b")?,
-        conv_pw2_weight: bind_loaded(loaded, &layer.conv_pw2_weight.name)?,
-        conv_pw2_bias: alloc_static(arena, &layer.conv_pw2_bias, "conv_pw2_b")?,
-        ff2_norm_weight: alloc_static(arena, &layer.ff2_norm_weight, "ff2_norm_w")?,
-        ff2_norm_bias: alloc_static(arena, &layer.ff2_norm_bias, "ff2_norm_b")?,
-        ff2_up_weight: bind_loaded(loaded, &layer.ff2_up_weight.name)?,
-        ff2_up_bias: alloc_static(arena, &layer.ff2_up_bias, "ff2_up_b")?,
-        ff2_down_weight: bind_loaded(loaded, &layer.ff2_down_weight.name)?,
-        ff2_down_bias: alloc_static(arena, &layer.ff2_down_bias, "ff2_down_b")?,
-        out_norm_weight: alloc_static(arena, &layer.out_norm_weight, "out_norm_w")?,
-        out_norm_bias: alloc_static(arena, &layer.out_norm_bias, "out_norm_b")?,
-    })
-}
-
-fn upload_layer(
-    arena: &mut GgmlStaticTensorArena,
-    layer: &ParakeetTdtEncoderLayerWeights,
-    h: &LayerArena,
-) -> Result<(), ParakeetTdtEncoderError> {
-    upload_static_f16(arena, h.conv_dw_weight, &layer.conv_dw_weight, "conv_dw_w")?;
-    let pairs: [(GgmlStaticTensor, &NamedTensor); 23] = [
-        (h.ff1_norm_weight, &layer.ff1_norm_weight),
-        (h.ff1_norm_bias, &layer.ff1_norm_bias),
-        (h.ff1_up_bias, &layer.ff1_up_bias),
-        (h.ff1_down_bias, &layer.ff1_down_bias),
-        (h.attn_norm_weight, &layer.attn_norm_weight),
-        (h.attn_norm_bias, &layer.attn_norm_bias),
-        (h.attn_q_bias, &layer.attn_q_bias),
-        (h.attn_k_bias, &layer.attn_k_bias),
-        (h.attn_v_bias, &layer.attn_v_bias),
-        (h.attn_out_bias, &layer.attn_out_bias),
-        (h.attn_pos_bias_u, &layer.attn_pos_bias_u),
-        (h.attn_pos_bias_v, &layer.attn_pos_bias_v),
-        (h.conv_norm_weight, &layer.conv_norm_weight),
-        (h.conv_norm_bias, &layer.conv_norm_bias),
-        (h.conv_pw1_bias, &layer.conv_pw1_bias),
-        (h.conv_dw_bias, &layer.conv_dw_bias),
-        (h.conv_pw2_bias, &layer.conv_pw2_bias),
-        (h.ff2_norm_weight, &layer.ff2_norm_weight),
-        (h.ff2_norm_bias, &layer.ff2_norm_bias),
-        (h.ff2_up_bias, &layer.ff2_up_bias),
-        (h.ff2_down_bias, &layer.ff2_down_bias),
-        (h.out_norm_weight, &layer.out_norm_weight),
-        (h.out_norm_bias, &layer.out_norm_bias),
-    ];
-    for (tensor, weight) in pairs {
-        upload_static(arena, tensor, weight, "layer_weight")?;
-    }
-    Ok(())
-}
-
-fn conformer_weights<'a>(
-    arena: &'a GgmlStaticTensorArena,
-    h: &LayerArena,
-) -> ConformerBlockWeights<'a> {
-    let g = |t: GgmlStaticTensor| arena.graph_tensor(t);
-    let b = |slot: WeightSlot| slot.graph(arena);
-    ConformerBlockWeights {
-        ff1_norm_weight: g(h.ff1_norm_weight),
-        ff1_norm_bias: g(h.ff1_norm_bias),
-        ff1_up_weight: b(h.ff1_up_weight),
-        ff1_up_bias: g(h.ff1_up_bias),
-        ff1_down_weight: b(h.ff1_down_weight),
-        ff1_down_bias: g(h.ff1_down_bias),
-        attn_norm_weight: g(h.attn_norm_weight),
-        attn_norm_bias: g(h.attn_norm_bias),
-        attn_q_weight: b(h.attn_q_weight),
-        attn_q_bias: g(h.attn_q_bias),
-        attn_k_weight: b(h.attn_k_weight),
-        attn_k_bias: g(h.attn_k_bias),
-        attn_v_weight: b(h.attn_v_weight),
-        attn_v_bias: g(h.attn_v_bias),
-        attn_out_weight: b(h.attn_out_weight),
-        attn_out_bias: g(h.attn_out_bias),
-        attn_pos_weight: b(h.attn_pos_weight),
-        attn_pos_bias_u: g(h.attn_pos_bias_u),
-        attn_pos_bias_v: g(h.attn_pos_bias_v),
-        conv_norm_weight: g(h.conv_norm_weight),
-        conv_norm_bias: g(h.conv_norm_bias),
-        conv_pw1_weight: b(h.conv_pw1_weight),
-        conv_pw1_bias: g(h.conv_pw1_bias),
-        conv_dw_weight: g(h.conv_dw_weight),
-        conv_dw_bias: g(h.conv_dw_bias),
-        conv_pw2_weight: b(h.conv_pw2_weight),
-        conv_pw2_bias: g(h.conv_pw2_bias),
-        ff2_norm_weight: g(h.ff2_norm_weight),
-        ff2_norm_bias: g(h.ff2_norm_bias),
-        ff2_up_weight: b(h.ff2_up_weight),
-        ff2_up_bias: g(h.ff2_up_bias),
-        ff2_down_weight: b(h.ff2_down_weight),
-        ff2_down_bias: g(h.ff2_down_bias),
-        out_norm_weight: g(h.out_norm_weight),
-        out_norm_bias: g(h.out_norm_bias),
     }
 }
 
@@ -750,6 +190,7 @@ fn conformer_weights<'a>(
 mod tests {
     use super::*;
     use crate::ggml_runtime::GgufTensorDataReader;
+    use crate::models::fastconformer::graph::conv_out_dim;
     use crate::models::parakeet_tdt::encoder_weights::load_parakeet_tdt_encoder_weights;
     use crate::models::parakeet_tdt::runtime_contract::parse_parakeet_tdt_execution_metadata;
     use std::path::Path;

--- a/crates/openasr-core/src/models/parakeet_tdt/encoder_weights.rs
+++ b/crates/openasr-core/src/models/parakeet_tdt/encoder_weights.rs
@@ -1,18 +1,24 @@
 //! Load a parakeet-tdt `.oasr` pack into host weights: the FastConformer
-//! encoder stack (mirroring `parakeet_ctc::encoder_weights`, including the
-//! conv BatchNorm fold), the encoder joint projection, and the host-side
-//! prediction-network / joint tensors.
+//! encoder stack (the shared `models::fastconformer::weights` skeleton --
+//! BatchNorm fold + zero-bias synthesis for the checkpoint's missing
+//! attn/conv/FFN biases -- `parakeet_ctc::encoder_weights` also builds on),
+//! the encoder joint projection, and the host-side prediction-network /
+//! joint tensors (parakeet-tdt-only, no `parakeet_ctc` equivalent).
 //!
 //! The v3 checkpoint has NO attention/conv/FFN biases (`attention_bias` /
-//! `convolution_bias` false), so the loader synthesizes zero biases for the
-//! shared `nn::encoder::conformer_block`, which is bias-shaped. Zero biases
-//! are mathematically identity — nothing model-specific is fabricated.
+//! `convolution_bias` false), so the shared loader synthesizes zero biases
+//! for the shared `nn::encoder::conformer_block`, which is bias-shaped. Zero
+//! biases are mathematically identity -- nothing model-specific is fabricated.
 
 use crate::ggml_runtime::{GgufTensorDataReadError, GgufTensorDataReader};
+use crate::models::fastconformer::{self, FastConformerLayerWeights, FastConformerWeightsError};
+// Re-exported (not just imported) so `parakeet_tdt::greedy`/`predictor` --
+// which construct `NamedTensor` values directly in their own tests -- can
+// keep referring to it as `encoder_weights::NamedTensor`, unchanged by the
+// type's move into the shared `fastconformer` module.
+pub(crate) use crate::models::fastconformer::NamedTensor;
 
 use super::runtime_contract::ParakeetTdtExecutionMetadata;
-
-const CONV_BN_EPSILON: f32 = 1.0e-5;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ParakeetTdtWeightsError {
@@ -28,68 +34,15 @@ pub(crate) enum ParakeetTdtWeightsError {
     BatchNormFold { reason: String },
 }
 
-/// A host weight: its stored dims (from the GGUF index) + dequantized f32
-/// values. Bias slots the checkpoint does not ship are synthesized as zeros
-/// (empty `name` marks them as synthetic for debugging only).
-#[derive(Debug, Clone)]
-pub(crate) struct NamedTensor {
-    pub name: String,
-    pub dims: Vec<usize>,
-    pub values: Vec<f32>,
-}
-
-impl NamedTensor {
-    fn element_count(&self) -> usize {
-        self.values.len()
-    }
-
-    /// Drop the resident f32 host `values` (keeping name + dims) for a weight
-    /// the encoder graph binds zero-copy from the mmap'd pack (see
-    /// `parakeet_ctc::encoder_weights::NamedTensor::drop_bound_payload`).
-    fn drop_bound_payload(&mut self) {
-        self.values = Vec::new();
+impl FastConformerWeightsError for ParakeetTdtWeightsError {
+    fn batchnorm_fold(reason: String) -> Self {
+        Self::BatchNormFold { reason }
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct ParakeetTdtEncoderLayerWeights {
-    pub ff1_norm_weight: NamedTensor,
-    pub ff1_norm_bias: NamedTensor,
-    pub ff1_up_weight: NamedTensor,
-    pub ff1_up_bias: NamedTensor,
-    pub ff1_down_weight: NamedTensor,
-    pub ff1_down_bias: NamedTensor,
-    pub attn_norm_weight: NamedTensor,
-    pub attn_norm_bias: NamedTensor,
-    pub attn_q_weight: NamedTensor,
-    pub attn_q_bias: NamedTensor,
-    pub attn_k_weight: NamedTensor,
-    pub attn_k_bias: NamedTensor,
-    pub attn_v_weight: NamedTensor,
-    pub attn_v_bias: NamedTensor,
-    pub attn_out_weight: NamedTensor,
-    pub attn_out_bias: NamedTensor,
-    pub attn_pos_weight: NamedTensor,
-    pub attn_pos_bias_u: NamedTensor,
-    pub attn_pos_bias_v: NamedTensor,
-    pub conv_norm_weight: NamedTensor,
-    pub conv_norm_bias: NamedTensor,
-    pub conv_pw1_weight: NamedTensor,
-    pub conv_pw1_bias: NamedTensor,
-    /// BatchNorm folded into these two at load (the graph sees a plain dw conv).
-    pub conv_dw_weight: NamedTensor,
-    pub conv_dw_bias: NamedTensor,
-    pub conv_pw2_weight: NamedTensor,
-    pub conv_pw2_bias: NamedTensor,
-    pub ff2_norm_weight: NamedTensor,
-    pub ff2_norm_bias: NamedTensor,
-    pub ff2_up_weight: NamedTensor,
-    pub ff2_up_bias: NamedTensor,
-    pub ff2_down_weight: NamedTensor,
-    pub ff2_down_bias: NamedTensor,
-    pub out_norm_weight: NamedTensor,
-    pub out_norm_bias: NamedTensor,
-}
+/// v3 ships no attn/conv/FFN bias tensors at all -- the shared loader
+/// synthesizes zero biases of the right width for every layer.
+pub(crate) type ParakeetTdtEncoderLayerWeights = FastConformerLayerWeights;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ParakeetTdtEncoderWeights {
@@ -136,191 +89,46 @@ pub(crate) struct ParakeetTdtJointWeights {
     pub out_bias: NamedTensor,
 }
 
-fn load_named(
-    reader: &GgufTensorDataReader,
-    name: &str,
+fn expect_elements(
+    tensor: NamedTensor,
+    expected: usize,
 ) -> Result<NamedTensor, ParakeetTdtWeightsError> {
-    let tensor = reader.tensor_index().get(name).ok_or_else(|| {
-        ParakeetTdtWeightsError::Read(GgufTensorDataReadError::TensorNotFound {
-            path: reader.tensor_index().path().to_path_buf(),
-            tensor_name: name.to_string(),
-        })
-    })?;
-    let dims: Vec<usize> = tensor.dims.iter().map(|&d| d as usize).collect();
-    let shape_u64: Vec<u64> = tensor.dims.clone();
-    let values = reader.host_tensor_f32_copy_dequantized_by_name(name, &shape_u64)?;
-    Ok(NamedTensor {
-        name: name.to_string(),
-        dims,
-        values,
-    })
-}
-
-/// Zero bias for a projection the checkpoint ships bias-free
-/// (`attention_bias`/`convolution_bias`/FFN bias all false in v3). The shared
-/// conformer block is bias-shaped; a zero bias is the mathematical identity.
-fn zero_bias(name: String, len: usize) -> NamedTensor {
-    NamedTensor {
-        name,
-        dims: vec![len],
-        values: vec![0.0; len],
-    }
-}
-
-fn load_layer(
-    reader: &GgufTensorDataReader,
-    metadata: &ParakeetTdtExecutionMetadata,
-    layer: usize,
-) -> Result<ParakeetTdtEncoderLayerWeights, ParakeetTdtWeightsError> {
-    let n = |suffix: &str| format!("enc.blk.{layer}.{suffix}");
-    let d_model = metadata.hidden_size;
-    let ffn = metadata.ffn_dim;
-    let mut weights = ParakeetTdtEncoderLayerWeights {
-        ff1_norm_weight: load_named(reader, &n("ff1.norm.weight"))?,
-        ff1_norm_bias: load_named(reader, &n("ff1.norm.bias"))?,
-        ff1_up_weight: load_named(reader, &n("ff1.up.weight"))?,
-        ff1_up_bias: zero_bias(n("ff1.up.bias"), ffn),
-        ff1_down_weight: load_named(reader, &n("ff1.down.weight"))?,
-        ff1_down_bias: zero_bias(n("ff1.down.bias"), d_model),
-        attn_norm_weight: load_named(reader, &n("attn.norm.weight"))?,
-        attn_norm_bias: load_named(reader, &n("attn.norm.bias"))?,
-        attn_q_weight: load_named(reader, &n("attn.q.weight"))?,
-        attn_q_bias: zero_bias(n("attn.q.bias"), d_model),
-        attn_k_weight: load_named(reader, &n("attn.k.weight"))?,
-        attn_k_bias: zero_bias(n("attn.k.bias"), d_model),
-        attn_v_weight: load_named(reader, &n("attn.v.weight"))?,
-        attn_v_bias: zero_bias(n("attn.v.bias"), d_model),
-        attn_out_weight: load_named(reader, &n("attn.out.weight"))?,
-        attn_out_bias: zero_bias(n("attn.out.bias"), d_model),
-        attn_pos_weight: load_named(reader, &n("attn.pos.weight"))?,
-        attn_pos_bias_u: load_named(reader, &n("attn.pos_bias_u"))?,
-        attn_pos_bias_v: load_named(reader, &n("attn.pos_bias_v"))?,
-        conv_norm_weight: load_named(reader, &n("conv.norm.weight"))?,
-        conv_norm_bias: load_named(reader, &n("conv.norm.bias"))?,
-        conv_pw1_weight: load_named(reader, &n("conv.pw1.weight"))?,
-        conv_pw1_bias: zero_bias(n("conv.pw1.bias"), 2 * d_model),
-        conv_dw_weight: load_named(reader, &n("conv.dw.weight"))?,
-        conv_dw_bias: zero_bias(n("conv.dw.bias"), d_model),
-        conv_pw2_weight: load_named(reader, &n("conv.pw2.weight"))?,
-        conv_pw2_bias: zero_bias(n("conv.pw2.bias"), d_model),
-        ff2_norm_weight: load_named(reader, &n("ff2.norm.weight"))?,
-        ff2_norm_bias: load_named(reader, &n("ff2.norm.bias"))?,
-        ff2_up_weight: load_named(reader, &n("ff2.up.weight"))?,
-        ff2_up_bias: zero_bias(n("ff2.up.bias"), ffn),
-        ff2_down_weight: load_named(reader, &n("ff2.down.weight"))?,
-        ff2_down_bias: zero_bias(n("ff2.down.bias"), d_model),
-        out_norm_weight: load_named(reader, &n("out.norm.weight"))?,
-        out_norm_bias: load_named(reader, &n("out.norm.bias"))?,
-    };
-    fold_batchnorm_into_depthwise(reader, layer, &mut weights)?;
-    Ok(weights)
-}
-
-/// Fold the conv BatchNorm1d into the depthwise weight + (zero-synthesized)
-/// bias so the graph runs a plain depthwise conv — identical math to
-/// `parakeet_ctc::encoder_weights::fold_batchnorm_into_depthwise`.
-fn fold_batchnorm_into_depthwise(
-    reader: &GgufTensorDataReader,
-    layer: usize,
-    weights: &mut ParakeetTdtEncoderLayerWeights,
-) -> Result<(), ParakeetTdtWeightsError> {
-    let n = |suffix: &str| format!("enc.blk.{layer}.{suffix}");
-    let gamma = load_named(reader, &n("conv.bn.weight"))?;
-    let beta = load_named(reader, &n("conv.bn.bias"))?;
-    let mean = load_named(reader, &n("conv.bn.mean"))?;
-    let var = load_named(reader, &n("conv.bn.var"))?;
-
-    let channels = weights.conv_dw_bias.element_count();
-    if gamma.element_count() != channels
-        || beta.element_count() != channels
-        || mean.element_count() != channels
-        || var.element_count() != channels
-    {
-        return Err(ParakeetTdtWeightsError::BatchNormFold {
-            reason: format!(
-                "per-channel sizes disagree: dw_bias={channels} gamma={} beta={} mean={} var={}",
-                gamma.element_count(),
-                beta.element_count(),
-                mean.element_count(),
-                var.element_count()
-            ),
+    if tensor.element_count() != expected {
+        return Err(ParakeetTdtWeightsError::ElementCount {
+            name: tensor.name.clone(),
+            got: tensor.element_count(),
+            expected,
         });
     }
-    let dw_elems = weights.conv_dw_weight.element_count();
-    if !dw_elems.is_multiple_of(channels) {
-        return Err(ParakeetTdtWeightsError::BatchNormFold {
-            reason: format!("depthwise weight {dw_elems} not divisible by channels {channels}"),
-        });
-    }
-    let kernel = dw_elems / channels;
-    let scale: Vec<f32> = (0..channels)
-        .map(|c| gamma.values[c] / (var.values[c] + CONV_BN_EPSILON).sqrt())
-        .collect();
-    #[allow(clippy::needless_range_loop)]
-    for c in 0..channels {
-        for k in 0..kernel {
-            weights.conv_dw_weight.values[c * kernel + k] *= scale[c];
-        }
-        weights.conv_dw_bias.values[c] =
-            beta.values[c] + (weights.conv_dw_bias.values[c] - mean.values[c]) * scale[c];
-    }
-    Ok(())
-}
-
-/// Drop the f32 host payload of the 2-D linears the encoder graph binds
-/// zero-copy (same set as parakeet-ctc plus the joint encoder projection).
-fn drop_bound_linear_payloads(layer: &mut ParakeetTdtEncoderLayerWeights) {
-    for w in [
-        &mut layer.ff1_up_weight,
-        &mut layer.ff1_down_weight,
-        &mut layer.attn_q_weight,
-        &mut layer.attn_k_weight,
-        &mut layer.attn_v_weight,
-        &mut layer.attn_out_weight,
-        &mut layer.attn_pos_weight,
-        &mut layer.conv_pw1_weight,
-        &mut layer.conv_pw2_weight,
-        &mut layer.ff2_up_weight,
-        &mut layer.ff2_down_weight,
-    ] {
-        w.drop_bound_payload();
-    }
-}
-
-fn drop_bound_subsampling_payloads(subsampling: &mut [NamedTensor]) {
-    for weight in subsampling {
-        if weight.name == "enc.sub.linear.weight" {
-            weight.drop_bound_payload();
-        }
-    }
+    Ok(tensor)
 }
 
 pub(crate) fn load_parakeet_tdt_encoder_weights(
     reader: &GgufTensorDataReader,
     metadata: &ParakeetTdtExecutionMetadata,
 ) -> Result<ParakeetTdtEncoderWeights, ParakeetTdtWeightsError> {
-    let mut subsampling = Vec::new();
-    for sub_layer in [0usize, 2, 3, 5, 6] {
-        for kind in ["weight", "bias"] {
-            let name = format!("enc.sub.layers.{sub_layer}.{kind}");
-            if reader.tensor_index().get(&name).is_some() {
-                subsampling.push(load_named(reader, &name)?);
-            }
-        }
-    }
-    subsampling.push(load_named(reader, "enc.sub.linear.weight")?);
-    subsampling.push(load_named(reader, "enc.sub.linear.bias")?);
-    drop_bound_subsampling_payloads(&mut subsampling);
+    let subsampling =
+        fastconformer::load_fastconformer_subsampling::<ParakeetTdtWeightsError>(reader)?;
 
     let mut layers = Vec::with_capacity(metadata.n_layers);
     for layer in 0..metadata.n_layers {
-        let mut layer_weights = load_layer(reader, metadata, layer)?;
-        drop_bound_linear_payloads(&mut layer_weights);
-        layers.push(layer_weights);
+        // bias_present = false: v3 ships no attn/conv/FFN bias tensors; the
+        // shared loader synthesizes zero biases of the right width instead.
+        layers.push(fastconformer::load_fastconformer_layer::<
+            ParakeetTdtWeightsError,
+        >(
+            reader,
+            layer,
+            metadata.hidden_size,
+            metadata.ffn_dim,
+            false,
+        )?);
     }
 
-    let mut enc_proj_weight = load_named(reader, "enc.proj.weight")?;
-    let enc_proj_bias = load_named(reader, "enc.proj.bias")?;
+    let mut enc_proj_weight: NamedTensor =
+        fastconformer::load_named::<ParakeetTdtWeightsError>(reader, "enc.proj.weight")?;
+    let enc_proj_bias: NamedTensor =
+        fastconformer::load_named::<ParakeetTdtWeightsError>(reader, "enc.proj.bias")?;
     let expected_proj = metadata.joint_hidden * metadata.hidden_size;
     if enc_proj_weight.element_count() != expected_proj {
         return Err(ParakeetTdtWeightsError::ElementCount {
@@ -346,37 +154,35 @@ pub(crate) fn load_parakeet_tdt_encoder_weights(
     })
 }
 
-fn expect_elements(
-    tensor: NamedTensor,
-    expected: usize,
-) -> Result<NamedTensor, ParakeetTdtWeightsError> {
-    if tensor.element_count() != expected {
-        return Err(ParakeetTdtWeightsError::ElementCount {
-            name: tensor.name.clone(),
-            got: tensor.element_count(),
-            expected,
-        });
-    }
-    Ok(tensor)
-}
-
 pub(crate) fn load_parakeet_tdt_predictor_weights(
     reader: &GgufTensorDataReader,
     metadata: &ParakeetTdtExecutionMetadata,
 ) -> Result<ParakeetTdtPredictorWeights, ParakeetTdtWeightsError> {
     let hidden = metadata.pred_hidden;
     let embedding = expect_elements(
-        load_named(reader, "dec.embed.weight")?,
+        fastconformer::load_named::<ParakeetTdtWeightsError>(reader, "dec.embed.weight")?,
         metadata.vocab_size * hidden,
     )?;
     let mut lstm_layers = Vec::with_capacity(metadata.pred_layers);
     for layer in 0..metadata.pred_layers {
         let n = |suffix: &str| format!("dec.lstm.{layer}.{suffix}");
         lstm_layers.push(ParakeetTdtLstmLayerWeights {
-            w_ih: expect_elements(load_named(reader, &n("w_ih"))?, 4 * hidden * hidden)?,
-            w_hh: expect_elements(load_named(reader, &n("w_hh"))?, 4 * hidden * hidden)?,
-            b_ih: expect_elements(load_named(reader, &n("b_ih"))?, 4 * hidden)?,
-            b_hh: expect_elements(load_named(reader, &n("b_hh"))?, 4 * hidden)?,
+            w_ih: expect_elements(
+                fastconformer::load_named::<ParakeetTdtWeightsError>(reader, &n("w_ih"))?,
+                4 * hidden * hidden,
+            )?,
+            w_hh: expect_elements(
+                fastconformer::load_named::<ParakeetTdtWeightsError>(reader, &n("w_hh"))?,
+                4 * hidden * hidden,
+            )?,
+            b_ih: expect_elements(
+                fastconformer::load_named::<ParakeetTdtWeightsError>(reader, &n("b_ih"))?,
+                4 * hidden,
+            )?,
+            b_hh: expect_elements(
+                fastconformer::load_named::<ParakeetTdtWeightsError>(reader, &n("b_hh"))?,
+                4 * hidden,
+            )?,
         });
     }
     Ok(ParakeetTdtPredictorWeights {
@@ -393,12 +199,21 @@ pub(crate) fn load_parakeet_tdt_joint_weights(
     let out_rows = metadata.vocab_size + metadata.n_durations;
     Ok(ParakeetTdtJointWeights {
         pred_weight: expect_elements(
-            load_named(reader, "joint.pred.weight")?,
+            fastconformer::load_named::<ParakeetTdtWeightsError>(reader, "joint.pred.weight")?,
             joint * metadata.pred_hidden,
         )?,
-        pred_bias: expect_elements(load_named(reader, "joint.pred.bias")?, joint)?,
-        out_weight: expect_elements(load_named(reader, "joint.out.weight")?, out_rows * joint)?,
-        out_bias: expect_elements(load_named(reader, "joint.out.bias")?, out_rows)?,
+        pred_bias: expect_elements(
+            fastconformer::load_named::<ParakeetTdtWeightsError>(reader, "joint.pred.bias")?,
+            joint,
+        )?,
+        out_weight: expect_elements(
+            fastconformer::load_named::<ParakeetTdtWeightsError>(reader, "joint.out.weight")?,
+            out_rows * joint,
+        )?,
+        out_bias: expect_elements(
+            fastconformer::load_named::<ParakeetTdtWeightsError>(reader, "joint.out.bias")?,
+            out_rows,
+        )?,
     })
 }
 


### PR DESCRIPTION
## Summary

parakeet-ctc and parakeet-tdt each carried their own byte-for-byte-identical
FastConformer encoder: dw-striding subsampling prelude, arena alloc/upload/bind
plumbing, BatchNorm fold + zero-bias synthesis, and the conformer-stack loop.
Extracted the shared skeleton into `crates/openasr-core/src/models/fastconformer/`
(`graph.rs` + `weights.rs`) and switched both families onto it, keeping only
each family's own tail (CTC head vs. joint encoder projection) and its own
error/output types.

## Why

The two families' `encoder_graph.rs`/`encoder_weights.rs` were maintained as
parallel copies that had to stay in lockstep by hand. This collapses that
duplication into one shared, model-agnostic core, generic over each family's
error enum via two small marker traits (`FastConformerGraphError`,
`FastConformerWeightsError`), with the tail threaded through
`FastConformerEncoderCore::build` as declare/upload closures so it
participates in the arena's single "declare everything, then upload
everything" pass. No `if`-family branching lives in the shared module.

## Changes

- New `models::fastconformer::{graph, weights}`: arena alloc/upload/bind,
  `LayerArena`/`SubsamplingArena`, `build_conformer_stack`, BatchNorm fold,
  zero-bias synthesis, generic GGUF tensor reads.
- `parakeet_ctc::encoder_graph`/`encoder_weights`: switched onto the shared
  core; kept the CTC head tail only.
- `parakeet_tdt::encoder_graph`/`encoder_weights`: switched onto the shared
  core; kept the joint encoder projection tail + the host-side
  predictor/joint weight loaders (parakeet-tdt-only).
- Net: -433 lines in `crates/openasr-core` despite adding a ~1,130-line
  shared module (1,846 deleted from the two families vs. 286 kept as
  family-specific code + the new shared module).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (workspace)
- [x] `cargo nextest run --workspace` (2397 passed, 122 skipped -- pack-gated)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

Built release `openasr` CLI binaries for this branch and for the parent
commit (`origin/main` / `b35647e`), ran `transcribe -f verbose_json` against
both `fixtures/jfk.wav` and `fixtures/zh_sample.wav`, and diffed the output.

| Model | Fixture | before sha256 | after sha256 | Result |
|---|---|---|---|---|
| parakeet-tdt-0.6b-v3 (q4_k, local) | jfk.wav | `c364303e...` | `c364303e...` | identical |
| parakeet-tdt-0.6b-v3 (q4_k, local) | zh_sample.wav | `3199a0b9...` | `3199a0b9...` | identical |
| firered-aed-l-v2 (q4_k, local, control -- untouched by this PR) | jfk.wav | `c95fffd5...` | `c95fffd5...` | identical |
| firered-aed-l-v2 (q4_k, local, control -- untouched by this PR) | zh_sample.wav | `193a4710...` | `193a4710...` | identical |

parakeet-ctc has no locally installed pack on this machine, so it could not
be end-to-end verified the same way; it is covered by the existing
pack-gated unit tests (`encoder_graph_smoke_produces_finite_logits_when_pack_present`,
`loads_parakeet_encoder_weights_and_folds_batchnorm_when_pack_present`), which
`cargo nextest run --workspace` skips here for the same reason (no local
pack) but which exercise the exact same shared-core code path parakeet-tdt's
end-to-end check exercises.

## Docs updated

- [x] No behavior or limitations changed; no docs updates needed.

## Scope / non-goals

- Pure internal refactor: no numeric, API, or CLI behavior change.
- Does not touch `graph_config.rs` (per-family GPU-backend env-var config),
  which stays intentionally separate per family.
- Does not touch the host-side parakeet-tdt predictor/joint (LSTM decoder +
  joiner) code, which has no parakeet-ctc equivalent.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI-assisted refactor extraction and review; verified via the local/manual checks listed above.
