### PR TITLE
feat(core): add in-process streaming transcription session

### DIFF
--- a/crates/openasr-core/src/api/mod.rs
+++ b/crates/openasr-core/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod audio_io;
 pub mod backend;
 pub mod native;
+pub mod streaming;

--- a/crates/openasr-core/src/api/streaming.rs
+++ b/crates/openasr-core/src/api/streaming.rs
@@ -1,0 +1,579 @@
+//! In-process streaming transcription session.
+//!
+//! This is the library-level counterpart to the desktop server's realtime
+//! WebSocket/SSE path: it takes 16 kHz mono `f32` PCM chunks, drives the same
+//! native ggml streaming engine the server uses
+//! ([`NativeAsrSession`]/[`NativeBackendExecutor`]), and returns incremental
+//! partial/committed transcript events plus a final [`Transcription`]. It is
+//! deliberately transport-free (no axum, no tokio) so an embedder that cannot
+//! spawn a local HTTP server -- iOS in particular, where process spawning and
+//! background servers are disallowed -- can run live captioning entirely
+//! in-process by linking the open core.
+//!
+//! It reuses, rather than reinvents, the pieces the server already relies on:
+//!
+//! - Model resolution + decode: [`native_runtime_model_adapter_for_path`] and
+//!   [`NativeAsrExecutor::start_streaming_session`], which return the same
+//!   `Box<dyn NativeAsrSession>` the server's native worker drives. Every
+//!   builtin ASR family registers a streaming executor, so packs go through
+//!   the shared greedy-decode driver -- this session never hand-rolls a decode
+//!   loop.
+//! - Utterance segmentation: the core energy [`VadStateMachine`], the same one
+//!   the server's session controller uses to turn a continuous stream into
+//!   per-utterance boundaries.
+//!
+//! The engine is fail-closed and offline: it only ever runs the local `.oasr`
+//! pack it is handed and never reaches for the network.
+
+use std::path::Path;
+
+use crate::realtime::{RealtimeEvent, RealtimeTranscriptEvent, RealtimeTranscriptWord};
+use crate::{
+    NativeAsrError, NativeAsrExecutor, NativeAsrHardwareTarget, NativeAsrModelAdapter,
+    NativeAsrModelPackRef, NativeAsrRequestOptions, NativeAsrSession, NativeAsrSessionContext,
+    NativeAsrStreamingSessionConfig, NativeBackendExecutor, RealtimeAudioFormat,
+    RealtimeAudioFrame, RealtimeEventEnvelope, Segment, Transcription, VadConfig, VadStateMachine,
+    native_runtime_model_adapter_for_path,
+};
+
+/// The kind of a [`StreamingEvent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamingEventKind {
+    /// A mutable in-progress hypothesis for the active utterance. Superseded by
+    /// later `Partial`s for the same `segment_id`, then by a `Committed` event.
+    Partial,
+    /// A settled segment. Emitted when a VAD speech pause (or `finish`) closes
+    /// an utterance; its text is stable and will not be revised except by a
+    /// later `Revision` carrying the same `segment_id`.
+    Committed,
+    /// A post-final correction to an already-committed segment (e.g. trailing
+    /// punctuation added once the segment settled). Rare; carries the same
+    /// `segment_id` as the `Committed` event it revises.
+    Revision,
+}
+
+/// An incremental transcript update produced by [`StreamingSession::feed`] or
+/// [`StreamingSession::finish`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct StreamingEvent {
+    pub kind: StreamingEventKind,
+    pub utterance_id: String,
+    pub segment_id: String,
+    /// Monotonic revision number for this segment; higher supersedes lower.
+    pub revision: u64,
+    pub text: String,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    /// Per-word timings, present only when `word_timestamps` was requested and
+    /// the model family produces them.
+    pub words: Vec<RealtimeTranscriptWord>,
+    /// Detected language for this segment, when the family reports one.
+    pub language: Option<String>,
+}
+
+/// Configuration for a [`StreamingSession`].
+#[derive(Debug, Clone)]
+pub struct StreamingConfig {
+    /// Emit mutable `Partial` events as audio arrives. When `false`, only
+    /// `Committed`/final segments surface.
+    pub partial_results: bool,
+    /// Attach per-word timings to events when the family supports them.
+    pub word_timestamps: bool,
+    /// When `Some`, an energy VAD segments the stream into utterances and a
+    /// `Committed` event is emitted at each speech pause -- the shape a live
+    /// caption UI wants. When `None`, the whole stream is treated as a single
+    /// utterance and only finalized at [`StreamingSession::finish`].
+    pub vad: Option<VadConfig>,
+    /// Optional decode language hint passed through to the model.
+    pub language: Option<String>,
+    /// Hardware target for the decode session. `Auto` lets the runtime choose.
+    pub hardware_target: NativeAsrHardwareTarget,
+    /// Optional inference thread cap.
+    pub inference_threads: Option<u16>,
+    /// Minimum new audio (ms) between partial re-decodes; `None` uses the
+    /// per-family default. See [`NativeAsrStreamingSessionConfig`].
+    pub min_partial_interval_ms: Option<u32>,
+    /// How much new audio (ms) to accumulate before polling the engine for a
+    /// partial re-decode. Mirrors the server's time-spaced poll: a fast family
+    /// whose encoder needs more than one frame must not be polled on a
+    /// near-empty buffer. Also caps partial re-decode frequency. Must be >= the
+    /// 20 ms frame size; smaller values are clamped up.
+    pub partial_poll_interval_ms: u64,
+}
+
+impl Default for StreamingConfig {
+    fn default() -> Self {
+        Self {
+            partial_results: true,
+            word_timestamps: false,
+            vad: Some(VadConfig::default()),
+            language: None,
+            hardware_target: NativeAsrHardwareTarget::Auto,
+            inference_threads: None,
+            min_partial_interval_ms: None,
+            partial_poll_interval_ms: DEFAULT_PARTIAL_POLL_INTERVAL_MS,
+        }
+    }
+}
+
+/// Default audio spacing between partial polls. Comfortably above any builtin
+/// family's encoder minimum framing while still a responsive live cadence.
+const DEFAULT_PARTIAL_POLL_INTERVAL_MS: u64 = 200;
+
+/// The audio contract: 16 kHz, mono, `f32` in `[-1.0, 1.0]`.
+const SAMPLE_RATE_HZ: u32 = 16_000;
+/// Frame the incoming stream at 20 ms (a supported realtime frame duration).
+const FRAME_DURATION_MS: u32 = 20;
+const FRAME_SAMPLES: usize = (SAMPLE_RATE_HZ as usize * FRAME_DURATION_MS as usize) / 1_000;
+
+/// A single accumulated segment, keyed by `segment_id`, tracked so `finish`
+/// can assemble a [`Transcription`] from the same events the caller streamed.
+#[derive(Debug, Clone)]
+struct TrackedSegment {
+    id: String,
+    order: usize,
+    start_ms: u64,
+    end_ms: u64,
+    text: String,
+    words: Vec<RealtimeTranscriptWord>,
+    language: Option<String>,
+}
+
+/// An in-process streaming transcription session over a local `.oasr` pack.
+pub struct StreamingSession {
+    session: Box<dyn NativeAsrSession>,
+    vad: Option<VadStateMachine>,
+    /// Leftover f32 samples that did not fill a whole 20 ms frame yet.
+    pending: Vec<f32>,
+    audio_format: RealtimeAudioFormat,
+    next_seq: u64,
+    /// Absolute ms offset of the next frame's first sample.
+    next_start_ms: u64,
+    word_timestamps: bool,
+    /// New audio (samples) accumulated since the last partial poll.
+    samples_since_poll: usize,
+    /// Poll the engine once this many new samples have accumulated.
+    poll_interval_samples: usize,
+    /// Ordered accumulation of the latest text per segment, for `finish`.
+    segments: Vec<TrackedSegment>,
+    closed: bool,
+}
+
+impl StreamingSession {
+    /// Open a streaming session over the local `.oasr` pack at `pack_path`.
+    ///
+    /// Fails closed with a typed [`NativeAsrError`] if the pack cannot be
+    /// resolved to a known model family or the family cannot start a streaming
+    /// session. Never touches the network.
+    pub fn new(pack_path: &Path, cfg: StreamingConfig) -> Result<Self, NativeAsrError> {
+        let adapter = native_runtime_model_adapter_for_path(pack_path).ok_or_else(|| {
+            NativeAsrError::SessionFailed {
+                message: format!(
+                    "no native model family recognizes the pack at {}",
+                    pack_path.display()
+                ),
+            }
+        })?;
+        let model_pack = NativeAsrModelPackRef::new(
+            "native-streaming",
+            adapter.model_family(),
+            pack_path.to_path_buf(),
+        );
+        let audio_format = RealtimeAudioFormat::pcm16_mono_16khz();
+        let options = NativeAsrRequestOptions::new()
+            .with_language(cfg.language.clone())
+            .with_inference_threads(cfg.inference_threads)
+            .with_partial_results(cfg.partial_results)
+            .with_word_timestamps(cfg.word_timestamps);
+        let session_config = NativeAsrStreamingSessionConfig::new()
+            .with_audio_format(audio_format)
+            .with_partial_results(cfg.partial_results)
+            .with_word_timestamps(cfg.word_timestamps)
+            .with_min_partial_interval_ms(cfg.min_partial_interval_ms);
+        let executor = NativeBackendExecutor;
+        let session = NativeAsrExecutor::start_streaming_session(
+            &executor,
+            &adapter,
+            &model_pack,
+            cfg.hardware_target,
+            NativeAsrSessionContext::new("in-process-streaming"),
+            options,
+            session_config,
+        )?;
+        Self::from_native_session(session, &cfg)
+    }
+
+    /// Build a session around an already-started [`NativeAsrSession`]. Used by
+    /// [`Self::new`] and by tests that inject a deterministic fake session.
+    fn from_native_session(
+        session: Box<dyn NativeAsrSession>,
+        cfg: &StreamingConfig,
+    ) -> Result<Self, NativeAsrError> {
+        let vad = match &cfg.vad {
+            Some(vad_cfg) => {
+                let vad_cfg = VadConfig {
+                    frame_duration_ms: FRAME_DURATION_MS,
+                    ..*vad_cfg
+                };
+                Some(VadStateMachine::new(vad_cfg).map_err(|error| {
+                    NativeAsrError::SessionFailed {
+                        message: format!("invalid streaming VAD config: {error}"),
+                    }
+                })?)
+            }
+            None => None,
+        };
+        let poll_interval_samples =
+            ((cfg.partial_poll_interval_ms as usize) * (SAMPLE_RATE_HZ as usize) / 1_000)
+                .max(FRAME_SAMPLES);
+        Ok(Self {
+            session,
+            vad,
+            pending: Vec::with_capacity(FRAME_SAMPLES),
+            audio_format: RealtimeAudioFormat::pcm16_mono_16khz(),
+            next_seq: 1,
+            next_start_ms: 0,
+            word_timestamps: cfg.word_timestamps,
+            samples_since_poll: 0,
+            poll_interval_samples,
+            segments: Vec::new(),
+            closed: false,
+        })
+    }
+
+    /// Feed a chunk of 16 kHz mono `f32` PCM (any length). Returns the
+    /// incremental transcript events produced by this chunk: `Partial`s for the
+    /// active utterance and a `Committed` event whenever a VAD speech pause
+    /// closes one.
+    pub fn feed(&mut self, pcm: &[f32]) -> Result<Vec<StreamingEvent>, NativeAsrError> {
+        if self.closed {
+            return Err(NativeAsrError::SessionClosed);
+        }
+        self.pending.extend_from_slice(pcm);
+        let mut events = Vec::new();
+        while self.pending.len() >= FRAME_SAMPLES {
+            let samples = self.pending.drain(..FRAME_SAMPLES).collect::<Vec<f32>>();
+            self.process_frame(samples, &mut events)?;
+        }
+        Ok(events)
+    }
+
+    /// Finish the stream: drain any buffered tail audio, finalize the active
+    /// utterance, and return the assembled full [`Transcription`].
+    pub fn finish(mut self) -> Result<Transcription, NativeAsrError> {
+        if !self.pending.is_empty() {
+            // Pad the tail to a whole frame with silence so the last samples
+            // still reach the decoder.
+            let mut samples = std::mem::take(&mut self.pending);
+            samples.resize(FRAME_SAMPLES, 0.0);
+            let mut drained = Vec::new();
+            self.process_frame(samples, &mut drained)?;
+        }
+        let finish_events = self.session.finish()?;
+        self.record_events(&finish_events);
+        self.closed = true;
+        Ok(self.assemble_transcription())
+    }
+
+    fn process_frame(
+        &mut self,
+        samples: Vec<f32>,
+        out: &mut Vec<StreamingEvent>,
+    ) -> Result<(), NativeAsrError> {
+        let start_ms = self.next_start_ms;
+        let frame = self.build_frame(samples, start_ms)?;
+
+        // Compute VAD boundaries before the frame is consumed by push_audio.
+        let boundaries = self
+            .vad
+            .as_mut()
+            .map(|vad| vad.process_energy_frame(&frame))
+            .unwrap_or_default();
+
+        // Push audio (advances the decode), then poll on a time cadence:
+        // buffered re-decode families emit their cadence-driven partials from
+        // `poll_events`, not from `push_audio`, so the server's session loop
+        // polls on a timer. Fast families (moonshine) attempt a partial as soon
+        // as audio exists, but their encoder needs more than a single 20 ms
+        // frame; the server never decodes a near-empty buffer because its poll
+        // is time-spaced. Match that here by only polling once at least
+        // `poll_interval_samples` of new audio have accumulated. The driver's
+        // own `min_partial_interval` throttles further; polling more often just
+        // wastes a re-decode.
+        let pushed = self.session.push_audio(frame)?;
+        self.emit(&pushed, out);
+        self.samples_since_poll += FRAME_SAMPLES;
+        if self.samples_since_poll >= self.poll_interval_samples {
+            self.samples_since_poll = 0;
+            let polled = self.session.poll_events()?;
+            self.emit(&polled, out);
+        }
+
+        for boundary in &boundaries {
+            use crate::SpeechBoundaryEvent::*;
+            match boundary {
+                SpeechStopped { .. } => {
+                    // A real speech pause: finalize the utterance (hard
+                    // boundary) so its text commits and the next one starts.
+                    let finalized = self.session.finalize_utterance()?;
+                    self.emit(&finalized, out);
+                    self.samples_since_poll = 0;
+                }
+                MaxUtterance { .. } => {
+                    // A forced max-duration cut: split without treating it as a
+                    // language boundary.
+                    let split = self.session.split_utterance()?;
+                    self.emit(&split, out);
+                    self.samples_since_poll = 0;
+                }
+                SpeechStarted { .. } | NoSpeechTimeout { .. } => {}
+            }
+        }
+
+        self.next_seq += 1;
+        self.next_start_ms += FRAME_DURATION_MS as u64;
+        Ok(())
+    }
+
+    /// Accumulate settled text and append the caller-facing events for one
+    /// batch of engine envelopes.
+    fn emit(&mut self, envelopes: &[RealtimeEventEnvelope], out: &mut Vec<StreamingEvent>) {
+        self.record_events(envelopes);
+        out.extend(self.map_events(envelopes));
+    }
+
+    fn build_frame(
+        &self,
+        samples: Vec<f32>,
+        start_ms: u64,
+    ) -> Result<RealtimeAudioFrame, NativeAsrError> {
+        let pcm16 = samples.into_iter().map(f32_to_i16).collect::<Vec<i16>>();
+        RealtimeAudioFrame::new(self.next_seq, start_ms, self.audio_format, pcm16).map_err(
+            |error| NativeAsrError::SessionFailed {
+                message: format!("invalid streaming audio frame: {error}"),
+            },
+        )
+    }
+
+    /// Translate the engine's rich wire events into the caller-facing
+    /// [`StreamingEvent`]s, keeping only transcript updates.
+    fn map_events(&self, envelopes: &[RealtimeEventEnvelope]) -> Vec<StreamingEvent> {
+        envelopes
+            .iter()
+            .filter_map(|envelope| self.map_event(envelope))
+            .collect()
+    }
+
+    fn map_event(&self, envelope: &RealtimeEventEnvelope) -> Option<StreamingEvent> {
+        let RealtimeEvent::Transcript(transcript) = &envelope.event else {
+            return None;
+        };
+        let event = match transcript {
+            RealtimeTranscriptEvent::Partial(partial) => StreamingEvent {
+                kind: StreamingEventKind::Partial,
+                utterance_id: partial.utterance_id.0.clone(),
+                segment_id: partial.segment_id.0.clone(),
+                revision: partial.revision,
+                text: partial.text.clone(),
+                start_ms: partial.start_ms,
+                end_ms: partial.end_ms,
+                words: self.select_words(&partial.words),
+                language: partial.language.clone(),
+            },
+            RealtimeTranscriptEvent::Final(final_event) => StreamingEvent {
+                kind: StreamingEventKind::Committed,
+                utterance_id: final_event.utterance_id.0.clone(),
+                segment_id: final_event.segment_id.0.clone(),
+                revision: final_event.revision,
+                text: final_event.text.clone(),
+                start_ms: final_event.start_ms,
+                end_ms: final_event.end_ms,
+                words: self.select_words(&final_event.words),
+                language: final_event.language.clone(),
+            },
+            RealtimeTranscriptEvent::Revision(revision) => StreamingEvent {
+                kind: StreamingEventKind::Revision,
+                utterance_id: revision.utterance_id.0.clone(),
+                segment_id: revision.segment_id.0.clone(),
+                revision: revision.revision,
+                text: revision.text.clone(),
+                start_ms: revision.start_ms,
+                end_ms: revision.end_ms,
+                words: self.select_words(&revision.words),
+                language: revision.language.clone(),
+            },
+        };
+        Some(event)
+    }
+
+    fn select_words(&self, words: &[RealtimeTranscriptWord]) -> Vec<RealtimeTranscriptWord> {
+        if self.word_timestamps {
+            words.to_vec()
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Accumulate the latest committed/final/revision text per segment so
+    /// `finish` can assemble the full transcript. Partials are intentionally
+    /// ignored here -- only settled text contributes to the final transcript.
+    fn record_events(&mut self, envelopes: &[RealtimeEventEnvelope]) {
+        for envelope in envelopes {
+            let RealtimeEvent::Transcript(transcript) = &envelope.event else {
+                continue;
+            };
+            let (segment_id, start_ms, end_ms, text, words, language) = match transcript {
+                RealtimeTranscriptEvent::Final(event) => (
+                    event.segment_id.0.clone(),
+                    event.start_ms,
+                    event.end_ms,
+                    event.text.clone(),
+                    event.words.clone(),
+                    event.language.clone(),
+                ),
+                RealtimeTranscriptEvent::Revision(event) => (
+                    event.segment_id.0.clone(),
+                    event.start_ms,
+                    event.end_ms,
+                    event.text.clone(),
+                    event.words.clone(),
+                    event.language.clone(),
+                ),
+                RealtimeTranscriptEvent::Partial(_) => continue,
+            };
+            self.upsert_segment(segment_id, start_ms, end_ms, text, words, language);
+        }
+    }
+
+    fn upsert_segment(
+        &mut self,
+        segment_id: String,
+        start_ms: u64,
+        end_ms: u64,
+        text: String,
+        words: Vec<RealtimeTranscriptWord>,
+        language: Option<String>,
+    ) {
+        if let Some(existing) = self
+            .segments
+            .iter_mut()
+            .find(|segment| segment.segment_id_matches(&segment_id))
+        {
+            existing.start_ms = start_ms;
+            existing.end_ms = end_ms;
+            existing.text = text;
+            existing.words = words;
+            existing.language = language;
+            return;
+        }
+        let order = self.segments.len();
+        self.segments.push(TrackedSegment {
+            order,
+            start_ms,
+            end_ms,
+            text,
+            words,
+            language,
+            id: segment_id,
+        });
+    }
+
+    fn assemble_transcription(&self) -> Transcription {
+        let mut ordered = self.segments.clone();
+        ordered.sort_by_key(|segment| segment.order);
+        let segments = ordered
+            .iter()
+            .filter(|segment| !segment.text.trim().is_empty())
+            .map(|segment| Segment {
+                start: ms_to_seconds(segment.start_ms),
+                end: ms_to_seconds(segment.end_ms),
+                text: segment.text.clone(),
+                speaker: None,
+                speaker_label: None,
+                speaker_profile_id: None,
+                words: if self.word_timestamps {
+                    segment
+                        .words
+                        .iter()
+                        .map(realtime_word_to_timestamp)
+                        .collect()
+                } else {
+                    Vec::new()
+                },
+            })
+            .collect::<Vec<_>>();
+        let text = join_segment_texts(segments.iter().map(|segment| segment.text.as_str()));
+        let language = ordered.iter().find_map(|segment| segment.language.clone());
+        Transcription {
+            text,
+            segments,
+            longform: None,
+            language,
+        }
+    }
+}
+
+impl TrackedSegment {
+    fn segment_id_matches(&self, id: &str) -> bool {
+        self.id == id
+    }
+}
+
+fn f32_to_i16(sample: f32) -> i16 {
+    let clamped = sample.clamp(-1.0, 1.0);
+    (clamped * i16::MAX as f32).round() as i16
+}
+
+fn ms_to_seconds(ms: u64) -> f32 {
+    ms as f32 / 1_000.0
+}
+
+fn realtime_word_to_timestamp(word: &RealtimeTranscriptWord) -> crate::WordTimestamp {
+    crate::WordTimestamp {
+        word: word.word.clone(),
+        start: ms_to_seconds(word.start_ms),
+        end: ms_to_seconds(word.end_ms),
+        confidence: word.confidence,
+    }
+}
+
+/// Join settled segment texts into one transcript. CJK families emit
+/// space-free text, so segments already ending or starting with a CJK
+/// character are concatenated without an inserted ASCII space; otherwise a
+/// single space separates them.
+fn join_segment_texts<'a>(texts: impl Iterator<Item = &'a str>) -> String {
+    let mut out = String::new();
+    for text in texts {
+        let text = text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            let prev = out.chars().last();
+            let next = text.chars().next();
+            if !boundary_is_cjk(prev) && !boundary_is_cjk(next) {
+                out.push(' ');
+            }
+        }
+        out.push_str(text);
+    }
+    out
+}
+
+fn boundary_is_cjk(ch: Option<char>) -> bool {
+    matches!(ch, Some(ch) if is_cjk(ch))
+}
+
+fn is_cjk(ch: char) -> bool {
+    matches!(ch as u32,
+        0x3400..=0x4DBF   // CJK Ext A
+        | 0x4E00..=0x9FFF // CJK Unified
+        | 0xF900..=0xFAFF // CJK Compatibility Ideographs
+        | 0x3000..=0x303F // CJK symbols/punctuation
+        | 0xFF00..=0xFFEF // Fullwidth forms
+    )
+}
+
+#[cfg(test)]
+#[path = "streaming_tests.rs"]
+mod tests;

