### PR TITLE
fix(dolphin): reject sub-receptive-field frames instead of aborting in ggml conv

### DIFF
--- a/crates/openasr-core/src/models/dolphin/encoder_graph.rs
+++ b/crates/openasr-core/src/models/dolphin/encoder_graph.rs
@@ -197,13 +197,51 @@ impl DolphinWeightProvider for HashMap<String, Vec<f32>> {
     }
 }
 
-/// Subsampled frame count after two `k3 s2` conv layers (4x time downsample).
-fn subsample_len(frames: usize) -> usize {
-    let after_first = (frames.saturating_sub(3)) / 2 + 1;
-    (after_first.saturating_sub(3)) / 2 + 1
+/// One `k3 s2` (no padding) Conv2d layer's output length along an axis, or
+/// `Err` if `input` is smaller than the kernel (the ggml `im2col`/`conv_2d`
+/// precondition `OH > 0` -- feeding it an under-sized input aborts the whole
+/// process instead of returning a Rust error, so this must be checked before
+/// the graph is ever built; see `subsample_len`/`subsample`/`encode`).
+fn conv2d_no_pad_stride2_out_len(
+    input: usize,
+    kernel: usize,
+) -> Result<usize, DolphinEncoderError> {
+    const STRIDE: usize = 2;
+    input
+        .checked_sub(kernel)
+        .and_then(|value| value.checked_div(STRIDE))
+        .and_then(|value| value.checked_add(1))
+        .ok_or_else(|| DolphinEncoderError::Shape {
+            reason: format!(
+                "conv2d subsampling requires at least {kernel} input frames, got {input}"
+            ),
+        })
+}
+
+/// Subsampled frame count after two `k3 s2` (no padding) conv layers (4x time
+/// downsample). `Err` when `frames_in` is too short for the two-layer
+/// receptive field (7 frames minimum: `(7-3)/2+1=3` after layer one, `(3-3)/2+1=1`
+/// after layer two) instead of silently producing a degenerate frame count that
+/// would abort the ggml conv at graph-build time.
+fn subsample_len(frames: usize) -> Result<usize, DolphinEncoderError> {
+    let after_first = conv2d_no_pad_stride2_out_len(frames, 3)?;
+    conv2d_no_pad_stride2_out_len(after_first, 3)
+}
+
+/// The smallest `frames_in` for which [`subsample_len`] succeeds. Derived by
+/// walking the same checked formula forward instead of a hardcoded constant,
+/// so it cannot drift out of sync with it.
+pub(crate) fn minimum_subsample_input_frames() -> usize {
+    (1..)
+        .find(|&frames| subsample_len(frames).is_ok())
+        .expect("subsample_len's two-layer k3/s2 chain has a finite minimum valid input")
 }
 
 /// Subsampled feature width after the same two conv layers on the mel axis.
+/// Unlike `subsample_len` this always runs over the model's fixed
+/// `feature_dim` config (e.g. 80 mel bins), never a runtime-variable audio
+/// length, so it stays infallible (saturating is safe: `feature_dim` is always
+/// far above the two-layer receptive field for every published Dolphin pack).
 fn subsample_width(features: usize) -> usize {
     let after_first = (features.saturating_sub(3)) / 2 + 1;
     (after_first.saturating_sub(3)) / 2 + 1
@@ -943,7 +981,7 @@ fn subsample<'a>(
     let d = config.d_model;
     let feat = config.feature_dim;
     let width = subsample_width(feat);
-    let frames = subsample_len(frames_in);
+    let frames = subsample_len(frames_in)?;
 
     // ggml conv_2d: data [W=feat, H=T, C_in=1, N=1], kernel [KW, KH, C_in, C_out].
     let data = graph
@@ -1004,7 +1042,16 @@ pub(crate) fn encode(
             ),
         });
     }
