### PR TITLE
feat(catalog): require sidecar signature for local catalog sources

### DIFF
--- a/crates/openasr-cli/src/catalog_cli.rs
+++ b/crates/openasr-cli/src/catalog_cli.rs
@@ -26,10 +26,17 @@ pub(super) fn load_cli_model_catalog(openasr_home: &Path) -> Result<Option<Model
             // checkout is the pre-deployment source of truth for the
             // canonical catalog identity (mirroring the binary's embedded
             // snapshot), so it is verified against that identity -- not the
-            // incidental local path -- accepting either the production
-            // signature (the committed `catalog.signature.json` as-is) or a
-            // locally (uncommitted) dev-signed one for previewing staged
-            // edits. See `load_local_catalog_file_with_identity`.
+            // incidental local path. Because that identity is the production
+            // `https://` `DEFAULT_CATALOG_URL`, ONLY the production signature
+            // verifies here (the committed `catalog.signature.json` as-is);
+            // the public local-dev key is not accepted for this call, so a
+            // malicious CWD cannot substitute a dev-signed catalog for the
+            // canonical one just by being `cd`-ed into. To preview staged,
+            // uncommitted catalog edits with the dev key instead, use an
+            // explicit `OPENASR_CATALOG_URL=file://<path>` override (which
+            // goes through `load_model_catalog`, verified against that
+            // literal `file://` identity, not this one). See
+            // `load_local_catalog_file_with_identity`.
             return load_local_catalog_file_with_identity(
                 &path,
                 default_catalog_url(),

--- a/crates/openasr-cli/src/catalog_cli.rs
+++ b/crates/openasr-cli/src/catalog_cli.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use openasr_core::{ModelCatalog, load_model_catalog};
+use openasr_core::{
+    ModelCatalog, default_catalog_url, load_local_catalog_file_with_identity, load_model_catalog,
+};
 
 const OPENASR_CATALOG_URL: &str = "OPENASR_CATALOG_URL";
 
@@ -20,11 +22,21 @@ pub(super) fn load_cli_model_catalog(openasr_home: &Path) -> Result<Option<Model
 
     for path in local_catalog_candidates()? {
         if path.is_file() {
-            return load_catalog(Some(path.to_string_lossy().as_ref()), openasr_home)
-                .map(Some)
-                .with_context(|| {
-                    format!("Could not load local model catalog '{}'", path.display())
-                });
+            // `model-registry/catalog.json` discovered relative to the repo
+            // checkout is the pre-deployment source of truth for the
+            // canonical catalog identity (mirroring the binary's embedded
+            // snapshot), so it is verified against that identity -- not the
+            // incidental local path -- accepting either the production
+            // signature (the committed `catalog.signature.json` as-is) or a
+            // locally (uncommitted) dev-signed one for previewing staged
+            // edits. See `load_local_catalog_file_with_identity`.
+            return load_local_catalog_file_with_identity(
+                &path,
+                default_catalog_url(),
+                openasr_home,
+            )
+            .map(Some)
+            .with_context(|| format!("Could not load local model catalog '{}'", path.display()));
         }
     }
 

--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -237,7 +237,13 @@ pub(crate) enum Command {
         /// Runtime pack path to parse.
         path: PathBuf,
     },
-    /// Internal helper for release catalog signature manifests.
+    /// Internal helper for release AND local/dev catalog signature manifests.
+    /// A local `--catalog-url file://...` catalog now requires the same
+    /// signed `catalog.signature.json` sidecar a production catalog does; use
+    /// `--key-id openasr-catalog-local-dev-v1` with
+    /// `OPENASR_CATALOG_SIGNING_KEY_SEED_HEX` set to
+    /// `openasr_core::LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX` (documented, not
+    /// secret) to sign a local preview catalog instead of the real release.
     #[command(name = "__openasr-sign-catalog-manifest", hide = true)]
     SignCatalogManifest {
         /// Catalog JSON file to sign.
@@ -251,7 +257,9 @@ pub(crate) enum Command {
         /// Override catalog_url from the catalog JSON.
         #[arg(long)]
         catalog_url: Option<String>,
-        /// Signature key id.
+        /// Signature key id: `openasr-catalog-v1` (production; needs the real
+        /// signing seed) or `openasr-catalog-local-dev-v1` (public dev key,
+        /// for local `--catalog-url file://...` previews only).
         #[arg(long, default_value = "openasr-catalog-v1")]
         key_id: String,
         /// Print the derived public key for the env signing seed and exit.

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -11,17 +11,18 @@ use clap::Parser;
 use openasr_core::api::backend::transcribe_with_mock_backend;
 use openasr_core::{
     AudioInputInfo, AudioInputIssue, AudioPreparationOptions, BackendKind, BatchFailure,
-    BatchOutput, BatchSummary, BenchmarkFormat, BenchmarkResult, CohereLocalSourceImportRequest,
-    ConfigKey, DEFAULT_BACKEND_ID, DEFAULT_MODEL_ID, ModelCard, NATIVE_RUNTIME_MODEL_ID_AUTO,
-    NativeBackend, OpenAsrConfig, PreparedAudioInput, Qwen3AsrLocalSourceImportRequest,
-    ResponseFormat, TranscriptionBackend, TranscriptionRequest, WhisperLocalSourceImportRequest,
-    atomic_write_text, config_path, convert_local_cohere_source_to_runtime_pack,
-    convert_local_qwen_source_to_runtime_pack, convert_local_whisper_hf_source_to_runtime_pack,
-    derive_catalog_public_key_hex, discover_batch_inputs, embedded_catalog_fingerprint,
-    load_config, openasr_home, parse_model_catalog, parse_model_ref, render_batch_summary,
-    render_benchmark, render_catalog_signature_manifest, resolve_registry_model_ref,
-    resolve_runtime_model_ref, runtime_registry, save_config,
-    validate_local_native_model_pack_path, verify_catalog_signature_manifest,
+    BatchOutput, BatchSummary, BenchmarkFormat, BenchmarkResult, CATALOG_SIGNATURE_KEY_ID,
+    CohereLocalSourceImportRequest, ConfigKey, DEFAULT_BACKEND_ID, DEFAULT_MODEL_ID, ModelCard,
+    NATIVE_RUNTIME_MODEL_ID_AUTO, NativeBackend, OpenAsrConfig, PreparedAudioInput,
+    Qwen3AsrLocalSourceImportRequest, ResponseFormat, TranscriptionBackend, TranscriptionRequest,
+    WhisperLocalSourceImportRequest, atomic_write_text, config_path,
+    convert_local_cohere_source_to_runtime_pack, convert_local_qwen_source_to_runtime_pack,
+    convert_local_whisper_hf_source_to_runtime_pack, derive_catalog_public_key_hex,
+    discover_batch_inputs, embedded_catalog_fingerprint, load_config, openasr_home,
+    parse_model_catalog, parse_model_ref, render_batch_summary, render_benchmark,
+    render_catalog_signature_manifest, resolve_registry_model_ref, resolve_runtime_model_ref,
+    runtime_registry, save_config, validate_local_native_model_pack_path,
+    verify_catalog_signature_manifest, verify_local_catalog_signature_manifest,
 };
 
 mod bench_suite_cli;
@@ -487,10 +488,20 @@ fn sign_catalog_manifest_command(
         &signing_key_seed_hex,
     )
     .context("Could not render catalog signature manifest")?;
-    verify_catalog_signature_manifest(&catalog_contents, &manifest, &resolved_catalog_url)
-        .context(
-            "Rendered catalog signature manifest did not verify against the built-in public key",
-        )?;
+    // The production trust root (`openasr-catalog-v1`) self-verifies against
+    // only the production public key; any other key id -- e.g. the public
+    // `openasr-catalog-local-dev-v1` dev key used to sign a local/preview
+    // catalog for `--catalog-url file://...` -- self-verifies against the
+    // wider local trust-root set instead, so this command stays usable for
+    // both the real release signing flow and local dev catalog previews.
+    let self_verify = if key_id == CATALOG_SIGNATURE_KEY_ID {
+        verify_catalog_signature_manifest(&catalog_contents, &manifest, &resolved_catalog_url)
+    } else {
+        verify_local_catalog_signature_manifest(&catalog_contents, &manifest, &resolved_catalog_url)
+    };
+    self_verify.context(
+        "Rendered catalog signature manifest did not verify against a known trust root for this key id",
+    )?;
 
     if let Some(parent) = out.parent().filter(|parent| !parent.as_os_str().is_empty()) {
         fs::create_dir_all(parent)

--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -1,7 +1,8 @@
 use assert_cmd::Command;
 use openasr_core::api::backend::transcribe_with_mock_backend;
 use openasr_core::testing::{
-    TinyGgufFixtureSpec, write_reserved_oasr_container, write_tiny_gguf_runtime_source,
+    TinyGgufFixtureSpec, write_local_dev_signed_catalog, write_reserved_oasr_container,
+    write_tiny_gguf_runtime_source,
 };
 use openasr_core::{ResponseFormat, TranscriptionRequest, render_transcription};
 use predicates::prelude::*;
@@ -163,7 +164,10 @@ fn write_catalog_models_fixture(path: &std::path::Path, models: Vec<Value>) {
       "models": models
     });
     let json = serde_json::to_string_pretty(&catalog).expect("serialize catalog fixture");
-    std::fs::write(path, json).expect("write catalog fixture");
+    // A local `file://` catalog now requires the same signed sidecar a
+    // production HTTPS catalog does; sign it with the public local-dev key so
+    // `--catalog-url file://<path>` fixtures keep loading.
+    write_local_dev_signed_catalog(path, &json, 1);
 }
 
 fn write_catalog_fixture(path: &std::path::Path, sha256: &str, size_bytes: u64) {
@@ -192,7 +196,7 @@ fn write_unsupported_catalog_schema_fixture(path: &std::path::Path) {
       "models": []
     });
     let json = serde_json::to_string_pretty(&catalog).expect("serialize catalog fixture");
-    std::fs::write(path, json).expect("write catalog fixture");
+    write_local_dev_signed_catalog(path, &json, 1);
 }
 
 fn write_ambiguous_moonshine_catalog_fixture(

--- a/crates/openasr-core/src/catalog_security.rs
+++ b/crates/openasr-core/src/catalog_security.rs
@@ -350,6 +350,88 @@ pub(crate) fn enforce_catalog_epoch(
     Ok(())
 }
 
+/// Whether a signature verified under `key_id` participates in the shared,
+/// cross-source anti-rollback epoch floor (`enforce_catalog_epoch_for_verified`
+/// / `record_catalog_epoch_for_verified`).
+///
+/// Scoped to the production key only. The local-dev key is public and
+/// self-signed by definition (see the doc comment on
+/// [`CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID`]), so a dev-key-verified local catalog
+/// must never touch the shared floor: not to advance it, and not to be
+/// rejected by it. Without this gate, loading a single local catalog signed
+/// with the (widely-known, publicly derivable) dev key at a very high
+/// `catalog_epoch` would permanently raise the floor every production source
+/// (HTTPS, on-disk signed cache, and the embedded offline snapshot) is checked
+/// against, bricking all of them until an operator manually deleted
+/// `catalog.epoch` -- a persistent, self-inflicted DoS with no signing-key
+/// compromise required. The local dev workflow does not need the anti-rollback
+/// floor's protection in the first place: it is a developer signing content
+/// for their own preview, not a production distribution channel that needs
+/// protecting against a stale/rolled-back re-serve.
+pub(crate) fn participates_in_epoch_floor(key_id: &str) -> bool {
+    key_id != CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID
+}
+
+/// Runs [`enforce_catalog_epoch`] for `verified`, but only if its key
+/// [`participates_in_epoch_floor`]. Use this (not the raw `enforce_catalog_epoch`)
+/// at every catalog-load call site so the local-dev key can never be rejected
+/// by -- or, via [`record_catalog_epoch_for_verified`], advance -- the shared
+/// production floor.
+pub(crate) fn enforce_catalog_epoch_for_verified(
+    openasr_home: &Path,
+    verified: &VerifiedCatalogSignature,
+) -> Result<(), CatalogSecurityError> {
+    if !participates_in_epoch_floor(&verified.key_id) {
+        return Ok(());
+    }
+    enforce_catalog_epoch(openasr_home, verified.catalog_epoch)
+}
+
+/// Runs [`record_catalog_epoch`] for `verified`, but only if its key
+/// [`participates_in_epoch_floor`]. See [`enforce_catalog_epoch_for_verified`].
+pub(crate) fn record_catalog_epoch_for_verified(
+    openasr_home: &Path,
+    verified: &VerifiedCatalogSignature,
+) -> Result<(), CatalogSecurityError> {
+    if !participates_in_epoch_floor(&verified.key_id) {
+        return Ok(());
+    }
+    record_catalog_epoch(openasr_home, verified.catalog_epoch)
+}
+
+/// Classifies a catalog `catalog_url`/identity into the two trust domains a
+/// catalog signature can be verified under. This single classification is
+/// deliberately the ONE place that decides both (a) which trust roots a
+/// signature may be verified against (production-only for [`Remote`],
+/// additionally the public local-dev key for [`Local`] --
+/// [`CatalogSourceKind::Remote`]/[`CatalogSourceKind::Local`]) and (b), in
+/// `registry::read_catalog_source`, which transport reads the bytes. Routing
+/// both decisions through the same function means a future catalog source
+/// scheme cannot be added to one without also changing the other -- there is
+/// no second `starts_with` check to forget and leave classified as `Local`
+/// (and therefore local-dev-key-eligible) by omission.
+///
+/// [`Remote`]: CatalogSourceKind::Remote
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogSourceKind {
+    /// Fetched over the network (`https://`); only the production key may
+    /// sign it.
+    Remote,
+    /// Read from the local filesystem (`file://` or a bare path), OR an
+    /// identity that is not itself a network address (e.g. a caller-supplied
+    /// non-production `expected_catalog_url`); additionally accepts the
+    /// public local-dev key.
+    Local,
+}
+
+pub(crate) fn classify_catalog_identity(identity: &str) -> CatalogSourceKind {
+    if identity.starts_with("https://") {
+        CatalogSourceKind::Remote
+    } else {
+        CatalogSourceKind::Local
+    }
+}
+
 pub(crate) fn cache_catalog_manifest(
     openasr_home: &Path,
     manifest_contents: &str,
@@ -687,5 +769,91 @@ mod tests {
             .to_string();
 
         assert!(error.contains("rollback"));
+    }
+
+    #[test]
+    fn only_the_production_key_participates_in_the_epoch_floor() {
+        // B1 unit guard: the gate the higher-level `registry.rs` call sites
+        // rely on to keep a dev-key-verified local catalog out of the shared
+        // anti-rollback floor.
+        assert!(participates_in_epoch_floor(CATALOG_SIGNATURE_KEY_ID));
+        assert!(!participates_in_epoch_floor(
+            CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID
+        ));
+        assert!(participates_in_epoch_floor("some-unrelated-key"));
+    }
+
+    #[test]
+    fn enforce_and_record_for_verified_skip_the_floor_for_the_dev_key() {
+        let temp = tempfile::tempdir().unwrap();
+        let dev_verified = VerifiedCatalogSignature {
+            catalog_epoch: u64::MAX,
+            catalog_sha256: "0".repeat(64),
+            key_id: CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID.to_string(),
+        };
+
+        // Recording a dev-key verification must not create the shared epoch
+        // file at all.
+        record_catalog_epoch_for_verified(temp.path(), &dev_verified).unwrap();
+        assert!(!default_catalog_epoch_path(temp.path()).exists());
+
+        // A production catalog at a low epoch must not be rejected as a
+        // rollback against the dev catalog's (never persisted) high epoch.
+        let production_verified = VerifiedCatalogSignature {
+            catalog_epoch: 1,
+            catalog_sha256: "0".repeat(64),
+            key_id: CATALOG_SIGNATURE_KEY_ID.to_string(),
+        };
+        enforce_catalog_epoch_for_verified(temp.path(), &production_verified)
+            .expect("no floor was ever recorded, so epoch 1 must be accepted");
+    }
+
+    #[test]
+    fn enforce_and_record_for_verified_still_apply_the_floor_for_the_production_key() {
+        let temp = tempfile::tempdir().unwrap();
+        let high = VerifiedCatalogSignature {
+            catalog_epoch: 10,
+            catalog_sha256: "0".repeat(64),
+            key_id: CATALOG_SIGNATURE_KEY_ID.to_string(),
+        };
+        record_catalog_epoch_for_verified(temp.path(), &high).unwrap();
+        assert_eq!(
+            read_catalog_epoch(&default_catalog_epoch_path(temp.path())).unwrap(),
+            Some(10)
+        );
+
+        let low = VerifiedCatalogSignature {
+            catalog_epoch: 9,
+            catalog_sha256: "0".repeat(64),
+            key_id: CATALOG_SIGNATURE_KEY_ID.to_string(),
+        };
+        let error = enforce_catalog_epoch_for_verified(temp.path(), &low)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("rollback"), "{error}");
+    }
+
+    #[test]
+    fn classify_catalog_identity_only_treats_https_as_remote() {
+        // S2 unit guard: this single classification is what both
+        // `registry::read_catalog_source` (transport) and
+        // `registry::verify_catalog_manifest_for_source` (trust roots) must
+        // consult, so they can never drift apart on a new scheme.
+        assert_eq!(
+            classify_catalog_identity("https://catalog.openasr.org/v1/catalog.json"),
+            CatalogSourceKind::Remote
+        );
+        assert_eq!(
+            classify_catalog_identity("file:///tmp/catalog.json"),
+            CatalogSourceKind::Local
+        );
+        assert_eq!(
+            classify_catalog_identity("/tmp/catalog.json"),
+            CatalogSourceKind::Local
+        );
+        assert_eq!(
+            classify_catalog_identity("http://catalog.openasr.org/v1/catalog.json"),
+            CatalogSourceKind::Local
+        );
     }
 }

--- a/crates/openasr-core/src/catalog_security.rs
+++ b/crates/openasr-core/src/catalog_security.rs
@@ -31,6 +31,51 @@ pub const OPENASR_CATALOG_TRUST_ROOTS: &[CatalogTrustRoot] = &[CatalogTrustRoot 
     public_key_hex: OPENASR_CATALOG_V1_PUBLIC_KEY_HEX,
 }];
 
