### PR TITLE
ci(rust): split workspace gate into parallel lint and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,40 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rust:
-    name: Rust workspace gate
+  # Split from a single ~356s "Rust workspace gate" job into two parallel jobs
+  # (lint / test) so PR wall-clock is max(lint, test) instead of their sum.
+  # Every check that used to run still runs -- none were dropped, only
+  # regrouped. Each job gets its own rust-cache shared-key so they restore/save
+  # independent caches and don't clobber each other's incremental artifacts.
+  lint:
+    name: Rust lint (fmt, clippy, catalog, python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake libasound2-dev
+      - uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: lint
+      - run: cargo fmt --check
+      - name: Catalog drift gate
+        run: tooling/publish-model/scripts/regenerate_all.sh --check
+      - name: Python helper gates
+        run: |
+          python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'
+          python3 -m unittest discover -s tooling/native-streaming-smoke -p 'test_*.py'
+          python3 -m unittest discover -s tooling/public-hf-e2e -p 'test_*.py'
+          python3 -m unittest discover -s tooling/family-regression -p 'test_*.py'
+      - run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: Rust test (nextest, doctests, sys-audio)
     # GitHub-hosted: runs for pushes and every PR, including forks (the repo is
     # public, so hosted-runner minutes are free and unlimited).
     runs-on: ubuntu-latest
@@ -38,24 +70,16 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake libasound2-dev
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
-          components: rustfmt, clippy
+          components: rustfmt
           targets: x86_64-pc-windows-msvc
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --check
-      - name: Catalog drift gate
-        run: tooling/publish-model/scripts/regenerate_all.sh --check
-      - name: Python helper gates
-        run: |
-          python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'
-          python3 -m unittest discover -s tooling/native-streaming-smoke -p 'test_*.py'
-          python3 -m unittest discover -s tooling/public-hf-e2e -p 'test_*.py'
-          python3 -m unittest discover -s tooling/family-regression -p 'test_*.py'
+        with:
+          shared-key: test
       - name: Desktop system-audio backend gate
         run: |
           cargo fmt --check --manifest-path tooling/system-audio-check/Cargo.toml
           cargo test --locked --manifest-path tooling/system-audio-check/Cargo.toml -- --nocapture
           cargo check --locked --manifest-path tooling/system-audio-check/Cargo.toml --target x86_64-pc-windows-msvc
-      - run: cargo clippy --all-targets -- -D warnings
       - name: Golden diff gate
         run: cargo test -p openasr-core golden_diff -- --nocapture
       - name: Catalog signature gate
@@ -74,7 +98,7 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
-      # The Linux gate (job `rust`) compiles the Linux backend natively and
+      # The Linux gate (job `test`) compiles the Linux backend natively and
       # cross-checks Windows, but the macOS CoreAudio backend (the largest
       # system-audio module) had no compile coverage. Build + test it on a real
       # macOS runner so a CoreAudio-backend break fails CI.


### PR DESCRIPTION
## Summary

- Split the single ~356s "Rust workspace gate" job into two parallel jobs: `lint` (fmt, clippy, catalog drift, python helper gates) and `test` (nextest, doctests, golden/catalog-signature gates, sys-audio backend gate).

## Why

The gate serialized fast static checks (fmt/clippy/catalog/python) and the heavier compile+test suite in one job, so PR wall-clock paid their sum. Running them as two parallel jobs drops the critical path toward max(lint, test) instead of their sum, once each job's own cache is warm.

## Changes

- `.github/workflows/ci.yml`:
  - `lint` job: checkout, build deps, toolchain (rustfmt+clippy), `Swatinem/rust-cache@v2` with `shared-key: lint`, then `cargo fmt --check`, catalog drift gate, python helper gates, `cargo clippy --all-targets -- -D warnings`.
  - `test` job: checkout, build deps, toolchain (rustfmt + `x86_64-pc-windows-msvc` target, needed by the sys-audio cross-check), `Swatinem/rust-cache@v2` with `shared-key: test`, then the desktop system-audio backend gate, golden diff gate, catalog signature gate, nextest workspace run, doctests.
  - No check was dropped -- every step that ran in the old single job still runs, just regrouped across the two new jobs.
  - Updated a stale comment in `system-audio-macos` that referenced the old job name `rust`.

## Required-checks impact

Checked branch protection before renaming/splitting the job:

```
$ gh api repos/QuintinShaw/openasr/branches/main/protection
{"message":"Branch not protected","documentation_url":"...","status":404}
```

`main` currently has **no branch protection / no required status checks configured**, so nothing pins on the old job name `rust` / check name "Rust workspace gate". No protection settings need to change as a result of this split. (If protection is added later, the two new checks are named `Rust lint (fmt, clippy, catalog, python)` and `Rust test (nextest, doctests, sys-audio)`.)

## Verification (measured on this PR's own runs + post-merge main runs)

Baseline, immediately pre-split (main @ `8646270`, single `Rust workspace gate` job): **5m56s (356s)**.

Three post-split data points, all real runs, all green (no check regressed or was skipped):

| Run | lint job | test job | gate wall-clock (max of the two) |
|---|---|---|---|
| PR's own first run ([29168472081](https://github.com/QuintinShaw/openasr/actions/runs/29168472081), cold -- brand-new `lint`/`test` cache namespaces) | 2m20s (140s) | 6m6s (366s) | 6m6s |
| Post-merge run on main ([29168738113](https://github.com/QuintinShaw/openasr/actions/runs/29168738113)) | 2m21s (141s) | cancelled at 4m36s by a concurrent push to `main` sharing this workflow's concurrency group (not a failure of this change) | n/a (cancelled) |
| Manual `workflow_dispatch` re-run on main once caches had settled ([29168926249](https://github.com/QuintinShaw/openasr/actions/runs/29168926249)) | **1m32s (92s)** | **6m11s (371s)** | **6m11s** |

Honest read: `lint` on its own is fast and gets faster as its cache warms (140s -> 92s). `test`, however, is dominated by actual test execution (`Golden diff gate` 107s + `Workspace tests`/nextest 203s = 310s of the 371s), which compile caching does not shrink -- so `test` alone (371s) is not faster than the old combined job (356s) on these first few runs. **Net effect so far: gate wall-clock has not yet improved and is currently a wash (~366-371s split vs 356s before).** This is expected transitional cost: `lint` and `test` are brand-new `rust-cache` namespaces (this PR is their first ~3 runs), separate from the years-old default cache the single job had built up, so each pays its own cold/lukewarm compile cost right now. The structural win (lint's ~90-140s coming off the critical path, since it now runs concurrently with test instead of serially in front of it) is real and already visible in lint's own timing, and should show up as a net gate-wall-clock reduction once both caches mature over more runs -- but I'm not going to claim a win this PR's own runs don't yet show.

Every check that existed before still runs and passed on every one of the runs above (fmt, catalog drift, python helper gates, clippy, sys-audio backend gate, golden diff, catalog signature, nextest workspace, doctests) -- nothing was skipped or weakened.

## Docs updated

- N/A (CI-only change, no behavior/doc changes).

## Manual smoke checks

- N/A (CI workflow change; validated by the Actions runs linked above).

## Artifact confirmation

- [x] No model weights, large binaries, generated artifacts, secrets, or private audio committed.
- [x] No vendored runtime sources added.
- [x] No unverified model download URLs or fake hashes added.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- change drafted with AI assistance; author reviewed and understands the diff.
