### PR TITLE
ci(catalog): gate deploys on released-binary compatibility

### DIFF
--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -6,6 +6,19 @@ name: Deploy catalog
 # CLOUDFLARE_API_TOKEN. The ed25519 signature is cryptographically verified by the
 # `rust` job's bundled-/public-projection gates on the same push; here we add cheap
 # consistency guardrails plus a post-deploy check.
+#
+# `gate-released-binary-compat` runs BEFORE `deploy` (see `needs:` below): catalog
+# data and CLI binaries ship on independent cadences, so a catalog edit that is
+# fine for the binary being cut right now can still hit an already-shipped,
+# already-in-the-wild binary in a way nothing else in CI ever checks. That job
+# downloads the latest *stable* CLI release and runs `openasr doctor` against the
+# candidate catalog before it goes live -- see scripts/gate-catalog-against-released-binary.sh
+# for the full mechanism and rationale. Its notion of "the latest released binary"
+# is a moving target by design: whichever vX.Y.Z is GitHub's current `latest`
+# release for this repo when the workflow runs is what gets tested. That is
+# intentional -- once a CLI release ships that is forward-compatible with a given
+# catalog shape, this gate should (and will, automatically, with no edits here)
+# start passing that catalog again.
 on:
   push:
     branches: [main]
@@ -20,7 +33,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  gate-released-binary-compat:
+    # Same repo scope as `deploy`: this reads public GitHub releases only (no
+    # secrets needed), but it exists to guard this repo's production deploy,
+    # not to run speculatively on forks.
+    if: github.repository == 'QuintinShaw/openasr'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Gate candidate catalog against the latest released CLI binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/gate-catalog-against-released-binary.sh \
+            model-registry/catalog.public.json \
+            model-registry/catalog.public.signature.json
+
   deploy:
+    needs: gate-released-binary-compat
     # Forks should never attempt to deploy to the maintainer's Cloudflare
     # account (and would fail anyway without CLOUDFLARE_API_TOKEN).
     if: github.repository == 'QuintinShaw/openasr'

