### PR TITLE
fix(core): emit terminal update on sub-floor finish, harden idle activity accounting

### DIFF
--- a/crates/openasr-core/src/models/incremental_streaming_driver.rs
+++ b/crates/openasr-core/src/models/incremental_streaming_driver.rs
@@ -720,6 +720,19 @@ impl IncrementalStreamingTranscriptDriver {
         Ok(emitted)
     }
 
+    /// Promote whatever text was last shown to the client (`last_text`) to a
+    /// terminal FINAL with no new decode. Used by `finish_updates`'s early
+    /// short circuits (empty buffer, sub-floor trailing window) that cannot
+    /// safely attempt a decode but must not silently drop text the client
+    /// has already seen as a PARTIAL: an empty increment (no new decoded
+    /// content), but a final snapshot of the last known text. `None` when
+    /// nothing was ever shown for the still-open segment, in which case
+    /// there is nothing to snapshot and finishing is a true no-op.
+    fn emit_terminal_snapshot(&mut self) -> Option<GgmlAsrStreamingTranscriptUpdate> {
+        let text = self.last_text.clone()?;
+        self.emit_update(&text, true)
+    }
+
     fn emit_update(
         &mut self,
         raw_text: &str,
@@ -788,17 +801,32 @@ impl GgmlAsrStreamingTranscriptDriver for IncrementalStreamingTranscriptDriver {
     fn finish_updates(
         &mut self,
     ) -> Result<Vec<GgmlAsrStreamingTranscriptUpdate>, GgmlAsrExecutionError> {
-        if self.buffer.is_empty() || self.final_emitted {
+        if self.final_emitted {
             return Ok(Vec::new());
+        }
+        // Nothing left to decode: whatever was already
+        // committed/finalized earlier in the utterance stands, and (per the
+        // buffer/last_text invariant maintained by `decode_and_commit_window`
+        // and `reset_current_utterance`) an empty buffer only ever coincides
+        // with `last_text` already being `None`, so this is a true no-op.
+        // Routed through the same terminal-snapshot helper as the sub-floor
+        // case below rather than duplicated, so both short circuits finish
+        // identically instead of via two copies of the same logic.
+        if self.buffer.is_empty() {
+            return Ok(self.emit_terminal_snapshot().into_iter().collect());
         }
         // A trailing window shorter than the encoder's receptive field is
         // normal usage (e.g. a very brief press-to-talk that never crossed
-        // the first-partial floor, so no partial ever ran either), not an
-        // error: finish cleanly with no additional update instead of
-        // attempting a decode the encoder cannot turn into output. Whatever
-        // was already committed/finalized earlier in the utterance stands.
+        // the first-partial floor, so no partial ever ran either) -- but it
+        // can also happen later in a longer utterance, e.g. right after a
+        // sentence cut drains the buffer down to a short trailing remainder.
+        // Either way, finish cleanly with no additional decode attempt (the
+        // encoder cannot turn this tail into output), but do not silently
+        // drop text the client has already seen as a PARTIAL: promote the
+        // last shown text (if any) to a terminal FINAL snapshot instead of
+        // leaving the client holding an un-finalized PARTIAL forever.
         if self.buffer_below_minimum_encodable_samples() {
-            return Ok(Vec::new());
+            return Ok(self.emit_terminal_snapshot().into_iter().collect());
         }
         // The FINAL decodes whatever audio remains in the buffer — i.e. the current
         // (still-uncut) trailing segment, since earlier sentences were already
@@ -1458,5 +1486,99 @@ mod tests {
         driver.push_audio(frame(1, 0)).unwrap();
         let final_ = driver.finish_updates().unwrap();
         assert_eq!(text_of(&final_[0]).0, "ok");
+    }
+
+    #[test]
+    fn finish_promotes_the_last_shown_partial_to_a_terminal_final_below_the_floor() {
+        // Regression test: a sub-floor finish must not silently drop text the
+        // client has already seen as a PARTIAL. Commit a normal windowed
+        // partial decode (so `last_text` holds real, already-surfaced text),
+        // then finish while the buffer sits below the minimum-encodable-
+        // samples floor (e.g. capture stopped just after the last partial,
+        // or a sentence cut drained the trailing remainder below the floor).
+        // The FINAL must still land -- carrying the last known text, with no
+        // new decode attempt -- instead of being swallowed.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut driver = counting_windowed_driver(30_000, Arc::clone(&calls));
+
+        for i in 1..=4 {
+            driver.push_audio(vframe(i, (i - 1) * 20)).unwrap();
+        }
+        // No floor yet, so this partial decodes normally and populates
+        // `last_text` -- modelling the real trigger (a sentence cut, or the
+        // capture simply stopping) that leaves the trailing buffer short
+        // enough to fall under the family's floor by the time finish runs.
+        let partial = driver.poll_updates().unwrap();
+        assert_eq!(text_of(&partial[0]).0, "w0 w1 w2 w3");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Now impose a floor above the current buffer, so finish hits the
+        // sub-floor short circuit under test.
+        driver.minimum_encodable_samples = Some(driver.buffer.sample_count() + 1);
+
+        let final_ = driver.finish_updates().unwrap();
+        assert_eq!(
+            final_.len(),
+            1,
+            "the last shown partial must be promoted to a terminal FINAL, not dropped"
+        );
+        assert_eq!(text_of(&final_[0]), ("w0 w1 w2 w3", 1, true));
+        assert!(driver.final_emitted);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "the sub-floor finish must not attempt a new decode"
+        );
+    }
+
+    #[test]
+    fn finish_below_the_floor_with_nothing_ever_shown_stays_a_true_no_op() {
+        // The empty-buffer and sub-floor short circuits share the same
+        // terminal-snapshot helper; when nothing was ever shown (`last_text`
+        // is `None`, as in the pre-existing
+        // `finish_skips_decode_and_returns_empty_below_the_minimum_encodable_samples_floor`
+        // scenario) there is nothing to promote and finish must stay empty.
+        let mut driver = counting_windowed_driver(30_000, Arc::new(AtomicUsize::new(0)))
+            .with_minimum_encodable_samples(2_000);
+        driver.push_audio(vframe(1, 0)).unwrap();
+        assert!(driver.last_text.is_none());
+
+        let final_ = driver.finish_updates().unwrap();
+        assert!(final_.is_empty());
+        assert!(!driver.final_emitted);
+    }
+
+    #[test]
+    fn poll_updates_below_the_floor_leaves_an_already_shown_partial_untouched() {
+        // Pinning the current (correct) contract: once a PARTIAL has been
+        // shown, a later poll tick whose buffer sits below the floor must
+        // stay a pure no-op -- it must not re-emit, promote to FINAL, or
+        // clear `last_text`. Only `finish_updates` promotes a pending
+        // snapshot to a terminal FINAL (the fix above); `poll_updates` has
+        // no terminal concept and the utterance is still ongoing, so the
+        // already-shown partial simply stands until either more audio lifts
+        // the buffer back over the floor or the utterance finishes.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut driver = counting_windowed_driver(30_000, Arc::clone(&calls));
+
+        for i in 1..=4 {
+            driver.push_audio(vframe(i, (i - 1) * 20)).unwrap();
+        }
+        let partial = driver.poll_updates().unwrap();
+        assert_eq!(text_of(&partial[0]).0, "w0 w1 w2 w3");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Impose a floor above the current buffer so the next poll tick
+        // short-circuits without decoding.
+        driver.minimum_encodable_samples = Some(driver.buffer.sample_count() + 1);
+        let updates = driver.poll_updates().unwrap();
+        assert!(updates.is_empty());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "must not attempt a decode below the floor"
+        );
+        assert_eq!(driver.last_text.as_deref(), Some("w0 w1 w2 w3"));
+        assert!(!driver.final_emitted);
     }
 }

--- a/crates/openasr-server/generated/http-wire/HealthResponse.ts
+++ b/crates/openasr-server/generated/http-wire/HealthResponse.ts
@@ -22,4 +22,27 @@ model_installed: boolean,
  * absent in the pre-0.1.13 contract, so an older client that only reads
  * `model_installed` keeps working unchanged.
  */
-model_resident: boolean, };
+model_resident: boolean, 
+/**
+ * Debug-observability field: the process-wide count of currently active
+ * native requests/sessions (see the `idle_activity` module doc) --
+ * in-flight offline transcriptions/translations and attached realtime
+ * native-streaming sessions both count. Not gated on `model_installed`;
+ * reads `0` on the mock backend and on a fresh install with no model
+ * bound, since nothing ever enters the tracker there. Not a stable
+ * health signal on its own -- a transient nonzero count during a single
+ * request is normal, not a problem -- but useful when diagnosing why
+ * `idle_unload` has not fired ("is a session still counted active?").
+ * Additive: absent in the pre-0.1.14 contract.
+ */
+native_active_count: number, 
+/**
+ * Debug-observability field: seconds elapsed since the process-wide
+ * native activity count last returned to zero, as of this response
+ * (`0` while `native_active_count` is nonzero -- there is no
+ * meaningful idle duration mid-request). Pairs with
+ * `native_active_count` to diagnose `idle_unload` timing: compare
+ * against the configured `idle_unload` threshold to see how close the
+ * next sweep is. Additive: absent in the pre-0.1.14 contract.
+ */
+idle_seconds: number, };

