### PR TITLE
feat(release): add install.sh and Homebrew tap auto-update

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -290,3 +290,82 @@ jobs:
           python3 scripts/splice-install-verify.py current-body.md install-verify.md > new-body.md
 
           gh release edit "$tag" --notes-file new-body.md
+
+  update-homebrew-tap:
+    name: Update Homebrew tap formula
+    # Needs the full asset matrix (binaries), not just the core build job's
+    # macOS arm64 + Linux x86_64 -- the formula also ships a Linux arm64
+    # target, which only release-binaries.yml's matrix produces.
+    needs: [resolve, release, binaries]
+    if: needs.resolve.outputs.should_release == 'true' && success()
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check for tap credentials
+        id: check
+        run: |
+          if [ -n "${{ secrets.HOMEBREW_TAP_TOKEN }}" ]; then
+            echo "has_token=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_token=false" >> "${GITHUB_OUTPUT}"
+            # ::notice, not ::error/::warning -- a maintainer who has not set
+            # up the tap yet should see a green release, not a red one, for a
+            # step that is inherently optional infrastructure.
+            echo "::notice::HOMEBREW_TAP_TOKEN secret not set -- skipping Homebrew tap formula update. See RELEASING.md for the fine-grained PAT this needs."
+          fi
+      - name: Checkout quintinshaw/homebrew-tap
+        if: steps.check.outputs.has_token == 'true'
+        uses: actions/checkout@v7
+        with:
+          repository: QuintinShaw/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+      - name: Compute per-target sha256 from the release's SHA256SUMS
+        if: steps.check.outputs.has_token == 'true'
+        id: sums
+        run: |
+          set -euo pipefail
+          tag="${{ needs.resolve.outputs.tag }}"
+          version="${{ needs.resolve.outputs.version }}"
+          curl -fsSL -o SHA256SUMS \
+            "https://github.com/${{ github.repository }}/releases/download/${tag}/SHA256SUMS"
+
+          sha_for() {
+            grep -F " openasr-${version}-$1.tar.gz" SHA256SUMS | awk '{print $1}'
+          }
+          for target in macos-arm64 linux-x86_64 linux-arm64; do
+            sha="$(sha_for "$target")"
+            if [ -z "$sha" ]; then
+              echo "::error::no SHA256SUMS entry for openasr-${version}-${target}.tar.gz -- did release-binaries.yml ship that target?"
+              exit 1
+            fi
+            echo "${target}=${sha}" >> shas.env
+          done
+          cat shas.env
+      - name: Update Formula/openasr.rb
+        if: steps.check.outputs.has_token == 'true'
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS='=' read -r target sha; do
+            args+=(--sha256 "${target}=${sha}")
+          done < shas.env
+          python3 scripts/update-homebrew-formula.py \
+            homebrew-tap/Formula/openasr.rb "${{ needs.resolve.outputs.version }}" \
+            "${args[@]}"
+      - name: Commit and push
+        if: steps.check.outputs.has_token == 'true'
+        run: |
+          set -euo pipefail
+          cd homebrew-tap
+          if git diff --quiet; then
+            echo "formula already up to date -- nothing to commit"
+            exit 0
+          fi
+          git config user.name "openasr-release-bot"
+          git config user.email "release-bot@users.noreply.github.com"
+          git add Formula/openasr.rb
+          git commit -m "openasr ${{ needs.resolve.outputs.tag }}"
+          git push origin main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -106,3 +106,22 @@ upload, and completeness-gate logic without mutating the release's assets
 (the completeness check still runs and will fail loudly if that release is
 genuinely incomplete -- that failure is expected and informative, not a bug
 in the dry run).
