### PR TITLE
chore(core): 0.1.13 tech-debt sweep -- changelog, devices docs, dead API, winnow, FFI header gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
           python3 -m unittest discover -s tooling/public-hf-e2e -p 'test_*.py'
           python3 -m unittest discover -s tooling/family-regression -p 'test_*.py'
       - run: cargo clippy --all-targets -- -D warnings
+      - name: Install cbindgen
+        run: cargo install cbindgen --locked
+      - name: FFI header drift gate
+        run: scripts/generate-ffi-header.sh --check
 
   test:
     name: Rust test (nextest, doctests, sys-audio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Server: `/health` now reports `model_resident`, whether the bound model's native runtime is currently loaded in memory versus idle-unloaded (or not yet loaded this boot) -- lets clients (e.g. the desktop status indicator) distinguish "ready, instant transcription" from "bound but will pay a cold rebuild on the next request" without guessing from the `idle_unload` timer. Additive; `model_installed` is unchanged.
+- Server: `GET /v1/devices` enumerates the daemon's own ggml compute devices (Auto/CPU/accelerated), so a UI can read the backends inference actually runs on instead of enumerating its own runtime -- a shell built in a different backend shape than the sidecar (e.g. a CPU-only desktop supervising a Vulkan sidecar on Windows) previously hid the GPU. Device shaping (`compute_devices_from_runtime`, `default_execution_target`, `ComputeDevice`) lives in `openasr-core` as the single source of truth, reused by the endpoint and by a shell offline fallback.
 
 ### Changed
 
 - Core: the offline and realtime-streaming dispatch stacks now share one process-wide executor instance for qwen, cohere, whisper, and moonshine (the families that host-materialize a prepared runtime instead of relying purely on the pack's own mmap), instead of each stack holding its own independent instance and cache. A model warmed on both stacks no longer pays for its resident weights twice: measured on `qwen3-asr-0.6b` q4_k, warming both stacks on the same pack now costs ~1x instead of ~2x (2965 MiB -> 2197 MiB physical footprint in a same-process repro). AED/CTC/transducer families keep zero-copy mmap-shared weights already and are unaffected.
+
+### Fixed
+
+- `ggml`: statically-linked builds (macOS, Linux, and Windows GPU-feature builds where `GGML_BACKEND_DL` is off) no longer unconditionally `dlopen()` every `ggml-*.dll` next to the exe on startup -- harmless on its own, but actively dangerous when the exe directory also carries CPU BACKEND_DL plugin DLLs (e.g. a desktop bundle shipping them for other components): loading a second copy of ggml core collided with the statically-linked copy's global state and fastfailed the process. The backend directory scan is now gated on `OPENASR_GGML_BACKEND_DL_ENABLED` (same pattern as `OPENASR_GGML_NATIVE_ENABLED`); genuine `GGML_BACKEND_DL` builds are unaffected. Also: `catalog.public.json`/`catalog.public.signature.json` were missing from the `eol=lf` rules covering the private catalog trio, so Windows checkouts with `core.autocrlf=true` rewrote them to CRLF and broke the bundled-catalog sha256 signature check (fail-closed, blocking desktop bundling on Windows).
 
 ## [0.1.12] - 2026-07-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,26 +2753,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -2791,9 +2782,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -2802,7 +2793,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -3412,12 +3403,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1.37", features = ["macros", "net", "rt-multi-thread", "sig
 tokio-stream = "0.1"
 tokio-rustls = "0.26"
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect"] }
-toml = "0.9"
+toml = "1"
 tower = "0.5"
 unicode-general-category = "1.1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -674,32 +674,6 @@ impl Listener for TlsListener {
     }
 }
 
-/// Generates a brand-new, wholly ephemeral self-signed identity for
-/// `subject_alt_names` and returns its certificate fingerprint. **Not** a
-/// preview of, or in any way tied to, the identity a real
-/// `--tls-self-signed` daemon actually serves: it calls
-/// `self_signed_tls_identity` directly (bypassing
-/// `load_or_generate_self_signed_tls_identity` and any `tls_identity_store`),
-/// so every call mints a fresh keypair+certificate with its own fingerprint,
-/// independent of whatever a running daemon has persisted to
-/// `OPENASR_HOME/tls-identity.json`. Do not use this to predict or display
-/// "the" server fingerprint for a paired/persisted identity -- read that from
-/// a live server's `/health` or pairing response instead. Kept as-is
-/// (unchanged by the TLS-identity-persistence work) because nothing in this
-/// codebase currently calls it for that purpose; if a future caller wants a
-/// persistence-aware preview, it should call
-/// `load_or_generate_self_signed_tls_identity` (or a thin wrapper around it)
-/// instead of this function.
-pub fn server_certificate_fingerprint_for_subject_alt_names(
-    subject_alt_names: impl IntoIterator<Item = impl Into<String>>,
-) -> anyhow::Result<String> {
-    let tls = ServerTlsConfig::self_signed(subject_alt_names);
-    let ServerTlsConfig::SelfSigned { subject_alt_names } = tls else {
-        unreachable!("self_signed always returns self-signed config")
-    };
-    Ok(self_signed_tls_identity(&subject_alt_names)?.certificate_sha256)
-}
-
 fn validate_listen_security(
     addr: SocketAddr,
     launch_options: &ServerLaunchOptions,

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -122,6 +122,11 @@ remote-serving flow.
   pack's runtime is currently loaded in memory, vs. idle-unloaded or not yet
   loaded this boot).
 - `GET /v1/models` -- installed packs.
