### PR TITLE
fix(release): inherit repository secrets in the release-binaries workflow_call

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -266,6 +266,11 @@ jobs:
     uses: ./.github/workflows/release-binaries.yml
     with:
       ref: ${{ needs.resolve.outputs.tag }}
+    # Reusable workflows do NOT see the caller's repository secrets unless
+    # they are passed explicitly; without this the called workflow's Windows
+    # legs read empty AZURE_* secrets and fail closed at their "refuse to
+    # ship an unsigned Windows release binary" gate.
+    secrets: inherit
 
   finalize-notes:
     name: Finalize Install & Verify with real assets


### PR DESCRIPTION
## Summary

Adds `secrets: inherit` to the `binaries` job in `release-core.yml`, the
`workflow_call` site that invokes `release-binaries.yml`.

## Why

The v0.1.15 release run failed all Windows legs at the fail-closed
"Refuse to ship an unsigned Windows release binary" gate, even though the
`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` repository
secrets are configured. Reusable workflows invoked via `workflow_call` do
not see the caller's repository secrets unless the caller passes them
(`secrets: inherit` or an explicit `secrets:` map), so the called
workflow's signing-check step read empty `AZURE_*` values and the gate
tripped exactly as designed. #127 wired the gate but missed this pass-through
at the only `workflow_call` site in the repo.

## Changes

- `.github/workflows/release-core.yml`: `secrets: inherit` on the
  `binaries` job, with a comment explaining the non-obvious default.
- Scanned all workflows for other `uses: ./.github/workflows/...` call
  sites: this is the only one.

## Tests run

- [ ] `cargo fmt --check` (no Rust code changed)
- [ ] `cargo clippy --all-targets -- -D warnings` (no Rust code changed)
- [ ] `cargo nextest run --workspace` (no Rust code changed)
- [ ] `cargo test --workspace --doc` (no Rust code changed)
- [ ] `cargo deny check` (no dependency changes)
- [x] `actionlint` (no new findings; pre-existing findings in unrelated files unchanged)

## Manual smoke checks

- Verified with `gh secret list` that the three `AZURE_*` repository secrets exist.
- Verified the failed jobs' failing step is the signing gate on all three
  completed Windows legs of run 29391019135.

## Docs updated

- [x] No docs change needed; behavior now matches what RELEASING.md and
  `tooling/release-manifest/README.md` already describe.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not retry or re-run the v0.1.15 release; asset backfill is a
  separate `workflow_dispatch` of `release-binaries.yml` on `ref: v0.1.15`
  after this merges.
- No changes to the signing gate itself; failing closed was correct.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - AI-assisted diagnosis and patch under maintainer direction and review.