+
+## Homebrew tap
+
+`release-core.yml`'s final job, `update-homebrew-tap`, bumps
+`Formula/openasr.rb` in [`QuintinShaw/homebrew-tap`](https://github.com/QuintinShaw/homebrew-tap)
+(version + per-target sha256 for `macos-arm64`, `linux-x86_64`, `linux-arm64`,
+read from the just-published release's `SHA256SUMS`) and pushes straight to
+that repo's `main`. It uses `scripts/update-homebrew-formula.py`, which fails
+closed if the formula's shape does not match what it expects (e.g. a target's
+`url` line has no corresponding `--sha256` given), rather than risk writing a
+formula with a stale hash paired with the new version.
+
+This needs a `HOMEBREW_TAP_TOKEN` repository secret: a **fine-grained GitHub
+PAT** scoped to the `QuintinShaw/homebrew-tap` repository only, with
+**Contents: Read and write** permission (nothing else). If the secret is not
+set, the job prints a `::notice::` and skips -- the release itself still
+succeeds and stays green; the tap formula just does not get bumped for that
+release (bump it manually by re-running the `update-homebrew-tap` job, or by
+hand, once the secret exists).

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+# OpenASR CLI installer.
+#
+#   curl -fsSL https://dl.openasr.org/install.sh | sh
+#
+# POSIX sh on purpose (invoked as `... | sh`, not `| bash`): this must run
+# unmodified under dash (Debian/Ubuntu's /bin/sh), busybox ash, and bash.
+#
+# What it does:
+#   1. Detects OS + arch and maps them to a released asset name.
+#   2. Resolves the latest GitHub release tag via the `releases/latest`
+#      redirect (no GitHub API call, so no unauthenticated rate limit).
+#   3. Downloads the release tarball and the release's SHA256SUMS file, and
+#      verifies the tarball's checksum before touching anything else. This
+#      is fail-closed by design, matching OpenASR's "no cloud, no unverified
+#      binaries" posture: a checksum mismatch (or missing checksum tool)
+#      deletes the download and exits non-zero rather than installing
+#      something unverified.
+#   4. Installs the `openasr` binary into --prefix (default ~/.local/bin,
+#      created if missing), never using sudo.
+#
+# Usage:
+#   install.sh [--prefix DIR] [--version vX.Y.Z]
+#
+# Env overrides (equivalent to the flags above): OPENASR_INSTALL_PREFIX,
+# OPENASR_INSTALL_VERSION.
+
+set -eu
+
+REPO="QuintinShaw/openasr"
+GITHUB="https://github.com"
+
+prefix="${OPENASR_INSTALL_PREFIX:-$HOME/.local/bin}"
+version="${OPENASR_INSTALL_VERSION:-}"
+
+err() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+info() {
+  echo "==> $*"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix)
+      [ $# -ge 2 ] || err "--prefix requires a directory argument"
+      prefix="$2"
+      shift 2
+      ;;
+    --prefix=*)
+      prefix="${1#--prefix=}"
+      shift
+      ;;
+    --version)
+      [ $# -ge 2 ] || err "--version requires a tag argument (e.g. v0.1.14)"
+      version="$2"
+      shift 2
+      ;;
+    --version=*)
+      version="${1#--version=}"
+      shift
+      ;;
+    -h | --help)
+      sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      err "unknown argument: $1 (see --help)"
+      ;;
+  esac
+done
+
+# -- OS / arch detection -----------------------------------------------------
+
+os_raw="$(uname -s)"
+arch_raw="$(uname -m)"
+
+case "$os_raw" in
+  Darwin) os="macos" ;;
+  Linux) os="linux" ;;
+  *) err "unsupported OS: $os_raw (OpenASR ships macOS and Linux builds; see $GITHUB/$REPO/releases for other platforms, e.g. Windows)" ;;
+esac
+
+case "$arch_raw" in
+  arm64 | aarch64) arch="arm64" ;;
+  x86_64 | amd64) arch="x86_64" ;;
+  *) err "unsupported architecture: $arch_raw" ;;
+esac
+
+# Linux uses the statically linked musl build by default: it runs unmodified
+# across glibc and musl distros alike (no dynamic-loader version to match),
+# which matters far more for a curl|sh installer hitting arbitrary hosts than
+# for the Homebrew tap (Homebrew-on-Linux already requires glibc, so it uses
+# the dynamic build instead). macOS has only one libc, so no musl variant
+# exists there.
+if [ "$os" = "linux" ]; then
+  target="linux-${arch}-musl"
+else
+  target="${os}-${arch}"
+fi
+
+# -- Resolve version ----------------------------------------------------------
+
+if [ -z "$version" ]; then
+  info "resolving latest release"
+  # `releases/latest` 302-redirects to `.../releases/tag/vX.Y.Z`; read the
+  # final URL rather than following it, so this needs one request and no
+  # GitHub API call (which is rate-limited per-IP for unauthenticated use).
+  latest_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' "$GITHUB/$REPO/releases/latest")" \
+    || err "could not resolve the latest release from $GITHUB/$REPO/releases/latest"
+  version="${latest_url##*/}"
+  [ -n "$version" ] || err "could not parse a release tag from $latest_url"
+fi
+
+case "$version" in
+  v*) version_num="${version#v}" ;;
+  *) version_num="$version" ;;
+esac
+
+info "installing openasr $version ($target) to $prefix"
+
+# -- Download + verify --------------------------------------------------------
+
+asset="openasr-${version_num}-${target}.tar.gz"
+base_url="$GITHUB/$REPO/releases/download/$version"
+
+workdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$workdir"
+}
+trap cleanup EXIT INT TERM
+
+archive="$workdir/$asset"
+sums="$workdir/SHA256SUMS"
+
+info "downloading $asset"
+curl -fsSL -o "$archive" "$base_url/$asset" \
+  || err "download failed: $base_url/$asset (check that $version shipped a $target build)"
+curl -fsSL -o "$sums" "$base_url/SHA256SUMS" \
+  || err "download failed: $base_url/SHA256SUMS"
+
+expected_line="$(grep -F " $asset" "$sums" || true)"
+[ -n "$expected_line" ] || err "SHA256SUMS has no entry for $asset -- refusing to install an unverifiable binary"
+expected_sha="${expected_line%% *}"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_sha="$(sha256sum "$archive" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_sha="$(shasum -a 256 "$archive" | awk '{print $1}')"
+else
+  err "no sha256sum/shasum found -- refusing to install without checksum verification"
+fi
+
+if [ "$actual_sha" != "$expected_sha" ]; then
+  err "checksum mismatch for $asset (expected $expected_sha, got $actual_sha) -- download deleted, not installing"
+fi
+info "checksum verified"
+
+# -- Extract + install ---------------------------------------------------------
+
+extract_dir="$workdir/extract"
+mkdir -p "$extract_dir"
+tar -xzf "$archive" -C "$extract_dir"
+
+binary="$(find "$extract_dir" -type f -name openasr -maxdepth 2 | head -n 1)"
+[ -n "$binary" ] || err "extracted archive did not contain an 'openasr' binary"
+chmod +x "$binary"
+
+mkdir -p "$prefix"
+dest="$prefix/openasr"
+
+if [ -x "$dest" ]; then
+  old_version="$("$dest" --version 2>/dev/null || echo unknown)"
+  info "found existing install ($old_version) at $dest -- upgrading to $version"
+fi
+
+mv "$binary" "$dest"
+info "installed $("$dest" --version) to $dest"
+
+case ":$PATH:" in
+  *":$prefix:"*) ;;
+  *)
+    echo
+    echo "$prefix is not on your PATH. Add it, e.g.:"
+    echo "  export PATH=\"$prefix:\$PATH\""
+    echo "(append that line to your shell's rc file to make it permanent)"
+    ;;
+esac

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,11 @@ Local engineering scripts for validation and iteration.
   - Replace the `<!-- install-verify:start/end -->` section of a release
     body in place (used by `.github/workflows/release-core.yml`'s
     `finalize-notes` job).