--- a/scripts/gate-catalog-against-released-binary.sh
+++ b/scripts/gate-catalog-against-released-binary.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Fail-closed pre-deploy gate: proves that the latest published *stable* CLI
+# release binary can still load and initialize a candidate catalog before
+# that catalog ships to catalog.openasr.org.
+#
+# Background: catalog data (model-registry/catalog.public.json) and CLI
+# binaries (release-binaries.yml) ship on independent cadences. A catalog
+# edit that is fine for the binary being cut *right now* can still break an
+# already-shipped, already-in-the-wild binary if it depends on a shape or
+# constraint that binary doesn't know about -- and there is nothing else in
+# this repo's CI that ever runs a *real released binary* against a *candidate*
+# catalog to check for that. This script is that check.
+#
+# Method: download the latest stable CLI release's linux-x86_64 tarball,
+# point it at the candidate catalog.json + catalog.signature.json pair via
+# OPENASR_CATALOG_FILE + OPENASR_CATALOG_IDENTITY (the same mechanism the
+# desktop client uses to load a bundled, production-signed catalog file under
+# its real https:// identity -- see load_local_catalog_file_with_identity in
+# crates/openasr-core/src/registry.rs), and run `openasr doctor` against a
+# throwaway OPENASR_HOME. `doctor` loads the full model registry from that
+# catalog and resolves the default model, so it fails closed (non-zero exit)
+# on anything the running binary's catalog-loading/registry pipeline rejects.
+#
+# Fail-closed by design: any failure to obtain and run a *real* released
+# binary (network error, missing asset, resolution ambiguity) blocks the
+# catalog rather than silently skipping verification. A green gate proves the
+# candidate catalog was actually exercised by a real binary; it never proves
+# that vacuously.
+#
+# Usage:
+#   scripts/gate-catalog-against-released-binary.sh <catalog.json> <catalog.signature.json>
+#
+# Env overrides (for local iteration / testing):
+#   OPENASR_RELEASE_REPO     GitHub repo to pull the release from
+#                            (default: QuintinShaw/openasr)
+#   OPENASR_GATE_BINARY      Path to an already-extracted `openasr` binary to
+#                            use instead of downloading one (skips the
+#                            release-resolution/download steps entirely).
+#   OPENASR_GATE_IDENTITY    Catalog identity to verify the candidate against
+#                            (default: the production catalog_url,
+#                            https://catalog.openasr.org/v1/catalog.json).
+#
+# Requires: `gh` authenticated with access to OPENASR_RELEASE_REPO (public
+# repo, so the default GITHUB_TOKEN in Actions is sufficient), `tar`.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <catalog.json> <catalog.signature.json>" >&2
+  exit 2
+fi
+
+candidate_catalog="$1"
+candidate_signature="$2"
+repo="${OPENASR_RELEASE_REPO:-QuintinShaw/openasr}"
+identity="${OPENASR_GATE_IDENTITY:-https://catalog.openasr.org/v1/catalog.json}"
+
+for f in "$candidate_catalog" "$candidate_signature"; do
+  if [ ! -f "$f" ]; then
+    echo "::error::gate input '$f' does not exist" >&2
+    exit 1
+  fi
+done
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+resolve_binary() {
+  if [ -n "${OPENASR_GATE_BINARY:-}" ]; then
+    echo "==> using OPENASR_GATE_BINARY override: ${OPENASR_GATE_BINARY}" >&2
+    printf '%s\n' "$OPENASR_GATE_BINARY"
+    return 0
+  fi
+
+  echo "==> resolving latest stable release for ${repo}" >&2
+  local tag
+  if ! tag="$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>&1)"; then
+    echo "::error::could not resolve the latest release for ${repo} (network or gh-auth failure). Fail-closed: refusing to bless a catalog without exercising a real released binary against it. gh output: ${tag}" >&2
+    exit 1
+  fi
+
+  case "$tag" in
+    v[0-9]*.[0-9]*.[0-9]*) ;;
+    *)
+      echo "::error::resolved 'latest' release tag '${tag}' for ${repo} does not look like a CLI release tag (expected vMAJOR.MINOR.PATCH -- e.g. it may have resolved to a non-CLI release such as a desktop-vX.Y.Z tag). Refusing to guess which asset to test against; fail-closed." >&2
+      exit 1
+      ;;
+  esac
+  echo "==> latest stable CLI release: ${tag}" >&2
+
+  local asset_dir="$work/release-asset"
+  mkdir -p "$asset_dir"
+  # Pattern match (not a hardcoded filename) so this survives a version bump
+  # without edits. Anchored to the plain (non-CUDA/Vulkan/ROCm/musl) Linux
+  # x86_64 CPU build: the runner is native linux-x86_64, so this is the one
+  # build we can execute directly with no extra toolchain.
+  if ! gh release download "$tag" --repo "$repo" \
+        --pattern 'openasr-*-linux-x86_64.tar.gz' \
+        --dir "$asset_dir" --clobber; then
+    echo "::error::failed to download the ${tag} linux-x86_64 CLI release asset from ${repo}. Fail-closed: refusing to bless a catalog without exercising a real released binary against it." >&2
+    exit 1
+  fi
+
+  local archive
+  archive="$(find "$asset_dir" -maxdepth 1 -type f -name '*.tar.gz' | head -n1)"
+  if [ -z "$archive" ]; then
+    echo "::error::no linux-x86_64 tar.gz asset found on release ${tag} of ${repo}" >&2
+    exit 1
+  fi
+
+  local extract_dir="$work/extracted"
+  mkdir -p "$extract_dir"
+  tar xzf "$archive" -C "$extract_dir"
+
+  local binary
+  binary="$(find "$extract_dir" -type f -name openasr | head -n1)"
+  if [ -z "$binary" ]; then
+    echo "::error::could not find an 'openasr' executable anywhere inside ${archive}" >&2
+    exit 1
+  fi
+  chmod +x "$binary"
+  printf '%s\n' "$binary"
+}
+
+binary="$(resolve_binary)"
+echo "==> gating candidate catalog against released binary: ${binary}" >&2
+"$binary" --version >&2 || true
+
+stage="$work/candidate"
+home="$work/home"
+mkdir -p "$stage" "$home"
+# The sidecar signature must sit next to the catalog file under the exact
+# name catalog_security::CATALOG_SIGNATURE_FILE_NAME ("catalog.signature.json"):
+# load_local_catalog_file_with_identity derives it via path.with_file_name(...).
+cp "$candidate_catalog" "$stage/catalog.json"
+cp "$candidate_signature" "$stage/catalog.signature.json"
+
+export OPENASR_HOME="$home"
+export OPENASR_CATALOG_FILE="$stage/catalog.json"
+export OPENASR_CATALOG_IDENTITY="$identity"
+
+echo "==> running: openasr doctor (OPENASR_CATALOG_FILE=${OPENASR_CATALOG_FILE}, OPENASR_CATALOG_IDENTITY=${identity})" >&2
+# NOTE: deliberately not `if "$binary" doctor; then ... fi` -- when the
+# condition of an `if` with no `else` is false, `$?` immediately after `fi`
+# is the *if statement's* exit status (0), not the condition command's; that
+# would silently turn a real failure into a fabricated "exited 0" success
+# report. `cmd || status=$?` is also `-e`-safe: as the left side of `||`,
+# cmd's failure does not trigger errexit.
+status=0
+"$binary" doctor || status=$?
+if [ "$status" -eq 0 ]; then
+  echo "==> OK: ${binary} loaded and initialized the candidate catalog cleanly." >&2
+  exit 0
+fi
+echo "::error::the latest released CLI binary (${binary}) failed to load/initialize the candidate catalog (doctor exited ${status}). A currently-shipping client would fail closed against this catalog. Blocking the deploy -- fix the catalog (or cut a compatible release) before retrying." >&2
+exit "$status"