-    let frames = subsample_len(frames_in);
+    // Reject a frames_in too short for the two-layer k3/s2 subsampling stem
+    // before any graph/runner allocation: ggml's `conv_2d`/`im2col` asserts
+    // `OH > 0` and aborts the whole process on an under-sized input rather
+    // than returning a Rust error, so this must fail closed here first (see
+    // `subsample_len`). A streaming FINAL over a too-short trailing window is
+    // the reachable real-world trigger (short press-to-talk after idle
+    // unload); the streaming driver also skips the encode call entirely in
+    // that case (see `incremental_streaming_driver`), so this is defense in
+    // depth for any other caller.
+    let frames = subsample_len(frames_in)?;
 
     let graph_config = GgmlCpuGraphConfig {
         context_bytes: 64 * 1024 * 1024,
@@ -1197,6 +1244,47 @@ pub(crate) fn encode(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Two k3/s2 (no padding) layers: `(7-3)/2+1=3` after layer one, `(3-3)/2+1=1`
+    /// after layer two -- the smallest input that survives both. Regression check
+    /// on `subsample_len`'s checked arithmetic (was a `saturating_sub` that
+    /// silently produced a degenerate frame count for anything shorter instead
+    /// of failing closed).
+    #[test]
+    fn minimum_subsample_input_frames_is_seven() {
+        assert_eq!(minimum_subsample_input_frames(), 7);
+        assert!(subsample_len(6).is_err());
+        assert!(subsample_len(7).is_ok());
+    }
+
+    /// The historical crash (mac 0.1.8 field report): a streaming FINAL over a
+    /// too-short trailing window (fewer frames than the Conv2dSubsampling4
+    /// receptive field) reached `ggml_conv_2d`/`ggml_im2col`, which asserts
+    /// `OH > 0` and `ggml_abort()`s the whole process -- not a catchable Rust
+    /// panic. `encode` must reject this before ever building the graph.
+    #[test]
+    fn encode_rejects_frames_below_subsampling_receptive_field_instead_of_aborting() {
+        let config = DolphinEncoderConfig::small_cn();
+        let feat = config.feature_dim;
+        let frames_in = minimum_subsample_input_frames() - 1;
+        let features = vec![0.0f32; frames_in * feat];
+        // The rejection happens before any weight is looked up, so an empty
+        // provider is enough -- if this regresses to reading weights first,
+        // the test will fail with a `MissingWeight` error instead of `Shape`.
+        let provider: HashMap<String, Vec<f32>> = HashMap::new();
+        let result = encode(
+            &config,
+            &provider,
+            &features,
+            frames_in,
+            GgmlCpuGraphBackend::Cpu,
+            false,
+        );
+        assert!(
+            matches!(result, Err(DolphinEncoderError::Shape { .. })),
+            "expected a typed Shape error for {frames_in} frames, got {result:?}"
+        );
+    }
 
     /// Pins the centered Transformer-XL `RelPositionalEncodingV1` table's shape
     /// and index direction (the multilingual dolphin encoder's only numeric

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -37,8 +37,12 @@ use crate::models::incremental_streaming_driver::{
 use super::decoder_graph::DolphinDecoderConfig;
 use super::encoder_graph::{
     DolphinEncoderConfig, DolphinEncoderOutput, DolphinNativeWeight, DolphinWeightProvider, encode,
+    minimum_subsample_input_frames,
 };
-use super::frontend::{DolphinEspnetFrontend, DolphinFbankFrontend, apply_global_cmvn};
+use super::frontend::{
+    DolphinEspnetFrontend, DolphinFbankFrontend, apply_global_cmvn, espnet_min_samples_for_frames,
+    kaldi_min_samples_for_frames,
+};
 use super::hotword_context::{
     apply_hotword_deep_biasing, encode_hotword_context_embeddings, tokenize_hotword_phrase,
 };
@@ -638,6 +642,28 @@ impl GgmlAsrStreamingExecutor for DolphinGgmlExecutor {
         &self,
         request: &GgmlAsrStreamingSessionRequest,
     ) -> Result<Box<dyn NativeAsrSession>, GgmlAsrExecutionError> {
+        let fail = |reason: String| GgmlAsrExecutionError::ExecutorFailed {
+            executor_id: DOLPHIN_STREAMING_EXECUTOR_ID,
+            adapter_id: request.selected_family.adapter_id,
+            reason,
+        };
+        // Resolve the pack's language scheme once here so the streaming driver
+        // can be told the minimum raw-sample count its frontend + encoder can
+        // turn into output (see `minimum_encodable_samples` below): a trailing
+        // window shorter than the Conv2dSubsampling4 receptive field (7 mel
+        // frames, no padding) reaches `ggml_conv_2d`'s `im2col` precondition
+        // and aborts the whole process instead of returning a Rust error (the
+        // idle_unload short-press crash), so the driver must skip that decode
+        // call entirely rather than rely on catching an error afterward.
+        let preflight = request
+            .resolve_runtime_source_preflight()
+            .map_err(|error| fail(error.to_string()))?;
+        let language_scheme = parse_dolphin_language_scheme(&preflight.metadata).map_err(fail)?;
+        let min_frames = minimum_subsample_input_frames();
+        let min_samples = match language_scheme {
+            DolphinLanguageScheme::CnDialect => kaldi_min_samples_for_frames(min_frames),
+            DolphinLanguageScheme::Multilingual => espnet_min_samples_for_frames(min_frames),
+        };
         // Dolphin has no cheap CTC-greedy partial surface (the pipeline output
         // exposes only the rescored transcript), so partials re-decode the
         // trailing window through the same offline joint decode as the FINAL.
@@ -650,7 +676,7 @@ impl GgmlAsrStreamingExecutor for DolphinGgmlExecutor {
             DOLPHIN_GGML_ADAPTER_ID,
             "dolphin",
             request,
-            STREAMING_PARTIAL_TUNING_HEAVY_SNAPSHOT,
+            STREAMING_PARTIAL_TUNING_HEAVY_SNAPSHOT.with_minimum_encodable_samples(min_samples),
             <DolphinGgmlExecutor as GgmlAsrExecutor>::execute,
         )
     }

--- a/crates/openasr-core/src/models/dolphin/frontend.rs
+++ b/crates/openasr-core/src/models/dolphin/frontend.rs
@@ -136,6 +136,19 @@ impl DolphinFbankFrontend {
     }
 }
 
+/// The inverse of `DolphinFbankFrontend::compute`'s frame-count formula
+/// (`1 + (len - FRAME_LENGTH) / FRAME_SHIFT`): the fewest 16 kHz samples
+/// guaranteed to produce at least `min_frames` snip-edges fbank frames. Lets a
+/// caller (the streaming driver) reject/skip a too-short trailing window
+/// before ever computing features, using the same framing constants
+/// `compute` does so the two cannot drift apart.
+pub(crate) fn kaldi_min_samples_for_frames(min_frames: usize) -> usize {
+    if min_frames == 0 {
+        return 0;
+    }
+    FRONTEND_CONFIG.frame_length + (min_frames - 1) * FRONTEND_CONFIG.frame_shift
+}
+
 /// Apply the checkpoint's `global_cmvn` `(x - mean) * istd` in place, per mel bin.
 /// `features` is row-major `[frames, feature_dim]`; `mean`/`istd` are the
 /// `encoder.global_cmvn.*` vectors baked in the pack (both length `feature_dim`).
@@ -289,6 +302,19 @@ impl DolphinEspnetFrontend {
             n_mels,
         })
     }
