### PR TITLE
refactor(core): consolidate f16-bits-to-f32 decode into nn::half

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/gguf_tensor_data.rs
+++ b/crates/openasr-core/src/ggml_runtime/gguf_tensor_data.rs
@@ -7,6 +7,8 @@ use std::{
 use memmap2::Mmap;
 use thiserror::Error;
 
+use crate::nn::half::f16_bits_slice_to_f32;
+
 use super::{
     GgmlRuntimeSource, GgmlRuntimeSourcePathError, GgufMetadataReadError, GgufTensorIndex,
     GgufTensorIndexReadError, GgufTensorMetadata, ffi, read_gguf_metadata,
@@ -366,7 +368,7 @@ impl GgufTensorDataReader {
             GGML_TYPE_F16 => {
                 let values =
                     self.host_tensor_f16_bits_copy_from_payload(payload, expected_shape)?;
-                Ok(values.into_iter().map(f16_bits_to_f32).collect())
+                Ok(f16_bits_slice_to_f32(&values))
             }
             _ => self.host_tensor_quantized_dequantize_to_f32_from_payload(payload),
         }
@@ -641,33 +643,6 @@ impl GgufTensorDataReader {
             len: borrowed.bytes.len(),
         })
     }
-}
-
-fn f16_bits_to_f32(bits: u16) -> f32 {
-    let sign = ((bits & 0x8000) as u32) << 16;
-    let exponent = ((bits >> 10) & 0x1f) as u32;
-    let mantissa = (bits & 0x03ff) as u32;
-    let f32_bits = if exponent == 0 {
-        if mantissa == 0 {
-            sign
-        } else {
-            let mut mant = mantissa;
-            let mut exp = -1_i32;
-            while (mant & 0x0400) == 0 {
-                mant <<= 1;
-                exp -= 1;
-            }
-            mant &= 0x03ff;
-            let exponent_f32 = (127 - 15 + 1 + exp) as u32;
-            sign | (exponent_f32 << 23) | (mant << 13)
-        }
-    } else if exponent == 0x1f {
-        sign | 0x7f80_0000 | (mantissa << 13)
-    } else {
-        let exponent_f32 = exponent + (127 - 15);
-        sign | (exponent_f32 << 23) | (mantissa << 13)
-    };
-    f32::from_bits(f32_bits)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/openasr-core/src/models/local_source_import.rs
+++ b/crates/openasr-core/src/models/local_source_import.rs
@@ -7,7 +7,7 @@ use memmap2::Mmap;
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::nn::half::f32_to_f16_bits;
+use crate::nn::half::{f16_bits_to_f32, f32_to_f16_bits};
 
 #[derive(Debug, Error)]
 pub enum LocalSourceImportError {
@@ -446,31 +446,6 @@ pub(crate) fn encode_f16_bits_le(values: Vec<u16>) -> Vec<u8> {
         encoded.extend_from_slice(&value.to_le_bytes());
     }
     encoded
-}
-
-pub(crate) fn f16_bits_to_f32(bits: u16) -> f32 {
-    let sign = ((bits & 0x8000) as u32) << 16;
-    let exponent = ((bits >> 10) & 0x1f) as u32;
-    let mantissa = (bits & 0x03ff) as u32;
-    let out = if exponent == 0 {
-        if mantissa == 0 {
-            sign
-        } else {
-            let mut mant = mantissa;
-            let mut exp = 113_u32;
-            while mant & 0x0400 == 0 {
-                mant <<= 1;
-                exp = exp.saturating_sub(1);
-            }
-            mant &= 0x03ff;
-            sign | (exp << 23) | (mant << 13)
-        }
-    } else if exponent == 0x1f {
-        sign | 0x7f80_0000 | (mantissa << 13)
-    } else {
-        sign | ((exponent + 112) << 23) | (mantissa << 13)
-    };
-    f32::from_bits(out)
 }
 
 pub(crate) fn tensor_element_count(

--- a/crates/openasr-core/src/models/qwen/token_embedding.rs
+++ b/crates/openasr-core/src/models/qwen/token_embedding.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use thiserror::Error;
 
 use crate::ggml_runtime::{GgufTensorDataReadError, GgufTensorDataReader};
+use crate::nn::half::f16_bits_to_f32;
 
 use super::runtime_contract::Qwen3AsrExecutionMetadata;
 use super::tensor_names::TOKEN_EMBD_WEIGHT as TOKEN_EMBEDDING_TENSOR_NAME;
@@ -180,43 +181,6 @@ fn token_index_or_error(
         });
     }
     Ok(token_index)
