### PR TITLE
refactor(core): migrate whisper/dolphin/xasr frontends onto shared audio_frontend DSP primitives

### DIFF
--- a/crates/openasr-core/src/models/audio_frontend/mel.rs
+++ b/crates/openasr-core/src/models/audio_frontend/mel.rs
@@ -22,9 +22,9 @@
 /// Which hz<->mel warping (and filter-construction convention) to use.
 ///
 /// `Htk`/`Kaldi` are not yet consumed by any switched-over family (only
-/// `Slaney` is, via `parakeet_ctc`) -- they're declared now per this
-/// module's target API and covered by their own unit tests below, so the
-/// family PRs that migrate `xasr_zipformer` / `kaldi_fbank`'s consumers
+/// `Slaney` is, via `parakeet_ctc`/`whisper`) -- they're declared now per
+/// this module's target API and covered by their own unit tests below, so
+/// the family PRs that migrate `xasr_zipformer` / `kaldi_fbank`'s consumers
 /// onto this module can wire them in directly instead of inventing the
 /// scale math a second time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +48,39 @@ pub(crate) enum MelScale {
     Kaldi,
 }
 
+/// Which floating-point operation order to use when placing `n_mels + 2`
+/// filter edges evenly spaced in the mel domain between `mel_min` and
+/// `mel_max`. Both orders compute the exact same real number; they round
+/// differently in f32 for some `(n_mels, mel_min, mel_max)` combinations
+/// (confirmed by exhaustive bit comparison for the whisper 80/128-mel
+/// configs), so picking the wrong one silently drifts filter weights -- and
+/// everything downstream -- from a family's pinned pre-refactor
+/// implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MelPointOrder {
+    /// `mel_min + (mel_max - mel_min) * i / (n_mels + 1)`: multiply the mel
+    /// span by the point index before dividing by the point count. Used by
+    /// `parakeet_ctc`/`parakeet_tdt` and `xasr_zipformer`'s Htk filterbank.
+    SpanTimesIndexFirst,
+    /// `mel_min + (i / (n_mels + 1)) * (mel_max - mel_min)`: compute the
+    /// `[0, 1]` ratio first, then scale by the mel span. Used by `whisper`.
+    RatioFirst,
+}
+
+impl MelPointOrder {
+    fn point(self, mel_min: f32, mel_max: f32, i: usize, n_mels: usize) -> f32 {
+        match self {
+            MelPointOrder::SpanTimesIndexFirst => {
+                mel_min + (mel_max - mel_min) * i as f32 / (n_mels + 1) as f32
+            }
+            MelPointOrder::RatioFirst => {
+                let ratio = i as f32 / (n_mels + 1) as f32;
+                mel_min + ratio * (mel_max - mel_min)
+            }
+        }
+    }
+}
+
 /// Geometry for [`filterbank`].
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FilterbankConfig {
@@ -57,6 +90,9 @@ pub(crate) struct FilterbankConfig {
     pub n_mels: usize,
     pub fmin: f32,
     pub fmax: f32,
+    /// Only consulted by the Hz-domain constructions (`Slaney`/`Htk`);
+    /// ignored by `Kaldi` (mel-domain edges, no round-trip).
+    pub mel_point_order: MelPointOrder,
 }
 
 /// `hz -> mel` for `scale`.
@@ -132,6 +168,7 @@ fn hz_domain_filterbank(config: FilterbankConfig, fft_bins: usize, slaney_norm: 
         n_mels,
         fmin,
         fmax,
+        mel_point_order,
     } = config;
     let fft_freqs: Vec<f32> = (0..fft_bins)
         .map(|i| i as f32 * sample_rate_hz / n_fft as f32)
@@ -139,7 +176,7 @@ fn hz_domain_filterbank(config: FilterbankConfig, fft_bins: usize, slaney_norm: 
     let mel_min = hz_to_mel(scale, fmin);
     let mel_max = hz_to_mel(scale, fmax);
     let mel_points: Vec<f32> = (0..n_mels + 2)
-        .map(|i| mel_min + (mel_max - mel_min) * i as f32 / (n_mels + 1) as f32)
+        .map(|i| mel_point_order.point(mel_min, mel_max, i, n_mels))
         .collect();
     let hz_points: Vec<f32> = mel_points.iter().map(|&m| mel_to_hz(scale, m)).collect();
 
@@ -178,6 +215,7 @@ fn mel_domain_filterbank(config: FilterbankConfig, fft_bins: usize) -> Vec<f32> 
         n_mels,
         fmin,
         fmax,
+        ..
     } = config;
     let fft_bin_width = sample_rate_hz / n_fft as f32;
     let mel_low = hz_to_mel(scale, fmin);
@@ -257,6 +295,7 @@ mod tests {
             n_mels,
             fmin: 0.0,
             fmax: 8_000.0,
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
         });
         assert_eq!(expected, actual);
 
@@ -269,6 +308,7 @@ mod tests {
             n_mels: n_mels128,
             fmin: 0.0,
             fmax: 8_000.0,
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
         });
         assert_eq!(expected128, actual128);
     }
@@ -291,6 +331,7 @@ mod tests {
             n_mels: 80,
             fmin: 20.0,
             fmax: 7_600.0,
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
         });
         for m in 0..80 {
             let row = &fb[m * 257..(m + 1) * 257];
@@ -313,6 +354,7 @@ mod tests {
             n_mels: 80,
             fmin: 20.0,
             fmax: 8_000.0,
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
         });
         for m in 0..80 {
             let row = &fb[m * 257..(m + 1) * 257];
@@ -347,6 +389,61 @@ mod tests {
                     "scale={scale:?} hz={hz} round_trip={back}"
                 );
             }
+        }
+    }
+
+    /// Exact reimplementation of the pre-refactor `whisper::mel::slaney_mel_filterbank`
+    /// (`RatioFirst` mel-point order), kept only in this test to pin
+    /// `MelPointOrder::RatioFirst` to the values `whisper` shipped before
+    /// this module existed.
+    fn reference_whisper_slaney_filterbank(
+        n_mels: usize,
+        n_fft: usize,
+        fft_bins: usize,
+    ) -> Vec<f32> {
+        const SAMPLE_RATE: f32 = 16_000.0;
+        let fft_frequencies = (0..fft_bins)
+            .map(|bin| bin as f32 * SAMPLE_RATE / n_fft as f32)
+            .collect::<Vec<_>>();
+        let mel_min = hz_to_mel_slaney(0.0);
+        let mel_max = hz_to_mel_slaney(8_000.0);
+        let mel_points = (0..n_mels + 2)
+            .map(|index| {
+                let ratio = index as f32 / (n_mels + 1) as f32;
+                mel_to_hz_slaney(mel_min + ratio * (mel_max - mel_min))
+            })
+            .collect::<Vec<_>>();
+        let mut filters = vec![0.0_f32; n_mels * fft_bins];
+        for mel_idx in 0..n_mels {
+            let left = mel_points[mel_idx];
+            let center = mel_points[mel_idx + 1];
+            let right = mel_points[mel_idx + 2];
+            let norm = 2.0 / (right - left).max(f32::EPSILON);
+            for (bin_idx, hz) in fft_frequencies.iter().copied().enumerate() {
+                let rising = (hz - left) / (center - left).max(f32::EPSILON);
+                let falling = (right - hz) / (right - center).max(f32::EPSILON);
+                let value = rising.min(falling).max(0.0) * norm;
+                filters[mel_idx * fft_bins + bin_idx] = value;
+            }
+        }
+        filters
+    }
+
+    #[test]
+    fn ratio_first_mel_point_order_is_byte_identical_to_pre_refactor_whisper_impl() {
+        for n_mels in [80usize, 128usize] {
+            let (n_fft, fft_bins) = (400, 201);
+            let expected = reference_whisper_slaney_filterbank(n_mels, n_fft, fft_bins);
+            let actual = filterbank(FilterbankConfig {
+                scale: MelScale::Slaney,
+                sample_rate_hz: 16_000.0,
+                n_fft,
+                n_mels,
+                fmin: 0.0,
+                fmax: 8_000.0,
+                mel_point_order: MelPointOrder::RatioFirst,
+            });
+            assert_eq!(expected, actual, "n_mels={n_mels}");
         }
     }
 }

--- a/crates/openasr-core/src/models/audio_frontend/mel.rs
+++ b/crates/openasr-core/src/models/audio_frontend/mel.rs
@@ -22,9 +22,9 @@
 /// Which hz<->mel warping (and filter-construction convention) to use.
 ///
 /// `Htk`/`Kaldi` are not yet consumed by any switched-over family (only
-/// `Slaney` is, via `parakeet_ctc`/`whisper`) -- they're declared now per
-/// this module's target API and covered by their own unit tests below, so
-/// the family PRs that migrate `xasr_zipformer` / `kaldi_fbank`'s consumers
+/// `Slaney` is, via `parakeet_ctc`) -- they're declared now per this
+/// module's target API and covered by their own unit tests below, so the
+/// family PRs that migrate `xasr_zipformer` / `kaldi_fbank`'s consumers
 /// onto this module can wire them in directly instead of inventing the
 /// scale math a second time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +46,15 @@ pub(crate) enum MelScale {
     /// `torchaudio.compliance.kaldi.fbank`'s construction, used by
     /// [`crate::models::kaldi_fbank`] (`firered_aed`/`dolphin`/`sensevoice`).
     Kaldi,
+    /// Same real-valued formula as [`MelScale::Slaney`]
+    /// (`librosa.filters.mel(..., htk=False)`), but every step -- hz<->mel
+    /// warp, edge placement, ramp/area-normalization -- runs in **f64**, only
+    /// casting the final per-bin weight to f32. This is ESPnet's
+    /// `DefaultFrontend`/`LogMel` precision (`dolphin-small`/`dolphin-base`);
+    /// an exhaustive bit comparison against the plain f32 [`MelScale::Slaney`]
+    /// construction shows real mismatches (not just theoretical), so this
+    /// stays a separate scale rather than a precision flag on the f32 path.
+    SlaneyF64Espnet,
 }
 
 /// Which floating-point operation order to use when placing `n_mels + 2`
@@ -91,7 +100,9 @@ pub(crate) struct FilterbankConfig {
     pub fmin: f32,
     pub fmax: f32,
     /// Only consulted by the Hz-domain constructions (`Slaney`/`Htk`);
-    /// ignored by `Kaldi` (mel-domain edges, no round-trip).
+    /// ignored by `Kaldi` (mel-domain edges, no round-trip) and
+    /// `SlaneyF64Espnet` (its own f64 edge placement, see
+    /// [`slaney_f64_espnet_filterbank`]).
     pub mel_point_order: MelPointOrder,
 }
 
@@ -100,6 +111,7 @@ pub(crate) fn hz_to_mel(scale: MelScale, hz: f32) -> f32 {
     match scale {
         MelScale::Slaney => hz_to_mel_slaney(hz),
         MelScale::Htk | MelScale::Kaldi => hz_to_mel_htk(hz),
+        MelScale::SlaneyF64Espnet => hz_to_mel_slaney_f64(hz as f64) as f32,
     }
 }
 
