### PR TITLE
perf(core): cache the Hy-MT2 translation pack probe on /v1/capabilities

### DIFF
--- a/crates/openasr-core/src/models/hymt2/runtime.rs
+++ b/crates/openasr-core/src/models/hymt2/runtime.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -359,6 +360,51 @@ impl Hymt2Runtime {
         validate_hymt2_runtime_tensors_with_index(&tensor_index, hymt2_metadata)
             .map_err(|source| Hymt2RuntimeError::Config { source })?;
         Ok(hymt2_metadata)
+    }
+
+    /// Process-lifetime-cached wrapper over [`Hymt2Runtime::probe_path`],
+    /// keyed on the canonicalized path -- same discipline as
+    /// `native_runtime_model_adapter_for_path` in
+    /// `api::backend::native`: an installed pack's bytes are immutable for
+    /// the life of the daemon process (a re-pull that actually changes
+    /// content lands under its own path per `pull_paths`'s
+    /// `model_id/quant/filename` layout, not by mutating an already-bound
+    /// path in place), so a fixed path deterministically reprobes to the
+    /// same metadata/error for the rest of the process's life.
+    ///
+    /// This exists because `translation_capability_for_distribution`
+    /// (`/v1/capabilities`) re-validated the full Hy-MT2 pack -- GGUF
+    /// metadata read, tensor-index read, and tensor-contract check -- on
+    /// every single call with no cross-call memoization, even though the
+    /// *discovery* of which pack path to probe
+    /// (`find_installed_hymt2_translation_pack`) is already a cheap,
+    /// uncached directory scan performed fresh on every call. Caching only
+    /// the expensive probe below means a pack installed or removed while
+    /// the daemon is running is still picked up immediately (discovery
+    /// reruns every call and hands this a different/absent path), while a
+    /// repeat probe of the same already-known pack no longer re-parses a
+    /// model many times larger than the ASR packs the sibling cache
+    /// targets.
+    ///
+    /// Errors are cached as their rendered message (`Hymt2RuntimeError`
+    /// itself is not `Clone`): callers here only ever display the error, and
+    /// a fixed input path fails the same way every time.
+    pub fn probe_path_cached(path: impl AsRef<Path>) -> Result<Hymt2ExecutionMetadata, String> {
+        static CACHE: OnceLock<Mutex<HashMap<PathBuf, Result<Hymt2ExecutionMetadata, String>>>> =
+            OnceLock::new();
+        let path = path.as_ref();
+        let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        let cache_key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        if let Ok(cache) = cache.lock()
+            && let Some(cached) = cache.get(&cache_key)
+        {
+            return cached.clone();
+        }
+        let result = Self::probe_path(path).map_err(|error| error.to_string());
+        if let Ok(mut cache) = cache.lock() {
+            cache.insert(cache_key, result.clone());
+        }
+        result
     }
 
     pub fn metadata(&self) -> Hymt2ExecutionMetadata {
@@ -2145,6 +2191,36 @@ mod tests {
         let active = cache.active.as_ref().expect("rebuilt active cache");
         assert_eq!(active.source_prefix_tokens, [1, 2, 3, 4, 5]);
         assert_eq!(active.layer_kv_caches[0].written_positions(), 5);
+    }
+
+    /// `probe_path_cached` must serve a repeat call for the same path from
+    /// the process-lifetime cache rather than re-reading the file: writes a
+    /// too-short file (fails as `FileTooShort`), probes it, then overwrites
+    /// the same path with a longer file carrying unrecognized magic bytes
+    /// (which would fail as a *different* `UnknownMagic` error if actually
+    /// re-probed). The second call must still report the first, cached
+    /// error string, proving it never touched the file the second time.
+    #[test]
+    fn probe_path_cached_does_not_reread_an_already_probed_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("probe-cache-test.oasr");
+
+        std::fs::write(&path, b"ab").expect("write too-short file");
+        let first = Hymt2Runtime::probe_path_cached(&path);
+        assert!(
+            first.is_err(),
+            "a 2-byte file must fail runtime source validation"
+        );
+
+        std::fs::write(&path, b"ZZZZ-not-a-real-gguf-package").expect("overwrite with new bytes");
+        let second = Hymt2Runtime::probe_path_cached(&path);
+
+        assert_eq!(
+            first, second,
+            "a cached probe must return the exact same error on a repeat call for the \
+             same path, even though the file's content (and therefore its uncached \
+             error) changed in between"
+        );
     }
 
     #[test]

--- a/crates/openasr-server/src/routes/translation.rs
+++ b/crates/openasr-server/src/routes/translation.rs
@@ -144,8 +144,15 @@ fn validate_hymt2_installed_pack_revision(pack: &InstalledPack) -> Result<(), St
     }
 }
 
