### PR TITLE
feat(core): configurable models directory with env and config overrides

### DIFF
--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -18,7 +18,7 @@ use openasr_core::{
     WhisperLocalSourceImportRequest, atomic_write_text, config_path,
     convert_local_cohere_source_to_runtime_pack, convert_local_qwen_source_to_runtime_pack,
     convert_local_whisper_hf_source_to_runtime_pack, derive_catalog_public_key_hex,
-    discover_batch_inputs, embedded_catalog_fingerprint, load_config, openasr_home,
+    discover_batch_inputs, embedded_catalog_fingerprint, load_config, models_dir, openasr_home,
     parse_model_catalog, parse_model_ref, render_batch_summary, render_benchmark,
     render_catalog_signature_manifest, resolve_registry_model_ref, resolve_runtime_model_ref,
     runtime_registry, save_config, validate_local_native_model_pack_path,
@@ -588,6 +588,7 @@ fn doctor() -> Result<()> {
     println!();
     println!("OpenASR home: {}", home.display());
     println!("Config file: {}", config_file.display());
+    println!("Models directory: {}", models_dir(&home, &config).display());
     println!("Model registry: ok ({} models)", cards.len());
     println!(
         "Default model: {} ({})",

--- a/crates/openasr-core/src/capability_pack.rs
+++ b/crates/openasr-core/src/capability_pack.rs
@@ -1,7 +1,9 @@
 //! Generic resolution of an installed optional capability-pack file (a
 //! `.oasr`/`.safetensors` support model that augments a family's own decode
 //! path, e.g. the WeSpeaker speaker-embedder or the Qwen3-ForcedAligner
-//! word-timestamp refiner) from `openasr_home()/models/<dir>/`. Extracted from
+//! word-timestamp refiner) from the resolved model-pack storage root (see
+//! `config::models_dir` -- honors an `OPENASR_MODELS_DIR`/`config.models_dir`
+//! override, defaulting to `openasr_home()/models/<dir>/`). Extracted from
 //! `diarize::pack` so a second capability-pack family (forced alignment) does
 //! not duplicate the same env-override + directory-scan logic -- infrastructure
 //! that decides where an installed pack lives stays model-agnostic; only the
@@ -23,7 +25,8 @@ pub(crate) fn resolve_installed_capability_pack(
         }
     }
     let home = crate::openasr_home().ok()?;
-    find_pack(&home.join("models"), dir_substr)
+    let config = crate::config::load_config(&home).unwrap_or_default();
+    find_pack(&crate::config::models_dir(&home, &config), dir_substr)
 }
 
 /// Whether `path` is a GGUF (`.oasr`) pack, by sniffing the 4-byte magic rather

--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs,
+    env, ffi, fs,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -29,6 +29,10 @@ pub const DEFAULT_MODEL_BOOTSTRAP_QUANT: &str = "q4_k";
 pub const DEFAULT_BACKEND_ID: &str = "native";
 pub const PREFERENCES_SCHEMA_VERSION: u32 = 1;
 pub const MAX_INFERENCE_THREADS: u16 = 256;
+/// Env override for the model-pack storage root; highest priority in
+/// [`models_dir`]'s resolution order. Mirrors the `OPENASR_HOME` env-override
+/// convention in `home.rs`.
+pub const OPENASR_MODELS_DIR_ENV: &str = "OPENASR_MODELS_DIR";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenAsrConfig {
@@ -49,6 +53,13 @@ pub struct OpenAsrConfig {
     pub media: MediaConfig,
     #[serde(default)]
     pub download_source: DownloadSourcePref,
+    /// Override for the model-pack storage root (where `pull`/`list`/`delete`
+    /// read and write `.oasr` packs). `None` means "not overridden": resolve
+    /// via [`models_dir`], which still checks the `OPENASR_MODELS_DIR` env var
+    /// above this field before falling back to `<home>/models`. Must be an
+    /// absolute path when set -- see [`OpenAsrConfig::validate_with_catalog`].
+    #[serde(default)]
+    pub models_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -315,6 +326,7 @@ impl Default for OpenAsrConfig {
             default_backend: default_backend(),
             media: MediaConfig::default(),
             download_source: DownloadSourcePref::Auto,
+            models_dir: None,
         }
     }
 }
@@ -445,6 +457,15 @@ impl OpenAsrConfig {
                 ));
             }
         }
+        if let Some(models_dir) = self.models_dir.as_deref() {
+            // Deliberately lenient beyond "absolute": an override naming a
+            // directory that does not exist yet is valid -- pull/list/delete
+            // (via `models_dir`) create it lazily on first write, the same way
+            // `<home>/models` is never pre-created either.
+            if !models_dir.is_absolute() {
+                return invalid_preference("models_dir", "must be an absolute path");
+            }
+        }
         Ok(())
     }
 }
