### PR TITLE
fix(core): install backend override in streaming decode closures

### DIFF
--- a/crates/openasr-core/src/models/ctc_streaming_driver.rs
+++ b/crates/openasr-core/src/models/ctc_streaming_driver.rs
@@ -8,6 +8,7 @@
 
 use std::time::Instant;
 
+use crate::ggml_runtime::install_request_backend_override;
 use crate::models::ctc_greedy_decode::CtcGreedyDecodeResult;
 use crate::models::ggml_asr_executor::{
     GgmlAsrExecutionError, GgmlAsrExecutionRequest, GgmlAsrExecutionResult, GgmlAsrPreparedAudio,
@@ -74,6 +75,14 @@ where
     let partial_executor = executor.clone();
     let partial_transcribe = Box::new(move |audio: &GgmlAsrPreparedAudio| {
         let _thread_override = install_request_inference_threads_override(inference_threads);
+        // Same as the seq2seq incremental driver: this closure calls the
+        // per-family decode fn directly instead of going through
+        // GgmlAsrExecutionDispatch::execute, so the request's
+        // backend_preference must be installed here or an explicit
+        // CpuOnly/Accelerated choice is silently dropped for streaming
+        // partials.
+        let _backend_override =
+            install_request_backend_override(backend_preference.request_backend_override());
         partial_decode(&partial_executor, &make_request(audio))
     });
 
@@ -93,6 +102,8 @@ where
     };
     let final_transcribe = Box::new(move |audio: &GgmlAsrPreparedAudio| {
         let _thread_override = install_request_inference_threads_override(inference_threads);
+        let _backend_override =
+            install_request_backend_override(backend_preference.request_backend_override());
         final_decode(&final_executor, &make_final_request(audio)).map(|result| result.transcription)
     });
 
@@ -303,6 +314,8 @@ impl GgmlAsrStreamingTranscriptDriver for CtcWindowedStreamingTranscriptDriver {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use super::*;
     use crate::{RealtimeAudioFormat, RealtimeAudioFrame};
 
@@ -394,5 +407,99 @@ mod tests {
             }
             other => panic!("expected final, got {other:?}"),
         }
