### PR TITLE
ci(deps): pin cargo-deny-action to last known-good commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      # Pinned to the last known-good commit: on 2026-07-13 the floating v2
+      # tag moved to a release whose entrypoint mis-assembles its arguments
+      # (cargo-deny exits with "unrecognized subcommand 'warn'"). Bump
+      # deliberately after verifying upstream fixed the entrypoint.
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe
         with:
           rust-version: 1.95.0


### PR DESCRIPTION
## Summary

The `dependency-policy` job went red on the latest main push with `error: unrecognized subcommand 'warn'` from cargo-deny. No workflow change on our side: green runs earlier today resolved `EmbarkStudios/cargo-deny-action@v2` to `bb137d7`, the red run resolved it to `6f99e34` -- upstream moved the floating v2 tag to a release whose entrypoint mis-assembles its arguments. Pin the action to the last known-good commit (also the supply-chain-hygienic form) with a comment explaining when to bump.

## Test plan

- `actionlint .github/workflows/ci.yml` clean.
- The `dependency-policy` check on this PR is the live proof (runs the pinned SHA).

AI disclosure: YES