+- `GET /v1/devices` -- OpenASR extension (0.1.13+): read-only enumeration of
+  this daemon's own ggml compute devices (always `auto` + `cpu`, plus an
+  `accelerated` entry when the runtime detects a GPU) and
+  `default_execution_target` (what `auto` resolves to here). Not
+  operator-gated.
 - `POST /v1/audio/transcriptions` -- OpenAI-compatible transcription
   (multipart `file` + `model`; `response_format` of `json`, `text`, `srt`,
   `vtt`, `verbose_json`, or `markdown`).

--- a/skills/openasr/references/http-api.md
+++ b/skills/openasr/references/http-api.md
@@ -50,6 +50,15 @@ pack that is being served.
 - `POST /v1/audio/transcriptions/{id}/pause|resume|cancel` -- OpenASR
   extension: control an in-flight request that supplied a `transcription_id`
   form field.
+- `GET /v1/devices` -- OpenASR extension (0.1.13+): read-only enumeration of
+  this daemon's own ggml compute devices (`{"object":"devices",
+  "default_execution_target","devices":[{"id","name","meta","kind","target",
+  "effective_target","memory"?}]}`). Always includes `auto` and `cpu`; an
+  `accelerated` entry (Metal/CUDA/Vulkan/HIP, per platform) is present only
+  when the runtime detects one. `default_execution_target` is what `auto`
+  resolves to on this daemon (`cpu` or `accelerated`). Not operator-gated --
+  same local-auth layer as `/v1/models`. Intended for a UI's execution-target
+  picker; reflects the daemon's own runtime, not a remote sidecar's.
 
 ## OpenAI parameter compatibility matrix
 


### PR DESCRIPTION
## Summary

0.1.13 tech-debt ledger sweep (mechanical items): backfill two missing CHANGELOG entries, document the `GET /v1/devices` endpoint, remove a dead public API, collapse a duplicate transitive dependency, and wire an existing CI gate script into the main per-PR workflow.

## Why

Routine housekeeping identified in a full-repo tech-debt audit ahead of 0.1.13: doc/changelog drift after merges, a zero-caller public function that is a semantic trap, a duplicate-version dependency warning, and a CI gate script that existed but was only wired into release/manual workflows instead of the fast per-PR gate.

## Changes

- `CHANGELOG.md`: add `[Unreleased]` entries for #88 (`GET /v1/devices`) and #87 (Windows stray backend DLL / catalog CRLF fixes), which were merged but never recorded.
- `docs/AGENT_INTEGRATION.md`, `skills/openasr/references/http-api.md`: document `GET /v1/devices` (shipped in #88, previously undocumented).
- `crates/openasr-server/src/lib.rs`: remove the dead public function `server_certificate_fingerprint_for_subject_alt_names` -- confirmed zero callers in this repo and in the `openasr-app` consumer; its own doc comment already said nothing calls it, and it was a semantically confusing wrapper around `self_signed_tls_identity` that any future caller should call directly instead.
- `Cargo.toml`/`Cargo.lock`: bump `toml` 0.9 -> 1, which collapses the two `winnow` versions in the dependency tree (0.7.15 and 1.0.2, both pulled in transitively via `toml`'s own dependency graph) down to a single `winnow` 1.0.2.
- `.github/workflows/ci.yml`: wire `scripts/generate-ffi-header.sh --check` into the main per-PR gate; it was previously only wired into `release-binaries.yml` and `xcframework-manual.yml`, so a header drift introduced by a PR would not be caught until release time.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2412 passed, 122 skipped by design, 0 failed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources all ok)
- [x] `tooling/publish-model/scripts/regenerate_all.sh --check` (no catalog drift)

## Manual smoke checks

N/A -- docs, changelog, dependency, and CI-config only changes; the one code change (dead-function removal) is covered by the full test suite compiling and passing.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR intentionally does not touch the broader tech-debt items in the ledger that need product/design judgment or hardware (e.g. `#![allow(dead_code)]` module audit, app mock A/B variant cleanup, Windows real-hardware signing verification) -- those are tracked separately, not part of this mechanical sweep.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- drafted with AI assistance (tech-debt sweep across changelog/docs/dead-code/dependency/CI), reviewed and understood in full before submission.