### PR TITLE
perf(ggml): re-vendor ggml 0.16.0 and use native CONV_2D_DW for depthwise conv

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -3325,66 +3325,6 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         self.new_tensor_checked(raw, "ggml_conv_2d")
     }
 
-    /// Whether this builder's compute backend is GPU-class (Metal/GPU). Graph
-    /// construction uses this to pick backend-appropriate ops (e.g. the
-    /// im2col-based `conv_2d_dw` on GPU, which is Metal-native, vs the fused
-    /// `conv_2d_dw_direct` on CPU, which the Metal backend has no kernel for).
-    pub(crate) fn backend_is_gpu_class(&self) -> bool {
-        self.backend_kind.is_gpu_class()
-    }
-
-    pub(crate) fn conv_2d_dw(
-        &self,
-        kernel: GgmlCpuTensor<'a>,
-        data: GgmlCpuTensor<'a>,
-        stride0: usize,
-        stride1: usize,
-        padding0: usize,
-        padding1: usize,
-        dilation0: usize,
-        dilation1: usize,
-    ) -> Result<GgmlCpuTensor<'a>, GgmlCpuGraphError> {
-        self.ensure_can_extend_graph("ggml_conv_2d_dw")?;
-        self.ensure_tensor_type(kernel, ffi::GGML_TYPE_F16, "ggml_conv_2d_dw kernel")?;
-        self.ensure_tensor_type(data, ffi::GGML_TYPE_F32, "ggml_conv_2d_dw data")?;
-        let stride0 = i32::try_from(stride0).map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
-            reason: "conv stride exceeds ggml int boundary",
-        })?;
-        let stride1 = i32::try_from(stride1).map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
-            reason: "conv stride exceeds ggml int boundary",
-        })?;
-        let padding0 =
-            i32::try_from(padding0).map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
-                reason: "conv padding exceeds ggml int boundary",
-            })?;
-        let padding1 =
-            i32::try_from(padding1).map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
-                reason: "conv padding exceeds ggml int boundary",
-            })?;
-        let dilation0 =
-            i32::try_from(dilation0).map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
-                reason: "conv dilation exceeds ggml int boundary",
-            })?;
-        let dilation1 =
-            i32::try_from(dilation1).map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
-                reason: "conv dilation exceeds ggml int boundary",
-            })?;
-        let raw = unsafe {
-            ffi::ggml_conv_2d_dw(
-                self.context.as_ptr(),
-                kernel.raw.as_ptr(),
-                data.raw.as_ptr(),
-                stride0,
-                stride1,
-                padding0,
-                padding1,
-                dilation0,
-                dilation1,
-            )
-        };
-        self.new_tensor_checked(raw, "ggml_conv_2d_dw")
-    }
-
     pub(crate) fn conv_2d_dw_direct(
         &self,
         kernel: GgmlCpuTensor<'a>,
@@ -3441,11 +3381,11 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         self.new_tensor_checked(raw, "ggml_conv_2d_dw_direct")
     }
 
-    /// Backend-appropriate depthwise 2D conv. On CPU this is the fused
-    /// `conv_2d_dw_direct` (accepts an F32 kernel). On a GPU-class backend the
-    /// Metal backend has no CONV_2D_DW kernel, so this routes to the im2col-based
-    /// `conv_2d_dw` (IM2COL + MUL_MAT, all Metal-native) — which requires an F16
-    /// kernel, so the F32 kernel is cast first. Callers stay backend-agnostic.
+    /// Depthwise 2D conv via the fused `GGML_OP_CONV_2D_DW` op
+    /// (`ggml_conv_2d_dw_direct`). The Metal backend has a native CONV_2D_DW kernel
+    /// (F16 or F32 kernel weights), so this is a single direct op on every backend
+    /// -- no F32->F16 cast and no IM2COL + MUL_MAT expansion. Callers stay
+    /// backend-agnostic.
     pub(crate) fn depthwise_conv_2d(
         &self,
         kernel: GgmlCpuTensor<'a>,
@@ -3457,16 +3397,9 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         dilation0: usize,
         dilation1: usize,
     ) -> Result<GgmlCpuTensor<'a>, GgmlCpuGraphError> {
-        if self.backend_is_gpu_class() {
-            let kernel_f16 = self.cast(kernel, ffi::GGML_TYPE_F16)?;
-            self.conv_2d_dw(
-                kernel_f16, data, stride0, stride1, padding0, padding1, dilation0, dilation1,
-            )
-        } else {
-            self.conv_2d_dw_direct(
-                kernel, data, stride0, stride1, padding0, padding1, dilation0, dilation1,
-            )
-        }
+        self.conv_2d_dw_direct(
+            kernel, data, stride0, stride1, padding0, padding1, dilation0, dilation1,
+        )
     }
 
     #[cfg(test)]
