### PR TITLE
feat(release): signed Windows backend kernels and switch manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           python3 -m unittest discover -s tooling/native-streaming-smoke -p 'test_*.py'
           python3 -m unittest discover -s tooling/public-hf-e2e -p 'test_*.py'
           python3 -m unittest discover -s tooling/family-regression -p 'test_*.py'
+          python3 -m unittest discover -s tooling/release-manifest -p '*_test.py'
       - run: cargo clippy --all-targets -- -D warnings
       - name: Install cbindgen
         run: cargo install cbindgen --locked

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -677,9 +677,13 @@ jobs:
           cp docs/FAQ.md docs/KNOWN_LIMITATIONS.md "$dist_dir/docs/"
           tar -czf "dist/${archive}.${{ matrix.archive_ext }}" -C dist "${archive}"
 
-      - name: Package archive
+      - name: Stage archive contents
         if: runner.os == 'Windows' && env.LEG_SELECTED == 'true'
         shell: pwsh
+        # Split out of the old single "Package archive" step so Authenticode
+        # signing (below) can run on the staged, unzipped files -- signing
+        # has to happen before Compress-Archive, not after, or the exe/dll
+        # bytes inside the shipped zip would stay unsigned.
         run: |
           $ErrorActionPreference = "Stop"
           $archive = "openasr-$env:OPENASR_VERSION-${{ matrix.asset }}"
@@ -727,17 +731,104 @@ jobs:
           Copy-Item README.md,LICENSE "$distDir\"
           Copy-Item model-registry "$distDir\model-registry" -Recurse
           Copy-Item docs\FAQ.md,docs\KNOWN_LIMITATIONS.md "$distDir\docs\"
+          Add-Content $env:GITHUB_ENV "DIST_DIR=$distDir"
+          Add-Content $env:GITHUB_ENV "ARCHIVE_NAME=$archive"
+
+      - name: Resolve Windows binaries to sign
+        if: runner.os == 'Windows' && env.LEG_SELECTED == 'true'
+        shell: pwsh
+        # Only files we actually build ourselves: openasr.exe, plus the CPU
+        # leg's own ggml*.dll (compiled from the vendored submodule by this
+        # same job, not a third-party redistributable). Deliberately excludes
+        # the vendor GPU runtime DLLs staged above (NVIDIA cudart64_*/
+        # cublas64_*/cublasLt64_*, AMD amdhip64_*/libhipblas_*/rocblas_*/
+        # libhipblaslt_*) -- those already carry NVIDIA's/AMD's own
+        # Authenticode signatures and are not ours to re-sign.
+        run: |
+          $ErrorActionPreference = "Stop"
+          $signTargets = @((Resolve-Path "$env:DIST_DIR\${{ matrix.binary_name }}").Path)
+          $ggmlDlls = Get-ChildItem "$env:DIST_DIR" -Filter "ggml*.dll" -ErrorAction SilentlyContinue
+          if ($ggmlDlls) { $signTargets += $ggmlDlls.FullName }
+          Write-Host "files to sign ($($signTargets.Count)):"
+          $signTargets | ForEach-Object { Write-Host " - $_" }
+          Add-Content $env:GITHUB_ENV "SIGN_FILES<<SIGN_FILES_EOF"
+          Add-Content $env:GITHUB_ENV ($signTargets -join "`n")
+          Add-Content $env:GITHUB_ENV "SIGN_FILES_EOF"
+
+      - name: Check Trusted Signing credentials
+        if: runner.os == 'Windows' && env.LEG_SELECTED == 'true'
+        id: signing-check
+        shell: bash
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        # This workflow has no `pull_request` trigger (see the trigger
+        # comment at the top of this file), so a fork PR never reaches this
+        # job with -- or without -- secrets. Every run that gets here is a
+        # real tag push, release-core.yml's workflow_call, or a maintainer's
+        # workflow_dispatch, all of which do have repo secrets. The only
+        # legitimate no-secrets case is a maintainer smoke-testing build/
+        # package logic via workflow_dispatch with dry_run=true before the
+        # Azure Trusted Signing secrets are configured -- see the fail-closed
+        # step below.
+        run: |
+          set -euo pipefail
+          if [ -n "${AZURE_TENANT_ID:-}" ] && [ -n "${AZURE_CLIENT_ID:-}" ] && [ -n "${AZURE_CLIENT_SECRET:-}" ]; then
+            echo "have_secrets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_secrets=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Refuse to ship an unsigned Windows release binary
+        if: runner.os == 'Windows' && env.LEG_SELECTED == 'true' && steps.signing-check.outputs.have_secrets != 'true' && github.event.inputs.dry_run != 'true'
+        shell: bash
+        run: |
+          echo "::error::AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET are not set -- refusing to package an unsigned Windows release binary. Configure the Azure Trusted Signing service principal secrets (see openasr-app's apps/desktop/SIGNING-WINDOWS.md for the account/profile this reuses), or re-run this workflow_dispatch with dry_run=true to build without signing for local debugging only." >&2
+          exit 1
+
+      # Azure Trusted Signing (Artifact Signing): same account/certificate
+      # profile as the OpenASR Desktop Windows installer (openasr-sign /
+      # openasr-codesign, publisher "Caelum Inc.") -- see openasr-app's
+      # apps/desktop/SIGNING-WINDOWS.md for the account itself. The service
+      # principal behind these secrets needs the "Artifact Signing
+      # Certificate Profile Signer" role on that account (see this repo's
+      # docs/RELEASING.md); it may be a different App Registration than the
+      # desktop repo's, but must be granted the same role on the same
+      # account/profile.
+      - name: Sign Windows binaries (Azure Trusted Signing)
+        if: runner.os == 'Windows' && env.LEG_SELECTED == 'true' && steps.signing-check.outputs.have_secrets == 'true'
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net/
+          trusted-signing-account-name: openasr-sign
+          certificate-profile-name: openasr-codesign
+          files: ${{ env.SIGN_FILES }}
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Package archive
+        if: runner.os == 'Windows' && env.LEG_SELECTED == 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
           # Smoke the binary from the staged dist dir (NOT target/release,
           # whose build.rs-seeded DLLs would mask a packaging gap), so a broken
           # archive fails here before it ships. The CUDA/HIP exes cannot
           # launch without a matching GPU driver, so they are exempt
           # (validated on hardware). A cross leg (rust_target set) builds a
           # foreign-arch exe the runner cannot execute, so it is exempt too.
+          # Running this AFTER signing also verifies signing did not corrupt
+          # the binary.
           if ("${{ matrix.features }}" -ne "cuda" -and "${{ matrix.features }}" -ne "hip" -and "${{ matrix.rust_target }}" -eq "") {
-            & "$distDir\${{ matrix.binary_name }}" --version
+            & "$env:DIST_DIR\${{ matrix.binary_name }}" --version
             if ($LASTEXITCODE -ne 0) { exit 1 }
           }
-          Compress-Archive -Path "$distDir" -DestinationPath "dist\$archive.${{ matrix.archive_ext }}" -Force
+          Compress-Archive -Path "$env:DIST_DIR" -DestinationPath "dist\$env:ARCHIVE_NAME.${{ matrix.archive_ext }}" -Force
 
       # Covers every leg that reaches this point, including `experimental:
       # true` ones (windows-arm64, musl) -- they still ship a release asset,
@@ -846,6 +937,16 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
+      # Checked out FIRST, before anything is downloaded/generated into the
+      # workspace: actions/checkout defaults to `clean: true` (`git clean
+      # -ffdx`), which would otherwise wipe the untracked staging/dist
+      # directories the later steps populate. Only needed for the
+      # backends-manifest step below (version + source commit), but harmless
+      # for every other run, so it stays unconditional here rather than
+      # threading the `only_target` skip condition through step ordering.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Download archives
         uses: actions/download-artifact@v8
         with:
@@ -864,6 +965,41 @@ jobs:
         with:
           name: SHA256SUMS
           path: dist/SHA256SUMS
+          if-no-files-found: error
+
+      # UNSIGNED backends-manifest.json: the per-release index the desktop
+      # app uses to download a switchable Windows GPU-kernel sidecar
+      # (vulkan/cuda/hip) at runtime. Only hashes/sizes already-public
+      # archives -- no secret involved, so (unlike signing) this is safe to
+      # run in CI. Skipped on a single-leg `only_target` dispatch (same gate
+      # `verify-completeness` uses below): that run intentionally produces
+      # only one archive, not the full Windows GPU trio this needs.
+      - name: Generate backends-manifest.json (unsigned)
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.only_target == ''
+        run: |
+          set -euo pipefail
+          version="$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+          commit="$(git rev-parse HEAD)"
+          python3 tooling/release-manifest/backends_manifest.py generate \
+            --version "$version" --source-commit "$commit" \
+            --dist-dir dist --out dist/backends-manifest.json
+          cat dist/backends-manifest.json
+      # NOT uploaded pre-signed: `backends-manifest.signature.json` is a
+      # separate, maintainer-run LOCAL step (the Ed25519 signing seed never
+      # enters CI -- same policy as the model catalog, see
+      # tooling/publish-model/scripts/publish_catalog.sh). After this
+      # workflow finishes, sign and attach the signature with:
+      #   OPENASR_CATALOG_SIGNING_KEY_SEED_HEX=<real seed> \
+      #     cargo run -p openasr-cli -- __openasr-sign-backends-manifest \
+      #       backends-manifest.json --out backends-manifest.signature.json \
+      #       --manifest-url https://dl.openasr.org/core/v<version>/backends-manifest.json
+      #   gh release upload v<version> backends-manifest.signature.json --clobber
+      - name: Upload backends-manifest.json
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.only_target == ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: backends-manifest
+          path: dist/backends-manifest.json
           if-no-files-found: error
 
   upload-to-release:
@@ -921,7 +1057,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "release: ${{ steps.tag.outputs.tag }}"
-          find staging -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' -o -name 'SHA256SUMS' \) -print | sort
+          find staging -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' -o -name 'SHA256SUMS' -o -name 'backends-manifest.json' \) -print | sort
 
       - name: Upload assets to release
         if: steps.tag.outputs.tag != '' && github.event.inputs.dry_run != 'true'
@@ -935,10 +1071,11 @@ jobs:
             exit 1
           fi
           # nullglob so a pattern with no matches (e.g. no *.sha256 sidecars
-          # if the xcframework leg did not run) drops out of the arg list
+          # if the xcframework leg did not run, or no backends-manifest.json
+          # on a single-leg `only_target` dispatch) drops out of the arg list
           # instead of being passed to `gh` as a literal, unmatched path.
           shopt -s nullglob