+/// Key id + public key for the **local-catalog development signing key**.
+///
+/// A local/`file://`/filesystem catalog source is only ever reached through an
+/// explicit `catalog_url` override (CLI `--catalog-url`, `OPENASR_CATALOG_URL`,
+/// or the server's equivalent) -- never the production HTTPS endpoint, the
+/// on-disk cache tier, or the embedded snapshot. Whoever supplies that catalog
+/// file already fully controls its contents, so this key adds no
+/// confidentiality; its only job is to force every local catalog through the
+/// same signature/sha256/catalog_url/schema checks a production catalog goes
+/// through, closing the "a local path skips verification entirely" bypass.
+///
+/// The seed is therefore intentionally NOT secret: it is the deterministic
+/// `sha256` of a fixed public label (see [`LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX`]),
+/// so any contributor can re-derive it without a shared secret. This key is
+/// added ONLY to [`OPENASR_LOCAL_CATALOG_TRUST_ROOTS`], never to
+/// [`OPENASR_CATALOG_TRUST_ROOTS`] -- a widely-known dev key must never be
+/// able to validate an HTTPS/cached/embedded production catalog.
+pub const CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID: &str = "openasr-catalog-local-dev-v1";
+const OPENASR_CATALOG_LOCAL_DEV_PUBLIC_KEY_HEX: &str =
+    "bc1306d4cc4a1cbc817a862ee0223713ff79208c39bc8ce732da851db3c6b6a1";
+
+/// The deterministic, publicly documented seed behind
+/// [`CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID`] --
+/// `sha256("openasr.catalog_manifest.v1.local-dev-signing-key-seed")`. Not a
+/// secret (see the trust-root doc comment above); exposed so tooling/tests can
+/// sign a local/dev catalog without touching the production signing seed.
+pub const LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX: &str =
+    "7181d685f3c226e1c111574368512b603d67964c057165ad004683b84998960e";
+
+/// Trust roots accepted for a LOCAL (`file://` / bare filesystem path) catalog
+/// source: the production key (so a local copy of the real, committed catalog
+/// and its production signature still verifies) plus the public local-dev key
+/// above. Never used for an `https://` source; see
+/// [`verify_local_catalog_signature_manifest`].
+pub const OPENASR_LOCAL_CATALOG_TRUST_ROOTS: &[CatalogTrustRoot] = &[
+    CatalogTrustRoot {
+        key_id: CATALOG_SIGNATURE_KEY_ID,
+        public_key_hex: OPENASR_CATALOG_V1_PUBLIC_KEY_HEX,
+    },
+    CatalogTrustRoot {
+        key_id: CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID,
+        public_key_hex: OPENASR_CATALOG_LOCAL_DEV_PUBLIC_KEY_HEX,
+    },
+];
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CatalogSignatureManifest {
@@ -199,6 +244,24 @@ pub fn verify_catalog_signature_manifest(
         manifest_contents,
         expected_catalog_url,
         OPENASR_CATALOG_TRUST_ROOTS,
+    )
+}
+
+/// Like [`verify_catalog_signature_manifest`], but for a LOCAL (`file://` /
+/// bare filesystem path) catalog source: trusts the production key or the
+/// public local-dev key (see [`OPENASR_LOCAL_CATALOG_TRUST_ROOTS`]). Never use
+/// this for an `https://`/embedded/cached-network source -- that must stay
+/// scoped to [`verify_catalog_signature_manifest`]'s production-only roots.
+pub fn verify_local_catalog_signature_manifest(
+    catalog_contents: &str,
+    manifest_contents: &str,
+    expected_catalog_url: &str,
+) -> Result<VerifiedCatalogSignature, CatalogSecurityError> {
+    verify_catalog_signature_manifest_with_roots(
+        catalog_contents,
+        manifest_contents,
+        expected_catalog_url,
+        OPENASR_LOCAL_CATALOG_TRUST_ROOTS,
     )
 }
 