+- `update-homebrew-formula.py`
+  - Bump `Formula/openasr.rb`'s version and per-target sha256 in place (used
+    by `.github/workflows/release-core.yml`'s `update-homebrew-tap` job
+    against a checkout of `QuintinShaw/homebrew-tap`). See `RELEASING.md`'s
+    "Homebrew tap" section.
 - `generate_longform_pause_probe.py`
   - Generate a deterministic longform pause probe from a local speech WAV — a
     test-data generator for longform planner validation.

--- a/scripts/update-homebrew-formula.py
+++ b/scripts/update-homebrew-formula.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Bump Formula/openasr.rb's version and per-target sha256 in place.
+
+Usage:
+  update-homebrew-formula.py <formula-path> <version> \\
+      --sha256 macos-arm64=<64-hex-char-sha256> \\
+      --sha256 linux-x86_64=<64-hex-char-sha256> \\
+      --sha256 linux-arm64=<64-hex-char-sha256>
+
+Used by .github/workflows/release-core.yml's `update-homebrew-tap` job, once a
+release's full asset matrix (release-binaries.yml) has finished uploading.
+
+Only two kinds of line change:
+  - the top `version "X.Y.Z"` line
+  - each target's `sha256 "..."` line (the one immediately following the
+    `url "...-<target>.tar.gz"` line for that target)
+`url` lines interpolate `#{version}` and need no edits.
+
+Fails loudly (nonzero exit) if the formula's shape does not match what this
+script expects: a target the formula's url lines reference has no --sha256
+given for it (would leave a stale hash for that platform paired with the new
+version -- a guaranteed checksum-mismatch install failure on that platform),
+or a --sha256 was given for a target no url line references. Silently writing
+a formula that does not match the intended release would be worse than a red
+release job.
+"""
+import argparse
+import re
+import sys
+
+# Matched against each line with its trailing "\n" already stripped (see the
+# main loop) -- otherwise a trailing `\s*` would greedily swallow that "\n"
+# itself, and re-appending "\n" in the replacement would double it into a
+# blank line.
+VERSION_LINE_RE = re.compile(r'^(\s*version\s+")([^"]+)("\s*)$')
+# The target name sits between the literal `#{version}-` interpolation and
+# `.tar.gz"` -- anchoring on that literal (rather than "the last `-`-joined
+# segment") avoids ambiguity for multi-hyphen targets like `linux-arm64`.
+URL_TARGET_RE = re.compile(r'url\s+".*#\{version\}-([A-Za-z0-9][A-Za-z0-9_.-]*)\.tar\.gz"')
+SHA_LINE_RE = re.compile(r'^(\s*sha256\s+")([0-9a-f]{64})("\s*)$')
+
+
+def parse_sha_arg(value):
+    target, _, sha = value.partition("=")
+    if not target or len(sha) != 64 or not re.fullmatch(r"[0-9a-f]{64}", sha):
+        raise argparse.ArgumentTypeError(
+            f"expected TARGET=<64-hex-char-sha256>, got {value!r}"
+        )
+    return target, sha
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("formula")
+    parser.add_argument("version")
+    parser.add_argument(
+        "--sha256",
+        action="append",
+        type=parse_sha_arg,
+        required=True,
+        metavar="TARGET=SHA256",
+        dest="shas",
+    )
+    args = parser.parse_args()
+    shas = dict(args.shas)
+
+    with open(args.formula, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    out = []
+    pending_target = None
+    version_replaced = False
+    formula_targets = set()
+    replaced_targets = set()
+
+    for raw_line in lines:
+        line = raw_line[:-1] if raw_line.endswith("\n") else raw_line
+
+        m = VERSION_LINE_RE.match(line)
+        if m and not version_replaced:
+            out.append(f"{m.group(1)}{args.version}{m.group(3)}\n")
+            version_replaced = True
+            continue
+
+        m = URL_TARGET_RE.search(line)
+        if m:
+            pending_target = m.group(1)
+            formula_targets.add(pending_target)
+            out.append(raw_line)
+            continue
+
+        m = SHA_LINE_RE.match(line)
+        if m and pending_target is not None and pending_target in shas:
+            out.append(f"{m.group(1)}{shas[pending_target]}{m.group(3)}\n")
+            replaced_targets.add(pending_target)
+            pending_target = None
+            continue
+
+        out.append(raw_line)
+
+    if not version_replaced:
+        print(f'error: no `version "..."` line found in {args.formula}', file=sys.stderr)
+        return 1
+
+    not_updated = formula_targets - replaced_targets
+    if not_updated:
+        print(
+            f"error: {args.formula} references target(s) with no matching "
+            f"--sha256 given, would leave a stale hash paired with the new "
+            f"version: {sorted(not_updated)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    extra = set(shas) - formula_targets
+    if extra:
+        print(
+            f"error: --sha256 given for target(s) not referenced by any url "
+            f"line in {args.formula}: {sorted(extra)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    with open(args.formula, "w", encoding="utf-8") as f:
+        f.writelines(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a one-line `curl | sh` installer (`install.sh`) for macOS/Linux, and
wires the release pipeline to keep a new Homebrew tap
([`QuintinShaw/homebrew-tap`](https://github.com/QuintinShaw/homebrew-tap))
in sync automatically.

## Why

`brew install` and `curl -fsSL .../install.sh | sh` are the two lowest-friction
install paths for a CLI; today the only documented path is "download a
release archive and extract it by hand." The tap itself already exists and
its formula was hand-verified against a real release (see PR description
checks below); this PR is the two pieces that live in this repo: the script
itself, and the automation that keeps the tap's formula from drifting out of
sync with each release the way a hand-maintained one eventually would.

## Changes

- `install.sh` (repo root): detects OS/arch, resolves the latest release via
  the `releases/latest` redirect (no GitHub API call, so no rate limit),
  downloads the matching archive plus the release's `SHA256SUMS`, verifies
  the checksum before touching anything else (fail-closed: mismatch deletes
  the download and exits non-zero), and installs to `~/.local/bin` by default
  (`--prefix` to override, no `sudo` ever). Linux defaults to the static musl
  build for portability across glibc/musl distros alike.
- `scripts/update-homebrew-formula.py`: bumps `Formula/openasr.rb`'s version
  and per-target sha256 in place; fails closed if the formula's shape doesn't
  match what it expects (a target with no `--sha256` given, or vice versa)
  rather than risk writing a stale hash paired with a new version.
- `.github/workflows/release-core.yml`: new `update-homebrew-tap` job (after
  the full release asset matrix is up) that checks out
  `QuintinShaw/homebrew-tap`, computes per-target sha256 from the release's
  `SHA256SUMS`, runs the script above, and pushes. Requires a
  `HOMEBREW_TAP_TOKEN` repo secret (fine-grained PAT, `Contents: Read and
  write` on the tap repo only); skips with `::notice::` (not a failure) if
  unset, so a release without that secret configured still goes green.
- `RELEASING.md` / `scripts/README.md`: document both of the above.

## Tests run

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

N/A — no Rust code changed in this PR (shell/Python scripts + a workflow
file only).

## Manual smoke checks

- `bash -n install.sh`, `sh -n install.sh` (dash): both clean.
- `shellcheck -s sh install.sh`: zero warnings.
- Real end-to-end run on macOS arm64 (`sh install.sh --prefix <scratch dir>`
  and the piped `cat install.sh | sh -s -- --prefix <dir>` form): resolves
  latest release, downloads `openasr-<version>-macos-arm64.tar.gz`, verifies
  against `SHA256SUMS`, installs a working `openasr` binary, prints the
  PATH hint. Re-running against an existing install correctly detects and
  reports the upgrade path.
- Verified the fail-closed checksum-mismatch branch exits non-zero and the
  `trap`-based cleanup removes the temp workdir (deletes the download).
- Linux path (`linux-x86_64-musl` / `linux-arm64-musl`) is **not**
  machine-verified in this PR (no Linux host available) — it follows the
  same asset-naming convention already verified against a real release for
  the Homebrew formula (`macos-arm64`, `linux-x86_64`, `linux-arm64`) and the
  same download/verify/install logic exercised end-to-end on macOS, but
  flagging it explicitly since it's the one path this PR does not prove.
- `python3 -m py_compile scripts/update-homebrew-formula.py`; `ruby -c` and
  `brew style` on a formula file mutated by the script, both clean.
- `actionlint .github/workflows/release-core.yml`: only pre-existing warning
  (present on `main` too, in a step this PR doesn't touch) — no new findings.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (`RELEASING.md`,
      `scripts/README.md`; the main README's install-method section is a
      separate PR against `docs/readme-bilingual-rewrite`.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch the main `README.md` — that lands as a follow-up commit on
  the existing `docs/readme-bilingual-rewrite` branch/PR.
- Does not add a Windows installer (`install.sh` errors clearly and points at
  the releases page; Homebrew doesn't target Windows either).
- Does not change what `release-binaries.yml` builds or ships.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — this PR (script, workflow job, and docs) was written by an AI coding agent under direct human task assignment and review.