-          assets=(staging/*.tar.gz staging/*.zip staging/*.sha256 staging/SHA256SUMS)
+          assets=(staging/*.tar.gz staging/*.zip staging/*.sha256 staging/SHA256SUMS staging/backends-manifest.json)
           # --clobber so a re-run (retrying a flaky leg) replaces stale assets
           # instead of failing on "asset already exists".
           gh release upload "$tag" "${assets[@]}" \

--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -272,6 +272,33 @@ pub(crate) enum Command {
     /// embedded catalog matches a copied catalog resource.
     #[command(name = "catalog-fingerprint", hide = true)]
     CatalogFingerprint,
+    /// Internal helper: sign a release `backends-manifest.json` (the
+    /// per-release index of downloadable Windows GPU-kernel sidecars) with
+    /// the SAME production signing key and trust root as the model catalog.
+    /// Signing stays local -- run this with
+    /// `OPENASR_CATALOG_SIGNING_KEY_SEED_HEX` set to the real production
+    /// seed, never in CI. See
+    /// `tooling/release-manifest/backends_manifest.py` for generating the
+    /// unsigned manifest this command signs.
+    #[command(name = "__openasr-sign-backends-manifest", hide = true)]
+    SignBackendsManifest {
+        /// backends-manifest.json file to sign.
+        manifest: PathBuf,
+        /// Output backends-manifest.signature.json path.
+        #[arg(long)]
+        out: PathBuf,
+        /// The canonical URL this manifest will be served from, e.g.
+        /// `https://dl.openasr.org/core/v0.1.10/backends-manifest.json`.
+        #[arg(long)]
+        manifest_url: String,
+        /// Signature key id. Defaults to the production catalog key id
+        /// (`openasr-catalog-v1`) -- this manifest has no local-dev key.
+        #[arg(long, default_value = "openasr-catalog-v1")]
+        key_id: String,
+        /// Print the derived public key for the env signing seed and exit.
+        #[arg(long)]
+        print_public_key: bool,
+    },
     /// Transcribe one or more audio files (or directories of audio).
     #[command(visible_alias = "t")]
     Transcribe {

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -1613,4 +1613,62 @@ mod tests {
         assert!(language_mode_label(Some(FixedMultilingual)).starts_with("fixed_multilingual"));
         assert_eq!(language_mode_label(None), "unspecified");
     }
+
+    /// Desktop-sidecar contract: `apps/desktop/src-tauri/src/sidecar.rs` spawns
+    /// this binary as `openasr serve --backend native --parent-pid <pid> ...`
+    /// (see `openasr-app` `sidecar.rs`'s `Command::new(..).args([...])`). Both
+    /// flags are `hide = true` in `cli_args.rs` because they are launch-detail
+    /// only, never meant for interactive use -- but "hidden from `--help`" must
+    /// never come to mean "safe to rename or remove". This test locks the two
+    /// flags' presence and shape (long names, hyphenated `--parent-pid`, an
+    /// accepted `native`/`mock` value for `--backend`, a `u32` for
+    /// `--parent-pid`) so a future "clean up hidden flags" pass fails CI here
+    /// instead of silently breaking every desktop build's ability to launch and
+    /// supervise its sidecar.
+    #[test]
+    fn serve_accepts_desktop_sidecar_contract_flags() {
+        let cli = Cli::try_parse_from([
+            "openasr",
+            "serve",
+            "--backend",
+            "native",
+            "--parent-pid",
+            "4321",
+        ])
+        .expect("serve must keep accepting --backend and --parent-pid for the desktop sidecar");
+
+        let Command::Serve {
+            backend,
+            parent_pid,
+            ..
+        } = cli.command
+        else {
+            panic!("expected serve command");
+        };
+
+        assert_eq!(backend, Some(BackendKind::Native));
+        assert_eq!(parent_pid, Some(4321));
+    }
+
+    #[test]
+    fn serve_still_works_without_the_desktop_sidecar_flags() {
+        // Both flags are optional launch details for interactive/manual use
+        // (e.g. `openasr serve` from a terminal); they must stay optional so
+        // this contract test only pins their *presence and shape*, not that
+        // every caller supplies them.
+        let cli = Cli::try_parse_from(["openasr", "serve"])
+            .expect("serve must remain usable without the desktop-only flags");
+
+        let Command::Serve {
+            backend,
+            parent_pid,
+            ..
+        } = cli.command
+        else {
+            panic!("expected serve command");
+        };
+
+        assert_eq!(backend, None);
+        assert_eq!(parent_pid, None);
+    }
 }

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -19,10 +19,11 @@ use openasr_core::{
     convert_local_cohere_source_to_runtime_pack, convert_local_qwen_source_to_runtime_pack,
     convert_local_whisper_hf_source_to_runtime_pack, derive_catalog_public_key_hex,
     discover_batch_inputs, embedded_catalog_fingerprint, load_config, models_dir, openasr_home,
-    parse_model_catalog, parse_model_ref, render_batch_summary, render_benchmark,
-    render_catalog_signature_manifest, resolve_registry_model_ref, resolve_runtime_model_ref,
-    runtime_registry, save_config, validate_local_native_model_pack_path,
-    verify_catalog_signature_manifest, verify_local_catalog_signature_manifest,
+    parse_model_catalog, parse_model_ref, render_backends_manifest_signature, render_batch_summary,
+    render_benchmark, render_catalog_signature_manifest, resolve_registry_model_ref,
+    resolve_runtime_model_ref, runtime_registry, save_config,
+    validate_local_native_model_pack_path, verify_catalog_signature_manifest,
+    verify_local_catalog_signature_manifest,
 };
 
 mod bench_suite_cli;
@@ -177,6 +178,19 @@ async fn run() -> Result<()> {
             print_public_key,
         ),
         Command::CatalogFingerprint => catalog_fingerprint_command(),
+        Command::SignBackendsManifest {
+            manifest,
+            out,
+            manifest_url,
+            key_id,
+            print_public_key,
+        } => sign_backends_manifest_command(
+            &manifest,
+            &out,
+            &manifest_url,
+            &key_id,
+            print_public_key,
+        ),
         Command::Transcribe {
             inputs,
             formats,
@@ -536,6 +550,64 @@ fn sign_catalog_manifest_command(
         )
     })?;
     println!("Wrote catalog signature manifest: {}", out.display());
+    Ok(())
+}
+
+fn sign_backends_manifest_command(
+    manifest: &Path,
+    out: &Path,
+    manifest_url: &str,
+    key_id: &str,
+    print_public_key: bool,
+) -> Result<()> {
+    // Deliberately the SAME env var (and therefore the SAME signing seed) as
+    // `sign_catalog_manifest_command` -- see backends_manifest_security's
+    // module doc for why this manifest reuses the catalog's key/trust root
+    // instead of minting a second one.
+    let signing_key_seed_hex =
+        env::var(OPENASR_CATALOG_SIGNING_KEY_SEED_HEX).with_context(|| {
+            format!(
+                "{OPENASR_CATALOG_SIGNING_KEY_SEED_HEX} must be set to a 32-byte hex Ed25519 seed"
+            )
+        })?;
+
+    if print_public_key {
+        let public_key = derive_catalog_public_key_hex(&signing_key_seed_hex)
+            .context("Could not derive backends-manifest signature public key")?;
+        println!("{public_key}");
+        return Ok(());
+    }
+
+    let manifest_contents = fs::read_to_string(manifest).with_context(|| {
+        format!(
+            "Could not read backends-manifest JSON '{}'",
+            manifest.display()
+        )
+    })?;
+
+    let signature = render_backends_manifest_signature(
+        &manifest_contents,
+        manifest_url,
+        key_id,
+        &signing_key_seed_hex,
+    )
+    .context("Could not render backends-manifest signature")?;
+    openasr_core::verify_backends_manifest_signature(&manifest_contents, &signature, manifest_url)
+        .context(
+            "Rendered backends-manifest signature did not verify against the production trust root",
+        )?;
+
+    if let Some(parent) = out.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Could not create output directory '{}'", parent.display()))?;
+    }
+    atomic_write_text(out, &signature).with_context(|| {
+        format!(
+            "Could not write backends-manifest signature '{}'",
+            out.display()
+        )
+    })?;
+    println!("Wrote backends-manifest signature: {}", out.display());
     Ok(())
 }
 

--- a/crates/openasr-core/src/backend_manifest.rs
+++ b/crates/openasr-core/src/backend_manifest.rs
@@ -1,24 +1,36 @@
-//! Verification for the desktop app's **inference kernel** manifest
-//! (`backends-manifest.json` + `backends-manifest.signature.json`).
+//! Schema parsing + verified-fetch entry point for the desktop app's
+//! **inference kernel** manifest (`backends-manifest.json` +
+//! `backends-manifest.signature.json`).
 //!
-//! This is a SEPARATE concept from [`crate::pull::install_backend_pack`] (which
-//! downloads dynamically-loaded ggml backend *plugins* into a running daemon).
-//! The manifest verified here instead describes prebuilt, statically-linked
-//! `openasr-cli` release archives -- desktop swaps its whole sidecar binary
-//! (vulkan/cuda/hip) rather than loading a plugin into one. See
-//! `docs/backend-kernels.md` for the full contract.
+//! Signature verification itself is NOT implemented here: it is owned by
+//! [`crate::backends_manifest_security`] (Ed25519, reusing the model
+//! catalog's production signing key and trust root under a distinct
+//! domain-separation label, `openasr.backends_manifest.v1` vs the catalog's
+//! `openasr.catalog_manifest.v1`, so a catalog signature can never be
+//! replayed as a backends-manifest signature or vice versa -- see that
+//! module's doc comment for the full rationale). This module only:
 //!
-//! Signing reuses the exact catalog-signature scheme and production trust
-//! roots from [`crate::catalog_security`] (same Ed25519 keys, same
-//! `schema_version`/`catalog_url`/`catalog_sha256`/`catalog_epoch`/`signature`
-//! envelope shape) -- there is no second signing key or verification path to
-//! keep in sync. `catalog_url` in that envelope is the manifest's own URL, and
-//! `catalog_epoch` is a monotonic publish counter for this manifest, not the
-//! model catalog's.
+//! - defines the manifest's own JSON schema ([`BackendsManifest`],
+//!   [`PlatformBackends`], [`BackendEntry`]),
+//! - calls [`crate::verify_backends_manifest_signature`] before ever parsing
+//!   the manifest body ([`verify_and_parse`] is fail-closed: an unverified
+//!   manifest is never parsed, let alone trusted),
+//! - enforces the `core_version` match rule desktop relies on
+//!   ([`verify_and_parse_for_core_version`]), and
+//! - looks up entries by platform/backend and verifies a downloaded
+//!   archive's sha256 against them ([`BackendsManifest::backend_entry`],
+//!   [`BackendEntry::verify_sha256`]).
 //!
-//! Fail-closed: any missing signature, tampered manifest, signature mismatch,
-//! or unsupported `schema_version` is rejected. There is no "trust anyway"
-//! path.
+//! This is a SEPARATE concept from [`crate::pull::install_backend_pack`]
+//! (which downloads dynamically-loaded ggml backend *plugins* into a running
+//! daemon). The manifest verified here instead describes prebuilt,
+//! statically-linked `openasr-cli` release archives -- desktop swaps its
+//! whole sidecar binary (vulkan/cuda/hip) rather than loading a plugin into
+//! one. See `docs/backend-kernels.md` for the full contract.
+//!
+//! Fail-closed: any missing signature, tampered manifest, signature
+//! mismatch, or unsupported `schema_version` is rejected. There is no
+//! "trust anyway" path.
 
 use std::collections::BTreeMap;
 use std::str::Utf8Error;
@@ -27,17 +39,19 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-use crate::catalog_security::{self, CatalogSecurityError, CatalogTrustRoot};
+use crate::BackendsManifestSecurityError;
+#[cfg(test)]
+use crate::catalog_security::CatalogTrustRoot;
 
 /// Only `1` is understood. A manifest declaring anything else is rejected
 /// rather than best-effort parsed -- see [`BackendManifestError::UnsupportedSchema`].
 pub const BACKENDS_MANIFEST_SCHEMA_VERSION: u32 = 1;
 
-/// Canonical manifest filename, served alongside its detached signature at
+/// Canonical manifest filename, served alongside its detached signature
+/// (see [`crate::BACKENDS_MANIFEST_SIGNATURE_FILE_NAME`], owned by
+/// [`crate::backends_manifest_security`]) at
 /// `https://dl.openasr.org/core/v<version>/` and as a GitHub release asset.
 pub const BACKENDS_MANIFEST_FILE_NAME: &str = "backends-manifest.json";
-/// Detached signature filename; same directory as the manifest.
-pub const BACKENDS_MANIFEST_SIGNATURE_FILE_NAME: &str = "backends-manifest.signature.json";
 
 /// Full parsed + schema-validated manifest. Signature verification and schema
 /// validation both already happened by the time a caller holds one of these --
@@ -130,7 +144,7 @@ pub enum BackendManifestError {
     #[error("could not parse backends manifest JSON: {0}")]
     Parse(#[source] serde_json::Error),
     #[error("backends manifest signature rejected: {0}")]
-    Signature(#[source] CatalogSecurityError),
+    Signature(#[source] BackendsManifestSecurityError),
     #[error(
         "unsupported backends manifest schema_version {found} (this build understands {BACKENDS_MANIFEST_SCHEMA_VERSION})"
     )]
@@ -147,28 +161,26 @@ pub enum BackendManifestError {
     Sha256Mismatch { expected: String, actual: String },
 }
 
-/// Verify the detached signature over `manifest_bytes` against the production
-/// catalog trust roots (see [`catalog_security::OPENASR_CATALOG_TRUST_ROOTS`]),
+/// Verify the detached signature over `manifest_bytes`
+/// ([`crate::verify_backends_manifest_signature`], production trust root),
 /// then parse and schema-validate the manifest. Fail-closed: a missing/invalid
 /// signature, a sha256 mismatch between `manifest_bytes` and what the signature
 /// covers, or an unsupported `schema_version` all return `Err` -- there is no
 /// partial-trust fallback.
 ///
 /// `expected_manifest_url` must be the exact URL the manifest was fetched from
-/// (or, for a local/dev manifest, the identity it was signed under) -- it is
-/// bound into the signed payload the same way a catalog URL is, so a signature
-/// for one manifest URL can never be replayed against another.
+/// -- it is bound into the signed payload the same way a catalog URL is, so a
+/// signature for one manifest URL can never be replayed against another.
 pub fn verify_and_parse(
     manifest_bytes: &[u8],
     signature_bytes: &[u8],
     expected_manifest_url: &str,
 ) -> Result<BackendsManifest, BackendManifestError> {
-    verify_and_parse_with_roots(
-        manifest_bytes,
-        signature_bytes,
-        expected_manifest_url,
-        catalog_security::OPENASR_CATALOG_TRUST_ROOTS,
-    )
+    let manifest_text = std::str::from_utf8(manifest_bytes)?;
+    let signature_text = std::str::from_utf8(signature_bytes)?;
+    crate::verify_backends_manifest_signature(manifest_text, signature_text, expected_manifest_url)
+        .map_err(BackendManifestError::Signature)?;
+    parse_and_validate_schema(manifest_text)
 }
 
 /// Like [`verify_and_parse`], additionally rejecting a manifest whose
@@ -193,11 +205,16 @@ pub fn verify_and_parse_for_core_version(
     Ok(manifest)
 }
 
-/// Test-only (and internal-reuse) hook: same as [`verify_and_parse`] but
-/// against a caller-supplied trust root set, mirroring
-/// `catalog_security::verify_catalog_signature_manifest_with_roots`. Exists so
-/// unit tests can sign fixtures with a throwaway keypair instead of the real
-/// (secret) production signing key -- see the `tests` module below.
+/// Test-only hook: same as [`verify_and_parse`] but against a caller-supplied
+/// trust root set, mirroring
+/// `backends_manifest_security::verify_backends_manifest_signature_with_roots`.
+/// Exists so unit tests can sign fixtures with a throwaway keypair instead of
+/// the real (secret) production signing key -- see the `tests` module below.
+/// `#[cfg(test)]`: unlike catalog_security's `_with_roots` (which the
+/// production-only wrapper itself funnels through), `verify_and_parse` calls
+/// `verify_backends_manifest_signature` directly, so this helper has no
+/// non-test caller.
+#[cfg(test)]
 pub(crate) fn verify_and_parse_with_roots(
     manifest_bytes: &[u8],
     signature_bytes: &[u8],
@@ -206,14 +223,19 @@ pub(crate) fn verify_and_parse_with_roots(
 ) -> Result<BackendsManifest, BackendManifestError> {
     let manifest_text = std::str::from_utf8(manifest_bytes)?;
     let signature_text = std::str::from_utf8(signature_bytes)?;
-    catalog_security::verify_catalog_signature_manifest_with_roots(
+    crate::backends_manifest_security::verify_backends_manifest_signature_with_roots(
         manifest_text,
         signature_text,
         expected_manifest_url,
         trust_roots,
     )
     .map_err(BackendManifestError::Signature)?;
+    parse_and_validate_schema(manifest_text)
+}
 
+fn parse_and_validate_schema(
+    manifest_text: &str,
+) -> Result<BackendsManifest, BackendManifestError> {
     let manifest: BackendsManifest =
         serde_json::from_str(manifest_text).map_err(BackendManifestError::Parse)?;
     if manifest.schema_version != BACKENDS_MANIFEST_SCHEMA_VERSION {
@@ -239,11 +261,12 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use catalog_security::{derive_catalog_public_key_hex, render_catalog_signature_manifest};
+    use crate::render_backends_manifest_signature;
 
     // Throwaway test keypair -- NOT the production signing key (that secret
-    // never appears in this repo). Mirrors catalog_security's own test
-    // fixtures, which use the identical pattern for the same reason.
+    // never appears in this repo). Mirrors both catalog_security's and
+    // backends_manifest_security's own test fixtures, which use the same
+    // pattern for the same reason.
     const TEST_SEED_HEX: &str = "0101010101010101010101010101010101010101010101010101010101010101";
     const TEST_KEY_ID: &str = "test-backends-manifest-key";
     const TEST_MANIFEST_URL: &str = "https://dl.openasr.org/core/v0.1.14/backends-manifest.json";
@@ -252,7 +275,7 @@ mod tests {
         [CatalogTrustRoot {
             key_id: TEST_KEY_ID,
             public_key_hex: Box::leak(
-                derive_catalog_public_key_hex(TEST_SEED_HEX)
+                crate::derive_catalog_public_key_hex(TEST_SEED_HEX)
                     .unwrap()
                     .into_boxed_str(),
             ),
@@ -289,8 +312,7 @@ mod tests {
     }
 
     fn sign(manifest_json: &str, url: &str) -> String {
-        render_catalog_signature_manifest(manifest_json, url, 1, TEST_KEY_ID, TEST_SEED_HEX)
-            .unwrap()
+        render_backends_manifest_signature(manifest_json, url, TEST_KEY_ID, TEST_SEED_HEX).unwrap()
     }
 
     #[test]
@@ -399,16 +421,16 @@ mod tests {
         let manifest_json = sample_manifest_json();
         let signature = sign(&manifest_json, TEST_MANIFEST_URL);
 
+        // verify_and_parse_for_core_version uses the production trust roots
+        // (via verify_and_parse), so this test-signed fixture fails signature
+        // verification first -- exercise the version-mismatch branch that is
+        // unique to this function directly against a parsed manifest instead.
         let error = verify_and_parse_for_core_version(
             manifest_json.as_bytes(),
             signature.as_bytes(),
             TEST_MANIFEST_URL,
             "9.9.9",
         );
-        // verify_and_parse_for_core_version uses the production trust roots, so
-        // this (test-signed) fixture fails signature verification first --
-        // exercise the version-mismatch branch directly against the parsed
-        // manifest instead, which is the part unique to this function.
         assert!(error.is_err());
 
         let parsed = verify_and_parse_with_roots(

--- a/crates/openasr-core/src/backend_manifest.rs
+++ b/crates/openasr-core/src/backend_manifest.rs
@@ -1,0 +1,475 @@
+//! Verification for the desktop app's **inference kernel** manifest
+//! (`backends-manifest.json` + `backends-manifest.signature.json`).
+//!
+//! This is a SEPARATE concept from [`crate::pull::install_backend_pack`] (which
+//! downloads dynamically-loaded ggml backend *plugins* into a running daemon).
+//! The manifest verified here instead describes prebuilt, statically-linked
+//! `openasr-cli` release archives -- desktop swaps its whole sidecar binary
+//! (vulkan/cuda/hip) rather than loading a plugin into one. See
+//! `docs/backend-kernels.md` for the full contract.
+//!
+//! Signing reuses the exact catalog-signature scheme and production trust
+//! roots from [`crate::catalog_security`] (same Ed25519 keys, same
+//! `schema_version`/`catalog_url`/`catalog_sha256`/`catalog_epoch`/`signature`
+//! envelope shape) -- there is no second signing key or verification path to
+//! keep in sync. `catalog_url` in that envelope is the manifest's own URL, and
+//! `catalog_epoch` is a monotonic publish counter for this manifest, not the
+//! model catalog's.
+//!
+//! Fail-closed: any missing signature, tampered manifest, signature mismatch,
+//! or unsupported `schema_version` is rejected. There is no "trust anyway"
+//! path.
+
+use std::collections::BTreeMap;
+use std::str::Utf8Error;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::catalog_security::{self, CatalogSecurityError, CatalogTrustRoot};
+
+/// Only `1` is understood. A manifest declaring anything else is rejected
+/// rather than best-effort parsed -- see [`BackendManifestError::UnsupportedSchema`].
+pub const BACKENDS_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// Canonical manifest filename, served alongside its detached signature at
+/// `https://dl.openasr.org/core/v<version>/` and as a GitHub release asset.
+pub const BACKENDS_MANIFEST_FILE_NAME: &str = "backends-manifest.json";
+/// Detached signature filename; same directory as the manifest.
+pub const BACKENDS_MANIFEST_SIGNATURE_FILE_NAME: &str = "backends-manifest.signature.json";
+
+/// Full parsed + schema-validated manifest. Signature verification and schema
+/// validation both already happened by the time a caller holds one of these --
+/// see [`verify_and_parse`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BackendsManifest {
+    pub schema_version: u32,
+    /// The `openasr-cli` semver these archives were built from (e.g. `"0.1.14"`).
+    /// Desktop only ever accepts a manifest whose `core_version` matches its own
+    /// bundled sidecar version -- see `docs/backend-kernels.md`'s version-match
+    /// rule and [`BackendManifestError::CoreVersionMismatch`].
+    pub core_version: String,
+    /// Full git commit sha the archives were built from, for traceability.
+    pub source_commit: String,
+    /// Keyed by platform id (currently only `"windows-x86_64"`).
+    pub platforms: BTreeMap<String, PlatformBackends>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlatformBackends {
+    /// Keyed by backend id (`"vulkan"`, `"cuda"`, `"hip"`).
+    pub backends: BTreeMap<String, BackendEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BackendEntry {
+    /// Release asset filename (e.g. `openasr-0.1.14-windows-x86_64-cuda.zip`).
+    pub asset: String,
+    pub size_bytes: u64,
+    /// Lowercase hex sha256 of the asset's exact bytes.
+    pub sha256: String,
+    /// Download URLs in try-order: `dl.openasr.org` first, GitHub release
+    /// download as fallback. See [`BackendEntry::urls`].
+    pub urls: Vec<String>,
+    /// PE import-table DLL-name prefixes (case-insensitive) that the resolved
+    /// `openasr.exe` inside this archive must import at least one of, e.g.
+    /// `["cublas64_"]` for `cuda`. This is the driver-linkage self-check a
+    /// downloader runs on the *extracted* binary; it is independent of the
+    /// sha256 check (that guards transport integrity, this guards "the right
+    /// binary for the right kernel").
+    pub pe_import_markers: Vec<String>,
+}
+
+impl BackendEntry {
+    /// Verify `bytes` (the downloaded archive) hashes to [`BackendEntry::sha256`].
+    /// Case-insensitive comparison since hex casing is not itself meaningful.
+    pub fn verify_sha256(&self, bytes: &[u8]) -> Result<(), BackendManifestError> {
+        let actual = sha256_hex(bytes);
+        if !actual.eq_ignore_ascii_case(&self.sha256) {
+            return Err(BackendManifestError::Sha256Mismatch {
+                expected: self.sha256.clone(),
+                actual,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl BackendsManifest {
+    /// Look up the entry for `platform`/`backend` (e.g. `"windows-x86_64"` /
+    /// `"cuda"`), fail-closed on either missing.
+    pub fn backend_entry(
+        &self,
+        platform: &str,
+        backend: &str,
+    ) -> Result<&BackendEntry, BackendManifestError> {
+        let platform_entry =
+            self.platforms
+                .get(platform)
+                .ok_or_else(|| BackendManifestError::UnknownPlatform {
+                    platform: platform.to_string(),
+                })?;
+        platform_entry
+            .backends
+            .get(backend)
+            .ok_or_else(|| BackendManifestError::UnknownBackend {
+                platform: platform.to_string(),
+                backend: backend.to_string(),
+            })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum BackendManifestError {
+    #[error("backends manifest bytes are not valid UTF-8: {0}")]
+    InvalidUtf8(#[from] Utf8Error),
+    #[error("could not parse backends manifest JSON: {0}")]
+    Parse(#[source] serde_json::Error),
+    #[error("backends manifest signature rejected: {0}")]
+    Signature(#[source] CatalogSecurityError),
+    #[error(
+        "unsupported backends manifest schema_version {found} (this build understands {BACKENDS_MANIFEST_SCHEMA_VERSION})"
+    )]
+    UnsupportedSchema { found: u32 },
+    #[error(
+        "backends manifest core_version '{manifest}' does not match the requested core_version '{requested}'; refusing a version-mismatched kernel manifest"
+    )]
+    CoreVersionMismatch { manifest: String, requested: String },
+    #[error("backends manifest has no entry for platform '{platform}'")]
+    UnknownPlatform { platform: String },
+    #[error("backends manifest has no entry for backend '{backend}' on platform '{platform}'")]
+    UnknownBackend { platform: String, backend: String },
+    #[error("backend archive sha256 mismatch: expected {expected}, got {actual}")]
+    Sha256Mismatch { expected: String, actual: String },
+}
+
+/// Verify the detached signature over `manifest_bytes` against the production
+/// catalog trust roots (see [`catalog_security::OPENASR_CATALOG_TRUST_ROOTS`]),
+/// then parse and schema-validate the manifest. Fail-closed: a missing/invalid
+/// signature, a sha256 mismatch between `manifest_bytes` and what the signature
+/// covers, or an unsupported `schema_version` all return `Err` -- there is no
+/// partial-trust fallback.
+///
+/// `expected_manifest_url` must be the exact URL the manifest was fetched from
+/// (or, for a local/dev manifest, the identity it was signed under) -- it is
+/// bound into the signed payload the same way a catalog URL is, so a signature
+/// for one manifest URL can never be replayed against another.
+pub fn verify_and_parse(
+    manifest_bytes: &[u8],
+    signature_bytes: &[u8],
+    expected_manifest_url: &str,
+) -> Result<BackendsManifest, BackendManifestError> {
+    verify_and_parse_with_roots(
+        manifest_bytes,
+        signature_bytes,
+        expected_manifest_url,
+        catalog_security::OPENASR_CATALOG_TRUST_ROOTS,
+    )
+}
+
+/// Like [`verify_and_parse`], additionally rejecting a manifest whose
+/// `core_version` does not equal `expected_core_version`. This is the entry
+/// point desktop should use in practice: a kernel manifest built for a
+/// different `openasr-cli` release must never be accepted, since the
+/// downloaded archive's `openasr.exe --version` is later checked against the
+/// SAME `core_version` string as a second, binary-level confirmation.
+pub fn verify_and_parse_for_core_version(
+    manifest_bytes: &[u8],
+    signature_bytes: &[u8],
+    expected_manifest_url: &str,
+    expected_core_version: &str,
+) -> Result<BackendsManifest, BackendManifestError> {
+    let manifest = verify_and_parse(manifest_bytes, signature_bytes, expected_manifest_url)?;
+    if manifest.core_version != expected_core_version {
+        return Err(BackendManifestError::CoreVersionMismatch {
+            manifest: manifest.core_version,
+            requested: expected_core_version.to_string(),
+        });
+    }
+    Ok(manifest)
+}
+
+/// Test-only (and internal-reuse) hook: same as [`verify_and_parse`] but
+/// against a caller-supplied trust root set, mirroring
+/// `catalog_security::verify_catalog_signature_manifest_with_roots`. Exists so
+/// unit tests can sign fixtures with a throwaway keypair instead of the real
+/// (secret) production signing key -- see the `tests` module below.
+pub(crate) fn verify_and_parse_with_roots(
+    manifest_bytes: &[u8],
+    signature_bytes: &[u8],
+    expected_manifest_url: &str,
+    trust_roots: &[CatalogTrustRoot],
+) -> Result<BackendsManifest, BackendManifestError> {
+    let manifest_text = std::str::from_utf8(manifest_bytes)?;
+    let signature_text = std::str::from_utf8(signature_bytes)?;
+    catalog_security::verify_catalog_signature_manifest_with_roots(
+        manifest_text,
+        signature_text,
+        expected_manifest_url,
+        trust_roots,
+    )
+    .map_err(BackendManifestError::Signature)?;
+
+    let manifest: BackendsManifest =
+        serde_json::from_str(manifest_text).map_err(BackendManifestError::Parse)?;
+    if manifest.schema_version != BACKENDS_MANIFEST_SCHEMA_VERSION {
+        return Err(BackendManifestError::UnsupportedSchema {
+            found: manifest.schema_version,
+        });
+    }
+    Ok(manifest)
+}
+
+/// Lowercase hex sha256 of `bytes`. Exposed so callers (in this crate and, via
+/// `openasr-core` as a path dependency, the desktop app) can hash a downloaded
+/// archive without re-deriving the format `sha256` fields use.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use catalog_security::{derive_catalog_public_key_hex, render_catalog_signature_manifest};
+
+    // Throwaway test keypair -- NOT the production signing key (that secret
+    // never appears in this repo). Mirrors catalog_security's own test
+    // fixtures, which use the identical pattern for the same reason.
+    const TEST_SEED_HEX: &str = "0101010101010101010101010101010101010101010101010101010101010101";
+    const TEST_KEY_ID: &str = "test-backends-manifest-key";
+    const TEST_MANIFEST_URL: &str = "https://dl.openasr.org/core/v0.1.14/backends-manifest.json";
+
+    fn test_roots() -> [CatalogTrustRoot; 1] {
+        [CatalogTrustRoot {
+            key_id: TEST_KEY_ID,
+            public_key_hex: Box::leak(
+                derive_catalog_public_key_hex(TEST_SEED_HEX)
+                    .unwrap()
+                    .into_boxed_str(),
+            ),
+        }]
+    }
+
+    fn sample_manifest_json() -> String {
+        r#"{
+            "schema_version": 1,
+            "core_version": "0.1.14",
+            "source_commit": "a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4",
+            "platforms": {
+                "windows-x86_64": {
+                    "backends": {
+                        "vulkan": {
+                            "asset": "openasr-0.1.14-windows-x86_64-vulkan.zip",
+                            "size_bytes": 123456,
+                            "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+                            "urls": ["https://dl.openasr.org/core/v0.1.14/openasr-0.1.14-windows-x86_64-vulkan.zip"],
+                            "pe_import_markers": ["vulkan-1.dll"]
+                        },
+                        "cuda": {
+                            "asset": "openasr-0.1.14-windows-x86_64-cuda.zip",
+                            "size_bytes": 559000000,
+                            "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+                            "urls": ["https://dl.openasr.org/core/v0.1.14/openasr-0.1.14-windows-x86_64-cuda.zip"],
+                            "pe_import_markers": ["cublas64_"]
+                        }
+                    }
+                }
+            }
+        }"#
+        .to_string()
+    }
+
+    fn sign(manifest_json: &str, url: &str) -> String {
+        render_catalog_signature_manifest(manifest_json, url, 1, TEST_KEY_ID, TEST_SEED_HEX)
+            .unwrap()
+    }
+
+    #[test]
+    fn verifies_and_parses_a_well_formed_signed_manifest() {
+        let manifest_json = sample_manifest_json();
+        let signature = sign(&manifest_json, TEST_MANIFEST_URL);
+
+        let parsed = verify_and_parse_with_roots(
+            manifest_json.as_bytes(),
+            signature.as_bytes(),
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .expect("well-formed signed manifest must verify");
+
+        assert_eq!(parsed.core_version, "0.1.14");
+        assert_eq!(parsed.schema_version, 1);
+        let vulkan = parsed.backend_entry("windows-x86_64", "vulkan").unwrap();
+        assert_eq!(vulkan.asset, "openasr-0.1.14-windows-x86_64-vulkan.zip");
+        assert_eq!(vulkan.pe_import_markers, vec!["vulkan-1.dll".to_string()]);
+        let cuda = parsed.backend_entry("windows-x86_64", "cuda").unwrap();
+        assert_eq!(cuda.pe_import_markers, vec!["cublas64_".to_string()]);
+    }
+
+    #[test]
+    fn rejects_a_tampered_manifest() {
+        let manifest_json = sample_manifest_json();
+        let signature = sign(&manifest_json, TEST_MANIFEST_URL);
+
+        // Flip one byte of a hash so the signed sha256 no longer matches.
+        let tampered = manifest_json.replacen("1111111111", "9999999999", 1);
+        assert_ne!(tampered, manifest_json);
+
+        let error = verify_and_parse_with_roots(
+            tampered.as_bytes(),
+            signature.as_bytes(),
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, BackendManifestError::Signature(_)),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_signature_that_does_not_match() {
+        let manifest_json = sample_manifest_json();
+        // Sign a DIFFERENT manifest, then pair that signature with the real one.
+        let other_signature = sign(
+            r#"{"schema_version":1,"core_version":"0.0.1","source_commit":"x","platforms":{}}"#,
+            TEST_MANIFEST_URL,
+        );
+
+        let error = verify_and_parse_with_roots(
+            manifest_json.as_bytes(),
+            other_signature.as_bytes(),
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, BackendManifestError::Signature(_)),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_empty_signature_bytes() {
+        let manifest_json = sample_manifest_json();
+        let error = verify_and_parse_with_roots(
+            manifest_json.as_bytes(),
+            b"",
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, BackendManifestError::Signature(_)),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_schema_version() {
+        let manifest_json =
+            sample_manifest_json().replacen("\"schema_version\": 1", "\"schema_version\": 2", 1);
+        let signature = sign(&manifest_json, TEST_MANIFEST_URL);
+
+        let error = verify_and_parse_with_roots(
+            manifest_json.as_bytes(),
+            signature.as_bytes(),
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, BackendManifestError::UnsupportedSchema { found: 2 }),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn core_version_mismatch_is_rejected() {
+        let manifest_json = sample_manifest_json();
+        let signature = sign(&manifest_json, TEST_MANIFEST_URL);
+
+        let error = verify_and_parse_for_core_version(
+            manifest_json.as_bytes(),
+            signature.as_bytes(),
+            TEST_MANIFEST_URL,
+            "9.9.9",
+        );
+        // verify_and_parse_for_core_version uses the production trust roots, so
+        // this (test-signed) fixture fails signature verification first --
+        // exercise the version-mismatch branch directly against the parsed
+        // manifest instead, which is the part unique to this function.
+        assert!(error.is_err());
+
+        let parsed = verify_and_parse_with_roots(
+            manifest_json.as_bytes(),
+            signature.as_bytes(),
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap();
+        assert_eq!(parsed.core_version, "0.1.14");
+        assert_ne!(parsed.core_version, "9.9.9");
+    }
+
+    #[test]
+    fn unknown_platform_and_backend_are_reported_distinctly() {
+        let manifest_json = sample_manifest_json();
+        let signature = sign(&manifest_json, TEST_MANIFEST_URL);
+        let parsed = verify_and_parse_with_roots(
+            manifest_json.as_bytes(),
+            signature.as_bytes(),
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            parsed.backend_entry("macos-arm64", "vulkan").unwrap_err(),
+            BackendManifestError::UnknownPlatform { .. }
+        ));
+        assert!(matches!(
+            parsed
+                .backend_entry("windows-x86_64", "rocm-legacy")
+                .unwrap_err(),
+            BackendManifestError::UnknownBackend { .. }
+        ));
+    }
+
+    #[test]
+    fn sha256_hex_matches_a_known_vector() {
+        // sha256("") -- standard test vector.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn backend_entry_verify_sha256_rejects_mismatch() {
+        let manifest_json = sample_manifest_json();
+        let signature = sign(&manifest_json, TEST_MANIFEST_URL);
+        let parsed = verify_and_parse_with_roots(
+            manifest_json.as_bytes(),
+            signature.as_bytes(),
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap();
+        let vulkan = parsed.backend_entry("windows-x86_64", "vulkan").unwrap();
+        let error = vulkan
+            .verify_sha256(b"not the real archive bytes")
+            .unwrap_err();
+        assert!(matches!(error, BackendManifestError::Sha256Mismatch { .. }));
+    }
+}

--- a/crates/openasr-core/src/backends_manifest_security.rs
+++ b/crates/openasr-core/src/backends_manifest_security.rs
@@ -1,0 +1,521 @@
+//! Ed25519 signing/verification for the `backends-manifest.json` release
+//! asset (the per-release index of downloadable Windows GPU-kernel sidecars
+//! -- vulkan/cuda/hip -- that the desktop app switches between at runtime).
+//!
+//! This deliberately reuses the SAME signing key material and the SAME
+//! production trust root as the model catalog
+//! (`catalog_security::OPENASR_CATALOG_TRUST_ROOTS`, key id
+//! [`CATALOG_SIGNATURE_KEY_ID`]) rather than minting a second keypair: one
+//! signing seed, one trust root, one place a maintainer manages key custody
+//! and rotation. Only the domain-separation label baked into the signed
+//! payload differs from the catalog's
+//! (`openasr.backends_manifest.v1` vs `openasr.catalog_manifest.v1`), so a
+//! signature produced for one manifest kind can never be replayed as a valid
+//! signature for the other, even though both verify under the same public
+//! key.
+//!
+//! Signing stays a LOCAL, maintainer-run operation, exactly like
+//! `tooling/publish-model/scripts/publish_catalog.sh`: the seed
+//! (`OPENASR_CATALOG_SIGNING_KEY_SEED_HEX`) never enters CI. Unlike the
+//! catalog, this manifest carries no anti-rollback `epoch` -- it is generated
+//! fresh per immutable, version-namespaced release URL
+//! (`https://dl.openasr.org/core/v<version>/backends-manifest.json`), so
+//! there is no shared mutable endpoint a stale signature could roll back.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::catalog_security::{
+    CATALOG_SIGNATURE_KEY_ID, CatalogTrustRoot, OPENASR_CATALOG_TRUST_ROOTS,
+};
+
+pub const BACKENDS_MANIFEST_SIGNATURE_SCHEMA_VERSION: u32 = 1;
+pub const BACKENDS_MANIFEST_SIGNATURE_FILE_NAME: &str = "backends-manifest.signature.json";
+pub const BACKENDS_MANIFEST_SIGNATURE_ALGORITHM: &str = "ed25519";
+
+const BACKENDS_MANIFEST_SIGNATURE_DOMAIN: &str = "openasr.backends_manifest.v1";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BackendsManifestSignature {
+    pub schema_version: u32,
+    pub manifest_url: String,
+    pub manifest_sha256: String,
+    pub signature: BackendsManifestSignatureValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BackendsManifestSignatureValue {
+    pub algorithm: String,
+    pub key_id: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedBackendsManifestSignature {
+    pub manifest_sha256: String,
+    pub key_id: String,
+}
+
+#[derive(Debug, Error)]
+pub enum BackendsManifestSecurityError {
+    #[error("Could not parse backends-manifest signature '{source}': {source_error}")]
+    ParseSignature {
+        source: String,
+        #[source]
+        source_error: serde_json::Error,
+    },
+    #[error("Could not serialize backends-manifest signature: {source}")]
+    SerializeSignature {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("Unsupported backends-manifest signature schema_version {found}")]
+    UnsupportedSchema { found: u32 },
+    #[error("Invalid backends-manifest signature field '{field}': {message}")]
+    InvalidField {
+        field: &'static str,
+        message: String,
+    },
+    #[error("backends-manifest signature URL mismatch: expected '{expected}', got '{actual}'")]
+    ManifestUrlMismatch { expected: String, actual: String },
+    #[error("backends-manifest sha256 mismatch: expected {expected}, got {actual}")]
+    ManifestShaMismatch { expected: String, actual: String },
+    #[error("Unknown backends-manifest signature key id '{key_id}'")]
+    UnknownKey { key_id: String },
+    #[error("Invalid backends-manifest signature public key for '{key_id}': {message}")]
+    InvalidPublicKey { key_id: String, message: String },
+    #[error("Invalid backends-manifest signature bytes: {message}")]
+    InvalidSignature { message: String },
+    #[error("backends-manifest signature verification failed for key '{key_id}'")]
+    SignatureRejected { key_id: String },
+}
+
+/// Renders a signed `backends-manifest.signature.json` sidecar for
+/// `manifest_contents` (the exact bytes of the already-written
+/// `backends-manifest.json`). Mirrors
+/// `catalog_security::render_catalog_signature_manifest`'s shape: caller
+/// supplies the signing seed (never read from the environment here -- the
+/// CLI entry point owns that so it stays a single, auditable place that
+/// touches `OPENASR_CATALOG_SIGNING_KEY_SEED_HEX`).
+pub fn render_backends_manifest_signature(
+    manifest_contents: &str,
+    manifest_url: &str,
+    key_id: &str,
+    signing_key_seed_hex: &str,
+) -> Result<String, BackendsManifestSecurityError> {
+    validate_text_field("manifest_url", manifest_url)?;
+    validate_text_field("signature.key_id", key_id)?;
+
+    let seed = decode_hex_exact::<32>(signing_key_seed_hex, "signing_key_seed_hex")?;
+    let signing_key = SigningKey::from_bytes(&seed);
+    let manifest_sha256 = sha256_hex(manifest_contents.as_bytes());
+    let signature = signing_key.sign(
+        signature_payload(
+            BACKENDS_MANIFEST_SIGNATURE_ALGORITHM,
+            key_id,
+            manifest_url,
+            &manifest_sha256,
+        )
+        .as_bytes(),
+    );
+    let manifest = BackendsManifestSignature {
+        schema_version: BACKENDS_MANIFEST_SIGNATURE_SCHEMA_VERSION,
+        manifest_url: manifest_url.to_string(),
+        manifest_sha256,
+        signature: BackendsManifestSignatureValue {
+            algorithm: BACKENDS_MANIFEST_SIGNATURE_ALGORITHM.to_string(),
+            key_id: key_id.to_string(),
+            value: hex_lower(&signature.to_bytes()),
+        },
+    };
+
+    serde_json::to_string_pretty(&manifest)
+        .map(|mut value| {
+            value.push('\n');
+            value
+        })
+        .map_err(|source| BackendsManifestSecurityError::SerializeSignature { source })
+}
+
+/// Verifies a `backends-manifest.signature.json` sidecar against the
+/// production catalog trust root
+/// (`catalog_security::OPENASR_CATALOG_TRUST_ROOTS`) -- the same key that
+/// signs the model catalog. There is no "local dev" variant of this
+/// signature (unlike the catalog's `CATALOG_SIGNATURE_LOCAL_DEV_KEY_ID`):
+/// the backends manifest is only ever fetched from the production
+/// `dl.openasr.org` / GitHub Releases endpoints, never a local dev override.
+pub fn verify_backends_manifest_signature(
+    manifest_contents: &str,
+    signature_contents: &str,
+    expected_manifest_url: &str,
+) -> Result<VerifiedBackendsManifestSignature, BackendsManifestSecurityError> {
+    verify_backends_manifest_signature_with_roots(
+        manifest_contents,
+        signature_contents,
+        expected_manifest_url,
+        OPENASR_CATALOG_TRUST_ROOTS,
+    )
+}
+
+/// Like [`verify_backends_manifest_signature`], but against an injectable
+/// trust-root set -- exists so tests can verify the sign/verify round trip
+/// with a throwaway test keypair instead of the real production seed (which
+/// never lives in this repo or CI; see the module doc).
+pub(crate) fn verify_backends_manifest_signature_with_roots(
+    manifest_contents: &str,
+    signature_contents: &str,
+    expected_manifest_url: &str,
+    trust_roots: &[CatalogTrustRoot],
+) -> Result<VerifiedBackendsManifestSignature, BackendsManifestSecurityError> {
+    let signature: BackendsManifestSignature =
+        serde_json::from_str(signature_contents).map_err(|source_error| {
+            BackendsManifestSecurityError::ParseSignature {
+                source: BACKENDS_MANIFEST_SIGNATURE_FILE_NAME.to_string(),
+                source_error,
+            }
+        })?;
+    validate_signature(&signature, expected_manifest_url)?;
+
+    let actual_sha = sha256_hex(manifest_contents.as_bytes());
+    if actual_sha != signature.manifest_sha256 {
+        return Err(BackendsManifestSecurityError::ManifestShaMismatch {
+            expected: signature.manifest_sha256,
+            actual: actual_sha,
+        });
+    }
+
+    let trust_root = trust_roots
+        .iter()
+        .find(|root| root.key_id == signature.signature.key_id)
+        .ok_or_else(|| BackendsManifestSecurityError::UnknownKey {
+            key_id: signature.signature.key_id.clone(),
+        })?;
+    let public_key =
+        decode_hex_exact::<32>(trust_root.public_key_hex, "public_key_hex").map_err(|error| {
+            BackendsManifestSecurityError::InvalidPublicKey {
+                key_id: trust_root.key_id.to_string(),
+                message: error.to_string(),
+            }
+        })?;
+    let verifying_key = VerifyingKey::from_bytes(&public_key).map_err(|error| {
+        BackendsManifestSecurityError::InvalidPublicKey {
+            key_id: trust_root.key_id.to_string(),
+            message: error.to_string(),
+        }
+    })?;
+    let signature_bytes = decode_hex_exact::<64>(&signature.signature.value, "signature.value")?;
+    let ed25519_signature = Signature::from_bytes(&signature_bytes);
+    verifying_key
+        .verify(
+            signature_payload(
+                &signature.signature.algorithm,
+                &signature.signature.key_id,
+                &signature.manifest_url,
+                &signature.manifest_sha256,
+            )
+            .as_bytes(),
+            &ed25519_signature,
+        )
+        .map_err(|_| BackendsManifestSecurityError::SignatureRejected {
+            key_id: signature.signature.key_id.clone(),
+        })?;
+
+    Ok(VerifiedBackendsManifestSignature {
+        manifest_sha256: signature.manifest_sha256,
+        key_id: signature.signature.key_id,
+    })
+}
+
+fn validate_signature(
+    signature: &BackendsManifestSignature,
+    expected_manifest_url: &str,
+) -> Result<(), BackendsManifestSecurityError> {
+    if signature.schema_version != BACKENDS_MANIFEST_SIGNATURE_SCHEMA_VERSION {
+        return Err(BackendsManifestSecurityError::UnsupportedSchema {
+            found: signature.schema_version,
+        });
+    }
+    validate_text_field("manifest_url", &signature.manifest_url)?;
+    validate_text_field("manifest_sha256", &signature.manifest_sha256)?;
+    validate_text_field("signature.algorithm", &signature.signature.algorithm)?;
+    validate_text_field("signature.key_id", &signature.signature.key_id)?;
+    validate_text_field("signature.value", &signature.signature.value)?;
+    if signature.manifest_url != expected_manifest_url {
+        return Err(BackendsManifestSecurityError::ManifestUrlMismatch {
+            expected: expected_manifest_url.to_string(),
+            actual: signature.manifest_url.clone(),
+        });
+    }
+    if signature.signature.algorithm != BACKENDS_MANIFEST_SIGNATURE_ALGORITHM {
+        return Err(BackendsManifestSecurityError::InvalidField {
+            field: "signature.algorithm",
+            message: format!(
+                "expected {BACKENDS_MANIFEST_SIGNATURE_ALGORITHM}, got {}",
+                signature.signature.algorithm
+            ),
+        });
+    }
+    if signature.manifest_sha256.len() != 64
+        || !signature
+            .manifest_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(BackendsManifestSecurityError::InvalidField {
+            field: "manifest_sha256",
+            message: "expected 64 lowercase hex characters".to_string(),
+        });
+    }
+    if signature.signature.value.len() != 128
+        || !signature
+            .signature
+            .value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(BackendsManifestSecurityError::InvalidField {
+            field: "signature.value",
+            message: "expected 128 hex characters".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn signature_payload(
+    algorithm: &str,
+    key_id: &str,
+    manifest_url: &str,
+    manifest_sha256: &str,
+) -> String {
+    format!(
+        "{BACKENDS_MANIFEST_SIGNATURE_DOMAIN}\nalgorithm:{algorithm}\nkey_id:{key_id}\nmanifest_url:{manifest_url}\nmanifest_sha256:{manifest_sha256}\n"
+    )
+}
+
+fn validate_text_field(
+    field: &'static str,
+    value: &str,
+) -> Result<(), BackendsManifestSecurityError> {
+    if value.trim().is_empty() {
+        return Err(BackendsManifestSecurityError::InvalidField {
+            field,
+            message: "must not be empty".to_string(),
+        });
+    }
+    if value.contains('\n') || value.contains('\r') {
+        return Err(BackendsManifestSecurityError::InvalidField {
+            field,
+            message: "must not contain newlines".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex_lower(&Sha256::digest(bytes))
+}
+
+fn decode_hex_exact<const N: usize>(
+    value: &str,
+    field: &'static str,
+) -> Result<[u8; N], BackendsManifestSecurityError> {
+    let value = value.trim();
+    let bytes = value.as_bytes();
+    if bytes.len() != N * 2 {
+        return Err(BackendsManifestSecurityError::InvalidField {
+            field,
+            message: format!("expected {} hex characters", N * 2),
+        });
+    }
+    let mut out = [0_u8; N];
+    for index in 0..N {
+        let hi = hex_nibble(bytes[index * 2], field)?;
+        let lo = hex_nibble(bytes[index * 2 + 1], field)?;
+        out[index] = (hi << 4) | lo;
+    }
+    Ok(out)
+}
+
+fn hex_nibble(byte: u8, field: &'static str) -> Result<u8, BackendsManifestSecurityError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(BackendsManifestSecurityError::InvalidField {
+            field,
+            message: "invalid hex digit".to_string(),
+        }),
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Convenience re-export so callers do not need to import
+/// `catalog_security::CATALOG_SIGNATURE_KEY_ID` separately to sign/verify
+/// with the production key id.
+pub const BACKENDS_MANIFEST_PRODUCTION_KEY_ID: &str = CATALOG_SIGNATURE_KEY_ID;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Well-known RFC 8032 Ed25519 test vector (same pair
+    // catalog_security's own tests use) -- NOT the real production seed,
+    // which never lives in this repo. `verify_backends_manifest_signature`
+    // itself is hardcoded to the real production trust root, so tests go
+    // through `verify_backends_manifest_signature_with_roots` with this
+    // throwaway keypair instead.
+    const TEST_SEED_HEX: &str = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+    const TEST_PUBLIC_KEY_HEX: &str =
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+    const TEST_KEY_ID: &str = "test-backends-key";
+    const TEST_MANIFEST_URL: &str = "https://dl.openasr.org/core/v0.1.10/backends-manifest.json";
+
+    fn test_roots() -> [CatalogTrustRoot; 1] {
+        [CatalogTrustRoot {
+            key_id: TEST_KEY_ID,
+            public_key_hex: TEST_PUBLIC_KEY_HEX,
+        }]
+    }
+
+    #[test]
+    fn signed_manifest_verifies_bytes_and_url() {
+        let manifest = r#"{"schema_version":1,"core_version":"0.1.10"}"#;
+        let signature = render_backends_manifest_signature(
+            manifest,
+            TEST_MANIFEST_URL,
+            TEST_KEY_ID,
+            TEST_SEED_HEX,
+        )
+        .unwrap();
+
+        let verified = verify_backends_manifest_signature_with_roots(
+            manifest,
+            &signature,
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap();
+
+        assert_eq!(verified.key_id, TEST_KEY_ID);
+        assert_eq!(verified.manifest_sha256.len(), 64);
+    }
+
+    #[test]
+    fn signed_manifest_rejects_tampered_bytes() {
+        let signature = render_backends_manifest_signature(
+            r#"{"schema_version":1,"core_version":"0.1.10"}"#,
+            TEST_MANIFEST_URL,
+            TEST_KEY_ID,
+            TEST_SEED_HEX,
+        )
+        .unwrap();
+
+        let error = verify_backends_manifest_signature_with_roots(
+            r#"{"schema_version":1,"core_version":"0.1.11-tampered"}"#,
+            &signature,
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("sha256 mismatch"));
+    }
+
+    #[test]
+    fn signed_manifest_rejects_url_mismatch() {
+        let manifest = r#"{"schema_version":1,"core_version":"0.1.10"}"#;
+        let signature = render_backends_manifest_signature(
+            manifest,
+            TEST_MANIFEST_URL,
+            TEST_KEY_ID,
+            TEST_SEED_HEX,
+        )
+        .unwrap();
+
+        let error = verify_backends_manifest_signature_with_roots(
+            manifest,
+            &signature,
+            "https://dl.openasr.org/core/v9.9.9/backends-manifest.json",
+            &test_roots(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("URL mismatch"));
+    }
+
+    #[test]
+    fn signed_manifest_rejects_unknown_key_id() {
+        let manifest = r#"{"schema_version":1,"core_version":"0.1.10"}"#;
+        // Signed with the real production key id but verified against a
+        // trust-root set that only knows the test key id -- must reject as
+        // unknown rather than silently accept.
+        let signature = render_backends_manifest_signature(
+            manifest,
+            TEST_MANIFEST_URL,
+            CATALOG_SIGNATURE_KEY_ID,
+            TEST_SEED_HEX,
+        )
+        .unwrap();
+
+        let error = verify_backends_manifest_signature_with_roots(
+            manifest,
+            &signature,
+            TEST_MANIFEST_URL,
+            &test_roots(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("Unknown backends-manifest signature key id"));
+    }
+
+    #[test]
+    fn backends_manifest_signature_cannot_be_replayed_as_a_catalog_signature() {
+        // Cross-protocol replay guard: the domain-separated payload differs
+        // from the catalog's, so a signature minted here must not verify as
+        // a valid CATALOG signature over the "same" bytes/url pairing, even
+        // though both use the same production key.
+        let payload = r#"{"schema_version":1,"core_version":"0.1.10"}"#;
+        let backends_signature = render_backends_manifest_signature(
+            payload,
+            TEST_MANIFEST_URL,
+            TEST_KEY_ID,
+            TEST_SEED_HEX,
+        )
+        .unwrap();
+
+        // A catalog signature manifest is shaped differently
+        // (catalog_url/catalog_sha256/catalog_epoch vs manifest_url/
+        // manifest_sha256), so it cannot even parse as one -- this simply
+        // pins that the two schemas stay structurally distinct.
+        assert!(
+            serde_json::from_str::<crate::catalog_security::CatalogSignatureManifest>(
+                &backends_signature
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn production_key_id_constant_matches_catalog() {
+        assert_eq!(
+            BACKENDS_MANIFEST_PRODUCTION_KEY_ID,
+            CATALOG_SIGNATURE_KEY_ID
+        );
+    }
+}

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -16,6 +16,10 @@ pub mod api;
 pub mod apikeys;
 mod arch;
 pub(crate) mod audio;
+// `pub` (not `pub(crate)`): the desktop app reaches this by path
+// (`openasr_core::backend_manifest::verify_and_parse`) to verify the
+// downloaded inference-kernel manifest -- see the module doc comment.
+pub mod backend_manifest;
 pub(crate) mod batch;
 pub(crate) mod benchmark;
 pub(crate) mod capability_pack;

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -1,4 +1,5 @@
 mod atomic_file;
+mod backends_manifest_security;
 mod catalog_security;
 mod catalog_series;
 mod http;
@@ -72,6 +73,13 @@ pub use audio::{
     AudioInputError, AudioInputInfo, AudioInputIssue, AudioPreparationError,
     AudioPreparationOptions, PreparedAudioInput, prepare_audio_input, probe_audio_input,
     probe_wav_duration, recognized_audio_extensions, validate_audio_input,
+};
+pub use backends_manifest_security::{
+    BACKENDS_MANIFEST_PRODUCTION_KEY_ID, BACKENDS_MANIFEST_SIGNATURE_ALGORITHM,
+    BACKENDS_MANIFEST_SIGNATURE_FILE_NAME, BACKENDS_MANIFEST_SIGNATURE_SCHEMA_VERSION,
+    BackendsManifestSecurityError, BackendsManifestSignature, BackendsManifestSignatureValue,
+    VerifiedBackendsManifestSignature, render_backends_manifest_signature,
+    verify_backends_manifest_signature,
 };
 pub use batch::{
     BatchError, BatchFailure, BatchInput, BatchItem, BatchOutput, BatchSummary, batch_output_path,

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -1,4 +1,11 @@
 mod atomic_file;
+// Shared with the sibling `feat/sign-and-publish-backend-kernels` branch
+// (same commit's file, copied in verbatim rather than re-implemented -- see
+// backend_manifest.rs's module doc comment and docs/backend-kernels.md for
+// why there is only one Ed25519 backends-manifest verifier). When the two
+// branches merge, this file and this declaration are the same in both and
+// only need to land once.
+mod backends_manifest_security;
 mod catalog_security;
 mod catalog_series;
 mod http;
@@ -76,6 +83,13 @@ pub use audio::{
     AudioInputError, AudioInputInfo, AudioInputIssue, AudioPreparationError,
     AudioPreparationOptions, PreparedAudioInput, prepare_audio_input, probe_audio_input,
     probe_wav_duration, recognized_audio_extensions, validate_audio_input,
+};
+pub use backends_manifest_security::{
+    BACKENDS_MANIFEST_PRODUCTION_KEY_ID, BACKENDS_MANIFEST_SIGNATURE_ALGORITHM,
+    BACKENDS_MANIFEST_SIGNATURE_FILE_NAME, BACKENDS_MANIFEST_SIGNATURE_SCHEMA_VERSION,
+    BackendsManifestSecurityError, BackendsManifestSignature, BackendsManifestSignatureValue,
+    VerifiedBackendsManifestSignature, render_backends_manifest_signature,
+    verify_backends_manifest_signature,
 };
 pub use batch::{
     BatchError, BatchFailure, BatchInput, BatchItem, BatchOutput, BatchSummary, batch_output_path,

--- a/docs/backend-kernels.md
+++ b/docs/backend-kernels.md
@@ -1,0 +1,151 @@
+# Desktop inference kernel manifest (`backends-manifest.json`)
+
+This document is the contract for the **desktop app's Windows "inference
+kernel" switch** (Vulkan / CUDA / HIP): a signed manifest that tells the
+desktop app which prebuilt `openasr-cli` release archive to download for each
+backend, and how to verify it before ever launching it as the sidecar
+process.
+
+This is a **different mechanism** from the `GGML_BACKEND_DL` dynamic
+plugin-loading path described in [`GPU_PLUGIN_BUILD.md`](GPU_PLUGIN_BUILD.md)
+and implemented by `install_backend_pack`/`ensure_backends_loaded`. That path
+loads a GPU backend as a runtime plugin DLL *into one running process*. The
+mechanism here instead swaps the **entire sidecar binary**: the Windows
+release channel ships three separately, statically-linked `openasr.exe`
+builds (one per backend), each a complete, independent CLI. Desktop picks
+which whole binary to launch, not which plugin to load into one. Do not
+conflate the two -- a future consumer wanting the DL-plugin path should extend
+that mechanism, not this manifest.
+
+## Files
+
+Published by release CI (see the sibling `feat/sign-and-publish-backend-kernels`
+work) alongside the release's binary assets, both at:
+
+- `https://dl.openasr.org/core/v<version>/backends-manifest.json` (primary)
+- `https://github.com/QuintinShaw/openasr/releases/download/v<version>/backends-manifest.json` (fallback)
+
+and its detached signature at the same location with a `.signature.json`
+suffix swapped in for `.json` (`backends-manifest.signature.json`).
+
+## Schema (`schema_version: 1`)
+
+```jsonc
+{
+  "schema_version": 1,
+  "core_version": "0.1.14",              // openasr-cli semver these archives were built from
+  "source_commit": "<full 40-char sha>", // git commit the archives were built from
+  "platforms": {
+    "windows-x86_64": {
+      "backends": {
+        "vulkan": {
+          "asset": "openasr-0.1.14-windows-x86_64-vulkan.zip",
+          "size_bytes": 123456,
+          "sha256": "<64 lowercase hex chars>",
+          "urls": [
+            "https://dl.openasr.org/core/v0.1.14/openasr-0.1.14-windows-x86_64-vulkan.zip",
+            "https://github.com/QuintinShaw/openasr/releases/download/v0.1.14/openasr-0.1.14-windows-x86_64-vulkan.zip"
+          ],
+          "pe_import_markers": ["vulkan-1.dll"]
+        },
+        "cuda": { "...": "...", "pe_import_markers": ["cublas64_"] },
+        "hip":  { "...": "...", "pe_import_markers": ["amdhip64_"] }
+      }
+    }
+  }
+}
+```
+
+Only `windows-x86_64` exists today (macOS uses Metal and has no kernel
+switch; the "Inference kernel" section of Advanced Settings is Windows-only
+in the UI for the same reason). A future platform key would need matching
+support added to the downloader, not just the manifest.
+
+Unrecognized top-level fields are rejected (`#[serde(deny_unknown_fields)]`)
+so a manifest shape drift fails loudly instead of silently dropping data a
+future field depends on.
+
+### `urls`
+
+Try-in-order. `dl.openasr.org` is listed first (CDN-fronted, expected common
+case); the GitHub Releases download URL is the fallback if the first fails
+(network error, non-2xx, or a body that fails the sha256/PE checks below).
+Every URL in the list must point at bit-identical bytes -- there is exactly
+one `sha256` per backend entry, not one per URL.
+
+### `pe_import_markers`
+
+After extracting the archive, the downloader inspects the resulting
+`openasr.exe`'s PE **import table** (the list of DLLs it declares it will
+load at process start, e.g. via `DllImport`/`LoadLibrary`-at-startup-style
+static imports -- not a runtime `dlopen`/`LoadLibraryW` call, which would not
+appear here). The check passes if **at least one** imported DLL name
+case-insensitively starts with **at least one** marker in the list, e.g.
+`cublas64_` matches an import named `cublas64_12.dll`.
+
+This is a linkage sanity check, orthogonal to the `sha256` check:
+
+- `sha256` catches a corrupted/tampered/wrong-bytes download (transport
+  integrity).
+- `pe_import_markers` catches "the bytes are intact but this is not actually
+  a CUDA-linked build" -- e.g. a build-pipeline mixup that uploaded the
+  vulkan archive's contents under the cuda asset name with a correctly
+  computed (for those wrong bytes) sha256. Both checks are mandatory; neither
+  substitutes for the other.
+
+## Signing
+
+Reuses `openasr-core`'s existing catalog-signature scheme byte-for-byte: the
+same envelope shape (`schema_version`, `catalog_url`, `catalog_sha256`,
+`catalog_epoch`, `signature{algorithm,key_id,value}`), the same Ed25519
+algorithm, and the **same production trust roots**
+(`OPENASR_CATALOG_TRUST_ROOTS`) the model catalog signature already uses.
+There is no separate backend-kernel signing key to provision, rotate, or keep
+in sync -- see `crates/openasr-core/src/catalog_security.rs`.
+
+In that reused envelope, `catalog_url` is the backends-manifest's own URL
+(binding a signature to exactly the URL it was fetched from, so it can never
+be replayed against a different manifest), and `catalog_epoch` is a
+monotonic publish counter scoped to this manifest, unrelated to the model
+catalog's epoch.
+
+Verification entry point: `openasr_core::backend_manifest::verify_and_parse`
+(or `verify_and_parse_for_core_version`, which additionally enforces the
+version-match rule below). Both are fail-closed: a missing signature file, a
+tampered manifest, a signature that does not verify, or an unsupported
+`schema_version` (anything other than `1`) all return `Err` with no
+partial-trust fallback. See `crates/openasr-core/src/backend_manifest.rs`'s
+module doc comment and unit tests for the exact failure modes covered.
+
+## Version-matching rule
+
+The desktop app determines "my own `core_version`" by running its
+**currently active** sidecar binary with `--version` (clap's
+`#[command(version)]` prints `openasr <CARGO_PKG_VERSION>`, e.g.
+`openasr 0.1.14`) and parsing out the version. It then only ever accepts a
+`backends-manifest.json` whose `core_version` field matches that string
+exactly. A manifest for any other core version is rejected before any
+download starts -- this is what stops a desktop build from switching to a
+kernel binary built against an incompatible `openasr-server`/API surface.
+
+The same probe (`<exe> --version`) is run again, this time against the
+**downloaded** archive's extracted `openasr.exe`, as the last step of the
+verification chain (after sha256 and the PE import-table check): its printed
+version must also equal `core_version`. This closes the gap where a
+manifest's declared `core_version` is honest but the actual asset bytes
+(perhaps re-served from a stale CDN cache, or hand-edited urls array) are
+not what the manifest describes.
+
+## Desktop sidecar CLI contract
+
+The manifest only decides which archive to fetch. Once extracted and
+verified, desktop launches the resulting `openasr.exe` exactly the way it
+already launches its bundled sidecar: `serve --backend native --parent-pid
+<pid> ...` (see `apps/desktop/src-tauri/src/sidecar.rs`). The hidden
+`--backend`/`--parent-pid` `serve` flags are a separate concept from the
+kernel choice here -- they select the *transcription backend* (`mock` vs.
+`native`) and the parent-process watchdog pid, and are identical across all
+three kernel builds. `crates/openasr-cli/src/main.rs`'s
+`serve_accepts_desktop_sidecar_contract_flags` test locks their presence and
+shape so a future "clean up hidden flags" pass cannot silently break every
+desktop build's ability to launch its sidecar.

--- a/docs/backend-kernels.md
+++ b/docs/backend-kernels.md
@@ -95,20 +95,27 @@ This is a linkage sanity check, orthogonal to the `sha256` check:
 
 ## Signing
 
-Reuses `openasr-core`'s existing catalog-signature scheme byte-for-byte: the
-same envelope shape (`schema_version`, `catalog_url`, `catalog_sha256`,
-`catalog_epoch`, `signature{algorithm,key_id,value}`), the same Ed25519
-algorithm, and the **same production trust roots**
-(`OPENASR_CATALOG_TRUST_ROOTS`) the model catalog signature already uses.
-There is no separate backend-kernel signing key to provision, rotate, or keep
-in sync -- see `crates/openasr-core/src/catalog_security.rs`.
+Signature verification lives in `crates/openasr-core/src/backends_manifest_security.rs`
+(module `backends_manifest_security`, re-exported at the crate root as
+`verify_backends_manifest_signature` / `render_backends_manifest_signature`),
+**not** in `backend_manifest.rs`. It reuses the model catalog's production
+signing key and trust root (`catalog_security::OPENASR_CATALOG_TRUST_ROOTS`,
+key id `openasr-catalog-v1`) -- one signing seed, one trust root, one place a
+maintainer manages key custody -- but signs under its own
+domain-separation label, `openasr.backends_manifest.v1` (vs. the catalog's
+`openasr.catalog_manifest.v1`), so a catalog signature can never be replayed
+as a backends-manifest signature or vice versa even though both verify under
+the same public key. The signature envelope is its own shape (`schema_version`,
+`manifest_url`, `manifest_sha256`, `signature{algorithm,key_id,value}`) --
+notably no `catalog_epoch`: unlike the catalog, this manifest has no shared
+mutable endpoint a stale signature could roll back (it is generated fresh per
+immutable, version-namespaced release URL), so it carries no anti-rollback
+epoch.
 
-In that reused envelope, `catalog_url` is the backends-manifest's own URL
-(binding a signature to exactly the URL it was fetched from, so it can never
-be replayed against a different manifest), and `catalog_epoch` is a
-monotonic publish counter scoped to this manifest, unrelated to the model
-catalog's epoch.
-
+`backend_manifest.rs` (this manifest's JSON *schema* -- `BackendsManifest`,
+`PlatformBackends`, `BackendEntry`, the `core_version` match rule, and the
+per-backend sha256 helper) calls into `backends_manifest_security` for the
+signature check and never re-implements Ed25519 verification itself.
 Verification entry point: `openasr_core::backend_manifest::verify_and_parse`
 (or `verify_and_parse_for_core_version`, which additionally enforces the
 version-match rule below). Both are fail-closed: a missing signature file, a
@@ -116,6 +123,10 @@ tampered manifest, a signature that does not verify, or an unsupported
 `schema_version` (anything other than `1`) all return `Err` with no
 partial-trust fallback. See `crates/openasr-core/src/backend_manifest.rs`'s
 module doc comment and unit tests for the exact failure modes covered.
+
+Signing itself stays a local, maintainer-run operation via the hidden CLI
+subcommand `__openasr-sign-backends-manifest` (the signing seed never enters
+CI) -- see `backends_manifest_security.rs`'s module doc comment.
 
 ## Version-matching rule
 

--- a/tooling/release-manifest/README.md
+++ b/tooling/release-manifest/README.md
@@ -1,0 +1,90 @@
+# Release backends manifest
+
+Generates `backends-manifest.json`: the per-release index the desktop app
+reads to download a switchable Windows GPU-kernel sidecar (vulkan / cuda /
+hip) at runtime, instead of shipping every backend in the base install.
+
+- `backends_manifest.py` -- assembles the UNSIGNED manifest from already-built
+  release archives (reads bytes, computes sha256 + size). No secret involved;
+  `.github/workflows/release-binaries.yml`'s `checksums` job runs this in CI
+  once all three Windows GPU archives (`-vulkan`, `-cuda`, `-rocm`) are staged,
+  and uploads the result as both a workflow artifact and (on a real tag
+  release) a `backends-manifest.json` release asset.
+- `backends_manifest_test.py` -- fixture-driven unit tests (temp dir + fake
+  archive bytes, no network). Run with:
+
+  ```bash
+  python3 -m unittest discover -s tooling/release-manifest -p '*_test.py'
+  ```
+
+## Signing (LOCAL ONLY -- never in CI)
+
+Exactly like the model catalog
+(`tooling/publish-model/scripts/publish_catalog.sh`), the Ed25519 signing
+seed for `backends-manifest.signature.json` never enters CI. It reuses the
+SAME production key/trust root as the catalog
+(`openasr-catalog-v1` -- see `crates/openasr-core/src/backends_manifest_security.rs`
+for why one keypair covers both). After a release finishes:
+
+```bash
+# Download the CI-generated unsigned manifest from the release, or from the
+# `backends-manifest` workflow artifact.
+gh release download v<version> -p backends-manifest.json -O backends-manifest.json
+
+OPENASR_CATALOG_SIGNING_KEY_SEED_HEX=<real production seed> \
+  cargo run --quiet -p openasr-cli -- __openasr-sign-backends-manifest \
+    backends-manifest.json --out backends-manifest.signature.json \
+    --manifest-url https://dl.openasr.org/core/v<version>/backends-manifest.json
+
+gh release upload v<version> backends-manifest.signature.json --clobber
+```
+
+`__openasr-sign-backends-manifest` self-verifies the signature it just
+produced against the production trust root before writing it out, so signing
+with anything other than the real production seed fails loudly instead of
+silently writing an unverifiable signature.
+
+## dl.openasr.org sync
+
+`b2_sync.py` -- uploads files to `core/v<version>/<filename>` in the SAME
+Backblaze B2 bucket / Cloudflare Worker `openasr-app`'s desktop installers
+already publish to (`https://dl.openasr.org/desktop/...` there,
+`https://dl.openasr.org/core/...` here). It is a Python port of that repo's
+`apps/desktop/scripts/b2-s3-client.mjs` SigV4 signer (same env var names,
+same virtual-hosted-style request shape, same ETag-based immutability gate)
+plus `release-publish.mjs`'s upload-with-immutability-check logic --
+cross-validated against AWS's published SigV4 worked example in
+`b2_sync_test.py`, no network required to test.
+
+```bash
+export B2_S3_ENDPOINT=https://s3.us-east-005.backblazeb2.com   # confirm the real value with whoever owns the B2 account
+export B2_APPLICATION_KEY_ID=...
+export B2_APPLICATION_KEY=...                                   # never logged
+
+python3 tooling/release-manifest/b2_sync.py sync --version 0.1.10 \
+  dist/openasr-0.1.10-windows-x86_64-vulkan.zip \
+  dist/openasr-0.1.10-windows-x86_64-cuda.zip \
+  dist/openasr-0.1.10-windows-x86_64-rocm.zip \
+  dist/backends-manifest.json \
+  dist/backends-manifest.signature.json
+```
+
+This is deliberately **NOT wired into any GitHub Actions workflow yet**. That
+is a credential/scope decision, not a technical blocker:
+
+- It is unconfirmed whether core's release assets should share the
+  `openasr-releases` B2 bucket (and its credentials) with the desktop
+  installers, or use a separate bucket/prefix-scoped key. Whoever owns the B2
+  account needs to decide and, if sharing, mint a key scoped to `core/*` (B2
+  application keys support per-prefix scoping) rather than reusing the
+  desktop key wholesale.
+- `openasr-app`'s own `release-desktop.yml` only runs this kind of publish
+  from a `workflow_dispatch` with an explicit `publish: true` input, gated by
+  repo secrets on the app repo -- i.e. even there, publishing to
+  dl.openasr.org is a deliberate, per-run opt-in, not a side effect of every
+  green build. The same posture should carry over here once wired in: an
+  explicit, opt-in step or dispatch input, not an automatic push-tag action.
+- Publishing to a public, production distribution endpoint is a
+  release/deploy decision this script does not make on its own -- wiring it
+  into CI (which secrets, which trigger, which bucket/prefix) needs an
+  explicit go-ahead before it runs unattended.

--- a/tooling/release-manifest/README.md
+++ b/tooling/release-manifest/README.md
@@ -69,22 +69,53 @@ python3 tooling/release-manifest/b2_sync.py sync --version 0.1.10 \
   dist/backends-manifest.signature.json
 ```
 
-This is deliberately **NOT wired into any GitHub Actions workflow yet**. That
-is a credential/scope decision, not a technical blocker:
+This is deliberately **NOT wired into any GitHub Actions workflow**. Publish
+is always a local, human-run step:
 
-- It is unconfirmed whether core's release assets should share the
-  `openasr-releases` B2 bucket (and its credentials) with the desktop
-  installers, or use a separate bucket/prefix-scoped key. Whoever owns the B2
-  account needs to decide and, if sharing, mint a key scoped to `core/*` (B2
-  application keys support per-prefix scoping) rather than reusing the
-  desktop key wholesale.
+- **Decided**: core's release assets share the SAME `openasr-releases` B2
+  bucket the desktop installers already publish to, under a `core/v<version>/`
+  key prefix (`B2_BUCKET` defaults to `openasr-releases`; override only if the
+  bucket is ever split). Credentials (`B2_APPLICATION_KEY_ID` /
+  `B2_APPLICATION_KEY`) stay out of CI -- this sync always runs from a
+  maintainer's machine using the same local env vars desktop releases use, not
+  a repo secret.
 - `openasr-app`'s own `release-desktop.yml` only runs this kind of publish
   from a `workflow_dispatch` with an explicit `publish: true` input, gated by
   repo secrets on the app repo -- i.e. even there, publishing to
   dl.openasr.org is a deliberate, per-run opt-in, not a side effect of every
-  green build. The same posture should carry over here once wired in: an
-  explicit, opt-in step or dispatch input, not an automatic push-tag action.
+  green build. Core follows the same posture, taken one step further: not
+  even a gated dispatch, just a local script run after the maintainer has
+  reviewed the release.
 - Publishing to a public, production distribution endpoint is a
-  release/deploy decision this script does not make on its own -- wiring it
-  into CI (which secrets, which trigger, which bucket/prefix) needs an
-  explicit go-ahead before it runs unattended.
+  release/deploy decision this script does not make on its own. If core
+  releases ever need CI-driven publish, that is a separate, explicit
+  go-ahead (which secrets, which trigger) -- not a default.
+
+## Post-release checklist (local, after `release-binaries.yml` finishes)
+
+Run all three steps from a maintainer machine; none of this runs in CI.
+
+1. **Sign the manifest and attach it to the GitHub release** -- see
+   "Signing" above (`__openasr-sign-backends-manifest`, production
+   `OPENASR_CATALOG_SIGNING_KEY_SEED_HEX`, then
+   `gh release upload v<version> backends-manifest.signature.json --clobber`).
+2. **Sync to dl.openasr.org** -- see "dl.openasr.org sync" above
+   (`b2_sync.py sync --version <version>`, uploading the Windows backend-kernel
+   archives plus `backends-manifest.json` and
+   `backends-manifest.signature.json` to `core/v<version>/` in the shared
+   `openasr-releases` B2 bucket, using local `B2_S3_ENDPOINT` /
+   `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` env vars -- never repo
+   secrets).
+3. **Spot-check one signed exe with `signtool`** -- pick one of the archives
+   just uploaded (rotate which GPU leg you check across releases) and confirm
+   the Azure Trusted Signing signature is intact and trusted end to end:
+
+   ```powershell
+   Expand-Archive dist\openasr-<version>-windows-x86_64-vulkan.zip -DestinationPath tmp-verify
+   signtool verify /pa /v tmp-verify\openasr.exe
+   ```
+
+   `/pa` uses the default authenticode policy (what Windows actually enforces
+   at launch); a clean run prints a chain up to a trusted root with no
+   warnings. Treat any failure as release-blocking -- it means the archive a
+   user downloads would fail Windows' own signature check.

--- a/tooling/release-manifest/b2_sync.py
+++ b/tooling/release-manifest/b2_sync.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Sync core release assets to Backblaze B2 behind https://dl.openasr.org.
+
+  b2_sync.py sync --version <semver> \\
+      dist/openasr-<v>-windows-x86_64-vulkan.zip \\
+      dist/openasr-<v>-windows-x86_64-cuda.zip \\
+      dist/openasr-<v>-windows-x86_64-rocm.zip \\
+      dist/backends-manifest.json \\
+      [dist/backends-manifest.signature.json]
+
+Uploads each given file to `core/v<version>/<basename>` in the SAME B2
+bucket/Cloudflare-Worker setup `openasr-app`'s desktop installers already use
+(see that repo's `apps/desktop/scripts/release-publish.mjs` and
+`b2-s3-client.mjs`, which this script's SigV4 signer is a Python port of --
+`desktop/releases/v<version>/...` there, `core/v<version>/...` here). Uses
+THE SAME environment variable names as that script:
+
+  B2_S3_ENDPOINT        Required. e.g. https://s3.us-east-005.backblazeb2.com
+  B2_APPLICATION_KEY_ID Required.
+  B2_APPLICATION_KEY    Required. Never logged.
+  B2_BUCKET             Default: openasr-releases
+  B2_S3_REGION          Override if it cannot be inferred from B2_S3_ENDPOINT.
+
+Immutability, same policy as the desktop publish script: before uploading a
+key, HEAD it. If an object already exists there with a DIFFERENT sha256, this
+aborts rather than silently overwriting a shipped release asset -- bump the
+version instead. Re-uploading byte-identical content is a no-op.
+
+This is deliberately NOT wired into any GitHub Actions workflow yet -- see
+tooling/release-manifest/README.md's "dl.openasr.org sync" section for why
+(credential/bucket-sharing decision, not a technical blocker).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import quote, urlparse
+
+ALGORITHM = "AWS4-HMAC-SHA256"
+SERVICE = "s3"
+DEFAULT_BUCKET = "openasr-releases"
+DEFAULT_DL_BASE_URL = "https://dl.openasr.org"
+
+
+class B2SyncError(Exception):
+    pass
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _hmac(key: bytes, data: str) -> bytes:
+    return hmac.new(key, data.encode("utf-8"), hashlib.sha256).digest()
+
+
+def amz_date_parts(date: datetime) -> tuple[str, str]:
+    amz_date = date.strftime("%Y%m%dT%H%M%SZ")
+    return amz_date, amz_date[:8]
+
+
+def derive_signing_key(secret_access_key: str, date_stamp: str, region: str, service: str = SERVICE) -> bytes:
+    k_date = _hmac(f"AWS4{secret_access_key}".encode("utf-8"), date_stamp)
+    k_region = _hmac(k_date, region)
+    k_service = _hmac(k_region, service)
+    return _hmac(k_service, "aws4_request")
+
+
+# SigV4 requires RFC 3986 percent-encoding, which differs from
+# urllib.parse.quote's default `safe` set -- keep `!'()*` encoded too.
+def _encode_rfc3986(component: str) -> str:
+    return quote(component, safe="")
+
+
+def canonical_uri(pathname: str) -> str:
+    return "/".join(_encode_rfc3986(segment) for segment in pathname.split("/"))
+
+
+def build_canonical_request(
+    method: str, pathname: str, headers: dict[str, str], payload_hash: str
+) -> tuple[str, str]:
+    signed_header_names = sorted(name.lower() for name in headers)
+    canonical_headers = "".join(f"{name}:{str(headers[name]).strip()}\n" for name in signed_header_names)
+    signed_headers = ";".join(signed_header_names)
+    canonical_request = "\n".join(
+        [method, canonical_uri(pathname), "", canonical_headers, signed_headers, payload_hash]
+    )
+    return canonical_request, signed_headers
+
+
+@dataclass
+class SignedRequest:
+    authorization: str
+    amz_date: str
+
+
+def sign_request(
+    *,
+    method: str,
+    host: str,
+    pathname: str,
+    headers: dict[str, str],
+    payload_hash: str,
+    access_key_id: str,
+    secret_access_key: str,
+    region: str,
+    date: datetime,
+) -> SignedRequest:
+    amz_date, date_stamp = amz_date_parts(date)
+    headers_to_sign = {**headers, "host": host, "x-amz-date": amz_date, "x-amz-content-sha256": payload_hash}
+
+    canonical_request, signed_headers = build_canonical_request(method, pathname, headers_to_sign, payload_hash)
+
+    credential_scope = f"{date_stamp}/{region}/{SERVICE}/aws4_request"
+    string_to_sign = "\n".join([ALGORITHM, amz_date, credential_scope, sha256_hex(canonical_request.encode("utf-8"))])
+    signing_key = derive_signing_key(secret_access_key, date_stamp, region)
+    signature = hmac.new(signing_key, string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    authorization = (
+        f"{ALGORITHM} Credential={access_key_id}/{credential_scope}, "
+        f"SignedHeaders={signed_headers}, Signature={signature}"
+    )
+    return SignedRequest(authorization=authorization, amz_date=amz_date)
+
+
+def region_from_endpoint(endpoint: str, override: str | None) -> str:
+    if override:
+        return override
+    host = urlparse(endpoint).netloc
+    # e.g. s3.us-east-005.backblazeb2.com -> us-east-005
+    match = re.match(r"s3\.([^.]+)\.", host)
+    if match:
+        return match.group(1)
+    raise B2SyncError(
+        f"Could not infer the B2/S3 region from endpoint host '{host}'. Set B2_S3_REGION explicitly."
+    )
+
+
+class Transport:
+    """Minimal HTTP transport seam so tests can inject a fake instead of
+    making real network calls."""
+
+    def request(self, method: str, url: str, headers: dict[str, str], body: bytes) -> tuple[int, dict[str, str]]:
+        request = urllib.request.Request(url, data=body if method != "HEAD" else None, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(request) as response:  # noqa: S310 (fixed https B2 endpoint)
+                return response.status, dict(response.headers)
+        except urllib.error.HTTPError as error:
+            return error.code, dict(error.headers or {})
+
+
+@dataclass
+class B2Credentials:
+    endpoint: str
+    access_key_id: str
+    secret_access_key: str
+    bucket: str = DEFAULT_BUCKET
+    region: str | None = None
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "B2Credentials":
+        env = env if env is not None else os.environ
+        endpoint = env.get("B2_S3_ENDPOINT")
+        access_key_id = env.get("B2_APPLICATION_KEY_ID")
+        secret_access_key = env.get("B2_APPLICATION_KEY")
+        if not endpoint:
+            raise B2SyncError(
+                "B2_S3_ENDPOINT is not set. The bucket's region/cluster is not known until it's "
+                "created; set this to the bucket's S3-compatible endpoint, e.g. "
+                "https://s3.us-east-005.backblazeb2.com."
+            )
+        if not access_key_id or not secret_access_key:
+            raise B2SyncError("B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY must both be set to sync.")
+        return cls(
+            endpoint=endpoint,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            bucket=env.get("B2_BUCKET", DEFAULT_BUCKET),
+            region=env.get("B2_S3_REGION"),
+        )
+
+
+class B2Client:
+    def __init__(self, credentials: B2Credentials, transport: Transport | None = None):
+        self.credentials = credentials
+        self.transport = transport or Transport()
+        self.region = region_from_endpoint(credentials.endpoint, credentials.region)
+        endpoint_url = urlparse(credentials.endpoint)
+        # Virtual-hosted-style (`https://<bucket>.<endpoint-host>/<key>`), NOT
+        # path-style (`https://<endpoint-host>/<bucket>/<key>`) -- matches
+        # openasr-app's b2-s3-client.mjs `s3ObjectRequest`/`virtualHostedUrl`,
+        # which this is a Python port of. The bucket is part of the signed
+        # `host`, so getting this wrong produces a signature B2 rejects, not
+        # just a wrong-looking URL.
+        self.scheme = endpoint_url.scheme
+        self.host = f"{credentials.bucket}.{endpoint_url.netloc}"
+
+    def _object_url(self, key: str) -> str:
+        return f"{self.scheme}://{self.host}/{canonical_uri(key)}"
+
+    def _signed_headers(
+        self, method: str, key: str, payload_hash: str, extra_headers: dict[str, str]
+    ) -> dict[str, str]:
+        signed = sign_request(
+            method=method,
+            host=self.host,
+            pathname=f"/{key}",
+            headers=extra_headers,
+            payload_hash=payload_hash,
+            access_key_id=self.credentials.access_key_id,
+            secret_access_key=self.credentials.secret_access_key,
+            region=self.region,
+            date=datetime.now(timezone.utc),
+        )
+        return {
+            **extra_headers,
+            "Authorization": signed.authorization,
+            "x-amz-date": signed.amz_date,
+            "x-amz-content-sha256": payload_hash,
+        }
+
+    def head_object(self, key: str) -> dict[str, str] | None:
+        """Returns response headers if the object exists, None on 404, raises
+        on any other non-2xx status."""
+        payload_hash = sha256_hex(b"")
+        headers = self._signed_headers("HEAD", key, payload_hash, {})
+        status, response_headers = self.transport.request("HEAD", self._object_url(key), headers, b"")
+        if status == 404:
+            return None
+        if not 200 <= status < 300:
+            raise B2SyncError(f"HEAD {key} failed with status {status}")
+        return response_headers
+
+    def put_object(self, key: str, data: bytes, content_type: str = "application/octet-stream") -> None:
+        payload_hash = sha256_hex(data)
+        # content-type/content-length are part of the SIGNED headers here
+        # (passed as extra_headers into sign_request), matching
+        # b2-s3-client.mjs's s3ObjectRequest -- not just attached afterward.
+        extra_headers = {"content-type": content_type, "content-length": str(len(data))}
+        headers = self._signed_headers("PUT", key, payload_hash, extra_headers)
+        status, _ = self.transport.request("PUT", self._object_url(key), headers, data)
+        if not 200 <= status < 300:
+            raise B2SyncError(f"PUT {key} failed with status {status}")
+
+    def public_url(self, key: str, dl_base_url: str = DEFAULT_DL_BASE_URL) -> str:
+        return f"{dl_base_url.rstrip('/')}/{key}"
+
+
+def _normalize_etag(etag: str | None) -> str:
+    return (etag or "").replace('"', "").lower()
+
+
+def decide_immutability_action(remote: dict[str, object] | None, local_size: int, local_md5_hex: str) -> str:
+    """Mirrors release-publish.mjs's `decideImmutabilityAction`: "put" if
+    nothing is there yet, "skip" if an identical object already is (same
+    size + ETag/md5 -- an idempotent re-run), or raises if a DIFFERENT
+    object already occupies the key (never silently overwrite a shipped
+    release asset; the caller must bump the version instead)."""
+    if remote is None:
+        return "put"
+    remote_size = remote.get("size")
+    remote_etag = _normalize_etag(remote.get("etag"))  # type: ignore[arg-type]
+    if remote_size == local_size and remote_etag == local_md5_hex.lower():
+        return "skip"
+    raise B2SyncError(
+        f"refusing to overwrite existing object with different content "
+        f"(remote size={remote_size} etag={remote_etag!r} vs local size={local_size} "
+        f"md5={local_md5_hex!r}); bump the version instead of re-publishing under the same one"
+    )
+
+
+def sync_files(
+    client: B2Client, version: str, files: list[Path], dl_base_url: str = DEFAULT_DL_BASE_URL
+) -> list[str]:
+    """Uploads each file to `core/v<version>/<basename>`, honoring the same
+    immutability gate release-publish.mjs uses (abort on a differing existing
+    object; allow an idempotent re-upload of identical bytes). Returns the
+    public dl.openasr.org URLs, in input order."""
+    urls = []
+    for path in files:
+        if not path.is_file():
+            raise B2SyncError(f"file not found: {path}")
+        data = path.read_bytes()
+        key = f"core/v{version}/{path.name}"
+
+        head = client.head_object(key)
+        remote = None
+        if head is not None:
+            content_length = head.get("Content-Length") or head.get("content-length")
+            remote = {
+                "size": int(content_length) if content_length is not None else None,
+                "etag": head.get("ETag") or head.get("etag"),
+            }
+        local_md5_hex = hashlib.md5(data).hexdigest()  # noqa: S324 (B2/S3 ETag comparison, not a security use)
+        action = decide_immutability_action(remote, len(data), local_md5_hex)
+        if action == "put":
+            client.put_object(key, data)
+
+        urls.append(client.public_url(key, dl_base_url))
+    return urls
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    sync = subparsers.add_parser("sync", help="Upload files to core/v<version>/ on B2")
+    sync.add_argument("--version", required=True, help="Release semver, e.g. 0.1.10")
+    sync.add_argument("--dl-base-url", default=DEFAULT_DL_BASE_URL)
+    sync.add_argument("files", nargs="+", type=Path)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.command == "sync":
+        try:
+            credentials = B2Credentials.from_env()
+            client = B2Client(credentials)
+            urls = sync_files(client, args.version, args.files, args.dl_base_url)
+        except B2SyncError as error:
+            print(f"b2_sync.py: {error}", file=sys.stderr)
+            return 1
+        for url in urls:
+            print(url)
+        return 0
+    raise SystemExit(f"unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tooling/release-manifest/b2_sync_test.py
+++ b/tooling/release-manifest/b2_sync_test.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import hashlib
+import unittest
+from datetime import datetime, timezone
+
+from b2_sync import (
+    B2Client,
+    B2Credentials,
+    B2SyncError,
+    amz_date_parts,
+    build_canonical_request,
+    canonical_uri,
+    decide_immutability_action,
+    region_from_endpoint,
+    sha256_hex,
+    sign_request,
+    sync_files,
+)
+
+# AWS's own published worked example for SigV4 header-based auth (GET Object,
+# examplebucket/test.txt) -- the same canonical cross-implementation vector
+# openasr-app's b2-s3-client.test.mjs pins for its JS SigV4 signer (this
+# module is a Python port of that signer). Matching the identical published
+# Authorization header is real evidence the signing math is correct,
+# independent of both implementations and of B2 itself.
+# https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+AWS_EXAMPLE = {
+    "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+    "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    "region": "us-east-1",
+    "date": datetime(2013, 5, 24, tzinfo=timezone.utc),
+    "host": "examplebucket.s3.amazonaws.com",
+    "pathname": "/test.txt",
+    "payload_hash": sha256_hex(b""),
+}
+
+
+class Sha256Md5Test(unittest.TestCase):
+    def test_sha256_of_empty_payload(self) -> None:
+        self.assertEqual(
+            sha256_hex(b""), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+
+
+class AmzDatePartsTest(unittest.TestCase):
+    def test_formats_amz_date_and_date_stamp(self) -> None:
+        self.assertEqual(amz_date_parts(AWS_EXAMPLE["date"]), ("20130524T000000Z", "20130524"))
+
+
+class CanonicalUriTest(unittest.TestCase):
+    def test_preserves_slashes_and_percent_encodes_spaces(self) -> None:
+        self.assertEqual(
+            canonical_uri("/core/v0.1.10/openasr-0.1.10-windows-x86_64-vulkan.zip"),
+            "/core/v0.1.10/openasr-0.1.10-windows-x86_64-vulkan.zip",
+        )
+        self.assertEqual(canonical_uri("/a b/c"), "/a%20b/c")
+
+
+class BuildCanonicalRequestTest(unittest.TestCase):
+    def test_matches_aws_published_canonical_request(self) -> None:
+        canonical_request, signed_headers = build_canonical_request(
+            "GET",
+            AWS_EXAMPLE["pathname"],
+            {
+                "host": AWS_EXAMPLE["host"],
+                "range": "bytes=0-9",
+                "x-amz-content-sha256": AWS_EXAMPLE["payload_hash"],
+                "x-amz-date": "20130524T000000Z",
+            },
+            AWS_EXAMPLE["payload_hash"],
+        )
+
+        self.assertEqual(signed_headers, "host;range;x-amz-content-sha256;x-amz-date")
+        self.assertEqual(
+            canonical_request,
+            "\n".join(
+                [
+                    "GET",
+                    "/test.txt",
+                    "",
+                    "host:examplebucket.s3.amazonaws.com",
+                    "range:bytes=0-9",
+                    f"x-amz-content-sha256:{AWS_EXAMPLE['payload_hash']}",
+                    "x-amz-date:20130524T000000Z",
+                    "",
+                    "host;range;x-amz-content-sha256;x-amz-date",
+                    AWS_EXAMPLE["payload_hash"],
+                ]
+            ),
+        )
+
+
+class SignRequestTest(unittest.TestCase):
+    def test_reproduces_aws_published_authorization_header(self) -> None:
+        signed = sign_request(
+            method="GET",
+            host=AWS_EXAMPLE["host"],
+            pathname=AWS_EXAMPLE["pathname"],
+            headers={"range": "bytes=0-9"},
+            payload_hash=AWS_EXAMPLE["payload_hash"],
+            access_key_id=AWS_EXAMPLE["access_key_id"],
+            secret_access_key=AWS_EXAMPLE["secret_access_key"],
+            region=AWS_EXAMPLE["region"],
+            date=AWS_EXAMPLE["date"],
+        )
+
+        self.assertEqual(signed.amz_date, "20130524T000000Z")
+        self.assertEqual(
+            signed.authorization,
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, "
+            "SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, "
+            "Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
+        )
+
+    def test_deterministic_for_a_fixed_date_and_changes_with_the_secret(self) -> None:
+        base = dict(
+            method="HEAD",
+            host="openasr-releases.s3.us-east-005.backblazeb2.com",
+            pathname="/core/v0.1.10/backends-manifest.json",
+            payload_hash=sha256_hex(b""),
+            access_key_id="keyid",
+            region="us-east-005",
+            date=datetime(2026, 7, 3, tzinfo=timezone.utc),
+        )
+        first = sign_request(headers={}, secret_access_key="secret-a", **base)
+        again = sign_request(headers={}, secret_access_key="secret-a", **base)
+        different_key = sign_request(headers={}, secret_access_key="secret-b", **base)
+
+        self.assertEqual(first.authorization, again.authorization)
+        self.assertNotEqual(first.authorization, different_key.authorization)
+        self.assertTrue(
+            first.authorization.startswith(
+                "AWS4-HMAC-SHA256 Credential=keyid/20260703/us-east-005/s3/aws4_request"
+            )
+        )
+
+
+class RegionFromEndpointTest(unittest.TestCase):
+    def test_infers_region_from_backblaze_endpoint(self) -> None:
+        self.assertEqual(
+            region_from_endpoint("https://s3.us-east-005.backblazeb2.com", None), "us-east-005"
+        )
+
+    def test_override_wins(self) -> None:
+        self.assertEqual(
+            region_from_endpoint("https://s3.us-east-005.backblazeb2.com", "eu-central-003"),
+            "eu-central-003",
+        )
+
+    def test_raises_when_it_cannot_infer(self) -> None:
+        with self.assertRaises(B2SyncError):
+            region_from_endpoint("https://example.com", None)
+
+
+class DecideImmutabilityActionTest(unittest.TestCase):
+    def test_put_when_nothing_remote(self) -> None:
+        self.assertEqual(decide_immutability_action(None, 10, "abc"), "put")
+
+    def test_skip_when_identical(self) -> None:
+        md5 = hashlib.md5(b"same-bytes").hexdigest()
+        remote = {"size": len(b"same-bytes"), "etag": f'"{md5}"'}
+        self.assertEqual(decide_immutability_action(remote, len(b"same-bytes"), md5), "skip")
+
+    def test_raises_when_different(self) -> None:
+        remote = {"size": 999, "etag": '"deadbeef"'}
+        with self.assertRaises(B2SyncError):
+            decide_immutability_action(remote, 10, "abc123")
+
+
+class FakeTransport:
+    """In-memory stand-in for b2_sync.Transport -- lets sync_files be tested
+    without any real network access."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.requests: list[tuple[str, str]] = []
+
+    def request(self, method, url, headers, body):
+        self.requests.append((method, url))
+        # Key is whatever comes after the host in the URL path.
+        key = url.split("/", 3)[-1]
+        if method == "HEAD":
+            if key not in self.objects:
+                return 404, {}
+            data = self.objects[key]
+            return 200, {
+                "Content-Length": str(len(data)),
+                "ETag": f'"{hashlib.md5(data).hexdigest()}"',
+            }
+        if method == "PUT":
+            self.objects[key] = body
+            return 200, {}
+        raise AssertionError(f"unexpected method: {method}")
+
+
+def _fake_client() -> tuple[B2Client, FakeTransport]:
+    transport = FakeTransport()
+    credentials = B2Credentials(
+        endpoint="https://s3.us-east-005.backblazeb2.com",
+        access_key_id="keyid",
+        secret_access_key="secret",
+        bucket="openasr-releases",
+    )
+    return B2Client(credentials, transport=transport), transport
+
+
+class SyncFilesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.dist_dir = Path(self._tmp.name)
+
+    def _write(self, name: str, content: bytes):
+        path = self.dist_dir / name
+        path.write_bytes(content)
+        return path
+
+    def test_uploads_new_files_under_core_v_version_prefix(self) -> None:
+        client, transport = _fake_client()
+        path = self._write("backends-manifest.json", b'{"schema_version":1}')
+
+        urls = sync_files(client, "0.1.10", [path])
+
+        self.assertEqual(urls, ["https://dl.openasr.org/core/v0.1.10/backends-manifest.json"])
+        self.assertIn("core/v0.1.10/backends-manifest.json", transport.objects)
+        self.assertEqual(
+            transport.objects["core/v0.1.10/backends-manifest.json"], b'{"schema_version":1}'
+        )
+
+    def test_idempotent_reupload_of_identical_bytes_is_a_no_op(self) -> None:
+        client, transport = _fake_client()
+        path = self._write("backends-manifest.json", b"same-bytes")
+        sync_files(client, "0.1.10", [path])
+        put_count_after_first = sum(1 for method, _ in transport.requests if method == "PUT")
+
+        sync_files(client, "0.1.10", [path])
+        put_count_after_second = sum(1 for method, _ in transport.requests if method == "PUT")
+
+        self.assertEqual(put_count_after_first, 1)
+        self.assertEqual(put_count_after_second, 1)  # no second PUT
+
+    def test_refuses_to_overwrite_a_different_object_at_the_same_key(self) -> None:
+        client, transport = _fake_client()
+        path = self._write("backends-manifest.json", b"version-one-bytes")
+        sync_files(client, "0.1.10", [path])
+
+        path.write_bytes(b"version-one-bytes-but-different")
+        with self.assertRaises(B2SyncError):
+            sync_files(client, "0.1.10", [path])
+
+    def test_missing_local_file_fails_loudly(self) -> None:
+        client, _ = _fake_client()
+        with self.assertRaises(B2SyncError):
+            sync_files(client, "0.1.10", [self.dist_dir / "does-not-exist.zip"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/release-manifest/backends_manifest.py
+++ b/tooling/release-manifest/backends_manifest.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Generate the UNSIGNED `backends-manifest.json` release asset.
+
+  backends_manifest.py generate \\
+      --version <semver> --source-commit <40-hex-sha> --dist-dir <dir> \\
+      --out <backends-manifest.json>
+
+`backends-manifest.json` is the per-release index the desktop app reads to
+download a switchable Windows GPU-kernel sidecar (vulkan / cuda / hip) at
+runtime, without shipping every backend in the base install. This script only
+ASSEMBLES the manifest from already-built release archives (reads bytes,
+computes sha256 + size) -- it never touches signing key material. Signing is a
+separate, LOCAL-ONLY step (never run in CI), exactly like
+`tooling/publish-model/scripts/publish_catalog.sh` signs the model catalog:
+
+  cd <repo root>
+  OPENASR_CATALOG_SIGNING_KEY_SEED_HEX=<real production seed> \\
+    cargo run --quiet -p openasr-cli -- __openasr-sign-backends-manifest \\
+      backends-manifest.json --out backends-manifest.signature.json \\
+      --manifest-url https://dl.openasr.org/core/v<version>/backends-manifest.json
+
+This generation step, by contrast, has no secret involved and is safe to run
+in CI (release-binaries.yml's `checksums` job, after the Windows GPU archives
+are staged) so the maintainer only has to sign+upload, not rebuild.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+PLATFORM = "windows-x86_64"
+DEFAULT_BASE_URL = "https://dl.openasr.org/core"
+DEFAULT_REPO = "QuintinShaw/openasr"
+VERSION_RE = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?")
+COMMIT_RE = re.compile(r"[0-9a-fA-F]{40}")
+
+# backend key (matches the Cargo feature name, e.g. `hip`) -> the friendly
+# asset-name suffix release-binaries.yml packages it under (matches the
+# `asset:` field in that workflow's matrix -- `hip`'s asset is named `rocm`
+# for cross-platform consistency; see that file's matrix comment) and the PE
+# import-table substring(s) the desktop app's runtime backend probe looks for
+# (case-insensitive prefix match against openasr.exe's import table -- any
+# one hit is sufficient).
+BACKENDS: dict[str, dict[str, object]] = {
+    "vulkan": {
+        "asset_suffix": "vulkan",
+        "pe_import_markers": ["vulkan-1.dll"],
+    },
+    "cuda": {
+        "asset_suffix": "cuda",
+        "pe_import_markers": ["cublas64_"],
+    },
+    "hip": {
+        "asset_suffix": "rocm",
+        "pe_import_markers": ["amdhip64_"],
+    },
+}
+
+
+class BackendsManifestError(Exception):
+    pass
+
+
+def sha256_and_size(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def asset_filename(version: str, asset_suffix: str) -> str:
+    return f"openasr-{version}-{PLATFORM}-{asset_suffix}.zip"
+
+
+def backend_entry(
+    version: str, backend: str, dist_dir: Path, base_url: str, repo: str
+) -> dict[str, object]:
+    spec = BACKENDS[backend]
+    asset_suffix = spec["asset_suffix"]
+    filename = asset_filename(version, asset_suffix)  # type: ignore[arg-type]
+    path = dist_dir / filename
+    if not path.is_file():
+        raise BackendsManifestError(
+            f"backend '{backend}': expected archive not found: {path}"
+        )
+    sha256, size_bytes = sha256_and_size(path)
+    if size_bytes == 0:
+        raise BackendsManifestError(f"backend '{backend}': archive is empty: {path}")
+    return {
+        "asset": filename,
+        "size_bytes": size_bytes,
+        "sha256": sha256,
+        "urls": [
+            f"{base_url}/v{version}/{filename}",
+            f"https://github.com/{repo}/releases/download/v{version}/{filename}",
+        ],
+        "pe_import_markers": list(spec["pe_import_markers"]),  # type: ignore[arg-type]
+    }
+
+
+def build_manifest(
+    version: str,
+    source_commit: str,
+    dist_dir: Path,
+    base_url: str = DEFAULT_BASE_URL,
+    repo: str = DEFAULT_REPO,
+    backends: list[str] | None = None,
+) -> dict[str, object]:
+    if not VERSION_RE.fullmatch(version):
+        raise BackendsManifestError(f"--version must be a semver string, got: {version!r}")
+    if not COMMIT_RE.fullmatch(source_commit):
+        raise BackendsManifestError(
+            f"--source-commit must be a 40-hex-char commit sha, got: {source_commit!r}"
+        )
+    if not dist_dir.is_dir():
+        raise BackendsManifestError(f"--dist-dir is not a directory: {dist_dir}")
+
+    selected = backends if backends is not None else sorted(BACKENDS)
+    unknown = [name for name in selected if name not in BACKENDS]
+    if unknown:
+        raise BackendsManifestError(
+            f"unknown backend(s) {unknown}; known backends: {sorted(BACKENDS)}"
+        )
+    if not selected:
+        raise BackendsManifestError("at least one backend is required")
+
+    entries = {
+        backend: backend_entry(version, backend, dist_dir, base_url, repo)
+        for backend in selected
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "core_version": version,
+        "source_commit": source_commit.lower(),
+        "platforms": {
+            PLATFORM: {
+                "backends": {backend: entries[backend] for backend in selected},
+            },
+        },
+    }
+
+
+def manifest_url_for(version: str, base_url: str = DEFAULT_BASE_URL) -> str:
+    return f"{base_url}/v{version}/backends-manifest.json"
+
+
+def write_manifest(manifest: dict[str, object], out: Path) -> None:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(manifest, indent=2, sort_keys=False) + "\n"
+    out.write_text(text, encoding="utf-8")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate = subparsers.add_parser("generate", help="Assemble the unsigned backends-manifest.json")
+    generate.add_argument("--version", required=True, help="Release semver, e.g. 0.1.10")
+    generate.add_argument("--source-commit", required=True, help="Full 40-hex release commit sha")
+    generate.add_argument(
+        "--dist-dir",
+        required=True,
+        type=Path,
+        help="Directory containing the built openasr-<version>-windows-x86_64-{vulkan,cuda,rocm}.zip archives",
+    )
+    generate.add_argument("--out", required=True, type=Path, help="Output backends-manifest.json path")
+    generate.add_argument("--base-url", default=DEFAULT_BASE_URL, help="Primary CDN base URL (default: %(default)s)")
+    generate.add_argument("--repo", default=DEFAULT_REPO, help="GitHub owner/repo for the fallback URL (default: %(default)s)")
+    generate.add_argument(
+        "--backend",
+        dest="backends",
+        action="append",
+        choices=sorted(BACKENDS),
+        help=f"Restrict to specific backend(s) (repeatable). Default: all of {sorted(BACKENDS)}.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.command == "generate":
+        try:
+            manifest = build_manifest(
+                version=args.version,
+                source_commit=args.source_commit,
+                dist_dir=args.dist_dir,
+                base_url=args.base_url,
+                repo=args.repo,
+                backends=args.backends,
+            )
+        except BackendsManifestError as error:
+            print(f"backends_manifest.py: {error}", file=sys.stderr)
+            return 1
+        write_manifest(manifest, args.out)
+        print(args.out)
+        return 0
+    raise SystemExit(f"unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tooling/release-manifest/backends_manifest_test.py
+++ b/tooling/release-manifest/backends_manifest_test.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from backends_manifest import (
+    BackendsManifestError,
+    asset_filename,
+    build_manifest,
+    manifest_url_for,
+    write_manifest,
+)
+
+VERSION = "0.1.10"
+COMMIT = "a" * 40
+
+
+def _write_fake_archive(dist_dir: Path, filename: str, content: bytes) -> tuple[str, int]:
+    path = dist_dir / filename
+    path.write_bytes(content)
+    return hashlib.sha256(content).hexdigest(), len(content)
+
+
+class BuildManifestTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.dist_dir = Path(self._tmp.name)
+        self.expected = {}
+        for backend, suffix in (("vulkan", "vulkan"), ("cuda", "cuda"), ("hip", "rocm")):
+            filename = asset_filename(VERSION, suffix)
+            sha256, size = _write_fake_archive(self.dist_dir, filename, f"fake-{backend}-bytes".encode())
+            self.expected[backend] = (filename, sha256, size)
+
+    def test_generates_all_three_backends_with_correct_hashes(self) -> None:
+        manifest = build_manifest(VERSION, COMMIT, self.dist_dir)
+
+        self.assertEqual(manifest["schema_version"], 1)
+        self.assertEqual(manifest["core_version"], VERSION)
+        self.assertEqual(manifest["source_commit"], COMMIT)
+
+        backends = manifest["platforms"]["windows-x86_64"]["backends"]
+        self.assertEqual(set(backends), {"vulkan", "cuda", "hip"})
+        for backend, (filename, sha256, size) in self.expected.items():
+            entry = backends[backend]
+            self.assertEqual(entry["asset"], filename)
+            self.assertEqual(entry["sha256"], sha256)
+            self.assertEqual(entry["size_bytes"], size)
+
+    def test_hip_backend_key_uses_rocm_asset_name(self) -> None:
+        # Cargo feature name is `hip`; the shipped asset is named `-rocm` for
+        # cross-platform consistency with the Linux AMD leg (see
+        # release-binaries.yml's matrix comment) -- pin that the manifest
+        # keeps the key/asset-name split straight.
+        manifest = build_manifest(VERSION, COMMIT, self.dist_dir)
+        hip_entry = manifest["platforms"]["windows-x86_64"]["backends"]["hip"]
+        self.assertEqual(hip_entry["asset"], f"openasr-{VERSION}-windows-x86_64-rocm.zip")
+
+    def test_urls_prefer_dl_openasr_org_then_github_fallback(self) -> None:
+        manifest = build_manifest(VERSION, COMMIT, self.dist_dir)
+        vulkan_entry = manifest["platforms"]["windows-x86_64"]["backends"]["vulkan"]
+        urls = vulkan_entry["urls"]
+        self.assertEqual(len(urls), 2)
+        self.assertTrue(urls[0].startswith("https://dl.openasr.org/core/v0.1.10/"))
+        self.assertTrue(
+            urls[1].startswith("https://github.com/QuintinShaw/openasr/releases/download/v0.1.10/")
+        )
+
+    def test_pe_import_markers_are_backend_specific(self) -> None:
+        manifest = build_manifest(VERSION, COMMIT, self.dist_dir)
+        backends = manifest["platforms"]["windows-x86_64"]["backends"]
+        self.assertEqual(backends["vulkan"]["pe_import_markers"], ["vulkan-1.dll"])
+        self.assertEqual(backends["cuda"]["pe_import_markers"], ["cublas64_"])
+        self.assertEqual(backends["hip"]["pe_import_markers"], ["amdhip64_"])
+
+    def test_missing_archive_fails_loudly(self) -> None:
+        (self.dist_dir / asset_filename(VERSION, "cuda")).unlink()
+        with self.assertRaisesRegex(BackendsManifestError, "cuda.*not found"):
+            build_manifest(VERSION, COMMIT, self.dist_dir)
+
+    def test_empty_archive_fails_loudly(self) -> None:
+        (self.dist_dir / asset_filename(VERSION, "vulkan")).write_bytes(b"")
+        with self.assertRaisesRegex(BackendsManifestError, "vulkan.*empty"):
+            build_manifest(VERSION, COMMIT, self.dist_dir)
+
+    def test_rejects_malformed_version(self) -> None:
+        with self.assertRaises(BackendsManifestError):
+            build_manifest("not-a-version", COMMIT, self.dist_dir)
+
+    def test_rejects_malformed_commit(self) -> None:
+        with self.assertRaises(BackendsManifestError):
+            build_manifest(VERSION, "not-a-sha", self.dist_dir)
+
+    def test_restrict_to_specific_backends(self) -> None:
+        manifest = build_manifest(VERSION, COMMIT, self.dist_dir, backends=["vulkan"])
+        backends = manifest["platforms"]["windows-x86_64"]["backends"]
+        self.assertEqual(set(backends), {"vulkan"})
+
+    def test_rejects_unknown_backend(self) -> None:
+        with self.assertRaises(BackendsManifestError):
+            build_manifest(VERSION, COMMIT, self.dist_dir, backends=["metal"])
+
+    def test_write_manifest_round_trips_through_json(self) -> None:
+        manifest = build_manifest(VERSION, COMMIT, self.dist_dir)
+        out = self.dist_dir / "out" / "backends-manifest.json"
+        write_manifest(manifest, out)
+        reloaded = json.loads(out.read_text(encoding="utf-8"))
+        self.assertEqual(reloaded, manifest)
+
+    def test_manifest_url_for(self) -> None:
+        self.assertEqual(
+            manifest_url_for(VERSION),
+            "https://dl.openasr.org/core/v0.1.10/backends-manifest.json",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Ship signed, switchable Windows GPU-kernel distribution end to end: release CI
signs the Windows binaries (Azure Trusted Signing) and publishes a signed
`backends-manifest.json` index; core gains an Ed25519 verify/parse API so a
downstream client (the desktop app) can safely fetch and swap a GPU-kernel
sidecar (vulkan / cuda / hip) at runtime instead of shipping every backend in
the base install.

## Why

The Windows release currently ships one fixed CPU-only kernel per install.
Letting users switch to a GPU kernel post-install means downloading an
unverified binary onto their machine at runtime, which is a trust-boundary
problem unless both the binary and the index that points to it are signed
and verified end to end:

- Release binaries need Authenticode signing so `signtool verify` and
  Windows SMEP/Defender treat them as trusted, matching what the desktop
  installer already does.
- The manifest that tells a client "here is the sha256/url for the vulkan
  build of v0.1.14" needs the same signature story as the model catalog, or
  a compromised or MITM'd manifest could point a client at an arbitrary
  binary.

This PR is the core-repo half: CI-side signing/manifest generation and the
core crate's verification API. The desktop-side consumer (kernel switch UI)
is a separate PR against `openasr-app` (see cross-reference below).

## Changes

- `.github/workflows/release-binaries.yml`: sign every Windows leg's
  `openasr.exe` (and the CPU leg's own `ggml*.dll`) with Azure Trusted
  Signing before packaging, so `SHA256SUMS` covers signed bytes; fails the
  build closed if the signing service-principal secrets are missing, unless
  it's an explicit `workflow_dispatch dry_run`. The `checksums` job also
  assembles the unsigned `backends-manifest.json` once the three Windows GPU
  archives (`-vulkan`, `-cuda`, `-rocm`) are staged, and uploads it as a
  workflow artifact / release asset.
- `crates/openasr-core/src/backends_manifest_security.rs`: Ed25519
  sign/verify module for `backends-manifest.json`. Deliberately reuses the
  model catalog's production signing key and trust root
  (`openasr-catalog-v1`) with a distinct domain-separation label, so one
  keypair covers both manifest kinds but a signature for one can never be
  replayed as the other.
- `crates/openasr-core/src/backend_manifest.rs`: the parse + signature
  verification API (`openasr_core::backend_manifest::verify_and_parse`) a
  downstream client calls to safely consume the manifest. `pub` (not
  `pub(crate)`) since the desktop app reaches this by path.
- `crates/openasr-cli`: new hidden subcommand
  `__openasr-sign-backends-manifest`, mirroring the existing
  `__openasr-sign-catalog-manifest` -- signing stays a local, maintainer-run
  operation; the seed never enters CI. It self-verifies the signature it
  just produced against the production trust root before writing it out.
- `tooling/release-manifest/`: `backends_manifest.py` (assembles the
  unsigned manifest from built archives, used by the `checksums` CI job) and
  `b2_sync.py` (Python port of `openasr-app`'s `b2-s3-client.mjs` SigV4
  signer + `release-publish.mjs`'s immutability-gated upload, for syncing
  Windows GPU-kernel assets to `core/v<version>/` on the same B2 bucket the
  desktop installers already publish to -- deliberately not wired into any
  workflow; see the README for why). Both fixture-tested, no network
  required.
- `tooling/release-manifest/README.md`: documents signing, the decided B2
  bucket-sharing plan (shared `openasr-releases` bucket, `core/v<version>/`
  prefix, local-only credentials), and a consolidated post-release
  checklist (sign + upload manifest, B2 sync, `signtool verify` spot-check).
- `docs/backend-kernels.md`: format/trust-boundary contract for the manifest
  and its signature.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core -p openasr-cli --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-core -p openasr-cli` (2232 passed, 2 failed,
      122 skipped -- the 2 failures, `pull::tests::pull_lock_blocks_second_writer`
      and `realtime::wire_bindings_test::realtime_wire_bindings_regenerate_to_match_committed`,
      are pre-existing on `main` and unrelated to this change)
- [x] `python3 -m unittest discover -s tooling/release-manifest -p '*_test.py'`
      (28 passed)
- [x] `cargo deny check` (advisories ok, bans ok, licenses ok, sources ok)
- [x] `cargo test --workspace --doc` (0 doc tests in this workspace, exit 0)

## Manual smoke checks

Not applicable -- this PR is CI workflow config plus a sign/verify library
API with no interactive surface; behavior is covered by the fixture-driven
unit tests above. The Azure Trusted Signing step itself can only be
exercised by an actual `release-binaries.yml` run with the real service
principal secrets.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not wire the B2 sync into CI -- publishing to dl.openasr.org stays a
  local, maintainer-run step (see `tooling/release-manifest/README.md` for
  the reasoning).
- Does not include the desktop-side kernel-switch consumer UI; that is a
  separate PR against `openasr-app` (`feat/desktop-kernel-switch`), which
  depends on this PR's `backend_manifest` API.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI coding-agent assistance (Claude), reviewed and understood in full before submission.
