### PR TITLE
feat(core): default the Windows dictation shortcut to left Ctrl + left Win

### DIFF
--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -663,10 +663,31 @@ fn render_download_source_pref(pref: &DownloadSourcePref) -> String {
     }
 }
 
-/// The product default dictation trigger: Option (macOS ⌥) alone, held or tapped
-/// per the push-to-talk mode. This is the single source of truth for the
-/// first-launch shortcut; the desktop frontend's `DEFAULT_DESKTOP_PREFERENCES`
-/// only mirrors it as an offline fallback (`"Alt"` <-> `["⌥"]`).
+/// The product default dictation trigger, held or tapped per the push-to-talk
+/// mode. This is the single source of truth for the first-launch shortcut;
+/// the desktop frontend's `DEFAULT_DESKTOP_PREFERENCES` only mirrors it as an
+/// offline fallback.
+///
+/// macOS/Linux: Option alone (`"Alt"` <-> `["⌥"]`). Windows ships a LEFT
+/// Ctrl+LEFT Win chord instead (`"LControl+LCommand"` <-> `["L⌃", "L⌘"]` on
+/// the desktop frontend) -- bare Alt collides there with the native
+/// Alt-menu-mode (WM_SYSKEYDOWN) and Win-key Start-Menu quirks that can steal
+/// window focus mid-press (see the desktop's dictation_hotkey.rs /
+/// ShortcutRecorder). It is pinned to the LEFT side of each key specifically
+/// (not the unsided `"Control+Command"`, which matched either side and was
+/// the default through 2026-07): the right Ctrl/Win keys stay completely free
+/// for their normal OS/IME use. `"LCommand"` here is the LITERAL Windows key
+/// (left side), not the cross-platform `"CommandOrControl"` alias -- the two
+/// must never be conflated, or a recorded Win key silently resolves back to
+/// Ctrl on Windows. See dictation_hotkey.rs's `FLAG_L*`/`MOD_*_L` side bits
+/// and `mods_satisfy` for how a sided token is matched at runtime; a legacy
+/// persisted `"Control+Command"` config keeps matching either side unchanged.
+#[cfg(windows)]
+fn default_dictation_shortcut() -> Option<String> {
+    Some("LControl+LCommand".to_string())
+}
+
+#[cfg(not(windows))]
 fn default_dictation_shortcut() -> Option<String> {
     Some("Alt".to_string())
 }

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+/// The product default `dictation_shortcut` for the host the test suite is
+/// compiled for -- mirrors `default_dictation_shortcut()`'s own `#[cfg]`
+/// split so these tests assert the SAME per-platform default the function
+/// actually returns, not a single hardcoded value that would false-fail on
+/// whichever platform did not get the hardcoded string.
+#[cfg(windows)]
+fn expected_default_dictation_shortcut() -> &'static str {
+    "LControl+LCommand"
+}
+
+#[cfg(not(windows))]
+fn expected_default_dictation_shortcut() -> &'static str {
+    "Alt"
+}
+
 fn registry() -> Vec<ModelCard> {
     vec![
         crate::registry::test_model_card("qwen3-asr-0.6b"),
@@ -130,12 +145,13 @@ fn missing_config_file_returns_default_config_document_preferences() {
     assert_eq!(document.preferences.hotwords, Vec::<String>::new());
     assert_eq!(document.preferences.theme, AppearanceTheme::System);
     assert_eq!(document.preferences.density, AppearanceDensity::Comfortable);
-    // Product default: Option (⌥) alone, push-to-talk on. A fresh install (no
-    // config file) must land on these; the desktop first-launch experience
-    // reads them straight through /v1/config.
+    // Product default: Option (⌥) alone on macOS/Linux, Ctrl+Win on Windows
+    // (see default_dictation_shortcut's doc comment), push-to-talk on. A fresh
+    // install (no config file) must land on these; the desktop first-launch
+    // experience reads them straight through /v1/config.
     assert_eq!(
         document.preferences.dictation_shortcut.as_deref(),
-        Some("Alt")
+        Some(expected_default_dictation_shortcut())
     );
     assert!(document.preferences.push_to_talk);
     assert_eq!(document.preferences.inference_threads, None);
@@ -150,7 +166,7 @@ fn preferences_missing_dictation_fields_fall_back_to_product_defaults() {
         serde_json::from_str(r#"{ "config": {}, "preferences": { "language": "en" } }"#).unwrap();
     assert_eq!(
         document.preferences.dictation_shortcut.as_deref(),
-        Some("Alt")
+        Some(expected_default_dictation_shortcut())
     );
     assert!(document.preferences.push_to_talk);
 }

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -23,6 +23,21 @@ use tower::ServiceExt;
 const SERVER_INSTANCE_TOKEN_ENV: &str = "OPENASR_SERVER_INSTANCE_TOKEN";
 const LIVE_PULL_FIXTURE_SIZE_BYTES: u64 = 64 * 1024 * 1024;
 
+/// The product default `dictation_shortcut` for the host this test binary is
+/// compiled for -- mirrors openasr-core's `default_dictation_shortcut()`
+/// `#[cfg]` split (Ctrl+Win on Windows, Option alone elsewhere), so the
+/// fresh-config assertion below tracks the real default on every platform
+/// instead of a single hardcoded string.
+#[cfg(windows)]
+fn expected_default_dictation_shortcut() -> &'static str {
+    "LControl+LCommand"
+}
+
+#[cfg(not(windows))]
+fn expected_default_dictation_shortcut() -> &'static str {
+    "Alt"
+}
+
 fn sample_wav_bytes() -> Vec<u8> {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/jfk.wav");
     std::fs::read(path).unwrap()
@@ -615,9 +630,13 @@ async fn config_endpoint_roundtrips_versioned_preferences() {
         document["preferences"]["version"],
         openasr_core::config::PREFERENCES_SCHEMA_VERSION
     );
-    // Fresh-config product defaults surfaced to the desktop: Option (⌥) alone,
-    // push-to-talk on. These are what a cleared-state first launch shows.
-    assert_eq!(document["preferences"]["dictation_shortcut"], "Alt");
+    // Fresh-config product defaults surfaced to the desktop: Option (⌥) alone
+    // on macOS/Linux, Ctrl+Win on Windows, push-to-talk on. These are what a
+    // cleared-state first launch shows.
+    assert_eq!(
+        document["preferences"]["dictation_shortcut"],
+        expected_default_dictation_shortcut()
+    );
     assert_eq!(document["preferences"]["push_to_talk"], true);
     assert_eq!(document["preferences"]["word_timestamps"], false);
 


### PR DESCRIPTION
## Summary

Change the default `dictation_shortcut` on Windows from `Alt` to the sided `LControl+LCommand` (left Ctrl + left Win). Other platforms keep `Alt` (Option).

## Why

Bare Alt fights the OS on Windows: tapping it activates the foreground app's menu bar, and in a WebView2 shell it blurs the webview the moment it is pressed (which also broke shortcut recording UX in the desktop app). Win alone opens the Start Menu. Ctrl+Win held together has no OS-level side effect, and pinning the left side keeps the right-hand keys free for their normal OS/IME use.

## Changes

- `crates/openasr-core/src/config.rs`: `default_dictation_shortcut()` split by `#[cfg(windows)]` -> `LControl+LCommand`; non-Windows unchanged (`Alt`).
- `crates/openasr-core/src/config_tests.rs`, `crates/openasr-server/tests/api.rs`: platform-aware default assertions on both cfg branches.

Sided tokens are parsed by the desktop shell's hotkey engine; core only validates non-emptiness, unchanged.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (openasr-core, openasr-server)
- [ ] `cargo nextest run --workspace` (scoped instead: `cargo test -p openasr-core --lib config` 105 pass; `cargo test -p openasr-server --test api` preferences/config 6 pass; workspace-wide run on this Windows checkout has 3 pre-existing env failures unrelated to this change: CRLF byte-compare in realtime codegen, a pull-lock test fixture, a Unix-only memory probe)
- [ ] `cargo test --workspace --doc` (not run; no doc changes)
- [ ] `cargo deny check` (not run; no dependency changes)

## Manual smoke checks

Deployed in the desktop shell on Windows hardware: fresh config (key absent) fills `LControl+LCommand` via `GET /v1/config`; hold-to-talk triggers on left Ctrl+left Win and not on the right-side keys.

## Docs updated

- [x] No docs overclaim current capabilities (no doc changes needed; default is surfaced in the desktop UI).

## Scope / non-goals

- No changes to shortcut parsing/validation in core.
- Existing user configs are not migrated; a persisted `Alt` (or any other value) is untouched.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES