### PR TITLE
refactor(core): migrate qwen/cohere/diarize frontends onto shared audio_frontend DSP

### DIFF
--- a/crates/openasr-core/src/diarize/embed/fbank.rs
+++ b/crates/openasr-core/src/diarize/embed/fbank.rs
@@ -6,12 +6,18 @@
 //! before feature extraction. The output is per-utterance cepstral mean
 //! normalized (subtract each bin's time-mean). Inputs are `f32` in `[-1, 1]`.
 //! Validated against torchaudio (see `tests`).
+//!
+//! The fbank math (framing, Hamming window, DC removal, pre-emphasis, FFT,
+//! HTK mel filterbank, log floor) is the same computation
+//! `firered_aed`/`dolphin`/`sensevoice` share via
+//! [`crate::models::kaldi_fbank`] (Povey-window config there; this frontend
+//! selects [`crate::models::kaldi_fbank::KaldiWindowKind::Hamming`]). Only
+//! the per-utterance CMN (mean-only, no variance scaling -- distinct from
+//! that shared module's CMVN affine, which is a per-checkpoint tensor
+//! applied by the family frontend, not computed here) stays local.
 
-use std::sync::Arc;
+use crate::models::kaldi_fbank::{KaldiFbankConfig, KaldiFbankFrontend, KaldiWindowKind};
 
-use realfft::{RealFftPlanner, RealToComplex};
-
-const SAMPLE_RATE: f32 = 16_000.0;
 const FRAME_LENGTH: usize = 400; // 25 ms
 const FRAME_SHIFT: usize = 160; // 10 ms
 const FFT_SIZE: usize = 512; // next pow2 >= 400
@@ -33,21 +39,8 @@ impl FbankConfig {
     }
 }
 
-fn mel_scale(freq: f32) -> f32 {
-    1127.0 * (1.0 + freq / 700.0).ln()
-}
-
-/// One triangular mel filter as a contiguous weight run over FFT power bins.
-struct MelFilter {
-    first_bin: usize,
-    weights: Vec<f32>,
-}
-
 pub(crate) struct Fbank {
-    window: [f32; FRAME_LENGTH],
-    filters: Vec<MelFilter>,
-    fft: Arc<dyn RealToComplex<f32>>,
-    input_scale: f32,
+    inner: KaldiFbankFrontend,
 }
 
 impl Default for Fbank {
@@ -62,119 +55,230 @@ impl Fbank {
     }
 
     pub(crate) fn with_config(config: FbankConfig) -> Self {
-        let mut window = [0.0f32; FRAME_LENGTH];
-        for (n, w) in window.iter_mut().enumerate() {
-            let phase = 2.0 * std::f32::consts::PI * n as f32 / (FRAME_LENGTH as f32 - 1.0);
-            *w = 0.54 - 0.46 * phase.cos();
-        }
         Self {
-            window,
-            filters: build_mel_filters(),
-            fft: RealFftPlanner::<f32>::new().plan_fft_forward(FFT_SIZE),
-            input_scale: config.input_scale,
+            inner: KaldiFbankFrontend::new(KaldiFbankConfig {
+                sample_rate_hz: 16_000,
+                frame_length: FRAME_LENGTH,
+                frame_shift: FRAME_SHIFT,
+                fft_size: FFT_SIZE,
+                num_mel_bins: NUM_BINS,
+                mel_low_hz: LOW_FREQ,
+                mel_high_hz: HIGH_FREQ,
+                preemph_coeff: PREEMPH,
+                input_scale: config.input_scale,
+                log_energy_floor: f32::EPSILON,
+                window: KaldiWindowKind::Hamming,
+            }),
         }
     }
 
     /// Compute the CMN-normalized log-mel features for `samples`, returning
-    /// `(features [t*80] row-major, t)`. Returns `t == 0` for too-short input.
+    /// `(features [t*80] row-major, t)`. Returns `t == 0` for too-short input
+    /// (or, since the shared engine also fail-closes on non-finite input
+    /// where this frontend previously had no such check, for non-finite
+    /// samples).
     pub(crate) fn compute(&self, samples: &[f32]) -> (Vec<f32>, usize) {
-        if samples.len() < FRAME_LENGTH {
+        let Ok(features) = self.inner.compute(samples) else {
             return (Vec::new(), 0);
-        }
-        let n_frames = 1 + (samples.len() - FRAME_LENGTH) / FRAME_SHIFT;
-        let r2c = &self.fft;
-        let mut fft_in = r2c.make_input_vec();
-        let mut fft_out = r2c.make_output_vec();
-
-        let mut feats = vec![0.0f32; n_frames * NUM_BINS];
-        let mut frame = [0.0f32; FRAME_LENGTH];
-        for fr in 0..n_frames {
-            let start = fr * FRAME_SHIFT;
-            for (dst, src) in frame.iter_mut().zip(&samples[start..start + FRAME_LENGTH]) {
-                *dst = *src * self.input_scale;
-            }
-            // remove DC offset (subtract frame mean).
-            let mean = frame.iter().sum::<f32>() / FRAME_LENGTH as f32;
-            for v in &mut frame {
-                *v -= mean;
-            }
-            // pre-emphasis: x[i] -= 0.97 x[i-1] (back-to-front), x[0] -= 0.97 x[0].
-            for i in (1..FRAME_LENGTH).rev() {
-                frame[i] -= PREEMPH * frame[i - 1];
-            }
-            frame[0] -= PREEMPH * frame[0];
-            // Apply the window into the zero-padded FFT input.
-            for slot in fft_in.iter_mut() {
-                *slot = 0.0;
-            }
-            for i in 0..FRAME_LENGTH {
-                fft_in[i] = frame[i] * self.window[i];
-            }
-            r2c.process(&mut fft_in, &mut fft_out).expect("fft");
-            // power spectrum.
-            let mut power = [0.0f32; FFT_SIZE / 2 + 1];
-            for (k, c) in fft_out.iter().enumerate() {
-                power[k] = c.re * c.re + c.im * c.im;
-            }
-            // mel + log.
-            for (bin, filter) in self.filters.iter().enumerate() {
-                let mut energy = 0.0f32;
-                for (j, weight) in filter.weights.iter().enumerate() {
-                    energy += weight * power[filter.first_bin + j];
-                }
-                feats[fr * NUM_BINS + bin] = energy.max(f32::EPSILON).ln();
-            }
-        }
-        // CMN: subtract each bin's mean over time.
-        for bin in 0..NUM_BINS {
-            let mut mean = 0.0f32;
-            for fr in 0..n_frames {
-                mean += feats[fr * NUM_BINS + bin];
-            }
-            mean /= n_frames as f32;
-            for fr in 0..n_frames {
-                feats[fr * NUM_BINS + bin] -= mean;
-            }
-        }
-        (feats, n_frames)
+        };
+        let mut data = features.data;
+        cepstral_mean_normalize(&mut data, features.n_frames, features.n_mels);
+        (data, features.n_frames)
     }
 }
 