@@ -545,6 +608,73 @@ mod tests {
         .to_string();
 
         assert!(error.contains("Catalog sha256 mismatch"));
+    }
+
+    #[test]
+    fn local_dev_public_key_matches_its_documented_seed() {
+        // The dev seed is intentionally public (see the doc comment on
+        // `CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID`); pin the derivation so the
+        // committed public key and the committed seed can never silently drift
+        // apart from each other.
+        assert_eq!(
+            derive_catalog_public_key_hex(LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX).unwrap(),
+            OPENASR_CATALOG_LOCAL_DEV_PUBLIC_KEY_HEX
+        );
+    }
+
+    #[test]
+    fn local_catalog_trust_roots_include_the_production_key() {
+        // A local copy of the real, committed catalog + its production
+        // signature must still verify through the local trust-root set.
+        assert!(
+            OPENASR_LOCAL_CATALOG_TRUST_ROOTS
+                .iter()
+                .any(|root| root.key_id == CATALOG_SIGNATURE_KEY_ID
+                    && root.public_key_hex == OPENASR_CATALOG_V1_PUBLIC_KEY_HEX)
+        );
+    }
+
+    #[test]
+    fn local_dev_signed_manifest_verifies_through_local_roots() {
+        let catalog = r#"{"schema_version":1,"models":[]}"#;
+        let source = "file:///tmp/local-catalog.json";
+        let manifest = render_catalog_signature_manifest(
+            catalog,
+            source,
+            7,
+            CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID,
+            LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX,
+        )
+        .unwrap();
+
+        let verified = verify_local_catalog_signature_manifest(catalog, &manifest, source).unwrap();
+        assert_eq!(verified.catalog_epoch, 7);
+        assert_eq!(verified.key_id, CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID);
+    }
+
+    #[test]
+    fn local_dev_signed_manifest_never_verifies_as_a_production_catalog() {
+        // The whole point of keeping the dev key out of
+        // `OPENASR_CATALOG_TRUST_ROOTS`: a widely-known dev key must never
+        // authorize an HTTPS/embedded/cached production catalog.
+        let catalog = r#"{"schema_version":1,"models":[]}"#;
+        let source = "https://catalog.openasr.org/v1/catalog.json";
+        let manifest = render_catalog_signature_manifest(
+            catalog,
+            source,
+            7,
+            CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID,
+            LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX,
+        )
+        .unwrap();
+
+        let error = verify_catalog_signature_manifest(catalog, &manifest, source)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("Unknown catalog signature key id"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -84,11 +84,12 @@ pub use benchmark::{
 };
 pub use catalog_security::{
     CATALOG_EPOCH_FILE_NAME, CATALOG_SIGNATURE_ALGORITHM, CATALOG_SIGNATURE_FILE_NAME,
-    CATALOG_SIGNATURE_KEY_ID, CATALOG_SIGNATURE_SCHEMA_VERSION, CatalogSecurityError,
-    CatalogSignature, CatalogSignatureManifest, VerifiedCatalogSignature, catalog_signature_source,
+    CATALOG_SIGNATURE_KEY_ID, CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID, CATALOG_SIGNATURE_SCHEMA_VERSION,
+    CatalogSecurityError, CatalogSignature, CatalogSignatureManifest,
+    LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX, VerifiedCatalogSignature, catalog_signature_source,
     default_catalog_epoch_path, default_catalog_signature_cache_path,
     derive_catalog_public_key_hex, render_catalog_signature_manifest,
-    verify_catalog_signature_manifest,
+    verify_catalog_signature_manifest, verify_local_catalog_signature_manifest,
 };
 pub use metrics::{
     WerCounts, cer_counts, normalize_text, peak_rss_bytes, wer, wer_counts, word_prefix_error_rate,
@@ -287,7 +288,8 @@ pub use registry::{
     ResolvedCatalogBackendPull, ResolvedCatalogPull, ResolvedModel, ResolvedRuntimeModelRef,
     RuntimeModelRefSource, RuntimeModelResolutionError, RuntimeRegistryError, canonical_quant_tag,
     current_cli_version, default_catalog_cache_path, default_catalog_url, default_registry_dir,
-    embedded_catalog_fingerprint, load_embedded_signed_catalog, load_model_catalog, load_registry,
+    embedded_catalog_fingerprint, load_embedded_signed_catalog,
+    load_local_catalog_file_with_identity, load_model_catalog, load_registry,
     model_cards_from_catalog, model_reference_matches_resolved_source,
     model_refs_match_with_optional_tag_alias, parse_model_catalog, parse_model_ref,
     recommend_catalog_quant, resolve_catalog_backend_pull, resolve_catalog_pull,

--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -989,6 +989,14 @@ pub fn default_catalog_cache_path(openasr_home: impl AsRef<Path>) -> PathBuf {
     openasr_home.as_ref().join("catalog.json")
 }
 
+/// Loads the model catalog from `catalog_url` (default: [`DEFAULT_CATALOG_URL`]),
+/// always through the same fail-closed signature-verification pipeline --
+/// remote (`https://`), local (`file://`/bare filesystem path), and the
+/// on-disk signed cache all require a matching, valid `catalog.signature.json`
+/// sidecar. There is no unsigned/trust-bypass path: a local catalog source is
+/// only ever reachable via an explicit `catalog_url` override, and whoever
+/// supplies it must sign it (see [`catalog_security::verify_local_catalog_signature_manifest`]
+/// and the local-dev key it accepts in addition to the production key).
 pub fn load_model_catalog(
     catalog_url: Option<&str>,
     openasr_home: impl AsRef<Path>,
@@ -997,33 +1005,81 @@ pub fn load_model_catalog(
     let cache_path = default_catalog_cache_path(home);
     let source = catalog_url.unwrap_or(DEFAULT_CATALOG_URL);
 
-    if catalog_source_requires_signature(source) {
-        match read_catalog_source(source) {
-            Ok(contents) => match read_and_verify_catalog_manifest(source, home, &contents) {
-                Ok(verified) => {
-                    let catalog = parse_model_catalog(&contents, source)?;
-                    cache_catalog(home, &cache_path, &contents)?;
-                    cache_catalog_security(
-                        home,
-                        &verified.manifest_contents,
-                        verified.catalog_epoch,
-                    )?;
-                    Ok(catalog)
-                }
-                Err(error) => load_cached_signed_catalog(source, home, &cache_path, error),
-            },
-            Err(error) => load_cached_signed_catalog(source, home, &cache_path, error),
-        }
-    } else {
-        match read_catalog_source(source) {
-            Ok(contents) => {
+    match read_catalog_source(source) {
+        Ok(contents) => match read_and_verify_catalog_manifest(source, home, &contents) {
+            Ok(verified) => {
                 let catalog = parse_model_catalog(&contents, source)?;
                 cache_catalog(home, &cache_path, &contents)?;
+                cache_catalog_security(home, &verified.manifest_contents, verified.catalog_epoch)?;
                 Ok(catalog)
             }
-            Err(error) => load_cached_catalog(source, &cache_path, error),
-        }
+            Err(error) => load_cached_signed_catalog(source, home, &cache_path, error),
+        },
+        Err(error) => load_cached_signed_catalog(source, home, &cache_path, error),
     }
+}
+
+/// Loads a LOCAL catalog file directly from `path`, verifying its adjacent
+/// `catalog.signature.json` sidecar against `expected_catalog_url` -- which is
+/// deliberately NOT required to be a `file://`/path form of `path` itself.
+///
+/// This exists for exactly one caller: the CLI's "run from a repo checkout"
+/// dev convenience that auto-discovers `model-registry/catalog.json` relative
+/// to the current directory / build tree with no `OPENASR_CATALOG_URL`
+/// override set (see `openasr-cli`'s `catalog_cli::load_cli_model_catalog`).
+/// That file and its committed sidecar ARE the pre-deployment source of truth
+/// for the canonical [`DEFAULT_CATALOG_URL`] identity -- the same relationship
+/// [`load_embedded_signed_catalog`] has to the binary's embedded snapshot --
+/// so verification is scoped to that identity, not the incidental local path,
+/// and (like every local source) accepts either the production key or the
+/// public local-dev key. A contributor iterating on `model-registry/catalog.json`
+/// can therefore preview staged entries by locally (uncommitted) re-signing
+/// `model-registry/catalog.signature.json` with the dev key, with no change to
+/// how the committed, production-signed pair behaves.
+///
+/// Runs the same anti-rollback epoch floor as every other source, scoped to
+/// `openasr_home` -- see [`load_embedded_signed_catalog`]'s doc comment for
+/// why that is a freshness floor, not a confidentiality mechanism.
+pub fn load_local_catalog_file_with_identity(
+    path: &Path,
+    expected_catalog_url: &str,
+    openasr_home: impl AsRef<Path>,
+) -> Result<ModelCatalog, CatalogError> {
+    let home = openasr_home.as_ref();
+    let source_label = path.display().to_string();
+    let contents = fs::read_to_string(path).map_err(|error| CatalogError::ReadCatalog {
+        catalog_source: source_label.clone(),
+        message: error.to_string(),
+    })?;
+    let manifest_path = path.with_file_name(catalog_security::CATALOG_SIGNATURE_FILE_NAME);
+    let manifest_contents =
+        fs::read_to_string(&manifest_path).map_err(|error| CatalogError::CatalogSecurity {
+            catalog_source: source_label.clone(),
+            message: format!(
+                "could not read signature manifest '{}': {error}",
+                manifest_path.display()
+            ),
+        })?;
+    let verified = catalog_security::verify_local_catalog_signature_manifest(
+        &contents,
+        &manifest_contents,
+        expected_catalog_url,
+    )
+    .map_err(|error| CatalogError::CatalogSecurity {
+        catalog_source: source_label.clone(),
+        message: error.to_string(),
+    })?;
+    catalog_security::enforce_catalog_epoch(home, verified.catalog_epoch).map_err(|error| {
+        CatalogError::CatalogSecurity {
+            catalog_source: source_label.clone(),
+            message: error.to_string(),
+        }
+    })?;
+    let catalog = parse_model_catalog(&contents, &source_label)?;
+    let cache_path = default_catalog_cache_path(home);
+    cache_catalog(home, &cache_path, &contents)?;
+    cache_catalog_security(home, &manifest_contents, verified.catalog_epoch)?;
+    Ok(catalog)
 }
 
 /// Whether the runtime should prefer the embedded catalog snapshot over the
@@ -1421,8 +1477,32 @@ struct VerifiedCatalogManifestContents {
     catalog_epoch: u64,
 }
 
-fn catalog_source_requires_signature(source: &str) -> bool {
-    source.starts_with("https://")
+/// Selects which signing keys a `catalog_url` may be trusted under:
+/// `https://` sources are restricted to the production-only root (the
+/// widely-known local-dev key must never authorize a network catalog), while
+/// every other source (`file://`, a bare filesystem path -- i.e. anything
+/// reached only through an explicit local `catalog_url` override) additionally
+/// accepts the public local-dev key. See the doc comment on
+/// `CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID` for why that key carries no
+/// confidentiality risk.
+fn verify_catalog_manifest_for_source(
+    source: &str,
+    catalog_contents: &str,
+    manifest_contents: &str,
+) -> Result<catalog_security::VerifiedCatalogSignature, catalog_security::CatalogSecurityError> {
+    if source.starts_with("https://") {
+        catalog_security::verify_catalog_signature_manifest(
+            catalog_contents,
+            manifest_contents,
+            source,
+        )
+    } else {
+        catalog_security::verify_local_catalog_signature_manifest(
+            catalog_contents,
+            manifest_contents,
+            source,
+        )
+    }
 }
 
 fn read_and_verify_catalog_manifest(
@@ -1436,11 +1516,7 @@ fn read_and_verify_catalog_manifest(
             catalog_source: source.to_string(),
             message: error.to_string(),
         })?;
-    let verified = match catalog_security::verify_catalog_signature_manifest(
-        contents,
-        &manifest_contents,
-        source,
-    ) {
+    let verified = match verify_catalog_manifest_for_source(source, contents, &manifest_contents) {
         Ok(verified) => verified,
         Err(error) => {
             return Err(CatalogError::CatalogSecurity {
@@ -1459,22 +1535,6 @@ fn read_and_verify_catalog_manifest(
         manifest_contents,
         catalog_epoch: verified.catalog_epoch,
     })
-}
-
-fn load_cached_catalog(
-    source: &str,
-    cache_path: &Path,
-    error: CatalogError,
-) -> Result<ModelCatalog, CatalogError> {
-    let cached =
-        fs::read_to_string(cache_path).map_err(|cache_error| CatalogError::ReadCatalog {
-            catalog_source: source.to_string(),
-            message: format!(
-                "{error}; no usable cache at '{}': {cache_error}",
-                cache_path.display()
-            ),
-        })?;
-    parse_model_catalog(&cached, &cache_path.display().to_string())
 }
 
 fn load_cached_signed_catalog(
@@ -1584,12 +1644,12 @@ fn read_and_verify_cached_catalog_manifest(
                 manifest_path.display()
             ),
         })?;
-    let verified =
-        catalog_security::verify_catalog_signature_manifest(cached, &manifest_contents, source)
-            .map_err(|error| CatalogError::CatalogSecurity {
-                catalog_source: source.to_string(),
-                message: format!("{original_error}; cached catalog rejected: {error}"),
-            })?;
+    let verified = verify_catalog_manifest_for_source(source, cached, &manifest_contents).map_err(
+        |error| CatalogError::CatalogSecurity {
+            catalog_source: source.to_string(),
+            message: format!("{original_error}; cached catalog rejected: {error}"),
+        },
+    )?;
     catalog_security::enforce_catalog_epoch(home, verified.catalog_epoch).map_err(|error| {
         CatalogError::CatalogSecurity {
             catalog_source: source.to_string(),

--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -1010,7 +1010,7 @@ pub fn load_model_catalog(
             Ok(verified) => {
                 let catalog = parse_model_catalog(&contents, source)?;
                 cache_catalog(home, &cache_path, &contents)?;
-                cache_catalog_security(home, &verified.manifest_contents, verified.catalog_epoch)?;
+                cache_catalog_security(home, &verified.manifest_contents, &verified.signature)?;
                 Ok(catalog)
             }
             Err(error) => load_cached_signed_catalog(source, home, &cache_path, error),
@@ -1029,17 +1029,31 @@ pub fn load_model_catalog(
 /// override set (see `openasr-cli`'s `catalog_cli::load_cli_model_catalog`).
 /// That file and its committed sidecar ARE the pre-deployment source of truth
 /// for the canonical [`DEFAULT_CATALOG_URL`] identity -- the same relationship
-/// [`load_embedded_signed_catalog`] has to the binary's embedded snapshot --
-/// so verification is scoped to that identity, not the incidental local path,
-/// and (like every local source) accepts either the production key or the
-/// public local-dev key. A contributor iterating on `model-registry/catalog.json`
-/// can therefore preview staged entries by locally (uncommitted) re-signing
-/// `model-registry/catalog.signature.json` with the dev key, with no change to
-/// how the committed, production-signed pair behaves.
+/// [`load_embedded_signed_catalog`] has to the binary's embedded snapshot.
+///
+/// The trust roots are chosen from `expected_catalog_url` itself, through the
+/// same [`catalog_security::classify_catalog_identity`] used for every other
+/// source (see [`verify_catalog_manifest_for_source`]): when the caller
+/// asserts the canonical production (`https://`) identity -- as the repo
+/// auto-discovery of `model-registry/catalog.json` does -- ONLY the
+/// production key verifies, exactly like a real HTTPS/cached/embedded
+/// production catalog. The committed `model-registry/catalog.signature.json`
+/// is production-signed, so this is zero-impact for the real, deployed pair.
+/// The widely-known public local-dev key is accepted only when
+/// `expected_catalog_url` is itself a non-production (local) identity -- i.e.
+/// an explicit `--catalog-url file://...`/`OPENASR_CATALOG_URL` override,
+/// which goes through [`load_model_catalog`], not this function. A local-dev
+/// key bound to the production identity must never be treated as a stand-in
+/// for the real production catalog (that would let a malicious CWD override
+/// what a careless `cd`-and-run sees as the canonical model list/pull
+/// targets); see `registry/tests/catalog.rs`'s
+/// `local_catalog_auto_discovery_rejects_dev_key_bound_to_production_identity`.
 ///
 /// Runs the same anti-rollback epoch floor as every other source, scoped to
 /// `openasr_home` -- see [`load_embedded_signed_catalog`]'s doc comment for
-/// why that is a freshness floor, not a confidentiality mechanism.
+/// why that is a freshness floor, not a confidentiality mechanism -- except
+/// that a local-dev-key verification never touches that floor at all (see
+/// [`catalog_security::participates_in_epoch_floor`]).
 pub fn load_local_catalog_file_with_identity(
     path: &Path,
     expected_catalog_url: &str,
@@ -1060,16 +1074,13 @@ pub fn load_local_catalog_file_with_identity(
                 manifest_path.display()
             ),
         })?;
-    let verified = catalog_security::verify_local_catalog_signature_manifest(
-        &contents,
-        &manifest_contents,
-        expected_catalog_url,
-    )
-    .map_err(|error| CatalogError::CatalogSecurity {
-        catalog_source: source_label.clone(),
-        message: error.to_string(),
-    })?;
-    catalog_security::enforce_catalog_epoch(home, verified.catalog_epoch).map_err(|error| {
+    let verified =
+        verify_catalog_manifest_for_source(expected_catalog_url, &contents, &manifest_contents)
+            .map_err(|error| CatalogError::CatalogSecurity {
+                catalog_source: source_label.clone(),
+                message: error.to_string(),
+            })?;
+    catalog_security::enforce_catalog_epoch_for_verified(home, &verified).map_err(|error| {
         CatalogError::CatalogSecurity {
             catalog_source: source_label.clone(),
             message: error.to_string(),
@@ -1078,7 +1089,7 @@ pub fn load_local_catalog_file_with_identity(
     let catalog = parse_model_catalog(&contents, &source_label)?;
     let cache_path = default_catalog_cache_path(home);
     cache_catalog(home, &cache_path, &contents)?;
-    cache_catalog_security(home, &manifest_contents, verified.catalog_epoch)?;
+    cache_catalog_security(home, &manifest_contents, &verified)?;
     Ok(catalog)
 }
 
@@ -1423,14 +1434,12 @@ fn model_card_from_catalog(model: &CatalogModel) -> ModelCard {
 }
 
 fn read_catalog_source(source: &str) -> Result<String, CatalogError> {
-    if let Some(path) = source.strip_prefix("file://") {
-        return fs::read_to_string(path).map_err(|error| CatalogError::ReadCatalog {
-            catalog_source: source.to_string(),
-            message: error.to_string(),
-        });
-    }
-
-    if source.starts_with("https://") {
+    // Transport dispatch shares `classify_catalog_identity` with trust-root
+    // selection (`verify_catalog_manifest_for_source`) so the two can never
+    // drift apart on a future scheme -- see that function's doc comment.
+    if catalog_security::classify_catalog_identity(source)
+        == catalog_security::CatalogSourceKind::Remote
+    {
         let client = http::blocking_client(CATALOG_HTTP_CONNECT_TIMEOUT, CATALOG_HTTP_TIMEOUT)
             .map_err(|error| CatalogError::ReadCatalog {
                 catalog_source: source.to_string(),
@@ -1459,6 +1468,13 @@ fn read_catalog_source(source: &str) -> Result<String, CatalogError> {
         });
     }
 
+    if let Some(path) = source.strip_prefix("file://") {
+        return fs::read_to_string(path).map_err(|error| CatalogError::ReadCatalog {
+            catalog_source: source.to_string(),
+            message: error.to_string(),
+        });
+    }
+
     if source.starts_with("http://") {
         return Err(CatalogError::ReadCatalog {
             catalog_source: source.to_string(),
@@ -1474,34 +1490,44 @@ fn read_catalog_source(source: &str) -> Result<String, CatalogError> {
 
 struct VerifiedCatalogManifestContents {
     manifest_contents: String,
-    catalog_epoch: u64,
+    signature: catalog_security::VerifiedCatalogSignature,
 }
 
-/// Selects which signing keys a `catalog_url` may be trusted under:
-/// `https://` sources are restricted to the production-only root (the
-/// widely-known local-dev key must never authorize a network catalog), while
-/// every other source (`file://`, a bare filesystem path -- i.e. anything
-/// reached only through an explicit local `catalog_url` override) additionally
-/// accepts the public local-dev key. See the doc comment on
-/// `CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID` for why that key carries no
-/// confidentiality risk.
+/// Selects which signing keys a `catalog_url`/identity may be trusted under,
+/// via the single shared [`catalog_security::classify_catalog_identity`]:
+/// [`catalog_security::CatalogSourceKind::Remote`] (`https://`) sources are
+/// restricted to the production-only root (the widely-known local-dev key
+/// must never authorize a network catalog), while
+/// [`catalog_security::CatalogSourceKind::Local`] (`file://`, a bare
+/// filesystem path, or any other non-production identity -- i.e. anything
+/// reached only through an explicit local `catalog_url` override, or asserted
+/// by a caller as a non-production identity) additionally accepts the public
+/// local-dev key. See the doc comment on `CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID`
+/// for why that key carries no confidentiality risk, and
+/// [`classify_catalog_identity`]'s doc comment for why `read_catalog_source`
+/// must classify through the same function.
+///
+/// [`classify_catalog_identity`]: catalog_security::classify_catalog_identity
 fn verify_catalog_manifest_for_source(
     source: &str,
     catalog_contents: &str,
     manifest_contents: &str,
 ) -> Result<catalog_security::VerifiedCatalogSignature, catalog_security::CatalogSecurityError> {
-    if source.starts_with("https://") {
-        catalog_security::verify_catalog_signature_manifest(
-            catalog_contents,
-            manifest_contents,
-            source,
-        )
-    } else {
-        catalog_security::verify_local_catalog_signature_manifest(
-            catalog_contents,
-            manifest_contents,
-            source,
-        )
+    match catalog_security::classify_catalog_identity(source) {
+        catalog_security::CatalogSourceKind::Remote => {
+            catalog_security::verify_catalog_signature_manifest(
+                catalog_contents,
+                manifest_contents,
+                source,
+            )
+        }
+        catalog_security::CatalogSourceKind::Local => {
+            catalog_security::verify_local_catalog_signature_manifest(
+                catalog_contents,
+                manifest_contents,
+                source,
+            )
+        }
     }
 }
 
@@ -1525,7 +1551,7 @@ fn read_and_verify_catalog_manifest(
             });
         }
     };
-    catalog_security::enforce_catalog_epoch(home, verified.catalog_epoch).map_err(|error| {
+    catalog_security::enforce_catalog_epoch_for_verified(home, &verified).map_err(|error| {
         CatalogError::CatalogSecurity {
             catalog_source: source.to_string(),
             message: error.to_string(),
@@ -1533,7 +1559,7 @@ fn read_and_verify_catalog_manifest(
     })?;
     Ok(VerifiedCatalogManifestContents {
         manifest_contents,
-        catalog_epoch: verified.catalog_epoch,
+        signature: verified,
     })
 }
 
@@ -1600,7 +1626,7 @@ pub fn load_embedded_signed_catalog(home: &Path) -> Result<ModelCatalog, Catalog
         catalog_source: DEFAULT_CATALOG_URL.to_string(),
         message: format!("embedded catalog rejected: {error}"),
     })?;
-    catalog_security::enforce_catalog_epoch(home, verified.catalog_epoch).map_err(|error| {
+    catalog_security::enforce_catalog_epoch_for_verified(home, &verified).map_err(|error| {
         CatalogError::CatalogSecurity {
             catalog_source: DEFAULT_CATALOG_URL.to_string(),
             message: format!("embedded catalog rejected: {error}"),
@@ -1650,7 +1676,7 @@ fn read_and_verify_cached_catalog_manifest(
             message: format!("{original_error}; cached catalog rejected: {error}"),
         },
     )?;
-    catalog_security::enforce_catalog_epoch(home, verified.catalog_epoch).map_err(|error| {
+    catalog_security::enforce_catalog_epoch_for_verified(home, &verified).map_err(|error| {
         CatalogError::CatalogSecurity {
             catalog_source: source.to_string(),
             message: format!("{original_error}; cached catalog rejected: {error}"),
@@ -1674,7 +1700,7 @@ fn cache_catalog(home: &Path, cache_path: &Path, contents: &str) -> Result<(), C
 fn cache_catalog_security(
     home: &Path,
     manifest_contents: &str,
-    catalog_epoch: u64,
+    verified: &catalog_security::VerifiedCatalogSignature,
 ) -> Result<(), CatalogError> {
     catalog_security::cache_catalog_manifest(home, manifest_contents).map_err(|error| {
         CatalogError::CatalogSecurity {
@@ -1684,7 +1710,10 @@ fn cache_catalog_security(
             message: error.to_string(),
         }
     })?;
-    catalog_security::record_catalog_epoch(home, catalog_epoch).map_err(|error| {
+    // Gated by `participates_in_epoch_floor`: a local-dev-key-verified catalog
+    // must never advance the shared production anti-rollback floor (see the
+    // doc comment on that function for the persistent DoS this closes).
+    catalog_security::record_catalog_epoch_for_verified(home, verified).map_err(|error| {
         CatalogError::CatalogSecurity {
             catalog_source: catalog_security::default_catalog_epoch_path(home)
                 .display()

--- a/crates/openasr-core/src/registry/tests/catalog.rs
+++ b/crates/openasr-core/src/registry/tests/catalog.rs
@@ -1098,6 +1098,154 @@ fn local_catalog_source_fails_closed_on_catalog_url_mismatch() {
 }
 
 #[test]
+fn local_dev_catalog_epoch_never_advances_or_is_blocked_by_the_shared_production_floor() {
+    // B1 regression guard: a local catalog verified with the public dev key
+    // must never touch the shared, cross-source anti-rollback floor in
+    // $OPENASR_HOME/catalog.epoch. Before this fix, loading ONE dev-signed
+    // local catalog with an inflated epoch would permanently reject every
+    // subsequent production catalog load (network, on-disk cache, and the
+    // embedded offline snapshot) until an operator manually deleted
+    // catalog.epoch -- a persistent, self-inflicted DoS requiring no key
+    // compromise at all, since the dev seed is public and derivable by
+    // anyone (see the doc comment on `CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID`).
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let evil_path = temp.path().join("evil-catalog.json");
+    let contents = catalog_json();
+    let evil_url = format!("file://{}", evil_path.display());
+
+    fs::write(&evil_path, &contents).unwrap();
+    let manifest = catalog_security::render_catalog_signature_manifest(
+        &contents,
+        &evil_url,
+        u64::MAX,
+        catalog_security::CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID,
+        catalog_security::LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX,
+    )
+    .unwrap();
+    fs::write(
+        evil_path.with_file_name(catalog_security::CATALOG_SIGNATURE_FILE_NAME),
+        manifest,
+    )
+    .unwrap();
+
+    load_model_catalog(Some(&evil_url), &home)
+        .expect("a dev-signed local catalog at a non-production identity loads at any epoch");
+
+    assert!(
+        !catalog_security::default_catalog_epoch_path(&home).exists(),
+        "a dev-key-verified local catalog must never persist a shared epoch floor"
+    );
+
+    // A subsequent production-signed load (here: the offline embedded
+    // snapshot, whose real epoch is far below u64::MAX) must still succeed --
+    // it must not be rejected as a rollback against the dev catalog's epoch.
+    super::load_embedded_signed_catalog(&home).expect(
+        "the embedded production catalog must not be bricked by a prior dev-key local catalog",
+    );
+}
+
+#[test]
+fn local_catalog_auto_discovery_rejects_dev_key_bound_to_production_identity() {
+    // S1 regression guard: `load_local_catalog_file_with_identity` is the
+    // repo-checkout auto-discovery path, always called with the canonical
+    // production `DEFAULT_CATALOG_URL` identity (see `catalog_cli.rs`). A
+    // dev-key-signed manifest bound to that SAME identity must be rejected --
+    // otherwise any CWD containing an attacker-controlled
+    // model-registry/catalog.json + catalog.signature.json pair (no flag
+    // needed) could substitute itself for the canonical production catalog,
+    // since the dev signing key is public and derivable by anyone.
+    let temp = tempfile::tempdir().unwrap();
+    let catalog_path = temp.path().join("catalog.json");
+    let home = temp.path().join("home");
+    let contents = catalog_json();
+    fs::write(&catalog_path, &contents).unwrap();
+
+    let manifest = catalog_security::render_catalog_signature_manifest(
+        &contents,
+        DEFAULT_CATALOG_URL,
+        1,
+        catalog_security::CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID,
+        catalog_security::LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX,
+    )
+    .unwrap();
+    fs::write(
+        catalog_path.with_file_name(catalog_security::CATALOG_SIGNATURE_FILE_NAME),
+        manifest,
+    )
+    .unwrap();
+
+    let error = load_local_catalog_file_with_identity(&catalog_path, DEFAULT_CATALOG_URL, &home)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("Unknown catalog signature key id"),
+        "{error}"
+    );
+}
+
+#[test]
+fn local_catalog_auto_discovery_accepts_the_real_production_signed_catalog() {
+    // Zero-impact check for the S1 fix: the committed, production-signed
+    // model-registry/catalog.json + catalog.signature.json pair -- exactly
+    // what the CLI's repo-checkout auto-discovery loads via
+    // `load_local_catalog_file_with_identity` -- must still verify once trust
+    // roots for the production identity are scoped to the production key
+    // only.
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../model-registry");
+    let temp = tempfile::tempdir().unwrap();
+    let catalog_path = temp.path().join("catalog.json");
+    let home = temp.path().join("home");
+    fs::copy(root.join("catalog.json"), &catalog_path).unwrap();
+    fs::copy(
+        root.join(catalog_security::CATALOG_SIGNATURE_FILE_NAME),
+        catalog_path.with_file_name(catalog_security::CATALOG_SIGNATURE_FILE_NAME),
+    )
+    .unwrap();
+
+    let catalog = load_local_catalog_file_with_identity(&catalog_path, DEFAULT_CATALOG_URL, &home)
+        .expect("the real committed production catalog + signature must still verify");
+    assert!(!catalog.models.is_empty());
+}
+
+#[test]
+fn local_catalog_file_with_identity_accepts_dev_key_for_a_non_production_identity() {
+    // `load_local_catalog_file_with_identity` also supports a non-production
+    // expected identity (any future caller besides the production-identity
+    // auto-discovery path currently in `catalog_cli.rs`) -- that case stays
+    // local-dev-key eligible, and (like every dev-key verification) never
+    // touches the shared epoch floor.
+    let temp = tempfile::tempdir().unwrap();
+    let catalog_path = temp.path().join("preview-catalog.json");
+    let home = temp.path().join("home");
+    let contents = catalog_json();
+    let identity = "file:///preview/staged-catalog.json";
+
+    fs::write(&catalog_path, &contents).unwrap();
+    let manifest = catalog_security::render_catalog_signature_manifest(
+        &contents,
+        identity,
+        3,
+        catalog_security::CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID,
+        catalog_security::LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX,
+    )
+    .unwrap();
+    fs::write(
+        catalog_path.with_file_name(catalog_security::CATALOG_SIGNATURE_FILE_NAME),
+        manifest,
+    )
+    .unwrap();
+
+    let catalog = load_local_catalog_file_with_identity(&catalog_path, identity, &home)
+        .expect("dev key must still verify a non-production expected identity");
+    assert_eq!(catalog.models.len(), 2);
+    assert!(
+        !catalog_security::default_catalog_epoch_path(&home).exists(),
+        "a dev-key-verified identity-decoupled load must not persist a shared epoch floor"
+    );
+}
+
+#[test]
 fn catalog_loader_falls_back_to_last_good_cache_when_local_source_is_tampered_without_resigning() {
     // Tampering with a local catalog's bytes WITHOUT re-signing must not be
     // silently accepted: the sha256 no longer matches the sidecar, so the

--- a/crates/openasr-core/src/registry/tests/catalog.rs
+++ b/crates/openasr-core/src/registry/tests/catalog.rs
@@ -924,7 +924,9 @@ fn catalog_loader_caches_file_source_and_falls_back_to_cache() {
     let temp = tempfile::tempdir().unwrap();
     let source_path = temp.path().join("source-catalog.json");
     let home = temp.path().join("home");
-    fs::write(&source_path, catalog_json()).unwrap();
+    // A local `file://` source now requires the same signed sidecar a
+    // production HTTPS catalog does; sign it with the public local-dev key.
+    crate::testing::write_local_dev_signed_catalog(&source_path, &catalog_json(), 1);
 
     let source = format!("file://{}", source_path.display());
     let catalog = load_model_catalog(Some(&source), &home).unwrap();
@@ -941,7 +943,7 @@ fn catalog_loader_falls_back_to_cache_on_network_failure() {
     let temp = tempfile::tempdir().unwrap();
     let source_path = temp.path().join("source-catalog.json");
     let home = temp.path().join("home");
-    fs::write(&source_path, catalog_json()).unwrap();
+    crate::testing::write_local_dev_signed_catalog(&source_path, &catalog_json(), 1);
 
     let seeded_source = format!("file://{}", source_path.display());
     load_model_catalog(Some(&seeded_source), &home).unwrap();
@@ -949,7 +951,180 @@ fn catalog_loader_falls_back_to_cache_on_network_failure() {
     let error = load_model_catalog(Some("https://127.0.0.1:1/catalog.json"), &home)
         .unwrap_err()
         .to_string();
-    assert!(error.contains("no usable signed cache"), "{error}");
+    // The on-disk signed cache is bound to the catalog_url identity that
+    // produced it (see the URL-mismatch test below): a DIFFERENT catalog_url
+    // cannot silently reuse it, so this now fails closed on the URL-mismatch
+    // check rather than the (no-signed-cache-exists) message it used to hit
+    // when local sources were unsigned and never wrote a signed cache at all.
+    assert!(error.contains("Could not read model catalog"), "{error}");
+    assert!(error.contains("URL mismatch"), "{error}");
+}
+
+#[test]
+fn local_catalog_source_fails_closed_when_signature_sidecar_is_missing() {
+    // The core of this fix: a local/`file://` catalog source with no adjacent
+    // `catalog.signature.json` at all must fail closed, exactly like an
+    // unsigned HTTPS response would -- there is no "local path skips
+    // verification" bypass left.
+    let temp = tempfile::tempdir().unwrap();
+    let source_path = temp.path().join("source-catalog.json");
+    let home = temp.path().join("home");
+    fs::write(&source_path, catalog_json()).unwrap();
+    // Deliberately no signature sidecar written.
+
+    let source = format!("file://{}", source_path.display());
+    let error = load_model_catalog(Some(&source), &home)
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        error.contains("Model catalog security check failed"),
+        "{error}"
+    );
+    assert!(!default_catalog_cache_path(&home).exists());
+}
+
+#[test]
+fn local_catalog_source_fails_closed_on_unknown_signing_key() {
+    // A signature manifest signed by a key that is neither the production
+    // root nor the public local-dev root must be rejected, not silently
+    // trusted because the source happens to be local.
+    let temp = tempfile::tempdir().unwrap();
+    let source_path = temp.path().join("source-catalog.json");
+    let home = temp.path().join("home");
+    let contents = catalog_json();
+    fs::write(&source_path, &contents).unwrap();
+    let source = format!("file://{}", source_path.display());
+
+    let manifest = catalog_security::render_catalog_signature_manifest(
+        &contents,
+        &source,
+        1,
+        "some-unrelated-key",
+        catalog_security::LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX,
+    )
+    .unwrap();
+    fs::write(
+        source_path.with_file_name(catalog_security::CATALOG_SIGNATURE_FILE_NAME),
+        manifest,
+    )
+    .unwrap();
+
+    let error = load_model_catalog(Some(&source), &home)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("Unknown catalog signature key id"),
+        "{error}"
+    );
+}
+
+#[test]
+fn local_catalog_source_fails_closed_when_signature_bytes_do_not_verify() {
+    // A structurally valid manifest (right schema, right key id, right
+    // catalog_url/sha256) whose signature bytes are simply wrong must be
+    // rejected -- not just a sha256/key-id mismatch, the actual ed25519
+    // check must run for local sources too.
+    let temp = tempfile::tempdir().unwrap();
+    let source_path = temp.path().join("source-catalog.json");
+    let home = temp.path().join("home");
+    let contents = catalog_json();
+    fs::write(&source_path, &contents).unwrap();
+    let source = format!("file://{}", source_path.display());
+
+    let manifest = catalog_security::render_catalog_signature_manifest(
+        &contents,
+        &source,
+        1,
+        catalog_security::CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID,
+        catalog_security::LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX,
+    )
+    .unwrap();
+    // Flip a single hex nibble of the signature value, leaving everything
+    // else (schema, catalog_url, catalog_sha256, key_id) intact.
+    let mut parsed: serde_json::Value = serde_json::from_str(&manifest).unwrap();
+    let signature_value = parsed["signature"]["value"].as_str().unwrap().to_string();
+    let flipped_first_char = if &signature_value[0..1] == "0" {
+        "1"
+    } else {
+        "0"
+    };
+    let tampered_value = format!("{flipped_first_char}{}", &signature_value[1..]);
+    parsed["signature"]["value"] = serde_json::Value::String(tampered_value);
+    let tampered_manifest = serde_json::to_string_pretty(&parsed).unwrap();
+    fs::write(
+        source_path.with_file_name(catalog_security::CATALOG_SIGNATURE_FILE_NAME),
+        tampered_manifest,
+    )
+    .unwrap();
+
+    let error = load_model_catalog(Some(&source), &home)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("Model catalog security check failed"),
+        "{error}"
+    );
+}
+
+#[test]
+fn local_catalog_source_fails_closed_on_catalog_url_mismatch() {
+    // A local catalog + sidecar signed for one path must not verify when
+    // copied and loaded from a different path -- the signature is bound to
+    // the exact catalog_url it was issued for, same as an HTTPS catalog.
+    let temp = tempfile::tempdir().unwrap();
+    let dir_a = temp.path().join("dir-a");
+    let dir_b = temp.path().join("dir-b");
+    fs::create_dir_all(&dir_a).unwrap();
+    fs::create_dir_all(&dir_b).unwrap();
+    let signed_for_path = dir_a.join("catalog.json");
+    let relocated_path = dir_b.join("catalog.json");
+    let home = temp.path().join("home");
+    let contents = catalog_json();
+
+    crate::testing::write_local_dev_signed_catalog(&signed_for_path, &contents, 1);
+    fs::copy(&signed_for_path, &relocated_path).unwrap();
+    fs::copy(
+        signed_for_path.with_file_name(catalog_security::CATALOG_SIGNATURE_FILE_NAME),
+        relocated_path.with_file_name(catalog_security::CATALOG_SIGNATURE_FILE_NAME),
+    )
+    .unwrap();
+
+    let source = format!("file://{}", relocated_path.display());
+    let error = load_model_catalog(Some(&source), &home)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("URL mismatch"), "{error}");
+}
+
+#[test]
+fn catalog_loader_falls_back_to_last_good_cache_when_local_source_is_tampered_without_resigning() {
+    // Tampering with a local catalog's bytes WITHOUT re-signing must not be
+    // silently accepted: the sha256 no longer matches the sidecar, so the
+    // loader falls back to the last verified-good on-disk cache instead of
+    // trusting the mutated bytes -- the same behavior an HTTPS source gets on
+    // a MITM/corruption. The on-disk cache stays untouched either way.
+    let temp = tempfile::tempdir().unwrap();
+    let source_path = temp.path().join("source-catalog.json");
+    let home = temp.path().join("home");
+    let source = format!("file://{}", source_path.display());
+    crate::testing::write_local_dev_signed_catalog(&source_path, &catalog_json(), 1);
+    load_model_catalog(Some(&source), &home).unwrap();
+    let cache_path = default_catalog_cache_path(&home);
+    let cached_before = fs::read_to_string(&cache_path).unwrap();
+
+    // Mutate the catalog bytes in place without touching the signature
+    // sidecar -- this is what an on-disk corruption/tamper looks like.
+    fs::write(
+        &source_path,
+        catalog_json().replace("\"schema_version\": 1", "\"schema_version\": 99"),
+    )
+    .unwrap();
+
+    let catalog = load_model_catalog(Some(&source), &home)
+        .expect("tampered local source falls back to the last verified-good cache");
+    assert_eq!(catalog.models.len(), 2);
+    assert_eq!(fs::read_to_string(&cache_path).unwrap(), cached_before);
 }
 
 #[test]
@@ -1245,27 +1420,23 @@ fn catalog_model_available_for_current_build() {
 
 #[test]
 fn catalog_loader_does_not_cache_invalid_source() {
+    // A properly-signed local catalog (signature matches these exact,
+    // schema-invalid bytes) still must not be cached: signature verification
+    // is orthogonal to schema validation, and a schema failure must surface
+    // as a hard error with no pre-existing cache to fall back to.
     let temp = tempfile::tempdir().unwrap();
     let source_path = temp.path().join("source-catalog.json");
     let home = temp.path().join("home");
-    fs::write(&source_path, catalog_json()).unwrap();
+    let bad_contents = catalog_json().replace("\"schema_version\": 1", "\"schema_version\": 99");
+    crate::testing::write_local_dev_signed_catalog(&source_path, &bad_contents, 1);
 
     let source = format!("file://{}", source_path.display());
-    load_model_catalog(Some(&source), &home).unwrap();
-    let cache_path = default_catalog_cache_path(&home);
-    let cached_before = fs::read_to_string(&cache_path).unwrap();
-
-    fs::write(
-        &source_path,
-        catalog_json().replace("\"schema_version\": 1", "\"schema_version\": 99"),
-    )
-    .unwrap();
     let error = load_model_catalog(Some(&source), &home)
         .unwrap_err()
         .to_string();
 
     assert!(error.contains("Unsupported model catalog schema_version 99"));
-    assert_eq!(fs::read_to_string(&cache_path).unwrap(), cached_before);
+    assert!(!default_catalog_cache_path(&home).exists());
 }
 
 #[test]

--- a/crates/openasr-core/src/testing.rs
+++ b/crates/openasr-core/src/testing.rs
@@ -1733,6 +1733,34 @@ pub fn write_reserved_oasr_container(path: impl AsRef<Path>) -> io::Result<()> {
     fs::write(path, bytes)
 }
 
+/// Writes `contents` to `path` plus an adjacent, matching LOCAL-catalog
+/// signature manifest signed with the public, non-secret local-dev catalog
+/// key (`catalog_security::CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID` /
+/// `LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX`). A local `file://`/filesystem
+/// catalog source now requires a valid sidecar signature just like a
+/// production HTTPS catalog does (see `registry::load_model_catalog`), so any
+/// test that loads a local catalog fixture must go through this helper (or
+/// deliberately omit/break the sidecar to exercise the fail-closed path).
+///
+/// Signs for the exact `file://<path>` catalog_url the caller will pass as
+/// `catalog_url`/`--catalog-url`. Call again (bumping `epoch` is not required,
+/// only monotonic-or-equal) after any in-place mutation of `path`'s contents:
+/// a stale sidecar is treated as tampering, not a no-op.
+pub fn write_local_dev_signed_catalog(path: &Path, contents: &str, epoch: u64) {
+    fs::write(path, contents).expect("write local catalog test fixture");
+    let catalog_url = format!("file://{}", path.display());
+    let manifest = crate::catalog_security::render_catalog_signature_manifest(
+        contents,
+        &catalog_url,
+        epoch,
+        crate::catalog_security::CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID,
+        crate::catalog_security::LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX,
+    )
+    .expect("sign local catalog test fixture with the dev key");
+    let signature_path = path.with_file_name(crate::catalog_security::CATALOG_SIGNATURE_FILE_NAME);
+    fs::write(signature_path, manifest).expect("write local catalog signature test fixture");
+}
+
 fn push_gguf_string(bytes: &mut Vec<u8>, value: &str) {
     bytes.extend_from_slice(&(value.len() as u64).to_le_bytes());
     bytes.extend_from_slice(value.as_bytes());

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -116,9 +116,22 @@ fn distribution_context_for_test(home: &std::path::Path) -> DistributionContext 
     })
 }
 
-fn bundled_catalog_url_for_test() -> String {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../model-registry/catalog.json");
-    format!("file://{}", path.display())
+/// Copies the real, committed `model-registry/catalog.json` into `dir` and
+/// re-signs the copy with the public local-dev key for the exact `file://`
+/// path the test will pass as `catalog_url`. The committed catalog's own
+/// signature is bound to the production HTTPS identity
+/// (`https://catalog.openasr.org/v1/catalog.json`), not to an arbitrary local
+/// path, so a test that wants to load the real bundled catalog contents
+/// through a local `--catalog-url` override must sign a fresh, path-bound
+/// copy rather than pointing straight at the committed file + its committed
+/// signature.
+fn bundled_catalog_url_for_test(dir: &std::path::Path) -> String {
+    let source_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../model-registry/catalog.json");
+    let contents = fs::read_to_string(&source_path).expect("read bundled catalog fixture");
+    let copy_path = dir.join("bundled-catalog-for-test.json");
+    openasr_core::testing::write_local_dev_signed_catalog(&copy_path, &contents, 1);
+    format!("file://{}", copy_path.display())
 }
 
 fn write_valid_installed_pack_for_test(
@@ -578,7 +591,7 @@ fn native_execution_target_mapping_preserves_server_request_semantics() {
 fn default_pack_lookup_resolves_series_alias_through_catalog() {
     let temp = tempfile::tempdir().unwrap();
     let pack = write_valid_installed_pack_for_test(temp.path(), "qwen3-asr-0.6b", "q8_0", "q8");
-    let catalog_url = bundled_catalog_url_for_test();
+    let catalog_url = bundled_catalog_url_for_test(temp.path());
 
     let resolved = find_installed_pack_reference(temp.path(), Some(&catalog_url), "qwen:q8")
         .unwrap()
@@ -590,7 +603,7 @@ fn default_pack_lookup_resolves_series_alias_through_catalog() {
 #[test]
 fn form_model_resolution_preserves_native_request_id() {
     let temp = tempfile::tempdir().unwrap();
-    let catalog_url = bundled_catalog_url_for_test();
+    let catalog_url = bundled_catalog_url_for_test(temp.path());
     let catalog = load_model_catalog(Some(&catalog_url), temp.path()).unwrap();
 
     let native_model =

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -6,7 +6,8 @@ use axum::{
 use futures_util::StreamExt;
 use openasr_core::api::backend::transcribe_with_mock_backend;
 use openasr_core::testing::{
-    TinyGgufFixtureSpec, write_reserved_oasr_container, write_tiny_gguf_runtime_source,
+    TinyGgufFixtureSpec, write_local_dev_signed_catalog, write_reserved_oasr_container,
+    write_tiny_gguf_runtime_source,
 };
 use openasr_core::{ResponseFormat, TranscriptionRequest, render_transcription};
 use serde_json::Value;
@@ -220,11 +221,12 @@ fn write_moonshine_pull_fixture(
         }]
     });
     let catalog_path = root.join("catalog.json");
-    std::fs::write(
-        &catalog_path,
-        serde_json::to_vec_pretty(&catalog).expect("serialize catalog fixture"),
-    )
-    .unwrap();
+    let catalog_json =
+        String::from_utf8(serde_json::to_vec_pretty(&catalog).expect("serialize catalog fixture"))
+            .expect("catalog fixture is valid utf-8");
+    // A local `file://` catalog now requires the same signed sidecar a
+    // production HTTPS catalog does; sign it with the public local-dev key.
+    write_local_dev_signed_catalog(&catalog_path, &catalog_json, 1);
 
     (
         pack_path,
@@ -261,7 +263,11 @@ fn pad_pull_fixture_pack_to(
     let quant = &mut catalog["models"][0]["quants"][0];
     quant["sha256"] = serde_json::json!(sha256);
     quant["size_bytes"] = serde_json::json!(bytes.len() as u64);
-    std::fs::write(catalog_path, serde_json::to_vec_pretty(&catalog).unwrap()).unwrap();
+    let catalog_json = String::from_utf8(serde_json::to_vec_pretty(&catalog).unwrap()).unwrap();
+    // Re-sign after mutating the catalog bytes in place: a stale sidecar
+    // would now be treated as tampering, not a no-op (see
+    // `write_local_dev_signed_catalog`'s doc comment).
+    write_local_dev_signed_catalog(catalog_path, &catalog_json, 1);
 }
 
 async fn create_approved_pairing_credential(app: &Router, device_name: &str) -> (String, String) {
@@ -489,7 +495,10 @@ fn mutate_fixture_catalog_pack_identity(distribution: &openasr_server::Distribut
     quant["sha256"] =
         serde_json::json!("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
     quant["size_bytes"] = serde_json::json!(1);
-    std::fs::write(catalog_path, serde_json::to_vec_pretty(&catalog).unwrap()).unwrap();
+    let catalog_json = String::from_utf8(serde_json::to_vec_pretty(&catalog).unwrap()).unwrap();
+    // Re-sign after mutating the catalog bytes in place (see
+    // `pad_pull_fixture_pack_to`'s matching comment).
+    write_local_dev_signed_catalog(catalog_path, &catalog_json, 1);
 }
 
 fn write_reserved_oasr_runtime_source(path: &std::path::Path) {

--- a/docs/MODEL_CATALOG_ARCHITECTURE.md
+++ b/docs/MODEL_CATALOG_ARCHITECTURE.md
@@ -179,12 +179,32 @@ catalog (an explicit `OPENASR_CATALOG_URL` override is honoured, not replaced).
 This guarantees a fresh, fully offline install still shows the verified model
 list; because every installer ships the sidecar binary, the offline catalog is
 bundled transitively with no per-installer packaging. The embedded snapshot is
-kept current by the catalog drift and bundled-signature CI gates. Unsigned caches
-are accepted only for local `file://` or filesystem catalog sources used by
-development and bundled-resource flows. Current trust
+kept current by the catalog drift and bundled-signature CI gates. Current trust
 comes from HTTPS, signature verification, anti-rollback epoch checks, schema
 validation, pinned immutable pack URLs, sha256/size verification, Rust GGUF
 preflight, runtime-source validation, and atomic install.
+
+A LOCAL (`file://` or bare filesystem path) `catalog_url` override -- CLI
+`--catalog-url`/`OPENASR_CATALOG_URL`, the server's equivalent, or the CLI's
+repo-checkout auto-discovery of `model-registry/catalog.json` with no override
+set -- goes through the same signature/schema/anti-rollback pipeline as an
+HTTPS catalog: there is no unsigned local path. It additionally trusts a
+public, non-secret **local-dev signing key**
+(`openasr-catalog-local-dev-v1` / `LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX` in
+`crates/openasr-core/src/catalog_security.rs`) alongside the production key --
+that key carries no confidentiality (whoever supplies a local catalog file
+already controls its contents), it only forces every local catalog through
+real signature/sha256/catalog_url verification instead of a bypass. A
+signature is bound to the exact catalog_url identity it was issued for (an
+HTTPS URL for a production catalog, the repo-checkout auto-discovery's
+canonical `DEFAULT_CATALOG_URL` identity for `model-registry/catalog.json`, or
+the literal `file://<path>` for an explicit override) -- copying a signed
+local catalog to a different path/URL does not carry its signature with it.
+To preview local/staged catalog edits (e.g. after `regenerate_all.sh`) without
+the real production signing seed, run
+`tooling/publish-model/scripts/sign_local_catalog.sh` to (re-)sign a dev copy;
+never commit its dev-signed output over the committed, production-signed
+`catalog.signature.json`.
 
 ## Forward Compatibility
 

--- a/docs/MODEL_CATALOG_ARCHITECTURE.md
+++ b/docs/MODEL_CATALOG_ARCHITECTURE.md
@@ -188,22 +188,47 @@ A LOCAL (`file://` or bare filesystem path) `catalog_url` override -- CLI
 `--catalog-url`/`OPENASR_CATALOG_URL`, the server's equivalent, or the CLI's
 repo-checkout auto-discovery of `model-registry/catalog.json` with no override
 set -- goes through the same signature/schema/anti-rollback pipeline as an
-HTTPS catalog: there is no unsigned local path. It additionally trusts a
-public, non-secret **local-dev signing key**
-(`openasr-catalog-local-dev-v1` / `LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX` in
-`crates/openasr-core/src/catalog_security.rs`) alongside the production key --
-that key carries no confidentiality (whoever supplies a local catalog file
-already controls its contents), it only forces every local catalog through
-real signature/sha256/catalog_url verification instead of a bypass. A
-signature is bound to the exact catalog_url identity it was issued for (an
-HTTPS URL for a production catalog, the repo-checkout auto-discovery's
-canonical `DEFAULT_CATALOG_URL` identity for `model-registry/catalog.json`, or
-the literal `file://<path>` for an explicit override) -- copying a signed
-local catalog to a different path/URL does not carry its signature with it.
+HTTPS catalog: there is no unsigned local path. Trust roots are chosen from
+the *identity a signature is checked against* (`catalog_security::classify_catalog_identity`),
+not merely from how the bytes were read:
+
+- A production (`https://`) identity -- including the repo-checkout
+  auto-discovery of `model-registry/catalog.json`, which is verified against
+  the canonical `DEFAULT_CATALOG_URL` identity, not its incidental local path
+  -- accepts **only the production key**. A widely-known dev key must never
+  be able to stand in for the canonical production catalog just because a
+  malicious CWD happens to contain a `model-registry/catalog.json` +
+  `catalog.signature.json` pair.
+- Any other (local) identity -- i.e. an explicit `file://<path>` override via
+  `--catalog-url`/`OPENASR_CATALOG_URL` -- additionally trusts a public,
+  non-secret **local-dev signing key** (`openasr-catalog-local-dev-v1` /
+  `LOCAL_CATALOG_DEV_SIGNING_KEY_SEED_HEX` in
+  `crates/openasr-core/src/catalog_security.rs`). That key carries no
+  confidentiality (whoever supplies a local catalog file already controls its
+  contents); it only forces every local catalog through real
+  signature/sha256/catalog_url verification instead of a bypass.
+
+A signature is bound to the exact catalog_url identity it was issued for (an
+HTTPS URL for a production catalog, or the literal `file://<path>` for an
+explicit override) -- copying a signed local catalog to a different path/URL
+does not carry its signature with it.
+
+A local-dev-key-verified catalog also never touches the shared, cross-source
+anti-rollback epoch floor in `$OPENASR_HOME/catalog.epoch` (neither reading it
+as a floor nor writing to it): that floor exists to protect genuine production
+distribution channels (HTTPS, the on-disk signed cache, the embedded offline
+snapshot) from a stale re-serve, and the dev key's self-signed preview content
+has no such channel to protect -- letting it participate would let one
+locally-signed catalog with an inflated epoch permanently brick every
+subsequent production catalog load until `catalog.epoch` was deleted by hand.
+
 To preview local/staged catalog edits (e.g. after `regenerate_all.sh`) without
 the real production signing seed, run
-`tooling/publish-model/scripts/sign_local_catalog.sh` to (re-)sign a dev copy;
-never commit its dev-signed output over the committed, production-signed
+`tooling/publish-model/scripts/sign_local_catalog.sh` to sign a dev copy bound
+to an explicit `file://<path>` identity, then load it with
+`OPENASR_CATALOG_URL=file://<path>` (the repo-checkout auto-discovery path no
+longer accepts the dev key, since it asserts the production identity). Never
+commit a dev-signed manifest over the committed, production-signed
 `catalog.signature.json`.
 
 ## Forward Compatibility

--- a/tooling/publish-model/scripts/sign_local_catalog.sh
+++ b/tooling/publish-model/scripts/sign_local_catalog.sh
@@ -15,17 +15,26 @@
 # Defaults:
 #   <catalog.json>   model-registry/catalog.json (repo-relative)
 #   --out            the catalog's own directory, i.e. <catalog.json's dir>/catalog.signature.json
-#   --catalog-url    the catalog JSON's own `catalog_url` field (normally
-#                     https://catalog.openasr.org/v1/catalog.json) -- this
-#                     matches the CLI's repo-checkout auto-discovery
-#                     (`openasr` run with no OPENASR_CATALOG_URL set finds
-#                     model-registry/catalog.json and verifies it against that
-#                     canonical identity, mirroring the binary's embedded
-#                     snapshot). Pass an explicit `file://<path>` here instead
-#                     if you plan to load the catalog via `--catalog-url`/
-#                     `OPENASR_CATALOG_URL` rather than the auto-discovery path.
+#   --catalog-url    `file://<absolute path to <catalog.json>>`. The dev key
+#                     is ONLY accepted for a non-production (local) identity
+#                     (see catalog_security::classify_catalog_identity /
+#                     docs/MODEL_CATALOG_ARCHITECTURE.md): the CLI's
+#                     repo-checkout auto-discovery of model-registry/catalog.json
+#                     verifies against the canonical production
+#                     `https://.../catalog.json` identity and requires the
+#                     real production signature, so a dev-signed manifest
+#                     bound to that identity would be rejected everywhere.
+#                     Load the dev-signed output of this script via an
+#                     explicit `OPENASR_CATALOG_URL=file://<path>` (or
+#                     `--catalog-url file://<path>`) override instead of
+#                     auto-discovery. Pass a different `--catalog-url` only if
+#                     you are intentionally signing for some other explicit
+#                     local override path.
 #   --epoch          the epoch already recorded in model-registry/catalog.epoch,
-#                     or 1 if that file does not exist yet.
+#                     or 1 if that file does not exist yet. A dev-key-signed
+#                     manifest never advances (or is blocked by) the shared
+#                     $OPENASR_HOME/catalog.epoch anti-rollback floor, so any
+#                     positive value is safe to reuse across runs.
 #
 # Environment:
 #   OPENASR_LOCAL_CATALOG_SIGNING_KEY_SEED_HEX overrides the (public,
@@ -34,8 +43,9 @@
 # WARNING: model-registry/catalog.signature.json is git-tracked and normally
 # holds the REAL PRODUCTION signature (see publish_catalog.sh). Running this
 # script overwrites it locally with a dev-signed manifest so you can preview
-# catalog edits -- never commit that dev-signed file. Restore the real one
-# with `git checkout -- model-registry/catalog.signature.json` (or by rerunning
+# catalog edits via `OPENASR_CATALOG_URL=file://<path>` -- never commit that
+# dev-signed file. Restore the real one with
+# `git checkout -- model-registry/catalog.signature.json` (or by rerunning
 # publish_catalog.sh with the real signing seed) before committing anything else.
 set -euo pipefail
 
@@ -108,21 +118,27 @@ if [[ -z "$EPOCH" ]]; then
 fi
 [[ "$EPOCH" =~ ^[0-9]+$ && "$EPOCH" != "0" ]] || die "epoch must be a positive integer, got: $EPOCH"
 
-CATALOG_URL_ARGS=()
-if [[ -n "$CATALOG_URL" ]]; then
-  CATALOG_URL_ARGS=(--catalog-url "$CATALOG_URL")
+if [[ -z "$CATALOG_URL" ]]; then
+  # The dev key only verifies against a non-production (local) identity (see
+  # the --catalog-url doc comment above), so default to the literal
+  # `file://<absolute path>` of the catalog being signed -- NOT the catalog
+  # JSON's own `catalog_url` field, which is the production https identity
+  # and would produce a manifest that verifies nowhere.
+  CATALOG_DIR="$(cd "$(dirname "$CATALOG")" && pwd)"
+  CATALOG_URL="file://$CATALOG_DIR/$(basename "$CATALOG")"
 fi
+CATALOG_URL_ARGS=(--catalog-url "$CATALOG_URL")
 
 log "signing '$CATALOG' with the public local-dev key ($LOCAL_DEV_KEY_ID) at epoch $EPOCH"
-# `${arr[@]+"${arr[@]}"}` (not plain `${arr[@]}`) is required under `set -u` on
-# bash 3.2 (macOS's default /bin/bash): an empty array expands to an unbound
-# variable error otherwise. The explicit assignment overrides whatever
-# OPENASR_CATALOG_SIGNING_KEY_SEED_HEX may already be set to in this shell.
+log "catalog_url identity: $CATALOG_URL"
+# The explicit assignment overrides whatever OPENASR_CATALOG_SIGNING_KEY_SEED_HEX
+# may already be set to in this shell.
 OPENASR_CATALOG_SIGNING_KEY_SEED_HEX="$LOCAL_DEV_SEED" \
   cargo run --quiet -p openasr-cli -- __openasr-sign-catalog-manifest "$CATALOG" \
     --out "$OUT" --epoch "$EPOCH" --key-id "$LOCAL_DEV_KEY_ID" \
-    "${CATALOG_URL_ARGS[@]+"${CATALOG_URL_ARGS[@]}"}"
+    "${CATALOG_URL_ARGS[@]}"
 
 log "wrote dev-signed manifest: $OUT"
 log "reminder: this is a LOCAL preview signature -- never commit it; restore the"
 log "committed production manifest with 'git checkout -- $OUT' before committing anything else"
+log "load it with: OPENASR_CATALOG_URL='$CATALOG_URL' cargo run -p openasr-cli -- <command>"

--- a/tooling/publish-model/scripts/sign_local_catalog.sh
+++ b/tooling/publish-model/scripts/sign_local_catalog.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Sign a LOCAL model catalog for dev/preview, using the public, non-secret
+# local-dev catalog signing key -- so a contributor iterating on
+# model-registry/catalog.json (e.g. after regenerate_all.sh) can preview
+# staged/unpublished entries through `openasr` without the real production
+# signing seed.
+#
+# A local ("file://" or bare filesystem path) catalog_url now requires a
+# signed catalog.signature.json sidecar exactly like the production HTTPS
+# catalog does (see docs/MODEL_CATALOG_ARCHITECTURE.md). This script fills
+# that requirement for local dev catalogs.
+#
+#   sign_local_catalog.sh [<catalog.json>] [--out <path>] [--epoch <n>] [--catalog-url <url>]
+#
+# Defaults:
+#   <catalog.json>   model-registry/catalog.json (repo-relative)
+#   --out            the catalog's own directory, i.e. <catalog.json's dir>/catalog.signature.json
+#   --catalog-url    the catalog JSON's own `catalog_url` field (normally
+#                     https://catalog.openasr.org/v1/catalog.json) -- this
+#                     matches the CLI's repo-checkout auto-discovery
+#                     (`openasr` run with no OPENASR_CATALOG_URL set finds
+#                     model-registry/catalog.json and verifies it against that
+#                     canonical identity, mirroring the binary's embedded
+#                     snapshot). Pass an explicit `file://<path>` here instead
+#                     if you plan to load the catalog via `--catalog-url`/
+#                     `OPENASR_CATALOG_URL` rather than the auto-discovery path.
+#   --epoch          the epoch already recorded in model-registry/catalog.epoch,
+#                     or 1 if that file does not exist yet.
+#
+# Environment:
+#   OPENASR_LOCAL_CATALOG_SIGNING_KEY_SEED_HEX overrides the (public,
+#   non-secret) local-dev signing seed; almost never needed.
+#
+# WARNING: model-registry/catalog.signature.json is git-tracked and normally
+# holds the REAL PRODUCTION signature (see publish_catalog.sh). Running this
+# script overwrites it locally with a dev-signed manifest so you can preview
+# catalog edits -- never commit that dev-signed file. Restore the real one
+# with `git checkout -- model-registry/catalog.signature.json` (or by rerunning
+# publish_catalog.sh with the real signing seed) before committing anything else.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+log() { printf '\033[1;36m[sign-local-catalog]\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31m[sign-local-catalog:err]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# The public, deterministic local-dev catalog signing key seed --
+# sha256("openasr.catalog_manifest.v1.local-dev-signing-key-seed"). NOT a
+# secret (see the doc comment on `CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID` in
+# crates/openasr-core/src/catalog_security.rs, the single source of truth).
+#
+# Deliberately read from ITS OWN env var (OPENASR_LOCAL_CATALOG_SIGNING_KEY_SEED_HEX),
+# never falling through to OPENASR_CATALOG_SIGNING_KEY_SEED_HEX: a maintainer's
+# shell may already export the latter (the REAL production seed) for
+# publish_catalog.sh, and silently reusing it here would render a "local dev"
+# manifest with production key material under the dev key id -- which then
+# fails self-verification (safe, but confusing) instead of doing what this
+# script is for. Set OPENASR_LOCAL_CATALOG_SIGNING_KEY_SEED_HEX yourself only
+# if you have set up a different local trust root.
+LOCAL_DEV_SEED="${OPENASR_LOCAL_CATALOG_SIGNING_KEY_SEED_HEX:-7181d685f3c226e1c111574368512b603d67964c057165ad004683b84998960e}"
+LOCAL_DEV_KEY_ID="openasr-catalog-local-dev-v1"
+
+CATALOG=""
+OUT=""
+EPOCH=""
+CATALOG_URL=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      OUT="${2:?--out requires <path>}"
+      shift 2
+      ;;
+    --epoch)
+      EPOCH="${2:?--epoch requires <n>}"
+      shift 2
+      ;;
+    --catalog-url)
+      CATALOG_URL="${2:?--catalog-url requires <url>}"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,33p' "$0"
+      exit 0
+      ;;
+    -*)
+      die "unknown flag: $1"
+      ;;
+    *)
+      [[ -z "$CATALOG" ]] || die "unexpected extra argument: $1"
+      CATALOG="$1"
+      shift
+      ;;
+  esac
+done
+
+CATALOG="${CATALOG:-$REPO_ROOT/model-registry/catalog.json}"
+[[ -f "$CATALOG" ]] || die "catalog file not found: $CATALOG"
+OUT="${OUT:-$(dirname "$CATALOG")/catalog.signature.json}"
+
+if [[ -z "$EPOCH" ]]; then
+  EPOCH_FILE="$(dirname "$CATALOG")/catalog.epoch"
+  if [[ -f "$EPOCH_FILE" ]]; then
+    EPOCH="$(tr -d '[:space:]' < "$EPOCH_FILE")"
+  else
+    EPOCH=1
+  fi
+fi
+[[ "$EPOCH" =~ ^[0-9]+$ && "$EPOCH" != "0" ]] || die "epoch must be a positive integer, got: $EPOCH"
+
+CATALOG_URL_ARGS=()
+if [[ -n "$CATALOG_URL" ]]; then
+  CATALOG_URL_ARGS=(--catalog-url "$CATALOG_URL")
+fi
+
+log "signing '$CATALOG' with the public local-dev key ($LOCAL_DEV_KEY_ID) at epoch $EPOCH"
+# `${arr[@]+"${arr[@]}"}` (not plain `${arr[@]}`) is required under `set -u` on
+# bash 3.2 (macOS's default /bin/bash): an empty array expands to an unbound
+# variable error otherwise. The explicit assignment overrides whatever
+# OPENASR_CATALOG_SIGNING_KEY_SEED_HEX may already be set to in this shell.
+OPENASR_CATALOG_SIGNING_KEY_SEED_HEX="$LOCAL_DEV_SEED" \
+  cargo run --quiet -p openasr-cli -- __openasr-sign-catalog-manifest "$CATALOG" \
+    --out "$OUT" --epoch "$EPOCH" --key-id "$LOCAL_DEV_KEY_ID" \
+    "${CATALOG_URL_ARGS[@]+"${CATALOG_URL_ARGS[@]}"}"
+
+log "wrote dev-signed manifest: $OUT"
+log "reminder: this is a LOCAL preview signature -- never commit it; restore the"
+log "committed production manifest with 'git checkout -- $OUT' before committing anything else"


### PR DESCRIPTION
## Summary

Local catalog sources (`--catalog-url file://...`, `OPENASR_CATALOG_URL`, and
the CLI's repo-checkout auto-discovery of `model-registry/catalog.json`)
previously bypassed signature verification entirely, unlike the production
HTTPS catalog. This closes that dev-only gap: every catalog source now goes
through the same fail-closed signature/schema/anti-rollback pipeline.

## Why

`docs/MODEL_CATALOG_ARCHITECTURE.md` documented the gap explicitly: "Unsigned
caches are accepted only for local `file://` or filesystem catalog sources
used by development and bundled-resource flows." A local catalog is still
only reachable through an explicit override, so this was never an attacker
foothold by itself, but it left a structural inconsistency (two different
trust codepaths for the same data shape) and meant a local catalog's bytes
could be corrupted/mismatched/swapped with no detection at all.

## Entry points audited

- `openasr-core::registry::load_model_catalog` -- the general catalog loader
  used by `--catalog-url`/`OPENASR_CATALOG_URL` overrides and the production
  default. Was gated by `catalog_source_requires_signature` (`https://` only);
  a `file://`/bare-path source skipped straight to parse+cache.
- `openasr-cli::catalog_cli::load_cli_model_catalog` -- the CLI's own local
  discovery: `OPENASR_CATALOG_URL`, else a repo-checkout auto-discovery of
  `model-registry/catalog.json` relative to CWD/`CARGO_MANIFEST_DIR` (used by
  `transcribe`/`live`/`show`/etc. for offline, network-free catalog reads and
  explicitly documented as "so a dev tree sees staged models too"). This is a
  second, distinct local-catalog path from the general loader above.
- `openasr-core::registry::load_embedded_signed_catalog` -- the binary's
  embedded snapshot (`include_str!` of the committed `catalog.public.json` +
  `catalog.public.signature.json`). Already signature/epoch-verified against
  the production key and `DEFAULT_CATALOG_URL`; unaffected by this change, and
  used here as the model for how `load_local_catalog_file_with_identity`
  binds a local file to a fixed identity.
- Existing verification/key management: `catalog_security.rs`
  (`OPENASR_CATALOG_TRUST_ROOTS`, `verify_catalog_signature_manifest`,
  ed25519 + sha256 + catalog_url binding + anti-rollback epoch), and the
  precedent `bundled_catalog_signature_verifies_committed_catalog_and_epoch`
  test for the committed catalog + signature pair.
- `openasr pull --from <local-pack>` / desktop-style local-file model install:
  consumes an already-`ResolvedCatalogPull`/`ModelCatalog` the caller obtained
  through the (now uniformly signed) catalog loader; it verifies the PACK's
  sha256/size against the catalog entry, not the catalog itself, so it is
  unaffected structurally and was exercised end-to-end by the updated CLI
  `pull_installs_local_pack_from_catalog_reference` fixture.

## Changes

- `catalog_security.rs`: adds a public, non-secret **local-dev catalog signing
  key** (`openasr-catalog-local-dev-v1`, seed = `sha256("openasr.catalog_manifest.v1.local-dev-signing-key-seed")`)
  and `OPENASR_LOCAL_CATALOG_TRUST_ROOTS` (production key + dev key), plus
  `verify_local_catalog_signature_manifest`. The dev key is added **only** to
  the local trust-root set, never to `OPENASR_CATALOG_TRUST_ROOTS`, so it can
  never authorize an HTTPS/embedded/cached production catalog.
- `registry.rs`: `load_model_catalog` now always verifies (removed the
  unsigned branch and the now-dead `load_cached_catalog`); a small
  `verify_catalog_manifest_for_source` helper picks production-only roots for
  `https://` and local roots (production + dev) for everything else. Adds
  `load_local_catalog_file_with_identity(path, expected_catalog_url, home)`
  for the one case where "the local file path" and "the identity to verify
  against" must differ: the CLI's repo-checkout auto-discovery, where
  `model-registry/catalog.json` + its committed sidecar are the
  pre-deployment source of truth for the canonical `DEFAULT_CATALOG_URL`
  identity (mirroring the embedded snapshot's relationship to that same
  identity), not the incidental checkout path.
- `catalog_cli.rs`: routes the auto-discovery candidates through
  `load_local_catalog_file_with_identity(path, default_catalog_url(), home)`
  instead of treating the bare path as both the read location and the
  verified identity.
- `main.rs`/`cli_args.rs`: the existing hidden `__openasr-sign-catalog-manifest`
  command now self-verifies against the right trust-root set based on
  `--key-id` (production key id keeps the old production-only check; any
  other key id, i.e. the local-dev key, self-verifies against the local roots)
  so the same command signs both release and local/dev catalogs.
- `docs/MODEL_CATALOG_ARCHITECTURE.md`: replaces the stale "unsigned local
  caches" note with the new invariant and the dev-signing workflow.

## Dev workflow

`tooling/publish-model/scripts/sign_local_catalog.sh` signs a local catalog
(default: `model-registry/catalog.json`) with the public local-dev key, for
previewing local/staged catalog edits (e.g. after `regenerate_all.sh`)
without the real production signing seed. It reads its own
`OPENASR_LOCAL_CATALOG_SIGNING_KEY_SEED_HEX` env var (defaulting to the
public dev seed) rather than falling through to
`OPENASR_CATALOG_SIGNING_KEY_SEED_HEX`, so a maintainer's shell that already
exports the real production seed for `publish_catalog.sh` cannot silently
leak it into a "local dev" signature. Output overwrites
`model-registry/catalog.signature.json` in place (git-tracked, normally the
real production signature) -- the script prints a reminder never to commit
that; restore it with `git checkout -- model-registry/catalog.signature.json`
before committing anything else.

## Tests

- `catalog_security.rs`: dev key <-> seed derivation is pinned; a dev-signed
  manifest verifies through the local roots and is rejected
  (`Unknown catalog signature key id`) through the production-only roots.
- `registry/tests/catalog.rs`: local-source fail-closed coverage --
  missing signature sidecar, unknown signing key, tampered signature bytes,
  catalog_url/path-identity mismatch (a signed local catalog does not verify
  when copied to a different path), and a tampered-without-resigning catalog
  falling back to the last verified-good on-disk cache instead of being
  trusted. Existing local-catalog loader tests (cache/fallback,
  invalid-schema-does-not-cache) updated to sign their fixtures and adjusted
  where the new URL-binding changes an error message.
- `openasr-cli/tests/cli.rs`: all `--catalog-url file://...` pull fixtures now
  sign through the shared `write_local_dev_signed_catalog` test helper; full
  suite green (70/70 + 110/110 unit tests, single-threaded to avoid a
  pre-existing, unrelated parallel-test env-var flake).
- `openasr-server`: `tests.rs`/`tests/api.rs` local-catalog fixtures
  (including two in-place-mutate-then-reload helpers) updated to sign/re-sign
  through the same helper; 165 lib tests + 82 api tests green.
- `crates/openasr-core/src/testing.rs` adds the shared
  `write_local_dev_signed_catalog` fixture helper (behind the existing
  `testing` feature) used by all three crates above.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2441 passed, 122 skipped, 0 failed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`
- [x] `tooling/publish-model/scripts/regenerate_all.sh --check`
- [x] `python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'` (155 passed)

## Manual smoke checks

- `sign_local_catalog.sh` against a scratch copy of `model-registry/catalog.json`,
  then `openasr pull moonshine-tiny:q8 --catalog-url file://<copy>` resolved
  and installed successfully using the dev-signed sidecar.

## Review fixes

An adversarial review of the original diff found one blocker and one
should-fix, both fixed in a follow-up commit:

- **Shared epoch floor DoS (blocker).** The local-dev key is public and
  self-signed by design, but a dev-key-verified local catalog was still
  writing/reading the shared, cross-source anti-rollback floor
  (`OPENASR_HOME/catalog.epoch`). Loading one local catalog signed with the
  (widely-known) dev key at a very high `catalog_epoch` would permanently
  reject every later production/on-disk-cache/embedded catalog load until an
  operator deleted `catalog.epoch` by hand -- a persistent DoS needing no key
  compromise. Fix: `catalog_security::participates_in_epoch_floor` scopes the
  floor to the production key only; `enforce_catalog_epoch_for_verified` /
  `record_catalog_epoch_for_verified` gate every call site on it. The local
  dev workflow doesn't need that floor's protection in the first place -- it
  is a developer signing content for their own preview, not a production
  distribution channel that needs protecting against a stale re-serve.
  New test: `local_dev_catalog_epoch_never_advances_or_is_blocked_by_the_shared_production_floor`
  loads a dev-signed local catalog at `u64::MAX`, then confirms the embedded
  production snapshot still loads afterward.
- **Dev key could stand in for the production identity (should-fix).**
  `load_local_catalog_file_with_identity` -- the CLI's repo-checkout
  auto-discovery of `model-registry/catalog.json`, always asserting the
  canonical production identity -- accepted the dev key for that same
  identity, so a malicious CWD holding a dev-signed
  `catalog.json`/`catalog.signature.json` pair could stand in for the real
  production catalog with no flags needed. Fix: trust roots are now chosen
  from the identity itself (production/`https://` identity -> production key
  only, exactly like a real HTTPS/cached/embedded catalog; the dev key stays
  available only for an explicit non-production `file://` identity). The
  committed `model-registry/catalog.json` + `catalog.signature.json` are
  production-signed, so this is zero-impact for the real, deployed pair --
  covered by `local_catalog_auto_discovery_accepts_the_real_production_signed_catalog`.
  New negative test:
  `local_catalog_auto_discovery_rejects_dev_key_bound_to_production_identity`.
  `sign_local_catalog.sh`'s default `--catalog-url` and
  `docs/MODEL_CATALOG_ARCHITECTURE.md` are updated for the resulting dev
  workflow (sign for the `file://` identity, load via
  `OPENASR_CATALOG_URL=file://<path>`, not auto-discovery).
- **Structural hardening.** Trust-root selection
  (`verify_catalog_manifest_for_source`) and read-transport dispatch
  (`read_catalog_source`) now share one `catalog_security::classify_catalog_identity`
  function instead of two independent `starts_with("https://")` checks, so a
  future catalog source scheme cannot be added to one without also updating
  the other.

Re-ran the full validation set after the fix (`fmt`, `clippy -D warnings`,
`nextest --workspace`, doc tests, `cargo deny check`, `golden_diff`,
`bundled_catalog_signature_verifies_committed_catalog_and_epoch`,
`regenerate_all.sh --check`, the tooling Python unit tests) and manually
re-verified the dev workflow end to end: `sign_local_catalog.sh` against a
scratch copy, loaded via `OPENASR_CATALOG_URL=file://<path>` through
`search`/`show`/a real `pull`, plus a live check that a malicious CWD with a
dev-signed `model-registry/catalog.json` bound to the production identity is
now rejected (fail-closed, non-zero exit) while the real committed pair still
loads via auto-discovery with no override.

## Docs updated

- [x] `docs/MODEL_CATALOG_ARCHITECTURE.md` updated for the new invariant and
      the dev-signing workflow.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch the production HTTPS catalog, embedded snapshot, or the
  actual publish/signing pipeline (`publish_catalog.sh`, the real signing
  seed) -- those are unchanged.
- Does not touch desktop's separate local-file model-pack install feature
  (lives in the closed `openasr-app` repo); confirmed here only that this
  repo's local-pack install path (`install_model_pack_from_path` /
  `install_catalog_model_pack_from_path`) verifies the pack's sha256/size
  against an already-loaded catalog, not the catalog itself, so it is
  unaffected structurally.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with heavy AI assistance (Claude Code), reviewed and validated locally per the checklist above.

