### PR TITLE
feat(cli): parent-pid watchdog for serve to avoid orphaned daemons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "cpal",
  "hound",
  "indicatif",
+ "libc",
  "openasr-core",
  "openasr-server",
  "openasr-system-audio",
@@ -1622,6 +1623,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/openasr-cli/Cargo.toml
+++ b/crates/openasr-cli/Cargo.toml
@@ -40,6 +40,12 @@ tokio.workspace = true
 toml.workspace = true
 hound = "3.5"
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true
+
 [dev-dependencies]
 assert_cmd.workspace = true
 axum.workspace = true

--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -527,6 +527,15 @@ pub(crate) enum Command {
         /// Local `.oasr` runtime pack file for native backend transcription.
         #[arg(long)]
         model_pack: Option<PathBuf>,
+        /// Pid of the process that launched this daemon (e.g. a desktop app's
+        /// supervisor). While set, this process watches that pid and exits
+        /// shortly after it disappears -- including an ungraceful death (a
+        /// SIGKILL, a crash, a Force Quit/End Task) that never reaches the
+        /// supervisor's normal stop/shutdown path and would otherwise leave
+        /// this daemon running forever as an orphan. Internal launch detail,
+        /// not meant for interactive use.
+        #[arg(long, hide = true)]
+        parent_pid: Option<u32>,
     },
     /// Manage local API keys for `openasr serve` (`Authorization: Bearer
     /// <key>`). Loopback callers need no key by default; creating one forces

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -32,6 +32,7 @@ mod doctor_cli;
 mod live;
 mod model_pack_cli;
 mod native_segment_cli;
+mod parent_watchdog;
 mod progress;
 mod pull_cli;
 