--- a/crates/openasr-server/src/idle_activity.rs
+++ b/crates/openasr-server/src/idle_activity.rs
@@ -36,11 +36,39 @@ impl NativeActivityTracker {
     }
 
     fn exit(&self) {
-        let previous = self.active.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(
-            previous > 0,
-            "native activity exited more times than it was entered"
-        );
+        // Saturate at zero instead of a plain `fetch_sub`: a bare `fetch_sub`
+        // on an already-zero counter wraps to `usize::MAX` (atomics use
+        // wrapping arithmetic unconditionally, in debug and release alike),
+        // which would pin `is_idle_for` to "never idle" -- silently and
+        // permanently disabling `idle_unload` -- for the rest of the
+        // process's life. `fetch_update` lets us clamp the new value while
+        // still reading the pre-update count to detect the mismatch.
+        let previous = self
+            .active
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                Some(current.saturating_sub(1))
+            })
+            .expect("closure always returns Some, so fetch_update never returns Err");
+        if previous == 0 {
+            // An enter/exit accounting bug (a double-release, or an exit
+            // whose matching enter never landed). Catch it loudly in debug
+            // builds where a panic is safe and useful to a developer -- but
+            // never panic a running release daemon over an internal
+            // bookkeeping mismatch; a live server killed by this would be
+            // far worse than idle_unload staying disabled (or, worst case,
+            // firing while a session is still attached) until the next
+            // balanced enter/exit. Log it (release and debug both) so an
+            // operator/maintainer can still notice and file it.
+            debug_assert!(
+                false,
+                "native activity exited more times than it was entered"
+            );
+            eprintln!(
+                "openasr-server: native activity accounting underflow: exit() called with no \
+                 matching enter() (idle_unload may misbehave until the next balanced enter/exit)"
+            );
+            return;
+        }
         if previous == 1 {
             *self
                 .idle_since
@@ -58,6 +86,34 @@ impl NativeActivityTracker {
             .lock()
             .expect("native activity idle mutex poisoned");
         now.checked_duration_since(idle_since).unwrap_or_default() >= idle_for
+    }
+
+    /// Current active native request/session count. Debug-observability
+    /// getter (surfaced by `/health` as `native_active_count`); the reaper
+    /// itself only ever needs [`Self::is_idle_for`]'s bool.
+    fn active_count(&self) -> usize {
+        self.active.load(Ordering::Acquire)
+    }
+
+    /// Seconds elapsed since the active count last returned to zero, as of
+    /// `now`. `0` while any activity is active -- there is no meaningful
+    /// "idle duration" mid-request, and `0` (rather than some stale prior
+    /// idle window) is the least surprising reading for a client polling
+    /// `/health` moment to moment. Debug-observability getter (surfaced by
+    /// `/health` as `idle_seconds`), expressed with the same `idle_since`
+    /// field `is_idle_for` already reads, so the two can never disagree
+    /// about what "idle" means.
+    fn idle_seconds(&self, now: Instant) -> u64 {
+        if self.active.load(Ordering::Acquire) != 0 {
+            return 0;
+        }
+        let idle_since = *self
+            .idle_since
+            .lock()
+            .expect("native activity idle mutex poisoned");
+        now.checked_duration_since(idle_since)
+            .unwrap_or_default()
+            .as_secs()
     }
 }
 