+    }
+
+    /// Regression test for the same streaming backend-override bypass fixed
+    /// in `incremental_streaming_driver.rs`: `build_ctc_streaming_driver`'s
+    /// `partial_transcribe`/`final_transcribe` closures call the family's
+    /// decode fns directly, not through `GgmlAsrExecutionDispatch::execute`,
+    /// so they must install `request.backend_preference` themselves or an
+    /// explicit choice is silently dropped for CTC (parakeet/wav2vec2)
+    /// streaming.
+    #[test]
+    fn ctc_streaming_closures_install_request_backend_override() {
+        use crate::ggml_runtime::{
+            GgmlCpuGraphBackend, GgmlCpuGraphConfig, RequestBackendPreference,
+        };
+        use std::path::PathBuf;
+
+        fn session_request(
+            backend_preference: crate::GgmlAsrBackendPreference,
+        ) -> GgmlAsrStreamingSessionRequest {
+            GgmlAsrStreamingSessionRequest {
+                runtime_source_path: PathBuf::from("/tmp/openasr-missing-runtime.gguf"),
+                runtime_source_preflight: None,
+                selected_family: crate::wav2vec2_ctc_runtime_descriptor_v1(),
+                request_options: crate::GgmlAsrExecutionOptions::default(),
+                configured_diarize: false,
+                backend_preference,
+                session_context: crate::NativeAsrSessionContext::new(
+                    "rt_ctc_backend_override_test",
+                ),
+                session_config: crate::NativeAsrStreamingSessionConfig::new()
+                    .with_partial_results(true)
+                    .into(),
+            }
+        }
+
+        // Drives one warm-up partial decode through the real
+        // `build_ctc_streaming_driver` closure and records what the decode
+        // fn observed via the thread-local override, plus what a gated
+        // family's `resolve_family_runtime_backend` would resolve to at that
+        // instant.
+        fn observed_backend_during_partial_decode(
+            backend_preference: crate::GgmlAsrBackendPreference,
+        ) -> (Option<RequestBackendPreference>, GgmlCpuGraphBackend) {
+            let request = session_request(backend_preference);
+            let observed: Arc<
+                Mutex<Option<(Option<RequestBackendPreference>, GgmlCpuGraphBackend)>>,
+            > = Arc::new(Mutex::new(None));
+            let observed_for_decode = Arc::clone(&observed);
+            let mut driver = build_ctc_streaming_driver(
+                (),
+                "ctc-backend-override-test-executor",
+                crate::WAV2VEC2_CTC_GGML_ADAPTER_ID,
+                &request,
+                crate::models::incremental_streaming_driver::STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT,
+                move |_executor: &(), _request: &GgmlAsrExecutionRequest| {
+                    *observed_for_decode.lock().unwrap() = Some((
+                        crate::ggml_runtime::request_backend_override(),
+                        GgmlCpuGraphConfig::resolve_family_runtime_backend(false),
+                    ));
+                    Ok(ctc_result("", 0))
+                },
+                move |_executor: &(), _request: &GgmlAsrExecutionRequest| {
+                    Ok(GgmlAsrExecutionResult {
+                        transcription: Transcription {
+                            text: String::new(),
+                            segments: Vec::new(),
+                            longform: None,
+                            language: None,
+                        },
+                        carry_context: None,
+                    })
+                },
+            );
+            driver.warm_up().expect("warm up should decode once");
+            observed
+                .lock()
+                .unwrap()
+                .take()
+                .expect("partial decode closure should have run")
+        }
+
+        // Auto: no override installed, so a gated family stays pinned to CPU.
+        let (auto_override, auto_backend) =
+            observed_backend_during_partial_decode(crate::GgmlAsrBackendPreference::Auto);
+        assert_eq!(auto_override, None);
+        assert_eq!(auto_backend, GgmlCpuGraphBackend::Cpu);
+
+        // Explicit Accelerated: the partial_transcribe closure must install
+        // the override itself, so a gated family's resolver sees Accelerated
+        // instead of silently falling back to CPU.
+        let (accel_override, accel_backend) =
+            observed_backend_during_partial_decode(crate::GgmlAsrBackendPreference::Accelerated);
+        assert_eq!(accel_override, Some(RequestBackendPreference::Accelerated));
+        assert_ne!(accel_backend, GgmlCpuGraphBackend::Cpu);
     }
 }

--- a/crates/openasr-core/src/models/ggml_asr_executor.rs
+++ b/crates/openasr-core/src/models/ggml_asr_executor.rs
@@ -141,6 +141,19 @@ pub struct GgmlAsrExecutionRequest {
     pub selected_family: GgmlFamilyAdapterDescriptor,
     pub prepared_audio: GgmlAsrPreparedAudio,
     pub request_options: GgmlAsrExecutionOptions,
+    /// Carried on the request but never read directly by an executor's
+    /// `execute()` -- backend resolution goes through the thread-local
+    /// override (`ggml_runtime::{install_request_backend_override,
+    /// request_backend_override}`), which `resolve_runtime_backend` /
+    /// `resolve_family_runtime_backend` consult. Any code path that builds a
+    /// request and drives a decode call WITHOUT going through
+    /// `GgmlAsrExecutionDispatch::execute` (which installs the override at
+    /// the top of that function) MUST call
+    /// `install_request_backend_override(backend_preference.request_backend_override())`
+    /// itself before decoding, or this field is silently inert and an
+    /// explicit CpuOnly/Accelerated choice never reaches the resolver -- see
+    /// the streaming closures in `incremental_streaming_driver.rs` and
+    /// `ctc_streaming_driver.rs` for the pattern.
     pub backend_preference: GgmlAsrBackendPreference,
 }
 

--- a/crates/openasr-core/src/models/incremental_streaming_driver.rs
+++ b/crates/openasr-core/src/models/incremental_streaming_driver.rs
@@ -16,6 +16,7 @@
 
 use std::time::Instant;
 