+/// Validates the pack via [`openasr_core::Hymt2Runtime::probe_path_cached`]
+/// rather than the raw `probe_path`: this is on the `/v1/capabilities` hot
+/// path (every call reaches here through `resolve_translation_pack_selection`
+/// once a Hy-MT2 pack is found), and the probe itself -- GGUF metadata +
+/// tensor-index read + tensor-contract validation -- was previously redone
+/// on every call against a model much larger than the ASR packs the sibling
+/// `native_runtime_model_adapter_for_path` cache already covers.
 fn validate_hymt2_translation_pack(path: &Path) -> Result<(), String> {
-    openasr_core::Hymt2Runtime::probe_path(path)
+    openasr_core::Hymt2Runtime::probe_path_cached(path)
         .map(|_| ())
         .map_err(|error| {
             format!(


### PR DESCRIPTION
## Summary

`/v1/capabilities` re-validated the full Hy-MT2 translation pack -- GGUF
metadata read, tensor-index read, and tensor-contract check -- on every
call, uncached. Add `Hymt2Runtime::probe_path_cached`, a process-lifetime
cache over `probe_path`, and switch the server's translation-capability
validation to use it.

## Why

PR #93 made the native ASR adapter build once per capability probe and
cached it for the daemon's lifetime, but its own description flagged an
"unrelated, uncached per-call Hy-MT2 translation-pack lookup" as a
follow-up, out of scope for that PR. That lookup is
`translation_capability_for_distribution` ->
`resolve_translation_pack_selection` ->
`validate_hymt2_translation_pack`, which calls
`Hymt2Runtime::probe_path` fresh on every request -- a full GGUF parse
against a pack roughly 20x larger than the ASR packs #93's cache targets.

I also re-checked the optimization roadmap's M1 item ("capabilities
adapter parse 3->1, native.rs:567") against live `main`: it is already
resolved by #93 (`native_runtime_model_adapter_for_path` builds the
adapter once per probe and caches it across calls), so no action was
needed there.

## Changes

- `crates/openasr-core/src/models/hymt2/runtime.rs`: add
  `Hymt2Runtime::probe_path_cached`, a process-lifetime cache over
  `probe_path` keyed on the canonicalized path, using the same
  installed-pack-content-immutability invariant as the sibling
  `native_runtime_model_adapter_for_path` cache. Errors are cached as
  their rendered message since `Hymt2RuntimeError` is not `Clone`.
- `crates/openasr-server/src/routes/translation.rs`:
  `validate_hymt2_translation_pack` now calls `probe_path_cached` instead
  of the raw `probe_path`.

### Semantic boundary: pack discovery stays uncached

Pack *discovery* (`find_installed_hymt2_translation_pack`'s directory scan
via `list_installed_packs`) is intentionally left uncached, so installing
or removing the Hy-MT2 pack while the daemon is running is still picked
up on the very next `/v1/capabilities` call -- there is no existing
install/uninstall event hook in `pull.rs` to invalidate a broader cache
against, and this endpoint's discovery is meant to reflect live install
state without a restart. Only the expensive *validation* of an
already-discovered pack is cached.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2427 passed, 0 failed, 122 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (2 passed, 2 ignored -- private dev-only packs unavailable in this environment)
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`
- [x] `cargo deny check` (advisories/bans/licenses/sources ok)

Added `probe_path_cached_does_not_reread_an_already_probed_path`: probes a
too-short file (fails), overwrites the same path with different bytes
that would fail a *different* way if re-probed, and asserts the second
call returns the identical cached error -- proving it never re-read the
file.

## Manual smoke checks

Isolated before/after (release build, real installed
`hymt2-1.8b-q4_k_m.oasr`, 200 calls each):

- `probe_path` (uncached): 56.6 ms/call average
- `probe_path_cached`: ~0.3 ms/call average across 200 calls (one real
  parse, then cache hits)

End-to-end `/v1/capabilities` against a populated local `OPENASR_HOME`
(20 installed packs including the real Hy-MT2 pack), own throwaway daemon
on a high port, 50 sequential requests:

- Before: mean 331.9 ms, p50 329.5 ms, p90 343.6 ms
- After: mean 282.8 ms, p50 275.0 ms, p90 294.9 ms

The remaining ~275 ms is dominated by a separate, pre-existing,
cross-family cost: `list_installed_packs` re-validates every installed
pack's full runtime contract on every call (an existing corruption/
integrity check unrelated to Hy-MT2 specifically). That is out of scope
for this change.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not cache pack discovery (`list_installed_packs`'s directory scan),
  to preserve live install/uninstall detection without a daemon restart.
- Does not touch `list_installed_packs`'s own per-pack full-contract
  re-validation, which is a separate, cross-family cost affecting all
  installed model families, not specific to Hy-MT2.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI assistance (Claude Code); all changes reviewed and validated by the submitter.