@@ -319,7 +320,11 @@ async fn run() -> Result<()> {
             backend,
             ffmpeg_bin,
             model_pack,
+            parent_pid,
         } => {
+            if let Some(parent_pid) = parent_pid {
+                parent_watchdog::spawn(parent_pid);
+            }
             serve(
                 addr,
                 model.as_deref(),

--- a/crates/openasr-cli/src/parent_watchdog.rs
+++ b/crates/openasr-cli/src/parent_watchdog.rs
@@ -1,0 +1,135 @@
+//! Kills this process when the process that spawned it (identified by
+//! `openasr serve --parent-pid <pid>`) disappears without cleanly stopping
+//! this one first.
+//!
+//! `openasr serve` is normally torn down by a supervisor (a desktop app's
+//! process supervisor, or whatever launched a remote-compute server) via a
+//! graceful path: an explicit stop call, `Drop`, or a Unix
+//! SIGTERM/SIGINT/SIGHUP the supervisor forwards. All of those assume the
+//! supervisor gets a chance to run its own shutdown code. A SIGKILL, a hard
+//! crash, or a Force Quit/End Task on the supervisor skips every one of them,
+//! leaving this process listening forever -- a silently orphaned daemon (and,
+//! for a remote-compute server, a still-open network listener) that nothing
+//! cleans up short of a reboot, because the next supervisor launch binds a
+//! fresh ephemeral port rather than noticing the leftover.
+//!
+//! `--parent-pid` closes that gap independent of *how* the supervisor dies:
+//! this process polls whether `parent_pid` is still alive and exits as soon
+//! as it is not, with no dependency on the supervisor sending any signal.
+
+use std::{thread, time::Duration};
+
+/// How often to poll the parent for liveness. Frequent enough that an orphan
+/// is cleaned up within a few seconds of the supervisor dying; infrequent
+/// enough that it costs nothing meaningful over a daemon's lifetime.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Spawns a background thread that exits this process shortly after
+/// `parent_pid` disappears. A no-op if `parent_pid` is 0 (never a valid pid,
+/// and clap's `Option<u32>` cannot itself reject it), so a malformed launch
+/// arg degrades to "watchdog disabled" rather than an instant self-kill.
+pub(crate) fn spawn(parent_pid: u32) {
+    if parent_pid == 0 {
+        return;
+    }
+    let spawned = thread::Builder::new()
+        .name("parent-death-watchdog".to_string())
+        .spawn(move || {
+            loop {
+                if !parent_is_alive(parent_pid) {
+                    eprintln!(
+                        "openasr serve: parent process {parent_pid} is gone; shutting down to avoid an orphaned daemon."
+                    );
+                    std::process::exit(0);
+                }
+                thread::sleep(POLL_INTERVAL);
+            }
+        });
+    // A failure to spawn the watchdog thread (exhausted OS resources) must not
+    // take the whole daemon down with it -- log and keep serving without the
+    // safety net rather than aborting a healthy startup.
+    if let Err(error) = spawned {
+        eprintln!("openasr serve: could not start parent-death watchdog: {error}");
+    }
+}
+
+/// Unix liveness probe: `kill(pid, 0)` sends no signal, it only asks the
+/// kernel whether `pid` exists and is one this process may signal. Mirrors
+/// the stale-pull-lock probe in `openasr-core`'s `pull.rs`.
+#[cfg(unix)]
+fn parent_is_alive(pid: u32) -> bool {
+    // SAFETY: signal 0 is the documented no-op "check for existence" form of
+    // kill(2); it has no effect on the target process.
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if result == 0 {
+        return true;
+    }
+    // ESRCH: no such process -- the parent is gone. Any other errno (e.g.
+    // EPERM for a pid owned by another user) is treated as "still alive":
+    // fail closed toward NOT self-killing on an inconclusive probe.
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+/// Windows liveness probe: open the pid with a query-only access right and
+/// read its exit code. A process that has exited keeps its pid reserved as
+/// long as anyone still holds an open handle to it, so "OpenProcess
+/// succeeded" is not proof of life -- only `STILL_ACTIVE` is. Mirrors the
+/// equivalent probe in `openasr-core`'s `pull.rs`.
+#[cfg(windows)]
+fn parent_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    const STILL_ACTIVE: u32 = 259;
+
+    // SAFETY: OpenProcess with a query-only access right is a read-only probe;
+    // the handle (if any) is closed before returning.
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            // No process object for this pid at all -- definitely gone.
+            return false;
+        }
+        let mut exit_code: u32 = 0;
+        let queried = GetExitCodeProcess(handle, &mut exit_code);
+        CloseHandle(handle);
+        // queried == 0 -> status unreadable; be conservative and treat as
+        // alive rather than risk a false-positive self-kill.
+        queried == 0 || exit_code == STILL_ACTIVE
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn parent_is_alive(_pid: u32) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_is_a_noop_for_pid_zero() {
+        // Must return promptly and must not spawn a thread that calls
+        // process::exit on the test binary.
+        spawn(0);
+    }
+
+    #[test]
+    fn current_process_is_alive() {
+        assert!(parent_is_alive(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_child_is_not_alive() {
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn `true`");
+        let pid = child.id();
+        child.wait().expect("wait for child");
+        assert!(!parent_is_alive(pid));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a hidden `openasr serve --parent-pid <pid>` flag: while set, the daemon polls whether `pid` is still alive and exits shortly after it is gone.

## Why

`openasr serve` only tears itself down through its supervisor's graceful stop/shutdown path, or a forwarded Unix SIGTERM/SIGINT/SIGHUP. A SIGKILL, a hard crash, or a Force Quit/End Task on the supervisor (e.g. a desktop app) skips all of those. The daemon then keeps running with no supervisor left to reap it; the next supervisor launch binds a fresh ephemeral port instead of noticing the leftover, so orphans accumulate across crashes.

## Changes

- `crates/openasr-cli/src/cli_args.rs`: new hidden `--parent-pid` arg on `Serve`.
- `crates/openasr-cli/src/parent_watchdog.rs`: background thread that polls the given pid's liveness (`libc::kill(pid, 0)` on Unix, `OpenProcess`/`GetExitCodeProcess` on Windows, mirroring the existing stale-pull-lock probe in `openasr-core`'s `pull.rs`) and calls `std::process::exit(0)` once it is gone.
- `crates/openasr-cli/src/main.rs`: spawns the watchdog at the top of the `Serve` handler when `--parent-pid` is set.
- `crates/openasr-cli/Cargo.toml`: adds `libc` (unix) / `windows-sys` (windows) target deps, both already used elsewhere in the workspace.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2435 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

## Manual smoke checks

Launched `openasr serve --parent-pid <placeholder-pid>` against a `sleep` process standing in for a supervisor, then `kill -9`'d that process: the daemon logged `parent process <pid> is gone; shutting down to avoid an orphaned daemon.` and exited within ~2s. A live parent left the daemon running for the duration of the check (no false-positive self-kill).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

(Flag is internal/hidden launch plumbing, not a documented user-facing feature; no README/docs change needed.)

## Scope / non-goals

Does not change default `serve` behavior when `--parent-pid` is absent (manual `openasr serve` invocations are unaffected). Does not address any of the OS-native alternatives (kqueue `NOTE_EXIT`, Windows Job Objects) - polling was chosen as the minimal, already-precedented (see `pull.rs`) cross-platform mechanism.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implemented with AI pair-programming assistance; reviewed and tested by the submitter.