+}
+
+/// The inverse of `DolphinEspnetFrontend::compute`'s frame-count formula
+/// (`1 + samples.len() / HOP_LENGTH`, per that method's doc comment): the
+/// fewest 16 kHz samples guaranteed to produce at least `min_frames`
+/// reflect-centered STFT frames. See `kaldi_min_samples_for_frames` for the
+/// `CnDialect` counterpart; the two schemes' framing differs (reflect-padded
+/// vs. snip-edges) so each frontend owns its own inverse.
+pub(crate) fn espnet_min_samples_for_frames(min_frames: usize) -> usize {
+    if min_frames == 0 {
+        return 0;
+    }
+    (min_frames - 1) * ESPNET_HOP_LENGTH
 }
 
 #[cfg(test)]
@@ -493,5 +519,52 @@ mod tests {
             DolphinEspnetFrontend::new().compute(&[]),
             Err(DolphinFrontendError::UnsupportedAudio)
         ));
+    }
+
+    // --- min-samples-for-frames inverses (streaming short-tail guard) ------
+
+    #[test]
+    fn kaldi_min_samples_for_frames_round_trips_through_compute() {
+        for min_frames in 1..=8usize {
+            let min_samples = kaldi_min_samples_for_frames(min_frames);
+            let features = DolphinFbankFrontend::new()
+                .compute(&vec![0.01f32; min_samples])
+                .expect("fbank");
+            assert!(
+                features.n_frames >= min_frames,
+                "min_frames={min_frames} min_samples={min_samples} produced only {} frames",
+                features.n_frames
+            );
+            // One sample short must not still reach `min_frames` (the bound is
+            // tight, not just sufficient), except at min_frames=1 where even 0
+            // samples is a distinct, separately-rejected edge case.
+            if min_samples > 0 {
+                let short = &vec![0.01f32; min_samples - 1];
+                let frames_short = DolphinFbankFrontend::new()
+                    .compute(short)
+                    .map(|f| f.n_frames)
+                    .unwrap_or(0);
+                assert!(
+                    frames_short < min_frames,
+                    "min_frames={min_frames}: {} samples unexpectedly reached {frames_short} frames",
+                    min_samples - 1
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn espnet_min_samples_for_frames_round_trips_through_compute() {
+        for min_frames in 1..=8usize {
+            let min_samples = espnet_min_samples_for_frames(min_frames);
+            let features = DolphinEspnetFrontend::new()
+                .compute(&vec![0.01f32; min_samples.max(1)])
+                .expect("espnet fbank");
+            assert!(
+                features.n_frames >= min_frames,
+                "min_frames={min_frames} min_samples={min_samples} produced only {} frames",
+                features.n_frames
+            );
+        }
     }
 }

--- a/crates/openasr-core/src/models/incremental_streaming_driver.rs
+++ b/crates/openasr-core/src/models/incremental_streaming_driver.rs
@@ -65,6 +65,15 @@ pub(crate) struct StreamingPartialTuning {
     first_partial_audio_ms: u32,
     window_ms: u64,
     partial_prompt_tail_words: Option<usize>,
+    /// Fewest raw samples this family's encoder can turn into at least one
+    /// output frame. `None` means every family sharing this tuning constant
+    /// already fails closed on a too-short input by itself (no separate
+    /// pre-decode floor needed); set per-session via
+    /// `with_minimum_encodable_samples` for families whose encoder aborts
+    /// instead of erroring on an under-sized input (see dolphin's
+    /// `start_streaming_session`). Below this floor the driver skips the
+    /// decode call entirely instead of attempting one the encoder cannot run.
+    minimum_encodable_samples: Option<usize>,
 }
 
 impl StreamingPartialTuning {
@@ -78,7 +87,17 @@ impl StreamingPartialTuning {
             first_partial_audio_ms,
             window_ms: DEFAULT_TOKEN_INCREMENTAL_WINDOW_MS,
             partial_prompt_tail_words,
+            minimum_encodable_samples: None,
         }
+    }
+
+    /// Attach a per-session minimum encodable sample count (computed from the
+    /// pack's own resolved config, e.g. dolphin's language scheme -> frontend
+    /// framing -> encoder receptive field), without disturbing the shared
+    /// `const` tuning profile other families reuse.
+    pub(crate) const fn with_minimum_encodable_samples(mut self, samples: usize) -> Self {
+        self.minimum_encodable_samples = Some(samples);
+        self
     }
 
     pub(crate) const fn min_partial_interval_ms(&self) -> u32 {
@@ -95,6 +114,10 @@ impl StreamingPartialTuning {
 
     pub(crate) const fn partial_prompt_tail_words(&self) -> Option<usize> {
         self.partial_prompt_tail_words
+    }
+
+    pub(crate) const fn minimum_encodable_samples(&self) -> Option<usize> {
+        self.minimum_encodable_samples
     }
 }
 
@@ -185,21 +208,23 @@ where
                 .map(|result| result.transcription)
         },
     );
-    Box::new(
-        IncrementalStreamingTranscriptDriver::new(
-            executor_id,
-            adapter_id,
-            utterance_id,
-            segment_id,
-            1,
-            transcribe,
-        )
-        .with_partial_results(partial_results)
-        .with_partial_cadence(partial_floor_ms)
-        .with_first_partial_audio_ms(u64::from(tuning.first_partial_audio_ms))
-        .with_partial_window_ms(tuning.window_ms)
-        .with_partial_prompt_tail_words(tuning.partial_prompt_tail_words()),
+    let mut driver = IncrementalStreamingTranscriptDriver::new(
+        executor_id,
+        adapter_id,
+        utterance_id,
+        segment_id,
+        1,
+        transcribe,
     )
+    .with_partial_results(partial_results)
+    .with_partial_cadence(partial_floor_ms)
+    .with_first_partial_audio_ms(u64::from(tuning.first_partial_audio_ms))
+    .with_partial_window_ms(tuning.window_ms)
+    .with_partial_prompt_tail_words(tuning.partial_prompt_tail_words());
+    if let Some(minimum_encodable_samples) = tuning.minimum_encodable_samples() {
+        driver = driver.with_minimum_encodable_samples(minimum_encodable_samples);
+    }
+    Box::new(driver)
 }
 
 /// Shared `start_streaming_session` body for the seq2seq GGML families
@@ -343,6 +368,13 @@ pub(crate) struct IncrementalStreamingTranscriptDriver {
     /// accumulated across re-decodes (that is what caused boundary drift).
     prompt_context: String,
     partial_prompt_tail_words: Option<usize>,
+    /// Fewest raw samples the family's encoder can turn into at least one
+    /// output frame (see `StreamingPartialTuning::minimum_encodable_samples`).
+    /// Below this floor, `poll_updates`/`finish_updates` skip the decode call
+    /// and return a clean empty result instead of attempting a decode the
+    /// encoder cannot run: a too-short trailing window (e.g. a very brief
+    /// press-to-talk) is normal usage, not an error.
+    minimum_encodable_samples: Option<usize>,
     /// Cached whole-buffer PARTIAL decode reused by an unchanged terminal
     /// finalize (see [`FinalizeReuse`]).
     finalize_reuse: Option<FinalizeReuse>,
@@ -385,6 +417,7 @@ impl IncrementalStreamingTranscriptDriver {
             window_ms: 0,
             prompt_context: String::new(),
             partial_prompt_tail_words: None,
+            minimum_encodable_samples: None,
             finalize_reuse: None,
             finalize_reuse_hits: 0,
             finalize_reuse_misses: 0,
@@ -422,6 +455,19 @@ impl IncrementalStreamingTranscriptDriver {
     pub(crate) fn with_partial_prompt_tail_words(mut self, tail_words: Option<usize>) -> Self {
         self.partial_prompt_tail_words = tail_words.filter(|words| *words > 0);
         self
+    }
+
+    /// See the field doc on `minimum_encodable_samples`.
+    pub(crate) fn with_minimum_encodable_samples(mut self, samples: usize) -> Self {
+        self.minimum_encodable_samples = Some(samples);
+        self
+    }
+
+    /// Whether the current buffer has fewer samples than the family's encoder
+    /// can turn into output (a no-op / `None` floor never blocks a decode).
+    fn buffer_below_minimum_encodable_samples(&self) -> bool {
+        self.minimum_encodable_samples
+            .is_some_and(|minimum| self.buffer.sample_count() < minimum)
     }
 
     fn new_cadence(&self) -> PartialDecodeCadence {
@@ -465,7 +511,11 @@ impl IncrementalStreamingTranscriptDriver {
     fn decode_partial_if_due(
         &mut self,
     ) -> Result<Vec<GgmlAsrStreamingTranscriptUpdate>, GgmlAsrExecutionError> {
-        if !self.partial_results || self.final_emitted || self.buffer.is_empty() {
+        if !self.partial_results
+            || self.final_emitted
+            || self.buffer.is_empty()
+            || self.buffer_below_minimum_encodable_samples()
+        {
             return Ok(Vec::new());
         }
         let audio_end_ms = self.buffer.end_ms().unwrap_or(0);
@@ -739,6 +789,15 @@ impl GgmlAsrStreamingTranscriptDriver for IncrementalStreamingTranscriptDriver {
         &mut self,
     ) -> Result<Vec<GgmlAsrStreamingTranscriptUpdate>, GgmlAsrExecutionError> {
         if self.buffer.is_empty() || self.final_emitted {
+            return Ok(Vec::new());
+        }
+        // A trailing window shorter than the encoder's receptive field is
+        // normal usage (e.g. a very brief press-to-talk that never crossed
+        // the first-partial floor, so no partial ever ran either), not an
+        // error: finish cleanly with no additional update instead of
+        // attempting a decode the encoder cannot turn into output. Whatever
+        // was already committed/finalized earlier in the utterance stands.
+        if self.buffer_below_minimum_encodable_samples() {
             return Ok(Vec::new());
         }
         // The FINAL decodes whatever audio remains in the buffer — i.e. the current
@@ -1320,5 +1379,84 @@ mod tests {
             trim_committed_overlap("确实是在我的预料之中啊。", "的预料之中啊！后续内容", 12),
             "后续内容"
         );
+    }
+
+    // --- minimum-encodable-samples short-tail guard -------------------------
+    //
+    // Regression coverage for the dolphin idle_unload crash: a streaming FINAL
+    // (or, defensively, a PARTIAL) over a trailing window shorter than the
+    // family's encoder can turn into output must finish cleanly with no
+    // decode attempt, not surface an error or crash.
+
+    #[test]
+    fn finish_skips_decode_and_returns_empty_below_the_minimum_encodable_samples_floor() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_decode = Arc::clone(&calls);
+        let mut driver = IncrementalStreamingTranscriptDriver::new(
+            "token-incremental-test-executor",
+            crate::QWEN3_ASR_GGML_ADAPTER_ID,
+            "utt_min_final",
+            "seg_min_final",
+            0,
+            Box::new(move |_audio, _prompt| {
+                calls_for_decode.fetch_add(1, Ordering::SeqCst);
+                Ok(transcription("should never be reached"))
+            }),
+        )
+        .with_partial_results(false)
+        .with_minimum_encodable_samples(1_000);
+
+        // One 20 ms frame is 320 samples, well under the 1,000-sample floor.
+        driver.push_audio(frame(0, 0)).unwrap();
+        let final_ = driver.finish_updates().unwrap();
+        assert!(
+            final_.is_empty(),
+            "a too-short trailing window must finish with an empty (not erroring) result"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "must not attempt a decode the encoder cannot run"
+        );
+    }
+
+    #[test]
+    fn finish_decodes_normally_once_the_buffer_reaches_the_minimum_encodable_samples_floor() {
+        let mut driver = driver(VecDeque::from(["ok"])).with_minimum_encodable_samples(100);
+        // frame() pushes 320 samples, at/over the 100-sample floor.
+        driver.push_audio(frame(1, 0)).unwrap();
+        let final_ = driver.finish_updates().unwrap();
+        assert_eq!(text_of(&final_[0]).0, "ok");
+    }
+
+    #[test]
+    fn poll_updates_skips_decode_below_the_minimum_encodable_samples_floor() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut driver = counting_windowed_driver(30_000, Arc::clone(&calls))
+            .with_minimum_encodable_samples(1_000);
+
+        // One 20 ms frame is 320 samples, under the floor: poll must not decode.
+        driver.push_audio(vframe(1, 0)).unwrap();
+        let updates = driver.poll_updates().unwrap();
+        assert!(updates.is_empty());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        // Once enough audio has accumulated, partials resume normally.
+        for i in 2..=4 {
+            driver.push_audio(vframe(i, (i - 1) * 20)).unwrap();
+        }
+        let updates = driver.poll_updates().unwrap();
+        assert_eq!(text_of(&updates[0]).0, "w0 w1 w2 w3");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn no_minimum_encodable_samples_floor_never_blocks_a_decode() {
+        // Default (no family opted in): even a single-frame buffer decodes
+        // normally, matching every family's behavior before this guard existed.
+        let mut driver = driver(VecDeque::from(["ok"]));
+        driver.push_audio(frame(1, 0)).unwrap();
+        let final_ = driver.finish_updates().unwrap();
+        assert_eq!(text_of(&final_[0]).0, "ok");
     }
 }


### PR DESCRIPTION
## Summary

Fixes a process-level crash: a streaming dictation FINAL over a trailing
window shorter than dolphin's encoder receptive field abort()s the whole
sidecar instead of returning an error. Adds a typed encoder-side guard plus a
clean streaming skip for the (normal) too-short-tail case, and audits every
other family sharing the streaming re-decode driver for the same bug class.

## Why

Real-machine field report (mac 0.1.8): after `idle_unload` unloads a dictation
session, the first short press-to-talk afterward can produce a FINAL whose
trailing audio window has fewer than 7 mel frames -- the minimum receptive
field of dolphin's `Conv2dSubsampling4` stem (two `k3 s2` conv layers with no
padding). `ggml_conv_2d`/`ggml_im2col` assert `OH > 0` on that input and call
`ggml_abort()`, killing the whole process. This is not a catchable Rust
panic -- it is a hard process abort, confirmed in the daemon crash log with
the call chain `ggml_im2col <- ggml_conv_2d <- dolphin::encoder_graph::subsample
<- encode <- DolphinGgmlExecutor::execute <- incremental_streaming_driver
(closure) <- finish_updates <- NativeAsrSession::finish <-
run_native_streaming_session_on_worker`. A very brief press-to-talk is normal
usage, not something that should ever crash or even error the daemon.

## Changes

- `crates/openasr-core/src/models/dolphin/encoder_graph.rs`: `subsample_len`
  now returns `Result<usize, DolphinEncoderError>` via a checked
  `conv2d_no_pad_stride2_out_len` helper instead of `saturating_sub`, so a
  too-short `frames_in` fails closed with a typed `Shape` error before any
  graph/runner allocation, instead of silently producing a degenerate frame
  count that later aborts ggml. Added `minimum_subsample_input_frames()`,
  which derives the 7-frame floor by walking the same checked formula (not a
  hardcoded constant), so the two cannot drift apart.
- `crates/openasr-core/src/models/dolphin/frontend.rs`: added
  `kaldi_min_samples_for_frames` / `espnet_min_samples_for_frames`, the
  inverse of each frontend's own frame-count formula (kaldi snip-edges vs.
  ESPnet reflect-centered framing differ, so each frontend owns its inverse)
  -- lets a caller compute the minimum raw sample count for N encodable
  frames without duplicating the framing math.
- `crates/openasr-core/src/models/incremental_streaming_driver.rs`:
  `StreamingPartialTuning` gained an optional `minimum_encodable_samples`
  floor (`with_minimum_encodable_samples`, default `None` so every other
  family/tuning-profile using this shared driver is unaffected).
  `poll_updates`/`finish_updates` skip the decode call entirely when the
  buffer is below that floor, returning a clean empty result -- a too-short
  trailing window finishes with whatever was already committed, no error.
- `crates/openasr-core/src/models/dolphin/executor.rs`:
  `start_streaming_session` resolves the pack's language scheme once (already
  available via the request preflight) and computes the minimum-encodable
  sample floor from the matching frontend's own inverse formula, attaching it
  to the shared `STREAMING_PARTIAL_TUNING_HEAVY_SNAPSHOT` profile for this
  session only.

Audited every other family reaching this shared driver --
qwen, cohere, moonshine, whisper, firered_aed, parakeet_tdt, parakeet_ctc,
wav2vec2_ctc, sensevoice -- for the same bug class (an under-sized encoder
input reaching an unguarded ggml conv). All of them already fail closed with
a typed error or are structurally immune (fixed-size padding before the
conv, checked conv-dimension arithmetic already in place, or a frontend that
guarantees a minimum frame count before the encoder ever runs). Dolphin was
the only encoder in this set whose subsampling stem could abort the process,
so no other family needed a change.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2470 passed, 123 skipped -- private-pack-gated dolphin/firered golden tests, unrelated to this change)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (not run; no dependency changes in this PR)

Also ran targeted:
- `cargo test -p openasr-core golden_diff -- --nocapture` -- passes unchanged
  (whisper golden cases; dolphin's own golden/parity tests are
  `#[ignore]`d, gated on a private local checkpoint not present in CI,
  per existing repo convention)
- `cargo test -p openasr-core --lib dolphin::` -- 55 passed, 7 ignored (private-pack-gated)
- `cargo test -p openasr-core --lib incremental_streaming_driver` -- 17 passed, including 4 new regression tests

New tests added:
- `dolphin::encoder_graph`: `minimum_subsample_input_frames_is_seven`,
  `encode_rejects_frames_below_subsampling_receptive_field_instead_of_aborting`
  (typed `Err`, not panic/abort, for a too-short `frames_in`)
- `dolphin::frontend`: `kaldi_min_samples_for_frames_round_trips_through_compute`,
  `espnet_min_samples_for_frames_round_trips_through_compute`
- `incremental_streaming_driver`:
  `finish_skips_decode_and_returns_empty_below_the_minimum_encodable_samples_floor`,
  `finish_decodes_normally_once_the_buffer_reaches_the_minimum_encodable_samples_floor`,
  `poll_updates_skips_decode_below_the_minimum_encodable_samples_floor`,
  `no_minimum_encodable_samples_floor_never_blocks_a_decode` (regression: the
  new opt-in floor must not affect any family that doesn't set it)

## Manual smoke checks

None beyond the automated suite above -- this fix targets a crash path that
only a real ggml conv graph build (not the `mock` backend) can reach; the new
unit tests exercise the exact failure boundary (frames_in = 6 vs. 7) directly
against the real encoder graph builder.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

No user-facing behavior/limitation changed (a too-short trailing window now
finishes silently instead of crashing/erroring, which is a bug fix, not a new
documented capability or limitation).

## Scope / non-goals

This PR does not touch the shared `fastconformer::graph::conv_out_dim` helper
(used by parakeet_tdt/parakeet_ctc), which uses unchecked arithmetic but is
currently safe in practice: its padding=1/kernel=3/stride=2 formula never
underflows for any frame count >= 1, and the shared STFT frontend already
guarantees >= 1 frame before the encoder runs. Converting it to checked
arithmetic for defense-in-depth consistency with its sibling implementations
(cohere, firered_aed, xasr_zipformer, and this dolphin fix) is a reasonable
follow-up but out of scope here to keep this PR focused on the actual crash.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- used AI-assisted coding (Claude Code) to investigate the crash, implement the encoder/driver guards, and write the regression tests described above; I reviewed and understand the full diff.
