### PR TITLE
perf(dolphin): offload encoder + CTC head to Metal and default Auto to GPU

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -2037,19 +2037,19 @@ mod tests {
 
     #[test]
     fn family_auto_gpu_enabled_lookup_matches_dolphin_and_xasr_gates() {
-        // Regression pin for the two builtin families whose Auto default is
-        // gated to CPU (see `auto_gpu_enabled`'s doc comment); every other
-        // builtin lets Auto pick GPU automatically.
-        assert!(
-            !crate::arch::family_auto_gpu_enabled_for_model_architecture(
-                crate::arch::DOLPHIN_GGML_ARCHITECTURE_ID
-            )
-        );
+        // Regression pin: xasr-zipformer is the one builtin family whose Auto
+        // default is still gated to CPU (see `auto_gpu_enabled`'s doc comment);
+        // every other builtin -- dolphin now included, after its encoder + CTC
+        // head weights moved into a Metal-offloadable arena and Metal beat CPU
+        // -- lets Auto pick GPU automatically.
         assert!(
             !crate::arch::family_auto_gpu_enabled_for_model_architecture(
                 crate::arch::XASR_ZIPFORMER_GGML_ARCHITECTURE_ID
             )
         );
+        assert!(crate::arch::family_auto_gpu_enabled_for_model_architecture(
+            crate::arch::DOLPHIN_GGML_ARCHITECTURE_ID
+        ));
         assert!(crate::arch::family_auto_gpu_enabled_for_model_architecture(
             crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID
         ));
@@ -2061,20 +2061,20 @@ mod tests {
         ));
     }
 
-    /// Regression for the dolphin-plus-Auto provenance mislabel: the
+    /// Regression for the gated-family-plus-Auto provenance mislabel: the
     /// `core.native.backend` label must resolve through the same
     /// family-aware gate the family's own executor used
     /// (`GgmlCpuGraphConfig::resolve_family_runtime_backend`), not recompute
     /// generically. Before this fix, `native_runtime_backend_label` called
     /// `GgmlCpuGraphConfig::resolve_runtime_backend()` directly, which on a
