### PR TITLE
fix(core): report the backend a request actually ran on, not Auto's generic pick

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -899,6 +899,12 @@ fn run_native_transcription_impl(
     // resolve_runtime_backend(), which consults this override.
     let _backend_guard =
         install_request_backend_override(backend_preference.request_backend_override());
+    // This family's Auto-mode GPU capability, so the provenance backend label
+    // below resolves through the same family-aware gate the family's own
+    // executor used (see `native_runtime_backend_label`'s doc comment).
+    let auto_gpu_enabled = crate::arch::family_auto_gpu_enabled_for_model_architecture(
+        selected_family.model_architecture,
+    );
     let mut longform_metadata: Option<TranscriptionLongFormMetadata> = None;
     if run_longform {
         let (vad_provider, vad_engine_label) = resolve_longform_vad_provider(&longform_options)?;
@@ -953,6 +959,7 @@ fn run_native_transcription_impl(
                     slice_kind_summary,
                     timeline_kind,
                     &longform_provenance,
+                    auto_gpu_enabled,
                 )),
                 language: reported_language.clone(),
             });
@@ -1114,6 +1121,7 @@ fn run_native_transcription_impl(
                 slice_kind_summary,
                 timeline_kind,
                 &longform_provenance,
+                auto_gpu_enabled,
             );
             if !ran_any_slice && suppressed_slice_count > 0 {
                 let fallback_options = request_options.clone();
@@ -1151,6 +1159,7 @@ fn run_native_transcription_impl(
             slice_kind_summary,
             timeline_kind,
             &longform_provenance,
+            auto_gpu_enabled,
         ));
     }
 
@@ -1798,6 +1807,7 @@ fn build_longform_metadata(
     slice_kind_summary: &'static str,
     timeline_kind: &'static str,
     extra_provenance: &[String],
+    auto_gpu_enabled: bool,
 ) -> TranscriptionLongFormMetadata {
     let mode = match options.mode {
         LongFormMode::Off => "off",
@@ -1810,7 +1820,10 @@ fn build_longform_metadata(
         format!("core.longform.plan:{mode}"),
         format!("core.longform.slice-kind:{slice_kind_summary}"),
         format!("core.longform.timeline:{timeline_kind}"),
-        format!("core.native.backend:{}", native_runtime_backend_label()),
+        format!(
+            "core.native.backend:{}",
+            native_runtime_backend_label(auto_gpu_enabled)
+        ),
         "core.longform.assembler".to_string(),
         "core.native.ggml".to_string(),
     ];
@@ -1846,14 +1859,6 @@ fn summarize_slice_kinds(slices: &[crate::AudioSlice]) -> &'static str {
         "full"
     } else {
         "unknown"
-    }
-}
-
-fn native_runtime_backend_label() -> &'static str {
-    match GgmlCpuGraphConfig::resolve_runtime_backend() {
-        GgmlCpuGraphBackend::Cpu => "cpu",
-        GgmlCpuGraphBackend::Metal => "metal",
-        GgmlCpuGraphBackend::Gpu => "gpu",
     }
 }
 
@@ -1998,6 +2003,24 @@ fn prefers_cpu_decoder_for_multichunk_metal(model_architecture: &str) -> bool {
         .is_some_and(|descriptor| descriptor.prefer_cpu_decoder_for_multichunk_metal)
 }
 