@@ -190,6 +246,24 @@ pub(crate) fn native_activity_is_idle_for(now: Instant, idle_for: Duration) -> b
     native_activity().is_idle_for(now, idle_for)
 }
 
+/// Process-wide active native request/session count right now. Debug-only
+/// observability, surfaced by `/health` as `native_active_count` so an
+/// operator/support session can tell "server looks idle but a session is
+/// still counted active" apart from "idle_unload just has not swept yet"
+/// without attaching a debugger.
+pub(crate) fn native_activity_active_count() -> usize {
+    native_activity().active_count()
+}
+
+/// Seconds since the process-wide tracker's active count last returned to
+/// zero, as of `now` (`0` while any activity is active). Debug-only
+/// observability, surfaced by `/health` as `idle_seconds`; expressed via the
+/// same tracker state `native_activity_is_idle_for` reads, so the two can
+/// never disagree about what "idle" means.
+pub(crate) fn native_activity_idle_seconds(now: Instant) -> u64 {
+    native_activity().idle_seconds(now)
+}
+
 /// RAII pairing of one `native_activity_enter`/`native_activity_exit` call.
 /// Used at the offline/backend-job transcribe call site, where the request's
 /// activity window is exactly one lexical scope, and at the realtime
@@ -306,10 +380,123 @@ mod tests {
     }
 
     #[test]