-    /// host with a GPU device reports "metal" for an Auto dolphin request
-    /// that in fact ran entirely on CPU (dolphin pins Auto to CPU; see
-    /// `dolphin::executor::dolphin_runtime_backend`).
+    /// host with a GPU device reports "metal" for an Auto request from a
+    /// CPU-gated family (xasr-zipformer today) that in fact ran entirely on
+    /// CPU; see `xasr_zipformer::graph_config::encoder_gpu_enabled`.
     #[test]
     fn native_runtime_backend_label_reflects_family_auto_gate_not_generic_resolver() {
         use crate::ggml_runtime::{RequestBackendPreference, install_request_backend_override};
 
-        // Auto, family gate disabled (dolphin/xasr-zipformer shape): must
+        // Auto, family gate disabled (xasr-zipformer shape): must
         // report "cpu" regardless of what the generic resolver would pick.
         assert_eq!(native_runtime_backend_label(false), "cpu");
 

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -273,17 +273,19 @@ pub(crate) struct OpenAsrArchitectureDescriptor {
     /// overrides an explicit `execution_target=accelerated` (or `cpu`)
     /// request, which always gets exactly what it asked for via
     /// `GgmlCpuGraphConfig::resolve_family_runtime_backend`. False only for
-    /// the two families with a measured Auto-mode GPU regression at their
-    /// normal (non-`accelerated`) workload size: dolphin's whole pipeline
-    /// (`models::dolphin::executor::dolphin_runtime_backend`) and
     /// xasr-zipformer's streaming encoder
-    /// (`models::xasr_zipformer::graph_config::encoder_gpu_enabled`) -- see
-    /// those functions' doc comments for the measured evidence. Any
+    /// (`models::xasr_zipformer::graph_config::encoder_gpu_enabled`), the one
+    /// family with a measured Auto-mode GPU regression at its normal
+    /// (non-`accelerated`) chunk size -- see that function's doc comment for
+    /// the measured evidence. (Dolphin was gated too until its encoder + CTC
+    /// head weights moved into a Metal-offloadable static arena; Metal then
+    /// beat CPU end-to-end, so its Auto default is now GPU -- see
+    /// `models::dolphin::executor::dolphin_runtime_backend`.) Any
     /// provenance/telemetry label reporting the backend a request actually
     /// ran on must resolve through the same function with this same flag,
     /// not recompute generically (a generic recompute is what produced a
-    /// `core.native.backend:metal` label on a dolphin Auto request that in
-    /// fact ran entirely on CPU).
+    /// `core.native.backend:metal` label on a gated-family Auto request that
+    /// in fact ran entirely on CPU).
     pub auto_gpu_enabled: bool,
     /// Whether this family's own decode loop can emit diarization tokens (the
     /// cohere token-stream is the only builtin case today). The single
@@ -1305,11 +1307,18 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: DOLPHIN_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
-        // Fail-closed to the golden, parity-validated CPU path: Metal is
-        // faster on this pipeline (AB-measured) but its fp16 numerics are not
-        // golden-validated (parity gate is CPU bit-exact), so Auto stays on
-        // CPU -- see `dolphin::executor::dolphin_runtime_backend`.
-        auto_gpu_enabled: false,
+        // Auto prefers the accelerator: once the E-Branchformer encoder + CTC
+        // head weights live in a WEIGHTS-usage static arena (so the ggml
+        // scheduler offloads them to Metal instead of pinning the whole encoder
+        // to the CPU), Metal beats CPU end-to-end on Apple Silicon (AB-measured,
+        // warm best-of-N on M1). The gate only ever picks the accelerator when
+        // one is actually present (`runtime_gpu_is_available`), so non-Metal
+        // hosts still resolve to CPU, and an explicit `--execution-target
+        // cpu` request always wins -- see
+        // `dolphin::executor::dolphin_runtime_backend`. fp16 Metal numerics
+        // reproduce the golden transcript on the parity clip (CPU stays the
+        // bit-exact reference gate).
+        auto_gpu_enabled: true,
         self_diarizes: false,
         // DataoceanAI's cn-dialect-small training corpus is transcribed
         // without punctuation and the model has no punctuation-prediction
@@ -1514,17 +1523,17 @@ mod tests {
         );
     }
 
-    /// Pins `auto_gpu_enabled` per builtin architecture -- dolphin and
-    /// xasr-zipformer are the only two builtins whose Auto default is gated
-    /// to CPU (a measured Auto-mode GPU regression at their normal chunk
-    /// size, not a correctness limit; see the field doc and the two
-    /// executors' own doc comments). Every other builtin lets Auto pick a
-    /// GPU-class backend automatically when available, matching how
-    /// `resolve_runtime_backend` behaves generically. A silent flip of this
-    /// table for any of the two gated families would either quietly start
-    /// running an unvalidated GPU path by default (dolphin) or regress Auto
-    /// throughput (xasr-zipformer); for any other family it would silently
-    /// start denying Auto users a GPU their hardware supports.
+    /// Pins `auto_gpu_enabled` per builtin architecture -- xasr-zipformer is
+    /// the only builtin whose Auto default is still gated to CPU (a measured
+    /// Auto-mode GPU regression at its normal chunk size, not a correctness
+    /// limit; see the field doc and that executor's own doc comment). Every
+    /// other builtin -- dolphin now included, after its encoder + CTC head
+    /// weights moved into a Metal-offloadable static arena and Metal beat CPU
+    /// end-to-end -- lets Auto pick a GPU-class backend automatically when
+    /// available, matching how `resolve_runtime_backend` behaves generically.
+    /// A silent flip of this table would either regress Auto throughput for
+    /// xasr-zipformer, or silently deny Auto users a GPU their hardware
+    /// supports for any GPU-enabled family.
     #[test]
     fn builtin_architectures_declare_auto_gpu_enabled() {
         let expected: &[(&str, bool)] = &[
@@ -1536,7 +1545,7 @@ mod tests {
             (WAV2VEC2_CTC_GGML_ARCHITECTURE_ID, true),
             (XASR_ZIPFORMER_GGML_ARCHITECTURE_ID, false),
             (MOONSHINE_GGML_ARCHITECTURE_ID, true),
-            (DOLPHIN_GGML_ARCHITECTURE_ID, false),
+            (DOLPHIN_GGML_ARCHITECTURE_ID, true),
             (SENSEVOICE_GGML_ARCHITECTURE_ID, true),
             (FIRERED_AED_GGML_ARCHITECTURE_ID, true),
             (FIRERED_LLM_GGML_ARCHITECTURE_ID, true),

--- a/crates/openasr-core/src/models/dolphin/encoder_graph.rs
+++ b/crates/openasr-core/src/models/dolphin/encoder_graph.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError,
-    GgmlCpuGraphRunner, GgmlCpuTensor,
+    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlStaticTensor, GgmlStaticTensorArena,
 };
 use crate::nn::attn::{
     AttentionHeadLayout, AttentionReshapeSteps, AttentionValueMergeSteps,
@@ -313,19 +313,49 @@ struct EncoderWeights<'a> {
     after_norm_b: GgmlCpuTensor<'a>,
 }
 
-/// Pending f32 weight upload: `(tensor, source-slice, static-label)`.
-type Upload<'a, 'p> = (GgmlCpuTensor<'a>, &'p [f32], &'static str);
-/// Pending native (quantized / f16) weight upload: `(tensor, raw-bytes,
-/// ggml-type, static-label)`.
-type NativeUpload<'a, 'p> = (GgmlCpuTensor<'a>, &'p [u8], i32, &'static str);
+/// Static-arena tensor count for [`GgmlCpuGraphConfig::metadata_context_bytes`].
+/// Per E-Branchformer block, `build_block_weights` allocates 41 weight tensors
+/// (macaron FFN norm+w1+w2 = 6, MHA norm = 2, rel-pos attention q/k/v/pos/out +
+/// pos_bias_u/v = 11, cgMLP norm = 2, cgMLP proj1/csgu-norm/csgu-conv/proj2 = 8,
+/// fusion conv + merge proj = 4, final FFN norm+w1+w2 = 6, block final norm = 2);
+/// the fixed set is the embed stem (2 convs + out = 6 tensors), the after_norm
+/// pair (2), and the position table (1).
+const DOLPHIN_ENCODER_ARENA_TENSORS_PER_BLOCK: usize = 41;
+const DOLPHIN_ENCODER_ARENA_FIXED_TENSORS: usize = 9;
 
-struct WeightBuilder<'a, 'p> {
-    provider: &'p dyn DolphinWeightProvider,
-    uploads: Vec<Upload<'a, 'p>>,
-    native_uploads: Vec<NativeUpload<'a, 'p>>,
+fn dolphin_encoder_arena_context_bytes(num_blocks: usize) -> usize {
+    let tensor_count = DOLPHIN_ENCODER_ARENA_FIXED_TENSORS
+        .saturating_add(DOLPHIN_ENCODER_ARENA_TENSORS_PER_BLOCK.saturating_mul(num_blocks));
+    GgmlCpuGraphConfig::metadata_context_bytes(tensor_count)
 }
 
-impl<'a, 'p> WeightBuilder<'a, 'p> {
+/// Pending f32 weight upload into the static arena: `(handle, source-slice,
+/// static-label)`.
+type Upload<'p> = (GgmlStaticTensor, &'p [f32], &'static str);
+/// Pending native (quantized / f16) weight upload: `(handle, raw-bytes,
+/// static-label)`.
+type NativeUpload<'p> = (GgmlStaticTensor, &'p [u8], &'static str);
+
+/// Allocates every encoder weight into the runtime's persistent
+/// [`GgmlStaticTensorArena`] (a `GGML_BACKEND_BUFFER_USAGE_WEIGHTS` backend
+/// buffer) rather than as per-call transient graph leaves. This is what lets the
+/// ggml multi-backend scheduler offload the encoder's matmuls to an accelerator:
+/// the scheduler only considers an op for `op_offload` when its weight `src`
+/// lives in a WEIGHTS-usage buffer, which the old per-call graph-input weights
+/// were not, so the whole E-Branchformer (the FLOPs-heavy stage) was pinned to
+/// the CPU even under an explicit Metal backend. Mirrors the sibling
+/// `decoder_graph::StaticWeightBuilder` and `sensevoice::SenseVoiceEncoderGraph`
+/// exactly: allocate every tensor first (the arena's first upload freezes
+/// further creation), then upload once. Weight placement changes no value the
+/// graph computes, so the encoder output stays golden-identical -- only the
+/// backend each op runs on changes.
+struct WeightBuilder<'p> {
+    provider: &'p dyn DolphinWeightProvider,
+    uploads: Vec<Upload<'p>>,
+    native_uploads: Vec<NativeUpload<'p>>,
+}
+
+impl<'p> WeightBuilder<'p> {
     fn new(provider: &'p dyn DolphinWeightProvider) -> Self {
         Self {
             provider,
@@ -352,18 +382,18 @@ impl<'a, 'p> WeightBuilder<'a, 'p> {
     }
 
     /// A 1-D weight (bias / norm gamma-beta / packed pos bias).
-    fn w1(
+    fn w1<'a>(
         &mut self,
-        graph: &GgmlCpuGraphBuilder<'a>,
+        arena: &GgmlStaticTensorArena,
         name: &str,
         len: usize,
     ) -> Result<GgmlCpuTensor<'a>, DolphinEncoderError> {
         let data = self.fetch(name, len)?;
-        let tensor = graph
+        let handle = arena
             .new_tensor_1d_f32(len, "dolphin_weight")
             .map_err(ggml_err("weight_alloc_1d"))?;
-        self.uploads.push((tensor, data, "dolphin_weight"));
-        Ok(tensor)
+        self.uploads.push((handle, data, "dolphin_weight"));
+        Ok(arena.graph_tensor(handle))
     }
 
     /// A 2-D `.weight` matmul operand bound as ggml `[ne0=in, ne1=out]` for
@@ -374,33 +404,33 @@ impl<'a, 'p> WeightBuilder<'a, 'p> {
     /// blow-up). Otherwise (the raw-safetensors parity provider) it falls back to
     /// the f32 bind. Both stored layouts (fp16's `[out, in]`, quant's reversed
     /// `[in, out]`) share the same in-innermost byte order, so uploading raw into
-    /// the `[ne0=in, ne1=out]` graph tensor is order-preserving in either case.
-    fn w2(
+    /// the `[ne0=in, ne1=out]` arena tensor is order-preserving in either case.
+    fn w2<'a>(
         &mut self,
-        graph: &GgmlCpuGraphBuilder<'a>,
+        arena: &GgmlStaticTensorArena,
         name: &str,
         ne0: usize,
         ne1: usize,
     ) -> Result<GgmlCpuTensor<'a>, DolphinEncoderError> {
         if let Some(native) = self.provider.native_weight(name) {
-            let tensor = graph
+            let handle = arena
                 .new_matmul_weight_2d_typed(ne0, ne1, native.ggml_type, "dolphin_weight")
                 .map_err(ggml_err("weight_alloc_2d_native"))?;
             self.native_uploads
-                .push((tensor, native.bytes, native.ggml_type, "dolphin_weight"));
-            return Ok(tensor);
+                .push((handle, native.bytes, "dolphin_weight"));
+            return Ok(arena.graph_tensor(handle));
         }
         let data = self.fetch(name, ne0 * ne1)?;
-        let tensor = graph
+        let handle = arena
             .new_tensor_2d_f32(ne0, ne1, "dolphin_weight")
             .map_err(ggml_err("weight_alloc_2d"))?;
-        self.uploads.push((tensor, data, "dolphin_weight"));
-        Ok(tensor)
+        self.uploads.push((handle, data, "dolphin_weight"));
+        Ok(arena.graph_tensor(handle))
     }
 
-    fn w4(
+    fn w4<'a>(
         &mut self,
-        graph: &GgmlCpuGraphBuilder<'a>,
+        arena: &GgmlStaticTensorArena,
         name: &str,
         ne0: usize,
         ne1: usize,
@@ -408,17 +438,17 @@ impl<'a, 'p> WeightBuilder<'a, 'p> {
         ne3: usize,
     ) -> Result<GgmlCpuTensor<'a>, DolphinEncoderError> {
         let data = self.fetch(name, ne0 * ne1 * ne2 * ne3)?;
-        let tensor = graph
+        let handle = arena
             .new_tensor_4d_f32(ne0, ne1, ne2, ne3, "dolphin_weight")
             .map_err(ggml_err("weight_alloc_4d"))?;
-        self.uploads.push((tensor, data, "dolphin_weight"));
-        Ok(tensor)
+        self.uploads.push((handle, data, "dolphin_weight"));
+        Ok(arena.graph_tensor(handle))
     }
 
     /// The first `frames` rows of the `[1, max_len, d_model]` position table.
-    fn pos_slice(
+    fn pos_slice<'a>(
         &mut self,
-        graph: &GgmlCpuGraphBuilder<'a>,
+        arena: &GgmlStaticTensorArena,
         name: &str,
         d_model: usize,
         frames: usize,
@@ -426,28 +456,47 @@ impl<'a, 'p> WeightBuilder<'a, 'p> {
     ) -> Result<GgmlCpuTensor<'a>, DolphinEncoderError> {
         let full = self.fetch(name, d_model * max_len)?;
         let slice = &full[..d_model * frames];
-        let tensor = graph
+        let handle = arena
             .new_tensor_2d_f32(d_model, frames, "dolphin_weight")
             .map_err(ggml_err("weight_alloc_pos"))?;
-        self.uploads.push((tensor, slice, "dolphin_weight"));
-        Ok(tensor)
+        self.uploads.push((handle, slice, "dolphin_weight"));
+        Ok(arena.graph_tensor(handle))
+    }
+
+    /// Upload every collected weight into the arena's backend buffer exactly
+    /// once (the first upload allocates the buffer and freezes further tensor
+    /// creation). Native (quantized / f16) rank-2 `.weight` operands upload
+    /// their raw block bytes verbatim so they stay quantized in the buffer;
+    /// everything else uploads dequantized f32.
+    fn upload(&self, arena: &mut GgmlStaticTensorArena) -> Result<(), DolphinEncoderError> {
+        for (handle, data, name) in &self.uploads {
+            arena
+                .set_f32_slice(*handle, data, name)
+                .map_err(ggml_err("upload_weight"))?;
+        }
+        for (handle, bytes, name) in &self.native_uploads {
+            arena
+                .set_bytes_slice(*handle, bytes, name)
+                .map_err(ggml_err("upload_weight_native"))?;
+        }
+        Ok(())
     }
 }
 
 fn build_embed_weights<'a, 'p>(
-    graph: &GgmlCpuGraphBuilder<'a>,
-    builder: &mut WeightBuilder<'a, 'p>,
+    arena: &GgmlStaticTensorArena,
+    builder: &mut WeightBuilder<'p>,
     config: &DolphinEncoderConfig,
 ) -> Result<EmbedWeights<'a>, DolphinEncoderError> {
     let d = config.d_model;
     let flat = d * subsample_width(config.feature_dim);
     Ok(EmbedWeights {
-        conv0_w: builder.w4(graph, "encoder.embed.conv.0.weight", 3, 3, 1, d)?,
-        conv0_b: builder.w4(graph, "encoder.embed.conv.0.bias", 1, 1, d, 1)?,
-        conv1_w: builder.w4(graph, "encoder.embed.conv.2.weight", 3, 3, d, d)?,
-        conv1_b: builder.w4(graph, "encoder.embed.conv.2.bias", 1, 1, d, 1)?,
-        out_w: builder.w2(graph, "encoder.embed.out.0.weight", flat, d)?,
-        out_b: builder.w1(graph, "encoder.embed.out.0.bias", d)?,
+        conv0_w: builder.w4(arena, "encoder.embed.conv.0.weight", 3, 3, 1, d)?,
+        conv0_b: builder.w4(arena, "encoder.embed.conv.0.bias", 1, 1, d, 1)?,
+        conv1_w: builder.w4(arena, "encoder.embed.conv.2.weight", 3, 3, d, d)?,
+        conv1_b: builder.w4(arena, "encoder.embed.conv.2.bias", 1, 1, d, 1)?,
+        out_w: builder.w2(arena, "encoder.embed.out.0.weight", flat, d)?,
+        out_b: builder.w1(arena, "encoder.embed.out.0.bias", d)?,
     })
 }
 
@@ -481,8 +530,8 @@ fn dolphin_relative_positional_table(d_model: usize, frames: usize) -> Option<Ve
 }
 
 fn build_block_weights<'a, 'p>(
-    graph: &GgmlCpuGraphBuilder<'a>,
-    builder: &mut WeightBuilder<'a, 'p>,
+    arena: &GgmlStaticTensorArena,
+    builder: &mut WeightBuilder<'p>,
     config: &DolphinEncoderConfig,
     index: usize,
 ) -> Result<BlockWeights<'a>, DolphinEncoderError> {
@@ -494,47 +543,47 @@ fn build_block_weights<'a, 'p>(
     let mk = config.merge_kernel;
     let p = |suffix: &str| format!("encoder.encoders.{index}.{suffix}");
     Ok(BlockWeights {
-        ff_macaron_norm_w: builder.w1(graph, &p("norm_ff_macaron.weight"), d)?,
-        ff_macaron_norm_b: builder.w1(graph, &p("norm_ff_macaron.bias"), d)?,
-        ff_macaron_w1_w: builder.w2(graph, &p("feed_forward_macaron.w_1.weight"), d, ffn)?,
-        ff_macaron_w1_b: builder.w1(graph, &p("feed_forward_macaron.w_1.bias"), ffn)?,
-        ff_macaron_w2_w: builder.w2(graph, &p("feed_forward_macaron.w_2.weight"), ffn, d)?,
-        ff_macaron_w2_b: builder.w1(graph, &p("feed_forward_macaron.w_2.bias"), d)?,
-        norm_mha_w: builder.w1(graph, &p("norm_mha.weight"), d)?,
-        norm_mha_b: builder.w1(graph, &p("norm_mha.bias"), d)?,
-        q_w: builder.w2(graph, &p("attn.linear_q.weight"), d, d)?,
-        q_b: builder.w1(graph, &p("attn.linear_q.bias"), d)?,
-        k_w: builder.w2(graph, &p("attn.linear_k.weight"), d, d)?,
-        k_b: builder.w1(graph, &p("attn.linear_k.bias"), d)?,
-        v_w: builder.w2(graph, &p("attn.linear_v.weight"), d, d)?,
-        v_b: builder.w1(graph, &p("attn.linear_v.bias"), d)?,
-        pos_w: builder.w2(graph, &p("attn.linear_pos.weight"), d, d)?,
-        pos_bias_u: builder.w1(graph, &p("attn.pos_bias_u"), d)?,
-        pos_bias_v: builder.w1(graph, &p("attn.pos_bias_v"), d)?,
-        out_w: builder.w2(graph, &p("attn.linear_out.weight"), d, d)?,
-        out_b: builder.w1(graph, &p("attn.linear_out.bias"), d)?,
-        norm_mlp_w: builder.w1(graph, &p("norm_mlp.weight"), d)?,
-        norm_mlp_b: builder.w1(graph, &p("norm_mlp.bias"), d)?,
-        cproj1_w: builder.w2(graph, &p("cgmlp.channel_proj1.0.weight"), d, cg)?,
-        cproj1_b: builder.w1(graph, &p("cgmlp.channel_proj1.0.bias"), cg)?,
-        csgu_norm_w: builder.w1(graph, &p("cgmlp.csgu.norm.weight"), cg_half)?,
-        csgu_norm_b: builder.w1(graph, &p("cgmlp.csgu.norm.bias"), cg_half)?,
-        csgu_conv_w: builder.w4(graph, &p("cgmlp.csgu.conv.weight"), ck, 1, 1, cg_half)?,
-        csgu_conv_b: builder.w1(graph, &p("cgmlp.csgu.conv.bias"), cg_half)?,
-        cproj2_w: builder.w2(graph, &p("cgmlp.channel_proj2.weight"), cg_half, d)?,
-        cproj2_b: builder.w1(graph, &p("cgmlp.channel_proj2.bias"), d)?,
-        fusion_conv_w: builder.w4(graph, &p("depthwise_conv_fusion.weight"), mk, 1, 1, d + d)?,
-        fusion_conv_b: builder.w1(graph, &p("depthwise_conv_fusion.bias"), d + d)?,
-        merge_w: builder.w2(graph, &p("merge_proj.weight"), d + d, d)?,
-        merge_b: builder.w1(graph, &p("merge_proj.bias"), d)?,
-        norm_ff_w: builder.w1(graph, &p("norm_ff.weight"), d)?,
-        norm_ff_b: builder.w1(graph, &p("norm_ff.bias"), d)?,
-        ff_w1_w: builder.w2(graph, &p("feed_forward.w_1.weight"), d, ffn)?,
-        ff_w1_b: builder.w1(graph, &p("feed_forward.w_1.bias"), ffn)?,
-        ff_w2_w: builder.w2(graph, &p("feed_forward.w_2.weight"), ffn, d)?,
-        ff_w2_b: builder.w1(graph, &p("feed_forward.w_2.bias"), d)?,
-        norm_final_w: builder.w1(graph, &p("norm_final.weight"), d)?,
-        norm_final_b: builder.w1(graph, &p("norm_final.bias"), d)?,
+        ff_macaron_norm_w: builder.w1(arena, &p("norm_ff_macaron.weight"), d)?,
+        ff_macaron_norm_b: builder.w1(arena, &p("norm_ff_macaron.bias"), d)?,
+        ff_macaron_w1_w: builder.w2(arena, &p("feed_forward_macaron.w_1.weight"), d, ffn)?,
+        ff_macaron_w1_b: builder.w1(arena, &p("feed_forward_macaron.w_1.bias"), ffn)?,
+        ff_macaron_w2_w: builder.w2(arena, &p("feed_forward_macaron.w_2.weight"), ffn, d)?,
+        ff_macaron_w2_b: builder.w1(arena, &p("feed_forward_macaron.w_2.bias"), d)?,
+        norm_mha_w: builder.w1(arena, &p("norm_mha.weight"), d)?,
+        norm_mha_b: builder.w1(arena, &p("norm_mha.bias"), d)?,
+        q_w: builder.w2(arena, &p("attn.linear_q.weight"), d, d)?,
+        q_b: builder.w1(arena, &p("attn.linear_q.bias"), d)?,
+        k_w: builder.w2(arena, &p("attn.linear_k.weight"), d, d)?,
+        k_b: builder.w1(arena, &p("attn.linear_k.bias"), d)?,
+        v_w: builder.w2(arena, &p("attn.linear_v.weight"), d, d)?,
+        v_b: builder.w1(arena, &p("attn.linear_v.bias"), d)?,
+        pos_w: builder.w2(arena, &p("attn.linear_pos.weight"), d, d)?,
+        pos_bias_u: builder.w1(arena, &p("attn.pos_bias_u"), d)?,
+        pos_bias_v: builder.w1(arena, &p("attn.pos_bias_v"), d)?,
+        out_w: builder.w2(arena, &p("attn.linear_out.weight"), d, d)?,
+        out_b: builder.w1(arena, &p("attn.linear_out.bias"), d)?,
+        norm_mlp_w: builder.w1(arena, &p("norm_mlp.weight"), d)?,
+        norm_mlp_b: builder.w1(arena, &p("norm_mlp.bias"), d)?,
+        cproj1_w: builder.w2(arena, &p("cgmlp.channel_proj1.0.weight"), d, cg)?,
+        cproj1_b: builder.w1(arena, &p("cgmlp.channel_proj1.0.bias"), cg)?,
+        csgu_norm_w: builder.w1(arena, &p("cgmlp.csgu.norm.weight"), cg_half)?,
+        csgu_norm_b: builder.w1(arena, &p("cgmlp.csgu.norm.bias"), cg_half)?,
+        csgu_conv_w: builder.w4(arena, &p("cgmlp.csgu.conv.weight"), ck, 1, 1, cg_half)?,
+        csgu_conv_b: builder.w1(arena, &p("cgmlp.csgu.conv.bias"), cg_half)?,
+        cproj2_w: builder.w2(arena, &p("cgmlp.channel_proj2.weight"), cg_half, d)?,
+        cproj2_b: builder.w1(arena, &p("cgmlp.channel_proj2.bias"), d)?,
+        fusion_conv_w: builder.w4(arena, &p("depthwise_conv_fusion.weight"), mk, 1, 1, d + d)?,
+        fusion_conv_b: builder.w1(arena, &p("depthwise_conv_fusion.bias"), d + d)?,
+        merge_w: builder.w2(arena, &p("merge_proj.weight"), d + d, d)?,
+        merge_b: builder.w1(arena, &p("merge_proj.bias"), d)?,
+        norm_ff_w: builder.w1(arena, &p("norm_ff.weight"), d)?,
+        norm_ff_b: builder.w1(arena, &p("norm_ff.bias"), d)?,
+        ff_w1_w: builder.w2(arena, &p("feed_forward.w_1.weight"), d, ffn)?,
+        ff_w1_b: builder.w1(arena, &p("feed_forward.w_1.bias"), ffn)?,
+        ff_w2_w: builder.w2(arena, &p("feed_forward.w_2.weight"), ffn, d)?,
+        ff_w2_b: builder.w1(arena, &p("feed_forward.w_2.bias"), d)?,
+        norm_final_w: builder.w1(arena, &p("norm_final.weight"), d)?,
+        norm_final_b: builder.w1(arena, &p("norm_final.bias"), d)?,
     })
 }
 
@@ -1070,17 +1119,28 @@ pub(crate) fn encode(
         use_scheduler: true,
     };
     let mut runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml_err("runner_init"))?;
-    let mut graph = runner.start_graph();
+    // Persistent weight arena (a WEIGHTS-usage backend buffer). Placing every
+    // encoder weight here -- instead of the per-call transient graph leaves the
+    // pre-arena encoder used -- is what lets the ggml multi-backend scheduler
+    // offload the E-Branchformer's matmuls to an accelerator (see
+    // `WeightBuilder`). Mirrors `decoder_graph::DolphinDecoderRescoreRuntime` and
+    // the sibling `sensevoice`/`cohere`/`moonshine` encoders. The arena is an
+    // owned value carrying a raw pointer into the runner's backend, so it and the
+    // per-call graph (a `&mut runner` borrow) coexist; `runner` outlives it.
+    let arena = runner
+        .start_static_tensor_arena(dolphin_encoder_arena_context_bytes(config.num_blocks))
+        .map_err(ggml_err("static_tensor_arena"))?;
 
-    // Phase A: create every weight tensor (must precede the first buffer alloc).
+    // Phase A: allocate every weight tensor in the arena (allocation must precede
+    // the arena's first upload, which freezes further creation).
     let mut builder = WeightBuilder::new(provider);
-    let embed = build_embed_weights(&graph, &mut builder, config)?;
+    let embed = build_embed_weights(&arena, &mut builder, config)?;
     let mut blocks = Vec::with_capacity(config.num_blocks);
     for index in 0..config.num_blocks {
-        blocks.push(build_block_weights(&graph, &mut builder, config, index)?);
+        blocks.push(build_block_weights(&arena, &mut builder, config, index)?);
     }
-    let after_norm_w = builder.w1(&graph, "encoder.after_norm.weight", config.d_model)?;
-    let after_norm_b = builder.w1(&graph, "encoder.after_norm.bias", config.d_model)?;
+    let after_norm_w = builder.w1(&arena, "encoder.after_norm.weight", config.d_model)?;
+    let after_norm_b = builder.w1(&arena, "encoder.after_norm.bias", config.d_model)?;
     let weights = EncoderWeights {
         embed,
         blocks,
@@ -1088,32 +1148,32 @@ pub(crate) fn encode(
         after_norm_b,
     };
 
-    // The encoder's relative-position table: a baked-table slice for
-    // `CnDialect` (via the provider, like every other weight), or a table
-    // computed fresh for this request's `frames` for `Multilingual` (never
-    // baked -- see `dolphin_relative_positional_table`). The latter is
-    // uploaded like `input` below (an owned buffer kept alive for the whole
-    // call), not through `WeightBuilder` (which only holds provider-borrowed
-    // slices).
+    // The encoder's relative-position table: a baked-table slice for `CnDialect`
+    // (via the provider, like every other weight), or a table computed fresh for
+    // this request's `frames` for `Multilingual` (never baked -- see
+    // `dolphin_relative_positional_table`). Both live in the arena (constant for
+    // the whole call); the computed one is uploaded separately below since it is
+    // an owned buffer, not a provider-borrowed slice `WeightBuilder` can hold.
     let is_multilingual = matches!(
         config.language_scheme,
         super::package_import::DolphinLanguageScheme::Multilingual
     );
-    let mut computed_pos_table: Option<Vec<f32>> = None;
+    let mut computed_pos: Option<(GgmlStaticTensor, Vec<f32>)> = None;
     let pos_emb = if is_multilingual {
         let table = dolphin_relative_positional_table(config.d_model, frames).ok_or_else(|| {
             DolphinEncoderError::Shape {
                 reason: "relative position table size overflow".to_string(),
             }
         })?;
-        let tensor = graph
+        let handle = arena
             .new_tensor_2d_f32(config.d_model, 2 * frames - 1, "dolphin_rel_pos")
             .map_err(ggml_err("weight_alloc_relpos"))?;
-        computed_pos_table = Some(table);
+        let tensor = arena.graph_tensor(handle);
+        computed_pos = Some((handle, table));
         tensor
     } else {
         builder.pos_slice(
-            &graph,
+            &arena,
             "encoder.embed.pos_enc.pe",
             config.d_model,
             frames,
@@ -1121,11 +1181,24 @@ pub(crate) fn encode(
         )?
     };
 
+    // Phase B: upload every weight (+ the computed rel-pos table) into the arena
+    // backend buffer exactly once. This freezes the arena.
+    let mut arena = arena;
+    builder.upload(&mut arena)?;
+    if let Some((handle, table)) = &computed_pos {
+        arena
+            .set_f32_slice(*handle, table, "dolphin_rel_pos")
+            .map_err(ggml_err("upload_rel_pos"))?;
+    }
+
+    // Phase C: build the per-call forward graph. Only the audio features are a
+    // genuine per-call graph input; every weight and the position table are
+    // already resident in the arena's backend buffer.
+    let mut graph = runner.start_graph();
     let input = graph
         .new_tensor_2d_f32(feat, frames_in, "dolphin_features")
         .map_err(ggml_err("input_alloc"))?;
 
-    // Phase B: build the forward graph and collect the taps.
     let (after_subsample, frames_check) =
         subsample(&graph, input, &weights.embed, config, frames_in)?;
     if frames_check != frames {
@@ -1162,30 +1235,13 @@ pub(crate) fn encode(
     for tap in &taps {
         graph.set_output(*tap).map_err(ggml_err("set_output"))?;
     }
-    // Every tensor this graph uploads to (rather than computes) must be
-    // flagged `set_input`: unlike firered/moonshine/cohere, dolphin has no
-    // persistent weight arena -- every weight (and the audio features / the
-    // relative-position table) is a fresh leaf tensor in this per-call graph
-    // with no buffer of its own yet, so without the flag the scheduler's
-    // backend-assignment pass has no rule to place it on and aborts.
+    // Only the audio-feature leaf is a fresh per-call graph tensor with no buffer
+    // of its own; the weights and position table are arena-resident (their
+    // backend buffer is already allocated), so -- like the decoder's arena path
+    // -- they need no `set_input`.
     graph
         .set_input(input)
         .map_err(ggml_err("mark_input(features)"))?;
-    if is_multilingual {
-        graph
-            .set_input(pos_emb)
-            .map_err(ggml_err("mark_input(rel_pos)"))?;
-    }
-    for (tensor, _, _) in &builder.uploads {
-        graph
-            .set_input(*tensor)
-            .map_err(ggml_err("mark_input(weight)"))?;
-    }
-    for (tensor, _, _, _) in &builder.native_uploads {
-        graph
-            .set_input(*tensor)
-            .map_err(ggml_err("mark_input(weight_native)"))?;
-    }
     // Allocate the forward graph through the scheduler's gallocr for
     // liveness-based buffer reuse before uploading inputs -- every tap above
     // is already marked as an output, so gallocr keeps each one's buffer
@@ -1194,27 +1250,10 @@ pub(crate) fn encode(
         .prepare_outputs_for_upload(&taps)
         .map_err(ggml_err("prepare_outputs"))?;
 
-    // Phase C: upload inputs + weights, then compute. Native (quantized/f16)
-    // rank-2 `.weight` operands upload their raw block bytes verbatim so they stay
-    // quantized in the backend buffer; everything else uploads dequantized f32.
+    // Phase D: upload the audio features, then compute.
     graph
         .set_f32_slice(input, features, "dolphin_features")
         .map_err(ggml_err("upload_features"))?;
-    if let Some(table) = &computed_pos_table {
-        graph
-            .set_f32_slice(pos_emb, table, "dolphin_rel_pos")
-            .map_err(ggml_err("upload_rel_pos"))?;
-    }
-    for (tensor, data, name) in &builder.uploads {
-        graph
-            .set_f32_slice(*tensor, data, name)
-            .map_err(ggml_err("upload_weight"))?;
-    }
-    for (tensor, bytes, ggml_type, name) in &builder.native_uploads {
-        graph
-            .set_matmul_weight_bytes(*tensor, bytes, *ggml_type, name)
-            .map_err(ggml_err("upload_weight_native"))?;
-    }
 
     let expected = frames * config.d_model;
     let output_specs: Vec<(GgmlCpuTensor, usize)> =

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -211,28 +211,29 @@ pub(crate) struct DolphinPipelineOutput {
     pub resolved_language: String,
 }
 
-/// Resolve the ggml backend for a Dolphin request. Fail-closed to the golden,
-/// parity-validated CPU path; a GPU backend engages only when the request
-/// explicitly asks for accelerated execution (`--execution-target accelerated`,
-/// which the bench-suite maps `OPENASR_GGML_BACKEND=metal` onto), never on the
-/// Auto default. Mirrors the xasr encoder policy so what runs is what was asked
-/// for, with no silent downgrade.
+/// Resolve the ggml backend for a Dolphin request. Auto prefers the
+/// accelerator: on a GPU-capable host (Metal on Apple Silicon) the Auto default
+/// resolves to that accelerator, and only fails closed to the golden,
+/// parity-validated CPU path when no accelerator is present. An explicit
+/// `--execution-target cpu` always wins (the gate only ever pins Auto, never
+/// overrides an explicit preference).
 ///
-/// Perf note (AB-measured on M1, best-of-5, 2.38 s Sichuan clip; see
-/// `perf/PERFORMANCE.md`): unlike xasr's chunked encoder -- where every Metal
-/// config loses to CPU -- this 0.4B E-Branchformer is wide enough per step that
-/// Metal is ~1.45x FASTER (RTF 0.47 vs CPU 0.68, warm) at comparable peak RSS,
-/// and reproduces the golden transcript on the clip. Metal stays an opt-in rather
-/// than the default only because its fp16 numerics are not golden-validated
-/// (the parity gate is CPU bit-exact); it is the recommended accelerated path.
+/// Perf note (AB-measured on M1, warm best-of-N, isolated host; see the
+/// `encoder_graph`/`joint_decode` static-arena change): with the E-Branchformer
+/// encoder + CTC head weights resident in a WEIGHTS-usage arena, the ggml
+/// scheduler offloads the whole encoder to Metal (previously it pinned the
+/// ~1348-op encoder to the CPU, a net GPU loss). Metal then beats CPU on both a
+/// 3 s and an 18 s clip (RTF 0.126 vs 0.174, and 0.081 vs 0.103) and reproduces
+/// the golden transcript. CPU stays the bit-exact parity reference, so it
+/// remains the honest fallback where no accelerator exists.
 ///
 /// Delegates to the shared `resolve_family_runtime_backend` gate (declared via
-/// this architecture's `auto_gpu_enabled = false`, see `arch::mod` /
+/// this architecture's `auto_gpu_enabled = true`, see `arch::mod` /
 /// `BUILTIN_ARCHITECTURE_DESCRIPTORS`) rather than hand-rolling the override
 /// check, so any provenance label resolving through the same gate can never
 /// drift from what this function actually decided.
 fn dolphin_runtime_backend() -> GgmlCpuGraphBackend {
-    GgmlCpuGraphConfig::resolve_family_runtime_backend(false)
+    GgmlCpuGraphConfig::resolve_family_runtime_backend(true)
 }
 
 /// Runtime weights for one pack, shared behind an `Arc` so the process-level pool

--- a/crates/openasr-core/src/models/dolphin/joint_decode.rs
+++ b/crates/openasr-core/src/models/dolphin/joint_decode.rs
@@ -199,27 +199,58 @@ fn compute_ctc_log_probs(
     };
     let ggml = |stage: &'static str| move |source| DolphinJointDecodeError::Ggml { stage, source };
     let mut runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml("runner_init"))?;
-    let mut graph = runner.start_graph();
+
+    // Persistent weight arena (a WEIGHTS-usage backend buffer): the CTC head's
+    // `ctc.ctc_lo.weight` matmul operand + bias live here so the ggml
+    // multi-backend scheduler can offload the projection to an accelerator, the
+    // same reason the encoder/decoder weights are arena-resident. Binding them as
+    // per-call transient graph leaves (the pre-arena path) pinned this matmul to
+    // the CPU even under an explicit Metal backend. Only `encoder_out` is a
+    // genuine per-call graph input. Weight placement changes no computed value,
+    // so the CTC log-probs stay golden-identical.
+    let arena = runner
+        .start_static_tensor_arena(GgmlCpuGraphConfig::metadata_context_bytes(2))
+        .map_err(ggml("static_tensor_arena"))?;
 
     // Weight `[vocab, d_model]` binds as ggml `[ne0=d_model, ne1=vocab]` so
     // `mul_mat(weight, enc)` projects each frame to the vocab logits. When the
     // provider keeps it quantized/f16, it binds at the stored ggml type and the
     // raw block bytes are uploaded verbatim (stays quantized in the buffer);
     // otherwise it binds f32.
-    let weight_tensor = match native_weight {
-        Some(native) => graph
+    let weight_handle = match native_weight {
+        Some(native) => arena
             .new_matmul_weight_2d_typed(d_model, vocab, native.ggml_type, "dolphin_ctc_weight")
             .map_err(ggml("weight_alloc_native"))?,
-        None => graph
+        None => arena
             .new_tensor_2d_f32(d_model, vocab, "dolphin_ctc_weight")
             .map_err(ggml("weight_alloc"))?,
     };
-    let bias_tensor = graph
+    let bias_handle = arena
         .new_tensor_1d_f32(vocab, "dolphin_ctc_bias")
         .map_err(ggml("bias_alloc"))?;
+
+    // Upload the weight + bias into the arena backend buffer exactly once (the
+    // first upload freezes further tensor creation).
+    let mut arena = arena;
+    match (native_weight, weight) {
+        (Some(native), _) => arena
+            .set_bytes_slice(weight_handle, native.bytes, "dolphin_ctc_weight")
+            .map_err(ggml("upload_weight_native"))?,
+        (None, Some(weight)) => arena
+            .set_f32_slice(weight_handle, weight, "dolphin_ctc_weight")
+            .map_err(ggml("upload_weight"))?,
+        (None, None) => unreachable!("ctc weight is fetched f32 when not native"),
+    }
+    arena
+        .set_f32_slice(bias_handle, bias, "dolphin_ctc_bias")
+        .map_err(ggml("upload_bias"))?;
+
+    let mut graph = runner.start_graph();
     let encoder_tensor = graph
         .new_tensor_2d_f32(d_model, frames, "dolphin_ctc_encoder_out")
         .map_err(ggml("encoder_alloc"))?;
+    let weight_tensor = arena.graph_tensor(weight_handle);
+    let bias_tensor = arena.graph_tensor(bias_handle);
 
     let logits = graph
         .mul_mat(weight_tensor, encoder_tensor)
@@ -228,16 +259,10 @@ fn compute_ctc_log_probs(
         .add(logits, bias_tensor)
         .map_err(ggml("ctc_bias_add"))?;
     graph.set_output(logits).map_err(ggml("set_output"))?;
-    // Every tensor this graph uploads to (rather than computes) must be
-    // flagged `set_input`: it is a fresh leaf tensor in this per-call graph
-    // with no buffer yet, so without the flag the scheduler's
-    // backend-assignment pass has no rule to place it on and aborts.
-    graph
-        .set_input(weight_tensor)
-        .map_err(ggml("mark_input(weight)"))?;
-    graph
-        .set_input(bias_tensor)
-        .map_err(ggml("mark_input(bias)"))?;
+    // Only `encoder_out` is a fresh per-call graph leaf with no buffer of its
+    // own; the weight + bias are arena-resident (backend buffer already
+    // allocated), so -- like the encoder/decoder arena paths -- they need no
+    // `set_input`.
     graph
         .set_input(encoder_tensor)
         .map_err(ggml("mark_input(encoder_out)"))?;
@@ -248,23 +273,6 @@ fn compute_ctc_log_probs(
         .prepare_outputs_for_upload(&[logits])
         .map_err(ggml("prepare_outputs"))?;
 
-    match (native_weight, weight) {
-        (Some(native), _) => graph
-            .set_matmul_weight_bytes(
-                weight_tensor,
-                native.bytes,
-                native.ggml_type,
-                "dolphin_ctc_weight",
-            )
-            .map_err(ggml("upload_weight_native"))?,
-        (None, Some(weight)) => graph
-            .set_f32_slice(weight_tensor, weight, "dolphin_ctc_weight")
-            .map_err(ggml("upload_weight"))?,
-        (None, None) => unreachable!("ctc weight is fetched f32 when not native"),
-    }
-    graph
-        .set_f32_slice(bias_tensor, bias, "dolphin_ctc_bias")
-        .map_err(ggml("upload_bias"))?;
     graph
         .set_f32_slice(encoder_tensor, encoder_out, "dolphin_ctc_encoder_out")
         .map_err(ggml("upload_encoder"))?;

--- a/perf/PERFORMANCE.md
+++ b/perf/PERFORMANCE.md
@@ -66,52 +66,44 @@ The two gating entries in the committed baseline are `whisper-tiny-en-q8` and
 
 ## Dolphin: CPU vs Metal (AB-measured on M1)
 
-The committed `dolphin-cn-dialect-small-fp16` baseline is the **CPU** default (the
-golden, parity-validated path). CPU-vs-Metal x with/without cross-request weight
-reuse was AB-measured on the 2.38 s Sichuan clip (M1, best-of-5); all four configs
-reproduce the golden transcript exactly (CER 0.0000):
+Dolphin's Auto default is **Metal** on a GPU-capable Apple Silicon host (fail-closed
+to CPU where no accelerator exists). This became the default once the
+E-Branchformer encoder + CTC head weights moved into a WEIGHTS-usage static arena:
+before that, the ggml scheduler only offloads an op whose weight `src` lives in a
+`GGML_BACKEND_BUFFER_USAGE_WEIGHTS` buffer, so the whole ~1348-op encoder plus the
+CTC projection stayed pinned to the CPU under an explicit Metal backend while only
+the small decoder rescoring graphs ran on Metal -- a net GPU loss. With the weights
+arena-resident, `GGML_SCHED_DEBUG=2` shows zero CPU compute splits: the encoder, the
+CTC head, and all 10 decoder rescoring graphs run on Metal.
 
-| Backend | Weight reuse | RTF | Peak RSS |
+Warm best-of-6 compute, isolated host (M1), q8_0, identical golden transcript on
+every cell:
+
+| Audio | Backend | RTF (before arena) | RTF (after arena) |
 | --- | --- | ---: | ---: |
-| CPU | cold (reload/dequant each request) | 0.34 | ~1.88 GB |
-| CPU | warm (pooled weights) | **0.29** | ~1.88 GB |
-| Metal | cold | 0.32 | ~1.78 GB |
-| Metal | warm (pooled weights) | **0.29** | ~1.78 GB |
+| 3 s  | CPU   | 0.180 | 0.174 |
+| 3 s  | Metal | 0.244 | **0.126** |
+| 18 s | CPU   | 0.171 | 0.157 |
+| 18 s | Metal | 0.334 | **0.081** |
 
-**Re-measured post-#P5/#P6** (attention-rescoring build-once/run-many decoder
-weights + gated encoder taps; release, best-of-5, same clip/host as above). The
-previous rows in this table (CPU 0.89/0.72, Metal 0.67/0.48, ~3.4-3.7 GB) predate
-both fixes: every one of the CTC n-best's `DOLPHIN_BEAM_SIZE=10` rescoring calls
-used to rebuild the whole decoder graph and re-upload all ~200 decoder weight
-tensors from scratch, and the encoder unconditionally materialized every
-per-block hidden state as an extra f32 graph output. Removing that per-hypothesis
-rebuild/re-upload (P5) plus gating the encoder's per-block taps off in production
-(P6) cuts RTF by roughly half-to-2/3 and peak RSS by close to 2x across every
-cell, dominating the older cross-request `DOLPHIN_WEIGHTS_POOL` reuse effect below.
+Findings, all measured (not assumed):
 
-Findings, both measured (not assumed):
+1. **The arena reverses the GPU deficit.** Before, Metal lost to CPU (1.35x slower
+   at 3 s, 2.07x at 18 s). After, Metal beats CPU on both lengths (1.38x faster at
+   3 s, 1.27x at 18 s) and Metal's own compute drops 1.9x/2.6x. CPU is unchanged --
+   weight placement does not alter the CPU path (`dolphin_encoder_parity` stays
+   bit-exact).
+2. **Margin is honest, not huge.** On a clean host the M1 CPU is strong, so the GPU
+   win is ~1.3x rather than a landslide; it is consistently positive across both
+   lengths. Peak RSS is also lower on Metal (quantized weights stay quantized in the
+   WEIGHTS buffer rather than a dequantized graph-input blow-up).
 
-1. **Reuse still helps, but far less than before.** The executor still pools the
-   dequantized f32 weights per pack (`DOLPHIN_WEIGHTS_POOL`) across *requests*,
-   so cold vs warm still shows a small gap (0.34 -> 0.29 CPU, 0.32 -> 0.29 Metal).
-   That gap used to be much larger because the old per-hypothesis decoder rebuild
-   dwarfed the one-time pack-load cost it was hiding; now that the rescore loop
-   itself is build-once/run-many, cross-request reuse is a minor tail rather than
-   the dominant lever.
-2. **CPU and Metal are now close, not a clear Metal win.** The previous "Metal
-   WINS here" conclusion was measured when the decoder rebuilt its whole graph
-   (weights included) 10x per utterance -- wide enough per rebuild to amortize
-   GPU dispatch. With the rebuild/re-upload gone, the two backends land within
-   noise of each other on this clip (warm RTF 0.29 both). Re-validate on a longer
-   clip before leaning on a backend recommendation from this table alone.
-
-**Default = CPU** anyway: the parity gate is CPU bit-exact and Metal's fp16
-numerics are not golden-validated (identical transcript on this clip is evidence,
-not a guarantee across GPUs/audio). Metal remains an **opt-in** via
-`--execution-target accelerated` / `OPENASR_GGML_BACKEND=metal`; the executor
-fail-closes to CPU on the Auto default and engages Metal only on an explicit
-accelerated request. Harness: the `dolphin_perf_ab` ignored test
-(`OPENASR_DOLPHIN_AB_BACKEND`/`_REUSE`/`_RUNS`).
+**Default = Metal on Apple Silicon**, CPU elsewhere: the Auto gate
+(`auto_gpu_enabled = true`) only ever selects an accelerator that is actually
+present (`runtime_gpu_is_available`), and an explicit `--execution-target cpu`
+always wins. CPU stays the bit-exact parity reference -- Metal fp16 reproduces the
+golden transcript on the parity clip but is not itself the golden gate. Harness: the
+`dolphin_perf_ab` ignored test (`OPENASR_DOLPHIN_AB_BACKEND`/`_REUSE`/`_RUNS`).
 
 ## Caveats
 


### PR DESCRIPTION
## Summary

Move the Dolphin E-Branchformer encoder and CTC head weights into a WEIGHTS-usage
static tensor arena so the ggml scheduler offloads them to Metal, then flip
Dolphin's Auto default from CPU-gated to GPU-enabled now that Metal beats CPU
end-to-end on Apple Silicon.

## Why

Under an explicit Metal backend, Dolphin was a net GPU loss (~2x slower than CPU).
Root cause: the encoder and CTC head allocated every weight as per-call transient
graph leaves (`start_graph` + `set_input` + upload), which land in the graph
compute buffer, not a `GGML_BACKEND_BUFFER_USAGE_WEIGHTS` buffer. The ggml
multi-backend scheduler only considers an op for `op_offload` when its weight `src`
lives in a WEIGHTS-usage buffer, so the whole ~1348-op encoder plus the CTC
projection stayed pinned to the CPU while only the small decoder rescoring graphs
ran on Metal. `GGML_SCHED_DEBUG=2` confirmed the encoder was a single all-CPU split.

## Changes

- `models/dolphin/encoder_graph.rs`: `WeightBuilder` now allocates every encoder
  weight into a `GgmlStaticTensorArena` (uploaded once) and the forward graph
  references them via `arena.graph_tensor`; only the audio features stay a per-call
  graph input. Same mechanism the Dolphin decoder rescoring runtime and the sibling
  sensevoice/cohere/moonshine encoders already use.
- `models/dolphin/joint_decode.rs`: the CTC head (`ctc.ctc_lo.weight` + bias) moves
  to the same arena path; only `encoder_out` stays a per-call input.
- `models/dolphin/executor.rs` + `arch/mod.rs`: declare `auto_gpu_enabled = true`
  and resolve the runtime backend through `resolve_family_runtime_backend(true)`.
  The gate only ever selects an accelerator that is actually present
  (`runtime_gpu_is_available`), so non-Metal hosts still resolve to CPU and an
  explicit `--execution-target cpu` always wins; provenance labels resolve through
  the same gate. Test/doc pins for the two formerly CPU-gated families updated
  (xasr-zipformer remains the sole CPU-gated builtin).
- `perf/PERFORMANCE.md`: replaced the stale "default = CPU" Dolphin section with the
  arena before/after RTF table and the fail-closed-to-CPU default note.

Weight placement changes no computed value, only the backend each op runs on.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2596 passed, 0 failed, 130 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

Also (local checkpoint under `tmp/`, ignored tests):
`dolphin_encoder_parity` (raw-f32 CPU bit-exact) passes, and
`dolphin_encoder_from_pack_parity` (fp16/q8_0/q4_k) stays within its committed
tolerances -- the arena move is numerically identical.

## Manual smoke checks

- `GGML_SCHED_DEBUG=2` on a q8_0 pack: after the change every ggml op (encoder, CTC
  head, all 10 decoder rescoring graphs) runs on `MTL0` with zero CPU compute
  splits, both under an explicit Metal backend and under Auto with no backend flag.
- Auto with no `OPENASR_GGML_BACKEND` and no `--execution-target` now resolves to
  Metal and reproduces the golden transcript; CPU and Metal outputs are byte-
  identical to the pre-change build.
- Warm best-of-6 on an isolated M1 host (q8_0): Metal RTF now below CPU on both a
  3 s clip (0.126 vs 0.174) and an 18 s clip (0.081 vs 0.103), reversing the prior
  ~2x GPU deficit; CPU unchanged.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (`perf/PERFORMANCE.md`)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch xasr-zipformer (its chunked streaming encoder has the same
  transient-weight pattern and a separately measured Auto-mode GPU regression; a
  follow-up can apply the same arena fix there).
- Does not touch the optional hotword deep-biasing fusion graph (runs only when
  phrase-bias hotwords are supplied); it keeps the transient path for now.
- CPU stays the bit-exact parity reference; this only moves the Auto default and the
  op backend, not the explicit-preference behavior.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implemented and measured with AI coding-assistant help; the submitter reviewed, understands, and owns the change and its maintenance.