+/// The `core.native.backend` provenance label always resolves through the
+/// same family-aware gate the family's own executor used
+/// (`GgmlCpuGraphConfig::resolve_family_runtime_backend`), keyed by this
+/// family's `auto_gpu_enabled` capability declaration. It must never call
+/// `GgmlCpuGraphConfig::resolve_runtime_backend()` directly for this purpose:
+/// that generic resolver reports what Auto would pick for a family with no
+/// gate, which drifts from reality for a family like dolphin or
+/// xasr-zipformer that pins Auto to CPU -- exactly the bug that produced a
+/// `core.native.backend:metal` label on a dolphin Auto request that in fact
+/// ran entirely on CPU.
+fn native_runtime_backend_label(auto_gpu_enabled: bool) -> &'static str {
+    match GgmlCpuGraphConfig::resolve_family_runtime_backend(auto_gpu_enabled) {
+        GgmlCpuGraphBackend::Cpu => "cpu",
+        GgmlCpuGraphBackend::Metal => "metal",
+        GgmlCpuGraphBackend::Gpu => "gpu",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2011,6 +2034,70 @@ mod tests {
     // run test functions across threads within one process, so serialize with
     // a lock rather than relying on scheduling luck.
     static PROGRESS_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn family_auto_gpu_enabled_lookup_matches_dolphin_and_xasr_gates() {
+        // Regression pin for the two builtin families whose Auto default is
+        // gated to CPU (see `auto_gpu_enabled`'s doc comment); every other
+        // builtin lets Auto pick GPU automatically.
+        assert!(
+            !crate::arch::family_auto_gpu_enabled_for_model_architecture(
+                crate::arch::DOLPHIN_GGML_ARCHITECTURE_ID
+            )
+        );
+        assert!(
+            !crate::arch::family_auto_gpu_enabled_for_model_architecture(
+                crate::arch::XASR_ZIPFORMER_GGML_ARCHITECTURE_ID
+            )
+        );
+        assert!(crate::arch::family_auto_gpu_enabled_for_model_architecture(
+            crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID
+        ));
+        // An unrecognized architecture defaults to the majority behavior
+        // (Auto may use GPU) rather than silently pinning an unknown family
+        // to CPU.
+        assert!(crate::arch::family_auto_gpu_enabled_for_model_architecture(
+            "not-a-real-architecture"
+        ));
+    }
+
+    /// Regression for the dolphin-plus-Auto provenance mislabel: the
+    /// `core.native.backend` label must resolve through the same
+    /// family-aware gate the family's own executor used
+    /// (`GgmlCpuGraphConfig::resolve_family_runtime_backend`), not recompute
+    /// generically. Before this fix, `native_runtime_backend_label` called
+    /// `GgmlCpuGraphConfig::resolve_runtime_backend()` directly, which on a
+    /// host with a GPU device reports "metal" for an Auto dolphin request
+    /// that in fact ran entirely on CPU (dolphin pins Auto to CPU; see
+    /// `dolphin::executor::dolphin_runtime_backend`).
+    #[test]
+    fn native_runtime_backend_label_reflects_family_auto_gate_not_generic_resolver() {
+        use crate::ggml_runtime::{RequestBackendPreference, install_request_backend_override};
+
+        // Auto, family gate disabled (dolphin/xasr-zipformer shape): must
+        // report "cpu" regardless of what the generic resolver would pick.
+        assert_eq!(native_runtime_backend_label(false), "cpu");
+
+        // Auto, family gate enabled (every other builtin's shape): reports
+        // exactly what the generic resolver picks -- unchanged behavior.
+        let generic_auto_label = match GgmlCpuGraphConfig::resolve_runtime_backend() {
+            GgmlCpuGraphBackend::Cpu => "cpu",
+            GgmlCpuGraphBackend::Metal => "metal",
+            GgmlCpuGraphBackend::Gpu => "gpu",
+        };
+        assert_eq!(native_runtime_backend_label(true), generic_auto_label);
+
+        // An explicit accelerated request always reports the accelerated
+        // backend, even for a family whose Auto default is gated to CPU --
+        // the gate never overrides an explicit per-request choice.
+        {
+            let _guard =
+                install_request_backend_override(Some(RequestBackendPreference::Accelerated));
+            let label = native_runtime_backend_label(false);
+            assert!(label == "metal" || label == "gpu", "got {label}");
+            assert_eq!(label, native_runtime_backend_label(true));
+        }
+    }
 
     #[test]
     fn native_progress_is_monotonic_across_phases_and_clears() {

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -250,6 +250,23 @@ pub(crate) struct OpenAsrArchitectureDescriptor {
     pub executor_component_id: &'static str,
     pub execution_capability: GgmlExecutionCapability,
     pub prefer_cpu_decoder_for_multichunk_metal: bool,
+    /// Whether Auto execution may select a GPU-class backend automatically
+    /// when one is available. This can only ever pin Auto to CPU -- it never
+    /// overrides an explicit `execution_target=accelerated` (or `cpu`)
+    /// request, which always gets exactly what it asked for via
+    /// `GgmlCpuGraphConfig::resolve_family_runtime_backend`. False only for
+    /// the two families with a measured Auto-mode GPU regression at their
+    /// normal (non-`accelerated`) workload size: dolphin's whole pipeline
+    /// (`models::dolphin::executor::dolphin_runtime_backend`) and
+    /// xasr-zipformer's streaming encoder
+    /// (`models::xasr_zipformer::graph_config::encoder_gpu_enabled`) -- see
+    /// those functions' doc comments for the measured evidence. Any
+    /// provenance/telemetry label reporting the backend a request actually
+    /// ran on must resolve through the same function with this same flag,
+    /// not recompute generically (a generic recompute is what produced a
+    /// `core.native.backend:metal` label on a dolphin Auto request that in
+    /// fact ran entirely on CPU).
+    pub auto_gpu_enabled: bool,
     /// Whether this family's own decode loop can emit diarization tokens (the
     /// cohere token-stream is the only builtin case today). The single
     /// declaration of this architecture-level capability fact -- runtime
@@ -342,6 +359,22 @@ pub(crate) fn emits_punctuation_for_model_architecture(model_architecture: &str)
     OpenAsrArchitectureRegistry::with_builtins()
         .find_by_model_architecture(model_architecture)
         .and_then(|descriptor| descriptor.emits_punctuation)
+}
+
+/// Whether a builtin family's Auto execution may select a GPU-class backend
+/// automatically (see [`OpenAsrArchitectureDescriptor::auto_gpu_enabled`]),
+/// looked up by GGUF `model_architecture`. An unrecognized architecture
+/// defaults to `true` (the majority behavior: Auto uses GPU when available)
+/// rather than silently pinning an unknown family to CPU. This is the
+/// accessor a provenance/telemetry label must call -- with the result fed
+/// into `GgmlCpuGraphConfig::resolve_family_runtime_backend` -- so the
+/// reported backend can never drift from what the family's own executor
+/// actually decided.
+pub(crate) fn family_auto_gpu_enabled_for_model_architecture(model_architecture: &str) -> bool {
+    OpenAsrArchitectureRegistry::with_builtins()
+        .find_by_model_architecture(model_architecture)
+        .map(|descriptor| descriptor.auto_gpu_enabled)
+        .unwrap_or(true)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -938,6 +971,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: COHERE_TRANSCRIBE_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: true,
+        auto_gpu_enabled: true,
         self_diarizes: true,
         emits_punctuation: Some(true),
         hparam_schema: COHERE_TRANSCRIBE_HPARAM_SCHEMA,
@@ -977,6 +1011,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: WHISPER_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        auto_gpu_enabled: true,
         self_diarizes: false,
         emits_punctuation: Some(true),
         hparam_schema: WHISPER_HPARAM_SCHEMA,
@@ -1009,6 +1044,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: QWEN3_ASR_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::NativeGraphLoweringV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        auto_gpu_enabled: true,
         self_diarizes: false,
         emits_punctuation: Some(true),
         hparam_schema: QWEN3_ASR_HPARAM_SCHEMA,
@@ -1046,6 +1082,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: PARAKEET_CTC_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        auto_gpu_enabled: true,
         self_diarizes: false,
         // Character/BPE CTC: whether an imported checkpoint's vocab includes
         // punctuation depends on that specific checkpoint's training corpus,
@@ -1091,6 +1128,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: PARAKEET_TDT_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        auto_gpu_enabled: true,
         self_diarizes: false,
         // Verified on the imported pack: trained on transcripts that preserve
         // punctuation and capitalization (mirrors `_catalog.py`'s
@@ -1124,6 +1162,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: WAV2VEC2_CTC_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        auto_gpu_enabled: true,
         self_diarizes: false,
         // Character CTC: same BYO-checkpoint reasoning as parakeet-ctc above.
         emits_punctuation: None,
@@ -1160,6 +1199,11 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: XASR_ZIPFORMER_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        // Measured on the M1 host: every Metal configuration loses to CPU for
+        // this streaming encoder's chunked workload (the per-chunk graph is
+        // too small to amortize GPU dispatch) -- see
+        // `xasr_zipformer::graph_config::encoder_gpu_enabled`.
+        auto_gpu_enabled: false,
         self_diarizes: false,
         emits_punctuation: Some(true),
         hparam_schema: XASR_ZIPFORMER_HPARAM_SCHEMA,
@@ -1187,6 +1231,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: MOONSHINE_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        auto_gpu_enabled: true,
         self_diarizes: false,
         emits_punctuation: Some(true),
         hparam_schema: MOONSHINE_HPARAM_SCHEMA,
@@ -1222,6 +1267,11 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: DOLPHIN_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        // Fail-closed to the golden, parity-validated CPU path: Metal is
+        // faster on this pipeline (AB-measured) but its fp16 numerics are not
+        // golden-validated (parity gate is CPU bit-exact), so Auto stays on
+        // CPU -- see `dolphin::executor::dolphin_runtime_backend`.
+        auto_gpu_enabled: false,
         self_diarizes: false,
         // DataoceanAI's cn-dialect-small training corpus is transcribed
         // without punctuation and the model has no punctuation-prediction
@@ -1254,6 +1304,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: SENSEVOICE_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        auto_gpu_enabled: true,
         self_diarizes: false,
         emits_punctuation: Some(true),
         hparam_schema: SENSEVOICE_HPARAM_SCHEMA,
@@ -1292,6 +1343,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: FIRERED_AED_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
+        auto_gpu_enabled: true,
         self_diarizes: false,
         // The reference tokenizer's dict.txt has no punctuation/<space>
         // entries (char + SPM vocab trained on unpunctuated Mandarin ASR
@@ -1370,6 +1422,58 @@ mod tests {
             assert_eq!(
                 emits_punctuation_for_model_architecture(model_architecture),
                 emits_punctuation,
+                "'{model_architecture}' accessor must match the descriptor field"
+            );
+            seen.insert(model_architecture);
+        }
+
+        assert_eq!(
+            seen.len(),
+            registry.descriptors().len(),
+            "expectation table must cover every builtin architecture, no more, no less"
+        );
+    }
+
+    /// Pins `auto_gpu_enabled` per builtin architecture -- dolphin and
+    /// xasr-zipformer are the only two builtins whose Auto default is gated
+    /// to CPU (a measured Auto-mode GPU regression at their normal chunk
+    /// size, not a correctness limit; see the field doc and the two
+    /// executors' own doc comments). Every other builtin lets Auto pick a
+    /// GPU-class backend automatically when available, matching how
+    /// `resolve_runtime_backend` behaves generically. A silent flip of this
+    /// table for any of the two gated families would either quietly start
+    /// running an unvalidated GPU path by default (dolphin) or regress Auto
+    /// throughput (xasr-zipformer); for any other family it would silently
+    /// start denying Auto users a GPU their hardware supports.
+    #[test]
+    fn builtin_architectures_declare_auto_gpu_enabled() {
+        let expected: &[(&str, bool)] = &[
+            (COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID, true),
+            (WHISPER_GGML_ARCHITECTURE_ID, true),
+            (QWEN3_ASR_GGML_ARCHITECTURE_ID, true),
+            (PARAKEET_CTC_GGML_ARCHITECTURE_ID, true),
+            (PARAKEET_TDT_GGML_ARCHITECTURE_ID, true),
+            (WAV2VEC2_CTC_GGML_ARCHITECTURE_ID, true),
+            (XASR_ZIPFORMER_GGML_ARCHITECTURE_ID, false),
+            (MOONSHINE_GGML_ARCHITECTURE_ID, true),
+            (DOLPHIN_GGML_ARCHITECTURE_ID, false),
+            (SENSEVOICE_GGML_ARCHITECTURE_ID, true),
+            (FIRERED_AED_GGML_ARCHITECTURE_ID, true),
+        ];
+        let registry = OpenAsrArchitectureRegistry::with_builtins();
+        let mut seen = std::collections::BTreeSet::new();
+
+        for (model_architecture, auto_gpu_enabled) in expected.iter().copied() {
+            let descriptor = registry
+                .find_by_model_architecture(model_architecture)
+                .unwrap_or_else(|| panic!("missing builtin architecture '{model_architecture}'"));
+            assert_eq!(
+                descriptor.auto_gpu_enabled, auto_gpu_enabled,
+                "'{model_architecture}' auto_gpu_enabled mismatch"
+            );
+            assert_eq!(
+                family_auto_gpu_enabled_for_model_architecture(model_architecture),
+                auto_gpu_enabled,
                 "'{model_architecture}' accessor must match the descriptor field"
             );
             seen.insert(model_architecture);

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -272,6 +272,37 @@ impl GgmlCpuGraphConfig {
         }
     }
 
+    /// Single choke point for "should this family run on GPU": every family
+    /// whose Auto default is gated (rather than always following
+    /// `resolve_runtime_backend()` unconditionally) must resolve its backend
+    /// through this function instead of hand-rolling the override check
+    /// (dolphin's `dolphin_runtime_backend` and xasr-zipformer's
+    /// `encoder_gpu_enabled` are the two builtin cases -- see their doc
+    /// comments for the measured Auto-mode evidence behind `auto_gpu_enabled
+    /// = false`). `auto_gpu_enabled` is a pure Auto-mode default: it can only
+    /// ever pin Auto to CPU, never override an explicit per-request
+    /// preference. A request that explicitly asked for `CpuOnly` or
+    /// `Accelerated` always gets what it asked for via
+    /// `resolve_runtime_backend()`, matching the product rule that hardware
+    /// selection is the engine's call only in Auto -- an explicit user choice
+    /// always wins, even where auto-mode would have picked differently.
+    ///
+    /// This is also the function any provenance/telemetry label reporting
+    /// "which backend actually ran" for such a family must call (with the
+    /// same `auto_gpu_enabled` the family itself used) instead of
+    /// `resolve_runtime_backend()` directly -- calling the generic resolver
+    /// for a gated family's provenance label reports what Auto would
+    /// generically pick, not what the family actually decided, which is
+    /// exactly the kind of drift that produced a `core.native.backend:metal`
+    /// label on a request that in fact ran entirely on CPU.
+    pub fn resolve_family_runtime_backend(auto_gpu_enabled: bool) -> GgmlCpuGraphBackend {
+        if auto_gpu_enabled || request_backend_override().is_some() {
+            Self::resolve_runtime_backend()
+        } else {
+            GgmlCpuGraphBackend::Cpu
+        }
+    }
+
     pub(crate) fn resolve_backend_name_for(
         backend: GgmlCpuGraphBackend,
     ) -> Result<String, GgmlCpuGraphError> {
@@ -5222,6 +5253,55 @@ mod tests {
             "probe: resolve_runtime_backend={:?}",
             GgmlCpuGraphConfig::resolve_runtime_backend()
         );
+    }
+
+    #[test]
+    fn resolve_family_runtime_backend_gates_auto_but_never_explicit() {
+        use super::{RequestBackendPreference, install_request_backend_override};
+
+        // No per-request preference installed (Auto): a family that declares
+        // `auto_gpu_enabled = false` must stay pinned to CPU...
+        assert_eq!(
+            GgmlCpuGraphConfig::resolve_family_runtime_backend(false),
+            GgmlCpuGraphBackend::Cpu
+        );
+        // ...while a family that allows Auto to pick GPU automatically just
+        // gets whatever the generic resolver would have picked anyway.
+        assert_eq!(
+            GgmlCpuGraphConfig::resolve_family_runtime_backend(true),
+            GgmlCpuGraphConfig::resolve_runtime_backend()
+        );
+
+        // An explicit CpuOnly preference is honored regardless of the gate.
+        {
+            let _guard = install_request_backend_override(Some(RequestBackendPreference::CpuOnly));
+            assert_eq!(
+                GgmlCpuGraphConfig::resolve_family_runtime_backend(false),
+                GgmlCpuGraphBackend::Cpu
+            );
+            assert_eq!(
+                GgmlCpuGraphConfig::resolve_family_runtime_backend(true),
+                GgmlCpuGraphBackend::Cpu
+            );
+        }
+
+        // An explicit Accelerated preference always wins, even for a family
+        // whose Auto default is gated to CPU -- the gate can only ever pin
+        // Auto, never override an explicit per-request choice.
+        {
+            let _guard =
+                install_request_backend_override(Some(RequestBackendPreference::Accelerated));
+            let expected = GgmlCpuGraphConfig::resolve_runtime_backend();
+            assert!(expected.is_gpu_class());
+            assert_eq!(
+                GgmlCpuGraphConfig::resolve_family_runtime_backend(false),
+                expected
+            );
+            assert_eq!(
+                GgmlCpuGraphConfig::resolve_family_runtime_backend(true),
+                expected
+            );
+        }
     }
 
     #[test]

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -24,7 +24,6 @@ use crate::arch::DOLPHIN_GGML_ADAPTER_ID;
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgufMetadata, GgufOwnedWeightTensorPayload,
     GgufTensorDataReadError, GgufTensorDataReader, GgufWeightTensorElementType,
-    RequestBackendPreference, request_backend_override,
 };
 use crate::models::ggml_asr_executor::{
     GgmlAsrExecutionError, GgmlAsrExecutionRequest, GgmlAsrExecutionResult, GgmlAsrExecutor,
@@ -226,15 +225,14 @@ pub(crate) struct DolphinPipelineOutput {
 /// and reproduces the golden transcript on the clip. Metal stays an opt-in rather
 /// than the default only because its fp16 numerics are not golden-validated
 /// (the parity gate is CPU bit-exact); it is the recommended accelerated path.
+///
+/// Delegates to the shared `resolve_family_runtime_backend` gate (declared via
+/// this architecture's `auto_gpu_enabled = false`, see `arch::mod` /
+/// `BUILTIN_ARCHITECTURE_DESCRIPTORS`) rather than hand-rolling the override
+/// check, so any provenance label resolving through the same gate can never
+/// drift from what this function actually decided.
 fn dolphin_runtime_backend() -> GgmlCpuGraphBackend {
-    if matches!(
-        request_backend_override(),
-        Some(RequestBackendPreference::Accelerated)
-    ) {
-        GgmlCpuGraphConfig::resolve_runtime_backend()
-    } else {
-        GgmlCpuGraphBackend::Cpu
-    }
+    GgmlCpuGraphConfig::resolve_family_runtime_backend(false)
 }
 
 /// Runtime weights for one pack, shared behind an `Arc` so the process-level pool

--- a/crates/openasr-core/src/models/graph_runtime_config.rs
+++ b/crates/openasr-core/src/models/graph_runtime_config.rs
@@ -97,12 +97,23 @@ pub(crate) fn gpu_stage_enabled_for_backend(
 ) -> bool {
     let gpu_raw = std::env::var(gpu_env).ok();
     let legacy_metal_raw = legacy_metal_env.and_then(|name| std::env::var(name).ok());
+    // An explicit `execution_target=accelerated` request always wins over a
+    // stage's tuned Auto-mode default -- these per-stage knobs (encoder
+    // prelude, decoder, ...) exist to keep Auto from picking a GPU path that
+    // measured worse for that specific op mix, not to second-guess a user who
+    // explicitly asked for acceleration. An explicit env var still wins over
+    // this (an operator-set kill switch is a deployment decision, not the
+    // engine choosing on the user's behalf), so only the *default* shifts.
+    let explicit_accelerated = matches!(
+        crate::ggml_runtime::request_backend_override(),
+        Some(crate::ggml_runtime::RequestBackendPreference::Accelerated)
+    );
     gpu_stage_enabled_for_backend_raw(
         backend,
         gpu_raw.as_deref(),
-        default_gpu_enabled,
+        default_gpu_enabled || explicit_accelerated,
         legacy_metal_raw.as_deref(),
-        default_metal_enabled,
+        default_metal_enabled || explicit_accelerated,
     )
 }
 
@@ -278,6 +289,38 @@ mod tests {
             true,
         ));
     }
+
+    /// Regression for a stage gate whose tuned Auto default disables a
+    /// backend (`default_gpu_enabled = false`, e.g. a hypothetical future
+    /// per-stage knob tuned off by default on some host class): with no env
+    /// var set, an explicit `execution_target=accelerated` request must
+    /// still enable the stage, not silently inherit the Auto-tuned default.
+    /// None of today's builtin stage gates actually reach this path in the
+    /// common (env-unset) case -- they all default enabled -- but every
+    /// gate goes through this one function, so this pins the override
+    /// priority for the whole class rather than per family.
+    #[test]
+    fn explicit_accelerated_overrides_a_stage_gate_disabled_by_default() {
+        use crate::ggml_runtime::{RequestBackendPreference, install_request_backend_override};
+
+        assert!(!gpu_stage_enabled_for_backend(
+            GgmlCpuGraphBackend::Metal,
+            "OPENASR_TEST_STAGE_ENABLE_GPU_NEVER_SET",
+            false,
+            Some("OPENASR_TEST_STAGE_ENABLE_METAL_NEVER_SET"),
+            false,
+        ));
+
+        let _guard = install_request_backend_override(Some(RequestBackendPreference::Accelerated));
+        assert!(gpu_stage_enabled_for_backend(
+            GgmlCpuGraphBackend::Metal,
+            "OPENASR_TEST_STAGE_ENABLE_GPU_NEVER_SET",
+            false,
+            Some("OPENASR_TEST_STAGE_ENABLE_METAL_NEVER_SET"),
+            false,
+        ));
+    }
+
     #[test]
     fn request_backend_override_forces_resolution() {
         use crate::ggml_runtime::{

--- a/crates/openasr-core/src/models/xasr_zipformer/graph_config.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/graph_config.rs
@@ -1,7 +1,4 @@
-use crate::ggml_runtime::{
-    GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphThreadingWorkload,
-    RequestBackendPreference, request_backend_override,
-};
+use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphThreadingWorkload};
 use crate::models::graph_runtime_config::{
     ModelMetalRuntimeOverrides, configure_model_runtime_graph_config_from_env,
     has_explicit_thread_override,
@@ -23,11 +20,13 @@ const FULL_ENCODER_GRAPH_SIZE: usize = 65_536;
 /// graph is too small to amortize GPU dispatch). Users on stronger GPUs can
 /// force it with execution_target=accelerated, and what runs is what was
 /// requested — no silent downgrade.
+///
+/// Delegates to the shared `resolve_family_runtime_backend` gate (declared via
+/// this architecture's `auto_gpu_enabled = false`) rather than hand-rolling
+/// the override check, so any provenance label resolving through the same
+/// gate can never drift from what this function actually decided.
 fn encoder_gpu_enabled() -> bool {
-    matches!(
-        request_backend_override(),
-        Some(RequestBackendPreference::Accelerated)
-    )
+    GgmlCpuGraphConfig::resolve_family_runtime_backend(false).is_gpu_class()
 }
 
 pub(crate) fn xasr_zipformer_encoder_graph_config() -> GgmlCpuGraphConfig {


### PR DESCRIPTION
## Summary

Full audit of every builtin ASR family's ggml backend dispatch against the product rule: an explicit `execution_target=accelerated` (or `cpu`) request must always get exactly what it asked for; only `auto` may pick CPU on the engine's own judgment; every provenance label must reflect what actually ran, not what Auto would generically pick.

## Why

`core.native.backend` recomputed the backend generically (`GgmlCpuGraphConfig::resolve_runtime_backend()`) instead of asking the family that actually ran the request. Dolphin and xasr-zipformer pin Auto to CPU (a measured, documented perf/parity decision, not a bug), but the generic resolver ignores that gate, so an Auto dolphin request on a GPU-equipped host reported `core.native.backend:metal` while the compute in fact ran entirely on CPU.

## Audit table (family x platform x auto behavior x explicit behavior x provenance)

| Family | Auto behavior | Explicit `accelerated` behavior | Provenance before | Provenance after | Verdict |
|---|---|---|---|---|---|
| dolphin | Pinned to CPU (documented: Metal fp16 not golden-validated, parity gate is CPU bit-exact) | Gets Metal/Gpu (already correct) | **Mislabeled `metal` under Auto+GPU-host** | Correctly reports `cpu` under Auto, `metal`/`gpu` under explicit | Fixed (legit Auto pin kept, provenance fixed) |
| xasr-zipformer (streaming encoder) | Pinned to CPU (measured: every Metal config loses to CPU on chunked streaming workload) | Gets Metal/Gpu (already correct) | Same generic-resolver mislabel risk as dolphin, same code shape | Correctly gated through the same shared function | Fixed (legit Auto pin kept, provenance fixed) |
| qwen3-asr | Auto uses GPU automatically | Gets Metal/Gpu | Correct (goes through generic resolver directly) | Unchanged | No violation |
| whisper | Auto uses GPU automatically; encoder-prelude conv/pos-embed stage has its own `default_metal_enabled=false` knob | Gets Metal/Gpu for the main graph | Traced the prelude asymmetry against 10 sibling stage-gates; confirmed it is dead code in the common (env-unset) case -- the legacy-Metal-env fallthrough only consults `default_metal_enabled` when that env var is actually set, so it silently falls back to `default_gpu_enabled=true` when unset. No live behavior difference exists today. | Unchanged (retracted as a live bug; the explicit-always-wins change to the shared stage gate still future-proofs it) | Initially suspected, traced, ruled out -- no live violation |
| firered-aed | Auto uses GPU automatically (encoder + decoder stage gates) | Gets Metal/Gpu | Correct | Unchanged | No violation |
| moonshine | Auto uses GPU automatically (encoder + decoder stage gates) | Gets Metal/Gpu | Correct | Unchanged | No violation |
| sensevoice | Auto uses GPU automatically | Gets Metal/Gpu | Correct | Unchanged | No violation |
| parakeet-ctc | Auto uses GPU automatically | Gets Metal/Gpu | Correct | Unchanged | No violation |
| parakeet-tdt | Auto uses GPU automatically | Gets Metal/Gpu | Correct | Unchanged | No violation |
| wav2vec2-ctc | Auto uses GPU automatically | Gets Metal/Gpu | Correct | Unchanged | No violation |
| cohere-transcribe | Auto uses GPU automatically; decoder additionally forces CPU during multichunk longform on Metal (`prefer_cpu_decoder_for_multichunk_metal`, documented in `KNOWN_LIMITATIONS.md` as a correctness/perf safety policy) even under explicit `accelerated` | Encoder gets Metal/Gpu; decoder still forces CPU during multichunk longform regardless of explicit choice | Already self-discloses via its own `core.native.longform.policy:cohere-metal-multichunk-prefer-cpu-decoder` provenance tag | Unchanged (left as-is, see rationale below) | Reviewed, not silent, out of scope |
| hymt2, fastconformer | No independent backend dispatch (reuse other families' resolved graph config / not a standalone ggml executor) | n/a | n/a | n/a | No dispatch code to audit |
| Non-macOS, no GPU device | `execution_target=accelerated` fails closed with a typed error (`ggml_available_devices().any(is_gpu)`, generic across platforms, not macOS-special-cased) | Same fail-closed path | Correct (explicit error, not silent CPU fallback) | Unchanged | No violation |
| Non-macOS, HIP/Vulkan/CUDA device present | Same `GgmlCpuGraphBackend::Gpu` generic lane as macOS Metal; same `auto_gpu_enabled` gate applies | Gets the `Gpu` lane | Same gate/label logic, platform-agnostic (`default_gpu_backend_for_target` is the only `cfg(target_os)` branch, and it only decides the Metal-vs-Gpu label, not the auto/explicit policy) | Unchanged | No violation |

Two items reviewed and intentionally left out of this PR's scope:

- **cohere's multichunk-decoder-CPU-preference**: documented, already self-disclosing (its own provenance tag), correctness/perf-motivated policy. Changing it needs re-validating the golden-diff/perf evidence behind that policy -- a different, larger piece of work than a dispatch-honesty audit, and it would touch the `prefer_cpu_backend` decode path this PR does not otherwise touch. Follow-up candidate, not bundled here.
- **CLI gap**: `openasr transcribe`/`live` still do not expose `--execution-target` (only the HTTP API and the bench-suite's `OPENASR_GGML_BACKEND` env mapping do), so CLI-only users of a gated family (dolphin, xasr-zipformer) cannot request acceleration at all today. Missing feature, not a dishonesty bug -- no request the CLI can make is misreported. Follow-up candidate.

## Changes

- `GgmlCpuGraphConfig::resolve_family_runtime_backend(auto_gpu_enabled: bool)` in `crates/openasr-core/src/ggml_runtime/cpu_graph.rs` -- the single choke point for "should this family run on GPU." An explicit per-request preference always wins; `auto_gpu_enabled` can only ever pin Auto to CPU.
- `OpenAsrArchitectureDescriptor::auto_gpu_enabled: bool` in `crates/openasr-core/src/arch/mod.rs` -- one capability declaration per architecture (table-driven test pins all 11 builtins), replacing hand-rolled per-family override checks.
- `dolphin::executor::dolphin_runtime_backend` and `xasr_zipformer::graph_config::encoder_gpu_enabled` now delegate to the shared function instead of duplicating the override check.
- `native_transcribe::native_runtime_backend_label` now takes the family's `auto_gpu_enabled` and resolves through the same shared function, so the provenance label is structurally guaranteed to match the family's actual decision.
- `graph_runtime_config::gpu_stage_enabled_for_backend` (used by every family's per-stage GPU knob: encoder/decoder/prelude) now applies the same explicit-always-wins rule as a defense-in-depth measure.
- Tests: `resolve_family_runtime_backend_gates_auto_but_never_explicit` (cpu_graph.rs), `explicit_accelerated_overrides_a_stage_gate_disabled_by_default` (graph_runtime_config.rs), `builtin_architectures_declare_auto_gpu_enabled` (arch/mod.rs), `family_auto_gpu_enabled_lookup_matches_dolphin_and_xasr_gates` + `native_runtime_backend_label_reflects_family_auto_gate_not_generic_resolver` (native_transcribe.rs).

No decode-output changes: this is dispatch/provenance-only. CPU golden diff is untouched; explicit-`accelerated` numerics were already independently opt-in and unchanged.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (ran `-p openasr-core`: 2047 passed, 0 failed, 122 skipped -- private-pack-gated/ignored)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

On-device verification (M1, `dolphin-base` fp16, independent `openasr serve` instance on an isolated port/HOME so as not to disturb the running desktop daemon):

| `execution_target` | `core.native.backend` | inference timing | Metal engaged? |
|---|---|---|---|
| `cpu` | `cpu` | ~3.5-4.3s | No (only a one-time-per-process alloc+free capability probe, identically reproduced on whisper -- unrelated pre-existing infra, not touched by this PR) |
| `auto` | `cpu` (was `metal` before this fix) | ~4.3-4.6s, matching `cpu` | No |
| `accelerated` | `metal` | ~5.9-7.7s (GPU dispatch overhead exceeds benefit on this short clip, matching the prior investigation's finding) | Yes -- persistent Metal backend allocation in the server log (no matching free until process exit), distinct from the transient probe-and-free pattern seen under `cpu`/`auto` |

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities. (No doc changes needed: this fixes an internal provenance bug and converges dispatch logic; the public-facing "no telemetry / fail-closed" claims and `KNOWN_LIMITATIONS.md`'s cohere note are unaffected and remain accurate.)

## Scope / non-goals

- Does not change cohere's multichunk-decoder-CPU-preference policy (reviewed, out of scope, see audit table).
- Does not add a CLI `--execution-target` flag (reviewed, out of scope, see audit table).
- Does not change any decode output, golden fixtures, or the parity gate.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI-assisted audit and implementation (code search, drafting the shared dispatch function, tests, and this PR body's factual content), human-reviewed and human-owned per AGENTS.md.

## Notes for reviewers

- CI is reported down for cost reasons at the time of this PR; opening anyway per instruction, all gates above run clean locally.
- `native_transcribe.rs` is shared with another in-flight PR touching longform slicing/VAD (#129, `core-slicing-coverage`). This PR's changes there are confined to the device/provenance region (`execution_target_backend_preference`, `native_runtime_backend_label`, `build_longform_metadata`'s signature, and one new `auto_gpu_enabled` let-binding) and do not touch slicing/VAD logic; flagging the shared-file overlap for merge-order awareness.
