### PR TITLE
refactor(core): migrate pack-build mel filterbanks onto shared audio_frontend DSP

### DIFF
--- a/crates/openasr-core/src/models/dolphin/package_import.rs
+++ b/crates/openasr-core/src/models/dolphin/package_import.rs
@@ -56,6 +56,7 @@ use crate::ggml_runtime::{
     GgufWriteTensor, GgufWriteTensorType, GgufWriteValue, quantize_f32_to_ggml_tensor_data,
     read_gguf_tensor_index, write_gguf_file_v0,
 };
+use crate::models::audio_frontend::mel::{FilterbankConfig, MelPointOrder, MelScale, filterbank};
 use crate::models::dolphin::language::{
     DOLPHIN_DEFAULT_LANGUAGE_CODE, DOLPHIN_MULTILINGUAL_CATALOG_LANGUAGES,
     build_dolphin_decode_prefix, build_dolphin_multilingual_decode_prefix,
@@ -775,35 +776,25 @@ fn make_runtime_tensor(
 }
 
 /// Kaldi/HTK mel filterbank `[n_mels, fft_bins]` (peak-normalized triangles, no
-/// Slaney area norm) reconstructed from the `train.yaml` fbank config. Stored for
-/// the later frontend phase; NOT exercised by the encoder-from-pack load path
-/// (which is fed the CMVN'd golden features directly), so it is not yet parity
-/// verified against a golden fbank.
+/// Slaney area norm) reconstructed from the `train.yaml` fbank config, via the
+/// shared [`crate::models::audio_frontend::mel`] `MelScale::Kaldi` construction
+/// (same mel-domain math `crate::models::kaldi_fbank`'s runtime engine uses).
+/// Stored for the later frontend phase; NOT exercised by the encoder-from-pack
+/// load path (which is fed the CMVN'd golden features directly), so it is not
+/// yet parity verified against a golden fbank.
 fn build_mel_filterbank_tensor() -> GgufWriteTensor {
     let fft_bins = FFT_SIZE / 2 + 1;
     let high_hz = (SAMPLE_RATE_HZ as f32) / 2.0;
-    let mel_low = hz_to_mel(MEL_LOW_HZ);
-    let mel_high = hz_to_mel(high_hz);
-    let mel_delta = (mel_high - mel_low) / (FEATURE_DIM as f32 + 1.0);
-
-    let mut filters = vec![0.0_f32; FEATURE_DIM * fft_bins];
-    for mel_idx in 0..FEATURE_DIM {
-        let left = mel_low + (mel_idx as f32) * mel_delta;
-        let center = mel_low + (mel_idx as f32 + 1.0) * mel_delta;
-        let right = mel_low + (mel_idx as f32 + 2.0) * mel_delta;
-        for (bin_idx, cell) in filters
-            .iter_mut()
-            .skip(mel_idx * fft_bins)
-            .take(fft_bins)
-            .enumerate()
-        {
-            let hz = (bin_idx as f32) * (SAMPLE_RATE_HZ as f32) / (FFT_SIZE as f32);
-            let mel = hz_to_mel(hz);
-            let rising = (mel - left) / (center - left);
-            let falling = (right - mel) / (right - center);
-            *cell = rising.min(falling).max(0.0);
-        }
-    }
+    let filters = filterbank(FilterbankConfig {
+        scale: MelScale::Kaldi,
+        sample_rate_hz: SAMPLE_RATE_HZ as f32,
+        n_fft: FFT_SIZE,
+        n_mels: FEATURE_DIM,
+        fmin: MEL_LOW_HZ,
+        fmax: high_hz,
+        // Not consulted by `MelScale::Kaldi` (mel-domain edges, no round-trip).
+        mel_point_order: MelPointOrder::SpanTimesIndexFirst,
+    });
     let mut bytes = Vec::with_capacity(filters.len() * 4);
     for value in &filters {
         bytes.extend_from_slice(&value.to_le_bytes());
@@ -814,11 +805,6 @@ fn build_mel_filterbank_tensor() -> GgufWriteTensor {
         tensor_type: GgufWriteTensorType::F32,
         data: bytes,
     }
-}
-
-/// Kaldi/HTK mel scale: `mel(f) = 1127 * ln(1 + f / 700)`.
-fn hz_to_mel(hz: f32) -> f32 {
-    1127.0 * (1.0 + hz / 700.0).ln()
 }
 
 fn dolphin_runtime_gguf_metadata(
@@ -1153,5 +1139,60 @@ mod tests {
                 "mel weight out of range: {value}"
             );
         }
+    }
+
+    /// Exact reimplementation of this importer's pre-shared-mel-module
+    /// `build_mel_filterbank_tensor`/`hz_to_mel` (the version that shipped
+    /// before it was switched to `crate::models::audio_frontend::mel`'s
+    /// `MelScale::Kaldi` construction), kept only here to pin the baked
+    /// `dolphin.mel_filters` tensor to a byte-identical value across the
+    /// migration.
+    fn reference_pre_refactor_build_mel_filterbank_tensor() -> GgufWriteTensor {
+        fn hz_to_mel(hz: f32) -> f32 {
+            1127.0 * (1.0 + hz / 700.0).ln()
+        }
+        let fft_bins = FFT_SIZE / 2 + 1;
+        let high_hz = (SAMPLE_RATE_HZ as f32) / 2.0;
+        let mel_low = hz_to_mel(MEL_LOW_HZ);
+        let mel_high = hz_to_mel(high_hz);
+        let mel_delta = (mel_high - mel_low) / (FEATURE_DIM as f32 + 1.0);
+
+        let mut filters = vec![0.0_f32; FEATURE_DIM * fft_bins];
+        for mel_idx in 0..FEATURE_DIM {
+            let left = mel_low + (mel_idx as f32) * mel_delta;
+            let center = mel_low + (mel_idx as f32 + 1.0) * mel_delta;
+            let right = mel_low + (mel_idx as f32 + 2.0) * mel_delta;
+            for (bin_idx, cell) in filters
+                .iter_mut()
+                .skip(mel_idx * fft_bins)
+                .take(fft_bins)
+                .enumerate()
+            {
+                let hz = (bin_idx as f32) * (SAMPLE_RATE_HZ as f32) / (FFT_SIZE as f32);
+                let mel = hz_to_mel(hz);
+                let rising = (mel - left) / (center - left);
+                let falling = (right - mel) / (right - center);
+                *cell = rising.min(falling).max(0.0);
+            }
+        }
+        let mut bytes = Vec::with_capacity(filters.len() * 4);
+        for value in &filters {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        GgufWriteTensor {
+            name: "dolphin.mel_filters".to_string(),
+            dims: vec![FEATURE_DIM as u64, fft_bins as u64],
+            tensor_type: GgufWriteTensorType::F32,
+            data: bytes,
+        }
+    }
+
+    #[test]
+    fn mel_filterbank_tensor_is_byte_identical_to_pre_refactor_impl() {
+        let expected = reference_pre_refactor_build_mel_filterbank_tensor();
+        let actual = build_mel_filterbank_tensor();
+        assert_eq!(expected.dims, actual.dims);
+        assert_eq!(expected.tensor_type, actual.tensor_type);
+        assert_eq!(expected.data, actual.data);
     }
 }

--- a/crates/openasr-core/src/models/firered_aed/package_import.rs
+++ b/crates/openasr-core/src/models/firered_aed/package_import.rs
@@ -49,6 +49,7 @@ use crate::ggml_runtime::{
     GgufWriteTensor, GgufWriteTensorType, GgufWriteValue, quantize_f32_to_ggml_tensor_data,
     read_gguf_tensor_index, write_gguf_file_v0,
 };
+use crate::models::audio_frontend::mel::{FilterbankConfig, MelPointOrder, MelScale, filterbank};
 use crate::models::ggml_family_adapter::GGML_TOKENIZER_ID_KEY;
 use crate::models::local_source_import::{
     LocalSourceImportError, SafetensorsFile, decode_safetensors_payload_as_f16_bits,
@@ -812,32 +813,21 @@ fn build_firered_runtime_tensors(
 
 /// Kaldi/HTK mel filterbank `[n_mels, fft_bins]` (peak-normalized triangles)
 /// for the frontend phase, matching the dolphin fbank convention (both
-/// frontends are kaldi-style 80-mel/25ms/10ms/16kHz).
+/// frontends are kaldi-style 80-mel/25ms/10ms/16kHz), via the shared
+/// [`crate::models::audio_frontend::mel`] `MelScale::Kaldi` construction.
 fn build_mel_filterbank_tensor(n_mels: usize) -> GgufWriteTensor {
     let fft_bins = FFT_SIZE / 2 + 1;
     let high_hz = (SAMPLE_RATE_HZ as f32) / 2.0;
-    let mel_low = hz_to_mel(MEL_LOW_HZ);
-    let mel_high = hz_to_mel(high_hz);
-    let mel_delta = (mel_high - mel_low) / (n_mels as f32 + 1.0);
-
-    let mut filters = vec![0.0_f32; n_mels * fft_bins];
-    for mel_idx in 0..n_mels {
-        let left = mel_low + (mel_idx as f32) * mel_delta;
-        let center = mel_low + (mel_idx as f32 + 1.0) * mel_delta;
-        let right = mel_low + (mel_idx as f32 + 2.0) * mel_delta;
-        for (bin_idx, cell) in filters
-            .iter_mut()
-            .skip(mel_idx * fft_bins)
-            .take(fft_bins)
-            .enumerate()
-        {
-            let hz = (bin_idx as f32) * (SAMPLE_RATE_HZ as f32) / (FFT_SIZE as f32);
-            let mel = hz_to_mel(hz);
-            let rising = (mel - left) / (center - left);
-            let falling = (right - mel) / (right - center);
-            *cell = rising.min(falling).max(0.0);
-        }
-    }
+    let filters = filterbank(FilterbankConfig {
+        scale: MelScale::Kaldi,
+        sample_rate_hz: SAMPLE_RATE_HZ as f32,
+        n_fft: FFT_SIZE,
+        n_mels,
+        fmin: MEL_LOW_HZ,
+        fmax: high_hz,
+        // Not consulted by `MelScale::Kaldi` (mel-domain edges, no round-trip).
+        mel_point_order: MelPointOrder::SpanTimesIndexFirst,
+    });
     let mut bytes = Vec::with_capacity(filters.len() * 4);
     for value in &filters {
         bytes.extend_from_slice(&value.to_le_bytes());
@@ -848,11 +838,6 @@ fn build_mel_filterbank_tensor(n_mels: usize) -> GgufWriteTensor {
         tensor_type: GgufWriteTensorType::F32,
         data: bytes,
     }
-}
-
-/// Kaldi/HTK mel scale: `mel(f) = 1127 * ln(1 + f / 700)`.
-fn hz_to_mel(hz: f32) -> f32 {
-    1127.0 * (1.0 + hz / 700.0).ln()
 }
 
 fn firered_runtime_gguf_metadata(
@@ -1227,6 +1212,63 @@ mod tests {
                 assert!(message.contains("unrecognized tensor"), "{message}");
             }
             other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    /// Exact reimplementation of this importer's pre-shared-mel-module
+    /// `build_mel_filterbank_tensor`/`hz_to_mel` (the version that shipped
+    /// before it was switched to `crate::models::audio_frontend::mel`'s
+    /// `MelScale::Kaldi` construction), kept only here to pin the baked
+    /// `firered.mel_filters` tensor to a byte-identical value across the
+    /// migration.
+    fn reference_pre_refactor_build_mel_filterbank_tensor(n_mels: usize) -> GgufWriteTensor {
+        fn hz_to_mel(hz: f32) -> f32 {
+            1127.0 * (1.0 + hz / 700.0).ln()
+        }
+        let fft_bins = FFT_SIZE / 2 + 1;
+        let high_hz = (SAMPLE_RATE_HZ as f32) / 2.0;
+        let mel_low = hz_to_mel(MEL_LOW_HZ);
+        let mel_high = hz_to_mel(high_hz);
+        let mel_delta = (mel_high - mel_low) / (n_mels as f32 + 1.0);
+
+        let mut filters = vec![0.0_f32; n_mels * fft_bins];
+        for mel_idx in 0..n_mels {
+            let left = mel_low + (mel_idx as f32) * mel_delta;
+            let center = mel_low + (mel_idx as f32 + 1.0) * mel_delta;
+            let right = mel_low + (mel_idx as f32 + 2.0) * mel_delta;
+            for (bin_idx, cell) in filters
+                .iter_mut()
+                .skip(mel_idx * fft_bins)
+                .take(fft_bins)
+                .enumerate()
+            {
+                let hz = (bin_idx as f32) * (SAMPLE_RATE_HZ as f32) / (FFT_SIZE as f32);
+                let mel = hz_to_mel(hz);
+                let rising = (mel - left) / (center - left);
+                let falling = (right - mel) / (right - center);
+                *cell = rising.min(falling).max(0.0);
+            }
+        }
+        let mut bytes = Vec::with_capacity(filters.len() * 4);
+        for value in &filters {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        GgufWriteTensor {
+            name: "firered.mel_filters".to_string(),
+            dims: vec![n_mels as u64, fft_bins as u64],
+            tensor_type: GgufWriteTensorType::F32,
+            data: bytes,
+        }
+    }
+
+    #[test]
+    fn mel_filterbank_tensor_is_byte_identical_to_pre_refactor_impl() {
+        for n_mels in [80usize, 128usize] {
+            let expected = reference_pre_refactor_build_mel_filterbank_tensor(n_mels);
+            let actual = build_mel_filterbank_tensor(n_mels);
+            assert_eq!(expected.dims, actual.dims, "n_mels={n_mels}");
+            assert_eq!(expected.tensor_type, actual.tensor_type, "n_mels={n_mels}");
+            assert_eq!(expected.data, actual.data, "n_mels={n_mels}");
         }
     }
 }

--- a/crates/openasr-core/src/models/qwen/package_import.rs
+++ b/crates/openasr-core/src/models/qwen/package_import.rs
@@ -10,6 +10,7 @@ use crate::ggml_runtime::{
     read_gguf_tensor_index_from_runtime_source, validate_ggml_runtime_source_path,
     write_gguf_file_v0,
 };
+use crate::models::audio_frontend::mel::{FilterbankConfig, MelPointOrder, MelScale, filterbank};
 use crate::models::ggml_family_adapter::GGML_TOKENIZER_ID_KEY;
 use crate::models::ggml_family_registry::{
     QWEN3_ASR_AUDIO_FRONTEND_ID, QWEN3_ASR_DECODE_POLICY_ID, QWEN3_ASR_GGML_ARCHITECTURE_ID,
@@ -835,6 +836,10 @@ fn hann_window(length: usize) -> Vec<f32> {
         .collect()
 }
 
+/// Slaney-scale filterbank, via the shared
+/// [`crate::models::audio_frontend::mel`] `MelScale::Slaney` +
+/// `MelPointOrder::RatioFirst` construction (the same hz<->mel warp, edge
+/// placement, and ramp/area-normalization `whisper`'s frontend uses).
 fn slaney_mel_filterbank(
     n_mels: usize,
     n_fft: usize,
@@ -843,57 +848,27 @@ fn slaney_mel_filterbank(
     fmax: f32,
 ) -> Result<Vec<f32>, LocalSourceImportError> {
     let fft_bins = n_fft / 2 + 1;
-    let fft_frequencies = (0..fft_bins)
-        .map(|bin| bin as f32 * sample_rate as f32 / n_fft as f32)
-        .collect::<Vec<_>>();
-    let mel_min = hz_to_mel(fmin);
-    let mel_max = hz_to_mel(fmax);
-    let mel_points = (0..n_mels + 2)
-        .map(|index| {
-            let ratio = index as f32 / (n_mels + 1) as f32;
-            mel_to_hz(mel_min + ratio * (mel_max - mel_min))
-        })
-        .collect::<Vec<_>>();
+    let mel_major = filterbank(FilterbankConfig {
+        scale: MelScale::Slaney,
+        sample_rate_hz: sample_rate as f32,
+        n_fft,
+        n_mels,
+        fmin,
+        fmax,
+        mel_point_order: MelPointOrder::RatioFirst,
+    });
     // GGUF stores qwen audio.mel_filters with dims [n_mels, fft_bins], but
     // ggml's ne0/ne1 memory layout makes the contiguous payload freq-major.
-    // Keep the runtime contract aligned with the working cstr reference.
+    // Keep the runtime contract aligned with the working cstr reference:
+    // transpose the shared module's mel-major `[n_mels, fft_bins]` matrix
+    // into `[fft_bins, n_mels]` (bin-major, mel innermost).
     let mut filters = vec![0.0_f32; n_mels * fft_bins];
     for mel_idx in 0..n_mels {
-        let left = mel_points[mel_idx];
-        let center = mel_points[mel_idx + 1];
-        let right = mel_points[mel_idx + 2];
-        let norm = 2.0 / (right - left).max(f32::EPSILON);
-        for (bin_idx, hz) in fft_frequencies.iter().copied().enumerate() {
-            let rising = (hz - left) / (center - left).max(f32::EPSILON);
-            let falling = (right - hz) / (right - center).max(f32::EPSILON);
-            filters[bin_idx * n_mels + mel_idx] = rising.min(falling).max(0.0) * norm;
+        for bin_idx in 0..fft_bins {
+            filters[bin_idx * n_mels + mel_idx] = mel_major[mel_idx * fft_bins + bin_idx];
         }
     }
     Ok(filters)
-}
-
-fn hz_to_mel(hz: f32) -> f32 {
-    let linear_scale = 200.0 / 3.0;
-    let min_log_hz = 1000.0;
-    let min_log_mel = min_log_hz / linear_scale;
-    if hz < min_log_hz {
-        hz / linear_scale
-    } else {
-        let log_step = 6.4_f32.ln() / 27.0;
-        min_log_mel + (hz / min_log_hz).ln() / log_step
-    }
-}
-
-fn mel_to_hz(mel: f32) -> f32 {
-    let linear_scale = 200.0 / 3.0;
-    let min_log_hz = 1000.0;
-    let min_log_mel = min_log_hz / linear_scale;
-    if mel < min_log_mel {
-        mel * linear_scale
-    } else {
-        let log_step = 6.4_f32.ln() / 27.0;
-        min_log_hz * (log_step * (mel - min_log_mel)).exp()
-    }
 }
 
 #[cfg(test)]
@@ -950,6 +925,81 @@ mod tests {
 
         for row in rows {
             assert_eq!(row.len(), 4);
+        }
+    }
+
+    /// Exact reimplementation of this importer's pre-shared-mel-module
+    /// `slaney_mel_filterbank`/`hz_to_mel`/`mel_to_hz` (the version that
+    /// shipped before it was switched to
+    /// `crate::models::audio_frontend::mel`'s `MelScale::Slaney` +
+    /// `MelPointOrder::RatioFirst` construction), kept only here to pin the
+    /// baked `audio.mel_filters` tensor to a byte-identical value across the
+    /// migration. Freq-major layout (`[fft_bins, n_mels]`), same as the live
+    /// function.
+    fn reference_pre_refactor_slaney_mel_filterbank(
+        n_mels: usize,
+        n_fft: usize,
+        sample_rate: u32,
+        fmin: f32,
+        fmax: f32,
+    ) -> Vec<f32> {
+        fn hz_to_mel(hz: f32) -> f32 {
+            let linear_scale = 200.0 / 3.0;
+            let min_log_hz = 1000.0;
+            let min_log_mel = min_log_hz / linear_scale;
+            if hz < min_log_hz {
+                hz / linear_scale
+            } else {
+                let log_step = 6.4_f32.ln() / 27.0;
+                min_log_mel + (hz / min_log_hz).ln() / log_step
+            }
+        }
+        fn mel_to_hz(mel: f32) -> f32 {
+            let linear_scale = 200.0 / 3.0;
+            let min_log_hz = 1000.0;
+            let min_log_mel = min_log_hz / linear_scale;
+            if mel < min_log_mel {
+                mel * linear_scale
+            } else {
+                let log_step = 6.4_f32.ln() / 27.0;
+                min_log_hz * (log_step * (mel - min_log_mel)).exp()
+            }
+        }
+        let fft_bins = n_fft / 2 + 1;
+        let fft_frequencies = (0..fft_bins)
+            .map(|bin| bin as f32 * sample_rate as f32 / n_fft as f32)
+            .collect::<Vec<_>>();
+        let mel_min = hz_to_mel(fmin);
+        let mel_max = hz_to_mel(fmax);
+        let mel_points = (0..n_mels + 2)
+            .map(|index| {
+                let ratio = index as f32 / (n_mels + 1) as f32;
+                mel_to_hz(mel_min + ratio * (mel_max - mel_min))
+            })
+            .collect::<Vec<_>>();
+        let mut filters = vec![0.0_f32; n_mels * fft_bins];
+        for mel_idx in 0..n_mels {
+            let left = mel_points[mel_idx];
+            let center = mel_points[mel_idx + 1];
+            let right = mel_points[mel_idx + 2];
+            let norm = 2.0 / (right - left).max(f32::EPSILON);
+            for (bin_idx, hz) in fft_frequencies.iter().copied().enumerate() {
+                let rising = (hz - left) / (center - left).max(f32::EPSILON);
+                let falling = (right - hz) / (right - center).max(f32::EPSILON);
+                filters[bin_idx * n_mels + mel_idx] = rising.min(falling).max(0.0) * norm;
+            }
+        }
+        filters
+    }
+
+    #[test]
+    fn mel_filterbank_is_byte_identical_to_pre_refactor_impl() {
+        for n_mels in [80usize, 128usize] {
+            let expected =
+                reference_pre_refactor_slaney_mel_filterbank(n_mels, 400, 16_000, 0.0, 8_000.0);
+            let actual = super::slaney_mel_filterbank(n_mels, 400, 16_000, 0.0, 8_000.0)
+                .expect("filterbank");
+            assert_eq!(expected, actual, "n_mels={n_mels}");
         }
     }
 }


### PR DESCRIPTION
## Summary

Migrates the three remaining pack-build (`.oasr` importer) mel filterbank
constructions -- `dolphin`, `firered_aed`, `qwen` -- onto the shared
`crate::models::audio_frontend::mel` module, closing the last item from the
copy inventory in #95's PR description. Runtime-side frontends already moved
onto this module in #95/#99; this PR only touches the pack-build (baked
tensor) side.

## Why

Each importer baked its own copy of the mel-filterbank math at packaging
time. `dolphin`/`firered_aed` duplicated the same kaldi/HTK mel-domain
construction `crate::models::kaldi_fbank`'s runtime engine already
implements once (and the shared module now exposes as `MelScale::Kaldi`);
`qwen` duplicated the Slaney construction `whisper`'s frontend uses (now
`MelScale::Slaney` + `MelPointOrder::RatioFirst`). Keeping a third copy of
this math per family risked silent drift between pack-build and runtime.

## Changes

Per-file parameter mapping used to call the shared `mel::filterbank`:

| File / function | `MelScale` | `MelPointOrder` | `fmin` | `fmax` | `n_fft` | `sample_rate_hz` | stored layout |
|---|---|---|---|---|---|---|---|
| `dolphin/package_import.rs::build_mel_filterbank_tensor` | `Kaldi` | unused (mel-domain edges, no round-trip) | 20.0 | 8000.0 (`sr/2`) | 512 | 16000 | `[n_mels, fft_bins]` mel-major, unchanged |
| `firered_aed/package_import.rs::build_mel_filterbank_tensor` | `Kaldi` | unused | 20.0 | 8000.0 (`sr/2`) | 512 | 16000 | `[n_mels, fft_bins]` mel-major, unchanged |
| `qwen/package_import.rs::slaney_mel_filterbank` | `Slaney` | `RatioFirst` | 0.0 | 8000.0 | 400 | 16000 | `[fft_bins, n_mels]` freq-major -- shared call returns mel-major, transposed after (ggml `ne0/ne1` contract, unchanged from before) |

No new `MelScale`/`MelPointOrder` variants were needed -- all three configs
matched existing variants exactly (`Kaldi` already existed for
`kaldi_fbank`; `Slaney` + `RatioFirst` already existed for `whisper`, same
`n_fft`/`fmin`/`fmax`/sample-rate family).

- `crates/openasr-core/src/models/dolphin/package_import.rs`: `hz_to_mel` +
  the hand-rolled mel-domain loop in `build_mel_filterbank_tensor` replaced
  by a single `mel::filterbank(FilterbankConfig { scale: MelScale::Kaldi, ... })`
  call.
- `crates/openasr-core/src/models/firered_aed/package_import.rs`: same
  change (parametrized by `n_mels`).
- `crates/openasr-core/src/models/qwen/package_import.rs`: `hz_to_mel` /
  `mel_to_hz` removed; `slaney_mel_filterbank` now calls the shared
  `MelScale::Slaney` + `MelPointOrder::RatioFirst` construction and
  transposes mel-major -> freq-major for the GGUF tensor payload.

## Same-source (bit-identical) verification

Per file, the pre-refactor implementation is kept inlined in a test-only
`reference_pre_refactor_*` function and asserted byte-for-byte equal to the
new shared-module call's output:

- `dolphin::package_import::tests::mel_filterbank_tensor_is_byte_identical_to_pre_refactor_impl`
- `firered_aed::package_import::tests::mel_filterbank_tensor_is_byte_identical_to_pre_refactor_impl`
  (checked at both `n_mels = 80` and `128`)
- `qwen::package_import::tests::mel_filterbank_is_byte_identical_to_pre_refactor_impl`
  (checked at both `n_mels = 80` and `128`)

All three pass with `assert_eq!` on the full `Vec<f32>` (or `GgufWriteTensor`
including `dims`/`tensor_type`/raw `data` bytes), i.e. every mel weight is
identical down to the bit pattern, not just numerically close.

`tooling/publish-model/scripts/regenerate_all.sh --check` also passed
(`catalog drift check passed for 27 model(s)`), confirming the registry/
catalog metadata this change could affect has not drifted.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2415 passed, 0 failed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources ok; pre-existing
      unrelated duplicate-dependency warnings only)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`
- [x] `tooling/publish-model/scripts/regenerate_all.sh --check`
- [x] `python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'` (155 passed)

## Manual smoke checks

None beyond the automated suite above -- this is a pure refactor of
pack-build tensor generation, verified by the byte-identical tests above
rather than an end-to-end pack build (no local checkpoint fixtures for
these three families in this environment).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities. (No user-facing behavior
      change; baked tensor bytes are provably unchanged.)

## Scope / non-goals

- Does not touch the runtime-side `kaldi_fbank.rs` mel-filter construction
  (still its own copy; a separate follow-up per the module's own doc
  comment).
- Does not touch `api/backend/native_transcribe.rs` or the
  `openasr-server` response structs/codegen (owned by other in-flight work).
- Does not change any baked tensor value, GGUF tensor name, or metadata key.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented by an AI coding agent under human supervision (code, tests, and verification run by the agent; reviewed by the submitter).