@@ -108,6 +120,7 @@ pub(crate) fn mel_to_hz(scale: MelScale, mel: f32) -> f32 {
     match scale {
         MelScale::Slaney => mel_to_hz_slaney(mel),
         MelScale::Htk | MelScale::Kaldi => mel_to_hz_htk(mel),
+        MelScale::SlaneyF64Espnet => mel_to_hz_slaney_f64(mel as f64) as f32,
     }
 }
 
@@ -118,6 +131,7 @@ pub(crate) fn filterbank(config: FilterbankConfig) -> Vec<f32> {
         MelScale::Slaney => hz_domain_filterbank(config, fft_bins, true),
         MelScale::Htk => hz_domain_filterbank(config, fft_bins, false),
         MelScale::Kaldi => mel_domain_filterbank(config, fft_bins),
+        MelScale::SlaneyF64Espnet => slaney_f64_espnet_filterbank(config, fft_bins),
     }
 }
 
@@ -237,6 +251,79 @@ fn mel_domain_filterbank(config: FilterbankConfig, fft_bins: usize) -> Vec<f32> 
                 };
                 filters[m * fft_bins + k] = weight;
             }
+        }
+    }
+    filters
+}
+
+fn hz_to_mel_slaney_f64(freq: f64) -> f64 {
+    const F_SP: f64 = 200.0 / 3.0;
+    const MIN_LOG_HZ: f64 = 1000.0;
+    const MIN_LOG_MEL: f64 = MIN_LOG_HZ / F_SP; // 15.0
+    let logstep = 6.4f64.ln() / 27.0;
+    if freq >= MIN_LOG_HZ {
+        MIN_LOG_MEL + (freq / MIN_LOG_HZ).ln() / logstep
+    } else {
+        freq / F_SP
+    }
+}
+
+fn mel_to_hz_slaney_f64(mel: f64) -> f64 {
+    const F_SP: f64 = 200.0 / 3.0;
+    const MIN_LOG_HZ: f64 = 1000.0;
+    const MIN_LOG_MEL: f64 = MIN_LOG_HZ / F_SP; // 15.0
+    let logstep = 6.4f64.ln() / 27.0;
+    if mel >= MIN_LOG_MEL {
+        MIN_LOG_HZ * (logstep * (mel - MIN_LOG_MEL)).exp()
+    } else {
+        F_SP * mel
+    }
+}
+
+/// `librosa.filters.mel(sr, n_fft, n_mels, fmin, fmax, htk=False)` computed
+/// entirely in f64 (edges, ramps, area-normalization) -- ESPnet's
+/// `DefaultFrontend`/`LogMel` precision (`dolphin-small`/`dolphin-base`, see
+/// `dolphin::frontend::DolphinEspnetFrontend`). Only the final per-bin
+/// weight is cast to f32. This is a literal port of the pre-refactor
+/// `dolphin::frontend::build_slaney_mel_filters` (same order of operations
+/// throughout), not a new construction.
+fn slaney_f64_espnet_filterbank(config: FilterbankConfig, fft_bins: usize) -> Vec<f32> {
+    let FilterbankConfig {
+        sample_rate_hz,
+        n_fft,
+        n_mels,
+        fmin,
+        fmax,
+        ..
+    } = config;
+    let sr = sample_rate_hz as f64;
+    let fft_freqs: Vec<f64> = (0..fft_bins)
+        .map(|k| k as f64 * sr / n_fft as f64)
+        .collect();
+
+    let min_mel = hz_to_mel_slaney_f64(fmin as f64);
+    let max_mel = hz_to_mel_slaney_f64(fmax as f64);
+    let n_edges = n_mels + 2;
+    let mel_edges_hz: Vec<f64> = (0..n_edges)
+        .map(|i| {
+            let mel = if n_edges == 1 {
+                min_mel
+            } else {
+                min_mel + (max_mel - min_mel) * i as f64 / (n_edges - 1) as f64
+            };
+            mel_to_hz_slaney_f64(mel)
+        })
+        .collect();
+    let fdiff: Vec<f64> = mel_edges_hz.windows(2).map(|w| w[1] - w[0]).collect();
+
+    let mut filters = vec![0.0f32; n_mels * fft_bins];
+    for m in 0..n_mels {
+        let enorm = 2.0 / (mel_edges_hz[m + 2] - mel_edges_hz[m]);
+        for (k, &freq) in fft_freqs.iter().enumerate() {
+            let lower = -(mel_edges_hz[m] - freq) / fdiff[m];
+            let upper = (mel_edges_hz[m + 2] - freq) / fdiff[m + 1];
+            let weight = lower.min(upper).max(0.0) * enorm;
+            filters[m * fft_bins + k] = weight as f32;
         }
     }
     filters
@@ -380,7 +467,12 @@ mod tests {
 
     #[test]
     fn hz_to_mel_and_mel_to_hz_round_trip_for_every_scale() {
-        for scale in [MelScale::Slaney, MelScale::Htk, MelScale::Kaldi] {
+        for scale in [
+            MelScale::Slaney,
+            MelScale::Htk,
+            MelScale::Kaldi,
+            MelScale::SlaneyF64Espnet,
+        ] {
             for hz in [0.0f32, 20.0, 440.0, 1000.0, 4000.0, 8000.0] {
                 let mel = hz_to_mel(scale, hz);
                 let back = mel_to_hz(scale, mel);
@@ -390,6 +482,93 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Exact reimplementation of the pre-refactor
+    /// `dolphin::frontend::build_slaney_mel_filters` (f64 throughout, cast to
+    /// f32 only for the final weight), kept only in this test to pin
+    /// `MelScale::SlaneyF64Espnet` to the values `DolphinEspnetFrontend`
+    /// shipped before this module existed.
+    fn reference_dolphin_espnet_slaney_f64_filterbank(
+        n_mels: usize,
+        n_fft: usize,
+        fft_bins: usize,
+    ) -> Vec<f32> {
+        fn hz_to_mel(freq: f64) -> f64 {
+            const F_SP: f64 = 200.0 / 3.0;
+            const MIN_LOG_HZ: f64 = 1000.0;
+            const MIN_LOG_MEL: f64 = MIN_LOG_HZ / F_SP;
+            let logstep = 6.4f64.ln() / 27.0;
+            if freq >= MIN_LOG_HZ {
+                MIN_LOG_MEL + (freq / MIN_LOG_HZ).ln() / logstep
+            } else {
+                freq / F_SP
+            }
+        }
+        fn mel_to_hz(mel: f64) -> f64 {
+            const F_SP: f64 = 200.0 / 3.0;
+            const MIN_LOG_HZ: f64 = 1000.0;
+            const MIN_LOG_MEL: f64 = MIN_LOG_HZ / F_SP;
+            let logstep = 6.4f64.ln() / 27.0;
+            if mel >= MIN_LOG_MEL {
+                MIN_LOG_HZ * (logstep * (mel - MIN_LOG_MEL)).exp()
+            } else {
+                F_SP * mel
+            }
+        }
+        const SAMPLE_RATE_HZ: u32 = 16_000;
+        let sr = f64::from(SAMPLE_RATE_HZ);
+        let fft_freqs: Vec<f64> = (0..fft_bins)
+            .map(|k| k as f64 * sr / n_fft as f64)
+            .collect();
+        let min_mel = hz_to_mel(0.0);
+        let max_mel = hz_to_mel(8_000.0);
+        let n_edges = n_mels + 2;
+        let mel_edges_hz: Vec<f64> = (0..n_edges)
+            .map(|i| {
+                let mel = if n_edges == 1 {
+                    min_mel
+                } else {
+                    min_mel + (max_mel - min_mel) * i as f64 / (n_edges - 1) as f64
+                };
+                mel_to_hz(mel)
+            })
+            .collect();
+        let fdiff: Vec<f64> = mel_edges_hz.windows(2).map(|w| w[1] - w[0]).collect();
+        let mut filters = vec![0.0f32; n_mels * fft_bins];
+        for m in 0..n_mels {
+            let enorm = 2.0 / (mel_edges_hz[m + 2] - mel_edges_hz[m]);
+            for (k, &freq) in fft_freqs.iter().enumerate() {
+                let lower = -(mel_edges_hz[m] - freq) / fdiff[m];
+                let upper = (mel_edges_hz[m + 2] - freq) / fdiff[m + 1];
+                let weight = lower.min(upper).max(0.0) * enorm;
+                filters[m * fft_bins + k] = weight as f32;
+            }
+        }
+        filters
+    }
+
+    #[test]
+    fn slaney_f64_espnet_filterbank_is_byte_identical_to_pre_refactor_dolphin_impl() {
+        let (n_mels, n_fft, fft_bins) = (80, 512, 257);
+        let expected = reference_dolphin_espnet_slaney_f64_filterbank(n_mels, n_fft, fft_bins);
+        let actual = filterbank(FilterbankConfig {
+            scale: MelScale::SlaneyF64Espnet,
+            sample_rate_hz: 16_000.0,
+            n_fft,
+            n_mels,
+            fmin: 0.0,
+            fmax: 8_000.0,
+            // Unused by this scale (its own f64 edge placement); any value
+            // must produce the same output.
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
+        });
+        assert_eq!(expected, actual);
+
+        // librosa.filters.mel(...)[0][:4] / [79][240:244] pinned values from
+        // dolphin's own parity test (`slaney_mel_filterbank_matches_librosa_reference`).
+        assert!((actual[1] - 2.253_456e-2).abs() < 1.0e-6);
+        assert!((actual[79 * fft_bins + 240] - 1.066_234_2e-3).abs() < 1.0e-6);
     }
 
     /// Exact reimplementation of the pre-refactor `whisper::mel::slaney_mel_filterbank`

--- a/crates/openasr-core/src/models/audio_frontend/mod.rs
+++ b/crates/openasr-core/src/models/audio_frontend/mod.rs
@@ -37,14 +37,36 @@ pub(crate) enum PadMode {
     /// `torch.stft(center=True, pad_mode="reflect")`: reflect-pad `n_fft/2`
     /// samples on both ends (no edge repeat) before framing at `hop`
     /// stride, i.e. `n_frames = (padded_len - n_fft) / hop + 1`. Used by
-    /// `parakeet_ctc`/`parakeet_tdt`, `whisper`, `cohere`, `qwen`.
+    /// `parakeet_ctc`/`parakeet_tdt`, `whisper`, `cohere`, `qwen`, and
+    /// `dolphin`'s ESPnet-variant frontend (`DolphinEspnetFrontend`).
     ReflectCenter,
+    /// Kaldi/sherpa-onnx `snip_edges=false`: frame `i`'s window starts at
+    /// absolute sample index `i*hop - (win/2 - hop/2)` (the asymmetric
+    /// kaldi offset, distinct from `ReflectCenter`'s symmetric `n_fft/2`
+    /// centering), reflected (no edge repeat) against the *total* stream
+    /// length rather than a once-materialized padded buffer. There is no
+    /// whole-buffer [`StftFramer::power_spectrogram`] entry point for this
+    /// mode -- drive it exclusively through
+    /// [`StftFramer::power_spectrogram_kaldi_snip_edges_false_range`], which
+    /// takes an explicit frame range and an optional dropped-prefix offset
+    /// so streaming callers can hold only a tail of the signal (O(1) memory)
+    /// instead of the whole utterance. Used by `xasr_zipformer`'s streaming
+    /// fbank.
+    KaldiSnipEdgesFalse,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum StftError {
     #[error("stft framer produced no frames from {samples} samples")]
     TooShort { samples: usize },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum KaldiFrameRangeError {
+    #[error(
+        "kaldi snip_edges=false frame range needs a sample earlier than the retained prefix (frame {frame})"
+    )]
+    MissingPrefix { frame: usize },
 }
 
 /// Power spectrogram, row-major `[frame][fft_bin]` (bin innermost).
@@ -57,7 +79,11 @@ pub(crate) struct PowerSpectrogram {
 
 /// Frames raw audio, applies an analysis window, and runs a real FFT to
 /// produce a power spectrogram. Owns the FFT plan (built once per instance)
-/// since planning dominates the per-call cost for short frames.
+/// since planning dominates the per-call cost for short frames. `Clone`
+/// clones the `Arc`-held FFT plan (cheap, shares the twiddle tables) --
+/// needed so `xasr_zipformer::frontend::XasrFbankFrontend` (which embeds
+/// this) can keep deriving `Clone` itself.
+#[derive(Clone)]
 pub(crate) struct StftFramer {
     n_fft: usize,
     /// Analysis window length before any `n_fft` zero-pad (documentation +
@@ -117,7 +143,68 @@ impl StftFramer {
     pub(crate) fn power_spectrogram(&self, samples: &[f32]) -> Result<PowerSpectrogram, StftError> {
         match self.pad_mode {
             PadMode::ReflectCenter => self.power_spectrogram_reflect_center(samples),
+            PadMode::KaldiSnipEdgesFalse => panic!(
+                "StftFramer::power_spectrogram: PadMode::KaldiSnipEdgesFalse has no whole-buffer \
+                 entry point -- use power_spectrogram_kaldi_snip_edges_false_range"
+            ),
         }
+    }
+
+    /// Kaldi `snip_edges=false` incremental framing (see
+    /// [`PadMode::KaldiSnipEdgesFalse`]): computes power-spectrogram rows for
+    /// frames `[start_frame, end_frame)` of a stream whose total length is
+    /// `total_len`, reading only `samples[sample_offset..]` (streaming
+    /// callers may have already dropped the earlier prefix). Returns
+    /// [`KaldiFrameRangeError::MissingPrefix`] instead of panicking when a
+    /// frame needs a sample before `sample_offset`.
+    pub(crate) fn power_spectrogram_kaldi_snip_edges_false_range(
+        &self,
+        samples: &[f32],
+        sample_offset: usize,
+        total_len: usize,
+        start_frame: usize,
+        end_frame: usize,
+    ) -> Result<PowerSpectrogram, KaldiFrameRangeError> {
+        debug_assert_eq!(self.pad_mode, PadMode::KaldiSnipEdgesFalse);
+        // Kaldi's asymmetric offset: half the window, minus half the hop.
+        let frame_offset = (self.win / 2) as i64 - (self.hop / 2) as i64;
+        let fft_bins = self.n_fft_bins();
+        let r2c = &self.fft;
+        let mut fft_in = r2c.make_input_vec();
+        let mut fft_out = r2c.make_output_vec();
+        let mut scratch = r2c.make_scratch_vec();
+
+        let n_frames = end_frame.saturating_sub(start_frame);
+        let mut data = vec![0.0f32; n_frames * fft_bins];
+        for frame in start_frame..end_frame {
+            for value in fft_in.iter_mut() {
+                *value = 0.0;
+            }
+            let start = frame as i64 * self.hop as i64 - frame_offset;
+            for (i, (slot, &window_value)) in fft_in
+                .iter_mut()
+                .zip(self.window.iter())
+                .enumerate()
+                .take(self.win)
+            {
+                let absolute_idx = reflect_index_no_repeat(total_len, start + i as i64);
+                let sample_idx = absolute_idx
+                    .checked_sub(sample_offset)
+                    .ok_or(KaldiFrameRangeError::MissingPrefix { frame })?;
+                *slot = samples[sample_idx] * window_value;
+            }
+            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
+                .expect("stft framer kaldi-range rfft");
+            let row_offset = (frame - start_frame) * fft_bins;
+            for (bin, c) in fft_out.iter().enumerate() {
+                data[row_offset + bin] = c.norm_sqr();
+            }
+        }
+        Ok(PowerSpectrogram {
+            data,
+            n_frames,
+            n_fft_bins: fft_bins,
+        })
     }
 
     fn power_spectrogram_reflect_center(
@@ -188,6 +275,26 @@ pub(crate) fn hann_window_periodic_scale_first(length: usize) -> Vec<f32> {
         .collect()
 }
 
+/// Kaldi "Povey" window (`hann(i)^0.85`, `torch.hann_window`'s
+/// `periodic=True` formula raised to the 0.85 power), zero-padded on the
+/// right into an `n_fft`-length buffer (`window[win_length..]` stays zero).
+/// This is the kaldi `snip_edges=false` left-aligned convention -- the
+/// `win_length < n_fft` slack goes entirely on the right, as opposed to
+/// [`hann_window_centered`]'s symmetric centering (see
+/// [`PadMode::KaldiSnipEdgesFalse`]). Used by `xasr_zipformer`'s streaming
+/// fbank; `kaldi_fbank.rs`'s batch engine builds its own copy of this same
+/// formula independently (unifying that is a separate follow-up, out of
+/// scope here).
+pub(crate) fn povey_window_left_aligned(win_length: usize, n_fft: usize) -> Vec<f32> {
+    let mut window = vec![0.0f32; n_fft];
+    for (i, slot) in window.iter_mut().enumerate().take(win_length) {
+        let hann =
+            0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / (win_length - 1) as f32).cos();
+        *slot = hann.powf(0.85);
+    }
+    window
+}
+
 /// numpy/`torch.stft`-style reflect padding (no edge repeat): pads `pad`
 /// samples of mirrored signal onto both ends of `samples`.
 fn reflect_pad(samples: &[f32], pad: usize) -> Vec<f32> {
@@ -202,6 +309,31 @@ fn reflect_pad(samples: &[f32], pad: usize) -> Vec<f32> {
         out.push(samples[idx.min(n.saturating_sub(1))]);
     }
     out
+}
+
+/// `numpy`/`torch` `mode="reflect"` sample lookup at a possibly
+/// out-of-range signal index (may be negative or `>= samples_len`): mirrors
+/// the signal about each edge without repeating the edge sample, matching
+/// `torch.stft`'s `pad_mode="reflect"` -- the per-index equivalent of
+/// [`reflect_pad`], usable when materializing the whole padded buffer up
+/// front isn't practical (kaldi `snip_edges=false` incremental streaming
+/// framing, `xasr_zipformer`; ESPnet per-frame framing, `dolphin`). Single-
+/// or zero-sample signals fold to index 0.
+pub(crate) fn reflect_index_no_repeat(samples_len: usize, index: i64) -> usize {
+    if samples_len <= 1 {
+        return 0;
+    }
+    let last = samples_len as i64 - 1;
+    let period = 2 * last;
+    let mut folded = index % period;
+    if folded < 0 {
+        folded += period;
+    }
+    if folded > last {
+        (period - folded) as usize
+    } else {
+        folded as usize
+    }
 }
 
 /// Per-feature (column) mean/std normalization of a row-major
@@ -349,5 +481,122 @@ mod tests {
                 "length={length}"
             );
         }
+    }
+
+    /// Exact reimplementation of the pre-refactor
+    /// `xasr_zipformer::frontend::povey_window`, kept only to pin
+    /// [`povey_window_left_aligned`] to the values `xasr_zipformer` shipped
+    /// before this module existed.
+    fn reference_xasr_povey_window(length: usize) -> Vec<f32> {
+        (0..length)
+            .map(|i| {
+                let hann =
+                    0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / (length - 1) as f32).cos();
+                hann.powf(0.85)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn povey_window_left_aligned_is_byte_identical_to_pre_refactor_xasr_impl() {
+        let expected = reference_xasr_povey_window(400);
+        let actual = povey_window_left_aligned(400, 512);
+        assert_eq!(&actual[..400], expected.as_slice());
+        assert!(actual[400..].iter().all(|&v| v == 0.0));
+    }
+
+    /// Exact reimplementation of the pre-refactor
+    /// `xasr_zipformer::frontend::reflect_sample_index`, kept only to pin
+    /// [`reflect_index_no_repeat`] to the values `xasr_zipformer` shipped
+    /// before this module existed. (`dolphin::frontend::reflect_sample`'s
+    /// per-index math is the same formula independently derived; both
+    /// families' pre-refactor golden coverage exercises this indirectly.)
+    fn reference_xasr_reflect_sample_index(index: i64, len: usize) -> usize {
+        if len <= 1 {
+            return 0;
+        }
+        let last = len as i64 - 1;
+        let period = 2 * last;
+        let mut folded = index % period;
+        if folded < 0 {
+            folded += period;
+        }
+        if folded > last {
+            (period - folded) as usize
+        } else {
+            folded as usize
+        }
+    }
+
+    #[test]
+    fn reflect_index_no_repeat_is_byte_identical_to_pre_refactor_xasr_impl() {
+        for len in [1usize, 2, 5, 400] {
+            for index in -20i64..40 {
+                assert_eq!(
+                    reference_xasr_reflect_sample_index(index, len),
+                    reflect_index_no_repeat(len, index),
+                    "len={len} index={index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reflect_index_no_repeat_stays_in_bounds() {
+        for &i in &(-20..20).collect::<Vec<i64>>() {
+            assert!(reflect_index_no_repeat(5, i) < 5);
+        }
+        assert_eq!(reflect_index_no_repeat(5, -1), 1);
+        assert_eq!(reflect_index_no_repeat(5, 5), 3);
+    }
+
+    fn xasr_style_framer() -> StftFramer {
+        StftFramer::new(
+            512,
+            400,
+            160,
+            PadMode::KaldiSnipEdgesFalse,
+            povey_window_left_aligned(400, 512),
+        )
+    }
+
+    #[test]
+    fn kaldi_snip_edges_false_range_matches_full_computation_when_split() {
+        let framer = xasr_style_framer();
+        let samples: Vec<f32> = (0..8_000)
+            .map(|i| (2.0 * std::f32::consts::PI * 313.0 * i as f32 / 16_000.0).sin() * 0.1)
+            .collect();
+        let total_len = samples.len();
+        // 7 frames covers the whole clip at this length; split the range to
+        // confirm the incremental range API is order/slice independent.
+        let full = framer
+            .power_spectrogram_kaldi_snip_edges_false_range(&samples, 0, total_len, 0, 7)
+            .expect("full range");
+        let head = framer
+            .power_spectrogram_kaldi_snip_edges_false_range(&samples, 0, total_len, 0, 3)
+            .expect("head range");
+        let tail = framer
+            .power_spectrogram_kaldi_snip_edges_false_range(&samples, 0, total_len, 3, 7)
+            .expect("tail range");
+        assert_eq!(head.data, full.data[..3 * full.n_fft_bins]);
+        assert_eq!(tail.data, full.data[3 * full.n_fft_bins..]);
+    }
+
+    #[test]
+    fn kaldi_snip_edges_false_range_rejects_dropped_prefix() {
+        let framer = xasr_style_framer();
+        let samples = vec![0.01f32; 8_000];
+        // Frame 0 needs samples starting at 0*160 - (400/2 - 160/2) = -120,
+        // reflected into [0, total_len); asking for frame 0 while
+        // `sample_offset` has already dropped everything before absolute
+        // sample 4000 must fail closed, not panic or read out of bounds.
+        let tail = &samples[4_000..];
+        let error = framer
+            .power_spectrogram_kaldi_snip_edges_false_range(tail, 4_000, 8_000, 0, 1)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            KaldiFrameRangeError::MissingPrefix { frame: 0 }
+        ));
     }
 }

--- a/crates/openasr-core/src/models/audio_frontend/mod.rs
+++ b/crates/openasr-core/src/models/audio_frontend/mod.rs
@@ -173,6 +173,21 @@ pub(crate) fn hann_window_centered(win_length: usize, n_fft: usize) -> Vec<f32> 
     window
 }
 
+/// Periodic Hann window of `length`, computed by pre-dividing the angular
+/// step (`2*pi / length`) once and multiplying by the sample index, rather
+/// than [`hann_window_centered`]'s per-sample `(2*pi*i) / length` operation
+/// order. The two are the exact same real-valued formula but round
+/// differently in f32 for some lengths (confirmed by exhaustive bit
+/// comparison at length 400); this is `whisper`'s own bit-exact
+/// construction, used only where `win_length == n_fft` (no centering slack,
+/// hence no `n_fft` parameter).
+pub(crate) fn hann_window_periodic_scale_first(length: usize) -> Vec<f32> {
+    let scale = std::f32::consts::PI * 2.0 / length as f32;
+    (0..length)
+        .map(|i| 0.5 - 0.5 * (scale * i as f32).cos())
+        .collect()
+}
+
 /// numpy/`torch.stft`-style reflect padding (no edge repeat): pads `pad`
 /// samples of mirrored signal onto both ends of `samples`.
 fn reflect_pad(samples: &[f32], pad: usize) -> Vec<f32> {
@@ -313,5 +328,26 @@ mod tests {
         // (ddof=0), so the ddof=1 std is larger and its normalized
         // magnitudes are smaller.
         assert!(ddof1[0].abs() < ddof0[0].abs());
+    }
+
+    /// Exact reimplementation of the pre-refactor `whisper::mel::hann_window`,
+    /// kept only to pin [`hann_window_periodic_scale_first`] to the values
+    /// `whisper` shipped before this module existed.
+    fn reference_whisper_hann_window(length: usize) -> Vec<f32> {
+        let scale = std::f32::consts::PI * 2.0 / length as f32;
+        (0..length)
+            .map(|index| 0.5 - 0.5 * (scale * index as f32).cos())
+            .collect()
+    }
+
+    #[test]
+    fn hann_window_periodic_scale_first_is_byte_identical_to_pre_refactor_whisper_impl() {
+        for length in [400usize, 512usize] {
+            assert_eq!(
+                reference_whisper_hann_window(length),
+                hann_window_periodic_scale_first(length),
+                "length={length}"
+            );
+        }
     }
 }

--- a/crates/openasr-core/src/models/dolphin/frontend.rs
+++ b/crates/openasr-core/src/models/dolphin/frontend.rs
@@ -31,15 +31,18 @@
 //! periodic Hann window (not Povey), `torch.stft`-style reflect-centered
 //! framing (not kaldi `snip_edges`), no pre-emphasis/DC-removal/int16 scaling,
 //! and a **Slaney**-normalized librosa mel scale/filterbank (not HTK
-//! peak-normalized) -- see `build_slaney_mel_filters`. It stays family-local
-//! (not shared kaldi-fbank infrastructure).
+//! peak-normalized, and f64-precision throughout --
+//! [`crate::models::audio_frontend::mel::MelScale::SlaneyF64Espnet`]). The
+//! STFT framing/windowing/FFT and mel filterbank construction now go through
+//! the shared [`crate::models::audio_frontend`] primitives (same arithmetic,
+//! relocated); the log-energy floor placement (before `.ln()`, no CMVN here
+//! since ESPnet checkpoints bake normalization into the encoder) stays
+//! family-local.
 
 #![allow(dead_code)]
 
-use std::sync::Arc;
-
-use realfft::{RealFftPlanner, RealToComplex};
-
+use crate::models::audio_frontend::mel::{FilterbankConfig, MelPointOrder, MelScale};
+use crate::models::audio_frontend::{PadMode, StftFramer, hann_window_centered};
 use crate::models::kaldi_fbank::{
     KaldiFbankConfig, KaldiFbankError, KaldiFbankFrontend, KaldiWindowKind,
 };
@@ -187,30 +190,19 @@ const ESPNET_FMAX_HZ: f64 = 8_000.0;
 /// `torch.clamp(mel_feat, min=1e-10)` before `.log()` in `LogMel.forward`.
 const ESPNET_LOG_ENERGY_FLOOR: f32 = 1.0e-10;
 
-/// One triangular Slaney mel filter over the full `0..=n_fft/2` power-bin
-/// range (unlike the shared kaldi engine's sparse filter, not gated to a
-/// contiguous nonzero run: the
-/// area-normalized Slaney weights are small enough near the band edges that
-/// hand-rolling a first/last-bin search buys little, and dense storage keeps
-/// the librosa reference formula ported verbatim below).
-struct EspnetMelFilter {
-    weights: Vec<f32>,
-}
-
 pub(crate) struct DolphinEspnetFrontend {
-    /// Periodic Hann window (`torch.hann_window(win_length)` default,
-    /// `periodic=True`), zero-padded/centered into the `n_fft`-length FFT
-    /// input buffer (`left = (n_fft - win_length) / 2`), mirroring
-    /// `torch.stft`'s own window centering when `win_length < n_fft`.
-    windowed_zero_pad: [f32; ESPNET_N_FFT],
-    filters: Vec<EspnetMelFilter>,
-    fft: Arc<dyn RealToComplex<f32>>,
+    framer: StftFramer,
+    /// Row-major `[n_mels][fft_bins]` Slaney mel filterbank
+    /// (`MelScale::SlaneyF64Espnet`'s f64-precision edge placement).
+    mel_filters: Vec<f32>,
+    n_mels: usize,
+    fft_bins: usize,
 }
 
 impl std::fmt::Debug for DolphinEspnetFrontend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DolphinEspnetFrontend")
-            .field("n_mels", &self.filters.len())
+            .field("n_mels", &self.n_mels)
             .finish_non_exhaustive()
     }
 }
@@ -223,27 +215,33 @@ impl Default for DolphinEspnetFrontend {
 
 impl DolphinEspnetFrontend {
     pub(crate) fn new() -> Self {
-        let mut windowed_zero_pad = [0.0f32; ESPNET_N_FFT];
-        let left = (ESPNET_N_FFT - ESPNET_WIN_LENGTH) / 2;
-        for (n, slot) in windowed_zero_pad[left..left + ESPNET_WIN_LENGTH]
-            .iter_mut()
-            .enumerate()
-        {
-            // Periodic Hann: `0.5 - 0.5*cos(2*pi*n/N)` (N = win_length in the
-            // denominator, not N-1 -- `torch.hann_window`'s default).
-            *slot = 0.5
-                - 0.5 * (2.0 * std::f32::consts::PI * n as f32 / ESPNET_WIN_LENGTH as f32).cos();
-        }
+        // Periodic Hann window (`torch.hann_window(win_length)` default,
+        // `periodic=True`), zero-padded/centered into the `n_fft`-length FFT
+        // input buffer, mirroring `torch.stft`'s own window centering when
+        // `win_length < n_fft`.
+        let framer = StftFramer::new(
+            ESPNET_N_FFT,
+            ESPNET_WIN_LENGTH,
+            ESPNET_HOP_LENGTH,
+            PadMode::ReflectCenter,
+            hann_window_centered(ESPNET_WIN_LENGTH, ESPNET_N_FFT),
+        );
+        let mel_filters = crate::models::audio_frontend::mel::filterbank(FilterbankConfig {
+            scale: MelScale::SlaneyF64Espnet,
+            sample_rate_hz: SAMPLE_RATE_HZ as f32,
+            n_fft: ESPNET_N_FFT,
+            n_mels: ESPNET_NUM_MEL_BINS,
+            fmin: ESPNET_FMIN_HZ as f32,
+            fmax: ESPNET_FMAX_HZ as f32,
+            // `SlaneyF64Espnet` places edges with its own f64 formula and
+            // ignores this field.
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
+        });
         Self {
-            windowed_zero_pad,
-            filters: build_slaney_mel_filters(
-                SAMPLE_RATE_HZ,
-                ESPNET_N_FFT,
-                ESPNET_NUM_MEL_BINS,
-                ESPNET_FMIN_HZ,
-                ESPNET_FMAX_HZ,
-            ),
-            fft: RealFftPlanner::<f32>::new().plan_fft_forward(ESPNET_N_FFT),
+            framer,
+            mel_filters,
+            n_mels: ESPNET_NUM_MEL_BINS,
+            fft_bins: ESPNET_N_FFT / 2 + 1,
         }
     }
 
@@ -262,33 +260,27 @@ impl DolphinEspnetFrontend {
         if samples.is_empty() || samples.iter().any(|v| !v.is_finite()) {
             return Err(DolphinFrontendError::UnsupportedAudio);
         }
-        let pad = ESPNET_N_FFT / 2;
-        let n_frames = 1 + samples.len() / ESPNET_HOP_LENGTH;
-        let r2c = &self.fft;
-        let mut fft_in = r2c.make_input_vec();
-        let mut fft_out = r2c.make_output_vec();
-        let mut scratch = r2c.make_scratch_vec();
-        let mut power = vec![0.0f32; ESPNET_N_FFT / 2 + 1];
+        let spectrogram = self
+            .framer
+            .power_spectrogram(samples)
+            // `ReflectCenter` pads by `n_fft/2` both sides, so `TooShort`
+            // never actually triggers for the nonempty input already
+            // checked above (see `audio_frontend`'s own equivalent note).
+            .map_err(|_| DolphinFrontendError::UnsupportedAudio)?;
+        let n_frames = spectrogram.n_frames;
+        let n_mels = self.n_mels;
+        let fft_bins = self.fft_bins;
 
-        let n_mels = self.filters.len();
         let mut feats = vec![0.0f32; n_frames * n_mels];
         for fr in 0..n_frames {
-            let frame_start = (fr * ESPNET_HOP_LENGTH) as i64 - pad as i64;
-            for (j, slot) in fft_in.iter_mut().enumerate() {
-                let sample = reflect_sample(samples, frame_start + j as i64);
-                *slot = sample * self.windowed_zero_pad[j];
-            }
-            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
-                .expect("dolphin espnet fbank rfft");
-            for (bin, value) in fft_out.iter().enumerate() {
-                power[bin] = value.re * value.re + value.im * value.im;
-            }
-            for (bin, filter) in self.filters.iter().enumerate() {
+            let power = &spectrogram.data[fr * fft_bins..(fr + 1) * fft_bins];
+            for m in 0..n_mels {
+                let row = &self.mel_filters[m * fft_bins..(m + 1) * fft_bins];
                 let mut energy = 0.0f32;
-                for (weight, p) in filter.weights.iter().zip(power.iter()) {
-                    energy += weight * p;
+                for bin in 0..fft_bins {
+                    energy += row[bin] * power[bin];
                 }
-                feats[fr * n_mels + bin] = energy.max(ESPNET_LOG_ENERGY_FLOOR).ln();
+                feats[fr * n_mels + m] = energy.max(ESPNET_LOG_ENERGY_FLOOR).ln();
             }
         }
         Ok(DolphinFbankFeatures {
@@ -297,108 +289,6 @@ impl DolphinEspnetFrontend {
             n_mels,
         })
     }
-}
-
-/// `numpy`/`torch` `mode="reflect"` boundary sample at signal index `k`
-/// (may be negative or `>= samples.len()`): mirrors the signal about each
-/// edge without repeating the edge sample itself, matching `torch.stft`'s
-/// `pad_mode="reflect"` centering. Single-sample signals fold to that sample.
-fn reflect_sample(samples: &[f32], k: i64) -> f32 {
-    let len = samples.len();
-    if len <= 1 {
-        return samples.first().copied().unwrap_or(0.0);
-    }
-    let period = 2 * (len as i64 - 1);
-    let mut m = k % period;
-    if m < 0 {
-        m += period;
-    }
-    let m = if m < len as i64 { m } else { period - m };
-    samples[m as usize]
-}
-
-/// librosa's Slaney (non-HTK) mel scale: linear below 1 kHz, logarithmic
-/// above. `htk=False` is `librosa.filters.mel`'s default and what
-/// `DefaultFrontend`'s `LogMel` uses when `htk` is left unset (as
-/// dolphin-small/dolphin-base's `frontend_conf` does).
-fn hz_to_mel_slaney(freq: f64) -> f64 {
-    const F_SP: f64 = 200.0 / 3.0;
-    const MIN_LOG_HZ: f64 = 1000.0;
-    const MIN_LOG_MEL: f64 = MIN_LOG_HZ / F_SP; // 15.0
-    let logstep = 6.4f64.ln() / 27.0;
-    if freq >= MIN_LOG_HZ {
-        MIN_LOG_MEL + (freq / MIN_LOG_HZ).ln() / logstep
-    } else {
-        freq / F_SP
-    }
-}
-
-fn mel_to_hz_slaney(mel: f64) -> f64 {
-    const F_SP: f64 = 200.0 / 3.0;
-    const MIN_LOG_HZ: f64 = 1000.0;
-    const MIN_LOG_MEL: f64 = MIN_LOG_HZ / F_SP; // 15.0
-    let logstep = 6.4f64.ln() / 27.0;
-    if mel >= MIN_LOG_MEL {
-        MIN_LOG_HZ * (logstep * (mel - MIN_LOG_MEL)).exp()
-    } else {
-        F_SP * mel
-    }
-}
-
-/// `librosa.filters.mel(sr, n_fft, n_mels, fmin, fmax, htk=False)` (default
-/// `norm="slaney"`): `n_mels` overlapping triangles over `n_fft/2+1` linear FFT
-/// bins, with edges chosen evenly spaced in Slaney-mel space and each row
-/// scaled by `2 / (mel_edge[i+2] - mel_edge[i])` (area, not peak, normalized --
-/// the opposite convention from the kaldi/HTK filters above).
-fn build_slaney_mel_filters(
-    sample_rate_hz: u32,
-    n_fft: usize,
-    n_mels: usize,
-    fmin_hz: f64,
-    fmax_hz: f64,
-) -> Vec<EspnetMelFilter> {
-    let n_fft_bins = n_fft / 2 + 1;
-    let sr = f64::from(sample_rate_hz);
-
-    // `fft_frequencies`: linear bins `k * sr / n_fft`.
-    let fft_freqs: Vec<f64> = (0..n_fft_bins)
-        .map(|k| k as f64 * sr / n_fft as f64)
-        .collect();
-
-    // `mel_frequencies(n_mels + 2, fmin, fmax)`: `n_mels+2` Hz edges, evenly
-    // spaced in mel space then mapped back to Hz.
-    let min_mel = hz_to_mel_slaney(fmin_hz);
-    let max_mel = hz_to_mel_slaney(fmax_hz);
-    let n_edges = n_mels + 2;
-    // `mel_frequencies`: Hz values of `n_edges` mel-evenly-spaced points.
-    // NOTE: librosa's `mel()` keeps `mel_f`/`fdiff`/`ramps` in **Hz** space
-    // from here on (only the edge placement itself uses the mel scale) --
-    // it never round-trips back through `hz_to_mel`.
-    let mel_edges_hz: Vec<f64> = (0..n_edges)
-        .map(|i| {
-            let mel = if n_edges == 1 {
-                min_mel
-            } else {
-                min_mel + (max_mel - min_mel) * i as f64 / (n_edges - 1) as f64
-            };
-            mel_to_hz_slaney(mel)
-        })
-        .collect();
-    let fdiff: Vec<f64> = mel_edges_hz.windows(2).map(|w| w[1] - w[0]).collect();
-
-    let mut filters = Vec::with_capacity(n_mels);
-    for m in 0..n_mels {
-        let enorm = 2.0 / (mel_edges_hz[m + 2] - mel_edges_hz[m]);
-        let mut weights = vec![0.0f32; n_fft_bins];
-        for (k, &freq) in fft_freqs.iter().enumerate() {
-            let lower = -(mel_edges_hz[m] - freq) / fdiff[m];
-            let upper = (mel_edges_hz[m + 2] - freq) / fdiff[m + 1];
-            let weight = lower.min(upper).max(0.0) * enorm;
-            weights[k] = weight as f32;
-        }
-        filters.push(EspnetMelFilter { weights });
-    }
-    filters
 }
 
 #[cfg(test)]
@@ -464,14 +354,17 @@ mod tests {
 
     #[test]
     fn slaney_mel_filterbank_matches_librosa_reference() {
-        let filters = build_slaney_mel_filters(
-            SAMPLE_RATE_HZ,
-            ESPNET_N_FFT,
-            ESPNET_NUM_MEL_BINS,
-            0.0,
-            8_000.0,
-        );
-        assert_eq!(filters.len(), 80);
+        let fft_bins = ESPNET_N_FFT / 2 + 1;
+        let filters = crate::models::audio_frontend::mel::filterbank(FilterbankConfig {
+            scale: MelScale::SlaneyF64Espnet,
+            sample_rate_hz: SAMPLE_RATE_HZ as f32,
+            n_fft: ESPNET_N_FFT,
+            n_mels: ESPNET_NUM_MEL_BINS,
+            fmin: 0.0,
+            fmax: 8_000.0,
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
+        });
+        assert_eq!(filters.len(), 80 * fft_bins);
 
         // librosa.filters.mel(...)[0][:10]
         let expected_row0: [f32; 10] = [
@@ -487,7 +380,7 @@ mod tests {
             0.0,
         ];
         for (bin, &expected) in expected_row0.iter().enumerate() {
-            let actual = filters[0].weights[bin];
+            let actual = filters[bin];
             assert!(
                 (actual - expected).abs() < 1.0e-6,
                 "mel row0 bin{bin}: actual {actual} expected {expected}"
@@ -515,7 +408,7 @@ mod tests {
             0.0,
         ];
         for (offset, &expected) in expected_row79_tail.iter().enumerate() {
-            let actual = filters[79].weights[240 + offset];
+            let actual = filters[79 * fft_bins + 240 + offset];
             assert!(
                 (actual - expected).abs() < 1.0e-6,
                 "mel row79 bin{}: actual {actual} expected {expected}",

--- a/crates/openasr-core/src/models/parakeet_ctc/frontend.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/frontend.rs
@@ -19,7 +19,7 @@
 
 use super::encoder_graph::ParakeetMelFeatures;
 use super::runtime_contract::ParakeetCtcExecutionMetadata;
-use crate::models::audio_frontend::mel::{FilterbankConfig, MelScale};
+use crate::models::audio_frontend::mel::{FilterbankConfig, MelPointOrder, MelScale};
 use crate::models::audio_frontend::{
     PadMode, StftError, StftFramer, hann_window_centered, per_feature_normalize,
 };
@@ -87,6 +87,7 @@ impl ParakeetFrontend {
             n_mels,
             fmin: MEL_FMIN,
             fmax: MEL_FMAX,
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
         });
         Self {
             n_mels,
@@ -186,6 +187,7 @@ mod tests {
             n_mels: 80,
             fmin: MEL_FMIN,
             fmax: MEL_FMAX,
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
         });
         // every row has positive mass, bounded weights.
         for m in 0..80 {

--- a/crates/openasr-core/src/models/whisper/mel.rs
+++ b/crates/openasr-core/src/models/whisper/mel.rs
@@ -1,8 +1,6 @@
-use std::sync::{Arc, OnceLock};
-
-use realfft::{RealFftPlanner, RealToComplex};
-
 use crate::NativeAsrError;
+use crate::models::audio_frontend::mel::{FilterbankConfig, MelPointOrder, MelScale};
+use crate::models::audio_frontend::{PadMode, StftFramer, hann_window_periodic_scale_first};
 use crate::models::ggml_asr_executor::GgmlAsrPreparedAudio;
 use crate::tensor::{TensorOwnedF32, TensorViewF32, linear_f32};
 
@@ -16,12 +14,14 @@ const WHISPER_LOG_SPEC_FLOOR: f32 = 1e-10;
 const WHISPER_LOG_SPEC_DYNAMIC_RANGE: f32 = 8.0;
 const WHISPER_LOG_SPEC_SHIFT: f32 = 4.0;
 
-static WHISPER_R2C_PLAN_V0: OnceLock<Arc<dyn RealToComplex<f32>>> = OnceLock::new();
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct WhisperMelFrontendPlan {
     pub n_mels: usize,
     pub target_frames: usize,
+    /// Periodic Hann window, `n_fft` (== `WHISPER_N_FFT`) long -- whisper
+    /// never needs the `win_length < n_fft` centering slack
+    /// [`crate::models::audio_frontend::hann_window_centered`] handles for
+    /// other families.
     pub window: Vec<f32>,
     pub mel_filters: Vec<f32>,
 }
@@ -75,14 +75,21 @@ pub fn build_whisper_mel_frontend_plan_v0(
     Ok(WhisperMelFrontendPlan {
         n_mels,
         target_frames,
-        window: hann_window(WHISPER_N_FFT),
-        mel_filters: slaney_mel_filterbank(
+        window: hann_window_periodic_scale_first(WHISPER_N_FFT),
+        mel_filters: crate::models::audio_frontend::mel::filterbank(FilterbankConfig {
+            scale: MelScale::Slaney,
+            sample_rate_hz: WHISPER_SAMPLE_RATE_HZ as f32,
+            n_fft: WHISPER_N_FFT,
             n_mels,
-            WHISPER_N_FFT,
-            WHISPER_SAMPLE_RATE_HZ,
-            WHISPER_MEL_FMIN,
-            WHISPER_MEL_FMAX,
-        )?,
+            fmin: WHISPER_MEL_FMIN,
+            fmax: WHISPER_MEL_FMAX,
+            // whisper's own pre-refactor filterbank builder computed the
+            // mel-domain edge ratio before scaling by the mel span; see
+            // `MelPointOrder::RatioFirst`'s doc for why this must stay
+            // pinned rather than reuse `parakeet_ctc`'s edge-construction
+            // order.
+            mel_point_order: MelPointOrder::RatioFirst,
+        }),
     })
 }
 
@@ -137,53 +144,50 @@ pub fn whisper_mel_features_from_samples_with_plan_v0(
         });
     }
 
-    let padded = whisper_pad_for_stft_center_v0(samples, plan.target_frames)?;
-    let r2c = whisper_r2c_plan_v0();
-    let mut fft_input = r2c.make_input_vec();
-    let mut fft_output = r2c.make_output_vec();
-    let mut fft_scratch = r2c.make_scratch_vec();
-
-    let all_frames = padded
-        .len()
-        .checked_sub(WHISPER_N_FFT)
+    // OpenAI whisper's `log_mel_spectrogram` pads/trims to a fixed
+    // `target_frames * hop` sample window before framing (untrusted-pack
+    // sizes stay checked-arithmetic since `target_frames` comes from parsed
+    // `.oasr` metadata).
+    let target_audio_samples = plan
+        .target_frames
+        .checked_mul(WHISPER_HOP_LENGTH)
         .ok_or_else(|| NativeAsrError::SessionFailed {
-            message: "Whisper frontend padded signal is shorter than the FFT window".to_string(),
-        })?
-        .checked_div(WHISPER_HOP_LENGTH)
-        .and_then(|value| value.checked_add(1))
-        .ok_or_else(|| NativeAsrError::SessionFailed {
-            message: "Whisper frontend frame count overflow".to_string(),
+            message: "Whisper frontend target frame count overflows audio length".to_string(),
         })?;
-    let frame_count = all_frames
-        .checked_sub(1)
-        .ok_or_else(|| NativeAsrError::SessionFailed {
-            message: "Whisper frontend produced zero spectrogram frames".to_string(),
-        })?;
-    if frame_count == 0 {
-        return Err(NativeAsrError::SessionFailed {
-            message: "Whisper frontend produced zero spectrogram frames".to_string(),
-        });
-    }
+    let audio = pad_or_trim_audio(samples, target_audio_samples);
 
-    let fft_bins = WHISPER_N_FFT / 2 + 1;
-    let mut power_spectrogram = vec![0.0_f32; frame_count * fft_bins];
-    for frame_idx in 0..frame_count {
-        let start = frame_idx * WHISPER_HOP_LENGTH;
-        let frame = &padded[start..start + WHISPER_N_FFT];
-        for (index, value) in fft_input.iter_mut().enumerate() {
-            *value = frame[index] * plan.window[index];
-        }
-        r2c.process_with_scratch(&mut fft_input, &mut fft_output, &mut fft_scratch)
+    let framer = StftFramer::new(
+        WHISPER_N_FFT,
+        WHISPER_N_FFT,
+        WHISPER_HOP_LENGTH,
+        PadMode::ReflectCenter,
+        plan.window.clone(),
+    );
+    let spectrogram =
+        framer
+            .power_spectrogram(&audio)
             .map_err(|error| NativeAsrError::SessionFailed {
-                message: format!("Whisper frontend FFT failed: {error}"),
+                message: format!("Whisper frontend STFT failed: {error}"),
             })?;
 
-        for (bin, complex) in fft_output.iter().enumerate() {
-            power_spectrogram[frame_idx * fft_bins + bin] = complex.norm_sqr();
-        }
+    // `torch.stft(..., center=True, pad_mode="reflect")` on a signal padded
+    // to exactly `target_frames * hop` samples yields `target_frames + 1`
+    // frames; OpenAI whisper's `log_mel_spectrogram` always drops the
+    // trailing frame (`log_spec[..., :-1]`) to land on exactly
+    // `target_frames`.
+    let fft_bins = framer.n_fft_bins();
+    if spectrogram.n_frames <= plan.target_frames {
+        return Err(NativeAsrError::SessionFailed {
+            message: format!(
+                "Whisper frontend produced {} spectrogram frames, expected more than {}",
+                spectrogram.n_frames, plan.target_frames
+            ),
+        });
     }
+    let frame_count = plan.target_frames;
+    let power_spectrogram = &spectrogram.data[..frame_count * fft_bins];
 
-    let power_view = TensorViewF32::contiguous(&power_spectrogram, &[frame_count, fft_bins])
+    let power_view = TensorViewF32::contiguous(power_spectrogram, &[frame_count, fft_bins])
         .map_err(|error| NativeAsrError::SessionFailed {
             message: format!("Whisper frontend power spectrogram view failed: {error}"),
         })?;
@@ -236,49 +240,6 @@ fn emit_mel_probe_trace(values: &[f32], n_mels: usize, n_frames: usize) {
     );
 }
 
-fn whisper_r2c_plan_v0() -> &'static Arc<dyn RealToComplex<f32>> {
-    WHISPER_R2C_PLAN_V0.get_or_init(|| {
-        let mut planner = RealFftPlanner::<f32>::new();
-        planner.plan_fft_forward(WHISPER_N_FFT)
-    })
-}
-
-fn whisper_pad_for_stft_center_v0(
-    samples: &[f32],
-    target_frames: usize,
-) -> Result<Vec<f32>, NativeAsrError> {
-    let target_audio_samples = target_frames
-        .checked_mul(WHISPER_HOP_LENGTH)
-        .ok_or_else(|| NativeAsrError::SessionFailed {
-            message: "Whisper frontend target frame count overflows audio length".to_string(),
-        })?;
-    let padded_audio_len = target_audio_samples
-        .checked_add(WHISPER_N_FFT)
-        .ok_or_else(|| NativeAsrError::SessionFailed {
-            message: "Whisper frontend target frame count overflows padded signal length"
-                .to_string(),
-        })?;
-    let pad = WHISPER_N_FFT / 2;
-    let audio = pad_or_trim_audio(samples, target_audio_samples);
-    let mut output = vec![0.0_f32; padded_audio_len];
-
-    for (index, out) in output.iter_mut().enumerate().take(pad) {
-        *out = reflect_index(&audio, pad - index);
-    }
-    output[pad..pad + audio.len()].copy_from_slice(&audio);
-    for index in 0..pad {
-        let reflect_pos =
-            audio
-                .len()
-                .checked_add(index)
-                .ok_or_else(|| NativeAsrError::SessionFailed {
-                    message: "Whisper frontend right-pad reflection index overflow".to_string(),
-                })?;
-        output[pad + audio.len() + index] = reflect_index(&audio, reflect_pos);
-    }
-    Ok(output)
-}
-
 fn pad_or_trim_audio(samples: &[f32], target_audio_samples: usize) -> Vec<f32> {
     let trimmed = if samples.len() > target_audio_samples {
         &samples[..target_audio_samples]
@@ -288,69 +249,6 @@ fn pad_or_trim_audio(samples: &[f32], target_audio_samples: usize) -> Vec<f32> {
     let mut output = vec![0.0_f32; target_audio_samples];
     output[..trimmed.len()].copy_from_slice(trimmed);
     output
-}
-
-fn reflect_index(samples: &[f32], index: usize) -> f32 {
-    if samples.is_empty() {
-        return 0.0;
-    }
-    if samples.len() == 1 {
-        return samples[0];
-    }
-    let period = samples.len().saturating_sub(1).saturating_mul(2);
-    if period == 0 {
-        return samples[0];
-    }
-    let folded = index % period;
-    let actual = if folded < samples.len() {
-        folded
-    } else {
-        period - folded
-    };
-    samples[actual]
-}
-
-fn hann_window(length: usize) -> Vec<f32> {
-    let scale = std::f32::consts::PI * 2.0 / length as f32;
-    (0..length)
-        .map(|index| 0.5 - 0.5 * (scale * index as f32).cos())
-        .collect()
-}
-
-fn slaney_mel_filterbank(
-    n_mels: usize,
-    n_fft: usize,
-    sample_rate: u32,
-    fmin: f32,
-    fmax: f32,
-) -> Result<Vec<f32>, NativeAsrError> {
-    let fft_bins = n_fft / 2 + 1;
-    let fft_frequencies = (0..fft_bins)
-        .map(|bin| bin as f32 * sample_rate as f32 / n_fft as f32)
-        .collect::<Vec<_>>();
-    let mel_min = hz_to_mel(fmin);
-    let mel_max = hz_to_mel(fmax);
-    let mel_points = (0..n_mels + 2)
-        .map(|index| {
-            let ratio = index as f32 / (n_mels + 1) as f32;
-            mel_to_hz(mel_min + ratio * (mel_max - mel_min))
-        })
-        .collect::<Vec<_>>();
-
-    let mut filters = vec![0.0_f32; n_mels * fft_bins];
-    for mel_idx in 0..n_mels {
-        let left = mel_points[mel_idx];
-        let center = mel_points[mel_idx + 1];
-        let right = mel_points[mel_idx + 2];
-        let norm = 2.0 / (right - left).max(f32::EPSILON);
-        for (bin_idx, hz) in fft_frequencies.iter().copied().enumerate() {
-            let rising = (hz - left) / (center - left).max(f32::EPSILON);
-            let falling = (right - hz) / (right - center).max(f32::EPSILON);
-            let value = rising.min(falling).max(0.0) * norm;
-            filters[mel_idx * fft_bins + bin_idx] = value;
-        }
-    }
-    Ok(filters)
 }
 
 fn normalize_log_mel_in_place(values: &mut [f32]) {
@@ -364,30 +262,6 @@ fn normalize_log_mel_in_place(values: &mut [f32]) {
     let floor = max_value - WHISPER_LOG_SPEC_DYNAMIC_RANGE;
     for value in values.iter_mut() {
         *value = ((*value).max(floor) + WHISPER_LOG_SPEC_SHIFT) / WHISPER_LOG_SPEC_SHIFT;
-    }
-}
-
-fn hz_to_mel(hz: f32) -> f32 {
-    let linear_scale = 200.0 / 3.0;
-    let min_log_hz = 1000.0;
-    let min_log_mel = min_log_hz / linear_scale;
-    if hz < min_log_hz {
-        hz / linear_scale
-    } else {
-        let log_step = 6.4_f32.ln() / 27.0;
-        min_log_mel + (hz / min_log_hz).ln() / log_step
-    }
-}
-
-fn mel_to_hz(mel: f32) -> f32 {
-    let linear_scale = 200.0 / 3.0;
-    let min_log_hz = 1000.0;
-    let min_log_mel = min_log_hz / linear_scale;
-    if mel < min_log_mel {
-        mel * linear_scale
-    } else {
-        let log_step = 6.4_f32.ln() / 27.0;
-        min_log_hz * (log_step * (mel - min_log_mel)).exp()
     }
 }
 

--- a/crates/openasr-core/src/models/xasr_zipformer/frontend.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/frontend.rs
@@ -4,20 +4,28 @@
 //! intentionally local to X-ASR because sherpa/icefall fbank parity is part of
 //! this family contract, not a generic OpenASR mel frontend.
 //!
-//! Deliberately **not** built on the shared batch engine in
-//! [`crate::models::kaldi_fbank`] (which firered_aed/dolphin/sensevoice do
-//! share): this frontend runs `snip_edges=false` framing with incremental,
-//! cacheable frame-range computation (`features_for_frame_range_from`,
-//! `earliest_sample_needed_for_frame`) for O(1)-memory streaming, skips
-//! pre-emphasis/DC-removal/int16 rescale entirely, and stores mel filters
-//! densely with precomputed per-mel bin ranges for that range slicing --
-//! folding it into the shared engine would mean threading streaming-only
-//! control flow through a batch-oriented API, i.e. a shared-layer special
-//! case rather than a config difference.
+//! The window/FFT/power-spectrum step now goes through
+//! [`crate::models::audio_frontend`]'s `StftFramer` via
+//! `PadMode::KaldiSnipEdgesFalse` (kaldi's asymmetric `snip_edges=false`
+//! offset, reflected against the *total* stream length rather than a
+//! once-materialized padded buffer), which preserves this frontend's O(1)
+//! streaming property: `power_spectrogram_kaldi_snip_edges_false_range`
+//! takes an explicit frame range plus a `sample_offset` for a tail-only
+//! buffer, so callers can drop consumed audio exactly as before
+//! (`features_for_frame_range_from`, `earliest_sample_needed_for_frame`).
+//! This is deliberately **not** the shared batch engine in
+//! [`crate::models::kaldi_fbank`] (which firered_aed/dolphin/sensevoice
+//! share): that engine computes a whole buffer in one call, and skips
+//! pre-emphasis/DC-removal/int16 rescale entirely here, plus stores mel
+//! filters densely with precomputed per-mel bin ranges for that range
+//! slicing -- folding *that* into the batch engine would still be a
+//! shared-layer special case rather than a config difference, so the
+//! frame-range caching and sparse-bin-range projection loop stay local.
 
-use std::sync::Arc;
-
-use realfft::{RealFftPlanner, RealToComplex};
+use crate::models::audio_frontend::mel::{FilterbankConfig, MelPointOrder, MelScale};
+use crate::models::audio_frontend::{
+    KaldiFrameRangeError, PadMode, StftFramer, povey_window_left_aligned,
+};
 
 pub(crate) const XASR_SAMPLE_RATE_HZ: u32 = 16_000;
 pub(crate) const XASR_CHANNELS: u16 = 1;
@@ -57,16 +65,17 @@ pub(crate) enum XasrFrontendError {
 
 #[derive(Clone)]
 pub(crate) struct XasrFbankFrontend {
-    window: Vec<f32>,
+    /// Owns the analysis window and the (planned-once) FFT; planning the
+    /// twiddle tables per call dominated the per-push cost of incremental
+    /// streaming fbank, which is why `StftFramer` builds its plan once at
+    /// construction rather than per `compute_frames_into` call.
+    framer: StftFramer,
     mel_filters: Vec<f32>,
     /// Per-mel half-open `[start, end)` range of nonzero filter bins; the
     /// triangular filters cover only a narrow band, so iterating the full
     /// 257-bin row wastes most of the multiply-adds.
     mel_bin_ranges: Vec<(usize, usize)>,
     fft_bins: usize,
-    /// Planned once: building the planner + twiddle tables per call dominated
-    /// the per-push cost of incremental streaming fbank.
-    fft: Arc<dyn RealToComplex<f32>>,
 }
 
 impl std::fmt::Debug for XasrFbankFrontend {
@@ -86,7 +95,15 @@ impl Default for XasrFbankFrontend {
 impl XasrFbankFrontend {
     pub(crate) fn new() -> Self {
         let fft_bins = N_FFT / 2 + 1;
-        let mel_filters = htk_mel_filterbank(N_MELS, N_FFT, fft_bins);
+        let mel_filters = crate::models::audio_frontend::mel::filterbank(FilterbankConfig {
+            scale: MelScale::Htk,
+            sample_rate_hz: XASR_SAMPLE_RATE_HZ as f32,
+            n_fft: N_FFT,
+            n_mels: N_MELS,
+            fmin: MEL_FMIN,
+            fmax: MEL_FMAX,
+            mel_point_order: MelPointOrder::SpanTimesIndexFirst,
+        });
         let mel_bin_ranges = (0..N_MELS)
             .map(|mel| {
                 let row = &mel_filters[mel * fft_bins..(mel + 1) * fft_bins];
@@ -95,12 +112,18 @@ impl XasrFbankFrontend {
                 (start, end.max(start))
             })
             .collect();
+        let framer = StftFramer::new(
+            N_FFT,
+            FRAME_LENGTH,
+            FRAME_SHIFT,
+            PadMode::KaldiSnipEdgesFalse,
+            povey_window_left_aligned(FRAME_LENGTH, N_FFT),
+        );
         Self {
-            window: povey_window(FRAME_LENGTH),
+            framer,
             mel_filters,
             mel_bin_ranges,
             fft_bins,
-            fft: RealFftPlanner::<f32>::new().plan_fft_forward(N_FFT),
         }
     }
 
@@ -179,28 +202,24 @@ impl XasrFbankFrontend {
         output: &mut [f32],
     ) -> Result<(), XasrFrontendError> {
         let total_len = sample_offset + samples.len();
-        let r2c = &self.fft;
-        let mut fft_in = r2c.make_input_vec();
-        let mut fft_out = r2c.make_output_vec();
-        let mut scratch = r2c.make_scratch_vec();
-        let mut power = vec![0.0_f32; self.fft_bins];
+        let spectrogram = self
+            .framer
+            .power_spectrogram_kaldi_snip_edges_false_range(
+                samples,
+                sample_offset,
+                total_len,
+                start_frame,
+                end_frame,
+            )
+            .map_err(|error| match error {
+                KaldiFrameRangeError::MissingPrefix { frame } => {
+                    XasrFrontendError::MissingPrefix { frame }
+                }
+            })?;
 
         for frame in start_frame..end_frame {
-            fft_in.fill(0.0);
-            let start = frame as isize * FRAME_SHIFT as isize - (FRAME_LENGTH as isize / 2)
-                + (FRAME_SHIFT as isize / 2);
-            for (i, sample) in fft_in.iter_mut().enumerate().take(FRAME_LENGTH) {
-                let absolute_idx = reflect_sample_index(start + i as isize, total_len);
-                let sample_idx = absolute_idx
-                    .checked_sub(sample_offset)
-                    .ok_or(XasrFrontendError::MissingPrefix { frame })?;
-                *sample = samples[sample_idx] * self.window[i];
-            }
-            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
-                .expect("rfft");
-            for (bin, value) in fft_out.iter().enumerate() {
-                power[bin] = value.norm_sqr();
-            }
+            let power = &spectrogram.data
+                [(frame - start_frame) * self.fft_bins..(frame - start_frame + 1) * self.fft_bins];
             let row_offset = (frame - start_frame) * N_MELS;
             for mel in 0..N_MELS {
                 let row = &self.mel_filters[mel * self.fft_bins..(mel + 1) * self.fft_bins];
@@ -241,65 +260,6 @@ fn snip_edges_false_frame_count(num_samples: usize) -> usize {
         return 0;
     }
     (num_samples + FRAME_SHIFT / 2) / FRAME_SHIFT
-}
-
-fn reflect_sample_index(index: isize, len: usize) -> usize {
-    if len <= 1 {
-        return 0;
-    }
-    let last = len as isize - 1;
-    let period = 2 * last;
-    let mut folded = index % period;
-    if folded < 0 {
-        folded += period;
-    }
-    if folded > last {
-        (period - folded) as usize
-    } else {
-        folded as usize
-    }
-}
-
-fn povey_window(length: usize) -> Vec<f32> {
-    (0..length)
-        .map(|i| {
-            let hann =
-                0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / (length - 1) as f32).cos();
-            hann.powf(0.85)
-        })
-        .collect()
-}
-
-fn hz_to_mel_htk(hz: f32) -> f32 {
-    1127.0 * (1.0 + hz / 700.0).ln()
-}
-
-fn mel_to_hz_htk(mel: f32) -> f32 {
-    700.0 * ((mel / 1127.0).exp() - 1.0)
-}
-
-fn htk_mel_filterbank(n_mels: usize, n_fft: usize, fft_bins: usize) -> Vec<f32> {
-    let mel_min = hz_to_mel_htk(MEL_FMIN);
-    let mel_max = hz_to_mel_htk(MEL_FMAX);
-    let mel_points = (0..n_mels + 2)
-        .map(|i| mel_min + (mel_max - mel_min) * i as f32 / (n_mels + 1) as f32)
-        .map(mel_to_hz_htk)
-        .collect::<Vec<_>>();
-    let fft_freqs = (0..fft_bins)
-        .map(|i| i as f32 * XASR_SAMPLE_RATE_HZ as f32 / n_fft as f32)
-        .collect::<Vec<_>>();
-    let mut filters = vec![0.0_f32; n_mels * fft_bins];
-    for mel in 0..n_mels {
-        let left = mel_points[mel];
-        let center = mel_points[mel + 1];
-        let right = mel_points[mel + 2];
-        for (bin, &freq) in fft_freqs.iter().enumerate() {
-            let lower = (freq - left) / (center - left);
-            let upper = (right - freq) / (right - center);
-            filters[mel * fft_bins + bin] = lower.min(upper).max(0.0);
-        }
-    }
-    filters
 }
 
 #[cfg(test)]
@@ -365,11 +325,16 @@ mod tests {
 
     #[test]
     fn reflection_stays_in_bounds() {
-        let values = (-20..20)
-            .map(|i| reflect_sample_index(i, 5))
+        // Same reflect-index math xasr shipped before this module existed,
+        // now `crate::models::audio_frontend::reflect_index_no_repeat`
+        // (pinned bit-exact there); re-checked here against xasr's own
+        // fixed points since this frontend depends on it directly.
+        use crate::models::audio_frontend::reflect_index_no_repeat;
+        let values = (-20i64..20)
+            .map(|i| reflect_index_no_repeat(5, i))
             .collect::<Vec<_>>();
         assert!(values.iter().all(|&i| i < 5));
-        assert_eq!(reflect_sample_index(-1, 5), 1);
-        assert_eq!(reflect_sample_index(5, 5), 3);
+        assert_eq!(reflect_index_no_repeat(5, -1), 1);
+        assert_eq!(reflect_index_no_repeat(5, 5), 3);
     }
 }


### PR DESCRIPTION
## Summary

Stage 2 of the shared audio-frontend DSP extraction (roadmap item C3, follow-up
to #95): migrates `whisper`, `dolphin`'s ESPnet-variant frontend, and
`xasr_zipformer`'s streaming fbank onto the shared `audio_frontend`
primitives (`StftFramer`, `mel::filterbank`) instead of each family's own
hand-rolled STFT/mel copy. One commit per family, each independently
compilable and testable.

## Why

#95 built the shared primitives and proved the pattern on `parakeet_ctc`,
leaving a documented road map of remaining per-family copies. This PR clears
three more entries off that list. Each family's own reduction order/precision
turned out to genuinely differ in a couple of places from what the shared
primitives already supported (confirmed by exhaustive bit comparison, not
assumed), so the shared primitives grew config extensions to carry each
family's exact arithmetic forward rather than forcing a family onto a
different family's rounding.

## Changes

### whisper (`crates/openasr-core/src/models/whisper/mel.rs`)

- STFT (frame + window + FFT) now goes through
  `audio_frontend::StftFramer` (`PadMode::ReflectCenter`) instead of a
  hand-rolled reflect-pad + FFT loop.
- Mel filterbank now goes through `audio_frontend::mel::filterbank`
  (`MelScale::Slaney`).
- whisper-specific business logic stays local: pad-or-trim to
  `target_frames * hop` (checked-arithmetic, `.oasr`-metadata-derived sizes),
  dropping the trailing STFT frame (OpenAI whisper's `log_spec[..., :-1]`),
  log10 dynamic-range normalization, and the mel-probe trace.
- Config extensions (both needed because whisper's own arithmetic order
  differs from `parakeet_ctc`'s, confirmed by exhaustive bit comparison, not
  just theoretically):
  - `audio_frontend::hann_window_periodic_scale_first`: whisper's
    scale-then-multiply Hann window construction (`win_length == n_fft`, no
    centering slack).
  - `audio_frontend::mel::MelPointOrder` (`SpanTimesIndexFirst` /
    `RatioFirst`): the mel-edge-placement operation order is now an explicit
    `FilterbankConfig` field. `SpanTimesIndexFirst` reproduces
    `parakeet_ctc`'s existing (unchanged) order; `RatioFirst` reproduces
    whisper's. `parakeet_ctc`'s two `FilterbankConfig` call sites pick up the
    new required field with their existing order (mechanical, unavoidable
    since the struct grew a field).

### dolphin ESPnet variant (`crates/openasr-core/src/models/dolphin/frontend.rs`)

- `DolphinEspnetFrontend`'s STFT now goes through `audio_frontend::StftFramer`
  (`PadMode::ReflectCenter`, same `n_fft=512`/`win=400`/`hop=160`), replacing
  a hand-rolled per-index reflect + FFT loop.
- Mel filterbank now goes through `audio_frontend::mel::filterbank`.
- The kaldi-variant `DolphinFbankFrontend`/`apply_global_cmvn` in the same
  file (`crate::models::kaldi_fbank`-backed) is untouched -- out of scope.
- Config extension: `MelScale::SlaneyF64Espnet` -- dolphin's own
  `build_slaney_mel_filters` ran the librosa Slaney mel-edge placement and
  ramp/area-normalization entirely in **f64** (only casting the final weight
  to f32); an exhaustive bit comparison shows this genuinely differs from the
  existing f32 `MelScale::Slaney` construction. The new variant is a literal
  port of dolphin's f64 pipeline (same operation order throughout).

### xasr_zipformer (`crates/openasr-core/src/models/xasr_zipformer/frontend.rs`)

- `XasrFbankFrontend`'s window/FFT/power-spectrum step now goes through a new
  `StftFramer` method instead of a hand-rolled reflect-index + FFT loop, while
  keeping the O(1)-memory incremental-streaming property #95 explicitly
  deferred (frame-range accounting and the sparse-mel-bin-range projection
  loop stay local).
- Mel filterbank now goes through `audio_frontend::mel::filterbank`
  (`MelScale::Htk`) directly -- xasr's existing mel-edge-placement order
  already matched `MelPointOrder::SpanTimesIndexFirst`, so no new order
  variant was needed there (unlike whisper's Slaney path).
- Config extensions (both anticipated by #95's own `PadMode` doc, which named
  "xasr's incremental reflect framing" as future work):
  - `PadMode::KaldiSnipEdgesFalse` +
    `StftFramer::power_spectrogram_kaldi_snip_edges_false_range`: kaldi's
    asymmetric `snip_edges=false` window offset (`win/2 - hop/2`, not
    `n_fft/2` centering), reflected against the *total* stream length. Takes
    an explicit frame range plus a `sample_offset` for a tail-only buffer,
    so incremental callers keep dropping consumed audio exactly as before;
    a dropped-prefix read returns `KaldiFrameRangeError::MissingPrefix`
    instead of panicking.
  - `audio_frontend::{povey_window_left_aligned, reflect_index_no_repeat}`:
    xasr's Povey window (left-aligned into the `n_fft` buffer, not centered
    -- the alignment convention `StftFramer`'s own docs called out as a
    future variant) and its per-index reflect lookup (the incremental analog
    of the existing array-based `reflect_pad`).
  - `StftFramer` gains `#[derive(Clone)]` (clones the `Arc`-held FFT plan)
    so `XasrFbankFrontend`, which embeds it, keeps its existing `Clone`
    derive.

All new config variants are pinned bit-exact (`assert_eq!`, not epsilon)
against a frozen copy of the pre-refactor per-family implementation in a new
unit test each.

## Byte-exact end-to-end evidence

Built two release `openasr-cli` binaries -- this branch's HEAD and its parent
commit (#95, `b35647e`, pre-stage-2) -- and ran `transcribe --format
verbose_json` against `fixtures/jfk.wav` and `fixtures/zh_sample.wav` for one
model per migrated family (plus dolphin's untouched kaldi variant as a
regression check), offline, against locally installed packs:

| Model | Family / frontend path | Fixture | sha256 (HEAD) | sha256 (parent) | Match |
|---|---|---|---|---|---|
| whisper-tiny | whisper | jfk.wav | `062a07dc...ff644` | `062a07dc...ff644` | identical |
| whisper-tiny | whisper | zh_sample.wav | `7840f33e...4657d` | `7840f33e...4657d` | identical |
| whisper-tiny.en | whisper | jfk.wav | `2a15440b...91001a` | `2a15440b...91001a` | identical |
| whisper-tiny.en | whisper | zh_sample.wav | `34bbd14c...a95a4f` | `34bbd14c...a95a4f` | identical |
| dolphin-base | dolphin (ESPnet variant, migrated) | jfk.wav | `7fa77372...277240` | `7fa77372...277240` | identical |
| dolphin-base | dolphin (ESPnet variant, migrated) | zh_sample.wav | `7331bb8a...28ec36` | `7331bb8a...28ec36` | identical |
| dolphin-cn-dialect-base | dolphin (kaldi variant, untouched) | jfk.wav | `0fa19eed...ac46b5c` | `0fa19eed...ac46b5c` | identical |
| dolphin-cn-dialect-base | dolphin (kaldi variant, untouched) | zh_sample.wav | `93bd1148...d309d71` | `93bd1148...d309d71` | identical |
| dolphin-cn-dialect-small | dolphin (kaldi variant, untouched) | jfk.wav | `332de691...403d3775` | `332de691...403d3775` | identical |
| dolphin-cn-dialect-small | dolphin (kaldi variant, untouched) | zh_sample.wav | `93bd1148...d309d71` | `93bd1148...d309d71` | identical |
| xasr-zh-en | xasr_zipformer | jfk.wav | `e96ed381...4a99de3` | `e96ed381...4a99de3` | identical |
| xasr-zh-en | xasr_zipformer | zh_sample.wav | `0b6f5bf0...66d2ce1` | `0b6f5bf0...66d2ce1` | identical |

All 12 sha256 pairs match exactly (0 diff). `dolphin-small`'s locally
installed pack directory was present but empty (pre-existing local install
issue, unrelated to this change) and was skipped; the ESPnet-variant path is
still covered by `dolphin-base`. Transcripts are real, non-empty, and
language-appropriate (spot-checked, not just identical-by-triviality).

## Golden / gate evidence

- `cargo fmt --check`: clean.
- `cargo clippy --all-targets -- -D warnings` (workspace): clean.
- `cargo test -p openasr-core golden_diff -- --nocapture`: 2 passed, 2 ignored
  (pre-existing, private-fixture-gated, unrelated to this change), 0 failed.
- `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`: 1 passed.
- `cargo nextest run --workspace`: **2404 passed** (2 slow), 122 skipped
  (private-fixture-gated, pre-existing), 0 failed.
- `cargo test --workspace --doc`: clean (0 doctests, as before).
- `tooling/publish-model/scripts/regenerate_all.sh --check`: catalog + prose
  locale drift check passed for all 27 models.
- `cargo deny check`: advisories/bans/licenses/sources ok (pre-existing
  duplicate-crate-version warnings only, not errors).
- Per-family unit tests: whisper's own pinned openai-whisper-slaney
  reference-point test, dolphin's own pinned librosa-reference-point
  filterbank test plus jfk.wav log-mel-value parity tests, and
  xasr_zipformer's own frame-range/head-tail consistency and clean-frame
  stability tests all pass unchanged (moved verbatim, not rewritten).
- New `audio_frontend` unit tests (all passing): bit-exact pins for
  `MelPointOrder::RatioFirst` vs. whisper's frozen pre-refactor filterbank,
  `MelScale::SlaneyF64Espnet` vs. dolphin's frozen pre-refactor filterbank,
  `hann_window_periodic_scale_first` vs. whisper's frozen hann window,
  `povey_window_left_aligned` and `reflect_index_no_repeat` vs. xasr's frozen
  pre-refactor functions, plus `power_spectrogram_kaldi_snip_edges_false_range`
  frame-range/head-tail-split and dropped-prefix-fails-closed coverage.

## Manual smoke checks

See "Byte-exact end-to-end evidence" above -- `openasr transcribe --format
verbose_json` against real installed packs and both committed fixtures for
every migrated family, offline.

## Docs updated

- [x] No behavior or limitations changed; no README/docs updates needed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does **not** migrate `cohere`, `qwen`, the two `diarize` DSP copies, or any
  pack-build importer -- left for their own follow-up PRs per #95's road map.
- Does **not** touch `kaldi_fbank.rs` or the kaldi-variant `DolphinFbankFrontend`
  in the same `dolphin/frontend.rs` file.
- Does **not** touch `models/builtin_execution_dispatch.rs`,
  `executor_component_registry.rs`, `prepared_runtime_cache.rs`, or
  `realtime/events.rs` (other in-flight work on those files).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts,
      secrets, or private audio.
- [x] I did not add vendored runtime sources outside
      `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage
      policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI
      assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI-assisted implementation of the whisper/
  dolphin/xasr_zipformer frontend migrations and the shared `audio_frontend`
  config extensions, under direct human direction and review.