-}
-
-fn f16_bits_to_f32(bits: u16) -> f32 {
-    let sign = ((bits & 0x8000) as u32) << 16;
-    let exponent = (bits >> 10) & 0x1f;
-    let fraction = (bits & 0x03ff) as u32;
-
-    let f32_bits = match exponent {
-        0 => {
-            if fraction == 0 {
-                sign
-            } else {
-                let mut fraction_norm = fraction;
-                let mut exponent_shift = -14_i32;
-                while (fraction_norm & 0x0400) == 0 {
-                    fraction_norm <<= 1;
-                    exponent_shift -= 1;
-                }
-                fraction_norm &= 0x03ff;
-                let exponent_bits = ((exponent_shift + 127) as u32) << 23;
-                let fraction_bits = fraction_norm << 13;
-                sign | exponent_bits | fraction_bits
-            }
-        }
-        0x1f => {
-            let exponent_bits = 0xff_u32 << 23;
-            let fraction_bits = fraction << 13;
-            sign | exponent_bits | fraction_bits
-        }
-        _ => {
-            let exponent_bits = ((exponent as i32 - 15 + 127) as u32) << 23;
-            let fraction_bits = fraction << 13;
-            sign | exponent_bits | fraction_bits
-        }
-    };
-
-    f32::from_bits(f32_bits)
 }
 
 fn transpose_vocab_hidden_to_token_major(

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -50,7 +50,7 @@ use crate::nn::conv::{
     Conv1dParams, ConvActivation, ConvBlockSteps, apply_conv_1d_bias_activation,
 };
 use crate::nn::decoder::{Seq2SeqReusableDecodeGraph, reusable_decode_graph_supported_for_runner};
-use crate::nn::half::f32_to_f16_bits;
+use crate::nn::half::{f16_bits_to_f32, f32_to_f16_bits};
 use crate::nn::norm::{AffineLayerNormSteps, apply_affine_layer_norm};
 use crate::{
     GgmlAsrExecutionError, GgmlAsrExecutionOptions, GgmlAsrExecutionRequest,
@@ -159,34 +159,6 @@ fn whisper_can_use_serve_batch(
     graph_config.backend.is_gpu_class() && !graph_config.use_scheduler
 }
 
-fn f16_to_f32_local_v0(bits: u16) -> f32 {
-    let sign = u32::from(bits & 0x8000) << 16;
-    let exponent = (bits >> 10) & 0x1f;
-    let mantissa = u32::from(bits & 0x03ff);
-    let fp32 = match exponent {
-        0 => {
-            if mantissa == 0 {
-                sign
-            } else {
-                let mut mantissa = mantissa;
-                let mut exponent = -14_i32;
-                while (mantissa & 0x0400) == 0 {
-                    mantissa <<= 1;
-                    exponent -= 1;
-                }
-                mantissa &= 0x03ff;
-                let exponent_bits = ((exponent + 127) as u32) << 23;
-                sign | exponent_bits | (mantissa << 13)
-            }
-        }
-        0x1f => sign | 0x7f80_0000 | (mantissa << 13),
-        _ => {
-            let exponent_bits = (u32::from(exponent) + 112) << 23;
-            sign | exponent_bits | (mantissa << 13)
-        }
-    };
-    f32::from_bits(fp32)
-}
 #[derive(Debug, Error)]
 pub enum WhisperGgmlExecutorError {
     #[error("whisper ggml executor requires adapter '{expected}', got '{found}'")]
@@ -391,10 +363,7 @@ impl WhisperDecoderTensorSource for WhisperDecoderMaterializedTensorSource {
                     },
                 );
             };
-            return Ok(values
-                .iter()
-                .map(|bits| f16_to_f32_local_v0(*bits))
-                .collect());
+            return Ok(values.iter().map(|bits| f16_bits_to_f32(*bits)).collect());
         };
         Ok(values.to_vec())
     }