+    fn active_count_and_idle_seconds_mirror_is_idle_for() {
+        // The `/health` debug-observability getters (`active_count`,
+        // `idle_seconds`) must never disagree with the boolean
+        // `is_idle_for` the reaper actually acts on -- they read the exact
+        // same `active`/`idle_since` state, just shaped differently.
+        let tracker = NativeActivityTracker::new();
+        assert_eq!(tracker.active_count(), 0);
+        assert_eq!(
+            tracker.idle_seconds(Instant::now() + Duration::from_secs(3600)),
+            3600,
+            "idle_seconds must read a real elapsed duration once idle, matching is_idle_for"
+        );
+
+        tracker.enter();
+        assert_eq!(tracker.active_count(), 1);
+        assert_eq!(
+            tracker.idle_seconds(Instant::now() + Duration::from_secs(3600)),
+            0,
+            "idle_seconds must read zero while active, no matter how far `now` is"
+        );
+
+        tracker.enter();
+        assert_eq!(tracker.active_count(), 2);
+
+        tracker.exit();
+        assert_eq!(
+            tracker.active_count(),
+            1,
+            "one remaining active entry still counts as active"
+        );
+        assert_eq!(tracker.idle_seconds(Instant::now()), 0);
+
+        tracker.exit();
+        assert_eq!(tracker.active_count(), 0);
+        assert_eq!(
+            tracker.idle_seconds(Instant::now()),
+            0,
+            "real elapsed time just after the count returns to zero is microseconds, not a full second yet"
+        );
+        assert_eq!(
+            tracker.idle_seconds(Instant::now() + Duration::from_secs(90)),
+            90
+        );
+    }
+
+    // Debug-only half of the contract: `debug_assert!` is compiled out under
+    // `cargo test --release`, where the release-safe (saturate + log,
+    // no panic) behavior applies instead -- see
+    // `release_builds_do_not_panic_on_an_accounting_underflow` below.
+    #[cfg(debug_assertions)]
+    #[test]
     #[should_panic(expected = "exited more times than it was entered")]
     fn exit_without_matching_enter_is_a_bug() {
         let tracker = NativeActivityTracker::new();
         tracker.exit();
+    }
+
+    #[test]
+    fn extra_exits_saturate_instead_of_wrapping_and_do_not_corrupt_the_counter() {
+        // A bare `fetch_sub` on an already-zero counter wraps to
+        // `usize::MAX` (atomics use wrapping arithmetic unconditionally,
+        // debug or release), which would pin `is_idle_for` to "never idle"
+        // forever -- silently disabling `idle_unload` for the rest of the
+        // process's life. The saturating fix in `exit` must land before the
+        // debug_assert/log, so this invariant holds in EVERY build profile,
+        // unlike the debug-only panic covered by
+        // `exit_without_matching_enter_is_a_bug` above. In a debug build
+        // (this one included, `cargo test`'s default) each extra `exit()`
+        // still panics via that same debug_assert; catch it so this test can
+        // assert the underlying counter state regardless.
+        let tracker = NativeActivityTracker::new();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| tracker.exit()));
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| tracker.exit()));
+
+        assert_eq!(
+            tracker.active.load(Ordering::Acquire),
+            0,
+            "the counter must saturate at zero, never wrap past it"
+        );
+        assert!(
+            tracker.is_idle_for(
+                Instant::now() + Duration::from_secs(3600),
+                Duration::from_secs(1)
+            ),
+            "a saturated (not wrapped) zero counter must still read as idle"
+        );
+
+        // The earlier accounting bug must not leave the tracker wedged: a
+        // later, legitimate enter/exit pair still works normally.
+        tracker.enter();
+        tracker.exit();
+        assert!(tracker.is_idle_for(
+            Instant::now() + Duration::from_secs(3600),
+            Duration::from_secs(1)
+        ));
+    }
+
+    // Only compiled (and only meaningful) with `debug_assertions` off, i.e.
+    // under `cargo test --release`: proves the release half of the
+    // contract that `exit_without_matching_enter_is_a_bug` cannot -- an
+    // accounting underflow must NOT panic a running release daemon. If this
+    // panicked, the test itself would fail (no `catch_unwind` here, unlike
+    // the profile-agnostic test above). Absent from the default
+    // `cargo test`/`cargo nextest run` (debug) run, where `debug_assert`
+    // deliberately still panics; that half of the contract is pinned by
+    // `exit_without_matching_enter_is_a_bug` instead.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn release_builds_do_not_panic_on_an_accounting_underflow() {
+        let tracker = NativeActivityTracker::new();
+        tracker.exit();
+        tracker.exit();
+        assert_eq!(tracker.active.load(Ordering::Acquire), 0);
+        assert!(tracker.is_idle_for(
+            Instant::now() + Duration::from_secs(3600),
+            Duration::from_secs(1)
+        ));
     }
 
     #[test]

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1773,6 +1773,8 @@ async fn health(
         instance_token: identity.instance_token.clone(),
         model_installed: runtime.has_model_bound(),
         model_resident: runtime.has_model_bound() && runtime.model_is_resident(),
+        native_active_count: idle_activity::native_activity_active_count() as u64,
+        idle_seconds: idle_activity::native_activity_idle_seconds(Instant::now()),
     })
 }
 
