### PR TITLE
docs(readme): swap hero screenshots for animated previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 [Website](https://openasr.org) · [Documentation](docs/DOCS_INDEX.md) · [License](LICENSE)
 
-<img src="https://openasr.org/assets/openasr-desktop-preview-en-final.jpg" alt="OpenASR Desktop App" width="720" />
+<img src="https://openasr.org/assets/openasr-desktop-preview-en.gif" alt="OpenASR Desktop App" width="720" />
 
 <sub>Pre-v1 — under active development. CLI flags, API surface, and pack format may change between 0.x releases.</sub>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 
 [官网](https://openasr.org) · [文档](docs/DOCS_INDEX.md) · [License](LICENSE)
 
-<img src="https://openasr.org/assets/openasr-desktop-preview-zh-final.jpg" alt="OpenASR 桌面应用" width="720" />
+<img src="https://openasr.org/assets/openasr-desktop-preview-zh.gif" alt="OpenASR 桌面应用" width="720" />
 
 <sub>v1 之前的早期阶段,正在活跃开发中。0.x 版本间的命令行参数、API 和包格式可能调整。</sub>
 


### PR DESCRIPTION
Summary
- Replace the static hero screenshots in both READMEs with the animated desktop preview GIFs served from openasr.org (en/zh localized, ~2.5MB each).

Test plan
- URLs return 200 after the site deploy that ships the GIFs; image tags unchanged otherwise.

AI disclosure: YES