### PR TITLE
refactor(core): collapse three finalize call chains in native_transcribe

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -995,31 +995,21 @@ fn run_native_transcription_impl(
                     fallback_options,
                     backend_preference,
                 )?;
-                return Ok(with_reported_language(
-                    apply_speaker_turns(
-                        with_longform_metadata(
-                            normalize_transcription_segments(
-                                fallback.into_transcription(),
-                                0.0,
-                                audio_duration_seconds,
-                            ),
-                            Some(run_metadata),
-                        ),
-                        &speaker_turns,
-                        strip_forced_word_timestamps,
-                    ),
+                return Ok(finalize_native_transcription(
+                    fallback.into_transcription(),
+                    audio_duration_seconds,
+                    Some(run_metadata),
+                    &speaker_turns,
+                    strip_forced_word_timestamps,
                     reported_language.clone(),
                 ));
             }
-            return Ok(with_reported_language(
-                apply_speaker_turns(
-                    with_longform_metadata(
-                        normalize_transcription_segments(assembled, 0.0, audio_duration_seconds),
-                        Some(run_metadata),
-                    ),
-                    &speaker_turns,
-                    strip_forced_word_timestamps,
-                ),
+            return Ok(finalize_native_transcription(
+                assembled,
+                audio_duration_seconds,
+                Some(run_metadata),
+                &speaker_turns,
+                strip_forced_word_timestamps,
                 reported_language.clone(),
             ));
         }
@@ -1042,19 +1032,47 @@ fn run_native_transcription_impl(
         request_options,
         backend_preference,
     )?;
-    let normalized = normalize_transcription_segments(
+    Ok(finalize_native_transcription(
         transcription.into_transcription(),
-        0.0,
         audio_duration_seconds,
-    );
-    Ok(with_reported_language(
+        longform_metadata,
+        &speaker_turns,
+        strip_forced_word_timestamps,
+        reported_language,
+    ))
+}
+
+/// Finalize a decoded transcription for return from
+/// `run_native_transcription_impl`: normalize segment timing/text (dropping
+/// empty segments, filling a fallback span from the request-level audio
+/// duration), stamp the longform metadata for this run, attribute + re-segment
+/// speaker turns, and stamp the reported source language -- in that fixed
+/// order. Every exit path of `run_native_transcription_impl` (the longform
+/// all-silent fallback, the longform assembled result, and the short-form /
+/// single-slice result) funnels through this single function so the order and
+/// parameters of the chain cannot drift between paths; only the decoded
+/// `Transcription` body and its longform metadata differ per call site. See
+/// the `C1` pipeline-split roadmap: this collapses what were three
+/// byte-for-byte-identical call chains into one.
+fn finalize_native_transcription(
+    transcription: Transcription,
+    audio_duration_seconds: f32,
+    longform_metadata: Option<TranscriptionLongFormMetadata>,
+    speaker_turns: &SpeakerAttribution,
+    strip_forced_word_timestamps: bool,
+    reported_language: Option<String>,
+) -> Transcription {
+    with_reported_language(
         apply_speaker_turns(
-            with_longform_metadata(normalized, longform_metadata),
-            &speaker_turns,
+            with_longform_metadata(
+                normalize_transcription_segments(transcription, 0.0, audio_duration_seconds),
+                longform_metadata,
+            ),
+            speaker_turns,
             strip_forced_word_timestamps,
         ),
         reported_language,
-    ))
+    )
 }
 
 /// Stamp the effective source language onto a finished transcription so every


### PR DESCRIPTION
## Summary

Stage 1 of the `run_native_transcription_impl` pipeline split (C1 in the
maintainability roadmap): collapse the three copy-pasted `finalize` call
chains at the end of `run_native_transcription_impl`
(`crates/openasr-core/src/api/backend/native_transcribe.rs`) into a single
`finalize_native_transcription` function that every exit path calls.

## Why

`run_native_transcription_impl` had three return paths at the end of the
function -- the longform all-silent fallback, the longform assembled result,
and the short-form / single-slice result -- each inlining the same
`normalize_transcription_segments -> with_longform_metadata ->
apply_speaker_turns -> with_reported_language` chain by copy-paste. Three
independent copies of a golden-critical chain is exactly the shape that lets
a future edit update one exit path and silently miss the other two (order
swap, dropped argument, etc.), which would only surface as a
transcript-shape difference on whichever exit path someone forgot.

### Three-site diff analysis

Comparing the pre-refactor call chains at the three sites line by line:

- Site A (longform, all slices silent -> whole-audio fallback dispatch)
- Site B (longform, multi-slice assembled result)
- Site C (short-form / single dispatch, no longform)

All three called the identical four-function chain in the identical order
with the identical fixed arguments (`0.0` fallback start,
`audio_duration_seconds` fallback end, the same `&speaker_turns`, the same
`strip_forced_word_timestamps`); the *only* things that varied per site were:

1. the input `Transcription` body (`fallback.into_transcription()` /
   `assembled` / `transcription.into_transcription()`), and
2. the longform metadata (`Some(run_metadata)` at A and B, the earlier
   `Option<TranscriptionLongFormMetadata>` `longform_metadata` local at C --
   `None` for a short-form run, `Some(...)` for a single-chunk longform run).

Conclusion: **no semantic drift existed between the three sites** -- they
were genuinely byte-for-byte identical modulo those two values. This PR
therefore does a pure refactor (extract function, no behavior change), not a
drift fix. `finalize_native_transcription` takes exactly those two values as
parameters and hard-codes the rest of the chain, so a future change to the
chain's order/arguments can only be made once, for every exit path at once.

One additional pre-existing early return (the "0 slices planned" empty-plan
early return higher in the function) constructs its own empty `Transcription`
directly and does not go through this chain -- it is a distinct branch not
named in the roadmap's three finalize sites and is intentionally left alone,
per the "stage 1 = finalize only" scope for this PR.

## Changes

- `crates/openasr-core/src/api/backend/native_transcribe.rs`: extract
  `finalize_native_transcription(transcription, audio_duration_seconds,
  longform_metadata, speaker_turns, strip_forced_word_timestamps,
  reported_language) -> Transcription`; all three exit paths call it instead
  of inlining the chain.
- No other files changed. No behavior, no new tests needed beyond golden/e2e
  (this is a pure structural extraction with identical call order and
  arguments).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (clean, no new warnings)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (byte-identical)
- [x] `cargo nextest run --workspace` (2412 passed, 0 failed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources all ok; pre-existing
      unrelated duplicate-dependency warnings only)

## Manual smoke checks

End-to-end byte-for-byte comparison: release `openasr` CLI built from this
branch vs. release `openasr` CLI built from `origin/main`, run against locally
installed model packs for four native families (qwen3-asr-0.6b, firered-aed-l-v2,
whisper-tiny, parakeet-tdt-0.6b-v3), across `fixtures/jfk.wav` and
`fixtures/zh_sample.wav`, comparing `sha256` of `verbose_json` stdout and exit
codes. Covered all three finalize exit paths plus word-timestamps and diarize
variants (forcing longform via the hidden `--segment-mode`/`--chunk-seconds`
flags, and forcing the all-silent fallback with a synthetic silent WAV plus
`--suppress-silent-slices`):

| case | branch rc | base rc | sha256 match |
| --- | --- | --- | --- |
| qwen3-asr / jfk / short-form | 0 | 0 | match |
| qwen3-asr / zh / short-form | 0 | 0 | match |
| firered-aed-l-v2 / jfk / short-form | 0 | 0 | match |
| firered-aed-l-v2 / zh / short-form | 0 | 0 | match |
| whisper-tiny / jfk / short-form | 0 | 0 | match |
| whisper-tiny / zh / short-form | 0 | 0 | match |
| parakeet-tdt-v3 / jfk / short-form | 0 | 0 | match |
| parakeet-tdt-v3 / zh / short-form | 0 | 0 | match |
| qwen3-asr / jfk / word-timestamps=approximate | 0 | 0 | match |
| firered-aed-l-v2 / jfk / word-timestamps=approximate | 0 | 0 | match |
| whisper-tiny / jfk / word-timestamps=approximate | 0 | 0 | match |
| parakeet-tdt-v3 / jfk / word-timestamps=approximate | 0 | 0 | match |
| whisper-tiny / jfk / word-timestamps=aligned, --offline (fail-closed, pack absent) | 1 | 1 | match |
| whisper-tiny / zh / --diarize | 0 | 0 | match |
| qwen3-asr / zh / --diarize | 0 | 0 | match |
| whisper-tiny / jfk / longform assembled (multi-slice, site B) | 0 | 0 | match |
| qwen3-asr / jfk / longform assembled | 0 | 0 | match |
| firered-aed-l-v2 / jfk / longform assembled | 0 | 0 | match |
| parakeet-tdt-v3 / jfk / longform assembled | 0 | 0 | match |
| whisper-tiny / zh / longform assembled | 0 | 0 | match |
| whisper-tiny / synthetic-silence / longform all-silent fallback (site A) | 0 | 0 | match |
| qwen3-asr / synthetic-silence / longform all-silent fallback | 0 | 0 | match |
| firered-aed-l-v2 / synthetic-silence / longform all-silent fallback | 0 | 0 | match |
| parakeet-tdt-v3 / synthetic-silence / longform all-silent fallback | 0 | 0 | match |

24/24 cases: identical exit code and identical `sha256` of stdout between
this branch and `origin/main`.

## Docs updated

- [x] No behavior or limitations changed; no docs updates needed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR only does stage 1 (finalize collapse) of the C1 pipeline split.
`prepare_native_transcription` extraction and `run_longform_decode` +
`RollingPromptState` extraction are separate follow-up PRs, per the staged
plan; not touched here.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- an AI coding agent located the three finalize call sites, confirmed they were byte-identical modulo two arguments, wrote the extraction, and ran the full validation gate plus the cross-binary e2e comparison described above.
