### PR TITLE
fix(tooling): point catalog drift gate's family-doc check at docs/FAQ.md

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -16,9 +16,10 @@ Cohere Transcribe, Qwen3-ASR, Parakeet-CTC, Parakeet-TDT (25 European
 languages), wav2vec2-CTC (incl. data2vec), Moonshine, Dolphin (Chinese
 dialects), SenseVoice (zh/yue/en/ja/ko), FireRedASR-AED (Mandarin + English
 bilingual), and X-ASR (Zipformer). They run local
-offline transcription on CPU and Metal lanes. The
-[model support matrix](../README.md#model-support) in the README lists
-per-family streaming, word-timestamp, and quant-tier support.
+offline transcription on CPU and Metal lanes. See
+[Known Limitations](KNOWN_LIMITATIONS.md) for per-family streaming and
+word-timestamp support, and the per-model cards under
+[`model-registry/models/`](../model-registry/models/) for quant tiers.
 
 ## What backends are active right now?
 

--- a/tooling/publish-model/scripts/check_catalog_drift.py
+++ b/tooling/publish-model/scripts/check_catalog_drift.py
@@ -30,9 +30,9 @@ from _catalog import (  # noqa: E402
 from _manifest import prose_locales_block, read_prose  # noqa: E402
 
 # Human-prose keyword each catalog `family` id is expected to be findable by
-# (case-insensitive substring) in README.md's Model support table and
-# ACKNOWLEDGMENTS.md's Speech recognition list. Family ids are internal
-# (e.g. "xasr-zipformer"); prose calls it "X-ASR (Zipformer)".
+# (case-insensitive substring) in docs/FAQ.md's "What native model families run
+# today?" answer and ACKNOWLEDGMENTS.md's Speech recognition list. Family ids
+# are internal (e.g. "xasr-zipformer"); prose calls it "X-ASR (Zipformer)".
 FAMILY_DOC_KEYWORDS = {
     "whisper": "whisper",
     "cohere": "cohere",
@@ -259,18 +259,29 @@ def check_family_count_strings(errors: list[str]) -> None:
                 )
 
 
+FAQ_FAMILY_SECTION_HEADING = "## What native model families run today?"
+
+
 def check_public_family_docs(machine_catalog: dict, errors: list[str]) -> None:
-    """Every publicly listed ASR family must be named in README.md's Model
-    support table and ACKNOWLEDGMENTS.md's Speech recognition list, so a newly
-    published public model can't silently ship without user-facing docs.
+    """Every publicly listed ASR family must be named in docs/FAQ.md's "What
+    native model families run today?" answer and ACKNOWLEDGMENTS.md's Speech
+    recognition list, so a newly published public model can't silently ship
+    without user-facing docs.
+
+    This used to check README.md's per-family "Model support" table, but the
+    818b1fe bilingual rewrite intentionally replaced that table with prose
+    (README.md is no longer a per-family enumeration surface -- see
+    docs/DOCS_INDEX.md). docs/FAQ.md's family-list answer is the surviving
+    user-facing doc that enumerates every native family by name, so the gate
+    now targets that instead of re-adding the table the rewrite removed.
     """
-    readme_path = REPO_ROOT / "README.md"
+    faq_path = REPO_ROOT / "docs" / "FAQ.md"
     ack_path = REPO_ROOT / "ACKNOWLEDGMENTS.md"
-    if not readme_path.exists() or not ack_path.exists():
+    if not faq_path.exists() or not ack_path.exists():
         return
 
-    readme_section = extract_section(
-        readme_path.read_text(encoding="utf-8"), "## Models", ("\n## ",)
+    faq_section = extract_section(
+        faq_path.read_text(encoding="utf-8"), FAQ_FAMILY_SECTION_HEADING, ("\n## ",)
     ).lower()
     ack_section = extract_section(
         ack_path.read_text(encoding="utf-8"), "**Speech recognition**", ("\n**", "\n## ")
@@ -289,10 +300,11 @@ def check_public_family_docs(machine_catalog: dict, errors: list[str]) -> None:
         if not family:
             continue
         keyword = FAMILY_DOC_KEYWORDS.get(family, family).lower()
-        if keyword not in readme_section:
+        if keyword not in faq_section:
             errors.append(
-                f"family '{family}' (public model) missing from README.md's Model support "
-                f"table (expected to find {keyword!r})"
+                f"family '{family}' (public model) missing from docs/FAQ.md's "
+                f"\"{FAQ_FAMILY_SECTION_HEADING.lstrip('# ')}\" answer "
+                f"(expected to find {keyword!r})"
             )
         if keyword not in ack_section:
             errors.append(

--- a/tooling/publish-model/scripts/check_catalog_drift_test.py
+++ b/tooling/publish-model/scripts/check_catalog_drift_test.py
@@ -84,11 +84,17 @@ class PublicFamilyDocsTest(unittest.TestCase):
             ]
         }
 
+    def _write_faq(self, root: Path, body: str = "Whisper is supported.") -> None:
+        (root / "docs").mkdir(parents=True, exist_ok=True)
+        (root / "docs" / "FAQ.md").write_text(
+            f"{drift.FAQ_FAMILY_SECTION_HEADING}\n\n{body}\n\n## What backends are active right now?\n"
+        )
+
     def test_documented_family_passes(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             drift.REPO_ROOT = root
-            (root / "README.md").write_text("## Models\n\nWhisper is supported.\n\n## Benchmarks\n")
+            self._write_faq(root)
             (root / "ACKNOWLEDGMENTS.md").write_text(
                 "**Speech recognition**\n\n- Whisper -- link\n\n**Speaker diarization**\n"
             )
@@ -102,7 +108,7 @@ class PublicFamilyDocsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             drift.REPO_ROOT = root
-            (root / "README.md").write_text("## Models\n\nWhisper is supported.\n\n## Benchmarks\n")
+            self._write_faq(root)
             (root / "ACKNOWLEDGMENTS.md").write_text(
                 "**Speech recognition**\n\n- Whisper -- link\n\n**Speaker diarization**\n"
             )
@@ -111,14 +117,14 @@ class PublicFamilyDocsTest(unittest.TestCase):
             drift.check_public_family_docs(self._catalog("dolphin"), errors)
 
             self.assertEqual(len(errors), 2)
-            self.assertIn("README.md", errors[0])
+            self.assertIn("docs/FAQ.md", errors[0])
             self.assertIn("ACKNOWLEDGMENTS.md", errors[1])
 
     def test_private_family_is_not_required_in_docs(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             drift.REPO_ROOT = root
-            (root / "README.md").write_text("## Models\n\nWhisper is supported.\n\n## Benchmarks\n")
+            self._write_faq(root)
             (root / "ACKNOWLEDGMENTS.md").write_text(
                 "**Speech recognition**\n\n- Whisper -- link\n\n**Speaker diarization**\n"
             )


### PR DESCRIPTION
## Summary

Retargets the catalog drift gate's public-family documentation check from
README.md's (removed) Model support table to docs/FAQ.md's existing family
list, and fixes the now-dangling FAQ link that pointed at it.

## Why

`tooling/publish-model/scripts/check_catalog_drift.py`'s
`check_public_family_docs` used to require every public ASR family's keyword
to appear in README.md's "## Models" section, matching text against the old
per-family Model support table. #118 (bilingual readme rewrite) intentionally
replaced that table with prose as part of a deliberate desktop-first
restructure -- this is the intended end state, not a regression. The check
was never updated, so `regenerate_all.sh --check` ("Catalog drift gate" in
CI) has failed on every public family since 818b1fe, and main has had no
green CI since. Any new PR (including #122) fails this gate through no fault
of its own.

## Changes

- `tooling/publish-model/scripts/check_catalog_drift.py`:
  `check_public_family_docs` now reads docs/FAQ.md's "What native model
  families run today?" answer instead of README.md's Models section. That
  FAQ answer already names every native family (it predates this gate and
  was unaffected by the README rewrite), so it fully satisfies the same
  invariant -- every public family has a name-checkable user-facing doc
  reference -- without touching README.md. The ACKNOWLEDGMENTS.md check is
  unchanged (it already passed).
  - No other assertion in `--check` is touched: registry-card drift,
    machine-catalog-entry drift, catalog `language_labels` drift, the
    family-count-string check across README.md/ARCHITECTURE.md/docs/FAQ.md,
    and prose-locale validation all still run exactly as before.
- `tooling/publish-model/scripts/check_catalog_drift_test.py`: updated
  `PublicFamilyDocsTest` fixtures to write `docs/FAQ.md` instead of
  `README.md`, matching the new target file/section.
- `docs/FAQ.md`: removed the family-list answer's link to
  `../README.md#model-support`, which pointed at an anchor that has not
  existed in README.md's rendered form since the rewrite. Replaced with
  links to Known Limitations (streaming / word-timestamp support) and the
  per-model registry cards under `model-registry/models/` (quant tiers) --
  the two places that information now actually lives.
- README.md is untouched. This PR does not re-add the removed table; the
  bilingual rewrite's structure and narrative stand as-is.

## Tests run

- [x] `python tooling/publish-model/scripts/check_catalog_drift.py` (no
      args, all 27 models) -- was failing with 8 "missing from README.md's
      Model support table" errors before this change; passes cleanly after.
- [x] `python -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'`
      -- all 9 tests in `check_catalog_drift_test.py` pass (including the 3
      updated `PublicFamilyDocsTest` cases). 14 errors / 1 failure remain
      elsewhere in the suite (`publish_catalog_test.py`,
      `publish_flow_test.py`, `render_card_test.py`); verified these are
      pre-existing on a clean origin/main checkout in this Windows
      environment (subprocess shebang / GBK-locale decoding issues local to
      this machine, not caused by this change) and are unrelated to the
      files this PR touches.
- Local `bash regenerate_all.sh --check` could not run directly on this
  machine: `python3` on PATH resolves to the Windows Store stub, not a real
  interpreter. Validated the equivalent invocation directly against the real
  interpreter instead (`python check_catalog_drift.py`, no args -- same
  default model selection `regenerate_all.sh --check` uses). CI runs on
  Linux with a real `python3`, where this is a non-issue.
- Not run: `cargo fmt` / `cargo clippy` / `cargo nextest` / `cargo deny` --
  this PR touches only Python tooling and docs, no Rust source.

## Manual smoke checks

N/A (tooling/docs only).

## Docs updated

- [x] docs/FAQ.md updated (dangling link removed, redirected to the docs
      that now hold that information).
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not restore or modify README.md's Model support table -- the
  bilingual rewrite's removal of it is treated as intentional per current
  project direction.
- Does not touch ACKNOWLEDGMENTS.md's side of the check (it already passes).
- Does not address the unrelated pre-existing local test failures noted
  above (`publish_catalog_test.py`, `publish_flow_test.py`,
  `render_card_test.py`); they reproduce identically on a clean origin/main
  checkout and are out of scope for this fix.

After this merges, PR #122 (and any other open PR) will need its checks
rerun to pick up a green Catalog drift gate.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- used an AI coding agent to diagnose the check_catalog_drift.py assertion, implement the docs/FAQ.md retarget and test updates, and fix the dangling FAQ link.