--- a/crates/openasr-core/src/api/streaming_tests.rs
+++ b/crates/openasr-core/src/api/streaming_tests.rs
@@ -1,0 +1,351 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use super::*;
+use crate::realtime::{
+    RealtimeEventEnvelope, RealtimeEventId, RealtimeSessionId, RealtimeTranscriptEvent,
+    RealtimeTranscriptFinal, RealtimeTranscriptPartial, TranscriptSegmentId, TranscriptUtteranceId,
+};
+use crate::{NativeAsrError, RealtimeAudioFrame};
+
+/// A deterministic in-memory streaming session for exercising the glue in
+/// [`StreamingSession`] without any model weights. Each `push_audio` reveals
+/// one more word of a fixed target sentence as a growing partial; a real VAD
+/// stop (`finalize_utterance`) or `finish` settles the revealed text into a
+/// FINAL and starts the next utterance.
+struct FakeStreamingSession {
+    words: Vec<&'static str>,
+    revealed: usize,
+    utterance: u64,
+    finalize_calls: usize,
+    finished: bool,
+}
+
+impl FakeStreamingSession {
+    fn new(sentence: &'static str) -> Self {
+        Self {
+            words: sentence.split_whitespace().collect(),
+            revealed: 0,
+            utterance: 1,
+            finalize_calls: 0,
+            finished: false,
+        }
+    }
+
+    fn current_text(&self) -> String {
+        self.words[..self.revealed.min(self.words.len())].join(" ")
+    }
+
+    fn ids(&self) -> (TranscriptUtteranceId, TranscriptSegmentId) {
+        (
+            TranscriptUtteranceId(format!("utt_{:06}", self.utterance)),
+            TranscriptSegmentId(format!("seg_{:06}", self.utterance)),
+        )
+    }
+
+    fn partial_envelope(&self) -> RealtimeEventEnvelope {
+        let (utterance_id, segment_id) = self.ids();
+        transcript_envelope(RealtimeTranscriptEvent::Partial(
+            RealtimeTranscriptPartial {
+                utterance_id,
+                segment_id,
+                revision: self.revealed as u64,
+                text: self.current_text(),
+                start_ms: 0,
+                end_ms: (self.revealed as u64) * 100,
+                is_final: false,
+                words: Vec::new(),
+                language: None,
+                speaker: None,
+                speaker_label: None,
+                speaker_profile_id: None,
+            },
+        ))
+    }
+
+    fn final_envelope(&self) -> RealtimeEventEnvelope {
+        let (utterance_id, segment_id) = self.ids();
+        transcript_envelope(RealtimeTranscriptEvent::Final(RealtimeTranscriptFinal {
+            utterance_id,
+            segment_id,
+            revision: self.revealed as u64 + 1,
+            text: self.current_text(),
+            start_ms: 0,
+            end_ms: (self.revealed as u64) * 100,
+            is_final: true,
+            words: Vec::new(),
+            language: Some("en".to_string()),
+            speaker: None,
+            speaker_label: None,
+            speaker_profile_id: None,
+        }))
+    }
+}
+
+impl NativeAsrSession for FakeStreamingSession {
+    fn session_id(&self) -> &str {
+        "fake"
+    }
+
+    fn push_audio(
+        &mut self,
+        _frame: RealtimeAudioFrame,
+    ) -> Result<Vec<RealtimeEventEnvelope>, NativeAsrError> {
+        if self.revealed < self.words.len() {
+            self.revealed += 1;
+            Ok(vec![self.partial_envelope()])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    fn poll_events(&mut self) -> Result<Vec<RealtimeEventEnvelope>, NativeAsrError> {
+        Ok(Vec::new())
+    }
+
+    fn finalize_utterance(&mut self) -> Result<Vec<RealtimeEventEnvelope>, NativeAsrError> {
+        self.finalize_calls += 1;
+        if self.revealed == 0 {
+            return Ok(Vec::new());
+        }
+        let event = self.final_envelope();
+        // Next utterance starts fresh.
+        self.utterance += 1;
+        self.revealed = 0;
+        Ok(vec![event])
+    }
+
+    fn finish(&mut self) -> Result<Vec<RealtimeEventEnvelope>, NativeAsrError> {
+        self.finished = true;
+        if self.revealed == 0 {
+            return Ok(Vec::new());
+        }
+        Ok(vec![self.final_envelope()])
+    }
+
+    fn cancel(&mut self) -> Result<Vec<RealtimeEventEnvelope>, NativeAsrError> {
+        Ok(Vec::new())
+    }
+}
+
+fn transcript_envelope(event: RealtimeTranscriptEvent) -> RealtimeEventEnvelope {
+    RealtimeEventEnvelope {
+        event_type: "transcript",
+        session_id: RealtimeSessionId("fake".to_string()),
+        event_id: RealtimeEventId("evt".to_string()),
+        seq: 0,
+        created_at: "1970-01-01T00:00:00.000Z".to_string(),
+        trace_id: None,
+        request_id: None,
+        event: RealtimeEvent::Transcript(event),
+    }
+}
+
+fn wrap(session: FakeStreamingSession, cfg: &StreamingConfig) -> StreamingSession {
+    StreamingSession::from_native_session(Box::new(session), cfg).unwrap()
+}
+
+/// One 20 ms frame worth of `f32` samples at `amplitude`.
+fn frame_samples(amplitude: f32) -> Vec<f32> {
+    vec![amplitude; FRAME_SAMPLES]
+}
+
+#[test]
+fn partials_grow_then_final_no_vad() {
+    let cfg = StreamingConfig {
+        vad: None,
+        ..Default::default()
+    };
+    let mut session = wrap(
+        FakeStreamingSession::new("hello world this is a test"),
+        &cfg,
+    );
+
+    // Feed 6 frames (one word revealed per frame in the fake).
+    let mut partial_texts = Vec::new();
+    for _ in 0..6 {
+        let events = session.feed(&frame_samples(0.3)).unwrap();
+        for event in events {
+            if event.kind == StreamingEventKind::Partial {
+                partial_texts.push(event.text);
+            }
+        }
+    }
+
+    // Partials strictly grow in length: an incremental live-caption stream.
+    assert!(partial_texts.len() >= 2, "expected multiple partials");
+    for window in partial_texts.windows(2) {
+        assert!(
+            window[1].len() >= window[0].len(),
+            "partial text must not shrink: {:?} -> {:?}",
+            window[0],
+            window[1]
+        );
+    }
+    assert_eq!(partial_texts.last().unwrap(), "hello world this is a test");
+
+    let transcription = session.finish().unwrap();
+    assert_eq!(transcription.text, "hello world this is a test");
+    assert_eq!(transcription.segments.len(), 1);
+    assert_eq!(transcription.language.as_deref(), Some("en"));
+}
+
+#[test]
+fn vad_pause_emits_committed_segment() {
+    let cfg = StreamingConfig::default(); // VAD on by default
+    let mut session = wrap(FakeStreamingSession::new("hello world"), &cfg);
+
+    let mut committed = Vec::new();
+    // ~400 ms of speech: enough loud frames to cross speech_start_ms (200 ms).
+    for _ in 0..20 {
+        let events = session.feed(&frame_samples(0.5)).unwrap();
+        committed.extend(
+            events
+                .into_iter()
+                .filter(|event| event.kind == StreamingEventKind::Committed),
+        );
+    }
+    // ~800 ms of silence: crosses speech_stop_ms (600 ms) -> utterance closes.
+    for _ in 0..40 {
+        let events = session.feed(&frame_samples(0.0)).unwrap();
+        committed.extend(
+            events
+                .into_iter()
+                .filter(|event| event.kind == StreamingEventKind::Committed),
+        );
+    }
+
+    assert!(
+        !committed.is_empty(),
+        "a VAD speech pause should commit a segment mid-stream"
+    );
+    assert_eq!(committed[0].text, "hello world");
+
+    let transcription = session.finish().unwrap();
+    assert!(transcription.text.contains("hello world"));
+}
+
+#[test]
+fn tail_audio_is_flushed_on_finish() {
+    let cfg = StreamingConfig {
+        vad: None,
+        ..Default::default()
+    };
+    let mut session = wrap(FakeStreamingSession::new("tail words here"), &cfg);
+    // A sub-frame chunk that never fills a 20 ms frame on its own.
+    let events = session.feed(&[0.1_f32; 100]).unwrap();
+    assert!(events.is_empty(), "a partial frame yields no events yet");
+    // finish() pads and flushes the tail, then finalizes.
+    let transcription = session.finish().unwrap();
+    assert!(!transcription.text.is_empty());
+}
+
+#[test]
+fn cjk_segments_join_without_inserted_space() {
+    let joined = super::join_segment_texts(["你好", "世界"].into_iter());
+    assert_eq!(joined, "你好世界");
+    let latin = super::join_segment_texts(["hello", "world"].into_iter());
+    assert_eq!(latin, "hello world");
+}
+
+#[test]
+fn cancellation_token_setter_is_accepted() {
+    // The fake ignores it, but the trait default must not panic when the
+    // session is boxed through StreamingSession.
+    let cfg = StreamingConfig {
+        vad: None,
+        ..Default::default()
+    };
+    let mut session = wrap(FakeStreamingSession::new("one two"), &cfg);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    session.session.set_cancellation_token(cancelled.clone());
+    assert!(!cancelled.load(Ordering::Relaxed));
+}
+
+/// End-to-end parity check against the batch path with a real moonshine pack.
+///
+/// Ignored by default (needs model weights + a compiled ggml backend, which
+/// the weight-free default test suite must not require). Run manually:
+///
+/// ```text
+/// OPENASR_TEST_STREAMING_PACK=/path/to/moonshine-tiny-q8_0.oasr \
+///   cargo test -p openasr-core streaming_matches_batch_transcribe -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "requires a real .oasr pack via OPENASR_TEST_STREAMING_PACK"]
+fn streaming_matches_batch_transcribe() {
+    use crate::{
+        NativeAsrExecutor, NativeAsrHardwareTarget, NativeAsrModelAdapter, NativeAsrModelPackRef,
+        NativeAsrOfflineRequest, NativeAsrRequestOptions, NativeBackendExecutor,
+        load_native_wav_16khz_mono_f32_v0, native_runtime_model_adapter_for_path,
+    };
+    use std::path::PathBuf;
+
+    let pack = PathBuf::from(
+        std::env::var("OPENASR_TEST_STREAMING_PACK")
+            .expect("set OPENASR_TEST_STREAMING_PACK to a local .oasr pack"),
+    );
+    let wav = PathBuf::from(
+        std::env::var("OPENASR_TEST_STREAMING_WAV")
+            .unwrap_or_else(|_| "fixtures/jfk.wav".to_string()),
+    );
+
+    let samples = load_native_wav_16khz_mono_f32_v0(&wav, "streaming-test", "streaming-input")
+        .expect("load wav as 16k mono f32");
+
+    // Streaming: feed in 100 ms chunks with VAD off (single utterance) so the
+    // final transcript is directly comparable to a whole-file batch decode.
+    let cfg = StreamingConfig {
+        partial_results: true,
+        vad: None,
+        hardware_target: NativeAsrHardwareTarget::Cpu,
+        ..Default::default()
+    };
+    let mut session = StreamingSession::new(&pack, cfg).expect("start streaming session");
+    let mut partial_count = 0usize;
+    let mut last_partial_len = 0usize;
+    let mut growing = 0usize;
+    for chunk in samples.chunks(1_600) {
+        for event in session.feed(chunk).expect("feed chunk") {
+            if event.kind == StreamingEventKind::Partial {
+                partial_count += 1;
+                if event.text.len() >= last_partial_len {
+                    growing += 1;
+                }
+                last_partial_len = event.text.len();
+            }
+        }
+    }
+    let streamed = session.finish().expect("finish streaming");
+
+    // Batch reference over the whole file, same executor/adapter/pack. The
+    // offline `transcribe` path validates the ref's model id against the pack's
+    // own runtime id, so resolve the pack's real id rather than a placeholder.
+    let adapter = native_runtime_model_adapter_for_path(&pack).expect("adapter");
+    let identity = crate::resolve_local_native_runtime_model_identity(&pack, None)
+        .expect("resolve pack model identity");
+    let model_pack =
+        NativeAsrModelPackRef::new(identity.model_id, adapter.model_family(), pack.clone());
+    let batch = NativeAsrExecutor::transcribe(
+        &NativeBackendExecutor,
+        &adapter,
+        &model_pack,
+        NativeAsrHardwareTarget::Cpu,
+        NativeAsrOfflineRequest::new(wav).with_options(NativeAsrRequestOptions::new()),
+    )
+    .expect("batch transcribe");
+
+    let wer = crate::wer(&batch.text, &streamed.text);
+    eprintln!("partials={partial_count} growing={growing}");
+    eprintln!("batch    = {:?}", batch.text);
+    eprintln!("streamed = {:?}", streamed.text);
+    eprintln!("wer(streamed vs batch) = {wer:.3}");
+
+    assert!(partial_count > 0, "expected incremental partials");
+    assert!(
+        wer <= 0.25,
+        "streamed final should closely match batch (wer={wer:.3})\nbatch={:?}\nstreamed={:?}",
+        batch.text,
+        streamed.text
+    );
+}

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -72,6 +72,7 @@ pub use api::native::{
     NativeAsrRuntimeReadiness, NativeAsrSession, NativeAsrSessionContext,
     NativeAsrStreamingSessionConfig, NativeAsrTensorLayoutRef, load_native_wav_16khz_mono_f32_v0,
 };
+pub use api::streaming::{StreamingConfig, StreamingEvent, StreamingEventKind, StreamingSession};
 pub use atomic_file::write_owner_only_file_atomically;
 pub use audio::{
     AudioInputError, AudioInputInfo, AudioInputIssue, AudioPreparationError,

--- a/crates/openasr-ffi/include/openasr.h
+++ b/crates/openasr-ffi/include/openasr.h
@@ -64,6 +64,44 @@ typedef enum OpenAsrPcmFormat {
 } OpenAsrPcmFormat;
 
 /**
+ * Hardware target for a streaming session's decode, mirroring
+ * [`openasr_core::NativeAsrHardwareTarget`]. `Auto` lets the runtime choose;
+ * on iOS/macOS only `Auto`, `Cpu`, `Accelerated`, and `AppleSilicon` are
+ * meaningful (the SDK is CPU-only today -- see `docs/SDK_IOS_MACOS.md`), but
+ * the full set is mapped so the contract does not silently drop a value.
+ */
+typedef enum OpenAsrHardwareTarget {
+  OPEN_ASR_HARDWARE_TARGET_AUTO = 0,
+  OPEN_ASR_HARDWARE_TARGET_CPU = 1,
+  OPEN_ASR_HARDWARE_TARGET_ACCELERATED = 2,
+  OPEN_ASR_HARDWARE_TARGET_APPLE_SILICON = 3,
+  OPEN_ASR_HARDWARE_TARGET_NVIDIA_CUDA = 4,
+  OPEN_ASR_HARDWARE_TARGET_AMD_GPU = 5,
+  OPEN_ASR_HARDWARE_TARGET_INTEL_CPU = 6,
+  OPEN_ASR_HARDWARE_TARGET_INTEL_GPU = 7,
+} OpenAsrHardwareTarget;
+
+/**
+ * The kind of an incremental streaming transcript event, mirroring
+ * [`openasr_core::StreamingEventKind`].
+ */
+typedef enum OpenAsrStreamingEventKind {
+  /**
+   * A mutable in-progress hypothesis for the active utterance, superseded by
+   * later events carrying the same segment id.
+   */
+  OPEN_ASR_STREAMING_EVENT_KIND_PARTIAL = 0,
+  /**
+   * A settled segment, emitted at a VAD speech pause or at `finish`.
+   */
+  OPEN_ASR_STREAMING_EVENT_KIND_COMMITTED = 1,
+  /**
+   * A post-final correction to an already-committed segment.
+   */
+  OPEN_ASR_STREAMING_EVENT_KIND_REVISION = 2,
+} OpenAsrStreamingEventKind;
+
+/**
  * Opaque handle to a validated local `.oasr` model pack path. Obtained from
  * [`openasr_model_open`], released with [`openasr_model_close`].
  *
@@ -80,6 +118,66 @@ typedef struct OpenAsrModel OpenAsrModel;
  * through `openasr_result_*` accessor functions.
  */
 typedef struct OpenAsrResult OpenAsrResult;
+
+/**
+ * Opaque batch of streaming events produced by one [`openasr_streaming_feed`]
+ * call. Read it through the `openasr_streaming_event_*` accessors, then free
+ * it with [`openasr_streaming_events_free`]. Mirrors [`OpenAsrResult`]: the
+ * events own Rust-side strings that are not a valid C value type, so they are
+ * read by index rather than returned as a raw struct array.
+ */
+typedef struct OpenAsrStreamingEvents OpenAsrStreamingEvents;
+
+/**
+ * Opaque handle to an in-process streaming transcription session over a local
+ * `.oasr` pack. Created with [`openasr_streaming_session_open`], driven with
+ * [`openasr_streaming_feed`], and consumed by [`openasr_streaming_finish`]
+ * (which returns the final transcript and frees the session) or discarded with
+ * [`openasr_streaming_free`].
+ */
+typedef struct OpenAsrStreamingSession OpenAsrStreamingSession;
+
+/**
+ * Configuration for [`openasr_streaming_session_open`]. Pass a null pointer to
+ * use the engine defaults (partial results on, word timestamps off, VAD on,
+ * auto hardware, default poll cadence). All fields are plain C values so the
+ * struct is a valid `#[repr(C)]` type; `language` is an optional borrowed C
+ * string (null = auto-detect), read only during the open call.
+ */
+typedef struct OpenAsrStreamingConfig {
+  /**
+   * Emit mutable `Partial` events as audio arrives.
+   */
+  bool partial_results;
+  /**
+   * Attach per-word timings to events when the family supports them.
+   */
+  bool word_timestamps;
+  /**
+   * Run an energy VAD that commits a segment at each speech pause. When
+   * false, the whole stream is one utterance finalized only at `finish`.
+   */
+  bool enable_vad;
+  /**
+   * Optional decode language hint (e.g. "en"), or null to auto-detect. Only
+   * borrowed for the duration of the open call.
+   */
+  const char *language;
+  /**
+   * Hardware target for the decode session.
+   */
+  enum OpenAsrHardwareTarget hardware_target;
+  /**
+   * Inference thread cap; `0` uses the per-family default.
+   */
+  uint16_t inference_threads;
+  /**
+   * New audio (ms) to accumulate before polling the engine for a partial
+   * re-decode; `0` uses the engine default. Values below the 20 ms frame
+   * size are clamped up by the engine.
+   */
+  uint64_t partial_poll_interval_ms;
+} OpenAsrStreamingConfig;
 
 #ifdef __cplusplus
 extern "C" {
@@ -200,6 +298,175 @@ float openasr_result_segment_end(const struct OpenAsrResult *result, uintptr_t i
  * `result`, if non-null, must be a live handle from [`openasr_transcribe_pcm`].
  */
 const char *openasr_result_segment_text(const struct OpenAsrResult *result, uintptr_t index);
+
+/**
+ * Opens an in-process streaming transcription session over the local `.oasr`
+ * pack at `path` and writes an opaque handle through `out_session`. Fails
+ * closed -- with [`OpenAsrStatus::ModelLoadFailed`] and no handle written --
+ * if the path is missing, not UTF-8, or not a pack a native model family
+ * recognizes / can stream. Never touches the network.
+ *
+ * Pass a null `config` to use the engine defaults; otherwise `config` is read
+ * (and its `language`, if non-null, borrowed) only for the duration of this
+ * call.
+ *
+ * # Safety
+ * `path` must be a valid, NUL-terminated UTF-8 C string. `config`, if
+ * non-null, must point to a valid [`OpenAsrStreamingConfig`] whose `language`
+ * is null or a valid NUL-terminated UTF-8 C string. `out_session` must be a
+ * valid, non-null pointer to a `*mut OpenAsrStreamingSession` the caller owns.
+ */
+enum OpenAsrStatus openasr_streaming_session_open(const char *path,
+                                                  const struct OpenAsrStreamingConfig *config,
+                                                  struct OpenAsrStreamingSession **out_session);
+
+/**
+ * Feeds a chunk of 16 kHz mono `f32` PCM (any length, including zero) into an
+ * open streaming session and writes the incremental events it produced through
+ * `out_events`: `Partial`s for the active utterance and a `Committed` event
+ * whenever a VAD speech pause closes one. An empty chunk is accepted and yields
+ * an empty (non-null) event batch. Read the batch with the
+ * `openasr_streaming_event_*` accessors, then free it with
+ * [`openasr_streaming_events_free`].
+ *
+ * # Safety
+ * `session` must be a live handle from [`openasr_streaming_session_open`] (not
+ * yet finished/freed). `pcm` must point to at least `pcm_len_samples` `f32`
+ * samples (may be null only when `pcm_len_samples` is 0). `out_events` must be
+ * a valid, non-null pointer to a `*mut OpenAsrStreamingEvents` the caller owns.
+ */
+enum OpenAsrStatus openasr_streaming_feed(struct OpenAsrStreamingSession *session,
+                                          const float *pcm,
+                                          uintptr_t pcm_len_samples,
+                                          struct OpenAsrStreamingEvents **out_events);
+
+/**
+ * Finishes a streaming session: drains any buffered tail audio, finalizes the
+ * active utterance, and writes the assembled final [`OpenAsrResult`] (with
+ * per-segment timestamps) through `out_result`. This **consumes** `session`:
+ * whether it succeeds or fails, the handle is freed and must not be reused or
+ * passed to [`openasr_streaming_free`]. Read the result with the
+ * `openasr_result_*` accessors and free it with [`openasr_result_free`].
+ *
+ * # Safety
+ * `session` must be a live handle from [`openasr_streaming_session_open`] that
+ * has not already been finished or freed. `out_result` must be a valid,
+ * non-null pointer to a `*mut OpenAsrResult` the caller owns.
+ */
+enum OpenAsrStatus openasr_streaming_finish(struct OpenAsrStreamingSession *session,
+                                            struct OpenAsrResult **out_result);
+
+/**
+ * Frees a streaming session without finishing it (aborts the stream). Null is
+ * accepted and is a no-op. Do not call this on a handle already consumed by
+ * [`openasr_streaming_finish`].
+ *
+ * # Safety
+ * `session`, if non-null, must be a live handle from
+ * [`openasr_streaming_session_open`] that has not been finished or freed.
+ */
+void openasr_streaming_free(struct OpenAsrStreamingSession *session);
+
+/**
+ * Returns the number of events in `events` (`0` if `events` is null).
+ *
+ * # Safety
+ * `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+ */
+uintptr_t openasr_streaming_events_count(const struct OpenAsrStreamingEvents *events);
+
+/**
+ * Returns event `index`'s kind, or [`OpenAsrStreamingEventKind::Partial`] if
+ * `events` is null or `index` is out of range (gate reads on
+ * [`openasr_streaming_events_count`]).
+ *
+ * # Safety
+ * `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+ */
+enum OpenAsrStreamingEventKind openasr_streaming_event_kind(const struct OpenAsrStreamingEvents *events,
+                                                            uintptr_t index);
+
+/**
+ * Returns event `index`'s text (UTF-8, NUL-terminated), or null if `events` is
+ * null or `index` is out of range. Valid until `events` is freed.
+ *
+ * # Safety
+ * `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+ */
+const char *openasr_streaming_event_text(const struct OpenAsrStreamingEvents *events,
+                                         uintptr_t index);
+
+/**
+ * Returns event `index`'s utterance id (UTF-8, NUL-terminated), or null if
+ * `events` is null or `index` is out of range. Valid until `events` is freed.
+ *
+ * # Safety
+ * `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+ */
+const char *openasr_streaming_event_utterance_id(const struct OpenAsrStreamingEvents *events,
+                                                 uintptr_t index);
+
+/**
+ * Returns event `index`'s segment id (UTF-8, NUL-terminated), or null if
+ * `events` is null or `index` is out of range. Valid until `events` is freed.
+ *
+ * # Safety
+ * `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+ */
+const char *openasr_streaming_event_segment_id(const struct OpenAsrStreamingEvents *events,
+                                               uintptr_t index);
+
+/**
+ * Returns event `index`'s detected language tag (e.g. "en"), UTF-8 and
+ * NUL-terminated, or null if `events` is null, `index` is out of range, or the
+ * family reported no language. Valid until `events` is freed.
+ *
+ * # Safety
+ * `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+ */
+const char *openasr_streaming_event_language(const struct OpenAsrStreamingEvents *events,
+                                             uintptr_t index);
+
+/**
+ * Returns event `index`'s monotonic revision number (higher supersedes lower
+ * for the same segment id), or `0` if `events` is null or `index` is out of
+ * range.
+ *
+ * # Safety
+ * `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+ */
+uint64_t openasr_streaming_event_revision(const struct OpenAsrStreamingEvents *events,
+                                          uintptr_t index);
+
+/**
+ * Returns event `index`'s start time in milliseconds, or `0` if `events` is
+ * null or `index` is out of range.
+ *
+ * # Safety
+ * `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+ */
+uint64_t openasr_streaming_event_start_ms(const struct OpenAsrStreamingEvents *events,
+                                          uintptr_t index);
+
+/**
+ * Returns event `index`'s end time in milliseconds, or `0` if `events` is null
+ * or `index` is out of range.
+ *
+ * # Safety
+ * `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+ */
+uint64_t openasr_streaming_event_end_ms(const struct OpenAsrStreamingEvents *events,
+                                        uintptr_t index);
+
+/**
+ * Frees an event batch returned by [`openasr_streaming_feed`]. Null is accepted
+ * and is a no-op.
+ *
+ * # Safety
+ * `events`, if non-null, must have been previously returned by
+ * [`openasr_streaming_feed`] and not already freed.
+ */
+void openasr_streaming_events_free(struct OpenAsrStreamingEvents *events);
 
 /**
  * Returns the last error message set on the calling thread by a failing

--- a/crates/openasr-ffi/src/lib.rs
+++ b/crates/openasr-ffi/src/lib.rs
@@ -1,12 +1,21 @@
 //! C ABI for embedding the OpenASR engine in iOS/macOS apps (see
 //! `scripts/build-xcframework.sh` and `docs/SDK_IOS_MACOS.md`).
 //!
-//! Deliberately minimal for v1: load a local `.oasr` pack, transcribe one
-//! whole in-memory 16 kHz mono PCM buffer (f32 or i16), get back text plus
-//! optional segment timestamps. No streaming, no dictation, no server, no
-//! model download -- SDK consumers manage their own model distribution (the
-//! product's "no silent download" boundary is a CLI/server concern, not an
-//! SDK one; see `AGENTS.md`).
+//! Two entry points, both fed the caller's own local `.oasr` pack:
+//!
+//! - **Batch**: load a pack, transcribe one whole in-memory 16 kHz mono PCM
+//!   buffer (f32 or i16), get back text plus optional segment timestamps
+//!   (`openasr_model_open` / `openasr_transcribe_pcm` / `openasr_result_*`).
+//! - **Streaming**: open a live session, feed 16 kHz mono f32 PCM chunks and
+//!   receive incremental partial/committed transcript events, then finish for
+//!   the assembled final transcript (`openasr_streaming_*`). This is the
+//!   in-process, transport-free path an iOS app uses for live captioning --
+//!   iOS cannot spawn the desktop realtime server, so it links the same
+//!   `openasr_core::StreamingSession` engine directly.
+//!
+//! No server, no model download -- SDK consumers manage their own model
+//! distribution (the product's "no silent download" boundary is a CLI/server
+//! concern, not an SDK one; see `AGENTS.md`).
 //!
 //! The API shape follows whisper.cpp's C API convention: opaque handles plus
 //! index-based accessor functions for the result
@@ -34,7 +43,8 @@ use std::path::PathBuf;
 use std::ptr;
 
 use openasr_core::{
-    NATIVE_RUNTIME_MODEL_ID_AUTO, NativeBackend, Transcription, TranscriptionBackend,
+    NATIVE_RUNTIME_MODEL_ID_AUTO, NativeAsrHardwareTarget, NativeBackend, StreamingConfig,
+    StreamingEvent, StreamingEventKind, StreamingSession, Transcription, TranscriptionBackend,
     TranscriptionRequest, validate_local_native_model_pack_path,
 };
 
@@ -132,6 +142,111 @@ pub struct OpenAsrResult {
     text: CString,
     language: Option<CString>,
     segments: Vec<OwnedSegment>,
+}
+
+/// Hardware target for a streaming session's decode, mirroring
+/// [`openasr_core::NativeAsrHardwareTarget`]. `Auto` lets the runtime choose;
+/// on iOS/macOS only `Auto`, `Cpu`, `Accelerated`, and `AppleSilicon` are
+/// meaningful (the SDK is CPU-only today -- see `docs/SDK_IOS_MACOS.md`), but
+/// the full set is mapped so the contract does not silently drop a value.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenAsrHardwareTarget {
+    Auto = 0,
+    Cpu = 1,
+    Accelerated = 2,
+    AppleSilicon = 3,
+    NvidiaCuda = 4,
+    AmdGpu = 5,
+    IntelCpu = 6,
+    IntelGpu = 7,
+}
+
+impl From<OpenAsrHardwareTarget> for NativeAsrHardwareTarget {
+    fn from(target: OpenAsrHardwareTarget) -> Self {
+        match target {
+            OpenAsrHardwareTarget::Auto => NativeAsrHardwareTarget::Auto,
+            OpenAsrHardwareTarget::Cpu => NativeAsrHardwareTarget::Cpu,
+            OpenAsrHardwareTarget::Accelerated => NativeAsrHardwareTarget::Accelerated,
+            OpenAsrHardwareTarget::AppleSilicon => NativeAsrHardwareTarget::AppleSilicon,
+            OpenAsrHardwareTarget::NvidiaCuda => NativeAsrHardwareTarget::NvidiaCuda,
+            OpenAsrHardwareTarget::AmdGpu => NativeAsrHardwareTarget::AmdGpu,
+            OpenAsrHardwareTarget::IntelCpu => NativeAsrHardwareTarget::IntelCpu,
+            OpenAsrHardwareTarget::IntelGpu => NativeAsrHardwareTarget::IntelGpu,
+        }
+    }
+}
+
+/// The kind of an incremental streaming transcript event, mirroring
+/// [`openasr_core::StreamingEventKind`].
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenAsrStreamingEventKind {
+    /// A mutable in-progress hypothesis for the active utterance, superseded by
+    /// later events carrying the same segment id.
+    Partial = 0,
+    /// A settled segment, emitted at a VAD speech pause or at `finish`.
+    Committed = 1,
+    /// A post-final correction to an already-committed segment.
+    Revision = 2,
+}
+
+/// Configuration for [`openasr_streaming_session_open`]. Pass a null pointer to
+/// use the engine defaults (partial results on, word timestamps off, VAD on,
+/// auto hardware, default poll cadence). All fields are plain C values so the
+/// struct is a valid `#[repr(C)]` type; `language` is an optional borrowed C
+/// string (null = auto-detect), read only during the open call.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct OpenAsrStreamingConfig {
+    /// Emit mutable `Partial` events as audio arrives.
+    pub partial_results: bool,
+    /// Attach per-word timings to events when the family supports them.
+    pub word_timestamps: bool,
+    /// Run an energy VAD that commits a segment at each speech pause. When
+    /// false, the whole stream is one utterance finalized only at `finish`.
+    pub enable_vad: bool,
+    /// Optional decode language hint (e.g. "en"), or null to auto-detect. Only
+    /// borrowed for the duration of the open call.
+    pub language: *const c_char,
+    /// Hardware target for the decode session.
+    pub hardware_target: OpenAsrHardwareTarget,
+    /// Inference thread cap; `0` uses the per-family default.
+    pub inference_threads: u16,
+    /// New audio (ms) to accumulate before polling the engine for a partial
+    /// re-decode; `0` uses the engine default. Values below the 20 ms frame
+    /// size are clamped up by the engine.
+    pub partial_poll_interval_ms: u64,
+}
+
+/// Opaque handle to an in-process streaming transcription session over a local
+/// `.oasr` pack. Created with [`openasr_streaming_session_open`], driven with
+/// [`openasr_streaming_feed`], and consumed by [`openasr_streaming_finish`]
+/// (which returns the final transcript and frees the session) or discarded with
+/// [`openasr_streaming_free`].
+pub struct OpenAsrStreamingSession {
+    inner: StreamingSession,
+}
+
+/// One incremental transcript event, owning C-string copies of its text fields.
+struct OwnedStreamingEvent {
+    kind: OpenAsrStreamingEventKind,
+    utterance_id: CString,
+    segment_id: CString,
+    revision: u64,
+    text: CString,
+    start_ms: u64,
+    end_ms: u64,
+    language: Option<CString>,
+}
+
+/// Opaque batch of streaming events produced by one [`openasr_streaming_feed`]
+/// call. Read it through the `openasr_streaming_event_*` accessors, then free
+/// it with [`openasr_streaming_events_free`]. Mirrors [`OpenAsrResult`]: the
+/// events own Rust-side strings that are not a valid C value type, so they are
+/// read by index rather than returned as a raw struct array.
+pub struct OpenAsrStreamingEvents {
+    events: Vec<OwnedStreamingEvent>,
 }
 
 /// Returns the engine version (the workspace product version), as a static,
@@ -444,6 +559,366 @@ pub unsafe extern "C" fn openasr_result_segment_text(
         .unwrap_or(ptr::null())
 }
 
+/// Opens an in-process streaming transcription session over the local `.oasr`
+/// pack at `path` and writes an opaque handle through `out_session`. Fails
+/// closed -- with [`OpenAsrStatus::ModelLoadFailed`] and no handle written --
+/// if the path is missing, not UTF-8, or not a pack a native model family
+/// recognizes / can stream. Never touches the network.
+///
+/// Pass a null `config` to use the engine defaults; otherwise `config` is read
+/// (and its `language`, if non-null, borrowed) only for the duration of this
+/// call.
+///
+/// # Safety
+/// `path` must be a valid, NUL-terminated UTF-8 C string. `config`, if
+/// non-null, must point to a valid [`OpenAsrStreamingConfig`] whose `language`
+/// is null or a valid NUL-terminated UTF-8 C string. `out_session` must be a
+/// valid, non-null pointer to a `*mut OpenAsrStreamingSession` the caller owns.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_session_open(
+    path: *const c_char,
+    config: *const OpenAsrStreamingConfig,
+    out_session: *mut *mut OpenAsrStreamingSession,
+) -> OpenAsrStatus {
+    catch(OpenAsrStatus::ModelLoadFailed, || {
+        if out_session.is_null() {
+            set_last_error("openasr_streaming_session_open: out_session must not be null");
+            return OpenAsrStatus::InvalidArgument;
+        }
+        // SAFETY: caller contract requires `out_session` to be a valid pointer.
+        unsafe {
+            *out_session = ptr::null_mut();
+        }
+        let path = match unsafe { c_str_to_path(path) } {
+            Ok(path) => path,
+            Err(status) => return status,
+        };
+        let cfg = match unsafe { streaming_config_from_c(config) } {
+            Ok(cfg) => cfg,
+            Err(status) => return status,
+        };
+        match StreamingSession::new(&path, cfg) {
+            Ok(session) => {
+                let handle = Box::new(OpenAsrStreamingSession { inner: session });
+                // SAFETY: checked non-null above.
+                unsafe {
+                    *out_session = Box::into_raw(handle);
+                }
+                OpenAsrStatus::Ok
+            }
+            Err(error) => {
+                set_last_error(format!("openasr_streaming_session_open: {error}"));
+                OpenAsrStatus::ModelLoadFailed
+            }
+        }
+    })
+}
+
+/// Feeds a chunk of 16 kHz mono `f32` PCM (any length, including zero) into an
+/// open streaming session and writes the incremental events it produced through
+/// `out_events`: `Partial`s for the active utterance and a `Committed` event
+/// whenever a VAD speech pause closes one. An empty chunk is accepted and yields
+/// an empty (non-null) event batch. Read the batch with the
+/// `openasr_streaming_event_*` accessors, then free it with
+/// [`openasr_streaming_events_free`].
+///
+/// # Safety
+/// `session` must be a live handle from [`openasr_streaming_session_open`] (not
+/// yet finished/freed). `pcm` must point to at least `pcm_len_samples` `f32`
+/// samples (may be null only when `pcm_len_samples` is 0). `out_events` must be
+/// a valid, non-null pointer to a `*mut OpenAsrStreamingEvents` the caller owns.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_feed(
+    session: *mut OpenAsrStreamingSession,
+    pcm: *const f32,
+    pcm_len_samples: usize,
+    out_events: *mut *mut OpenAsrStreamingEvents,
+) -> OpenAsrStatus {
+    catch(OpenAsrStatus::TranscribeFailed, || {
+        if out_events.is_null() {
+            set_last_error("openasr_streaming_feed: out_events must not be null");
+            return OpenAsrStatus::InvalidArgument;
+        }
+        // SAFETY: caller contract requires `out_events` to be a valid pointer.
+        unsafe {
+            *out_events = ptr::null_mut();
+        }
+        if session.is_null() {
+            set_last_error("openasr_streaming_feed: session handle must not be null");
+            return OpenAsrStatus::InvalidArgument;
+        }
+        if pcm.is_null() && pcm_len_samples > 0 {
+            set_last_error("openasr_streaming_feed: pcm must not be null when non-empty");
+            return OpenAsrStatus::InvalidArgument;
+        }
+        // SAFETY: `pcm` points at `pcm_len_samples` f32 samples per the safety
+        // contract; the empty case uses a valid dangling-free slice so
+        // `from_raw_parts` is never called with a null base pointer.
+        let samples: &[f32] = if pcm_len_samples == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(pcm, pcm_len_samples) }
+        };
+        // SAFETY: `session` was checked non-null above and, per the safety
+        // contract, is a live handle from `openasr_streaming_session_open`.
+        let session_ref = unsafe { &mut *session };
+        match session_ref.inner.feed(samples) {
+            Ok(events) => {
+                let batch = Box::new(OpenAsrStreamingEvents {
+                    events: events.into_iter().map(owned_streaming_event).collect(),
+                });
+                // SAFETY: checked non-null above.
+                unsafe {
+                    *out_events = Box::into_raw(batch);
+                }
+                OpenAsrStatus::Ok
+            }
+            Err(error) => {
+                set_last_error(format!("openasr_streaming_feed: {error}"));
+                OpenAsrStatus::TranscribeFailed
+            }
+        }
+    })
+}
+
+/// Finishes a streaming session: drains any buffered tail audio, finalizes the
+/// active utterance, and writes the assembled final [`OpenAsrResult`] (with
+/// per-segment timestamps) through `out_result`. This **consumes** `session`:
+/// whether it succeeds or fails, the handle is freed and must not be reused or
+/// passed to [`openasr_streaming_free`]. Read the result with the
+/// `openasr_result_*` accessors and free it with [`openasr_result_free`].
+///
+/// # Safety
+/// `session` must be a live handle from [`openasr_streaming_session_open`] that
+/// has not already been finished or freed. `out_result` must be a valid,
+/// non-null pointer to a `*mut OpenAsrResult` the caller owns.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_finish(
+    session: *mut OpenAsrStreamingSession,
+    out_result: *mut *mut OpenAsrResult,
+) -> OpenAsrStatus {
+    catch(OpenAsrStatus::TranscribeFailed, || {
+        if out_result.is_null() {
+            set_last_error("openasr_streaming_finish: out_result must not be null");
+            return OpenAsrStatus::InvalidArgument;
+        }
+        // SAFETY: caller contract requires `out_result` to be a valid pointer.
+        unsafe {
+            *out_result = ptr::null_mut();
+        }
+        if session.is_null() {
+            set_last_error("openasr_streaming_finish: session handle must not be null");
+            return OpenAsrStatus::InvalidArgument;
+        }
+        // SAFETY: caller contract requires this came from `Box::into_raw` in
+        // `openasr_streaming_session_open` and has not been finished/freed.
+        // `finish` consumes the session, so ownership is taken back here and the
+        // box is dropped exactly once regardless of the decode outcome.
+        let handle = unsafe { Box::from_raw(session) };
+        match handle.inner.finish() {
+            Ok(transcription) => {
+                let result = Box::new(build_result(transcription, true));
+                // SAFETY: checked non-null above.
+                unsafe {
+                    *out_result = Box::into_raw(result);
+                }
+                OpenAsrStatus::Ok
+            }
+            Err(error) => {
+                set_last_error(format!("openasr_streaming_finish: {error}"));
+                OpenAsrStatus::TranscribeFailed
+            }
+        }
+    })
+}
+
+/// Frees a streaming session without finishing it (aborts the stream). Null is
+/// accepted and is a no-op. Do not call this on a handle already consumed by
+/// [`openasr_streaming_finish`].
+///
+/// # Safety
+/// `session`, if non-null, must be a live handle from
+/// [`openasr_streaming_session_open`] that has not been finished or freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_free(session: *mut OpenAsrStreamingSession) {
+    let _ = catch(OpenAsrStatus::Ok, || {
+        if !session.is_null() {
+            // SAFETY: caller contract requires this came from `Box::into_raw`
+            // in `openasr_streaming_session_open` and is not double-freed.
+            drop(unsafe { Box::from_raw(session) });
+        }
+        OpenAsrStatus::Ok
+    });
+}
+
+/// Returns the number of events in `events` (`0` if `events` is null).
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_events_count(
+    events: *const OpenAsrStreamingEvents,
+) -> usize {
+    if events.is_null() {
+        return 0;
+    }
+    // SAFETY: caller contract requires a live handle.
+    unsafe { (*events).events.len() }
+}
+
+/// Returns event `index`'s kind, or [`OpenAsrStreamingEventKind::Partial`] if
+/// `events` is null or `index` is out of range (gate reads on
+/// [`openasr_streaming_events_count`]).
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_event_kind(
+    events: *const OpenAsrStreamingEvents,
+    index: usize,
+) -> OpenAsrStreamingEventKind {
+    if events.is_null() {
+        return OpenAsrStreamingEventKind::Partial;
+    }
+    // SAFETY: caller contract requires a live handle; `get` bounds-checks `index`.
+    unsafe { (&*events).events.get(index) }
+        .map(|event| event.kind)
+        .unwrap_or(OpenAsrStreamingEventKind::Partial)
+}
+
+/// Returns event `index`'s text (UTF-8, NUL-terminated), or null if `events` is
+/// null or `index` is out of range. Valid until `events` is freed.
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_event_text(
+    events: *const OpenAsrStreamingEvents,
+    index: usize,
+) -> *const c_char {
+    // SAFETY: caller contract requires a live handle from openasr_streaming_feed.
+    unsafe { streaming_event_cstr(events, index, |event| Some(&event.text)) }
+}
+
+/// Returns event `index`'s utterance id (UTF-8, NUL-terminated), or null if
+/// `events` is null or `index` is out of range. Valid until `events` is freed.
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_event_utterance_id(
+    events: *const OpenAsrStreamingEvents,
+    index: usize,
+) -> *const c_char {
+    // SAFETY: caller contract requires a live handle from openasr_streaming_feed.
+    unsafe { streaming_event_cstr(events, index, |event| Some(&event.utterance_id)) }
+}
+
+/// Returns event `index`'s segment id (UTF-8, NUL-terminated), or null if
+/// `events` is null or `index` is out of range. Valid until `events` is freed.
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_event_segment_id(
+    events: *const OpenAsrStreamingEvents,
+    index: usize,
+) -> *const c_char {
+    // SAFETY: caller contract requires a live handle from openasr_streaming_feed.
+    unsafe { streaming_event_cstr(events, index, |event| Some(&event.segment_id)) }
+}
+
+/// Returns event `index`'s detected language tag (e.g. "en"), UTF-8 and
+/// NUL-terminated, or null if `events` is null, `index` is out of range, or the
+/// family reported no language. Valid until `events` is freed.
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_event_language(
+    events: *const OpenAsrStreamingEvents,
+    index: usize,
+) -> *const c_char {
+    // SAFETY: caller contract requires a live handle from openasr_streaming_feed.
+    unsafe { streaming_event_cstr(events, index, |event| event.language.as_ref()) }
+}
+
+/// Returns event `index`'s monotonic revision number (higher supersedes lower
+/// for the same segment id), or `0` if `events` is null or `index` is out of
+/// range.
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_event_revision(
+    events: *const OpenAsrStreamingEvents,
+    index: usize,
+) -> u64 {
+    if events.is_null() {
+        return 0;
+    }
+    // SAFETY: caller contract requires a live handle; `get` bounds-checks `index`.
+    unsafe { (&*events).events.get(index) }
+        .map(|event| event.revision)
+        .unwrap_or(0)
+}
+
+/// Returns event `index`'s start time in milliseconds, or `0` if `events` is
+/// null or `index` is out of range.
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_event_start_ms(
+    events: *const OpenAsrStreamingEvents,
+    index: usize,
+) -> u64 {
+    if events.is_null() {
+        return 0;
+    }
+    // SAFETY: caller contract requires a live handle; `get` bounds-checks `index`.
+    unsafe { (&*events).events.get(index) }
+        .map(|event| event.start_ms)
+        .unwrap_or(0)
+}
+
+/// Returns event `index`'s end time in milliseconds, or `0` if `events` is null
+/// or `index` is out of range.
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_event_end_ms(
+    events: *const OpenAsrStreamingEvents,
+    index: usize,
+) -> u64 {
+    if events.is_null() {
+        return 0;
+    }
+    // SAFETY: caller contract requires a live handle; `get` bounds-checks `index`.
+    unsafe { (&*events).events.get(index) }
+        .map(|event| event.end_ms)
+        .unwrap_or(0)
+}
+
+/// Frees an event batch returned by [`openasr_streaming_feed`]. Null is accepted
+/// and is a no-op.
+///
+/// # Safety
+/// `events`, if non-null, must have been previously returned by
+/// [`openasr_streaming_feed`] and not already freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn openasr_streaming_events_free(events: *mut OpenAsrStreamingEvents) {
+    let _ = catch(OpenAsrStatus::Ok, || {
+        if !events.is_null() {
+            // SAFETY: caller contract requires this came from `Box::into_raw`
+            // in `openasr_streaming_feed` and is not double-freed.
+            drop(unsafe { Box::from_raw(events) });
+        }
+        OpenAsrStatus::Ok
+    });
+}
+
 /// Returns the last error message set on the calling thread by a failing
 /// `openasr_*` call, or null if none is set / the last call succeeded. Valid
 /// until the next `openasr_*` call on the same thread; copy it out if you
@@ -549,6 +1024,96 @@ fn build_result(transcription: Transcription, with_segments: bool) -> OpenAsrRes
         language,
         segments,
     }
+}
+
+/// Builds a [`StreamingConfig`] from the optional C config. A null pointer
+/// yields the engine defaults; a non-null pointer overrides only the fields it
+/// carries (its `language`, if non-null, is borrowed for this call).
+///
+/// # Safety
+/// `config`, if non-null, must point to a valid [`OpenAsrStreamingConfig`]
+/// whose `language` is null or a valid NUL-terminated C string.
+unsafe fn streaming_config_from_c(
+    config: *const OpenAsrStreamingConfig,
+) -> Result<StreamingConfig, OpenAsrStatus> {
+    let mut cfg = StreamingConfig::default();
+    if config.is_null() {
+        return Ok(cfg);
+    }
+    // SAFETY: caller contract requires a valid pointer when non-null.
+    let raw = unsafe { &*config };
+    cfg.partial_results = raw.partial_results;
+    cfg.word_timestamps = raw.word_timestamps;
+    // `StreamingConfig::default()` already enables VAD; only clear it when the
+    // caller opts out (whole stream treated as a single utterance).
+    if !raw.enable_vad {
+        cfg.vad = None;
+    }
+    cfg.language = if raw.language.is_null() {
+        None
+    } else {
+        // SAFETY: caller contract requires a valid NUL-terminated C string when
+        // `language` is non-null.
+        let c_str = unsafe { CStr::from_ptr(raw.language) };
+        match c_str.to_str() {
+            Ok(text) if !text.is_empty() => Some(text.to_string()),
+            Ok(_) => None,
+            Err(error) => {
+                set_last_error(format!(
+                    "openasr_streaming_session_open: language is not valid UTF-8: {error}"
+                ));
+                return Err(OpenAsrStatus::InvalidArgument);
+            }
+        }
+    };
+    cfg.hardware_target = raw.hardware_target.into();
+    cfg.inference_threads = if raw.inference_threads == 0 {
+        None
+    } else {
+        Some(raw.inference_threads)
+    };
+    if raw.partial_poll_interval_ms != 0 {
+        cfg.partial_poll_interval_ms = raw.partial_poll_interval_ms;
+    }
+    Ok(cfg)
+}
+
+fn owned_streaming_event(event: StreamingEvent) -> OwnedStreamingEvent {
+    OwnedStreamingEvent {
+        kind: match event.kind {
+            StreamingEventKind::Partial => OpenAsrStreamingEventKind::Partial,
+            StreamingEventKind::Committed => OpenAsrStreamingEventKind::Committed,
+            StreamingEventKind::Revision => OpenAsrStreamingEventKind::Revision,
+        },
+        utterance_id: cstring_lossy(event.utterance_id),
+        segment_id: cstring_lossy(event.segment_id),
+        revision: event.revision,
+        text: cstring_lossy(event.text),
+        start_ms: event.start_ms,
+        end_ms: event.end_ms,
+        language: event.language.map(cstring_lossy),
+    }
+}
+
+/// Shared body for the string-returning streaming-event accessors: fail closed
+/// to null on a null handle or an out-of-range index, otherwise hand back a
+/// borrowed pointer valid until the batch is freed.
+///
+/// # Safety
+/// `events`, if non-null, must be a live handle from [`openasr_streaming_feed`].
+unsafe fn streaming_event_cstr(
+    events: *const OpenAsrStreamingEvents,
+    index: usize,
+    select: impl FnOnce(&OwnedStreamingEvent) -> Option<&CString>,
+) -> *const c_char {
+    if events.is_null() {
+        return ptr::null();
+    }
+    // SAFETY: caller contract requires a live handle; `get` bounds-checks `index`.
+    unsafe { (&*events).events.get(index) }
+        .and_then(select)
+        .map(|value| value.as_ptr())
+        .unwrap_or(ptr::null())
 }
 
 #[cfg(test)]
@@ -759,6 +1324,284 @@ mod tests {
             assert_eq!(openasr_result_segment_end(result, 0), 1.0);
             let segment_text = CStr::from_ptr(openasr_result_segment_text(result, 0));
             assert_eq!(segment_text.to_str().unwrap(), "hello world");
+            openasr_result_free(result);
+        }
+    }
+
+    fn sample_streaming_event(kind: StreamingEventKind, text: &str) -> StreamingEvent {
+        StreamingEvent {
+            kind,
+            utterance_id: "utt_000001".to_string(),
+            segment_id: "seg_000001".to_string(),
+            revision: 3,
+            text: text.to_string(),
+            start_ms: 100,
+            end_ms: 900,
+            words: Vec::new(),
+            language: Some("en".to_string()),
+        }
+    }
+
+    #[test]
+    fn streaming_session_open_rejects_null_out_param() {
+        let path = StdCString::new("/nonexistent/model.oasr").unwrap();
+        // SAFETY: valid C string; the null `out_session` is the case under test.
+        let status =
+            unsafe { openasr_streaming_session_open(path.as_ptr(), ptr::null(), ptr::null_mut()) };
+        assert_eq!(status, OpenAsrStatus::InvalidArgument);
+        assert!(last_error().contains("out_session"));
+    }
+
+    #[test]
+    fn streaming_session_open_fails_closed_on_missing_pack() {
+        let path = StdCString::new("/nonexistent/does-not-exist.oasr").unwrap();
+        let mut session: *mut OpenAsrStreamingSession = ptr::null_mut();
+        // SAFETY: valid C string, null config (defaults), valid out pointer.
+        let status =
+            unsafe { openasr_streaming_session_open(path.as_ptr(), ptr::null(), &mut session) };
+        assert_eq!(status, OpenAsrStatus::ModelLoadFailed);
+        assert!(session.is_null());
+        assert!(!last_error().is_empty());
+    }
+
+    #[test]
+    fn streaming_feed_rejects_null_session_and_out() {
+        let samples = [0.0_f32; 320];
+        let mut events: *mut OpenAsrStreamingEvents = ptr::null_mut();
+        // SAFETY: null session with a valid out pointer is the case under test.
+        let status = unsafe {
+            openasr_streaming_feed(
+                ptr::null_mut(),
+                samples.as_ptr(),
+                samples.len(),
+                &mut events,
+            )
+        };
+        assert_eq!(status, OpenAsrStatus::InvalidArgument);
+        assert!(events.is_null());
+
+        // SAFETY: null out pointer is separately rejected before any deref.
+        let status = unsafe {
+            openasr_streaming_feed(
+                ptr::null_mut(),
+                samples.as_ptr(),
+                samples.len(),
+                ptr::null_mut(),
+            )
+        };
+        assert_eq!(status, OpenAsrStatus::InvalidArgument);
+    }
+
+    #[test]
+    fn streaming_finish_rejects_null_session_and_out() {
+        let mut result: *mut OpenAsrResult = ptr::null_mut();
+        // SAFETY: null session with a valid out pointer is the case under test.
+        let status = unsafe { openasr_streaming_finish(ptr::null_mut(), &mut result) };
+        assert_eq!(status, OpenAsrStatus::InvalidArgument);
+        assert!(result.is_null());
+
+        // SAFETY: null out pointer is separately rejected before any deref.
+        let status = unsafe { openasr_streaming_finish(ptr::null_mut(), ptr::null_mut()) };
+        assert_eq!(status, OpenAsrStatus::InvalidArgument);
+    }
+
+    #[test]
+    fn streaming_free_and_events_free_accept_null() {
+        // SAFETY: null is an explicitly documented no-op for both.
+        unsafe {
+            openasr_streaming_free(ptr::null_mut());
+            openasr_streaming_events_free(ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn streaming_event_accessors_fail_closed_on_null_batch() {
+        // SAFETY: null `events` is the documented fail-closed case for every
+        // accessor below.
+        unsafe {
+            assert_eq!(openasr_streaming_events_count(ptr::null()), 0);
+            assert_eq!(
+                openasr_streaming_event_kind(ptr::null(), 0),
+                OpenAsrStreamingEventKind::Partial
+            );
+            assert!(openasr_streaming_event_text(ptr::null(), 0).is_null());
+            assert!(openasr_streaming_event_utterance_id(ptr::null(), 0).is_null());
+            assert!(openasr_streaming_event_segment_id(ptr::null(), 0).is_null());
+            assert!(openasr_streaming_event_language(ptr::null(), 0).is_null());
+            assert_eq!(openasr_streaming_event_revision(ptr::null(), 0), 0);
+            assert_eq!(openasr_streaming_event_start_ms(ptr::null(), 0), 0);
+            assert_eq!(openasr_streaming_event_end_ms(ptr::null(), 0), 0);
+        }
+    }
+
+    #[test]
+    fn streaming_events_roundtrip_through_accessors() {
+        let batch = Box::into_raw(Box::new(OpenAsrStreamingEvents {
+            events: vec![
+                owned_streaming_event(sample_streaming_event(StreamingEventKind::Partial, "hello")),
+                owned_streaming_event(sample_streaming_event(
+                    StreamingEventKind::Committed,
+                    "hello world",
+                )),
+            ],
+        }));
+        // SAFETY: `batch` came from `Box::into_raw` above and is freed at the
+        // end of this test.
+        unsafe {
+            assert_eq!(openasr_streaming_events_count(batch), 2);
+
+            assert_eq!(
+                openasr_streaming_event_kind(batch, 0),
+                OpenAsrStreamingEventKind::Partial
+            );
+            assert_eq!(
+                CStr::from_ptr(openasr_streaming_event_text(batch, 0))
+                    .to_str()
+                    .unwrap(),
+                "hello"
+            );
+
+            assert_eq!(
+                openasr_streaming_event_kind(batch, 1),
+                OpenAsrStreamingEventKind::Committed
+            );
+            assert_eq!(
+                CStr::from_ptr(openasr_streaming_event_text(batch, 1))
+                    .to_str()
+                    .unwrap(),
+                "hello world"
+            );
+            assert_eq!(
+                CStr::from_ptr(openasr_streaming_event_utterance_id(batch, 1))
+                    .to_str()
+                    .unwrap(),
+                "utt_000001"
+            );
+            assert_eq!(
+                CStr::from_ptr(openasr_streaming_event_segment_id(batch, 1))
+                    .to_str()
+                    .unwrap(),
+                "seg_000001"
+            );
+            assert_eq!(
+                CStr::from_ptr(openasr_streaming_event_language(batch, 1))
+                    .to_str()
+                    .unwrap(),
+                "en"
+            );
+            assert_eq!(openasr_streaming_event_revision(batch, 1), 3);
+            assert_eq!(openasr_streaming_event_start_ms(batch, 1), 100);
+            assert_eq!(openasr_streaming_event_end_ms(batch, 1), 900);
+
+            // Out-of-range index fails closed rather than reading OOB.
+            assert!(openasr_streaming_event_text(batch, 5).is_null());
+            assert_eq!(openasr_streaming_event_revision(batch, 5), 0);
+
+            openasr_streaming_events_free(batch);
+        }
+    }
+
+    #[test]
+    fn streaming_config_from_c_null_is_defaults() {
+        // SAFETY: a null config pointer is the documented "use defaults" case.
+        let cfg = unsafe { streaming_config_from_c(ptr::null()) }.unwrap();
+        let default = StreamingConfig::default();
+        assert_eq!(cfg.partial_results, default.partial_results);
+        assert_eq!(cfg.word_timestamps, default.word_timestamps);
+        assert!(cfg.vad.is_some());
+        assert!(cfg.language.is_none());
+    }
+
+    #[test]
+    fn streaming_config_from_c_applies_overrides() {
+        let language = StdCString::new("es").unwrap();
+        let raw = OpenAsrStreamingConfig {
+            partial_results: false,
+            word_timestamps: true,
+            enable_vad: false,
+            language: language.as_ptr(),
+            hardware_target: OpenAsrHardwareTarget::Cpu,
+            inference_threads: 4,
+            partial_poll_interval_ms: 250,
+        };
+        // SAFETY: `raw` is a valid config with a valid, live `language` C string.
+        let cfg = unsafe { streaming_config_from_c(&raw) }.unwrap();
+        assert!(!cfg.partial_results);
+        assert!(cfg.word_timestamps);
+        assert!(cfg.vad.is_none());
+        assert_eq!(cfg.language.as_deref(), Some("es"));
+        assert_eq!(cfg.hardware_target, NativeAsrHardwareTarget::Cpu);
+        assert_eq!(cfg.inference_threads, Some(4));
+        assert_eq!(cfg.partial_poll_interval_ms, 250);
+    }
+
+    /// End-to-end C-ABI roundtrip against a real `.oasr` pack: open a session,
+    /// feed synthetic PCM in chunks, drain events through the accessors, finish,
+    /// read the transcript, and free everything -- asserting only that the C
+    /// plumbing does not crash, leak, or fail (transcript quality is covered by
+    /// `openasr-core`'s `streaming_matches_batch_transcribe`). Ignored by
+    /// default because it needs model weights + a compiled ggml backend, which
+    /// the weight-free default suite must not require. Run manually:
+    ///
+    /// ```text
+    /// OPENASR_TEST_STREAMING_PACK=/path/to/moonshine-tiny-q8_0.oasr \
+    ///   cargo test -p openasr-ffi streaming_c_abi_roundtrip -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "requires a real .oasr pack via OPENASR_TEST_STREAMING_PACK"]
+    fn streaming_c_abi_roundtrip() {
+        let pack = std::env::var("OPENASR_TEST_STREAMING_PACK")
+            .expect("set OPENASR_TEST_STREAMING_PACK to a local .oasr pack");
+        let pack_c = StdCString::new(pack).unwrap();
+
+        let cfg = OpenAsrStreamingConfig {
+            partial_results: true,
+            word_timestamps: false,
+            enable_vad: false,
+            language: ptr::null(),
+            hardware_target: OpenAsrHardwareTarget::Cpu,
+            inference_threads: 0,
+            partial_poll_interval_ms: 0,
+        };
+
+        let mut session: *mut OpenAsrStreamingSession = ptr::null_mut();
+        // SAFETY: valid pack C string, valid config, valid out pointer.
+        let status = unsafe { openasr_streaming_session_open(pack_c.as_ptr(), &cfg, &mut session) };
+        assert_eq!(status, OpenAsrStatus::Ok, "open: {}", last_error());
+        assert!(!session.is_null());
+
+        // ~2s of a low-amplitude 440 Hz tone at 16 kHz, fed in 100 ms chunks.
+        let total: Vec<f32> = (0..32_000)
+            .map(|n| 0.1 * (2.0 * std::f32::consts::PI * 440.0 * n as f32 / 16_000.0).sin())
+            .collect();
+        for chunk in total.chunks(1_600) {
+            let mut events: *mut OpenAsrStreamingEvents = ptr::null_mut();
+            // SAFETY: live session, valid chunk pointer/len, valid out pointer.
+            let status = unsafe {
+                openasr_streaming_feed(session, chunk.as_ptr(), chunk.len(), &mut events)
+            };
+            assert_eq!(status, OpenAsrStatus::Ok, "feed: {}", last_error());
+            assert!(!events.is_null());
+            // SAFETY: `events` is a live batch; drain then free it.
+            unsafe {
+                for i in 0..openasr_streaming_events_count(events) {
+                    let _ = openasr_streaming_event_kind(events, i);
+                    let _ = openasr_streaming_event_text(events, i);
+                }
+                openasr_streaming_events_free(events);
+            }
+        }
+
+        let mut result: *mut OpenAsrResult = ptr::null_mut();
+        // SAFETY: live session (consumed here), valid out pointer.
+        let status = unsafe { openasr_streaming_finish(session, &mut result) };
+        assert_eq!(status, OpenAsrStatus::Ok, "finish: {}", last_error());
+        assert!(!result.is_null());
+        // SAFETY: `result` is a live handle from finish; read then free it.
+        unsafe {
+            let text_ptr = openasr_result_text(result);
+            assert!(!text_ptr.is_null());
+            let _ = CStr::from_ptr(text_ptr).to_str().unwrap();
             openasr_result_free(result);
         }
     }

--- a/docs/SDK_IOS_MACOS.md
+++ b/docs/SDK_IOS_MACOS.md
@@ -10,15 +10,21 @@ plus a generated header, not a Rust-shaped API.
 
 - Version query.
 - Load a local `.oasr` model pack path -> opaque handle.
-- Transcribe one whole in-memory 16 kHz mono PCM buffer (`f32` or `i16`) ->
-  text, optional per-segment timestamps, detected/requested language.
+- **Batch**: transcribe one whole in-memory 16 kHz mono PCM buffer (`f32` or
+  `i16`) -> text, optional per-segment timestamps, detected/requested language.
+- **Streaming**: open a live session, feed 16 kHz mono `f32` PCM chunks, receive
+  incremental partial/committed transcript events, then finish for the assembled
+  final transcript (`openasr_streaming_*`). This is the in-process,
+  transport-free path an iOS app uses for live captioning -- iOS cannot spawn the
+  desktop realtime server, so it links the same
+  `openasr_core::StreamingSession` engine directly.
 - Error codes + last-error text; every call is panic-safe (no unwind crosses
   the FFI boundary; see `crates/openasr-ffi/src/lib.rs` module docs).
 
-**Not in v1**: streaming/live dictation, the local HTTP server, or model
-download. SDK consumers bring and manage their own `.oasr` packs -- OpenASR's
-"no silent download" product boundary (see `AGENTS.md`) is a CLI/server
-concern; an embedded SDK has no business reaching the network on its own.
+**Not in v1**: the local HTTP server, or model download. SDK consumers bring and
+manage their own `.oasr` packs -- OpenASR's "no silent download" product boundary
+(see `AGENTS.md`) is a CLI/server concern; an embedded SDK has no business
+reaching the network on its own.
 
 **CPU-only v1, and iOS Metal is not wired up at all yet.** `crates/openasr-core/build.rs`
 gates the `GGML_METAL`/`GGML_METAL_EMBED_LIBRARY` cmake flags on
@@ -136,6 +142,62 @@ for (uintptr_t i = 0; i < openasr_result_segment_count(result); i++) {
 
 openasr_result_free(result);
 openasr_model_close(model);
+```
+
+### Streaming (live captioning)
+
+The streaming surface is a separate session type -- not the batch
+`OpenAsrModel` -- because it holds live decoder state across chunks. Shape (see
+the header for the full accessor set and ownership rules):
+
+```c
+// Open / drive / finish a live session. finish() consumes the session and
+// returns the final transcript as an OpenAsrResult (read with the same
+// openasr_result_* accessors as the batch path).
+OpenAsrStatus openasr_streaming_session_open(const char *path,
+                                             const OpenAsrStreamingConfig *config,  // NULL = defaults
+                                             OpenAsrStreamingSession **out_session);
+OpenAsrStatus openasr_streaming_feed(OpenAsrStreamingSession *session,
+                                     const float *pcm, uintptr_t pcm_len_samples,  // 16 kHz mono f32
+                                     OpenAsrStreamingEvents **out_events);
+OpenAsrStatus openasr_streaming_finish(OpenAsrStreamingSession *session, OpenAsrResult **out_result);
+void openasr_streaming_free(OpenAsrStreamingSession *session);   // abort without finishing
+
+// Read one feed()'s events by index (whisper.cpp-style accessors again).
+uintptr_t                 openasr_streaming_events_count(const OpenAsrStreamingEvents *events);
+OpenAsrStreamingEventKind openasr_streaming_event_kind(const OpenAsrStreamingEvents *events, uintptr_t i);
+const char               *openasr_streaming_event_text(const OpenAsrStreamingEvents *events, uintptr_t i);
+const char               *openasr_streaming_event_segment_id(const OpenAsrStreamingEvents *events, uintptr_t i);
+uint64_t                  openasr_streaming_event_start_ms(const OpenAsrStreamingEvents *events, uintptr_t i);
+void                      openasr_streaming_events_free(OpenAsrStreamingEvents *events);
+```
+
+```c
+OpenAsrStreamingSession *session = NULL;
+if (openasr_streaming_session_open("/path/to/model.oasr", NULL, &session) != OPEN_ASR_STATUS_OK) {
+    fprintf(stderr, "open failed: %s\n", openasr_last_error_message());
+    return 1;
+}
+
+// Feed captured audio as it arrives (any chunk length):
+while (capturing) {
+    OpenAsrStreamingEvents *events = NULL;
+    if (openasr_streaming_feed(session, chunk_f32, chunk_len, &events) != OPEN_ASR_STATUS_OK) break;
+    for (uintptr_t i = 0; i < openasr_streaming_events_count(events); i++) {
+        printf("%s: %s\n",
+               openasr_streaming_event_kind(events, i) == OPEN_ASR_STREAMING_EVENT_KIND_COMMITTED
+                   ? "final" : "partial",
+               openasr_streaming_event_text(events, i));
+    }
+    openasr_streaming_events_free(events);
+}
+
+OpenAsrResult *final = NULL;
+if (openasr_streaming_finish(session, &final) == OPEN_ASR_STATUS_OK) {   // consumes session
+    printf("%s\n", openasr_result_text(final));
+    openasr_result_free(final);
+}
+// session is already freed by finish(); on an error path use openasr_streaming_free(session) instead.
 ```
 
 ### Swift bridging (minimal sketch)


### PR DESCRIPTION
## Summary

Add `StreamingSession`, a transport-free in-process streaming transcription API in `openasr-core`. It feeds 16 kHz mono `f32` PCM chunks into the same native ggml streaming engine the desktop server's realtime path drives, and returns incremental partial/committed transcript events plus a final `Transcription`.

## Why

The desktop realtime path is only reachable over the server's WebSocket/SSE transport. iOS cannot spawn a process or run a background HTTP server, so live captioning there needs a library-level API it can call in-process. This is the core-side groundwork for iOS Live captions (0.2-0.3 mobile support).

## Changes

- `crates/openasr-core/src/api/streaming.rs`: `StreamingSession` (`new(pack_path, cfg)` / `feed(&[f32])` / `finish()`), `StreamingConfig`, `StreamingEvent`, `StreamingEventKind`.
  - Reuses existing infrastructure, no new subsystem: model resolution via `native_runtime_model_adapter_for_path`, decode via `NativeAsrExecutor::start_streaming_session` (the shared greedy-decode driver; no hand-rolled loop), utterance segmentation via the core energy `VadStateMachine`. Engine events (`RealtimeEventEnvelope`) are mapped to a compact `StreamingEvent`.
  - Frames the incoming stream at 20 ms; partial polling is time-spaced (default 200 ms of accumulated audio) to mirror the server's timer-driven poll, so a fast family whose encoder needs more than one frame is never polled on a near-empty buffer.
  - Fail-closed and offline: only runs the local `.oasr` pack it is handed; never touches the network.
- `crates/openasr-core/src/api/mod.rs`, `lib.rs`: register module and re-export the four public types.
- `streaming_tests.rs`: weight-free unit tests (framing, VAD segmentation, event mapping, CJK joining) plus an env-gated end-to-end parity test.

## Tests run

- [x] `cargo fmt --check` (openasr-core)
- [x] `cargo clippy --all-targets -- -D warnings` (openasr-core)
- [ ] `cargo nextest run --workspace` — ran `cargo test -p openasr-core --lib` instead (2111 passed, 0 failed); change is additive and isolated to openasr-core.
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

End-to-end parity against the batch path with a real `moonshine-tiny-q8_0` pack (isolated `OPENASR_HOME`, `fixtures/jfk.wav`): chunk-fed streaming produced 39 growing partials and a final byte-identical to the whole-file `NativeBackend` batch decode (WER 0.000). Reproduce:

```text
OPENASR_TEST_STREAMING_PACK=/path/to/moonshine-tiny-q8_0.oasr \
  cargo test -p openasr-core streaming_matches_batch_transcribe -- --ignored --nocapture
```

## Scope / non-goals

- No FFI/C ABI surface yet; this is the Rust library API the mobile bridge will call.
- No mic capture or UI (those live in the app repo).
- `moonshine-tiny` streams via buffered re-decode (the true-streaming path every builtin family registers), not frame-sync append-only partials; that is expected for this family.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implemented with AI assistance; author reviewed and owns the change.
