### PR TITLE
feat(windows): per-process WASAPI loopback capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,6 +1711,7 @@ dependencies = [
  "objc2-foundation",
  "serde",
  "wasapi",
+ "windows",
 ]
 
 [[package]]

--- a/crates/openasr-system-audio/Cargo.toml
+++ b/crates/openasr-system-audio/Cargo.toml
@@ -22,3 +22,12 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = ["s
 
 [target.'cfg(windows)'.dependencies]
 wasapi = "0.23.0"
+# Only for the process-enumeration and OpenProcess existence checks that back
+# per-process loopback capture; the loopback activation itself goes through
+# wasapi::AudioClient::new_application_loopback_client, which already wraps
+# ActivateAudioInterfaceAsync / AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK.
+windows = { version = "0.62", default-features = false, features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Threading",
+] }

--- a/crates/openasr-system-audio/src/lib.rs
+++ b/crates/openasr-system-audio/src/lib.rs
@@ -44,6 +44,42 @@ pub struct CaptureBackendError {
     pub diagnostic: String,
 }
 
+/// Whether a target process should include or exclude its child-process tree
+/// when the platform backend supports per-process loopback capture (see
+/// `process_loopback_support`). Named after the Windows
+/// `AUDIOCLIENT_PROCESS_LOOPBACK_MODE` semantics, the only backend that
+/// implements this today; other platforms report `supported: false` via
+/// `process_loopback_support` instead of interpreting this value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessLoopbackMode {
+    /// Capture audio from the target process and every process it spawns.
+    IncludeProcessTree,
+    /// Capture audio from only the target process, not its children.
+    ExcludeProcessTree,
+}
+
+/// Capability probe for per-process loopback capture, distinct from
+/// `SystemAudioSupport` (which covers the existing all-system loopback path).
+/// A platform can support all-system loopback while reporting `supported:
+/// false` here (e.g. macOS/Linux today, or Windows older than the 2004
+/// update, which lacks `AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK`).
+#[derive(Debug, Clone, Serialize)]
+pub struct ProcessLoopbackSupport {
+    pub supported: bool,
+    pub detail: String,
+    pub platform: String,
+}
+
+/// A running process a caller can offer as a per-process loopback capture
+/// target. `name` is the best-effort executable/display name; enumeration
+/// must stay panic-free and skip processes it cannot read rather than fail
+/// the whole listing.
+#[derive(Debug, Clone, Serialize)]
+pub struct CandidateProcess {
+    pub pid: u32,
+    pub name: String,
+}
+
 pub fn support_status() -> SystemAudioSupport {
     platform::support_status()
 }
@@ -54,4 +90,33 @@ pub fn run_loopback_capture(
     on_diagnostic: impl FnMut(&str) -> Result<(), String>,
 ) -> Result<String, CaptureBackendError> {
     platform::run_loopback_capture(stop, on_frame, on_diagnostic)
+}
+
+/// Capability probe for `run_process_loopback_capture`. Cheap enough to call
+/// before showing per-process capture UI; platforms without an
+/// implementation return `supported: false` rather than panicking.
+pub fn process_loopback_support() -> ProcessLoopbackSupport {
+    platform::process_loopback_support()
+}
+
+/// Lists candidate processes a caller may pick as a per-process loopback
+/// target. Returns a typed `unsupported` `CaptureBackendError` on platforms
+/// without an implementation.
+pub fn list_candidate_processes() -> Result<Vec<CandidateProcess>, CaptureBackendError> {
+    platform::list_candidate_processes()
+}
+
+/// Per-process loopback capture: only audio rendered by `process_id` (and,
+/// depending on `mode`, its child processes) is captured, instead of the
+/// whole system. Platforms without an implementation fail closed with a
+/// typed `unsupported` `CaptureBackendError` rather than panicking or
+/// silently falling back to all-system capture.
+pub fn run_process_loopback_capture(
+    process_id: u32,
+    mode: ProcessLoopbackMode,
+    stop: Arc<AtomicBool>,
+    on_frame: impl FnMut(Vec<i16>) -> Result<(), String>,
+    on_diagnostic: impl FnMut(&str) -> Result<(), String>,
+) -> Result<String, CaptureBackendError> {
+    platform::run_process_loopback_capture(process_id, mode, stop, on_frame, on_diagnostic)
 }