@@ -415,7 +384,7 @@ impl WhisperDecoderTensorSource for WhisperDecoderMaterializedTensorSource {
             return Ok(Arc::<[f32]>::from(
                 values
                     .iter()
-                    .map(|bits| f16_to_f32_local_v0(*bits))
+                    .map(|bits| f16_bits_to_f32(*bits))
                     .collect::<Vec<_>>()
                     .into_boxed_slice(),
             ));
@@ -1756,7 +1725,7 @@ fn encoder_tensor_values_f32<'a>(
         WhisperMaterializedTensorPayload::F32(values) => Cow::Borrowed(values.as_slice()),
         WhisperMaterializedTensorPayload::F16Bits(values) => values
             .iter()
-            .map(|bits| f16_to_f32_local_v0(*bits))
+            .map(|bits| f16_bits_to_f32(*bits))
             .collect::<Vec<_>>()
             .into(),
         WhisperMaterializedTensorPayload::Quantized { ggml_type, .. } => {

--- a/crates/openasr-core/src/models/whisper/package_import.rs
+++ b/crates/openasr-core/src/models/whisper/package_import.rs
@@ -28,7 +28,7 @@ use crate::models::{
     pack_quant::{PackQuant, classify_quant_tensor},
     whisper::WHISPER_MODEL_FAMILY,
 };
-use crate::nn::half::f32_to_f16_bits;
+use crate::nn::half::{f16_bits_slice_to_f32, f32_to_f16_bits};
 
 use crate::models::local_source_import::{
     SafetensorsFile, SafetensorsHeader, SafetensorsTensorHeader,
@@ -538,39 +538,12 @@ fn decode_safetensors_payload_as_f32(
         }
         "F16" => {
             let values = decode_f16_safetensors_payload_bits(tensor_name, data)?;
-            Ok(values.into_iter().map(f16_bits_to_f32).collect())
+            Ok(f16_bits_slice_to_f32(&values))
         }
         other => Err(validate_error(format!(
             "Whisper local-source GGUF import tensor '{tensor_name}' quantization supports only F32/F16 source tensors, got '{other}'"
         ))),
     }
-}
-
-fn f16_bits_to_f32(bits: u16) -> f32 {
-    let sign = ((bits & 0x8000) as u32) << 16;
-    let exponent = ((bits >> 10) & 0x1f) as u32;
-    let mantissa = (bits & 0x03ff) as u32;
-    let f32_bits = if exponent == 0 {
-        if mantissa == 0 {
-            sign
-        } else {
-            let mut mant = mantissa;
-            let mut exp = -1_i32;
-            while (mant & 0x0400) == 0 {
-                mant <<= 1;
-                exp -= 1;
-            }
-            mant &= 0x03ff;
-            let exponent_f32 = (127 - 15 + 1 + exp) as u32;
-            sign | (exponent_f32 << 23) | (mant << 13)
-        }
-    } else if exponent == 0x1f {
-        sign | 0x7f80_0000 | (mantissa << 13)
-    } else {
-        let exponent_f32 = exponent + (127 - 15);
-        sign | (exponent_f32 << 23) | (mantissa << 13)
-    };
-    f32::from_bits(f32_bits)
 }
 
 fn gguf_tensor_type_from_safetensors_dtype(

--- a/crates/openasr-core/src/nn/half.rs
+++ b/crates/openasr-core/src/nn/half.rs
@@ -1,25 +1,47 @@
-//! Single authoritative f32 -> f16 bit-level conversion.
+//! Single authoritative f32 <-> f16 bit-level conversions.
 //!
 //! # Single source of truth -- read this before adding another copy
 //!
-//! A 2026-07 audit found **12 independent reimplementations** of this exact
-//! bit-twiddling routine scattered across `nn/decoder.rs`, `adapter_pack.rs`,
-//! and half a dozen `models/*/package_import.rs` / `encoder_graph.rs` /
+//! A 2026-07 audit found **12 independent reimplementations** of the f32 ->
+//! f16 direction scattered across `nn/decoder.rs`, `adapter_pack.rs`, and
+//! half a dozen `models/*/package_import.rs` / `encoder_graph.rs` /
 //! `decoder_graph.rs` files, encoding at least four different rounding
 //! behaviors. One of them (`models/wav2vec2_ctc/encoder_graph.rs`) did not
 //! round at all -- it truncated the mantissa unconditionally, which is a real
 //! correctness bug: the exact same source f32 weight was quantized to a
-//! different f16 bit pattern than every other model family.
+//! different f16 bit pattern than every other model family. That direction
+//! was consolidated into [`f32_to_f16_bits`] first.
+//!
+//! A follow-up 2026-07 audit found the same drift in the *reverse* direction:
+//! **5 independent reimplementations** of f16 bits -> f32, in
+//! `models/whisper/package_import.rs`, `ggml_runtime/gguf_tensor_data.rs`,
+//! `models/whisper/ggml_executor.rs` (as `f16_to_f32_local_v0`),
+//! `models/qwen/token_embedding.rs`, and `models/local_source_import.rs`.
+//! Bit-exact sweep of all 65536 possible `u16` patterns against both `numpy`'s
+//! `float16 -> float32` cast and ggml's own `ggml_compute_fp16_to_fp32`
+//! (`third_party/openasr-ggml/src/ggml-impl.h`) showed **two of the five were
+//! wrong**: the copies in `whisper/package_import.rs` and
+//! `gguf_tensor_data.rs` were byte-identical to each other and shared a
+//! subnormal-decode bug -- their subnormal-input loop initialized the
+//! exponent accumulator to `-1` instead of `-14`, so every subnormal f16
+//! input (2046 of the 65536 possible bit patterns: all nonzero mantissas
+//! with a zero exponent field, both signs) decoded to exactly **half** the
+//! correct magnitude. The other three copies (`ggml_executor.rs`,
+//! `token_embedding.rs`, `local_source_import.rs`) were already bit-exact
+//! matches for all 65536 patterns and became this shared implementation
+//! unchanged. See `f16_bits_to_f32`'s test module for the full-sweep
+//! regression test pinning this.
 //!
 //! If you are about to write `fn f32_to_f16_bits(value: f32) -> u16 { ... }`
-//! anywhere in this crate: **stop, and call [`f32_to_f16_bits`] (or
-//! [`f32_slice_to_f16_bits`] for a batch) instead.** Adding a 13th copy
-//! reintroduces the exact drift this module exists to kill. If a call site
-//! is in a different crate/module and importing this one is awkward, that is
-//! a sign the conversion belongs in a lower shared layer, not a reason to
-//! hand-roll another copy.
+//! or `fn f16_bits_to_f32(bits: u16) -> f32 { ... }` anywhere in this crate:
+//! **stop, and call [`f32_to_f16_bits`] / [`f16_bits_to_f32`] (or their slice
+//! variants) instead.** Adding another copy reintroduces the exact drift
+//! this module exists to kill. If a call site is in a different
+//! crate/module and importing this one is awkward, that is a sign the
+//! conversion belongs in a lower shared layer, not a reason to hand-roll
+//! another copy.
 //!
-//! # Semantics
+//! # Semantics: f32 -> f16 ([`f32_to_f16_bits`])
 //!
 //! Round-to-nearest-even (IEEE 754 default rounding), matching what a
 //! hardware `vcvtps2ph`/`FCVT` instruction or `f32::to_f16` (once stabilized)
@@ -36,6 +58,13 @@
 //!   finite f16 value overflowing to infinity) ripples through the exponent
 //!   field via plain integer addition, which is exact because the f16 bit
 //!   layout packs sign/exponent/mantissa as one integer.
+//!
+//! # Semantics: f16 -> f32 ([`f16_bits_to_f32`])
+//!
+//! Exact (lossless): every finite f16 value, subnormal or normal, converts to
+//! the identical mathematical value as an f32; signed zero, signed infinity,
+//! and NaN (sign + truncated payload, left-justified into the wider f32
+//! mantissa) all round-trip exactly, matching `ggml_compute_fp16_to_fp32`.
 
 /// Convert one `f32` to its IEEE 754 binary16 bit pattern, rounding to
 /// nearest with ties to even. See the module docs for full semantics.
@@ -83,6 +112,49 @@ pub(crate) fn f32_to_f16_bits(value: f32) -> u16 {
 /// Convert a slice of `f32` values to f16 bit patterns element-wise.
 pub(crate) fn f32_slice_to_f16_bits(values: &[f32]) -> Vec<u16> {
     values.iter().copied().map(f32_to_f16_bits).collect()
+}
+
+/// Convert an IEEE 754 binary16 bit pattern to its exact `f32` value. See the
+/// module docs for full semantics.
+pub(crate) fn f16_bits_to_f32(bits: u16) -> f32 {
+    let sign = u32::from(bits & 0x8000) << 16;
+    let exponent = (bits >> 10) & 0x1f;
+    let mantissa = u32::from(bits & 0x03ff);
+
+    let f32_bits = if exponent == 0 {
+        if mantissa == 0 {
+            sign // +/-0
+        } else {
+            // Subnormal f16: normalize the mantissa into an implicit-leading-1
+            // form by shifting left until the hidden bit (0x400) appears,
+            // tracking how many shifts that took. The f16 subnormal exponent
+            // is -14 (bias 15, field 0), so the normalized binade starts
+            // there and each shift descends one more power of two.
+            let mut mant = mantissa;
+            let mut exp = -14_i32;
+            while (mant & 0x0400) == 0 {
+                mant <<= 1;
+                exp -= 1;
+            }
+            mant &= 0x03ff; // drop the now-explicit hidden bit
+            let exponent_f32 = (exp + 127) as u32;
+            sign | (exponent_f32 << 23) | (mant << 13)
+        }
+    } else if exponent == 0x1f {
+        // Infinity (mantissa == 0) or NaN (mantissa != 0): widen the mantissa
+        // into the f32 payload position, preserving a NaN's non-zero payload.
+        sign | 0x7f80_0000 | (mantissa << 13)
+    } else {
+        // Normal range: f16 bias 15 -> f32 bias 127.
+        let exponent_f32 = exponent as u32 + (127 - 15);
+        sign | (exponent_f32 << 23) | (mantissa << 13)
+    };
+    f32::from_bits(f32_bits)
+}
+
+/// Convert a slice of f16 bit patterns to `f32` values element-wise.
+pub(crate) fn f16_bits_slice_to_f32(bits: &[u16]) -> Vec<f32> {
+    bits.iter().copied().map(f16_bits_to_f32).collect()
 }
 
 /// Round `value >> shift` to the nearest integer, ties to even, using only
@@ -212,5 +284,236 @@ mod tests {
         let values = [0.0_f32, 1.0, -2.5, f32::INFINITY];
         let expected: Vec<u16> = values.iter().copied().map(f32_to_f16_bits).collect();
         assert_eq!(f32_slice_to_f16_bits(&values), expected);
+    }
+}
+
+#[cfg(test)]
+mod f16_bits_to_f32_tests {
+    use super::*;
+
+    #[test]
+    fn zero_preserves_sign() {
+        assert_eq!(f16_bits_to_f32(0x0000).to_bits(), 0f32.to_bits());
+        assert_eq!(f16_bits_to_f32(0x8000).to_bits(), (-0f32).to_bits());
+    }
+
+    #[test]
+    fn common_exact_values_round_trip() {
+        assert_eq!(f16_bits_to_f32(0x3c00), 1.0);
+        assert_eq!(f16_bits_to_f32(0xbc00), -1.0);
+        assert_eq!(f16_bits_to_f32(0x4000), 2.0);
+        assert_eq!(f16_bits_to_f32(0x3800), 0.5);
+        assert_eq!(f16_bits_to_f32(0x7bff), 65504.0); // largest finite f16
+    }
+
+    #[test]
+    fn infinities() {
+        assert_eq!(f16_bits_to_f32(0x7c00), f32::INFINITY);
+        assert_eq!(f16_bits_to_f32(0xfc00), f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn nan_preserves_sign_and_nonzero_payload() {
+        let positive_nan = f16_bits_to_f32(0x7c01);
+        assert!(positive_nan.is_nan());
+        assert_eq!(positive_nan.to_bits() & 0x8000_0000, 0);
+        assert_ne!(positive_nan.to_bits() & 0x007f_ffff, 0);
+
+        let negative_nan = f16_bits_to_f32(0xfe00);
+        assert!(negative_nan.is_nan());
+        assert_eq!(negative_nan.to_bits() & 0x8000_0000, 0x8000_0000);
+        assert_ne!(negative_nan.to_bits() & 0x007f_ffff, 0);
+    }
+
+    #[test]
+    fn subnormal_boundaries() {
+        // Smallest positive f16 subnormal (bits 0x0001) is exactly 2^-24.
+        // This is the exact value the pre-consolidation `whisper/package_import.rs`
+        // / `gguf_tensor_data.rs` copy got wrong (it returned 2^-25, half the
+        // correct magnitude) -- see the module docs for the audit writeup.
+        assert_eq!(f16_bits_to_f32(0x0001), f32::from_bits(0x3380_0000)); // 2^-24
+        assert_eq!(f16_bits_to_f32(0x0001), 2.0f32.powi(-24));
+        // Largest f16 subnormal: 1023 * 2^-24.
+        assert_eq!(f16_bits_to_f32(0x03ff), f32::from_bits(0x387f_c000));
+        // Smallest normal f16 value: 2^-14 = 1024 * 2^-24, exactly at the
+        // subnormal/normal boundary the decode loop must land on precisely.
+        assert_eq!(f16_bits_to_f32(0x0400), f32::from_bits(0x3880_0000));
+        assert_eq!(f16_bits_to_f32(0x0400), 2.0f32.powi(-14));
+        // Sign is preserved through the subnormal branch.
+        assert_eq!(f16_bits_to_f32(0x8001), -(2.0f32.powi(-24)));
+    }
+
+    #[test]
+    fn f16_to_f32_round_trips_through_f32_to_f16_bits_for_exactly_representable_values() {
+        // Every value f16 can represent exactly should survive f32 -> f16 ->
+        // f32 unchanged; this exercises both directions of the shared module
+        // against each other for a spread of exponents/mantissas.
+        let values = [
+            0.0_f32,
+            -0.0,
+            1.0,
+            -1.0,
+            0.5,
+            2.0,
+            65504.0,
+            -65504.0,
+            1024.0,
+            2.0f32.powi(-12), // exactly representable in f16
+        ];
+        for value in values {
+            let bits = f32_to_f16_bits(value);
+            let round_tripped = f16_bits_to_f32(bits);
+            assert_eq!(
+                round_tripped.to_bits(),
+                value.to_bits(),
+                "value {value} did not round-trip via f16 bits (got {round_tripped})"
+            );
+        }
+    }
+
+    /// Historical duplicate that lived in `models/whisper/package_import.rs`
+    /// and byte-identically in `ggml_runtime/gguf_tensor_data.rs` before this
+    /// consolidation. Kept here, inline, purely as a regression oracle: it
+    /// reproduces the exact subnormal-decode bug (exponent accumulator
+    /// initialized to `-1` instead of `-14`) so the test below can pin
+    /// *precisely* which 2046 of the 65536 bit patterns the fix changes
+    /// behavior for, and assert every other pattern is untouched.
+    fn buggy_historical_f16_bits_to_f32(bits: u16) -> f32 {
+        let sign = ((bits & 0x8000) as u32) << 16;
+        let exponent = ((bits >> 10) & 0x1f) as u32;
+        let mantissa = (bits & 0x03ff) as u32;
+        let f32_bits = if exponent == 0 {
+            if mantissa == 0 {
+                sign
+            } else {
+                let mut mant = mantissa;
+                let mut exp = -1_i32; // bug: should start at -14
+                while (mant & 0x0400) == 0 {
+                    mant <<= 1;
+                    exp -= 1;
+                }
+                mant &= 0x03ff;
+                let exponent_f32 = (127 - 15 + 1 + exp) as u32;
+                sign | (exponent_f32 << 23) | (mant << 13)
+            }
+        } else if exponent == 0x1f {
+            sign | 0x7f80_0000 | (mantissa << 13)
+        } else {
+            let exponent_f32 = exponent + (127 - 15);
+            sign | (exponent_f32 << 23) | (mantissa << 13)
+        };
+        f32::from_bits(f32_bits)
+    }
+
+    /// Full 65536-value sweep, exhaustively pinning behavior against the
+    /// pre-consolidation buggy copy above: the shared implementation must
+    /// differ *only* on subnormal inputs (f16 exponent field == 0, mantissa
+    /// != 0), and must differ from the buggy copy by exactly a factor of two
+    /// there (the bug's off-by-one exponent bias). This documents, byte for
+    /// byte, that the consolidation intentionally changes output only for
+    /// bit patterns the old code already got wrong -- it does not "silently"
+    /// unify onto a different behavior for any value real model weights
+    /// would plausibly carry outside that subnormal corner.
+    #[test]
+    fn matches_buggy_historical_copy_everywhere_except_the_subnormal_bug_it_had() {
+        let mut mismatches = 0usize;
+        for bits in 0..=u16::MAX {
+            let fixed = f16_bits_to_f32(bits);
+            let buggy = buggy_historical_f16_bits_to_f32(bits);
+            let exponent_field = (bits >> 10) & 0x1f;
+            let mantissa_field = bits & 0x03ff;
+            let is_subnormal_nonzero = exponent_field == 0 && mantissa_field != 0;
+
+            if fixed.to_bits() == buggy.to_bits() {
+                assert!(
+                    !is_subnormal_nonzero,
+                    "bits {bits:#06x} unexpectedly matched the buggy copy on a \
+                     subnormal input; the bug should make these differ"
+                );
+                continue;
+            }
+
+            mismatches += 1;
+            assert!(
+                is_subnormal_nonzero,
+                "bits {bits:#06x} diverged from the buggy historical copy \
+                 outside the known subnormal bug -- consolidation must not \
+                 change behavior anywhere else"
+            );
+            // The bug is exactly a missing factor of two (exponent off by one).
+            assert_eq!(
+                fixed,
+                buggy * 2.0,
+                "bits {bits:#06x}: fix should be exactly 2x the buggy value"
+            );
+        }
+        // 1023 nonzero mantissas x 2 signs = 2046 subnormal bit patterns.
+        assert_eq!(mismatches, 2046);
+    }
+
+    /// Independent oracle: ggml's own `ggml_compute_fp16_to_fp32`
+    /// (`third_party/openasr-ggml/src/ggml-impl.h`), transcribed as a
+    /// standalone Rust port purely for this test, using its bit-trick
+    /// algorithm (magic-number float arithmetic instead of a normalize
+    /// loop). Every GGUF tensor this crate reads is ultimately produced or
+    /// consumed by that C code, so bit-exact agreement across all 65536
+    /// patterns is the correctness bar, independent of this module's own
+    /// (differently structured) implementation.
+    fn ggml_reference_f16_bits_to_f32(bits: u16) -> f32 {
+        let w = u32::from(bits) << 16;
+        let sign = w & 0x8000_0000;
+        let two_w = w.wrapping_add(w);
+
+        let exp_offset: u32 = 0xE0 << 23;
+        let exp_scale = f32::from_bits(0x7800000);
+        let normalized_value = f32::from_bits((two_w >> 4).wrapping_add(exp_offset)) * exp_scale;
+
+        let magic_mask: u32 = 126 << 23;
+        let magic_bias = 0.5f32;
+        let denormalized_value = f32::from_bits((two_w >> 17) | magic_mask) - magic_bias;
+
+        let denormalized_cutoff: u32 = 1 << 27;
+        let result = sign
+            | if two_w < denormalized_cutoff {
+                denormalized_value.to_bits()
+            } else {
+                normalized_value.to_bits()
+            };
+        f32::from_bits(result)
+    }
+
+    #[test]
+    fn matches_ggml_reference_bit_exact_for_every_u16_pattern() {
+        // NaN payloads are deliberately excluded from the bit-exact
+        // comparison: the ggml reference here computes the NaN case via a
+        // float *multiplication* against a NaN bit pattern
+        // (`normalized_value = f32::from_bits(...) * exp_scale`), and IEEE
+        // 754 does not mandate which payload survives arithmetic on a NaN
+        // operand -- that is architecture/compiler dependent, so pinning a
+        // specific payload from this Rust port would be testing an
+        // unportable accident, not a real invariant. `f16_bits_to_f32` uses
+        // direct bit manipulation instead (matching the 3-of-5 pre-existing
+        // duplicate implementations this consolidation kept unchanged), so
+        // its NaN payload is deterministic; that invariant is covered by
+        // `nan_preserves_sign_and_nonzero_payload` above.
+        for bits in 0..=u16::MAX {
+            let ours = f16_bits_to_f32(bits);
+            let theirs = ggml_reference_f16_bits_to_f32(bits);
+            if ours.is_nan() && theirs.is_nan() {
+                continue;
+            }
+            assert_eq!(
+                ours.to_bits(),
+                theirs.to_bits(),
+                "bits {bits:#06x}: ours={ours:?} ggml={theirs:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn slice_conversion_matches_scalar() {
+        let values: [u16; 5] = [0x0000, 0x3c00, 0xbc00, 0x7c00, 0x0001];
+        let expected: Vec<f32> = values.iter().copied().map(f16_bits_to_f32).collect();
+        assert_eq!(f16_bits_slice_to_f32(&values), expected);
     }
 }


### PR DESCRIPTION
## Summary

Consolidates the f16-bits -> f32 decode routine, which had drifted into 5
independent copies, into the single `nn::half` module that already held the
canonical f32 -> f16 encode routine (`f32_to_f16_bits`).

## Why

`nn::half` documents a prior 2026-07 audit that found and fixed 12 duplicate
copies of the f32 -> f16 direction. This PR is the follow-up audit for the
reverse direction: `f16_bits_to_f32` had 5 independent reimplementations
across `models/whisper/package_import.rs`, `ggml_runtime/gguf_tensor_data.rs`,
`models/whisper/ggml_executor.rs` (as `f16_to_f32_local_v0`),
`models/qwen/token_embedding.rs`, and `models/local_source_import.rs`.

A bit-exact sweep of all 65536 possible `u16` bit patterns against both
numpy's `float16 -> float32` cast and ggml's own `ggml_compute_fp16_to_fp32`
(`crates/openasr-core/third_party/openasr-ggml/src/ggml-impl.h`) showed the
copies were **not** all equivalent:

- `models/whisper/package_import.rs` and `ggml_runtime/gguf_tensor_data.rs`
  had byte-identical implementations that shared a subnormal-decode bug: the
  mantissa-normalize loop seeded the exponent accumulator to `-1` instead of
  `-14`. Every subnormal f16 input (2046 of the 65536 bit patterns -- all
  nonzero mantissas with a zero exponent field, both signs) decoded to
  exactly **half** the correct magnitude.
- `models/whisper/ggml_executor.rs`, `models/qwen/token_embedding.rs`, and
  `models/local_source_import.rs` were already bit-exact matches for all
  65536 patterns (verified against numpy and ggml's own algorithm) and become
  the shared implementation unchanged.

Subnormal f16 magnitudes (< ~6.1e-5) are extremely unlikely to appear in real
trained-model weights, which is presumably why this had gone unnoticed, but
it is a real, silent correctness bug in two call paths (Whisper safetensors
F16 import and general GGUF F16 tensor reads) that this PR fixes as part of
consolidating to a single implementation.

## Changes

- `crates/openasr-core/src/nn/half.rs`: adds `f16_bits_to_f32` and
  `f16_bits_slice_to_f32` next to the existing `f32_to_f16_bits` /
  `f32_slice_to_f16_bits`, with module docs recording the audit (which copies
  existed, which were correct, exactly what the bug was and how many bit
  patterns it affected).
- `models/whisper/package_import.rs`, `ggml_runtime/gguf_tensor_data.rs`,
  `models/whisper/ggml_executor.rs`, `models/qwen/token_embedding.rs`,
  `models/local_source_import.rs`: delete the local duplicate and switch call
  sites to the shared function.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2421 passed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources all ok; only
      pre-existing, unrelated duplicate-dependency warnings)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

New unit tests in `nn::half` (all passing):
- Standard values, subnormal/normal boundary values, Inf, and NaN
  (sign + non-zero truncated payload preserved).
- `f16_to_f32_round_trips_through_f32_to_f16_bits_for_exactly_representable_values`:
  cross-checks both directions of the shared module against each other.
- `matches_buggy_historical_copy_everywhere_except_the_subnormal_bug_it_had`:
  keeps the deleted buggy implementation inline as a regression oracle and
  exhaustively sweeps all 65536 bit patterns, asserting the fix changes
  output *only* for the 2046 subnormal patterns (by exactly 2x) and is
  byte-identical everywhere else -- i.e. the consolidation does not silently
  change behavior anywhere the old (correct) implementations already agreed.
- `matches_ggml_reference_bit_exact_for_every_u16_pattern`: transcribes
  ggml's own `ggml_compute_fp16_to_fp32` bit-trick algorithm inline and
  sweeps all 65536 patterns for bit-exact agreement (NaN payloads excluded
  from this one specific comparison, since the ggml algorithm's NaN case
  routes through a float multiplication and IEEE 754 does not mandate which
  payload survives arithmetic on a NaN operand -- that would be pinning an
  unportable accident of this Rust port, not a real invariant; NaN payload
  determinism is instead covered by the direct bit-manipulation test above).

## Manual smoke checks

None beyond the automated suite above; this is a pure internal refactor with
no CLI/API-visible behavior change (the only behavior change -- the
subnormal bug fix -- is exercised by the golden_diff/nextest suites above,
which stayed green).

## Docs updated

- [x] No README/docs behavior claims changed; this is an internal
      consolidation. The `nn::half` module doc comment is the durable record
      of the audit for future contributors.

## Scope / non-goals

- Does not touch the f32 -> f16 direction (`f32_to_f16_bits`), already
  consolidated in a prior PR.
- Does not touch pack-build/tooling (`tooling/publish-model/`), so
  `regenerate_all.sh --check` was not run (nothing under its scope changed).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI-assisted audit (cross-checking all 5 implementations bit-for-bit against numpy/ggml references) and refactor, human-reviewed.