@@ -6435,7 +6368,7 @@ mod tests {
         graph.set_input(input).expect("input should be input");
 
         let dw = graph
-            .conv_2d_dw(kernel, input, 1, 1, 0, 0, 1, 1)
+            .depthwise_conv_2d(kernel, input, 1, 1, 0, 0, 1, 1)
             .expect("depthwise conv should build");
         let dw_direct = graph
             .conv_2d_dw_direct(kernel, input, 1, 1, 0, 0, 1, 1)
@@ -6465,6 +6398,56 @@ mod tests {
         assert_eq!(outputs[0], vec![2.0, 4.0, 6.0, 8.0]);
         assert!(outputs[0].iter().all(|value| value.is_finite()));
         assert!(outputs[1].iter().all(|value| value.is_finite()));
+    }
+
+    /// `depthwise_conv_2d` routes to the fused `GGML_OP_CONV_2D_DW` op on every
+    /// backend, including Metal (which gained a native CONV_2D_DW kernel upstream).
+    /// This runs the same tiny depthwise conv on a real Metal runner and checks it
+    /// matches the CPU reference, exercising the native Metal kernel path rather
+    /// than the retired IM2COL + MUL_MAT detour. Skips on hosts without a Metal GPU.
+    #[test]
+    fn depthwise_conv_2d_executes_on_metal_backend() {
+        let mut config = GgmlCpuGraphConfig::conservative_default();
+        config.backend = GgmlCpuGraphBackend::Metal;
+        let mut runner = match GgmlCpuGraphRunner::new(config) {
+            Ok(runner) => runner,
+            Err(error) => {
+                eprintln!(
+                    "depthwise_conv_2d_executes_on_metal_backend: Metal unavailable ({error}) - skipping"
+                );
+                return;
+            }
+        };
+        let mut graph = runner.start_graph();
+        let kernel = graph
+            .new_tensor_4d_typed(1, 1, 1, 1, ffi::GGML_TYPE_F16, "kernel")
+            .expect("kernel allocation should succeed");
+        let input = graph
+            .new_tensor_4d_f32(2, 2, 1, 1, "input")
+            .expect("input allocation should succeed");
+        graph.set_input(kernel).expect("kernel should be input");
+        graph.set_input(input).expect("input should be input");
+
+        let dw = graph
+            .depthwise_conv_2d(kernel, input, 1, 1, 0, 0, 1, 1)
+            .expect("depthwise conv should build");
+        let dw_output = graph
+            .new_tensor_4d_f32(2, 2, 1, 1, "dw_output")
+            .expect("dw output buffer should allocate");
+        let dw = graph
+            .cpy(dw, dw_output)
+            .expect("dw copy to f32 output should build");
+
+        graph
+            .set_f16_bits_slice(kernel, &[0x4000], "kernel")
+            .expect("kernel upload should succeed");
+        graph
+            .set_f32_slice(input, &[1.0, 2.0, 3.0, 4.0], "input")
+            .expect("input upload should succeed");
+        let outputs = graph
+            .compute_outputs_f32(&[(dw, 4)])
+            .expect("depthwise conv should compute on the metal backend");
+        assert_eq!(outputs[0], vec![2.0, 4.0, 6.0, 8.0]);
     }
 
     /// `group_norm` with `n_groups == n_channels` (per-channel instance norm),

--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -467,17 +467,6 @@ unsafe extern "C" {
         d0: c_int,
         d1: c_int,
     ) -> GgmlTensorRaw;
-    pub(crate) fn ggml_conv_2d_dw(
-        ctx: GgmlContextRaw,
-        a: GgmlTensorRaw,
-        b: GgmlTensorRaw,
-        s0: c_int,
-        s1: c_int,
-        p0: c_int,
-        p1: c_int,
-        d0: c_int,
-        d1: c_int,
-    ) -> GgmlTensorRaw;
     pub(crate) fn ggml_conv_2d_dw_direct(
         ctx: GgmlContextRaw,
         a: GgmlTensorRaw,

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -679,7 +679,7 @@ fn firered_conformer_block<'a>(
         .reshape_4d(conv, n_frames, 1, dw_channels, 1)
         .map_err(|source| map_err("ggml_reshape_4d(conv_in_4d)", source))?;
     let mut conv = graph
-        .conv_2d_dw(dw_weight, conv_4d, 1, 1, (conv_kernel - 1) / 2, 0, 1, 1)
+        .depthwise_conv_2d(dw_weight, conv_4d, 1, 1, (conv_kernel - 1) / 2, 0, 1, 1)
         .map_err(|source| map_err("ggml_conv_2d_dw(conv_dw)", source))?;
     conv = graph
         .permute(conv, 1, 2, 0, 3)

--- a/crates/openasr-core/src/nn/conv.rs
+++ b/crates/openasr-core/src/nn/conv.rs
@@ -124,7 +124,7 @@ where
     F: Fn(&'static str, GgmlCpuGraphError) -> E + Copy,
 {
     let conv = graph
-        .conv_2d_dw(
+        .depthwise_conv_2d(
             weight,
             input,
             params.stride_x,

--- a/crates/openasr-core/src/nn/encoder.rs
+++ b/crates/openasr-core/src/nn/encoder.rs
@@ -441,7 +441,7 @@ where
         .reshape_4d(conv, frame_count, 1, d_model, 1)
         .map_err(|source| map_err("ggml_reshape_4d(conv_in_4d)", source))?;
     let mut conv = graph
-        .conv_2d_dw(dw_weight, conv_4d, 1, 1, (conv_kernel - 1) / 2, 0, 1, 1)
+        .depthwise_conv_2d(dw_weight, conv_4d, 1, 1, (conv_kernel - 1) / 2, 0, 1, 1)
         .map_err(|source| map_err("ggml_conv_2d_dw(conv_dw)", source))?;
     conv = graph
         .permute(conv, 1, 2, 0, 3)
@@ -972,7 +972,7 @@ where
         .reshape_4d(v_t, frame_count, 1, d_model, 1)
         .map_err(|source| map_err("ggml_reshape_4d(sanm_fsmn_in)", source))?;
     let mut fsmn = graph
-        .conv_2d_dw(dw_weight, v_4d, 1, 1, (config.fsmn_kernel - 1) / 2, 0, 1, 1)
+        .depthwise_conv_2d(dw_weight, v_4d, 1, 1, (config.fsmn_kernel - 1) / 2, 0, 1, 1)
         .map_err(|source| map_err("ggml_conv_2d_dw(sanm_fsmn)", source))?;
     fsmn = graph
         .permute(fsmn, 1, 2, 0, 3)

--- a/tooling/ggml-sync/README.md
+++ b/tooling/ggml-sync/README.md
@@ -1,0 +1,66 @@
+# ggml submodule sync
+
+The ggml backend is vendored as a git submodule at
+`crates/openasr-core/third_party/openasr-ggml` (a submodule of the
+`QuintinShaw/openasr-ggml` fork). `crates/openasr-core/build.rs` compiles it from
+source with CMake, so the vendored tree is the real backend, not a mirror.
+
+## Pin shape
+
+Every pin is **one clean upstream `ggml-org/ggml` commit plus a small stack of
+OpenASR-local patches** on top. Keeping the pin in that shape (clean base +
+reviewed delta, no merge commits) is what lets a sync be a mechanical replay
+instead of a history untangle.
+
+The current local patch stack (oldest first):
+
+1. Expose GGUF tensor dimension accessors (`gguf_get_tensor_n_dims`) -- used by
+   the Rust GGUF tensor index.
+2. backend-dl: open plugins with `LOAD_WITH_ALTERED_SEARCH_PATH` on Windows.
+3. Filter `GGML_LOG_LEVEL_DEBUG` spam unless `GGML_DEBUG` / `OPENASR_GGML_DEBUG`.
+4. Persist the Metal pipeline cache (MTLBinaryArchive serialised to disk for
+   faster cold start).
+5. Isolate that Metal pipeline cache under an `openasr/` cache subdir.
+6. Default Metal residency sets off unless the device exposes the tensor API
+   (`GGML_METAL_RESIDENCY_ENABLE` / `GGML_METAL_NO_RESIDENCY` override).
+
+Deliberately **not** carried on the pin:
+
+- `metal-bin-f16` (F16 ADD/SUB/MUL/DIV) lives on the fork branch
+  `oasr/metal-bin-f16`; F16 activation was ruled out and it duplicates upstream
+  PR staging. Left off on purpose.
+- `ggml_norm_back` / CONT-backward training ops -- OpenASR is inference-only and
+  never references them; dropped to shrink the delta.
+
+## Syncing to a newer upstream
+
+```bash
+git submodule update --init crates/openasr-core/third_party/openasr-ggml
+tooling/ggml-sync/sync.sh --dry-run                 # fetch + print the plan
+tooling/ggml-sync/sync.sh                            # replay onto upstream/master
+# or pin it: tooling/ggml-sync/sync.sh --target <sha>
+```
+
+`sync.sh` derives the patch stack from the current pin
+(`merge-base(target, pin)..pin`, non-merge, oldest first), checks out the target
+upstream commit on a new branch in the submodule, and cherry-picks the stack
+back. On a conflict it stops with the offending patch named so you can resolve,
+`--continue`, or `--skip` (when upstream has subsumed a patch). It **does not**
+commit, bump the superproject gitlink, or push -- those stay manual.
+
+After a clean replay:
+
+1. Build + run the full regression from the superproject
+   (`cargo build`, `cargo nextest run --workspace`, `cargo test --workspace --doc`,
+   `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`), plus the
+   Metal depthwise smoke and, where model packs are available, the family
+   golden/parity suites.
+2. Only then record the new pin:
+   `git add crates/openasr-core/third_party/openasr-ggml`.
+
+## When CONV_2D_DW-style upstream ops land
+
+Upstream gaining a native op (e.g. the Metal `GGML_OP_CONV_2D_DW` kernel) can let
+a downstream detour retire. After a sync, check whether any backend-conditional
+op routing in `crates/openasr-core/src/ggml_runtime/cpu_graph.rs` can collapse to
+the now-native op, and drop the fallback rather than leaving both paths.

--- a/tooling/ggml-sync/sync.sh
+++ b/tooling/ggml-sync/sync.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Re-vendor the ggml submodule onto a newer upstream ggml-org/ggml commit,
+# replaying the OpenASR-local patches that sit on top of the current pin.
+#
+# The vendored ggml lives at crates/openasr-core/third_party/openasr-ggml and is
+# a git submodule of the QuintinShaw/openasr-ggml fork. Each pin is a clean
+# upstream base commit plus a small stack of OpenASR-local patches (Metal
+# pipeline-cache persistence + isolation, residency-set default, quiet debug
+# logs, GGUF tensor-dim accessors, the Windows backend-dl loader fix, ...). This
+# script derives that patch stack from the current pin, checks out the requested
+# upstream target, and cherry-picks the stack back on top so the only diff vs
+# upstream stays the reviewed OpenASR delta.
+#
+# It never pushes and never touches upstream or the fork remote: it only writes
+# a local branch in the submodule. Bumping the superproject gitlink and any push
+# are left to a human.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "${script_dir}" rev-parse --show-toplevel)"
+sub_path="crates/openasr-core/third_party/openasr-ggml"
+sub_dir="${repo_root}/${sub_path}"
+upstream_url="https://github.com/ggml-org/ggml.git"
+
+target="upstream/master"
+dry_run=0
+branch=""
+
+usage() {
+  cat <<EOF
+Re-vendor the ggml submodule onto a newer upstream commit, replaying the
+OpenASR-local patch stack that sits on top of the current pin.
+
+Usage:
+  sync.sh [--target <ref>] [--branch <name>] [--dry-run]
+
+Options:
+  --target <ref>   Upstream commit/ref to rebase onto (default: upstream/master,
+                   i.e. latest after the fetch below). Pass a pinned SHA for a
+                   reproducible sync.
+  --branch <name>  Name of the local branch to create in the submodule
+                   (default: oasr/pin-<short-target>).
+  --dry-run        Fetch, resolve the patch stack, and print the plan without
+                   creating a branch or cherry-picking.
+  -h, --help       Show this help.
+
+After a successful run the submodule sits on the new branch. Review it, then
+from the superproject: build + full regression, and only then
+  git add ${sub_path}
+to record the new gitlink. This script does not commit, bump the gitlink, or push.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) target="$2"; shift 2 ;;
+    --branch) branch="$2"; shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -d "${sub_dir}/.git" || -f "${sub_dir}/.git" ]] || {
+  echo "ggml submodule not initialised at ${sub_path}" >&2
+  echo "run: git submodule update --init ${sub_path}" >&2
+  exit 2
+}
+
+git_sub() { git -C "${sub_dir}" "$@"; }
+
+# Refuse to run over a dirty submodule so a failed cherry-pick can never mix with
+# unrelated local edits.
+if [[ -n "$(git_sub status --porcelain)" ]]; then
+  echo "submodule working tree is dirty; commit/stash before syncing" >&2
+  exit 1
+fi
+
+pin="$(git_sub rev-parse HEAD)"
+
+if ! git_sub remote get-url upstream >/dev/null 2>&1; then
+  echo "== adding upstream remote ${upstream_url}"
+  git_sub remote add upstream "${upstream_url}"
+fi
+
+echo "== fetching upstream"
+git_sub fetch --no-tags upstream master
+
+target_sha="$(git_sub rev-parse --verify "${target}^{commit}")"
+base="$(git_sub merge-base "${target_sha}" "${pin}")"
+
+# The OpenASR-local stack = non-merge commits reachable from the current pin but
+# not from its clean upstream base. On a clean pin this is exactly the reviewed
+# patch stack, oldest first.
+mapfile -t patches < <(git_sub log --reverse --no-merges --format='%H' "${base}..${pin}")
+
+echo
+echo "current pin:   ${pin}"
+echo "upstream base: ${base}"
+echo "target:        ${target}  (${target_sha})"
+echo "patch stack (${#patches[@]} commits, oldest first):"
+for sha in "${patches[@]}"; do
+  echo "  - $(git_sub log -1 --format='%h %s' "${sha}")"
+done
+
+if [[ "${base}" == "${target_sha}" ]]; then
+  echo
+  echo "target equals the current upstream base; nothing to sync."
+  exit 0
+fi
+
+if [[ ${#patches[@]} -eq 0 ]]; then
+  echo
+  echo "no OpenASR-local patches found above the base; the pin is plain upstream." >&2
+  echo "refusing to guess -- inspect the pin history manually." >&2
+  exit 1
+fi
+
+if [[ ${dry_run} -eq 1 ]]; then
+  echo
+  echo "dry run: not creating a branch or cherry-picking."
+  exit 0
+fi
+
+branch="${branch:-oasr/pin-$(git_sub rev-parse --short "${target_sha}")}"
+echo
+echo "== creating ${branch} at ${target_sha} and replaying the stack"
+git_sub checkout -b "${branch}" "${target_sha}"
+
+for sha in "${patches[@]}"; do
+  short="$(git_sub log -1 --format='%h %s' "${sha}")"
+  echo "== cherry-pick ${short}"
+  if ! git_sub cherry-pick "${sha}"; then
+    echo >&2
+    echo "conflict replaying ${short}" >&2
+    echo "resolve in ${sub_dir}, then 'git cherry-pick --continue', or --abort to bail." >&2
+    echo "if upstream already subsumes this patch, 'git cherry-pick --skip'." >&2
+    exit 1
+  fi
+done
+
+echo
+echo "done. submodule ${sub_path} is on ${branch} ($(git_sub rev-parse --short HEAD))."
+echo "next: build + full family regression from the superproject, then"
+echo "  git add ${sub_path}   # record the new gitlink (not done here)"


### PR DESCRIPTION
## Summary

Re-vendor the pinned `openasr-ggml` submodule to the 0.16.0 line and switch
depthwise convolution to ggml's native `CONV_2D_DW` operator.

## Why

The previous pin predated ggml 0.16.0. Moving to 0.16.0 lets the depthwise
conv path use the native `CONV_2D_DW` op instead of the hand-rolled im2col-style
expansion, simplifying the CPU graph and keeping the vendored runtime current.

## Changes

- Bump submodule `crates/openasr-core/third_party/openasr-ggml` to the 0.16.0
  pin (`b9852c35`, branch `oasr/pin-202607`).
- Use native `CONV_2D_DW` for depthwise conv; drop the now-unused FFI shim and
  the manual expansion in `cpu_graph.rs`.
- Minor call-site updates in `nn/conv.rs`, `nn/encoder.rs`, and the firered_aed
  encoder graph to match the new op.
- Add `tooling/ggml-sync/` (sync script + README) to document the re-vendor
  procedure.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2597 passed, 130 skipped)
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

- M1 Metal depthwise-conv path exercised; family-regression (firered / dolphin /
  xasr) byte-identical against baseline on the 0.16.0 pin.

## Docs updated

- [x] Added `tooling/ggml-sync/README.md` documenting the re-vendor flow.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No model-behavior changes; no catalog or download-path changes.
- Does not re-vendor beyond the pinned commit or add new runtime sources outside
  `crates/openasr-core/third_party/openasr-ggml`.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - AI assistance was used for the re-vendor mechanics, graph simplification, and verification runs; the change is human-owned.