### PR DESCRIPTION
## Summary

Adds a `gate-released-binary-compat` job to `deploy-catalog.yml` that runs
before `deploy`: it downloads the latest stable CLI release and runs
`openasr doctor` against the candidate `catalog.public.json` /
`catalog.public.signature.json` pair before they ship to
catalog.openasr.org.

## Why

Catalog data (`model-registry/catalog.public.json`) and CLI release
binaries ship on independent cadences. Nothing else in this repo's CI ever
exercises a real, already-released binary against a candidate catalog
before it goes live -- the `rust` job verifies the signature/schema against
the *current* workspace code, not against what is actually running on
users' machines already. A catalog change that is fine for the binary being
cut right now could still break an already-shipped one, and the only way to
find out today is production.

(Investigating a suspected live incident along these lines turned up that
the specific reported case -- new Chinese dialect language codes in the
catalog vs. a shipped v0.1.15 binary -- does not actually reproduce:
`languages` is an unvalidated `Vec<String>` client-side and non-public
catalog entries are filtered automatically, so v0.1.15 loads that catalog
cleanly via every path tried, including the exact committed
`model-registry/catalog.json` + signature pair from the commit in question.
The gate itself is still worth having regardless -- `validate_model_catalog`
has several real fail-closed checks (schema_version, signature/sha256
integrity, hf_revision format, recommended-quant presence, etc.) that a
genuinely breaking catalog change would trip, and this job is what actually
proves a live release binary tolerates the catalog before it deploys.)

## Changes

- `scripts/gate-catalog-against-released-binary.sh`: resolves the release
  GitHub marks "latest" for this repo, downloads its linux-x86_64 CLI
  tarball (pattern-matched, not hardcoded to a version), points it at the
  candidate catalog via `OPENASR_CATALOG_FILE` + `OPENASR_CATALOG_IDENTITY`
  (the same mechanism the desktop client uses to load a bundled,
  production-signed catalog file under its real `https://` identity), and
  runs `openasr doctor` against a throwaway `OPENASR_HOME`. Any failure to
  obtain/run a real released binary (network error, missing asset, an
  unexpected "latest" tag shape) fails closed and blocks the catalog rather
  than skipping verification.
- `.github/workflows/deploy-catalog.yml`: new `gate-released-binary-compat`
  job (same repo-scope guard as `deploy`), with `deploy` now `needs:` it.
  Added a doc comment noting the gate's "latest release" target is a moving
  baseline by design -- once a forward-compatible CLI release ships, the
  gate starts passing the same catalog again with no edits needed here.

## Tests run

- [ ] `cargo fmt --check` (no Rust code changed)
- [ ] `cargo clippy --all-targets -- -D warnings` (no Rust code changed)
- [ ] `cargo nextest run --workspace` (no Rust code changed)
- [ ] `cargo test --workspace --doc` (no Rust code changed)
- [ ] `cargo deny check` (no dependency changes)
- [x] `actionlint .github/workflows/deploy-catalog.yml` -- clean
- [x] `shellcheck scripts/gate-catalog-against-released-binary.sh` -- clean

## Manual smoke checks

Ran the script's logic directly against a real downloaded v0.1.15 binary
(macOS arm64, since this sandbox cannot execute the release's linux-x86_64
ELF; also separately verified the actual `gh release download` +
extraction path against the real linux-x86_64 asset to confirm the runner
path resolves correctly):

- Positive: today's committed `catalog.public.json` / signature -> `openasr
  doctor` exits 0, gate passes.
- Negative (signature/integrity): a byte-tampered catalog paired with the
  original (now-mismatched) signature -> sha256 check fails, `openasr
  doctor` exits 1, gate fails closed.
- Negative (schema): `catalog.public.json` with `schema_version` bumped
  1 -> 2, validly re-signed with the repo's public local-dev catalog key
  under a `file://` identity -> `openasr doctor` exits 1 (`validate_model_catalog`'s
  schema_version check), gate fails closed. Isolated from the signature
  path via a matching control catalog signed the same way without the
  schema break, which passes.
- Also confirmed the previously-suspected incident does not reproduce: the
  exact committed `model-registry/catalog.json` (full, non-public
  projection) + `catalog.signature.json` from the commit that added the new
  dialect codes, fed to the real v0.1.15 binary via the same mechanism,
  loads and initializes cleanly (`doctor` exits 0).

## Docs updated

- [x] No separate docs; rationale is captured in the workflow's doc comment
      and the script's header comment.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch `model-registry/` data.
- Does not change any client/runtime Rust code (that is a separate,
  forward-compat CLI change if one turns out to be needed).
- Does not attempt to reproduce or fix the originally suspected incident;
  see "Why" above for what the investigation found instead.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES, this change (implementation, local verification, and PR description) was produced with heavy AI assistance.