@@ -1944,6 +1946,25 @@ struct HealthResponse {
     /// absent in the pre-0.1.13 contract, so an older client that only reads
     /// `model_installed` keeps working unchanged.
     model_resident: bool,
+    /// Debug-observability field: the process-wide count of currently active
+    /// native requests/sessions (see the `idle_activity` module doc) --
+    /// in-flight offline transcriptions/translations and attached realtime
+    /// native-streaming sessions both count. Not gated on `model_installed`;
+    /// reads `0` on the mock backend and on a fresh install with no model
+    /// bound, since nothing ever enters the tracker there. Not a stable
+    /// health signal on its own -- a transient nonzero count during a single
+    /// request is normal, not a problem -- but useful when diagnosing why
+    /// `idle_unload` has not fired ("is a session still counted active?").
+    /// Additive: absent in the pre-0.1.14 contract.
+    native_active_count: u64,
+    /// Debug-observability field: seconds elapsed since the process-wide
+    /// native activity count last returned to zero, as of this response
+    /// (`0` while `native_active_count` is nonzero -- there is no
+    /// meaningful idle duration mid-request). Pairs with
+    /// `native_active_count` to diagnose `idle_unload` timing: compare
+    /// against the configured `idle_unload` threshold to see how close the
+    /// next sweep is. Additive: absent in the pre-0.1.14 contract.
+    idle_seconds: u64,
 }
 
 #[derive(Serialize)]

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -1114,6 +1114,19 @@ async fn daemon_starts_and_reports_ready_with_zero_models_installed() {
         parsed["model_resident"], false,
         "nothing can be resident when no model is bound at all"
     );
+    // Additive debug-observability fields (see `HealthResponse`'s doc
+    // comments): with `model_pack_path: None`, `spawn_boot_native_warmup`
+    // returns immediately without ever entering the native activity
+    // tracker, so this fresh-in-process tracker reads deterministically
+    // zero on both.
+    assert_eq!(
+        parsed["native_active_count"], 0,
+        "nothing ever entered the native activity tracker when no model is bound"
+    );
+    assert_eq!(
+        parsed["idle_seconds"], 0,
+        "a tracker that has never seen any activity reads zero idle seconds, not stale/uninitialized"
+    );
 }
 
 #[tokio::test]
