### PR TITLE
fix(core): remove empty model directory on DELETE /v1/models/{id}

### DIFF
--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -709,11 +709,33 @@ pub fn remove_model_pack(
     let Some(pack) = find_installed_pack(home.as_ref(), reference)? else {
         return Ok(None);
     };
-    if let Some(parent) = pack.path.parent() {
-        fs::remove_dir_all(parent).map_err(|source| PullError::Io {
-            path: parent.to_path_buf(),
+    if let Some(quant_dir) = pack.path.parent() {
+        fs::remove_dir_all(quant_dir).map_err(|source| PullError::Io {
+            path: quant_dir.to_path_buf(),
             source,
         })?;
+        // The quant dir just removed lives at <models>/<model_id>/<quant>/. If
+        // that was the only installed quant, <models>/<model_id>/ is now an
+        // empty leftover; clean it up too. `remove_dir` only ever deletes an
+        // *empty* directory, so a sibling quant (or any other file a caller
+        // left behind) is never touched -- we just swallow the "not empty"
+        // and "already gone" outcomes as expected, non-error states.
+        if let Some(model_dir) = quant_dir.parent() {
+            match fs::remove_dir(model_dir) {
+                Ok(()) => {}
+                Err(source)
+                    if matches!(
+                        source.kind(),
+                        io::ErrorKind::NotFound | io::ErrorKind::DirectoryNotEmpty
+                    ) => {}
+                Err(source) => {
+                    return Err(PullError::Io {
+                        path: model_dir.to_path_buf(),
+                        source,
+                    });
+                }
+            }
+        }
     }
     Ok(Some(pack))
 }

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -1895,6 +1895,102 @@ fn remove_model_pack_deletes_installed_quant() {
 }
 
 #[test]
+fn remove_model_pack_deletes_empty_model_dir() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let mut client = FakeClient::with_responses(vec![ResponseSpec {
+        status: 200,
+        body: bytes,
+    }]);
+    let installed = pull_model_pack_with_client(
+        &resolved,
+        temp.path(),
+        &mut client,
+        PullOptions::default(),
+        |_| {},
+    )
+    .unwrap();
+    let model_dir = temp.path().join("models").join(&installed.model_id);
+    assert!(
+        model_dir.exists(),
+        "fixture setup: model dir must exist before removal"
+    );
+
+    remove_model_pack(temp.path(), "moonshine-tiny:q8")
+        .unwrap()
+        .unwrap();
+
+    // Removing the only installed quant must also clean up the now-empty
+    // <models>/<model_id>/ directory, not just the <quant>/ subdirectory --
+    // otherwise uninstall leaves a stale empty `models/<id>/` behind.
+    assert!(
+        !model_dir.exists(),
+        "empty model dir must be removed once its last quant is uninstalled"
+    );
+}
+
+#[test]
+fn remove_model_pack_keeps_model_dir_when_sibling_quant_remains() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    let model_dir = home.join("models").join("moonshine-tiny");
+
+    let mut client = FakeClient::with_responses(vec![ResponseSpec {
+        status: 200,
+        body: bytes.clone(),
+    }]);
+    let first =
+        pull_model_pack_with_client(&resolved, home, &mut client, PullOptions::default(), |_| {})
+            .unwrap();
+
+    // A second quant for the same model, written directly so the test does
+    // not need a second distinct catalog/download fixture.
+    let second_quant_dir = model_dir.join("q4_k");
+    fs::create_dir_all(&second_quant_dir).unwrap();
+    let second_path = second_quant_dir.join("moonshine-tiny-q4_k.oasr");
+    fs::write(&second_path, &bytes).unwrap();
+    let second_pack = InstalledPack {
+        model_id: "moonshine-tiny".to_string(),
+        display_name: first.display_name.clone(),
+        quant: "q4_k".to_string(),
+        suffix: "q4".to_string(),
+        pull: "moonshine-tiny:q4".to_string(),
+        filename: "moonshine-tiny-q4_k.oasr".to_string(),
+        path: second_path.clone(),
+        url: first.url.clone(),
+        hf_revision: first.hf_revision.clone(),
+        sha256: sha256_hex(&bytes),
+        size_bytes: bytes.len() as u64,
+        installed_at_unix_seconds: 1,
+        source: None,
+    };
+    let json = serde_json::to_string_pretty(&second_pack).unwrap();
+    fs::write(second_quant_dir.join("installed.json"), format!("{json}\n")).unwrap();
+
+    let removed = remove_model_pack(home, "moonshine-tiny:q8")
+        .unwrap()
+        .unwrap();
+    assert_eq!(removed.pull, first.pull);
+
+    // The sibling q4_k quant is a different, still-installed pack: removing
+    // q8 must not touch it or the shared model dir that contains it.
+    assert!(
+        model_dir.exists(),
+        "model dir must survive: a sibling quant is still installed"
+    );
+    assert!(
+        second_path.exists(),
+        "sibling quant file must not be touched"
+    );
+    let remaining = list_installed_packs(home).unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].pull, "moonshine-tiny:q4");
+}
+
+#[test]
 fn resolve_installed_pack_reference_matches_quant_aliases() {
     let bytes = tiny_pack_bytes();
     let resolved = resolved_for(&bytes);


### PR DESCRIPTION
## Summary

`DELETE /v1/models/{id}` (`remove_model_pack`) removed the quant subdirectory
but left the parent `models/<id>/` directory behind once it was the last
installed quant, since it only ever removed `pack.path.parent()` (the quant
dir), never the model dir above it.

## Why

Uninstalling the last quant of a model left an empty `models/<id>/` directory
on disk. It did not corrupt state, but it is a stray leftover that clutters
the install directory and can be surprising when inspecting `OPENASR_HOME`.

## Changes

- `crates/openasr-core/src/pull.rs`: after removing the quant directory, also
  attempt `fs::remove_dir` on its parent (the model dir). `remove_dir` only
  succeeds on an empty directory, so a sibling quant or any other file left in
  the model dir is never touched; `NotFound` and `DirectoryNotEmpty` are
  treated as expected non-error outcomes, other I/O errors still propagate as
  `PullError::Io`.
- `crates/openasr-core/src/pull_tests.rs`: two new tests --
  `remove_model_pack_deletes_empty_model_dir` (last quant removed -> model dir
  is gone) and `remove_model_pack_keeps_model_dir_when_sibling_quant_remains`
  (sibling quant present -> model dir and sibling survive).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core -p openasr-server --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core --lib pull::` (77 passed, including the 2 new tests)
- [x] `cargo test -p openasr-server delete_model` (1 passed)

## Manual smoke checks

N/A -- covered by the new unit tests exercising `remove_model_pack` directly.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (No
      user-facing behavior/docs change -- this only removes a stray empty
      directory that was never part of any documented contract.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR only fixes the leftover empty model directory on full uninstall. It
does not change the installed-pack record format, the pull/download path, or
any other DELETE-endpoint behavior.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI assistance was used to implement and test this fix.