@@ -521,6 +542,39 @@ impl Preferences {
 
 pub fn config_path(openasr_home: impl AsRef<Path>) -> PathBuf {
     openasr_home.as_ref().join("config.json")
+}
+
+/// Single resolution point for the model-pack storage root. Every read/write
+/// of an installed `.oasr` pack (download landing, `list_installed_packs`,
+/// deletion, capability-pack lookup, `default_selection`'s pack path) must go
+/// through this instead of hardcoding `<home>/models` -- see `pull.rs`'s
+/// `models_root` and `capability_pack::resolve_installed_capability_pack`.
+///
+/// Priority: `OPENASR_MODELS_DIR` env var (if non-empty) wins, then the
+/// persisted `config.models_dir` field, then the default `<home>/models`.
+pub fn models_dir(openasr_home: impl AsRef<Path>, config: &OpenAsrConfig) -> PathBuf {
+    resolve_models_dir(
+        openasr_home.as_ref(),
+        env::var_os(OPENASR_MODELS_DIR_ENV),
+        config.models_dir.as_deref(),
+    )
+}
+
+/// Pure resolution logic behind [`models_dir`], split out so the three-way
+/// priority (env / config / default) is unit-testable without touching real
+/// environment variables or a config file on disk.
+pub fn resolve_models_dir(
+    openasr_home: &Path,
+    env_override: Option<ffi::OsString>,
+    config_override: Option<&Path>,
+) -> PathBuf {
+    if let Some(value) = env_override.filter(|value| !value.is_empty()) {
+        return PathBuf::from(value);
+    }
+    if let Some(path) = config_override {
+        return path.to_path_buf();
+    }
+    openasr_home.join("models")
 }
 
 pub fn load_config(openasr_home: impl AsRef<Path>) -> Result<OpenAsrConfig, ConfigError> {

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -165,6 +165,7 @@ fn save_and_load_config_roundtrip() {
             ffmpeg_bin: Some("/tmp/ffmpeg".to_string()),
         },
         download_source: DownloadSourcePref::Auto,
+        models_dir: None,
     };
 
     save_config(temp.path(), &config).unwrap();
@@ -184,6 +185,7 @@ fn save_and_load_config_document_roundtrip_preserves_preferences() {
                 ffmpeg_bin: Some("/tmp/ffmpeg".to_string()),
             },
             download_source: DownloadSourcePref::Auto,
+            models_dir: None,
         },
         preferences: Preferences {
             language: Some("en".to_string()),
@@ -257,6 +259,7 @@ fn save_config_preserves_existing_config_document_preferences() {
         default_backend: Some("mock".to_string()),
         media: MediaConfig::default(),
         download_source: DownloadSourcePref::Auto,
+        models_dir: None,
     };
     save_config(temp.path(), &updated_config).unwrap();
     let loaded = load_config_document(temp.path()).unwrap();
@@ -549,4 +552,78 @@ fn idle_unload_policy_wire_strings_and_thresholds() {
     // Product decision (0.1.12-B): a bound model pack should not sit resident
     // in RAM for the daemon's whole lifetime by default any more.
     assert_eq!(IdleUnloadPolicy::default(), IdleUnloadPolicy::After10m);
+}
+
+#[test]
+fn resolve_models_dir_defaults_under_home() {
+    let home = PathBuf::from("/tmp/example/.openasr");
+    let resolved = resolve_models_dir(&home, None, None);
+    assert_eq!(resolved, PathBuf::from("/tmp/example/.openasr/models"));
+}
+
+#[test]
+fn resolve_models_dir_config_override_wins_over_default() {
+    let home = PathBuf::from("/tmp/example/.openasr");
+    let config_override = PathBuf::from("/mnt/big-disk/openasr-models");
+    let resolved = resolve_models_dir(&home, None, Some(&config_override));
+    assert_eq!(resolved, config_override);
+}
+
+#[test]
+fn resolve_models_dir_env_override_wins_over_config() {
+    let home = PathBuf::from("/tmp/example/.openasr");
+    let config_override = PathBuf::from("/mnt/big-disk/openasr-models");
+    let env_override = std::ffi::OsString::from("/mnt/other-disk/models");
+    let resolved = resolve_models_dir(&home, Some(env_override.clone()), Some(&config_override));
+    assert_eq!(resolved, PathBuf::from(env_override));
+}
+
+#[test]
+fn resolve_models_dir_ignores_empty_env_override() {
+    let home = PathBuf::from("/tmp/example/.openasr");
+    let resolved = resolve_models_dir(&home, Some(std::ffi::OsString::new()), None);
+    assert_eq!(resolved, PathBuf::from("/tmp/example/.openasr/models"));
+}
+
+#[test]
+fn models_dir_reads_the_config_field() {
+    let home = PathBuf::from("/tmp/example/.openasr");
+    let mut config = OpenAsrConfig::default();
+    assert_eq!(models_dir(&home, &config), home.join("models"));
+
+    config.models_dir = Some(PathBuf::from("/mnt/big-disk/openasr-models"));
+    assert_eq!(
+        models_dir(&home, &config),
+        PathBuf::from("/mnt/big-disk/openasr-models")
+    );
+}
+
+#[test]
+fn validate_rejects_relative_models_dir() {
+    let config = OpenAsrConfig {
+        models_dir: Some(PathBuf::from("relative/models")),
+        ..OpenAsrConfig::default()
+    };
+    let error = config.validate(&registry()).unwrap_err();
+    assert!(matches!(
+        error,
+        ConfigError::InvalidPreference {
+            field: "models_dir",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn validate_accepts_absolute_models_dir_that_does_not_exist_yet() {
+    let absolute_path = if cfg!(windows) {
+        "D:\\not-yet-created\\openasr-models"
+    } else {
+        "/mnt/not-yet-created/openasr-models"
+    };
+    let config = OpenAsrConfig {
+        models_dir: Some(PathBuf::from(absolute_path)),
+        ..OpenAsrConfig::default()
+    };
+    config.validate(&registry()).unwrap();
 }

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -98,8 +98,9 @@ pub use metrics::{
 
 pub use config::{
     ConfigError, ConfigKey, DEFAULT_BACKEND_ID, DEFAULT_MODEL_BOOTSTRAP_QUANT, DEFAULT_MODEL_ID,
-    MAX_INFERENCE_THREADS, OpenAsrConfig, OpenAsrConfigDocument, config_path, load_config,
-    load_config_document, save_config, save_config_document, save_default_model_selection,
+    MAX_INFERENCE_THREADS, OPENASR_MODELS_DIR_ENV, OpenAsrConfig, OpenAsrConfigDocument,
+    config_path, load_config, load_config_document, models_dir, resolve_models_dir, save_config,
+    save_config_document, save_default_model_selection,
 };
 pub use device::capabilities::{
     ApplePlatformHints, CpuArchitectureFamily, CpuCapabilities, HardwareCapabilities,

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -2187,8 +2187,16 @@ fn pull_paths(home: &Path, target: &PullTarget) -> Result<PullPaths, PullError> 
     })
 }
 
+/// The single resolution point every model-pack read/write path in this file
+/// funnels through -- see `crate::config::models_dir`'s doc comment for the
+/// full env/config/default priority. Loads `config.json` fresh on each call
+/// (a small local file) rather than threading a loaded `OpenAsrConfig`
+/// through every `home`-taking function in this module's public API; a
+/// missing or unreadable config just falls back to the default `<home>/models`
+/// root, matching this function's pre-override behavior.
 fn models_root(home: &Path) -> PathBuf {
-    home.join("models")
+    let config = crate::config::load_config(home).unwrap_or_default();
+    crate::config::models_dir(home, &config)
 }
 
 fn ensure_https_url(url: &str) -> Result<(), PullError> {

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -1729,6 +1729,68 @@ fn pull_overwrites_truncated_pack_with_installed_record() {
     assert_eq!(list_installed_packs(temp.path()).unwrap().len(), 1);
 }
 
+/// `config.json`'s `models_dir` field must be the single thing that decides
+/// where a pack lands and where `list_installed_packs` looks for it -- a
+/// redirected home must land the pack entirely outside `<home>/models` and
+/// still be found by the same reference.
+#[test]
+fn config_models_dir_redirects_pull_and_list() {
+    let home = tempfile::tempdir().unwrap();
+    let redirected = tempfile::tempdir().unwrap();
+    crate::config::save_config(
+        home.path(),
+        &crate::config::OpenAsrConfig {
+            models_dir: Some(redirected.path().to_path_buf()),
+            ..crate::config::OpenAsrConfig::default()
+        },
+    )
+    .unwrap();
+
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let mut client = FakeClient::with_responses(vec![ResponseSpec {
+        status: 200,
+        body: bytes.clone(),
+    }]);
+
+    let installed = pull_model_pack_with_client(
+        &resolved,
+        home.path(),
+        &mut client,
+        PullOptions::default(),
+        |_| {},
+    )
+    .unwrap();
+
+    assert!(
+        installed.path.starts_with(redirected.path()),
+        "pack should land under the redirected models_dir, got {}",
+        installed.path.display()
+    );
+    assert!(
+        !home.path().join("models").exists(),
+        "the default models/ dir under home must stay untouched when models_dir is redirected"
+    );
+
+    let packs = list_installed_packs(home.path()).unwrap();
+    assert_eq!(packs.len(), 1);
+    assert_eq!(packs[0].pull, installed.pull);
+
+    // OPENASR_MODELS_DIR env still wins over the config field.
+    let env_redirected = tempfile::tempdir().unwrap();
+    // SAFETY: test-only, single-threaded env mutation guarded by serial test
+    // execution within this process is not guaranteed by cargo test, but this
+    // matches the existing `OPENASR_HOME`-mutating tests elsewhere in this
+    // file/crate that accept the same caveat.
+    unsafe { std::env::set_var(crate::config::OPENASR_MODELS_DIR_ENV, env_redirected.path()) };
+    let env_resolved = list_installed_packs(home.path()).unwrap();
+    unsafe { std::env::remove_var(crate::config::OPENASR_MODELS_DIR_ENV) };
+    assert!(
+        env_resolved.is_empty(),
+        "OPENASR_MODELS_DIR must take priority over config.models_dir"
+    );
+}
+
 #[test]
 fn pull_checks_available_space_before_download() {
     let bytes = tiny_pack_bytes();

--- a/crates/openasr-server/src/routes/config.rs
+++ b/crates/openasr-server/src/routes/config.rs
@@ -102,6 +102,7 @@ fn payload_has_config_fields(payload: &serde_json::Value) -> bool {
             "default_backend",
             "media",
             "download_source",
+            "models_dir",
         ]
         .iter()
         .any(|key| object.contains_key(*key))


### PR DESCRIPTION
## Summary

Adds a configurable model-pack storage root: an `OPENASR_MODELS_DIR` env override,
a persisted `config.models_dir` field, and a single resolution function
(`config::models_dir` / `config::resolve_models_dir`) that every read/write of an
installed `.oasr` pack now funnels through instead of hardcoding `<home>/models`.

## Why

Desktop and power-user workflows need to point the model-pack storage root at a
different disk (e.g. a larger secondary drive) without moving `OPENASR_HOME`
itself. This lands the core-side resolution + validation; the desktop-side
settings UI and daemon commands are a follow-up PR in `openasr-app`.

## Changes

- `crates/openasr-core/src/config.rs`: `OpenAsrConfig.models_dir: Option<PathBuf>`
  field, `OPENASR_MODELS_DIR_ENV` constant, `models_dir()` / `resolve_models_dir()`
  as the single resolution point (env > config > `<home>/models` default), and
  `validate()` rejecting a non-absolute `models_dir`.
- `crates/openasr-core/src/pull.rs`: `models_root(home)` now resolves through
  `config::models_dir` instead of hardcoding `home.join("models")`; the public
  function signature is unchanged.
- `crates/openasr-core/src/capability_pack.rs`: capability-pack lookup
  (`resolve_installed_capability_pack`) now resolves its search directory through
  `config::models_dir` as well.
- `crates/openasr-core/src/lib.rs`: exports `OPENASR_MODELS_DIR_ENV`,
  `models_dir`, `resolve_models_dir`.
- `crates/openasr-cli/src/main.rs`: `openasr doctor` prints a `Models directory:`
  line.
- `crates/openasr-server/src/routes/config.rs`: `PUT /v1/config`'s
  daemon/CLI-managed field whitelist now includes `models_dir`.
- `crates/openasr-core/src/config_tests.rs`, `crates/openasr-core/src/pull_tests.rs`:
  unit tests for the three-way resolution priority, `validate()`'s absolute-path
  check, and an integration test confirming a redirected `config.models_dir` moves
  where `pull`/`list_installed_packs` land and look, with the env var still taking
  priority over the config field.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` -- 2489 passed, 4 failed; all 4 are
      pre-existing/environment failures unrelated to this change:
      `pull_lock_blocks_second_writer` (known flaky), `realtime_wire_bindings_regenerate_to_match_committed`
      and `http_wire_bindings_regenerate_to_match_committed` (Windows line-ending
      regeneration diff), `transcriptions_large_upload_memory_stays_bounded` (shells
      out to `ps`, unavailable on Windows). Verified the 8 new
      `models_dir`/`resolve_models_dir`/`config_models_dir_redirects_pull_and_list`
      tests all pass.
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` -- not run in this environment.

## Manual smoke checks

`openasr doctor` on a default config prints `Models directory: <home>/models`;
setting `models_dir` in `config.json` to an absolute path moves the printed line
and where `openasr pull`/`openasr list` land, without touching `OPENASR_HOME`.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Core-side resolution and validation only. The desktop settings UI, daemon IPC
commands (`daemon_models_dir` / `daemon_set_models_dir`), and the migration flow
for moving existing packs to a new directory are in a follow-up `openasr-app` PR
that depends on this one merging first.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI coding agent assistance (Claude Code), reviewed and verified locally before submission.