@@ -1151,6 +1164,19 @@ async fn health_reports_model_bound_but_not_resident_before_any_load() {
     assert_eq!(
         parsed["model_resident"], false,
         "a bound pack whose runtime has never been loaded this boot must not read resident"
+    );
+    // Additive debug-observability fields: unlike the zero-models-installed
+    // test above, a background boot warm-up is spawned here (even though it
+    // never completes a load in time to flip `model_resident`), so this only
+    // pins the wire shape/type -- not an exact count/duration, which would
+    // race the warm-up task's own scheduling.
+    assert!(
+        parsed["native_active_count"].is_u64(),
+        "native_active_count must serialize as a JSON number"
+    );
+    assert!(
+        parsed["idle_seconds"].is_u64(),
+        "idle_seconds must serialize as a JSON number"
     );
 }
 
@@ -2404,7 +2430,12 @@ async fn health_returns_identity_json_without_instance_token() {
         parsed["model_resident"], true,
         "the mock backend has no runtime to unload, so it reads resident whenever bound"
     );
-    assert_eq!(parsed.as_object().expect("health response object").len(), 6);
+    assert_eq!(
+        parsed.as_object().expect("health response object").len(),
+        8,
+        "status/server_version/pid/instance_token/model_installed/model_resident \
+         plus the 0.1.14 additive native_active_count/idle_seconds debug fields"
+    );
 }
 
 #[tokio::test]
@@ -2436,7 +2467,12 @@ async fn health_echoes_launch_instance_token_without_env() {
         parsed["instance_token"],
         serde_json::json!("launch-health-token")
     );
-    assert_eq!(parsed.as_object().expect("health response object").len(), 6);
+    assert_eq!(
+        parsed.as_object().expect("health response object").len(),
+        8,
+        "status/server_version/pid/instance_token/model_installed/model_resident \
+         plus the 0.1.14 additive native_active_count/idle_seconds debug fields"
+    );
 }
 
 #[tokio::test]
@@ -2470,7 +2506,12 @@ async fn health_prefers_env_instance_token_over_launch_option() {
         parsed["instance_token"],
         serde_json::json!("env-health-token")
     );