--- a/crates/openasr-system-audio/src/linux.rs
+++ b/crates/openasr-system-audio/src/linux.rs
@@ -8,7 +8,8 @@ use std::sync::{
 use std::time::Duration;
 
 use crate::{
-    CaptureBackendError, SystemAudioSupport,
+    CandidateProcess, CaptureBackendError, ProcessLoopbackMode, ProcessLoopbackSupport,
+    SystemAudioSupport,
     pcm::{Pcm16FrameChunker, TARGET_CHANNELS, TARGET_SAMPLE_RATE_HZ},
 };
 
@@ -139,6 +140,45 @@ pub fn run_loopback_capture(
     ))?;
 
     Ok("Capture stopped".to_string())
+}
+
+/// Per-process loopback capture is not implemented on Linux: PulseAudio/
+/// PipeWire expose per-application streams through `pactl`/session APIs
+/// distinct from the monitor-source capture this backend uses, and wiring
+/// that up is separate scope from the Windows per-process work this module
+/// was written for. Fail closed rather than pretending support exists.
+pub fn process_loopback_support() -> ProcessLoopbackSupport {
+    ProcessLoopbackSupport {
+        supported: false,
+        detail: "Linux per-process loopback capture is not implemented; use the default sink monitor via run_loopback_capture instead."
+            .to_string(),
+        platform: "linux".to_string(),
+    }
+}
+
+pub fn list_candidate_processes() -> Result<Vec<CandidateProcess>, CaptureBackendError> {
+    Err(CaptureBackendError {
+        code: "unsupported",
+        message:
+            "Process enumeration for per-process loopback capture is not implemented on Linux."
+                .to_string(),
+        diagnostic: "list_candidate_processes has no Linux backend yet.".to_string(),
+    })
+}
+
+pub fn run_process_loopback_capture(
+    _process_id: u32,
+    _mode: ProcessLoopbackMode,
+    _stop: Arc<AtomicBool>,
+    _on_frame: impl FnMut(Vec<i16>) -> Result<(), String>,
+    _on_diagnostic: impl FnMut(&str) -> Result<(), String>,
+) -> Result<String, CaptureBackendError> {
+    Err(CaptureBackendError {
+        code: "unsupported",
+        message: "Per-process loopback capture is not implemented on Linux.".to_string(),
+        diagnostic: "run_process_loopback_capture has no Linux backend yet; use run_loopback_capture for default-sink monitor capture."
+            .to_string(),
+    })
 }
 
 fn ensure_linux_tools() -> Result<(), CaptureBackendError> {

--- a/crates/openasr-system-audio/src/macos.rs
+++ b/crates/openasr-system-audio/src/macos.rs
@@ -31,7 +31,8 @@ use objc2_core_foundation::{CFArray, CFBoolean, CFDictionary, CFRetained, CFStri
 use objc2_foundation::{NSArray, NSNumber, NSString, NSUUID};
 
 use crate::{
-    CaptureBackendError, SystemAudioSupport,
+    CandidateProcess, CaptureBackendError, ProcessLoopbackMode, ProcessLoopbackSupport,
+    SystemAudioSupport,
     pcm::{Pcm16FrameChunker, TARGET_SAMPLE_RATE_HZ},
 };
 
@@ -119,6 +120,46 @@ pub fn run_loopback_capture(
     ))?;
 
     Ok("Capture stopped".to_string())
+}
+
+/// Per-process loopback capture is not implemented on macOS: the Core Audio
+/// process tap this backend uses (`AudioHardwareCreateProcessTap`) already
+/// captures a single process's audio when constructed with a specific PID
+/// instead of `initMonoGlobalTapButExcludeProcesses`, but wiring that up is
+/// separate scope from the Windows per-process work this module was written
+/// for. Fail closed rather than pretending support exists.
+pub fn process_loopback_support() -> ProcessLoopbackSupport {
+    ProcessLoopbackSupport {
+        supported: false,
+        detail: "macOS per-process loopback capture is not implemented; use the all-system Core Audio process tap via run_loopback_capture instead."
+            .to_string(),
+        platform: "macos".to_string(),
+    }
+}
+
+pub fn list_candidate_processes() -> Result<Vec<CandidateProcess>, CaptureBackendError> {
+    Err(CaptureBackendError {
+        code: "unsupported",
+        message:
+            "Process enumeration for per-process loopback capture is not implemented on macOS."
+                .to_string(),
+        diagnostic: "list_candidate_processes has no macOS backend yet.".to_string(),
+    })
+}
+
+pub fn run_process_loopback_capture(
+    _process_id: u32,
+    _mode: ProcessLoopbackMode,
+    _stop: Arc<AtomicBool>,
+    _on_frame: impl FnMut(Vec<i16>) -> Result<(), String>,
+    _on_diagnostic: impl FnMut(&str) -> Result<(), String>,
+) -> Result<String, CaptureBackendError> {
+    Err(CaptureBackendError {
+        code: "unsupported",
+        message: "Per-process loopback capture is not implemented on macOS.".to_string(),
+        diagnostic: "run_process_loopback_capture has no macOS backend yet; use run_loopback_capture for all-system Core Audio process-tap capture."
+            .to_string(),
+    })
 }
 
 struct MacOsCaptureSession {

--- a/crates/openasr-system-audio/src/stub.rs
+++ b/crates/openasr-system-audio/src/stub.rs
@@ -1,6 +1,9 @@
 use std::sync::{Arc, atomic::AtomicBool};
 
-use crate::{CaptureBackendError, SystemAudioSupport};
+use crate::{
+    CandidateProcess, CaptureBackendError, ProcessLoopbackMode, ProcessLoopbackSupport,
+    SystemAudioSupport,
+};
 
 pub fn support_status() -> SystemAudioSupport {
     SystemAudioSupport {
@@ -19,6 +22,36 @@ pub fn run_loopback_capture(
     Err(CaptureBackendError {
         code: "unsupported",
         message: "System-audio smoke capture is not implemented on this platform.".to_string(),
+        diagnostic: unsupported_detail(),
+    })
+}
+
+pub fn process_loopback_support() -> ProcessLoopbackSupport {
+    ProcessLoopbackSupport {
+        supported: false,
+        detail: unsupported_detail(),
+        platform: std::env::consts::OS.to_string(),
+    }
+}
+
+pub fn list_candidate_processes() -> Result<Vec<CandidateProcess>, CaptureBackendError> {
+    Err(CaptureBackendError {
+        code: "unsupported",
+        message: "Process enumeration is not implemented on this platform.".to_string(),
+        diagnostic: unsupported_detail(),
+    })
+}
+
+pub fn run_process_loopback_capture(
+    _process_id: u32,
+    _mode: ProcessLoopbackMode,
+    _stop: Arc<AtomicBool>,
+    _on_frame: impl FnMut(Vec<i16>) -> Result<(), String>,
+    _on_diagnostic: impl FnMut(&str) -> Result<(), String>,
+) -> Result<String, CaptureBackendError> {
+    Err(CaptureBackendError {
+        code: "unsupported",
+        message: "Per-process loopback capture is not implemented on this platform.".to_string(),
         diagnostic: unsupported_detail(),
     })
 }

--- a/crates/openasr-system-audio/src/windows.rs
+++ b/crates/openasr-system-audio/src/windows.rs
@@ -7,19 +7,31 @@ use std::sync::{
 use wasapi::{
     AudioClient, DeviceEnumerator, Direction, SampleType, StreamMode, WasapiError, WaveFormat,
 };
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW, TH32CS_SNAPPROCESS,
+};
+use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
 
 use crate::{
-    CaptureBackendError, SystemAudioSupport,
+    CandidateProcess, CaptureBackendError, ProcessLoopbackMode, ProcessLoopbackSupport,
+    SystemAudioSupport,
     pcm::{Pcm16FrameChunker, TARGET_CHANNELS, TARGET_FRAME_SAMPLES, TARGET_SAMPLE_RATE_HZ},
 };
 
 const SILENT_STREAK_DIAGNOSTIC_FRAMES: u32 = 250;
+// Fallback WASAPI buffer duration (100ns units = 20ms), used when the
+// default render endpoint does not report a usable minimum period, and
+// always for process-loopback clients: AudioClient::get_device_period() is
+// documented by the wasapi crate to return "Not implemented" for those, so
+// that path cannot query a device-reported minimum at all.
+const DEFAULT_BUFFER_DURATION_HNS: i64 = 200_000;
 
 pub fn support_status() -> SystemAudioSupport {
     SystemAudioSupport {
         supported: true,
         label: "System audio (Windows smoke)".to_string(),
-        detail: "Windows WASAPI all-system loopback smoke path is available. Per-process loopback remains deferred."
+        detail: "Windows WASAPI all-system loopback smoke path is available. Call process_loopback_support() to probe per-process capture separately."
             .to_string(),
         platform: "windows".to_string(),
     }
@@ -27,8 +39,8 @@ pub fn support_status() -> SystemAudioSupport {
 
 pub fn run_loopback_capture(
     stop: Arc<AtomicBool>,
-    mut on_frame: impl FnMut(Vec<i16>) -> Result<(), String>,
-    mut on_diagnostic: impl FnMut(&str) -> Result<(), String>,
+    on_frame: impl FnMut(Vec<i16>) -> Result<(), String>,
+    on_diagnostic: impl FnMut(&str) -> Result<(), String>,
 ) -> Result<String, CaptureBackendError> {
     wasapi::initialize_mta()
         .ok()
@@ -57,11 +69,236 @@ pub fn run_loopback_capture(
             "No default render endpoint is available",
         ))?;
 
-    let mut client: AudioClient = device.get_iaudioclient().map_err(map_wasapi_error(
+    let client: AudioClient = device.get_iaudioclient().map_err(map_wasapi_error(
         "capture_backend_failed",
         "Could not acquire IAudioClient",
     ))?;
 
+    // get_device_period() only works on a device-backed client (it is
+    // documented not to work at all on process-loopback clients), so this
+    // probe stays in the all-system path rather than the shared session
+    // helper below.
+    let (_default_period_hns, min_period_hns) =
+        client.get_device_period().map_err(map_wasapi_error(
+            "capture_backend_failed",
+            "Could not read WASAPI device period",
+        ))?;
+    let buffer_duration_hns = if min_period_hns > 0 {
+        min_period_hns
+    } else {
+        DEFAULT_BUFFER_DURATION_HNS
+    };
+
+    run_wasapi_loopback_session(client, buffer_duration_hns, stop, on_frame, on_diagnostic)
+}
+
+/// Per-process loopback capture: captures only audio rendered by
+/// `process_id` (and, per `mode`, its child processes), using the Windows
+/// 10 2004+ `AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK` API. The wasapi
+/// crate's `AudioClient::new_application_loopback_client` wraps the
+/// `ActivateAudioInterfaceAsync` COM activation dance for this.
+pub fn run_process_loopback_capture(
+    process_id: u32,
+    mode: ProcessLoopbackMode,
+    stop: Arc<AtomicBool>,
+    on_frame: impl FnMut(Vec<i16>) -> Result<(), String>,
+    on_diagnostic: impl FnMut(&str) -> Result<(), String>,
+) -> Result<String, CaptureBackendError> {
+    ensure_process_exists(process_id)?;
+
+    wasapi::initialize_mta()
+        .ok()
+        .map_err(|error| CaptureBackendError {
+            code: "capture_backend_failed",
+            message: "Could not initialize COM for WASAPI".to_string(),
+            diagnostic: error.to_string(),
+        })?;
+
+    // See ComUninitGuard's doc comment on run_loopback_capture: pairs this
+    // initialize_mta() with deinitialize() on every exit path, including the
+    // early returns inside run_wasapi_loopback_session.
+    let _com = ComUninitGuard;
+
+    let client = AudioClient::new_application_loopback_client(
+        process_id,
+        include_tree_for_mode(mode),
+    )
+    .map_err(
+        |error| CaptureBackendError {
+            // ensure_process_exists() above already confirmed process_id is a
+            // real, currently-running process, so an activation failure here
+            // is far more likely a missing OS feature (pre-Windows 10 2004,
+            // which lacks AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK) than a
+            // transient per-call error. Fail closed as "unsupported" so
+            // callers degrade cleanly instead of surfacing a bare backend
+            // error for what is really a capability gap. Callers that want to
+            // distinguish this ahead of time should call
+            // process_loopback_support() first.
+            code: "unsupported",
+            message: "Could not activate a Windows process-loopback audio client. This requires Windows 10 2004 (build 19041) or later.".to_string(),
+            diagnostic: error.to_string(),
+        },
+    )?;
+
+    run_wasapi_loopback_session(
+        client,
+        DEFAULT_BUFFER_DURATION_HNS,
+        stop,
+        on_frame,
+        on_diagnostic,
+    )
+}
+
+/// Capability probe for `run_process_loopback_capture`. Performs a genuine
+/// runtime activation probe (targeting this process's own PID, dropped
+/// immediately without starting a stream) rather than an OS-version
+/// heuristic: `GetVersionEx`-style checks can be lied to by application
+/// compatibility shims, whereas attempting the real activation the capture
+/// path uses cannot. This mirrors the CoreAudio symbol-load probe the macOS
+/// backend uses for the same "does this API actually exist here" question.
+pub fn process_loopback_support() -> ProcessLoopbackSupport {
+    match probe_process_loopback_activation() {
+        Ok(()) => ProcessLoopbackSupport {
+            supported: true,
+            detail: "Windows process-loopback capture (AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK) is available."
+                .to_string(),
+            platform: "windows".to_string(),
+        },
+        Err(error) => ProcessLoopbackSupport {
+            supported: false,
+            detail: format!(
+                "Windows process-loopback capture is not available on this system (requires Windows 10 2004 / build 19041 or later). {}: {}",
+                error.message, error.diagnostic
+            ),
+            platform: "windows".to_string(),
+        },
+    }
+}
+
+fn probe_process_loopback_activation() -> Result<(), CaptureBackendError> {
+    wasapi::initialize_mta()
+        .ok()
+        .map_err(|error| CaptureBackendError {
+            code: "capture_backend_failed",
+            message: "Could not initialize COM for WASAPI".to_string(),
+            diagnostic: error.to_string(),
+        })?;
+    let _com = ComUninitGuard;
+
+    AudioClient::new_application_loopback_client(std::process::id(), false)
+        .map(|_client| ())
+        .map_err(map_wasapi_error(
+            "unsupported",
+            "Could not activate a Windows process-loopback audio client",
+        ))
+}
+
+fn include_tree_for_mode(mode: ProcessLoopbackMode) -> bool {
+    matches!(mode, ProcessLoopbackMode::IncludeProcessTree)
+}
+
+fn ensure_process_exists(process_id: u32) -> Result<(), CaptureBackendError> {
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_id) };
+    match handle {
+        Ok(handle) => {
+            unsafe {
+                let _ = CloseHandle(handle);
+            }
+            Ok(())
+        }
+        // Covers both "no such process" and "exists but access denied"
+        // (e.g. a protected process): either way this pid cannot be used as
+        // a per-process loopback target, so fail closed with one typed code
+        // and let the OS error text in `diagnostic` distinguish the reason.
+        Err(error) => Err(CaptureBackendError {
+            code: "process_not_found",
+            message: format!(
+                "Process {process_id} could not be opened for per-process loopback capture."
+            ),
+            diagnostic: error.to_string(),
+        }),
+    }
+}
+
+/// Lists running processes as candidates for `run_process_loopback_capture`.
+/// Uses a Toolhelp32 snapshot (`CreateToolhelp32Snapshot` /
+/// `Process32FirstW` / `Process32NextW`), which does not require per-process
+/// open rights to read pid + executable name, unlike `OpenProcess`.
+pub fn list_candidate_processes() -> Result<Vec<CandidateProcess>, CaptureBackendError> {
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) }.map_err(|error| {
+        CaptureBackendError {
+            code: "capture_backend_failed",
+            message: "Could not snapshot running processes for per-process loopback capture."
+                .to_string(),
+            diagnostic: error.to_string(),
+        }
+    })?;
+    if snapshot.is_invalid() {
+        return Err(CaptureBackendError {
+            code: "capture_backend_failed",
+            message: "Could not snapshot running processes for per-process loopback capture."
+                .to_string(),
+            diagnostic: "CreateToolhelp32Snapshot returned an invalid handle.".to_string(),
+        });
+    }
+    let _snapshot_guard = ToolhelpSnapshotGuard(snapshot);
+
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+
+    let mut processes = Vec::new();
+    // If even the first entry can't be read, treat it as an empty list
+    // rather than an error: a snapshot that activated successfully but
+    // yields no readable entries is a degenerate-but-not-fatal case for a
+    // "candidate processes" listing (nothing to capture, not a backend
+    // failure), and callers should not have to special-case it.
+    let mut step = unsafe { Process32FirstW(snapshot, &mut entry) };
+    while step.is_ok() {
+        processes.push(CandidateProcess {
+            pid: entry.th32ProcessID,
+            name: process_name_from_entry(&entry),
+        });
+        entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+        step = unsafe { Process32NextW(snapshot, &mut entry) };
+    }
+
+    Ok(processes)
+}
+
+struct ToolhelpSnapshotGuard(HANDLE);
+
+impl Drop for ToolhelpSnapshotGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+fn process_name_from_entry(entry: &PROCESSENTRY32W) -> String {
+    let end = entry
+        .szExeFile
+        .iter()
+        .position(|&unit| unit == 0)
+        .unwrap_or(entry.szExeFile.len());
+    String::from_utf16_lossy(&entry.szExeFile[..end])
+}
+
+/// Runs the shared post-activation WASAPI capture loop: format negotiation,
+/// PCM16 mono 16k framing, the discontinuity/silence diagnostics, and clean
+/// stream teardown. Both the all-system loopback path (`run_loopback_capture`)
+/// and the per-process loopback path (`run_process_loopback_capture`) reach
+/// this after obtaining an `AudioClient` in whatever way is specific to that
+/// source; everything past that point is identical.
+fn run_wasapi_loopback_session(
+    mut client: AudioClient,
+    buffer_duration_hns: i64,
+    stop: Arc<AtomicBool>,
+    mut on_frame: impl FnMut(Vec<i16>) -> Result<(), String>,
+    mut on_diagnostic: impl FnMut(&str) -> Result<(), String>,
+) -> Result<String, CaptureBackendError> {
     let desired = WaveFormat::new(
         16,
         16,
@@ -71,19 +308,9 @@ pub fn run_loopback_capture(
         None,
     );
 
-    let (_default_period_hns, min_period_hns) =
-        client.get_device_period().map_err(map_wasapi_error(
-            "capture_backend_failed",
-            "Could not read WASAPI device period",
-        ))?;
-
     let stream_mode = StreamMode::EventsShared {
         autoconvert: true,
-        buffer_duration_hns: if min_period_hns > 0 {
-            min_period_hns
-        } else {
-            200_000
-        },
+        buffer_duration_hns,
     };
 
     client
@@ -243,6 +470,158 @@ mod tests {
     fn detects_silence_with_threshold() {
         assert!(is_silent_frame(&[0, 1, -2, 63]));
         assert!(!is_silent_frame(&[0, 70, 0]));
+    }
+
+    #[test]
+    fn maps_process_loopback_mode_to_include_tree() {
+        assert!(include_tree_for_mode(
+            ProcessLoopbackMode::IncludeProcessTree
+        ));
+        assert!(!include_tree_for_mode(
+            ProcessLoopbackMode::ExcludeProcessTree
+        ));
+    }
+
+    #[test]
+    fn process_name_from_entry_trims_at_null_terminator() {
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+        let name: Vec<u16> = "notepad.exe\0garbage-after-terminator"
+            .encode_utf16()
+            .collect();
+        entry.szExeFile[..name.len()].copy_from_slice(&name);
+
+        assert_eq!(process_name_from_entry(&entry), "notepad.exe");
+    }
+
+    #[test]
+    fn process_name_from_entry_handles_missing_terminator() {
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+        let name: Vec<u16> = "a".repeat(entry.szExeFile.len()).encode_utf16().collect();
+        entry.szExeFile.copy_from_slice(&name);
+
+        assert_eq!(
+            process_name_from_entry(&entry),
+            "a".repeat(entry.szExeFile.len())
+        );
+    }
+
+    #[test]
+    fn ensure_process_exists_rejects_an_unlikely_pid() {
+        // Windows process IDs are allocated in multiples of 4; u32::MAX is
+        // never a live pid, so OpenProcess must fail closed here rather than
+        // panicking or silently treating a missing process as present.
+        let error =
+            ensure_process_exists(u32::MAX).expect_err("u32::MAX should not be a live process");
+        assert_eq!(error.code, "process_not_found");
+    }
+
+    #[test]
+    fn list_candidate_processes_includes_this_process() {
+        let processes = list_candidate_processes().expect("list candidate processes");
+        let own_pid = std::process::id();
+        assert!(
+            processes.iter().any(|process| process.pid == own_pid),
+            "expected the current process ({own_pid}) in the candidate list of {} processes",
+            processes.len()
+        );
+        assert!(
+            processes
+                .iter()
+                .all(|process| !process.name.trim().is_empty()),
+            "every candidate process should have a non-empty name"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires a Windows 10 2004+ (build 19041) process-loopback API"]
+    fn windows_process_loopback_smoke_emits_non_silent_frames() {
+        use super::super::smoke_test_support::{
+            MIN_SMOKE_FRAMES, NON_SILENT_PEAK_THRESHOLD, frame_peak, write_smoke_wav,
+        };
+        use std::path::Path;
+        use std::process::{Child, Command};
+        use std::thread;
+        use std::time::Duration;
+
+        let probe = process_loopback_support();
+        assert!(
+            probe.supported,
+            "process-loopback support should be available for smoke: {}",
+            probe.detail
+        );
+
+        let playback_path = write_smoke_wav("openasr-windows-process-loopback-smoke");
+        let mut playback = spawn_windows_playback(&playback_path);
+        let process_id = playback.id();
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_after_timeout = Arc::clone(&stop);
+        let stopper = thread::spawn(move || {
+            thread::sleep(Duration::from_secs(5));
+            stop_after_timeout.store(true, Ordering::SeqCst);
+        });
+
+        let mut frames = 0_usize;
+        let mut peak = 0_i32;
+        let stop_after_signal = Arc::clone(&stop);
+        let result = run_process_loopback_capture(
+            process_id,
+            ProcessLoopbackMode::IncludeProcessTree,
+            Arc::clone(&stop),
+            |samples| {
+                frames += 1;
+                peak = peak.max(frame_peak(&samples));
+                if frames >= MIN_SMOKE_FRAMES && peak > NON_SILENT_PEAK_THRESHOLD {
+                    stop_after_signal.store(true, Ordering::SeqCst);
+                }
+                Ok(())
+            },
+            |message| {
+                eprintln!("{message}");
+                Ok(())
+            },
+        );
+
+        stop.store(true, Ordering::SeqCst);
+        let _ = playback.kill();
+        let _ = playback.wait();
+        let _ = stopper.join();
+        let _ = std::fs::remove_file(&playback_path);
+
+        result.expect("Windows process-loopback capture should run");
+        eprintln!("Windows process-loopback smoke captured {frames} frames, peak {peak}");
+        assert!(
+            frames >= MIN_SMOKE_FRAMES,
+            "expected at least {MIN_SMOKE_FRAMES} frames, got {frames}"
+        );
+        assert!(
+            peak > NON_SILENT_PEAK_THRESHOLD,
+            "expected non-silent process-loopback audio, peak={peak}"
+        );
+
+        fn spawn_windows_playback(path: &Path) -> Child {
+            let escaped_path = path.to_string_lossy().replace('\'', "''");
+            let command = format!(
+                "$player = New-Object System.Media.SoundPlayer '{}'; $player.PlaySync()",
+                escaped_path
+            );
+            Command::new("powershell.exe")
+                .args([
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    &command,
+                ])
+                .spawn()
+                .expect("start PowerShell SoundPlayer")
+        }
     }
 
     #[test]

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -92,10 +92,23 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   prefers CPU decoder). It matches current correctness/perf evidence and is not yet
   generalized into a model-agnostic runtime tuning layer.
 - System-audio capture now has native smoke backends on macOS, Windows, and
-  Linux, but Windows remains all-system WASAPI loopback rather than per-process
-  capture, Linux depends on `pactl`/`parec` monitor-source capture, and
-  Windows/Linux real playback smoke still needs to be executed on those OS
-  sessions.
+  Linux. Windows additionally supports per-process loopback capture
+  (`run_process_loopback_capture`, via `AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK`)
+  alongside its existing all-system WASAPI loopback path; this requires
+  Windows 10 2004 (build 19041) or later and is capability-gated by
+  `process_loopback_support()`, which performs a real runtime activation
+  probe (not an OS-version heuristic, so it cannot be fooled by application
+  compatibility shims) and fails closed to "unsupported" on older systems.
+  `list_candidate_processes()` enumerates pid + executable name via a
+  Toolhelp32 snapshot for callers building a process picker. macOS and Linux
+  do not implement per-process capture yet -- both report it as `unsupported`
+  through the same capability probe rather than emulating it or silently
+  falling back to all-system capture; macOS keeps its Core Audio process-tap
+  all-system path and Linux keeps its `pactl`/`parec` monitor-source capture.
+  Windows real playback smoke (both all-system and per-process) has been
+  executed on a real Windows 11 session; Linux real playback smoke still
+  needs to be executed on a Linux session. Per-process capture has no desktop
+  UI wiring yet -- it is a library-level API only.
 - `serve` is single-model: it runs the one pack resolved at launch
   (`--model-pack` / an installed `--model`). There is no per-request lazy model
   loading or an `openasr ps`-style multi-model runner yet -- restart `serve` to

--- a/tooling/system-audio-check/Cargo.lock
+++ b/tooling/system-audio-check/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "objc2-foundation",
  "serde",
  "wasapi",
+ "windows",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add Windows per-process WASAPI loopback capture to `openasr-system-audio`: a new
`run_process_loopback_capture` entry point captures audio rendered by a single
target process (optionally including its child-process tree) instead of the
whole system, alongside the existing all-system loopback path.

## Why

The existing `run_loopback_capture` only supports all-system WASAPI loopback on
Windows. Per-process capture lets a future picker UI record just one
application's audio (e.g. a browser tab or meeting app) without mixing in the
rest of the system's sound.

## Changes

- `crates/openasr-system-audio/src/lib.rs`: new `ProcessLoopbackMode`,
  `ProcessLoopbackSupport`, `CandidateProcess` types and three public
  functions: `process_loopback_support()`, `list_candidate_processes()`,
  `run_process_loopback_capture()`.
- `crates/openasr-system-audio/src/windows.rs`:
  - `run_process_loopback_capture` using
    `AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK` (Windows 10 2004 / build
    19041+), via `wasapi::AudioClient::new_application_loopback_client`.
  - `process_loopback_support()` performs a real runtime activation probe
    (targeting this process's own PID, dropped immediately) rather than an
    OS-version heuristic, so it cannot be fooled by compatibility shims and
    fails closed on older systems.
  - `list_candidate_processes()` enumerates pid + executable name via a
    Toolhelp32 snapshot, which does not require per-process open rights.
  - `ensure_process_exists()` validates the target pid via `OpenProcess`
    before attempting activation, failing closed with a typed
    `process_not_found` error.
  - Extracted a shared `run_wasapi_loopback_session` helper so the existing
    all-system loopback path and the new per-process path share format
    negotiation, PCM16 mono 16k framing, discontinuity/silence diagnostics,
    and stream teardown; only client acquisition differs between the two.
- `crates/openasr-system-audio/src/macos.rs`, `linux.rs`, `stub.rs`: add the
  same three entry points as fail-closed `unsupported` stubs. No behavior
  change to existing all-system capture on those platforms.
- `crates/openasr-system-audio/Cargo.toml`: add the `windows` crate
  (`Win32_Foundation`, `Win32_System_Diagnostics_ToolHelp`,
  `Win32_System_Threading`) for process enumeration and existence checks; the
  loopback activation itself already goes through
  `wasapi::AudioClient::new_application_loopback_client`.
- `Cargo.lock`, `tooling/system-audio-check/Cargo.lock`: regenerated for the
  new `windows` dependency edge (one line each).
- `docs/KNOWN_LIMITATIONS.md`: document the new capability (Windows-only for
  now, capability-gated, no desktop UI wiring yet).

## Tests run

- [x] `cargo fmt --check` (scoped to `openasr-system-audio`) - clean
- [x] `cargo clippy -p openasr-system-audio --all-targets -- -D warnings` - no issues found
- [x] `cargo test -p openasr-system-audio` - 11 passed, 2 ignored (2 suites)
- [x] `cargo test -p openasr-system-audio --lib -- --ignored --nocapture` (real-machine smoke, see below)
- [x] `cargo test` in `tooling/system-audio-check` - 1 passed (`platform_support_contract_is_well_formed`)
- [ ] `cargo nextest run --workspace` / `cargo test --workspace --doc` / `cargo deny check` - not run repo-wide; this PR only touches `openasr-system-audio` and a standalone tooling crate, verification above is scoped to those

## Manual smoke checks

Ran the two `#[ignore]` real-hardware tests on a real Windows 11 session
(plays a local WAV via PowerShell `SoundPlayer` and captures it back):

```
Windows process-loopback smoke captured 33 frames, peak 11433
test windows::tests::windows_process_loopback_smoke_emits_non_silent_frames ... ok
Windows system-audio smoke captured 11 frames, peak 11631
test windows::tests::windows_wasapi_system_audio_smoke_emits_non_silent_frames ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out
```

Both the pre-existing all-system path and the new per-process path capture
non-silent audio end to end.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (`docs/KNOWN_LIMITATIONS.md`)
- [x] No docs overclaim current capabilities. (macOS/Linux explicitly documented as not implementing per-process capture yet; per-process capture explicitly documented as library-only with no desktop UI wiring)

## Scope / non-goals

- No desktop UI wiring for a process picker - this PR is a library-level API
  only (`process_loopback_support`, `list_candidate_processes`,
  `run_process_loopback_capture`).
- No macOS or Linux per-process implementation - both fail closed with
  `unsupported` through the same capability probe; macOS keeps its Core Audio
  process-tap all-system path and Linux keeps its `pactl`/`parec`
  monitor-source capture.
- Requires Windows 10 2004 (build 19041) or later; older Windows reports
  `unsupported` via `process_loopback_support()`.
- Not verified on Windows versions older than 2004 or on Windows Server SKUs
  in this PR - only tested on a current Windows 11 session.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implementation and this PR description were produced with AI assistance (Claude Code), reviewed and submitted by the maintainer.