+use crate::ggml_runtime::install_request_backend_override;
 use crate::models::ggml_asr_executor::{
     GgmlAsrExecutionError, GgmlAsrExecutionRequest, GgmlAsrExecutionResult, GgmlAsrPreparedAudio,
     GgmlAsrStreamingSessionRequest,
@@ -204,6 +205,16 @@ where
     let transcribe = Box::new(
         move |audio: &GgmlAsrPreparedAudio, partial_prompt: Option<&str>| {
             let _thread_override = install_request_inference_threads_override(inference_threads);
+            // Mirror GgmlAsrExecutionDispatch::execute's override install (the
+            // offline/batch entry point): the streaming path calls the
+            // per-family `decode` fn directly instead of going through that
+            // dispatch, so without this the request's `backend_preference`
+            // (already threaded into every rebuilt request below) is silently
+            // never read by `resolve_runtime_backend`/`resolve_family_runtime_backend`
+            // and an explicit Accelerated choice would decode on CPU for any
+            // `auto_gpu_enabled = false` family.
+            let _backend_override =
+                install_request_backend_override(backend_preference.request_backend_override());
             decode(&executor, &make_request(audio, partial_prompt))
                 .map(|result| result.transcription)
         },
@@ -1580,5 +1591,93 @@ mod tests {
         );
         assert_eq!(driver.last_text.as_deref(), Some("w0 w1 w2 w3"));
         assert!(!driver.final_emitted);
+    }
+
+    /// Regression test for the streaming backend-override bypass: `transcribe`
+    /// (built by `build_streaming_driver`) calls a family's `decode` fn
+    /// directly instead of going through `GgmlAsrExecutionDispatch::execute`,
+    /// so it must install the request's `backend_preference` itself. Before
+    /// the fix only the thread-count override was installed here, so an
+    /// explicit `Accelerated` streaming request never reached
+    /// `resolve_family_runtime_backend`/`resolve_runtime_backend` and a gated
+    /// family (dolphin, `auto_gpu_enabled = false`) silently decoded on CPU
+    /// even with GPU explicitly selected.
+    #[test]
+    fn streaming_transcribe_closure_installs_request_backend_override() {
+        use crate::ggml_runtime::{
+            GgmlCpuGraphBackend, GgmlCpuGraphConfig, RequestBackendPreference,
+        };
+        use std::path::PathBuf;
+
+        fn session_request(
+            backend_preference: crate::GgmlAsrBackendPreference,
+        ) -> GgmlAsrStreamingSessionRequest {
+            GgmlAsrStreamingSessionRequest {
+                runtime_source_path: PathBuf::from("/tmp/openasr-missing-runtime.gguf"),
+                runtime_source_preflight: None,
+                selected_family: crate::qwen3_asr_runtime_descriptor_v1(),
+                request_options: crate::GgmlAsrExecutionOptions::default(),
+                configured_diarize: false,
+                backend_preference,
+                session_context: crate::NativeAsrSessionContext::new("rt_backend_override_test"),
+                session_config: crate::NativeAsrStreamingSessionConfig::new()
+                    .with_partial_results(true)
+                    .into(),
+            }
+        }
+
+        // Drives one warm-up decode through the real `build_streaming_driver`
+        // closure and records what the decode fn observed via the
+        // thread-local override -- the exact mechanism a gated family's
+        // `resolve_family_runtime_backend` reads -- plus what that resolver
+        // itself would return for a gated family (`auto_gpu_enabled = false`)
+        // at that instant.
+        fn observed_backend_during_decode(
+            backend_preference: crate::GgmlAsrBackendPreference,
+        ) -> (Option<RequestBackendPreference>, GgmlCpuGraphBackend) {
+            let request = session_request(backend_preference);
+            let observed: Arc<
+                Mutex<Option<(Option<RequestBackendPreference>, GgmlCpuGraphBackend)>>,
+            > = Arc::new(Mutex::new(None));
+            let observed_for_decode = Arc::clone(&observed);
+            let mut driver = build_streaming_driver(
+                (),
+                "backend-override-test-executor",
+                crate::QWEN3_ASR_GGML_ADAPTER_ID,
+                &request,
+                STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT,
+                move |_executor: &(), _request: &GgmlAsrExecutionRequest| {
+                    *observed_for_decode.lock().unwrap() = Some((
+                        crate::ggml_runtime::request_backend_override(),
+                        GgmlCpuGraphConfig::resolve_family_runtime_backend(false),
+                    ));
+                    Ok(GgmlAsrExecutionResult {
+                        transcription: transcription(""),
+                        carry_context: None,
+                    })
+                },
+            );
+            driver.warm_up().expect("warm up should decode once");
+            observed
+                .lock()
+                .unwrap()
+                .take()
+                .expect("decode closure should have run")
+        }
+
+        // Auto: no override installed, so a gated family stays pinned to CPU
+        // -- pins the existing Auto-mode semantics against regression.
+        let (auto_override, auto_backend) =
+            observed_backend_during_decode(crate::GgmlAsrBackendPreference::Auto);
+        assert_eq!(auto_override, None);
+        assert_eq!(auto_backend, GgmlCpuGraphBackend::Cpu);
+
+        // Explicit Accelerated: the transcribe closure must install the
+        // override itself, so a gated family's resolver sees Accelerated and
+        // does not fall back to CPU. This is the case that regressed.
+        let (accel_override, accel_backend) =
+            observed_backend_during_decode(crate::GgmlAsrBackendPreference::Accelerated);
+        assert_eq!(accel_override, Some(RequestBackendPreference::Accelerated));
+        assert_ne!(accel_backend, GgmlCpuGraphBackend::Cpu);
     }
 }