-    assert_eq!(parsed.as_object().expect("health response object").len(), 6);
+    assert_eq!(
+        parsed.as_object().expect("health response object").len(),
+        8,
+        "status/server_version/pid/instance_token/model_installed/model_resident \
+         plus the 0.1.14 additive native_active_count/idle_seconds debug fields"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Three targeted fixes closing out the 0.1.14 streaming/idle-activity work:

1. A too-short trailing window at `finish_updates` silently dropped the last
   PARTIAL text instead of finalizing it.
2. `NativeActivityTracker::exit`'s enter/exit balance guard was debug-only,
   so a release build could silently wedge `idle_unload` forever.
3. `/health` gains two additive debug fields for diagnosing (2) without a
   debugger: `native_active_count` and `idle_seconds`.

## Why

**(1)** `IncrementalStreamingTranscriptDriver::finish_updates` has a short
circuit for the `minimum_encodable_samples` floor: if the trailing buffer is
shorter than the family's encoder can turn into output, it skips the decode
attempt (correct -- the encoder cannot run on it). But it returned an empty
result unconditionally, even when an earlier tick had already decoded and
shown the caller a PARTIAL for that same still-open segment (e.g. right
after a sentence cut drains the buffer down to a short remainder, or
capture simply stops moments after the last partial). The client never
receives the FINAL for that text -- it is silently dropped. Verified this
against a real trigger: build a windowed driver, push audio, poll once to
get a real PARTIAL (populating `last_text`), then finish while the buffer
sits under the floor -- pre-fix, `finish_updates` returned nothing.

**(2)** `exit`'s `debug_assert!(previous > 0, ...)` only fires with
`debug_assertions` on. In a release build, a stray double-`exit()` (or an
`exit()` whose matching `enter()` never happened) hits a bare `fetch_sub`
on an already-zero atomic, which wraps to `usize::MAX` -- pinning
`is_idle_for` to "never idle" for the rest of the process's life, with zero
log output. This is exactly the kind of accounting bug the module's own
tests already guard against on the debug side (see
`failed_native_streaming_attach_send_retires_the_activity_guard`'s
regression story) -- but the release path had no detection at all.

**(3)** Diagnosing (2) without a debugger needs some visibility into the
tracker; `/health` already exposes `model_resident` for the sibling
`idle_unload` concept, so the same additive-field pattern applies here.

## Changes

- `crates/openasr-core/src/models/incremental_streaming_driver.rs`:
  - New `emit_terminal_snapshot` helper: promotes `last_text` (if any) to a
    terminal FINAL with no new decode.
  - `finish_updates`'s empty-buffer and sub-floor short circuits both route
    through it now, instead of two copies of "return empty" -- when nothing
    was ever shown (`last_text: None`), both stay a true no-op, matching
    the pre-existing behavior/test.
  - New tests: sub-floor finish promotes a previously-shown PARTIAL to a
    terminal FINAL (no new decode call); sub-floor finish with nothing ever
    shown still stays empty (pins the pre-existing contract); `poll_updates`
    below the floor leaves an already-shown PARTIAL untouched (pins that
    `poll` has no terminal concept -- only `finish` promotes to FINAL).
- `crates/openasr-server/src/idle_activity.rs`:
  - `exit` now decrements via `fetch_update` with a saturating closure, so
    the counter can never wrap past zero in any build. On an underflow it
    still `debug_assert!`s (dev/test builds keep panicking -- the existing
    regression test for that is now `#[cfg(debug_assertions)]`, since
    `--release` test builds do not panic there anymore) and logs via
    `eprintln!` (matching this crate's existing logging convention; no
    `tracing` dependency here).
  - New `active_count`/`idle_seconds` getters plus process-wide
    `native_activity_active_count`/`native_activity_idle_seconds` functions,
    backing the new `/health` fields.
  - New tests: extra exits saturate instead of wrapping (profile-agnostic --
    catches the debug panic to assert the counter itself, regardless of
    build profile); a `#[cfg(not(debug_assertions))]` test proving the
    release path really does not panic; a test pinning
    `active_count`/`idle_seconds` against `is_idle_for`.
- `crates/openasr-server/src/lib.rs`: `/health` gains `native_active_count`
  (`u64`) and `idle_seconds` (`u64`, `0` while active) -- additive, doc
  comments follow the existing `model_resident` style.
- `crates/openasr-server/generated/http-wire/HealthResponse.ts`:
  regenerated via `REGENERATE_HTTP_WIRE_BINDINGS=1 cargo test -p
  openasr-server --lib http_wire_bindings_test`; golden test is clean.
- `crates/openasr-server/tests/api.rs`: updated the three `/health` object
  shape assertions from 6 to 8 fields; added assertions for the two new
  fields (exact `0` where the scenario makes that deterministic, type-only
  where a background boot warm-up could otherwise race the exact value).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2475 passed, 123 skipped, 0 failed)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (not run; unrelated to this change, and main's
      `dependency-policy` CI is currently red from an upstream Action tag --
      already being fixed in #115, not touched here)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` -- byte-for-byte
      unchanged (2 run against the local whisper-tiny fixture, 2 ignored --
      they require a private dev-only pack unavailable here, same as before
      this change)
- [x] `cargo test -p openasr-core
      bundled_catalog_signature_verifies_committed_catalog_and_epoch --
      --nocapture`

## Manual smoke checks

None beyond the automated tests above -- this is a targeted internal-state
fix plus additive wire fields, not a new user-facing flow.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (No
      user-facing docs describe this internal streaming/idle-tracking
      behavior; the additive `/health` fields are self-documented via their
      doc comments, following the existing `model_resident` precedent.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Did not attempt an integration test that attaches a real streaming
  session end-to-end through a super-short utterance and asserts
  `native_activity_is_idle_for`: this test binary's `NativeAsrSession` test
  double (`TestServerNativeSession`) is a hand-written stub that never goes
  through `IncrementalStreamingTranscriptDriver` at all (no real ggml
  executor/adapter in this test target), so it cannot exercise the actual
  sub-floor code path fixed here -- it would only re-prove
  `NativeActivityGuard`'s `Drop` semantics, already covered by
  `attached_native_streaming_session_keeps_the_global_activity_tracker_non_idle`
  and `failed_native_streaming_attach_send_retires_the_activity_guard`.
  Fix (1) itself is covered end-to-end at the real driver level instead.
- Did not touch `ci.yml` / the `dependency-policy` workflow; that is #115's
  scope.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- used AI assistance to investigate the sub-floor finish gap and idle-activity underflow, and to draft/verify the fix and tests.