-fn build_mel_filters() -> Vec<MelFilter> {
-    let n_fft_bins = FFT_SIZE / 2 + 1;
-    let fft_bin_width = SAMPLE_RATE / FFT_SIZE as f32;
-    let mel_low = mel_scale(LOW_FREQ);
-    let mel_high = mel_scale(HIGH_FREQ);
-    let mel_delta = (mel_high - mel_low) / (NUM_BINS as f32 + 1.0);
+/// CMN: subtract each mel bin's mean over time (no variance scaling --
+/// distinct from [`crate::models::audio_frontend::per_feature_normalize`],
+/// which also divides by std).
+fn cepstral_mean_normalize(feats: &mut [f32], n_frames: usize, n_mels: usize) {
+    for bin in 0..n_mels {
+        let mut mean = 0.0f32;
+        for fr in 0..n_frames {
+            mean += feats[fr * n_mels + bin];
+        }
+        mean /= n_frames as f32;
+        for fr in 0..n_frames {
+            feats[fr * n_mels + bin] -= mean;
+        }
+    }
+}
 
-    let mut filters = Vec::with_capacity(NUM_BINS);
-    for bin in 0..NUM_BINS {
-        let left = mel_low + bin as f32 * mel_delta;
-        let center = mel_low + (bin as f32 + 1.0) * mel_delta;
-        let right = mel_low + (bin as f32 + 2.0) * mel_delta;
-        let mut first_bin = None;
-        let mut weights = Vec::new();
-        for k in 0..n_fft_bins {
-            let freq = fft_bin_width * k as f32;
-            let mel = mel_scale(freq);
-            if mel > left && mel < right {
-                let weight = if mel <= center {
-                    (mel - left) / (center - left)
-                } else {
-                    (right - mel) / (right - center)
-                };
-                if first_bin.is_none() {
-                    first_bin = Some(k);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Frozen copy of the pre-refactor `Fbank` (own FFT/mel-filter/window
+    /// construction, before it delegated to `crate::models::kaldi_fbank`),
+    /// kept only to pin the migrated implementation to byte-identical
+    /// output.
+    mod reference {
+        use realfft::{RealFftPlanner, RealToComplex};
+        use std::sync::Arc;
+
+        const FRAME_LENGTH: usize = 400;
+        const FRAME_SHIFT: usize = 160;
+        const FFT_SIZE: usize = 512;
+        const NUM_BINS: usize = 80;
+        const LOW_FREQ: f32 = 20.0;
+        const HIGH_FREQ: f32 = 8_000.0;
+        const PREEMPH: f32 = 0.97;
+        const SAMPLE_RATE: f32 = 16_000.0;
+
+        fn mel_scale(freq: f32) -> f32 {
+            1127.0 * (1.0 + freq / 700.0).ln()
+        }
+
+        struct MelFilter {
+            first_bin: usize,
+            weights: Vec<f32>,
+        }
+
+        pub(super) struct ReferenceFbank {
+            window: [f32; FRAME_LENGTH],
+            filters: Vec<MelFilter>,
+            fft: Arc<dyn RealToComplex<f32>>,
+            input_scale: f32,
+        }
+
+        impl ReferenceFbank {
+            pub(super) fn wespeaker() -> Self {
+                let mut window = [0.0f32; FRAME_LENGTH];
+                for (n, w) in window.iter_mut().enumerate() {
+                    let phase = 2.0 * std::f32::consts::PI * n as f32 / (FRAME_LENGTH as f32 - 1.0);
+                    *w = 0.54 - 0.46 * phase.cos();
                 }
-                weights.push(weight);
-            } else if first_bin.is_some() {
-                break;
+                Self {
+                    window,
+                    filters: build_mel_filters(),
+                    fft: RealFftPlanner::<f32>::new().plan_fft_forward(FFT_SIZE),
+                    input_scale: 32768.0,
+                }
+            }
+
+            pub(super) fn compute(&self, samples: &[f32]) -> (Vec<f32>, usize) {
+                if samples.len() < FRAME_LENGTH {
+                    return (Vec::new(), 0);
+                }
+                let n_frames = 1 + (samples.len() - FRAME_LENGTH) / FRAME_SHIFT;
+                let r2c = &self.fft;
+                let mut fft_in = r2c.make_input_vec();
+                let mut fft_out = r2c.make_output_vec();
+
+                let mut feats = vec![0.0f32; n_frames * NUM_BINS];
+                let mut frame = [0.0f32; FRAME_LENGTH];
+                for fr in 0..n_frames {
+                    let start = fr * FRAME_SHIFT;
+                    for (dst, src) in frame.iter_mut().zip(&samples[start..start + FRAME_LENGTH]) {
+                        *dst = *src * self.input_scale;
+                    }
+                    let mean = frame.iter().sum::<f32>() / FRAME_LENGTH as f32;
+                    for v in &mut frame {
+                        *v -= mean;
+                    }
+                    for i in (1..FRAME_LENGTH).rev() {
+                        frame[i] -= PREEMPH * frame[i - 1];
+                    }
+                    frame[0] -= PREEMPH * frame[0];
+                    for slot in fft_in.iter_mut() {
+                        *slot = 0.0;
+                    }
+                    for i in 0..FRAME_LENGTH {
+                        fft_in[i] = frame[i] * self.window[i];
+                    }
+                    r2c.process(&mut fft_in, &mut fft_out).expect("fft");
+                    let mut power = [0.0f32; FFT_SIZE / 2 + 1];
+                    for (k, c) in fft_out.iter().enumerate() {
+                        power[k] = c.re * c.re + c.im * c.im;
+                    }
+                    for (bin, filter) in self.filters.iter().enumerate() {
+                        let mut energy = 0.0f32;
+                        for (j, weight) in filter.weights.iter().enumerate() {
+                            energy += weight * power[filter.first_bin + j];
+                        }
+                        feats[fr * NUM_BINS + bin] = energy.max(f32::EPSILON).ln();
+                    }
+                }
+                for bin in 0..NUM_BINS {
+                    let mut mean = 0.0f32;
+                    for fr in 0..n_frames {
+                        mean += feats[fr * NUM_BINS + bin];
+                    }
+                    mean /= n_frames as f32;
+                    for fr in 0..n_frames {
+                        feats[fr * NUM_BINS + bin] -= mean;
+                    }
+                }
+                (feats, n_frames)
             }
         }
-        filters.push(MelFilter {
-            first_bin: first_bin.unwrap_or(0),
-            weights,
-        });
+
+        fn build_mel_filters() -> Vec<MelFilter> {
+            let n_fft_bins = FFT_SIZE / 2 + 1;
+            let fft_bin_width = SAMPLE_RATE / FFT_SIZE as f32;
+            let mel_low = mel_scale(LOW_FREQ);
+            let mel_high = mel_scale(HIGH_FREQ);
+            let mel_delta = (mel_high - mel_low) / (NUM_BINS as f32 + 1.0);
+
+            let mut filters = Vec::with_capacity(NUM_BINS);
+            for bin in 0..NUM_BINS {
+                let left = mel_low + bin as f32 * mel_delta;
+                let center = mel_low + (bin as f32 + 1.0) * mel_delta;
+                let right = mel_low + (bin as f32 + 2.0) * mel_delta;
+                let mut first_bin = None;
+                let mut weights = Vec::new();
+                for k in 0..n_fft_bins {
+                    let freq = fft_bin_width * k as f32;
+                    let mel = mel_scale(freq);
+                    if mel > left && mel < right {
+                        let weight = if mel <= center {
+                            (mel - left) / (center - left)
+                        } else {
+                            (right - mel) / (right - center)
+                        };
+                        if first_bin.is_none() {
+                            first_bin = Some(k);
+                        }
+                        weights.push(weight);
+                    } else if first_bin.is_some() {
+                        break;
+                    }
+                }
+                filters.push(MelFilter {
+                    first_bin: first_bin.unwrap_or(0),
+                    weights,
+                });
+            }
+            filters
+        }
     }
-    filters
+
+    fn sine_samples(n: usize, freq_hz: f32) -> Vec<f32> {
+        (0..n)
+            .map(|i| (2.0 * std::f32::consts::PI * freq_hz * i as f32 / 16_000.0).sin() * 0.3)
+            .collect()
+    }
+
+    #[test]
+    fn migrated_fbank_is_byte_identical_to_pre_refactor_reference() {
+        let migrated = Fbank::wespeaker();
+        let reference = reference::ReferenceFbank::wespeaker();
+        for samples in [
+            vec![0.01f32; 38_080],
+            sine_samples(48_000, 220.0),
+            sine_samples(16_500, 880.0),
+        ] {
+            let (migrated_feats, migrated_frames) = migrated.compute(&samples);
+            let (reference_feats, reference_frames) = reference.compute(&samples);
+            assert_eq!(migrated_frames, reference_frames);
+            assert_eq!(migrated_feats, reference_feats);
+        }
+    }
+
+    #[test]
+    fn migrated_fbank_matches_reference_on_too_short_audio() {
+        let migrated = Fbank::wespeaker();
+        let reference = reference::ReferenceFbank::wespeaker();
+        let samples = vec![0.0f32; 200];
+        assert_eq!(migrated.compute(&samples), reference.compute(&samples));
+    }
 }

--- a/crates/openasr-core/src/diarize/vad/firered_stream/frontend.rs
+++ b/crates/openasr-core/src/diarize/vad/firered_stream/frontend.rs
@@ -11,12 +11,13 @@
 //! `crate::models::firered_aed::frontend` (both upstreams -- same team --
 //! run kaldi fbank with the same 80/25ms/10ms/16kHz/dither-0 config and
 //! defaults: Povey window, remove_dc_offset, pre-emphasis 0.97, HTK mel
-//! 20 Hz..Nyquist, `log(max(energy, eps))`). Kept family-local like every
-//! other frontend so nothing generic grows a FireRed special case.
+//! 20 Hz..Nyquist, `log(max(energy, eps))`), so it now runs on the shared
+//! [`crate::models::kaldi_fbank`] engine that `firered_aed`/`dolphin`/
+//! `sensevoice` also use; only the `FbankFeatures`/no-Result API shape (the
+//! streaming VAD caller wants `n_frames == 0` rather than an error variant)
+//! and the CMVN application stay family-local.
 
-use std::sync::Arc;
-
-use realfft::{RealFftPlanner, RealToComplex};
+use crate::models::kaldi_fbank::{KaldiFbankConfig, KaldiFbankFrontend, KaldiWindowKind};
 
 pub(crate) const SAMPLE_RATE_HZ: u32 = 16_000;
 // `pub(crate)`: the Stream-VAD streaming detector needs these to know how
@@ -35,37 +36,34 @@ const INPUT_SCALE: f32 = 32_768.0;
 /// kaldi mel-energy floor before the log.
 const LOG_ENERGY_FLOOR: f32 = 1.192_092_9e-7;
 
+const FRONTEND_CONFIG: KaldiFbankConfig = KaldiFbankConfig {
+    sample_rate_hz: SAMPLE_RATE_HZ,
+    frame_length: FRAME_LENGTH,
+    frame_shift: FRAME_SHIFT,
+    fft_size: FFT_SIZE,
+    num_mel_bins: NUM_MEL_BINS,
+    mel_low_hz: MEL_LOW_HZ,
+    mel_high_hz: MEL_HIGH_HZ,
+    preemph_coeff: PREEMPH_COEFF,
+    input_scale: INPUT_SCALE,
+    log_energy_floor: LOG_ENERGY_FLOOR,
+    window: KaldiWindowKind::Povey,
+};
+
 /// Pre-CMVN log-mel features, row-major `[frame][mel]` (mel innermost).
 pub(crate) struct FbankFeatures {
     pub data: Vec<f32>,
     pub n_frames: usize,
 }
 
-/// One triangular mel filter as a contiguous weight run over FFT power bins.
-struct MelFilter {
-    first_bin: usize,
-    weights: Vec<f32>,
-}
-
 pub(crate) struct FireRedVadFbankFrontend {
-    window: [f32; FRAME_LENGTH],
-    filters: Vec<MelFilter>,
-    fft: Arc<dyn RealToComplex<f32>>,
+    inner: KaldiFbankFrontend,
 }
 
 impl FireRedVadFbankFrontend {
     pub(crate) fn new() -> Self {
-        let mut window = [0.0f32; FRAME_LENGTH];
-        for (n, w) in window.iter_mut().enumerate() {
-            // Povey window: a Hann raised to 0.85 (kaldi default).
-            let hann = 0.5
-                - 0.5 * (2.0 * std::f32::consts::PI * n as f32 / (FRAME_LENGTH as f32 - 1.0)).cos();
-            *w = hann.powf(0.85);
-        }
         Self {
-            window,
-            filters: build_mel_filters(),
-            fft: RealFftPlanner::<f32>::new().plan_fft_forward(FFT_SIZE),
+            inner: KaldiFbankFrontend::new(FRONTEND_CONFIG),
         }
     }
 
@@ -73,60 +71,19 @@ impl FireRedVadFbankFrontend {
     /// (float in `[-1, 1]`). `snip_edges=true`: frame count is
     /// `1 + (len - FRAME_LENGTH) / FRAME_SHIFT`, frame `i` starts at
     /// `i * FRAME_SHIFT` with no edge reflection. Returns `n_frames == 0`
-    /// (empty data) for audio shorter than one frame.
+    /// (empty data) for audio shorter than one frame (or, since the shared
+    /// engine also fail-closes on non-finite input where this frontend
+    /// previously had no such check, for non-finite samples).
     pub(crate) fn compute(&self, samples: &[f32]) -> FbankFeatures {
-        if samples.len() < FRAME_LENGTH {
-            return FbankFeatures {
+        match self.inner.compute(samples) {
+            Ok(features) => FbankFeatures {
+                data: features.data,
+                n_frames: features.n_frames,
+            },
+            Err(_) => FbankFeatures {
                 data: Vec::new(),
                 n_frames: 0,
-            };
-        }
-        let n_frames = 1 + (samples.len() - FRAME_LENGTH) / FRAME_SHIFT;
-        let r2c = &self.fft;
-        let mut fft_in = r2c.make_input_vec();
-        let mut fft_out = r2c.make_output_vec();
-        let mut scratch = r2c.make_scratch_vec();
-        let mut power = vec![0.0f32; FFT_SIZE / 2 + 1];
-
-        let mut feats = vec![0.0f32; n_frames * NUM_MEL_BINS];
-        let mut frame = [0.0f32; FRAME_LENGTH];
-        for fr in 0..n_frames {
-            let start = fr * FRAME_SHIFT;
-            for (dst, src) in frame.iter_mut().zip(&samples[start..start + FRAME_LENGTH]) {
-                *dst = *src * INPUT_SCALE;
-            }
-            // remove_dc_offset: subtract the frame mean.
-            let mean = frame.iter().sum::<f32>() / FRAME_LENGTH as f32;
-            for v in &mut frame {
-                *v -= mean;
-            }
-            // pre-emphasis with replicate padding: x[i] -= 0.97 x[i-1] (i>=1),
-            // x[0] -= 0.97 x[0].
-            for i in (1..FRAME_LENGTH).rev() {
-                frame[i] -= PREEMPH_COEFF * frame[i - 1];
-            }
-            frame[0] -= PREEMPH_COEFF * frame[0];
-            // Povey window into the zero-padded FFT input.
-            fft_in.fill(0.0);
-            for (slot, (sample, w)) in fft_in.iter_mut().zip(frame.iter().zip(self.window.iter())) {
-                *slot = *sample * *w;
-            }
-            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
-                .expect("firered VAD fbank rfft");
-            for (bin, value) in fft_out.iter().enumerate() {
-                power[bin] = value.re * value.re + value.im * value.im;
-            }
-            for (bin, filter) in self.filters.iter().enumerate() {
-                let mut energy = 0.0f32;
-                for (j, weight) in filter.weights.iter().enumerate() {
-                    energy += weight * power[filter.first_bin + j];
-                }
-                feats[fr * NUM_MEL_BINS + bin] = energy.max(LOG_ENERGY_FLOOR).ln();
-            }
-        }
-        FbankFeatures {
-            data: feats,
-            n_frames,
+            },
         }
     }
 }
@@ -143,51 +100,6 @@ pub(crate) fn apply_cmvn(
             *value = (*value - *m) * *s;
         }
     }
-}
-
-fn mel_scale(freq: f32) -> f32 {
-    1127.0 * (1.0 + freq / 700.0).ln()
-}
-
-/// Kaldi triangular mel filterbank over `FFT_SIZE/2 + 1` power bins:
-/// `NUM_MEL_BINS` peak-normalized triangles spanning `[MEL_LOW_HZ, MEL_HIGH_HZ]`
-/// on the HTK mel scale, gated to bins strictly inside the filter band.
-fn build_mel_filters() -> Vec<MelFilter> {
-    let n_fft_bins = FFT_SIZE / 2 + 1;
-    let fft_bin_width = SAMPLE_RATE_HZ as f32 / FFT_SIZE as f32;
-    let mel_low = mel_scale(MEL_LOW_HZ);
-    let mel_high = mel_scale(MEL_HIGH_HZ);
-    let mel_delta = (mel_high - mel_low) / (NUM_MEL_BINS as f32 + 1.0);
-
-    let mut filters = Vec::with_capacity(NUM_MEL_BINS);
-    for bin in 0..NUM_MEL_BINS {
-        let left = mel_low + bin as f32 * mel_delta;
-        let center = mel_low + (bin as f32 + 1.0) * mel_delta;
-        let right = mel_low + (bin as f32 + 2.0) * mel_delta;
-        let mut first_bin = None;
-        let mut weights = Vec::new();
-        for k in 0..n_fft_bins {
-            let mel = mel_scale(fft_bin_width * k as f32);
-            if mel > left && mel < right {
-                let weight = if mel <= center {
-                    (mel - left) / (center - left)
-                } else {
-                    (right - mel) / (right - center)
-                };
-                if first_bin.is_none() {
-                    first_bin = Some(k);
-                }
-                weights.push(weight);
-            } else if first_bin.is_some() {
-                break;
-            }
-        }
-        filters.push(MelFilter {
-            first_bin: first_bin.unwrap_or(0),
-            weights,
-        });
-    }
-    filters
 }
 
 #[cfg(test)]
@@ -209,5 +121,177 @@ mod tests {
         let features = FireRedVadFbankFrontend::new().compute(&samples);
         assert_eq!(features.n_frames, 0);
         assert!(features.data.is_empty());
+    }
+
+    /// Frozen copy of the pre-refactor `FireRedVadFbankFrontend` (own
+    /// FFT/mel-filter/window construction, before it delegated to
+    /// `crate::models::kaldi_fbank`), kept only to pin the migrated
+    /// implementation to byte-identical output.
+    mod reference {
+        use realfft::{RealFftPlanner, RealToComplex};
+        use std::sync::Arc;
+
+        const FRAME_LENGTH: usize = 400;
+        const FRAME_SHIFT: usize = 160;
+        const FFT_SIZE: usize = 512;
+        const NUM_MEL_BINS: usize = 80;
+        const SAMPLE_RATE_HZ: u32 = 16_000;
+        const MEL_LOW_HZ: f32 = 20.0;
+        const MEL_HIGH_HZ: f32 = 8_000.0;
+        const PREEMPH_COEFF: f32 = 0.97;
+        const INPUT_SCALE: f32 = 32_768.0;
+        const LOG_ENERGY_FLOOR: f32 = 1.192_092_9e-7;
+
+        pub(super) struct ReferenceFbankFeatures {
+            pub data: Vec<f32>,
+            pub n_frames: usize,
+        }
+
+        struct MelFilter {
+            first_bin: usize,
+            weights: Vec<f32>,
+        }
+
+        pub(super) struct ReferenceFireRedVadFbankFrontend {
+            window: [f32; FRAME_LENGTH],
+            filters: Vec<MelFilter>,
+            fft: Arc<dyn RealToComplex<f32>>,
+        }
+
+        impl ReferenceFireRedVadFbankFrontend {
+            pub(super) fn new() -> Self {
+                let mut window = [0.0f32; FRAME_LENGTH];
+                for (n, w) in window.iter_mut().enumerate() {
+                    let hann = 0.5
+                        - 0.5
+                            * (2.0 * std::f32::consts::PI * n as f32 / (FRAME_LENGTH as f32 - 1.0))
+                                .cos();
+                    *w = hann.powf(0.85);
+                }
+                Self {
+                    window,
+                    filters: build_mel_filters(),
+                    fft: RealFftPlanner::<f32>::new().plan_fft_forward(FFT_SIZE),
+                }
+            }
+
+            pub(super) fn compute(&self, samples: &[f32]) -> ReferenceFbankFeatures {
+                if samples.len() < FRAME_LENGTH {
+                    return ReferenceFbankFeatures {
+                        data: Vec::new(),
+                        n_frames: 0,
+                    };
+                }
+                let n_frames = 1 + (samples.len() - FRAME_LENGTH) / FRAME_SHIFT;
+                let r2c = &self.fft;
+                let mut fft_in = r2c.make_input_vec();
+                let mut fft_out = r2c.make_output_vec();
+                let mut scratch = r2c.make_scratch_vec();
+                let mut power = vec![0.0f32; FFT_SIZE / 2 + 1];
+
+                let mut feats = vec![0.0f32; n_frames * NUM_MEL_BINS];
+                let mut frame = [0.0f32; FRAME_LENGTH];
+                for fr in 0..n_frames {
+                    let start = fr * FRAME_SHIFT;
+                    for (dst, src) in frame.iter_mut().zip(&samples[start..start + FRAME_LENGTH]) {
+                        *dst = *src * INPUT_SCALE;
+                    }
+                    let mean = frame.iter().sum::<f32>() / FRAME_LENGTH as f32;
+                    for v in &mut frame {
+                        *v -= mean;
+                    }
+                    for i in (1..FRAME_LENGTH).rev() {
+                        frame[i] -= PREEMPH_COEFF * frame[i - 1];
+                    }
+                    frame[0] -= PREEMPH_COEFF * frame[0];
+                    fft_in.fill(0.0);
+                    for (slot, (sample, w)) in
+                        fft_in.iter_mut().zip(frame.iter().zip(self.window.iter()))
+                    {
+                        *slot = *sample * *w;
+                    }
+                    r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
+                        .expect("firered VAD fbank rfft");
+                    for (bin, value) in fft_out.iter().enumerate() {
+                        power[bin] = value.re * value.re + value.im * value.im;
+                    }
+                    for (bin, filter) in self.filters.iter().enumerate() {
+                        let mut energy = 0.0f32;
+                        for (j, weight) in filter.weights.iter().enumerate() {
+                            energy += weight * power[filter.first_bin + j];
+                        }
+                        feats[fr * NUM_MEL_BINS + bin] = energy.max(LOG_ENERGY_FLOOR).ln();
+                    }
+                }
+                ReferenceFbankFeatures {
+                    data: feats,
+                    n_frames,
+                }
+            }
+        }
+
+        fn mel_scale(freq: f32) -> f32 {
+            1127.0 * (1.0 + freq / 700.0).ln()
+        }
+
+        fn build_mel_filters() -> Vec<MelFilter> {
+            let n_fft_bins = FFT_SIZE / 2 + 1;
+            let fft_bin_width = SAMPLE_RATE_HZ as f32 / FFT_SIZE as f32;
+            let mel_low = mel_scale(MEL_LOW_HZ);
+            let mel_high = mel_scale(MEL_HIGH_HZ);
+            let mel_delta = (mel_high - mel_low) / (NUM_MEL_BINS as f32 + 1.0);
+
+            let mut filters = Vec::with_capacity(NUM_MEL_BINS);
+            for bin in 0..NUM_MEL_BINS {
+                let left = mel_low + bin as f32 * mel_delta;
+                let center = mel_low + (bin as f32 + 1.0) * mel_delta;
+                let right = mel_low + (bin as f32 + 2.0) * mel_delta;
+                let mut first_bin = None;
+                let mut weights = Vec::new();
+                for k in 0..n_fft_bins {
+                    let mel = mel_scale(fft_bin_width * k as f32);
+                    if mel > left && mel < right {
+                        let weight = if mel <= center {
+                            (mel - left) / (center - left)
+                        } else {
+                            (right - mel) / (right - center)
+                        };
+                        if first_bin.is_none() {
+                            first_bin = Some(k);
+                        }
+                        weights.push(weight);
+                    } else if first_bin.is_some() {
+                        break;
+                    }
+                }
+                filters.push(MelFilter {
+                    first_bin: first_bin.unwrap_or(0),
+                    weights,
+                });
+            }
+            filters
+        }
+    }
+
+    fn sine_samples(n: usize, freq_hz: f32) -> Vec<f32> {
+        (0..n)
+            .map(|i| (2.0 * std::f32::consts::PI * freq_hz * i as f32 / 16_000.0).sin() * 0.3)
+            .collect()
+    }
+
+    #[test]
+    fn migrated_frontend_is_byte_identical_to_pre_refactor_reference() {
+        let migrated = FireRedVadFbankFrontend::new();
+        let reference = reference::ReferenceFireRedVadFbankFrontend::new();
+        for samples in [
+            vec![0.01f32; 48_000],
+            sine_samples(38_080, 220.0),
+            sine_samples(16_500, 880.0),
+        ] {
+            let migrated_features = migrated.compute(&samples);
+            let reference_features = reference.compute(&samples);
+            assert_eq!(migrated_features.n_frames, reference_features.n_frames);
+            assert_eq!(migrated_features.data, reference_features.data);
+        }
     }
 }

--- a/crates/openasr-core/src/models/audio_frontend/mod.rs
+++ b/crates/openasr-core/src/models/audio_frontend/mod.rs
@@ -37,9 +37,18 @@ pub(crate) enum PadMode {
     /// `torch.stft(center=True, pad_mode="reflect")`: reflect-pad `n_fft/2`
     /// samples on both ends (no edge repeat) before framing at `hop`
     /// stride, i.e. `n_frames = (padded_len - n_fft) / hop + 1`. Used by
-    /// `parakeet_ctc`/`parakeet_tdt`, `whisper`, `cohere`, `qwen`, and
-    /// `dolphin`'s ESPnet-variant frontend (`DolphinEspnetFrontend`).
+    /// `parakeet_ctc`/`parakeet_tdt`, `whisper`, and `dolphin`'s ESPnet-variant
+    /// frontend (`DolphinEspnetFrontend`).
     ReflectCenter,
+    /// Zero-pad `n_fft/2` samples on both ends (no reflection) before framing
+    /// at `hop` stride -- same `n_frames = (padded_len - n_fft) / hop + 1`
+    /// formula as [`Self::ReflectCenter`], but the padding is silence rather
+    /// than a mirrored signal. `qwen` and `cohere`'s own pre-refactor
+    /// frontends both build this padding as a zero-filled buffer with the
+    /// real samples copied into the middle (not `torch.stft`'s reflect
+    /// convention despite `center=True`-shaped framing math), so this is a
+    /// distinct mode rather than reuse of [`Self::ReflectCenter`].
+    ZeroCenter,
     /// Kaldi/sherpa-onnx `snip_edges=false`: frame `i`'s window starts at
     /// absolute sample index `i*hop - (win/2 - hop/2)` (the asymmetric
     /// kaldi offset, distinct from `ReflectCenter`'s symmetric `n_fft/2`
@@ -143,6 +152,7 @@ impl StftFramer {
     pub(crate) fn power_spectrogram(&self, samples: &[f32]) -> Result<PowerSpectrogram, StftError> {
         match self.pad_mode {
             PadMode::ReflectCenter => self.power_spectrogram_reflect_center(samples),
+            PadMode::ZeroCenter => self.power_spectrogram_zero_center(samples),
             PadMode::KaldiSnipEdgesFalse => panic!(
                 "StftFramer::power_spectrogram: PadMode::KaldiSnipEdgesFalse has no whole-buffer \
                  entry point -- use power_spectrogram_kaldi_snip_edges_false_range"
@@ -213,9 +223,30 @@ impl StftFramer {
     ) -> Result<PowerSpectrogram, StftError> {
         let pad = self.n_fft / 2;
         let padded = reflect_pad(samples, pad);
+        self.power_spectrogram_from_centered_pad(padded, samples.len())
+    }
+
+    fn power_spectrogram_zero_center(
+        &self,
+        samples: &[f32],
+    ) -> Result<PowerSpectrogram, StftError> {
+        let pad = self.n_fft / 2;
+        let padded = zero_pad(samples, pad);
+        self.power_spectrogram_from_centered_pad(padded, samples.len())
+    }
+
+    /// Shared frame + window + FFT loop for the two centered pad modes
+    /// ([`PadMode::ReflectCenter`] and [`PadMode::ZeroCenter`]) once the
+    /// caller has already produced the padded buffer -- identical arithmetic,
+    /// only the padding differs between them.
+    fn power_spectrogram_from_centered_pad(
+        &self,
+        padded: Vec<f32>,
+        original_len: usize,
+    ) -> Result<PowerSpectrogram, StftError> {
         if padded.len() < self.n_fft {
             return Err(StftError::TooShort {
-                samples: samples.len(),
+                samples: original_len,
             });
         }
         let n_frames = (padded.len() - self.n_fft) / self.hop + 1;
@@ -260,6 +291,19 @@ pub(crate) fn hann_window_centered(win_length: usize, n_fft: usize) -> Vec<f32> 
     window
 }
 
+/// Center-embeds an arbitrary analysis `window` (e.g. one loaded verbatim
+/// from a model checkpoint, so not one of this module's own hann/povey
+/// builders) into an `n_fft`-length buffer, using the same symmetric
+/// centering offset as [`hann_window_centered`] (`(n_fft - window.len()) /
+/// 2`). Used by `cohere` and `qwen`, whose checkpoints ship their own
+/// window values rather than a formula this module would compute.
+pub(crate) fn center_embed_window(window: &[f32], n_fft: usize) -> Vec<f32> {
+    let mut embedded = vec![0.0f32; n_fft];
+    let offset = (n_fft - window.len()) / 2;
+    embedded[offset..offset + window.len()].copy_from_slice(window);
+    embedded
+}
+
 /// Periodic Hann window of `length`, computed by pre-dividing the angular
 /// step (`2*pi / length`) once and multiplying by the sample index, rather
 /// than [`hann_window_centered`]'s per-sample `(2*pi*i) / length` operation
@@ -293,6 +337,15 @@ pub(crate) fn povey_window_left_aligned(win_length: usize, n_fft: usize) -> Vec<
         *slot = hann.powf(0.85);
     }
     window
+}
+
+/// Zero padding: pads `pad` silent samples onto both ends of `samples`
+/// (contrast [`reflect_pad`], which mirrors the signal instead). Used by
+/// [`PadMode::ZeroCenter`].
+fn zero_pad(samples: &[f32], pad: usize) -> Vec<f32> {
+    let mut out = vec![0.0f32; samples.len() + 2 * pad];
+    out[pad..pad + samples.len()].copy_from_slice(samples);
+    out
 }
 
 /// numpy/`torch.stft`-style reflect padding (no edge repeat): pads `pad`
@@ -420,6 +473,94 @@ mod tests {
         let spectrogram = framer.power_spectrogram(&samples).expect("spectrogram");
         assert_eq!(spectrogram.n_frames, 1);
         assert!(spectrogram.data.iter().all(|v| v.is_finite() && *v >= 0.0));
+    }
+
+    fn qwen_style_framer(window: Vec<f32>) -> StftFramer {
+        StftFramer::new(400, 400, 160, PadMode::ZeroCenter, window)
+    }
+
+    #[test]
+    fn zero_center_frame_count_matches_zero_padded_formula() {
+        let framer = qwen_style_framer(vec![1.0f32; 400]);
+        // 1 s @ 16 kHz -> padded len = 16000 + 400, n_frames = (padded -
+        // 400) / 160 + 1 -- same frame-count formula as ReflectCenter, only
+        // the padding differs.
+        let samples = vec![0.01f32; 16_000];
+        let spectrogram = framer.power_spectrogram(&samples).expect("spectrogram");
+        let expected_frames = (16_000 + 400 - 400) / 160 + 1;
+        assert_eq!(spectrogram.n_frames, expected_frames);
+        assert_eq!(spectrogram.n_fft_bins, 201);
+        assert!(spectrogram.data.iter().all(|v| v.is_finite() && *v >= 0.0));
+    }
+
+    /// Reimplementation of the pre-refactor `qwen`/`cohere`
+    /// `center_pad_samples` (zero-fill a buffer, copy samples into the
+    /// middle) -- kept only to pin [`PadMode::ZeroCenter`] to the exact
+    /// values those frontends produced before this module existed.
+    fn reference_zero_center_pad(samples: &[f32], pad_each_side: usize) -> Vec<f32> {
+        let mut padded = vec![0.0f32; samples.len() + 2 * pad_each_side];
+        padded[pad_each_side..pad_each_side + samples.len()].copy_from_slice(samples);
+        padded
+    }
+
+    #[test]
+    fn zero_center_matches_reference_zero_pad_power_spectrogram() {
+        let n_fft = 400;
+        let hop = 160;
+        let window: Vec<f32> = (0..n_fft)
+            .map(|i| 0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / n_fft as f32).cos())
+            .collect();
+        let samples: Vec<f32> = (0..8_000)
+            .map(|i| (2.0 * std::f32::consts::PI * 220.0 * i as f32 / 16_000.0).sin() * 0.3)
+            .collect();
+
+        let framer = StftFramer::new(n_fft, n_fft, hop, PadMode::ZeroCenter, window.clone());
+        let actual = framer.power_spectrogram(&samples).expect("spectrogram");
+
+        // Reference: manual zero-pad + frame + window + rfft, mirroring the
+        // pre-refactor qwen/cohere loop directly (not via StftFramer).
+        let padded = reference_zero_center_pad(&samples, n_fft / 2);
+        let n_frames = (padded.len() - n_fft) / hop + 1;
+        let fft_bins = n_fft / 2 + 1;
+        let mut planner = realfft::RealFftPlanner::<f32>::new();
+        let r2c = planner.plan_fft_forward(n_fft);
+        let mut fft_in = r2c.make_input_vec();
+        let mut fft_out = r2c.make_output_vec();
+        let mut scratch = r2c.make_scratch_vec();
+        let mut expected = vec![0.0f32; n_frames * fft_bins];
+        for frame_idx in 0..n_frames {
+            let start = frame_idx * hop;
+            for i in 0..n_fft {
+                fft_in[i] = padded[start + i] * window[i];
+            }
+            r2c.process_with_scratch(&mut fft_in, &mut fft_out, &mut scratch)
+                .expect("reference rfft");
+            for (bin, c) in fft_out.iter().enumerate() {
+                expected[frame_idx * fft_bins + bin] = c.norm_sqr();
+            }
+        }
+
+        assert_eq!(actual.n_frames, n_frames);
+        assert_eq!(actual.data, expected);
+    }
+
+    #[test]
+    fn center_embed_window_matches_reference_zero_pad_window() {
+        // Reimplementation of the pre-refactor `cohere::frontend::zero_pad_window`.
+        fn reference_zero_pad_window(window: &[f32], n_fft: usize) -> Vec<f32> {
+            let mut padded = vec![0.0f32; n_fft];
+            let left_pad = (n_fft - window.len()) / 2;
+            padded[left_pad..left_pad + window.len()].copy_from_slice(window);
+            padded
+        }
+        let window = vec![0.1f32, 0.2, 0.3, 0.4];
+        assert_eq!(
+            center_embed_window(&window, 8),
+            reference_zero_pad_window(&window, 8)
+        );
+        // win_length == n_fft (qwen's invariant): a no-op copy.
+        let full = vec![0.5f32; 6];
+        assert_eq!(center_embed_window(&full, 6), full);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/cohere/frontend.rs
+++ b/crates/openasr-core/src/models/cohere/frontend.rs
@@ -1,7 +1,7 @@
-use realfft::RealFftPlanner;
 use thiserror::Error;
 
 use crate::ggml_runtime::{GgufTensorDataReadError, GgufTensorDataReader};
+use crate::models::audio_frontend::{PadMode, StftFramer, center_embed_window};
 use crate::models::ggml_asr_executor::GgmlAsrPreparedAudio;
 
 use super::runtime_contract::CohereTranscribeExecutionMetadata;
@@ -46,8 +46,6 @@ pub(crate) enum CohereTranscribeFrontendError {
     InvalidAudioSamples,
     #[error("cohere-transcribe frontend frame calculation overflowed")]
     FrameCountOverflow,
-    #[error("cohere-transcribe frontend FFT failed: {reason}")]
-    FftFailed { reason: String },
 }
 
 pub(crate) fn load_cohere_transcribe_frontend_plan_from_reader(
@@ -123,47 +121,31 @@ fn cohere_transcribe_features_from_samples(
     }
 
     let emphasized = apply_preemphasis(samples);
-    let padded = center_pad_samples(&emphasized, plan.n_fft / 2)?;
-    let all_frames = padded
-        .len()
-        .checked_sub(plan.n_fft)
-        .ok_or(CohereTranscribeFrontendError::FrameCountOverflow)?
-        .checked_div(plan.hop_length)
-        .and_then(|value| value.checked_add(1))
-        .ok_or(CohereTranscribeFrontendError::FrameCountOverflow)?;
-    let frame_count = all_frames
+    let framer = StftFramer::new(
+        plan.n_fft,
+        plan.win_length,
+        plan.hop_length,
+        PadMode::ZeroCenter,
+        center_embed_window(&plan.window, plan.n_fft),
+    );
+    let spectrogram = framer
+        .power_spectrogram(&emphasized)
+        .map_err(|_| CohereTranscribeFrontendError::FrameCountOverflow)?;
+    // `torch.stft`-shaped framing over a signal zero-padded to `n_fft/2` on
+    // each side yields one more frame than the audio's "real" frame count;
+    // the pre-refactor frontend always dropped that trailing frame.
+    let frame_count = spectrogram
+        .n_frames
         .checked_sub(1)
         .ok_or(CohereTranscribeFrontendError::FrameCountOverflow)?;
     if frame_count == 0 {
         return Err(CohereTranscribeFrontendError::InvalidAudioSamples);
     }
-
-    let fft_bins = plan.n_fft / 2 + 1;
-    let padded_window = zero_pad_window(plan);
-    let mut planner = RealFftPlanner::<f32>::new();
-    let r2c = planner.plan_fft_forward(plan.n_fft);
-    let mut fft_input = r2c.make_input_vec();
-    let mut fft_output = r2c.make_output_vec();
-    let mut fft_scratch = r2c.make_scratch_vec();
-    let mut power_spectrogram = vec![0.0_f32; frame_count * fft_bins];
-
-    for frame_idx in 0..frame_count {
-        let start = frame_idx * plan.hop_length;
-        let frame = &padded[start..start + plan.n_fft];
-        for (index, value) in fft_input.iter_mut().enumerate() {
-            *value = frame[index] * padded_window[index];
-        }
-        r2c.process_with_scratch(&mut fft_input, &mut fft_output, &mut fft_scratch)
-            .map_err(|error| CohereTranscribeFrontendError::FftFailed {
-                reason: error.to_string(),
-            })?;
-        for (bin, complex) in fft_output.iter().enumerate() {
-            power_spectrogram[frame_idx * fft_bins + bin] = complex.norm_sqr();
-        }
-    }
+    let fft_bins = framer.n_fft_bins();
+    let power_spectrogram = &spectrogram.data[..frame_count * fft_bins];
 
     let mut mel_values = project_power_spectrogram_to_time_major_mels(
-        &power_spectrogram,
+        power_spectrogram,
         frame_count,
         fft_bins,
         plan,
@@ -185,29 +167,6 @@ fn apply_preemphasis(samples: &[f32]) -> Vec<f32> {
         emphasized.push(pair[1] - COHERE_PREEMPHASIS * pair[0]);
     }
     emphasized
-}
-
-fn center_pad_samples(
-    samples: &[f32],
-    pad_each_side: usize,
-) -> Result<Vec<f32>, CohereTranscribeFrontendError> {
-    let total_len = samples
-        .len()
-        .checked_add(pad_each_side)
-        .and_then(|value| value.checked_add(pad_each_side))
-        .ok_or(CohereTranscribeFrontendError::FrameCountOverflow)?;
-    let mut padded = vec![0.0_f32; total_len];
-    let start = pad_each_side;
-    let end = start + samples.len();
-    padded[start..end].copy_from_slice(samples);
-    Ok(padded)
-}
-
-fn zero_pad_window(plan: &CohereTranscribeFrontendPlan) -> Vec<f32> {
-    let mut padded = vec![0.0_f32; plan.n_fft];
-    let left_pad = (plan.n_fft - plan.win_length) / 2;
-    padded[left_pad..left_pad + plan.win_length].copy_from_slice(&plan.window);
-    padded
 }
 
 fn project_power_spectrogram_to_time_major_mels(

--- a/crates/openasr-core/src/models/qwen/frontend.rs
+++ b/crates/openasr-core/src/models/qwen/frontend.rs
@@ -1,7 +1,7 @@
-use realfft::RealFftPlanner;
 use thiserror::Error;
 
 use crate::ggml_runtime::{GgufTensorDataReadError, GgufTensorDataReader};
+use crate::models::audio_frontend::{PadMode, StftFramer, center_embed_window};
 use crate::models::ggml_asr_executor::GgmlAsrPreparedAudio;
 
 use super::runtime_contract::Qwen3AsrExecutionMetadata;
@@ -43,8 +43,6 @@ pub(crate) enum Qwen3AsrMelFrontendError {
     InvalidAudioSamples,
     #[error("qwen3-asr mel frontend frame calculation overflowed")]
     FrameCountOverflow,
-    #[error("qwen3-asr mel frontend FFT failed: {reason}")]
-    FftFailed { reason: String },
     #[error("qwen3-asr mel frontend mel projection failed: {reason}")]
     MelProjectionFailed { reason: String },
 }
@@ -124,46 +122,35 @@ fn qwen3_mel_features_from_samples(
     if samples.is_empty() {
         return Err(Qwen3AsrMelFrontendError::InvalidAudioSamples);
     }
-    let padded = center_pad_samples(samples, plan.n_fft / 2)?;
-    let all_frames = padded
-        .len()
-        .checked_sub(plan.n_fft)
-        .ok_or(Qwen3AsrMelFrontendError::FrameCountOverflow)?
-        .checked_div(plan.hop_length)
-        .and_then(|value| value.checked_add(1))
-        .ok_or(Qwen3AsrMelFrontendError::FrameCountOverflow)?;
-    let frame_count = all_frames
+
+    // `win_length == n_fft` is enforced by `load_qwen3_mel_frontend_plan_from_reader`,
+    // so `center_embed_window` is a no-op copy here (offset 0); kept for
+    // parity with `cohere`, whose `win_length` can be shorter than `n_fft`.
+    let framer = StftFramer::new(
+        plan.n_fft,
+        plan.n_fft,
+        plan.hop_length,
+        PadMode::ZeroCenter,
+        center_embed_window(&plan.window, plan.n_fft),
+    );
+    let spectrogram = framer
+        .power_spectrogram(samples)
+        .map_err(|_| Qwen3AsrMelFrontendError::FrameCountOverflow)?;
+    // `torch.stft`-shaped framing over a signal zero-padded to `n_fft/2` on
+    // each side yields one more frame than the audio's "real" frame count;
+    // the pre-refactor frontend always dropped that trailing frame.
+    let frame_count = spectrogram
+        .n_frames
         .checked_sub(1)
         .ok_or(Qwen3AsrMelFrontendError::FrameCountOverflow)?;
     if frame_count == 0 {
         return Err(Qwen3AsrMelFrontendError::InvalidAudioSamples);
     }
-
-    let fft_bins = plan.n_fft / 2 + 1;
-    let mut planner = RealFftPlanner::<f32>::new();
-    let r2c = planner.plan_fft_forward(plan.n_fft);
-    let mut fft_input = r2c.make_input_vec();
-    let mut fft_output = r2c.make_output_vec();
-    let mut fft_scratch = r2c.make_scratch_vec();
-    let mut power_spectrogram = vec![0.0_f32; frame_count * fft_bins];
-
-    for frame_idx in 0..frame_count {
-        let start = frame_idx * plan.hop_length;
-        let frame = &padded[start..start + plan.n_fft];
-        for (index, value) in fft_input.iter_mut().enumerate() {
-            *value = frame[index] * plan.window[index];
-        }
-        r2c.process_with_scratch(&mut fft_input, &mut fft_output, &mut fft_scratch)
-            .map_err(|error| Qwen3AsrMelFrontendError::FftFailed {
-                reason: error.to_string(),
-            })?;
-        for (bin, complex) in fft_output.iter().enumerate() {
-            power_spectrogram[frame_idx * fft_bins + bin] = complex.norm_sqr();
-        }
-    }
+    let fft_bins = framer.n_fft_bins();
+    let power_spectrogram = &spectrogram.data[..frame_count * fft_bins];
 
     let mut mel_values = project_power_spectrogram_to_mels_time(
-        &power_spectrogram,
+        power_spectrogram,
         frame_count,
         fft_bins,
         &plan.mel_filters,
@@ -223,22 +210,6 @@ fn project_power_spectrogram_to_mels_time(
         }
     }
     Ok(mel_values)
-}
-
-fn center_pad_samples(
-    samples: &[f32],
-    pad_each_side: usize,
-) -> Result<Vec<f32>, Qwen3AsrMelFrontendError> {
-    let total_len = samples
-        .len()
-        .checked_add(pad_each_side)
-        .and_then(|value| value.checked_add(pad_each_side))
-        .ok_or(Qwen3AsrMelFrontendError::FrameCountOverflow)?;
-    let mut padded = vec![0.0_f32; total_len];
-    let start = pad_each_side;
-    let end = start + samples.len();
-    padded[start..end].copy_from_slice(samples);
-    Ok(padded)
 }
 
 fn normalize_log_mel_in_place(values: &mut [f32]) {


### PR DESCRIPTION
## Summary

Stage 4 (closing) of the shared audio-frontend DSP extraction (roadmap item
C3, follow-up to #95/#99/#101): migrates the last four remaining STFT/mel
copies -- `qwen`, `cohere`, and the two `diarize` frontends -- onto the
shared `audio_frontend`/`kaldi_fbank` primitives. Every family/site in #95's
original "DSP copy inventory" is now on the shared engines; see "C3
completion: residual `rg` sweep" below for the verification.

## Why

#95 built the shared STFT/mel primitives and proved the pattern on
`parakeet_ctc`; #99 and #101 cleared `whisper`/`dolphin`/`xasr_zipformer` and
the pack-build importers. This PR clears the remaining four entries: `qwen`
and `cohere`'s own zero-pad + FFT loops, and the two `diarize` fbank
frontends (`WeSpeaker` speaker embedder, `FireRedVAD`) that duplicated
`kaldi_fbank.rs`'s already-shared engine a fourth and fifth time.

## Changes

### `audio_frontend` primitive addition (`crates/openasr-core/src/models/audio_frontend/mod.rs`)

Investigating `qwen`/`cohere` found their pre-refactor STFT framing was
**not** `PadMode::ReflectCenter` as #95's road map assumed -- both zero-pad
(silence) the signal rather than reflecting it, and both embed a
checkpoint-provided window (not one of this module's own hann/povey
builders) into the `n_fft` buffer. Rather than force them onto
`ReflectCenter` (which would silently change their output), this PR adds:

- `PadMode::ZeroCenter`: same `n_frames = (padded_len - n_fft) / hop + 1`
  framing formula as `ReflectCenter`, but zero-padded. The frame + window +
  FFT loop is now shared between the two modes via a new
  `power_spectrogram_from_centered_pad` helper (pure extraction, same
  arithmetic, same order -- not a rewrite).
- `center_embed_window`: center-embeds an arbitrary checkpoint-provided
  window into an `n_fft` buffer (same centering offset as
  `hann_window_centered`, generalized to non-computed window values).

Both are pinned with reference-reimplementation tests against the
pre-refactor `qwen`/`cohere` math (`zero_center_matches_reference_zero_pad_power_spectrogram`,
`center_embed_window_matches_reference_zero_pad_window`), following the same
pattern #95/#99 already used for `ReflectCenter`/`hann_window_centered`.

### `qwen` (`crates/openasr-core/src/models/qwen/frontend.rs`)

`qwen3_mel_features_from_samples` now builds an `audio_frontend::StftFramer`
(`PadMode::ZeroCenter`) instead of its own `center_pad_samples` + manual
`RealFftPlanner` loop, and drops the trailing frame the same way (the
pre-refactor frontend always computed `all_frames - 1`; now
`spectrogram.n_frames - 1`). The freq-major mel projection (GGUF tensor
layout, checkpoint-baked filters -- not something the shared mel module
builds) and the log-mel normalization stay local. Removed the now-dead
`center_pad_samples` helper and the never-constructed `FftFailed` error
variant.

### `cohere` (`crates/openasr-core/src/models/cohere/frontend.rs`)

Same shape: `cohere_transcribe_features_from_samples` now builds a
`StftFramer` (`PadMode::ZeroCenter`, `center_embed_window` for the
`win_length < n_fft` checkpoint window) instead of its own
`center_pad_samples` + `zero_pad_window` + manual FFT loop, dropping the
trailing frame the same way. Pre-emphasis, the time-major mel projection
(checkpoint filter layout), and the log + per-mel-bin variance
normalization stay local. `cohere`'s mel filterbank itself continues to come
from the source checkpoint (never rebuilt by our importer), so unlike every
other family there was never a filterbank-construction copy to migrate for
it -- only the STFT.

### `diarize` speaker embedder (`crates/openasr-core/src/diarize/embed/fbank.rs`)

`Fbank` (WeSpeaker/pyannote Hamming-window kaldi fbank, 25/10 ms, HTK mel
20-8000 Hz, `snip_edges=true`) now wraps `kaldi_fbank::KaldiFbankFrontend`
(`KaldiWindowKind::Hamming`) instead of its own window/filter/FFT copy.
Per-utterance CMN (mean-only, no variance scaling) stays local -- it is a
different normalization from both the shared engine's CMVN-affine consumers
and `audio_frontend::per_feature_normalize` (mean **and** std). Pinned
bit-exact against a frozen copy of the pre-refactor implementation.

### `diarize` VAD (`crates/openasr-core/src/diarize/vad/firered_stream/frontend.rs`)

`FireRedVadFbankFrontend` (Povey window, same 80/25ms/10ms/16kHz/dither-0
config as `firered_aed`) now wraps `KaldiFbankFrontend` the same way instead
of its own copy; the `FbankFeatures`/no-`Result` API shape (the streaming
VAD wants `n_frames == 0`, not an error variant) and CMVN application stay
local. Pinned bit-exact against a frozen copy of the pre-refactor
implementation.

**Disclosed minor behavior change (both `diarize` frontends):** the shared
`kaldi_fbank` engine fail-closes (`KaldiFbankError::UnsupportedAudio`) on
non-finite input; neither pre-refactor `diarize` frontend had that check and
would have silently propagated NaN through the network instead. Both
migrated wrappers map that error to their existing "too short / zero frames"
return shape. This is a behavior change only on already-invalid (NaN) input,
never on valid audio, and is consistent with the repo's fail-closed
posture -- not something either frontend's tests pinned before.

## C3 completion: residual `rg` sweep

Every production STFT/FFT construction in the tree now goes through one of
the two shared engines:

```
$ rg -n "RealFftPlanner|plan_fft_forward" crates/openasr-core/src/
```

only matches inside `audio_frontend/mod.rs` itself (the shared
`StftFramer`), `kaldi_fbank.rs` itself (the shared `KaldiFbankFrontend`),
and `#[cfg(test)] mod reference { ... }` frozen pre-refactor copies kept
solely to pin the two migrated `diarize` frontends and the primitive-level
`ZeroCenter` addition bit-exact (same pattern the pack-build importers'
`reference_pre_refactor_*` tests already established in #101) -- no
production duplicate remains.

| Family / site | Status |
|---|---|
| `kaldi_fbank` shared engine | shared engine (firered_aed, dolphin kaldi variant, sensevoice) |
| `parakeet_ctc`/`parakeet_tdt` | shared (#95) |
| `whisper` | shared (#99) |
| `dolphin` ESPnet variant | shared (#99) |
| `xasr_zipformer` | shared, own streaming O(1) wrapper by design (#99) |
| pack-build: dolphin/firered_aed/qwen mel filterbanks | shared (#101) |
| `qwen` STFT | **shared this PR** |
| `cohere` STFT | **shared this PR** |
| `cohere` mel filterbank | not a copy -- sourced from the checkpoint, never rebuilt (unchanged, by design) |
| `diarize` speaker embedder (`embed/fbank.rs`) | **shared this PR** |
| `diarize` VAD (`vad/firered_stream/frontend.rs`) | **shared this PR** |

Mel-filterbank builders: `audio_frontend::mel::filterbank` (Slaney/Htk/Kaldi)
covers parakeet/whisper/dolphin-ESPnet/xasr and the dolphin/firered_aed/qwen
pack-build importers; `kaldi_fbank::build_mel_filters` (mel-domain sparse
Kaldi construction) is internal to `KaldiFbankFrontend` and now also backs
both `diarize` frontends. `cohere` is the sole remaining "not shared"
entry, and it is not a copy to migrate -- it never builds a filterbank at
all, only consumes one from its source checkpoint.

## Byte-exact end-to-end evidence

Built release `openasr` binaries from this branch and from `origin/main`
(`bf8e14d`, this branch's fork point) in separate worktrees, then ran
`transcribe --format verbose_json --offline` against real installed
`.oasr` packs and the two committed fixtures, comparing sha256 of the full
JSON output:

| Case | Model | Fixture | sha256 (branch) | sha256 (origin/main) | Match |
|---|---|---|---|---|---|
| qwen | qwen3-asr-0.6b | jfk.wav | `dd2f8c7a...bebc47` | `dd2f8c7a...bebc47` | identical |
| qwen | qwen3-asr-0.6b | zh_sample.wav | `ecee4ac0...b2b2ac` | `ecee4ac0...b2b2ac` | identical |
| cohere | cohere-transcribe-03-2026 | jfk.wav | `cd742a1c...cb3a93a` | `cd742a1c...cb3a93a` | identical |
| cohere | cohere-transcribe-03-2026 | zh_sample.wav | `3edb9189...5831951a` | `3edb9189...5831951a` | identical |
| diarize | qwen3-asr-0.6b `--diarize` | jfk.wav | `5e52d2ca...6685ce4` | `5e52d2ca...6685ce4` | identical |
| diarize | qwen3-asr-0.6b `--diarize` | zh_sample.wav | `9f697895...817619` | `9f697895...817619` | identical |
| control (untouched family) | whisper-tiny | jfk.wav | `062a07dc...ff644` | `062a07dc...ff644` | identical |
| control (untouched family) | whisper-tiny | zh_sample.wav | `7840f33e...4657d` | `7840f33e...4657d` | identical |

All 8 sha256 pairs match exactly (0 diff). The `--diarize` runs exercise
both migrated `diarize` frontends together (WeSpeaker speaker embedding via
`diarize/embed/fbank.rs`, speech-region resolution via the vendored
`diarize/vad/firered_stream` Stream-VAD). The `whisper-tiny` control hashes
also match the identical fixture hashes recorded in #99's own table, an
independent sanity check that this harness and the fixtures are consistent
across PRs. Transcripts are real, non-trivial, and language-appropriate
(spot-checked, not just identical-by-triviality): the qwen/diarize runs
produce full English and Mandarin sentences with correct segment timing,
and the diarize run's per-segment `speaker` field is present and alternates
sensibly across `SPEAKER_00`/`SPEAKER_01`.

## Golden / gate evidence

- `cargo fmt --check`: clean.
- `cargo clippy --all-targets -- -D warnings` (workspace): clean.
- `cargo test -p openasr-core golden_diff -- --nocapture`: 2 passed, 2
  ignored (firered_aed's golden tests require a private dev-only pack not
  present in this environment -- pre-existing, unrelated to this change), 0
  failed.
- `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`: 1 passed.
- `cargo nextest run --workspace`: **2431 passed** (1 slow), 122 skipped
  (private-fixture-gated, pre-existing), 0 failed.
- `cargo test --workspace --doc`: clean (0 doctests, as before).
- `tooling/publish-model/scripts/regenerate_all.sh --check`: catalog + prose
  locale drift check passed for all 27 models.
- `cargo deny check`: advisories/bans/licenses/sources ok (pre-existing
  duplicate-crate-version notices only, not errors).
- New/updated unit tests, all passing: `audio_frontend`'s `PadMode::ZeroCenter`
  and `center_embed_window` reference-pinning tests; both `diarize`
  frontends' `migrated_*_is_byte_identical_to_pre_refactor_reference` tests;
  the pre-existing `diarize::vad::firered_stream` golden-clip tests
  (`forward_pass_matches_reference_within_tolerance`,
  `chunked_streaming_forward_matches_batch_forward_bit_close`,
  `provider_shared_computes_speech_slices_on_golden_clip`) all still pass
  unchanged against the migrated frontend.

## Manual smoke checks

See "Byte-exact end-to-end evidence" above -- `openasr transcribe --format
verbose_json` (plus `--diarize`) against real installed packs and both
committed fixtures for every migrated family, offline.

## Docs updated

- [x] No behavior or limitations changed (the non-finite-input fail-closed
      note above is a disclosed edge-case-only change, not a documented
      capability change); no README/docs updates needed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch `models/builtin_execution_dispatch.rs`,
  `native_segment_cli.rs`, `symphonia_decode.rs`, `hymt2/runtime.rs`, or
  `api/backend/native.rs` (other in-flight work on those files).
- Does not change any model's numeric output on valid audio (see byte-exact
  evidence above); the only behavior change is the disclosed non-finite-input
  fail-close in the two `diarize` frontends.
- Does not add a new `PadMode`/`MelScale` variant beyond `ZeroCenter` and
  `center_embed_window` -- no other family needed one.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts,
      secrets, or private audio.
- [x] I did not add vendored runtime sources outside
      `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI
      usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI
      assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI-assisted implementation of the qwen/cohere/
      diarize frontend migrations and the shared `audio_frontend`
      `PadMode::ZeroCenter`/`center_embed_window` additions, under direct
      human direction and review.
