### PR TITLE
perf(core): four quick-win hot-path optimizations

### DIFF
--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -471,9 +471,14 @@ pub(super) async fn serve(
     security: ServeSecurityOptions,
 ) -> Result<()> {
     let home = openasr_home()?;
-    let config = load_config(&home)?;
-    let backend = resolve_backend(backend_kind, &config)?;
-    let model_source = resolve_serve_model_source(model, backend, model_pack, &config)?;
+    // Read the config document once: `config` and `idle_unload` (used below
+    // for `idle_unload_after`) both live on it, so reading it a second time
+    // further down would be a redundant fs::read + serde_json parse on every
+    // serve() startup.
+    let config_document = openasr_core::load_config_document(&home)?;
+    let config = &config_document.config;
+    let backend = resolve_backend(backend_kind, config)?;
+    let model_source = resolve_serve_model_source(model, backend, model_pack, config)?;
     if backend == BackendKind::Native
         && let Some(model_pack_path) = model_source.model_pack_path.as_deref()
     {
@@ -502,8 +507,8 @@ pub(super) async fn serve(
         );
     }
     let ffmpeg_bin_explicit =
-        resolve_explicit_ffmpeg_bin(runtime_paths.ffmpeg_bin.clone(), &config).is_some();
-    let ffmpeg_bin = resolve_ffmpeg_bin(runtime_paths.ffmpeg_bin.clone(), &config);
+        resolve_explicit_ffmpeg_bin(runtime_paths.ffmpeg_bin.clone(), config).is_some();
+    let ffmpeg_bin = resolve_ffmpeg_bin(runtime_paths.ffmpeg_bin.clone(), config);
     let api_key_hashes = if supervised_daemon_launch() {
         // The desktop supervisor's managed daemon (marked by the instance-token
         // env it always sets) has its own trust model: the UI talks to its
@@ -529,14 +534,9 @@ pub(super) async fn serve(
     // and every already-paired client's TOFU pin) across the restarts the
     // desktop performs on every model switch. No-op when TLS is disabled.
     launch_options.tls_identity_store = Some(home.join("tls-identity.json"));
-    // `idle_unload` lives on `Preferences`, not the plain `OpenAsrConfig`
-    // already loaded above -- read the full config document for it. A
-    // missing/unreadable document (fresh install) falls back to the default
-    // policy rather than failing serve over a preferences read.
-    launch_options.idle_unload_after = openasr_core::load_config_document(&home)
-        .map(|document| document.preferences.idle_unload)
-        .unwrap_or_default()
-        .idle_threshold();
+    // `idle_unload` lives on `Preferences`, on the same document already
+    // loaded above as `config_document` -- no second read needed.
+    launch_options.idle_unload_after = config_document.preferences.idle_unload.idle_threshold();
     openasr_server::serve_with_launch_options(
         addr,
         openasr_server::ServerRuntime {

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -736,10 +736,26 @@ fn build_native_runtime_model_adapter_for_path(path: &Path) -> Option<NativeRunt
         .select_from_gguf_metadata_v1(&selection_metadata)
         .ok()?
         .clone();
+    // Only Dolphin's phrase-bias probe
+    // (`native_runtime_descriptor_supports_phrase_bias`) ever consults the
+    // tensor index -- every other architecture answers phrase-bias support
+    // from the architecture constant alone
+    // (`builtin_executor_supports_phrase_bias_for_model_architecture`) and
+    // never looks at `tensor_index`. Gate the read on architecture so the
+    // other (large majority) of installed packs skip a full GGUF tensor
+    // directory parse (`gguf_init_from_file`) here; this build already runs
+    // at most once per pack per process thanks to
+    // `NATIVE_RUNTIME_MODEL_ADAPTER_CACHE` above, so this trims that one
+    // parse rather than a per-request cost.
+    //
     // Best-effort: a tensor index read failure here should not fail the whole
     // capability lookup (the adapter still resolves from metadata alone); it
     // only narrows the Dolphin per-pack phrase-bias probe to "unsupported".
-    let tensor_index = read_gguf_tensor_index_from_runtime_source(&runtime_source).ok();
+    let tensor_index = if descriptor.model_architecture == DOLPHIN_GGML_ARCHITECTURE_ID {
+        read_gguf_tensor_index_from_runtime_source(&runtime_source).ok()
+    } else {
+        None
+    };
     Some(NativeRuntimeModelAdapter::new(
         descriptor,
         &metadata,
@@ -2617,6 +2633,57 @@ mod tests {
             &whisper_descriptor,
             Some(&base_tensor_index),
         ));
+    }
+
+    #[test]
+    fn dolphin_adapter_builder_still_probes_tensor_index_end_to_end() {
+        // Regression test for the tensor-index read gating in
+        // `build_native_runtime_model_adapter_for_path`: the read is now
+        // conditional on `descriptor.model_architecture ==
+        // DOLPHIN_GGML_ARCHITECTURE_ID`, so this exercises the full
+        // `native_runtime_model_adapter_for_path` -> family-registry
+        // selection -> conditional tensor-index read path end to end (not
+        // just the already-covered `native_runtime_descriptor_supports_phrase_bias`
+        // unit above) to confirm Dolphin's per-pack phrase-bias probe still
+        // fires correctly through the gate.
+        let temp = tempfile::tempdir().unwrap();
+        let mut architecture_only_metadata = std::collections::BTreeMap::new();
+        architecture_only_metadata.insert(
+            crate::arch::GENERAL_ARCHITECTURE_KEY.to_string(),
+            DOLPHIN_GGML_ARCHITECTURE_ID.to_string(),
+        );
+
+        let base_path = temp.path().join("dolphin-base-e2e.gguf");
+        write_tiny_gguf_runtime_source(
+            &base_path,
+            &TinyGgufFixtureSpec::new(architecture_only_metadata.clone()),
+        )
+        .unwrap();
+        let base_adapter = native_runtime_model_adapter_for_path(&base_path).unwrap();
+        assert_eq!(
+            base_adapter.descriptor.model_architecture,
+            DOLPHIN_GGML_ARCHITECTURE_ID
+        );
+        assert!(
+            !base_adapter.capabilities().supports_phrase_bias,
+            "a Dolphin pack without the context-module tensor must not advertise phrase bias"
+        );
+
+        let hotword_path = temp.path().join("dolphin-hotword-e2e.gguf");
+        let hotword_spec = TinyGgufFixtureSpec::new(architecture_only_metadata).with_added_tensor(
+            crate::models::dolphin::hotword_context::CONTEXT_MODULE_WORD_EMBEDDING_TENSOR_NAME,
+        );
+        write_tiny_gguf_runtime_source(&hotword_path, &hotword_spec).unwrap();
+        let hotword_adapter = native_runtime_model_adapter_for_path(&hotword_path).unwrap();
+        assert!(
+            hotword_adapter.capabilities().supports_phrase_bias,
+            "a Dolphin pack with the baked context-module tensor must advertise phrase bias"
+        );
+
+        // Non-Dolphin architectures never consult the tensor index; the
+        // Cohere/whisper full-path tests elsewhere in this module already
+        // cover their `supports_phrase_bias` derivation running through this
+        // same builder with the read now skipped.
     }
 
     #[test]

--- a/crates/openasr-core/src/audio/symphonia_decode.rs
+++ b/crates/openasr-core/src/audio/symphonia_decode.rs
@@ -202,6 +202,17 @@ where
 /// Resamples mono `input` at `input_rate` Hz to 16 kHz using a pure-Rust FFT
 /// resampler (rubato), processing fixed-size chunks and flushing the
 /// resampler's internal delay at the end so no trailing audio is dropped.
+///
+/// The main loop uses `process_into_buffer` with a pair of buffers allocated
+/// once up front (`Resampler::input_buffer_allocate` /
+/// `output_buffer_allocate`, sized to what `FftFixedIn` needs per call) and
+/// reused across every chunk, instead of the convenience `process()` +
+/// `chunk.to_vec()` pairing that used to allocate a fresh input `Vec` and a
+/// fresh output `Vec<Vec<f32>>` for every `RESAMPLE_CHUNK_FRAMES` chunk (a
+/// 10-minute 48 kHz input is ~2160 chunks). The numeric path is unchanged --
+/// `process_into_buffer` is what `process()` itself calls internally after
+/// allocating its buffers (see `Resampler::process` in rubato); only the
+/// buffer lifetime moved from per-chunk to per-call.
 fn resample_mono_to_16k(input: &[f32], input_rate: u32) -> Option<Vec<f32>> {
     let mut resampler = FftFixedIn::<f32>::new(
         input_rate as usize,
@@ -218,20 +229,37 @@ fn resample_mono_to_16k(input: &[f32], input_rate: u32) -> Option<Vec<f32>> {
     );
     let mut position = 0usize;
 
+    // `FftFixedIn::input_frames_max()` is the fixed `RESAMPLE_CHUNK_FRAMES`
+    // chunk size, so this input buffer is reused verbatim (only its contents
+    // change) across every full-chunk iteration below.
+    let mut input_buffer = resampler.input_buffer_allocate(true);
+    let mut output_buffer = resampler.output_buffer_allocate(true);
+
     while position + RESAMPLE_CHUNK_FRAMES <= input.len() {
-        let chunk = vec![input[position..position + RESAMPLE_CHUNK_FRAMES].to_vec()];
-        let processed = resampler.process(&chunk, None).ok()?;
-        output.extend_from_slice(&processed[0]);
+        input_buffer[0].copy_from_slice(&input[position..position + RESAMPLE_CHUNK_FRAMES]);
+        let (_, out_len) = resampler
+            .process_into_buffer(&input_buffer, &mut output_buffer, None)
+            .ok()?;
+        output.extend_from_slice(&output_buffer[0][..out_len]);
         position += RESAMPLE_CHUNK_FRAMES;
     }
 
+    // Tail handling (a short final chunk, plus the zero-input flush that
+    // drains the resampler's internal delay line) runs at most twice per
+    // call regardless of input length, so it keeps using the
+    // `process_partial_into_buffer` convenience method for its zero-padding;
+    // only the *output* buffer is the shared, pre-allocated one.
     if position < input.len() {
-        let remainder = vec![input[position..].to_vec()];
-        let processed = resampler.process_partial(Some(&remainder), None).ok()?;
-        output.extend_from_slice(&processed[0]);
+        let remainder = [input[position..].to_vec()];
+        let (_, out_len) = resampler
+            .process_partial_into_buffer(Some(&remainder), &mut output_buffer, None)
+            .ok()?;
+        output.extend_from_slice(&output_buffer[0][..out_len]);
     } else {
-        let processed = resampler.process_partial::<Vec<f32>>(None, None).ok()?;
-        output.extend_from_slice(&processed[0]);
+        let (_, out_len) = resampler
+            .process_partial_into_buffer(Option::<&[Vec<f32>]>::None, &mut output_buffer, None)
+            .ok()?;
+        output.extend_from_slice(&output_buffer[0][..out_len]);
     }
 
     Some(output)

--- a/crates/openasr-core/src/models/hymt2/runtime.rs
+++ b/crates/openasr-core/src/models/hymt2/runtime.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use thiserror::Error;
@@ -1720,14 +1720,23 @@ fn hymt2_prefill_chunk_size_for(
     decoder.safe_multi_query_prefill_chunk_size_for(token_count)
 }
 
+// `OPENASR_HYMT2_PROFILE` is a process-level launch toggle (set once, before
+// the daemon/CLI starts, to opt into per-step profiling), not something a
+// running process is expected to hot-toggle. Cache the parsed result behind
+// a `OnceLock` -- same pattern as `diarize::debug::diarize_debug_enabled` --
+// so per-token/per-step call sites in the decode loop pay one atomic load
+// instead of a full env lookup (lock + environ scan) every time.
 fn hymt2_profile_enabled() -> bool {
-    std::env::var(HYMT2_PROFILE_ENV)
-        .ok()
-        .map(|value| {
-            let normalized = value.trim().to_ascii_lowercase();
-            !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
-        })
-        .unwrap_or(false)
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var(HYMT2_PROFILE_ENV)
+            .ok()
+            .map(|value| {
+                let normalized = value.trim().to_ascii_lowercase();
+                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+            })
+            .unwrap_or(false)
+    })
 }
 
 fn hymt2_profile_start() -> Option<Instant> {


### PR DESCRIPTION
## Summary

Four independent, self-contained quick-win optimizations from the R2
optimization roadmap (QW1-QW4), one commit each: a redundant config read on
`serve` startup, per-chunk resampler allocations, a per-token env re-read in
the hymt2 translation path, and an unconditional GGUF tensor-index read that
only Dolphin ever consumes.

## Why

Each finding was independently re-verified against live `main` (`cab0267`)
before implementing, since the roadmap doc predates several recent merges.

- **QW1** (`crates/openasr-cli/src/native_segment_cli.rs`): confirmed --
  `serve()` called `load_config(&home)` at the top and a second, separate
  `openasr_core::load_config_document(&home)` further down just to read
  `idle_unload` off `Preferences`. Both reads happen on every daemon boot.
- **QW2** (`crates/openasr-core/src/audio/symphonia_decode.rs`): confirmed --
  `resample_mono_to_16k()` allocated a fresh input `Vec` (`chunk.to_vec()`)
  and a fresh output `Vec<Vec<f32>>` (via the `process()` convenience method)
  for every `RESAMPLE_CHUNK_FRAMES` (4096-frame) chunk.
- **QW3** (`crates/openasr-core/src/models/hymt2/runtime.rs`): confirmed --
  `hymt2_profile_enabled()` re-read and re-parsed `OPENASR_HYMT2_PROFILE` on
  every call, and it's called from several profiling checkpoints per decode
  step in the hot per-token loop.
- **QW4** (`crates/openasr-core/src/api/backend/native.rs`): confirmed, with
  one correction to the roadmap -- `native_runtime_model_adapter_for_path`
  is already process-cached per pack (a prior PR, #93, already collapsed the
  3x-per-facet re-parse the roadmap described). What remains true today:
  `build_native_runtime_model_adapter_for_path` unconditionally read the
  full GGUF tensor index for every architecture, even though
  `native_runtime_descriptor_supports_phrase_bias` only ever consults it for
  Dolphin. So the saving is "skip one tensor-directory parse in the
  one-time-per-process adapter build" rather than "per-request", smaller
  than the roadmap assumed but still a real, structural no-op removal for
  the large majority (non-Dolphin) of installed packs.

## Changes

- `perf(cli): read config.json once on serve startup` -- single
  `load_config_document` call at the top of `serve()`; `config` and
  `idle_unload_after` both derive from it.
- `perf(core): reuse rubato buffers across resample chunks` -- allocate
  input/output buffers once via `Resampler::input_buffer_allocate` /
  `output_buffer_allocate`, reuse them across the loop via
  `process_into_buffer` (the same call `process()` makes internally after
  allocating its own buffers). Tail handling (final short chunk + delay-line
  flush) still uses `process_partial_into_buffer` since it runs at most
  twice per call regardless of input length.
- `perf(hymt2): cache OPENASR_HYMT2_PROFILE behind a OnceLock` -- same
  pattern as the existing `diarize::debug::diarize_debug_enabled()`; the env
  var is a process-level launch toggle, not hot-toggled at runtime, so
  caching it is safe.
- `perf(core): gate GGUF tensor-index read to Dolphin adapters` -- select
  the family descriptor first, then only read the tensor index when
  `descriptor.model_architecture == DOLPHIN_GGML_ARCHITECTURE_ID`. Added an
  end-to-end regression test (`dolphin_adapter_builder_still_probes_tensor_index_end_to_end`)
  that drives the full `native_runtime_model_adapter_for_path` path for a
  base and a hotword-tier Dolphin fixture, alongside the existing
  architecture-level unit test.

## Quantified evidence

- **QW2 numerical equivalence (byte-identical, sha256)**: built a release
  CLI from this branch and from `origin/main` (`cab0267`), ran
  `transcribe -f verbose_json --offline` for `whisper-tiny`, `moonshine-tiny`,
  and `dolphin-base` against `jfk.wav`/`zh_sample.wav` at their native 16 kHz
  (resample skipped -- sanity check) plus 44.1 kHz/48 kHz wav and 44.1 kHz
  mp3 re-encodes (all of which force the FFT resample path this PR touches).
  All 24 combinations produced identical sha256 verbose_json output between
  branch and baseline.
- **QW4 correctness**: `dolphin_phrase_bias_probe_reports_true_only_when_context_module_tensor_is_baked`
  (existing) plus the new end-to-end test both pass; both also verified via
  the same byte-identical release-CLI comparison above (`dolphin-base` runs
  included).
- **QW1**: structural saving is one `fs::read` + `serde_json::from_str` of
  an 806-byte file per `serve` startup, removed. Instrumented boot-stage
  timing (`server_boot: stage=ready total_ms=...`, existing logging) starts
  *after* this read in both branches, so it doesn't capture the removed
  read directly; 8-run external wall-clock samples (process spawn to
  "listening" banner) were too noisy (~0.4-1.0s, dominated by process
  startup/Metal init, not by an 806-byte parse) to attribute a measurable
  delta to this change specifically -- reporting this honestly rather than
  claiming a wall-clock win the harness didn't actually produce. The
  concurrency-relevant reference point: this read only ever runs once, at
  daemon boot, off the request path, so it has no effect on request
  concurrency/throughput.
- **QW3**: no dedicated microbenchmark; correctness verified by the
  existing hymt2 test suite passing unchanged (call sites and observable
  behavior are identical, only the read moved from "every call" to "once,
  cached").

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2416 passed, 122 skipped, 0 failed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (advisories/bans/licenses/sources all ok)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`
- [x] Each of the 4 commits individually checked out and `cargo check --workspace` clean

## Manual smoke checks

- Release-CLI byte-identical (sha256) comparison described above: 24
  transcribe runs (3 families x 8 audio variants) matched between this
  branch and `origin/main`.
- `openasr serve --addr 127.0.0.1:0` smoke-started on both binaries;
  `idle_unload` boot-stage behavior unchanged.

## Docs updated

- [x] N/A -- internal perf-only changes, no behavior/limitations change.

## Scope / non-goals

This PR is scoped to exactly QW1-QW4 from the R2 roadmap. It does not touch
`native_transcribe.rs` (finalize chain), f16-conversion files, the
`openasr-server` response-struct codegen line, or the `server/lib.rs` dead-API
cleanup line -- all flagged as other in-flight work in the roadmap's collision
table. It also does not implement the roadmap's M1 (capabilities single-parse
collapse), since that already landed in `main` via #93 before this PR was
written.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts,
      secrets, or private audio.
- [x] I did not add vendored runtime sources outside
      `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI
      usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI
      assistance, and I own its maintenance.
- AI usage disclosure: YES -- an AI coding agent implemented these four
  changes (verified each roadmap claim against live code first, one commit
  per finding) and ran the full local verification gate plus the
  byte-identical release-CLI comparison described above under human
  direction.
