### PR TITLE
refactor(core): single-authority default model selection

### DIFF
--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -342,16 +342,45 @@ pub(super) fn resolve_model_source_for_backend(
 /// normal state right after a fresh install, before the user has pulled any
 /// model). Genuine environment/registry errors (unreadable `OPENASR_HOME`,
 /// corrupt registry, ...) still return `Err`. Never pulls either way.
+///
+/// An explicit `model` reference is a CLI-local concern (not "the default") and
+/// is matched directly against installed packs with `QuantPreference::Auto`.
+/// With no explicit reference, resolving `config.default_model` against
+/// installed packs -- including the `default.json` pointer fallback and
+/// `Pinned` quant recovery -- is delegated to `openasr_core::default_selection`,
+/// the single authority also used by the server; only the
+/// no-persisted-default-at-all fallback to `DEFAULT_MODEL_ID` stays here, since
+/// that bare-invocation convention is CLI-specific, not part of "the default".
 fn resolve_installed_native_pack_opt(
     model: Option<&str>,
-    config: &OpenAsrConfig,
+    // `default_selection::resolve_with_catalog` reads `config.default_model`
+    // straight off disk (the single-authority contract requires re-reading, not
+    // trusting a possibly-stale in-memory copy); kept for signature parity with
+    // `resolve_installed_native_pack`, whose error message still needs it.
+    _config: &OpenAsrConfig,
     catalog: Option<&openasr_core::ModelCatalog>,
 ) -> Result<Option<PathBuf>> {
     let home = openasr_home()?;
-    let model_ref = selected_model_ref(model, config, &[]);
-    let packs = openasr_core::list_installed_packs(&home)?;
+    if let Some(model_ref) = model {
+        return resolve_launch_pack_path(&home, model_ref, catalog);
+    }
+
+    use openasr_core::default_selection::DefaultModelResolution;
+    match openasr_core::default_selection::resolve_with_catalog(&home, catalog)? {
+        DefaultModelResolution::Installed(pack) => Ok(Some(pack.path)),
+        DefaultModelResolution::NotInstalled(_) => Ok(None),
+        DefaultModelResolution::Unset => resolve_launch_pack_path(&home, DEFAULT_MODEL_ID, catalog),
+    }
+}
+
+fn resolve_launch_pack_path(
+    home: &Path,
+    model_ref: &str,
+    catalog: Option<&openasr_core::ModelCatalog>,
+) -> Result<Option<PathBuf>> {
+    let packs = openasr_core::list_installed_packs(home)?;
     let request = openasr_core::LaunchPackRequest {
-        model_ref: &model_ref,
+        model_ref,
         preference: &openasr_core::QuantPreference::Auto,
         catalog,
         host_profile: openasr_core::host_quant_recommendation_profile(),
@@ -1260,6 +1289,43 @@ mod tests {
     fn with_env_lock<T>(run: impl FnOnce() -> T) -> T {
         let _guard = env_lock();
         run()
+    }
+
+    // Locks the three-tier priority `selected_model_ref` must keep: an explicit
+    // `--model` always wins, then the persisted `config.default_model`, and only
+    // with neither does the CLI fall back to `DEFAULT_MODEL_ID` -- the
+    // bare-invocation convention that (post-refactor) is no longer implicitly
+    // written into `config.json` (see `openasr_core::config::DEFAULT_MODEL_ID`
+    // and `default_selection`).
+    #[test]
+    fn selected_model_ref_explicit_wins_over_config_default() {
+        let config = OpenAsrConfig {
+            default_model: Some("whisper-small".to_string()),
+            ..OpenAsrConfig::default()
+        };
+        assert_eq!(
+            selected_model_ref(Some("whisper-large-v3-turbo"), &config, &[]),
+            "whisper-large-v3-turbo"
+        );
+    }
+
+    #[test]
+    fn selected_model_ref_falls_back_to_config_default_when_no_explicit_model() {
+        let config = OpenAsrConfig {
+            default_model: Some("whisper-small".to_string()),
+            ..OpenAsrConfig::default()
+        };
+        assert_eq!(selected_model_ref(None, &config, &[]), "whisper-small");
+    }
+
+    #[test]
+    fn selected_model_ref_falls_back_to_default_model_id_when_config_default_is_unset() {
+        // A fresh config (or one built by `OpenAsrConfig::default()`) has
+        // `default_model: None` -- the CLI convention fallback, not a config value,
+        // must still resolve to something usable.
+        let config = OpenAsrConfig::default();
+        assert_eq!(config.default_model, None);
+        assert_eq!(selected_model_ref(None, &config, &[]), DEFAULT_MODEL_ID);
     }
 
     #[test]

--- a/crates/openasr-cli/src/pull_cli.rs
+++ b/crates/openasr-cli/src/pull_cli.rs
@@ -6,9 +6,8 @@ use openasr_core::{
     InstalledPack, LaunchPackRequest, LicenseClass, ModelCatalog, OpenAsrConfig,
     PullModelPackRequest, QuantPreference, ResolvedCatalogPull, host_quant_recommendation_profile,
     install_model_pack_from_path, list_installed_packs, load_config, load_model_catalog,
-    openasr_home, persist_default_pack_pointer, remove_model_pack,
-    resolve_catalog_pull_with_profile, resolve_chain, resolve_launch_pack,
-    save_default_model_selection,
+    openasr_home, remove_model_pack, resolve_catalog_pull_with_profile, resolve_chain,
+    resolve_launch_pack,
 };
 
 use crate::PullCommandOptions;
@@ -70,8 +69,7 @@ pub(crate) fn pull(options: PullCommandOptions<'_>) -> Result<()> {
         QuantPreference::Auto
     };
     if should_update_default_asr_model(&catalog, &installed.model_id) {
-        save_default_model_selection(&home, installed.model_id.clone(), preference)?;
-        persist_default_pack_pointer(&home, &installed)?;
+        openasr_core::default_selection::persist(&home, &installed, preference)?;
     } else {
         eprintln!(
             "{}",
@@ -277,8 +275,7 @@ pub(crate) fn ensure_asr_model_installed(
     })?;
     if should_update_default_asr_model(&catalog, &installed.model_id) {
         let preference = QuantPreference::pinned(&installed.quant);
-        save_default_model_selection(&home, installed.model_id.clone(), preference)?;
-        persist_default_pack_pointer(&home, &installed)?;
+        openasr_core::default_selection::persist(&home, &installed, preference)?;
     }
     Ok(())
 }

--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -14,6 +14,12 @@ use crate::{
 };
 use crate::{download_source::DownloadSourcePref, launch_pack::QuantPreference};
 
+/// The CLI's bare-invocation convention: which model id `transcribe`/`live`/
+/// `pull` resolve to when the caller passes neither `--model` nor has a
+/// persisted `default_model` in `config.json`. This is decoupled from config
+/// persistence -- it is never written into a fresh config as an implicit
+/// selection (see `OpenAsrConfig::default`); it only feeds the CLI's
+/// last-resort fallback in `selected_model_ref` and the consent-pull prompt.
 pub const DEFAULT_MODEL_ID: &str = "qwen3-asr-0.6b";
 /// Quant pinned for the first-run install of `DEFAULT_MODEL_ID`, so the very
 /// first download a newcomer triggers is bounded and predictable instead of the
@@ -26,7 +32,16 @@ pub const MAX_INFERENCE_THREADS: u16 = 256;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenAsrConfig {
-    #[serde(default = "default_model")]
+    /// The user's persisted default model, or `None` when nothing has been
+    /// explicitly selected yet. Unlike `default_backend`, this field carries
+    /// no implicit value: a fresh config (missing field, or `OpenAsrConfig::
+    /// default()`) deserializes to `None`, not `DEFAULT_MODEL_ID`. Conflating
+    /// "the CLI's bare-invocation convention" with "the user's saved choice"
+    /// is what made a fresh install report a phantom default that was never
+    /// actually installed; see `openasr_core::default_selection` for the
+    /// single resolver that turns this (plus the `default.json` pointer)
+    /// into an actual installed pack.
+    #[serde(default)]
     pub default_model: Option<String>,
     #[serde(default = "default_backend")]
     pub default_backend: Option<String>,
@@ -296,7 +311,7 @@ pub enum ConfigError {
 impl Default for OpenAsrConfig {
     fn default() -> Self {
         Self {
-            default_model: default_model(),
+            default_model: None,
             default_backend: default_backend(),
             media: MediaConfig::default(),
             download_source: DownloadSourcePref::Auto,
@@ -568,10 +583,6 @@ fn write_config_atomically(path: &Path, contents: &[u8]) -> Result<(), ConfigErr
         path: path.to_path_buf(),
         source,
     })
-}
-
-fn default_model() -> Option<String> {
-    Some(DEFAULT_MODEL_ID.to_string())
 }
 
 fn default_backend() -> Option<String> {

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -85,9 +85,35 @@ fn missing_config_file_returns_default_config() {
     let temp = tempfile::tempdir().unwrap();
     let config = load_config(temp.path()).unwrap();
 
-    assert_eq!(config.default_model.as_deref(), Some("qwen3-asr-0.6b"));
+    // A fresh install has no persisted default -- see `default_selection` for the
+    // module that turns `None` here (plus the `default.json` pointer) into an
+    // actual resolved pack, and `DEFAULT_MODEL_ID` for the separate CLI
+    // bare-invocation convention this field must not be conflated with.
+    assert_eq!(config.default_model, None);
     assert_eq!(config.default_backend.as_deref(), Some("native"));
     assert_eq!(config.media.ffmpeg_bin, None);
+}
+
+#[test]
+fn default_config_document_has_no_default_model() {
+    assert_eq!(OpenAsrConfig::default().default_model, None);
+}
+
+#[test]
+fn config_json_missing_default_model_field_deserializes_to_none() {
+    // Simulates an older config.json written before `default_model` existed, or
+    // one hand-edited to remove the key -- the field must default via serde
+    // rather than fail to deserialize or silently reintroduce an implicit value.
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(config_path(temp.path()), r#"{ "default_backend": "mock" }"#).unwrap();
+
+    let loaded = load_config_document(temp.path()).unwrap();
+
+    assert_eq!(loaded.config.default_model, None);
+    loaded
+        .config
+        .validate(&registry())
+        .expect("None default_model must not fail validation");
 }
 
 #[test]

--- a/crates/openasr-core/src/default_selection.rs
+++ b/crates/openasr-core/src/default_selection.rs
@@ -1,0 +1,197 @@
+//! Single authority for resolving and persisting the "default model" state,
+//! which spans two files under the OpenASR home: `config.json`'s
+//! `default_model` field (the user's explicit choice) and `default.json` (a
+//! pointer recording the last pack a default write installed). Before this
+//! module existed, the server, the CLI, and the config layer each carried
+//! their own reading of these two files, and only the server's read the
+//! `default.json` pointer as a fallback -- see `docs/default-model-resolution.md`
+//! for the contract this module now owns for every caller (server routes,
+//! CLI serve/transcribe pack lookup, and eventually the desktop shell).
+//!
+//! Fail-closed by design: `resolve` never invents a default when nothing is
+//! configured, and never substitutes a different installed pack when the
+//! configured one is missing. Silently picking "some" installed model would
+//! defeat the point of a "default" (the user chose *this* model) and could
+//! route audio through an unexpected model/quant.
+
+use std::path::Path;
+
+use thiserror::Error;
+
+use crate::{
+    CatalogError, ConfigError, InstalledPack, LaunchPackRequest, ModelCatalog, PullError,
+    QuantPreference, default_pack_pointer_path, host_quant_recommendation_profile,
+    list_installed_packs, load_config_document, load_model_catalog, persist_default_pack_pointer,
+    read_default_pack_pointer, resolve_launch_pack, save_config_document,
+    save_default_model_selection,
+};
+
+#[derive(Debug, Error)]
+pub enum DefaultSelectionError {
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+    #[error(transparent)]
+    Pull(#[from] PullError),
+    #[error(transparent)]
+    Catalog(#[from] CatalogError),
+}
+
+/// The result of resolving the persisted default model against the packs
+/// actually installed on disk. A bare `Option<InstalledPack>` cannot tell
+/// "nothing configured" apart from "configured but not installed" -- both
+/// collapse to `None` -- yet callers (the desktop default-model banner, the
+/// `GET /v1/models/default` status field) need to tell those apart to show
+/// the right prompt ("choose a model" vs. "reinstall your default").
+// `resolve` returns this by value at most once per call (never in a hot loop
+// or a large collection), so the `Installed(InstalledPack)` / `NotInstalled
+// (String)` size delta doesn't warrant boxing every caller's match arm --
+// server routes and the CLI both want to destructure it directly.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DefaultModelResolution {
+    /// `config.default_model` (or the `default.json` pointer as a fallback)
+    /// names a model that has a matching pack installed.
+    Installed(InstalledPack),
+    /// A default is configured, but no installed pack matches it (removed,
+    /// never installed, or the wrong quant with no fallback available).
+    NotInstalled(String),
+    /// Neither `config.default_model` nor the `default.json` pointer is set.
+    Unset,
+}
+
+impl DefaultModelResolution {
+    pub fn installed_pack(&self) -> Option<&InstalledPack> {
+        match self {
+            Self::Installed(pack) => Some(pack),
+            Self::NotInstalled(_) | Self::Unset => None,
+        }
+    }
+
+    pub fn into_installed_pack(self) -> Option<InstalledPack> {
+        match self {
+            Self::Installed(pack) => Some(pack),
+            Self::NotInstalled(_) | Self::Unset => None,
+        }
+    }
+}
+
+/// Resolves the persisted default model against installed packs, loading the
+/// catalog from `catalog_url` first (a bare `None` skips catalog loading
+/// entirely rather than falling back to the bundled catalog -- see
+/// `resolve_with_catalog` for the shared logic and why callers that already
+/// hold a loaded catalog, like the CLI, should call that instead).
+///
+/// Priority (ported verbatim from the original server-only resolver):
+/// `config.default_model` wins when set; the `default.json` pointer's model
+/// id is a fallback only when `config.default_model` is unset. When
+/// `preferences.quant_preference` is `Pinned` and a pointer exists, the
+/// pointer's quant is tried first (falling back to the best installed quant
+/// if that exact quant was removed) -- this keeps `openasr pull <id>:<quant>`
+/// sticky across quant changes without re-filtering the candidate list to a
+/// single quant (which would break the Pinned-missing fallback ladder).
+pub fn resolve(
+    home: &Path,
+    catalog_url: Option<&str>,
+) -> Result<DefaultModelResolution, DefaultSelectionError> {
+    let catalog = catalog_url
+        .map(|catalog_url| load_model_catalog(Some(catalog_url), home))
+        .transpose()?;
+    resolve_with_catalog(home, catalog.as_ref())
+}
+
+/// Same resolution as `resolve`, but against an already-loaded catalog
+/// (or `None` to resolve without catalog-assisted alias matching). Lets a
+/// caller that owns its own catalog-loading policy -- the CLI's
+/// `OPENASR_CATALOG_URL`/local-file override in `load_cli_model_catalog`,
+/// distinct from the server's `catalog_url` override -- share this resolver
+/// without loading the catalog twice or adopting the server's policy.
+pub fn resolve_with_catalog(
+    home: &Path,
+    catalog: Option<&ModelCatalog>,
+) -> Result<DefaultModelResolution, DefaultSelectionError> {
+    let packs = list_installed_packs(home)?;
+    let document = load_config_document(home)?;
+    let pointer = read_default_pack_pointer(home)?;
+
+    if matches!(
+        document.preferences.quant_preference,
+        QuantPreference::Pinned { .. }
+    ) && let Some(pointer) = pointer.as_ref()
+    {
+        let pointer_preference = QuantPreference::pinned(&pointer.quant);
+        let reference = document
+            .config
+            .default_model
+            .as_deref()
+            .unwrap_or(pointer.model_id.as_str());
+        return Ok(select(&packs, reference, &pointer_preference, catalog));
+    }
+
+    let Some(default_model) = document
+        .config
+        .default_model
+        .as_deref()
+        .or_else(|| pointer.as_ref().map(|pointer| pointer.model_id.as_str()))
+    else {
+        return Ok(DefaultModelResolution::Unset);
+    };
+    Ok(select(
+        &packs,
+        default_model,
+        &document.preferences.quant_preference,
+        catalog,
+    ))
+}
+
+fn select(
+    packs: &[InstalledPack],
+    reference: &str,
+    preference: &QuantPreference,
+    catalog: Option<&ModelCatalog>,
+) -> DefaultModelResolution {
+    let request = LaunchPackRequest {
+        model_ref: reference,
+        preference,
+        catalog,
+        host_profile: host_quant_recommendation_profile(),
+    };
+    match resolve_launch_pack(packs, &request) {
+        Ok(selection) => DefaultModelResolution::Installed(selection.pack),
+        Err(_) => DefaultModelResolution::NotInstalled(reference.to_string()),
+    }
+}
+
+/// Persists `pack` as the default model: writes `config.json`'s
+/// `default_model` (bare model id) and the `default.json` pointer, in that
+/// order. Callers must go through this single function rather than calling
+/// the two underlying writes separately, so the two files never drift.
+pub fn persist(
+    home: &Path,
+    pack: &InstalledPack,
+    quant_preference: QuantPreference,
+) -> Result<(), DefaultSelectionError> {
+    save_default_model_selection(home, pack.model_id.clone(), quant_preference)?;
+    persist_default_pack_pointer(home, pack)?;
+    Ok(())
+}
+
+/// Clears the persisted default: resets `config.json`'s `default_model` and
+/// `quant_preference` to their unset states and removes the `default.json`
+/// pointer file (a missing pointer file is not an error).
+pub fn clear(home: &Path) -> Result<(), DefaultSelectionError> {
+    let mut document = load_config_document(home)?;
+    document.config.default_model = None;
+    document.preferences.quant_preference = QuantPreference::Auto;
+    save_config_document(home, &document)?;
+
+    let path = default_pack_pointer_path(home);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(DefaultSelectionError::Pull(PullError::Io { path, source })),
+    }
+}
+
+#[cfg(test)]
+#[path = "default_selection_tests.rs"]
+mod default_selection_tests;

--- a/crates/openasr-core/src/default_selection_tests.rs
+++ b/crates/openasr-core/src/default_selection_tests.rs
@@ -1,0 +1,179 @@
+use std::fs;
+use std::path::Path;
+
+use super::*;
+use crate::testing::{TinyGgufFixtureSpec, write_tiny_gguf_runtime_source};
+use crate::{OpenAsrConfigDocument, config_path};
+
+/// Writes an `installed.json` plus a real backing pack file for `model_id`/
+/// `quant`. `list_installed_packs` re-validates every on-disk pack on each
+/// lookup (`installed_pack_matches_quant_dir` in pull.rs checks the file
+/// exists, its size matches `size_bytes`, and it passes
+/// `validate_native_runtime_model_pack_contract`) -- a bare `installed.json`
+/// with no backing file is silently dropped, not "installed". Mirror the
+/// graph-complete whisper fixture `openasr-server`'s tests use for the same
+/// reason (the bare non-graph spec omits required whisper runtime keys and
+/// fails contract validation).
+fn write_installed_pack(home: &Path, model_id: &str, quant: &str, suffix: &str) -> InstalledPack {
+    let filename = format!("{model_id}-{quant}.oasr");
+    let dir = home.join("models").join(model_id).join(quant);
+    fs::create_dir_all(&dir).expect("create installed pack dir");
+    let path = dir.join(&filename);
+    let spec = TinyGgufFixtureSpec::whisper_oasr_v1_encoder_graph_one_layer(model_id);
+    write_tiny_gguf_runtime_source(&path, &spec).expect("write tiny gguf runtime source");
+    let size_bytes = fs::metadata(&path)
+        .expect("stat installed pack fixture")
+        .len();
+    let pack = InstalledPack {
+        model_id: model_id.to_string(),
+        display_name: model_id.to_string(),
+        quant: quant.to_string(),
+        suffix: suffix.to_string(),
+        pull: format!("{model_id}:{suffix}"),
+        filename,
+        path,
+        url: format!("https://example.test/{model_id}-{quant}.oasr"),
+        hf_revision: "0123456789abcdef0123456789abcdef01234567".to_string(),
+        sha256: "a".repeat(64),
+        size_bytes,
+        installed_at_unix_seconds: 1,
+        source: None,
+    };
+    fs::write(
+        dir.join("installed.json"),
+        serde_json::to_string_pretty(&pack).expect("serialize installed pack"),
+    )
+    .expect("write installed pack metadata");
+    pack
+}
+
+fn write_config_default_model(home: &Path, model_id: &str) {
+    let document = OpenAsrConfigDocument {
+        config: crate::OpenAsrConfig {
+            default_model: Some(model_id.to_string()),
+            ..crate::OpenAsrConfig::default()
+        },
+        ..OpenAsrConfigDocument::default()
+    };
+    save_config_document(home, &document).expect("save config document");
+}
+
+#[test]
+fn resolve_is_unset_with_no_config_and_no_pointer() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let resolution = resolve(temp.path(), None).unwrap();
+
+    assert_eq!(resolution, DefaultModelResolution::Unset);
+}
+
+#[test]
+fn resolve_is_installed_when_config_default_matches_an_installed_pack() {
+    let temp = tempfile::tempdir().unwrap();
+    let pack = write_installed_pack(temp.path(), "whisper-small", "q8_0", "q8");
+    write_config_default_model(temp.path(), "whisper-small");
+
+    let resolution = resolve(temp.path(), None).unwrap();
+
+    assert_eq!(resolution, DefaultModelResolution::Installed(pack));
+}
+
+#[test]
+fn resolve_is_not_installed_when_configured_model_has_no_matching_pack() {
+    let temp = tempfile::tempdir().unwrap();
+    write_config_default_model(temp.path(), "whisper-small");
+
+    let resolution = resolve(temp.path(), None).unwrap();
+
+    assert_eq!(
+        resolution,
+        DefaultModelResolution::NotInstalled("whisper-small".to_string())
+    );
+}
+
+/// Fail-closed core assertion: a configured-but-uninstalled default model
+/// must resolve to `NotInstalled`, never silently substitute a different
+/// pack that happens to be on disk (even with no pointer file at all). This
+/// is the exact bug class described in the refactor brief: a fresh install
+/// with a stale/unreachable `default_model` must not fall back to "whatever
+/// is installed".
+#[test]
+fn resolve_does_not_fall_back_to_a_different_installed_pack() {
+    let temp = tempfile::tempdir().unwrap();
+    // A different model is installed on disk...
+    write_installed_pack(temp.path(), "dolphin-base", "q8_0", "q8");
+    // ...but the configured default points elsewhere, and there is no
+    // default.json pointer to fall back to.
+    write_config_default_model(temp.path(), "whisper-small");
+    assert!(
+        !crate::default_pack_pointer_path(temp.path()).exists(),
+        "test setup must not have a pointer file"
+    );
+
+    let resolution = resolve(temp.path(), None).unwrap();
+
+    assert_eq!(
+        resolution,
+        DefaultModelResolution::NotInstalled("whisper-small".to_string())
+    );
+    assert!(resolution.installed_pack().is_none());
+}
+
+#[test]
+fn resolve_falls_back_to_pointer_model_id_when_config_default_is_unset() {
+    let temp = tempfile::tempdir().unwrap();
+    let pack = write_installed_pack(temp.path(), "whisper-small", "q8_0", "q8");
+    persist_default_pack_pointer(temp.path(), &pack).unwrap();
+    // config.default_model stays None (fresh config document).
+
+    let resolution = resolve(temp.path(), None).unwrap();
+
+    assert_eq!(resolution, DefaultModelResolution::Installed(pack));
+}
+
+#[test]
+fn persist_writes_config_and_pointer_together() {
+    let temp = tempfile::tempdir().unwrap();
+    let pack = write_installed_pack(temp.path(), "whisper-small", "q8_0", "q8");
+
+    persist(temp.path(), &pack, QuantPreference::pinned("q8_0")).unwrap();
+
+    let document = load_config_document(temp.path()).unwrap();
+    assert_eq!(
+        document.config.default_model.as_deref(),
+        Some("whisper-small")
+    );
+    let pointer = read_default_pack_pointer(temp.path()).unwrap().unwrap();
+    assert_eq!(pointer.model_id, "whisper-small");
+    assert_eq!(
+        resolve(temp.path(), None).unwrap(),
+        DefaultModelResolution::Installed(pack)
+    );
+}
+
+#[test]
+fn clear_resets_config_and_removes_pointer() {
+    let temp = tempfile::tempdir().unwrap();
+    let pack = write_installed_pack(temp.path(), "whisper-small", "q8_0", "q8");
+    persist(temp.path(), &pack, QuantPreference::pinned("q8_0")).unwrap();
+    assert!(config_path(temp.path()).exists());
+
+    clear(temp.path()).unwrap();
+
+    let document = load_config_document(temp.path()).unwrap();
+    assert_eq!(document.config.default_model, None);
+    assert_eq!(document.preferences.quant_preference, QuantPreference::Auto);
+    assert!(!crate::default_pack_pointer_path(temp.path()).exists());
+    assert_eq!(
+        resolve(temp.path(), None).unwrap(),
+        DefaultModelResolution::Unset
+    );
+}
+
+#[test]
+fn clear_is_idempotent_without_a_pointer_file() {
+    let temp = tempfile::tempdir().unwrap();
+
+    clear(temp.path()).unwrap();
+    clear(temp.path()).unwrap();
+}

--- a/crates/openasr-core/src/diarize/enrollment.rs
+++ b/crates/openasr-core/src/diarize/enrollment.rs
@@ -782,7 +782,7 @@ fn write_owner_only_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     crate::atomic_file::write_owner_only_file_atomically(path, bytes)
 }
 
-fn set_owner_only_dir_permissions(path: &Path) {
+fn set_owner_only_dir_permissions(#[cfg_attr(not(unix), allow(unused_variables))] path: &Path) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/crates/openasr-core/src/download_source.rs
+++ b/crates/openasr-core/src/download_source.rs
@@ -1,4 +1,6 @@
-use std::{env, fs};
+use std::env;
+#[cfg(unix)]
+use std::fs;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/openasr-core/src/home.rs
+++ b/crates/openasr-core/src/home.rs
@@ -10,6 +10,10 @@ pub enum OpenAsrHomeError {
     MissingHome,
 }
 
+// Resolution contract: OPENASR_HOME overrides, otherwise <user home>/.openasr.
+// Downstream installers that cannot link this crate replicate this rule (e.g.
+// the desktop NSIS uninstaller's app-data cleanup); keep them in sync when
+// changing it.
 pub fn openasr_home() -> Result<PathBuf, OpenAsrHomeError> {
     resolve_openasr_home(env::var_os("OPENASR_HOME"), user_home_dir())
 }

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -20,6 +20,7 @@ pub(crate) mod batch;
 pub(crate) mod benchmark;
 pub(crate) mod capability_pack;
 pub mod config;
+pub mod default_selection;
 pub mod device;
 pub mod diarize;
 pub(crate) mod download_source;

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -2381,10 +2381,7 @@ fn windows_in_use_os_errors_classify_as_model_in_use() {
     // ERROR_FILE_NOT_FOUND (2) and ERROR_ACCESS_DENIED (5, ambiguous) are not.
     assert!(!is_file_in_use_error(&io::Error::from_raw_os_error(2)));
     assert!(!is_file_in_use_error(&io::Error::from_raw_os_error(5)));
-    assert!(!is_file_in_use_error(&io::Error::new(
-        io::ErrorKind::Other,
-        "x"
-    )));
+    assert!(!is_file_in_use_error(&io::Error::other("x")));
 }
 
 #[cfg(windows)]

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -46,22 +46,20 @@ use axum::{
 };
 use futures_util::stream;
 use openasr_core::api::backend::TranscriptionBackendCapabilities;
-use openasr_core::config::{load_config_document, save_config_document};
 pub use openasr_core::pairing_safety_code_for_certificate_fingerprint;
 use openasr_core::realtime::history::{DaemonHistoryEntry, DaemonHistoryStoreError};
 use openasr_core::{
     AudioPreparationError, BackendKind, CatalogError, CatalogMirror, CatalogPullRequest,
     InstalledPack, LaunchPackRequest, LicenseClass, ModelCatalog, OpenAsrHomeError, PullError,
     PullModelPackRequest, PullProgress, QuantPreference, RealtimeBackendCapabilities,
-    ResolvedCatalogPull, certificate_fingerprint_sha256, default_pack_pointer_path,
-    host_quant_recommendation_profile, install_catalog_model_pack_from_path,
-    install_model_pack_from_path, list_installed_packs, load_config,
+    ResolvedCatalogPull, certificate_fingerprint_sha256, host_quant_recommendation_profile,
+    install_catalog_model_pack_from_path, install_model_pack_from_path, list_installed_packs,
     load_local_catalog_file_with_identity, load_model_catalog,
     native_runtime_realtime_capabilities_for_path,
-    native_runtime_transcription_capabilities_for_path, openasr_home, persist_default_pack_pointer,
-    read_default_pack_pointer, remove_model_pack, resolve_catalog_pull,
-    resolve_installed_pack_reference, resolve_installed_pack_reference_with_catalog,
-    resolve_launch_pack, resolve_runtime_catalog, runtime_registry, save_default_model_selection,
+    native_runtime_transcription_capabilities_for_path, openasr_home, remove_model_pack,
+    resolve_catalog_pull, resolve_installed_pack_reference,
+    resolve_installed_pack_reference_with_catalog, resolve_launch_pack, resolve_runtime_catalog,
+    runtime_registry,
 };
 use rcgen::{Certificate, CertificateParams};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
@@ -524,6 +522,11 @@ fn load_or_generate_self_signed_tls_identity(
 /// boot sequence that is guaranteed to have created `OPENASR_HOME` first).
 /// Never fails serve over this: a create or chmod failure is logged and
 /// swallowed, matching every other persistence step in this module.
+// On non-unix targets the `#[cfg(unix)]` chmod block below does not exist, so
+// this early `return` becomes the function's last statement and clippy (on
+// those targets only) reads it as needless; it stays required on unix to skip
+// that block after a failed `create_dir_all`.
+#[cfg_attr(not(unix), allow(clippy::needless_return))]
 fn harden_tls_identity_store_dir_permissions(store_path: &Path) {
     let Some(parent) = store_path.parent() else {
         return;
@@ -2149,6 +2152,14 @@ struct DefaultModelResponse {
     object: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_model: Option<String>,
+    /// Tri-state read straight off `openasr_core::default_selection::
+    /// DefaultModelResolution`: "installed" (`pack`/`default_pull` populated),
+    /// "not_installed" (a default is configured but has no matching installed
+    /// pack -- `default_model` still names it), or "unset" (nothing configured
+    /// at all). Always present, unlike the other fields, so a client can
+    /// distinguish "reinstall your default" from "choose a model" without
+    /// falling back to null-checking `pack`.
+    default_model_status: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_pull: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2185,6 +2196,22 @@ impl From<openasr_core::RuntimeRegistryError> for ApiError {
         match error {
             openasr_core::RuntimeRegistryError::Registry(error) => Self::Registry(error),
             openasr_core::RuntimeRegistryError::Catalog(error) => Self::Catalog(error),
+        }
+    }
+}
+
+impl From<openasr_core::default_selection::DefaultSelectionError> for ApiError {
+    fn from(error: openasr_core::default_selection::DefaultSelectionError) -> Self {
+        match error {
+            openasr_core::default_selection::DefaultSelectionError::Config(error) => {
+                Self::Config(error)
+            }
+            openasr_core::default_selection::DefaultSelectionError::Pull(error) => {
+                Self::Pull(error)
+            }
+            openasr_core::default_selection::DefaultSelectionError::Catalog(error) => {
+                Self::Catalog(error)
+            }
         }
     }
 }

--- a/crates/openasr-server/src/routes/models_api.rs
+++ b/crates/openasr-server/src/routes/models_api.rs
@@ -96,74 +96,59 @@ pub(crate) fn matching_installed_pack(
     }))
 }
 
+// Default-model resolution/persistence is NOT reimplemented here: it is owned
+// by `openasr_core::default_selection` (fail-closed: config.default_model wins,
+// the default.json pointer is a fallback only, and a configured-but-uninstalled
+// default never silently substitutes a different installed pack). This module
+// stays a thin delegate so the server, the CLI, and (eventually) the desktop
+// shell all read the same resolver -- see docs/default-model-resolution.md.
+
 pub(crate) fn resolve_default_pack(
     home: &Path,
     catalog_source: Option<CatalogSource<'_>>,
 ) -> Result<Option<InstalledPack>, ApiError> {
-    let packs = list_installed_packs(home).map_err(ApiError::Pull)?;
     let catalog = catalog_source
         .map(|source| load_catalog_for_source(source, home))
         .transpose()
         .map_err(ApiError::Catalog)?;
-    let document = load_config_document(home).map_err(ApiError::Config)?;
-    let pointer = read_default_pack_pointer(home).map_err(ApiError::Pull)?;
-    if matches!(
-        document.preferences.quant_preference,
-        QuantPreference::Pinned { .. }
-    ) && let Some(pointer) = pointer.as_ref()
-    {
-        let pointer_preference = QuantPreference::pinned(&pointer.quant);
-        // Use the BARE model id (preferring config.default_model when set) so
-        // installed_packs_for_model enumerates ALL quants: this lets the Pinned-hit /
-        // Pinned-missing-fallback ladder work, and honors `config set default_model`.
-        // Passing the quant-tagged pointer.pull would pre-filter to one quant and make
-        // the fallback unreachable (default model would break if that quant is removed).
-        let reference = document
-            .config
-            .default_model
-            .as_deref()
-            .unwrap_or(pointer.model_id.as_str());
-        return Ok(select_launch_pack_from_list(
-            &packs,
-            reference,
-            &pointer_preference,
-            catalog.as_ref(),
-        ));
-    }
-
-    let Some(default_model) = document
-        .config
-        .default_model
-        .as_deref()
-        .or_else(|| pointer.as_ref().map(|pointer| pointer.model_id.as_str()))
-    else {
-        return Ok(None);
-    };
-    Ok(select_launch_pack_from_list(
-        &packs,
-        default_model,
-        &document.preferences.quant_preference,
-        catalog.as_ref(),
-    ))
+    Ok(
+        openasr_core::default_selection::resolve_with_catalog(home, catalog.as_ref())?
+            .into_installed_pack(),
+    )
 }
 
 pub(crate) fn default_model_response(
     home: &Path,
     catalog_source: Option<CatalogSource<'_>>,
 ) -> Result<DefaultModelResponse, ApiError> {
-    let pack = resolve_default_pack(home, catalog_source)?;
+    let catalog = catalog_source
+        .map(|source| load_catalog_for_source(source, home))
+        .transpose()
+        .map_err(ApiError::Catalog)?;
+    let resolution = openasr_core::default_selection::resolve_with_catalog(home, catalog.as_ref())?;
+    let status = match &resolution {
+        openasr_core::default_selection::DefaultModelResolution::Installed(_) => "installed",
+        openasr_core::default_selection::DefaultModelResolution::NotInstalled(_) => "not_installed",
+        openasr_core::default_selection::DefaultModelResolution::Unset => "unset",
+    };
     // The `default_model` field reports the bare model identity; the quant lives in
     // `default_pull`/`pack.pull`. Appending the quant here would duplicate it (with a
     // different spelling) and diverge from the persisted bare `config.default_model`.
-    let default_model = pack.as_ref().map(|pack| pack.model_id.clone()).or_else(|| {
-        load_config(home)
-            .ok()
-            .and_then(|config| config.default_model)
-    });
+    let default_model = match &resolution {
+        openasr_core::default_selection::DefaultModelResolution::Installed(pack) => {
+            Some(pack.model_id.clone())
+        }
+        openasr_core::default_selection::DefaultModelResolution::NotInstalled(reference) => {
+            Some(reference.clone())
+        }
+        openasr_core::default_selection::DefaultModelResolution::Unset => None,
+    };
+    let pack = resolution.into_installed_pack();
 
     Ok(DefaultModelResponse {
         object: "model.default",
         default_model,
+        default_model_status: status,
         default_pull: pack.as_ref().map(|pack| pack.pull.clone()),
         pack,
     })
@@ -235,21 +220,13 @@ pub(crate) fn persist_default_pack(
     pack: &InstalledPack,
     quant_preference: QuantPreference,
 ) -> Result<(), ApiError> {
-    save_default_model_selection(home, pack.model_id.clone(), quant_preference)
-        .map_err(ApiError::Config)?;
-    persist_default_pack_pointer(home, pack).map_err(ApiError::Pull)
+    Ok(openasr_core::default_selection::persist(
+        home,
+        pack,
+        quant_preference,
+    )?)
 }
 
 pub(crate) fn clear_default_model_selection(home: &Path) -> Result<(), ApiError> {
-    let mut document = load_config_document(home).map_err(ApiError::Config)?;
-    document.config.default_model = None;
-    document.preferences.quant_preference = QuantPreference::Auto;
-    save_config_document(home, &document).map_err(ApiError::Config)?;
-
-    let path = default_pack_pointer_path(home);
-    match fs::remove_file(&path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(source) => Err(ApiError::Pull(PullError::Io { path, source })),
-    }
+    Ok(openasr_core::default_selection::clear(home)?)
 }

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -1472,6 +1472,37 @@ async fn delete_model_allows_current_default_and_clears_default_selection() {
     assert!(default.default_model.is_none());
     assert!(default.default_pull.is_none());
     assert!(default.pack.is_none());
+    assert_eq!(default.default_model_status, "unset");
+}
+
+#[tokio::test]
+async fn default_model_response_reports_installed_not_installed_and_unset() {
+    let temp = tempfile::tempdir().unwrap();
+    let distribution = distribution_context_for_test(temp.path());
+
+    let unset = default_model_response(temp.path(), distribution.catalog_source()).unwrap();
+    assert_eq!(unset.default_model_status, "unset");
+    assert!(unset.pack.is_none());
+
+    let mut document = openasr_core::load_config_document(temp.path()).unwrap();
+    document.config.default_model = Some("whisper-small".to_string());
+    openasr_core::save_config_document(temp.path(), &document).unwrap();
+    let not_installed = default_model_response(temp.path(), distribution.catalog_source()).unwrap();
+    assert_eq!(not_installed.default_model_status, "not_installed");
+    assert_eq!(
+        not_installed.default_model.as_deref(),
+        Some("whisper-small")
+    );
+    assert!(not_installed.pack.is_none());
+
+    let pack = write_valid_installed_pack_for_test(temp.path(), "whisper-small", "q8_0", "q8");
+    persist_default_pack(temp.path(), &pack, QuantPreference::pinned(&pack.quant)).unwrap();
+    let installed = default_model_response(temp.path(), distribution.catalog_source()).unwrap();
+    assert_eq!(installed.default_model_status, "installed");
+    assert_eq!(
+        installed.pack.as_ref().map(|pack| pack.pull.as_str()),
+        Some("whisper-small:q8")
+    );
 }
 
 #[test]

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -19,6 +19,7 @@ contributors -- crate relationships, the audio-to-transcript pipeline, and the
 | [FAQ](FAQ.md) | Current-behavior questions: what OpenASR is, which families run, which backends are active, and the conservative offline transcription lane. |
 | [Releasing](../RELEASING.md) | The commit-driven release process: the single workspace version, `scripts/bump-version.sh`, and the version-triggered `Release core` workflow. |
 | [Agent Integration](AGENT_INTEGRATION.md) | How a coding agent uses OpenASR: the `skills/openasr` Skill (CLI path) and the local OpenAI-compatible HTTP API, including `openasr apikey` for opt-in loopback authentication. |
+| [Default Model Resolution](default-model-resolution.md) | The single-authority `default_selection` resolver (fail-closed, `config.json` + `default.json` pointer, three-state result) that the server, CLI, and any future shell must all read/write through -- no second resolver, no fabricated defaults. |
 
 ## Format contracts (`docs/format/`)
 

--- a/docs/default-model-resolution.md
+++ b/docs/default-model-resolution.md
@@ -1,0 +1,107 @@
+# Default Model Resolution
+
+Normative contract for what "the default model" means across OpenASR, and for
+the single resolver every caller must go through to read or change it.
+
+## Single authority
+
+`openasr_core::default_selection` (`crates/openasr-core/src/default_selection.rs`)
+is the **only** place that resolves or persists the default model. It is used
+by:
+
+- `openasr-server`'s `GET/POST/PUT /v1/models/default` and `DELETE
+  /v1/models/{id}` routes (`crates/openasr-server/src/routes/models_api.rs`,
+  thin delegates only).
+- `openasr-cli`'s `serve`/`transcribe`/`live` pack resolution
+  (`crates/openasr-cli/src/native_segment_cli.rs`) for the "no `--model`
+  passed" case.
+- `openasr pull`'s auto-set-default-on-install behavior
+  (`crates/openasr-cli/src/pull_cli.rs`).
+
+No shell, frontend, or new server/CLI code may reimplement this resolution or
+fabricate a default from in-memory state. If a new surface needs "what is the
+default model," it calls `default_selection::resolve` (or the server's `GET
+/v1/models/default`, which is backed by the same resolver) -- it does not read
+`config.json`'s `default_model` field directly and assume that is the whole
+answer, because it isn't (see "Two files" below).
+
+## Two files, one state machine
+
+The default model spans two files under `OPENASR_HOME`:
+
+- `config.json`'s `default_model` field: the user's explicit choice (a bare
+  model id, no quant tag). `None` means "the user has not chosen one yet."
+  This field carries **no implicit value** -- a fresh config (missing key, or
+  `OpenAsrConfig::default()`) deserializes to `None`, never to a hardcoded
+  model id.
+- `default.json` (`default_pack_pointer_path`): a pointer recording the
+  quant-tagged pack that the last default-setting write actually installed
+  against. It is a fallback, read only when `config.default_model` is unset,
+  and it is also how a `QuantPreference::Pinned` preference recovers which
+  quant was pinned.
+
+`default_selection::persist` writes both files together (config first, then
+the pointer) so they never drift; `default_selection::clear` resets both
+(clearing `default_model` and `quant_preference`, removing the pointer file).
+Callers must never write one without the other.
+
+## Fail-closed: never invent a default
+
+`resolve` never substitutes a different installed pack when the configured
+default is missing, and never picks "some" installed model when nothing is
+configured. A configured-but-uninstalled default model resolves to
+`NotInstalled`, not to whatever else happens to be on disk -- silently
+substituting a different model/quant than the one the user chose would defeat
+the point of "default" and could route audio through unexpected weights.
+
+## Priority
+
+1. `config.default_model`, if set.
+2. Otherwise, `default.json`'s pointer model id, if a pointer file exists.
+3. Otherwise: unset.
+
+If `preferences.quant_preference` is `Pinned` and a pointer file exists, the
+pointer's *quant* is tried first for whichever bare model id priority (1) or
+(2) selects, falling back to the best installed quant for that model if the
+exact pinned quant was removed.
+
+## Three-state result
+
+A bare `Option<InstalledPack>` cannot distinguish "nothing configured" from
+"configured but not installed" -- both collapse to `None`. Callers that need
+to show the right prompt ("choose a model" vs. "reinstall your default") use
+`DefaultModelResolution`:
+
+- `Installed(InstalledPack)` -- a default is configured (directly or via the
+  pointer) and a matching pack is installed.
+- `NotInstalled(String)` -- a default is configured but nothing installed
+  matches it (removed, never pulled, or an unrecoverable quant).
+- `Unset` -- neither `config.default_model` nor the `default.json` pointer is
+  set.
+
+`GET /v1/models/default` exposes this as `default_model_status`: `"installed"`
+| `"not_installed"` | `"unset"`. See the JSON shape below.
+
+```jsonc
+{
+  "object": "model.default",
+  // Bare model id. Present for "installed" and "not_installed"; absent for "unset".
+  "default_model": "whisper-small",
+  "default_model_status": "not_installed",
+  // Quant-tagged pull id + full pack metadata, only when status is "installed".
+  "default_pull": null,
+  "pack": null
+}
+```
+
+## What this module is not
+
+`DEFAULT_MODEL_ID` (`crates/openasr-core/src/config.rs`) is a **separate,
+CLI-only** concept: the bare-invocation convention `transcribe`/`live`/`pull`
+fall back to when the caller passes neither `--model` nor has a persisted
+`config.default_model`. It feeds the CLI's last-resort reference and the
+consent-pull prompt copy; it is never written into `config.json` and never
+flows through `default_selection`. Conflating the two is the bug class this
+module was written to close: a fresh install used to get an implicit
+`config.default_model` pointing at a model nobody had installed, so the
+default-model status looked "configured" everywhere except in reality.


### PR DESCRIPTION
## Summary

Makes `openasr_core::default_selection` the single authority for resolving and
persisting the "default model" (spanning `config.json`'s `default_model` field
and the `default.json` pointer). A fresh config no longer seeds an implicit
`default_model`; it stays `None` until the user (or a `pull` auto-set) actually
chooses one. The server and CLI both delegate to the same fail-closed resolver
instead of each carrying their own copy of the resolution logic.

## Why

Before this change, a fresh install's `config.json` deserialized `default_model`
to a hardcoded `DEFAULT_MODEL_ID` via `#[serde(default = "default_model")]`, even
though nothing was actually installed. That made "default model" look configured
everywhere except in reality, and the server, the CLI, and the config layer each
had their own reading of the two files (`config.json` + `default.json` pointer)
involved in resolution, with only the server reading the pointer as a fallback.

## Changes

- `crates/openasr-core/src/config.rs`, `config_tests.rs`: `default_model` no
  longer has a serde default; a fresh/missing-field config deserializes to
  `None`. `fn default_model()` is removed. `DEFAULT_MODEL_ID`'s doc comment is
  reworded to make clear it is a CLI-only bare-invocation convention, decoupled
  from config persistence.
- `crates/openasr-core/src/default_selection.rs` (new) +
  `default_selection_tests.rs`: single-authority module with a three-state
  `DefaultModelResolution` (`Installed(InstalledPack)` / `NotInstalled(String)` /
  `Unset`), `resolve`/`resolve_with_catalog`, `persist` (writes `config.json` and
  the `default.json` pointer together so they never drift), and `clear`.
  Fail-closed: never substitutes a different installed pack when the configured
  default is missing, and never invents a default when nothing is configured.
- `crates/openasr-server/src/routes/models_api.rs`: `resolve_default_pack`,
  `default_model_response`, `persist_default_pack`, `clear_default_model_selection`
  become thin delegates to `default_selection`. `GET /v1/models/default` gains an
  always-present `default_model_status` field (`"installed"` / `"not_installed"` /
  `"unset"`) so a client can distinguish "reinstall your default" from "choose a
  model" without null-checking `pack`.
- `crates/openasr-cli/src/native_segment_cli.rs`: `resolve_installed_native_pack_opt`
  delegates the no-`--model` case to `default_selection::resolve_with_catalog`;
  an explicit `--model` reference is still matched directly. The `DEFAULT_MODEL_ID`
  fallback (when nothing is configured at all) stays CLI-local, since it is the
  bare-invocation convention, not "the default".
- `crates/openasr-cli/src/pull_cli.rs`: the auto-set-default-on-install path now
  calls `default_selection::persist` instead of writing the config field and the
  pointer file as two separate calls.
- `docs/default-model-resolution.md` (new) + `docs/DOCS_INDEX.md`: normative
  contract for the two-files/three-state resolution, linked from the docs index.
  `crates/openasr-core/src/home.rs` gets a short comment noting the installer
  path-sync contract on `openasr_home()`.
- Unrelated Windows/clippy portability fixes carried over from the original
  commit: `crates/openasr-core/src/diarize/enrollment.rs` (silence an
  unused-variable warning on non-unix targets), `download_source.rs` (gate an
  unused `fs` import behind `#[cfg(unix)]`), `pull_tests.rs` (use
  `io::Error::other` per clippy).

This PR was rebased from a local commit built on an older base onto the current
`origin/main` (audio_frontend DSP migration, server watchdog, the new
`CatalogSource`/`load_catalog_for_source` split for local-catalog-file
overrides, etc). The only real (non-mechanical) conflict was bridging
`default_selection`'s `catalog_url: Option<&str>` shape into the new
`CatalogSource` abstraction: `resolve_default_pack` and `default_model_response`
now load the catalog via `load_catalog_for_source` (same "skip when `None`"
semantics as the old `catalog_url.map(...).transpose()`) and call
`default_selection::resolve_with_catalog` with the already-loaded catalog.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (not run; not part of this repo's documented validation set for a core-only change)

`cargo nextest run --workspace`: 2476 passed, 4 failed, 123 skipped. The 4
failures are pre-existing on a clean `origin/main` checkout on Windows (verified
by running the same 4 tests against an unmodified `origin/main` worktree, same
panics) and unrelated to this change:
- `pull::tests::pull_lock_blocks_second_writer` -- the test's stale-lock fixture
  writes `pid=1` assuming a Unix-style always-alive PID 1; `lock_owner_is_gone`'s
  Windows `OpenProcess`-based check does not find that PID alive, so the lock is
  treated as stale instead of held.
- `realtime::wire_bindings_test::realtime_wire_bindings_regenerate_to_match_committed`
  and `http_wire_bindings_test::http_wire_bindings_regenerate_to_match_committed`
  -- the committed generated `.ts` golden files are LF, but `core.autocrlf=true`
  on this Windows checkout converts them to CRLF on checkout, so the byte-for-byte
  comparison against freshly-regenerated (LF) output reports every golden file as
  drifted.
- `transcriptions_large_upload_memory_stays_bounded` -- the RSS probe shells out
  to `ps -o rss=`, which is not available on Windows.

## Manual smoke checks

None beyond the automated suite above (no CLI/API behavior change requires a
manual walkthrough beyond what `default_selection_tests.rs` and the updated
`openasr-server` tests already exercise for the three resolution states).

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (added
      `docs/default-model-resolution.md`, linked from `docs/DOCS_INDEX.md`)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not change the desktop/app-side default-model UI or any other consumer
outside this repo; does not touch the `DEFAULT_MODEL_ID` bare-invocation value
itself, catalog signature verification, or pull/download behavior. Does not add
`ts-rs` bindings for `DefaultModelResponse` -- it does not derive `TS` in this
codebase's ts-export mechanism (that mechanism currently only covers the
`realtime-wire` event types), so the new `default_model_status` field needs no
generated-bindings update.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented and validated with AI assistance (Claude Code), including rebasing the original commit onto the current `origin/main` base and resolving the resulting conflicts.