### PR DESCRIPTION
## Summary

Install the per-request backend override in the shared streaming decode closures, so an explicit Accelerated execution target reaches the GPU during realtime/streaming decode the same way it already does for offline transcription.

## Why

`GgmlAsrExecutionDispatch::execute` installs the request's backend override before decoding, but the shared seq2seq and CTC streaming drivers call the family decode fn directly on every partial/final tick and only installed the inference-threads override. The per-request `backend_preference` was threaded into every rebuilt `GgmlAsrExecutionRequest` but never installed as the thread-local override, so `resolve_family_runtime_backend` never saw it. For gated families (`auto_gpu_enabled = false`, currently dolphin and xasr-zipformer) this silently pinned realtime decode to CPU even when the user explicitly selected a GPU device: periodic CPU spikes, idle GPU, and no error or telemetry signal that anything was wrong.

## Changes

- `crates/openasr-core/src/models/incremental_streaming_driver.rs`: install the request backend override (alongside the existing threads override) in the per-decode closure of the shared seq2seq streaming driver; regression test asserting the override value seen at decode time for Auto (None, preserves gated-family CPU semantics) and explicit Accelerated (Some).
- `crates/openasr-core/src/models/ctc_streaming_driver.rs`: same fix and test for the partial and final decode closures of the CTC streaming driver.
- `crates/openasr-core/src/models/ggml_asr_executor.rs`: invariant comment on `GgmlAsrExecutionRequest::backend_preference` documenting that any path bypassing the dispatch must install the override itself.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2544 passed; 3 failures are pre-existing machine-local environment issues, reproduced identically on a clean main checkout)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (not run; no dependency changes)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`

## Manual smoke checks

- Real hardware A/B on AMD RX 9060 XT (Vulkan): dolphin streaming session with explicit Accelerated loads no CPU backend and shows GPU compute load after the fix; with the fix reverted it silently pins to CPU.
- Re-verified on HIP (ROCm 7.1, same GPU) against ggml 0.16.0: xasr streaming with explicit Accelerated moves from 0% GPU / 22 CPU-cores to 7% GPU compute / 9 CPU-cores with correct transcription output.

## Docs updated

- [x] No user-facing docs describe this internal dispatch detail; invariant comment added at the field definition.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not change `auto_gpu_enabled` gating semantics: Auto on a gated family still resolves to CPU by design.
- Does not make executors read `request.backend_preference` directly (would require re-plumbing context through many resolver call sites); the thread-local override remains the single mechanism, now installed on every decode path.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implementation, tests, and real-hardware verification were done with AI assistance under my direction and review.
