### PR TITLE
feat(moss): MOSS-Transcribe-Diarize family (transcription + diarization + timestamps)

### DIFF
--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -966,6 +966,27 @@ pub fn validate_native_runtime_model_pack_contract(path: &Path) -> Result<(), St
                     )
                 })
         }
+        crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID => {
+            crate::models::moss_transcribe_diarize::runtime_contract::parse_encoder_metadata(&metadata)
+                .map(|_| ())
+                .and_then(|()| {
+                    crate::models::moss_transcribe_diarize::runtime_contract::parse_adaptor_metadata(
+                        &metadata,
+                    )
+                    .map(|_| ())
+                })
+                .and_then(|()| {
+                    crate::models::moss_transcribe_diarize::runtime_contract::parse_decoder_metadata(
+                        &metadata,
+                    )
+                    .map(|_| ())
+                })
+                .map_err(|error| {
+                    format!(
+                        "moss-transcribe-diarize runtime metadata contract validation failed: {error} ({RUNTIME_CONTRACT_OUTDATED_PACK_HINT})"
+                    )
+                })
+        }
         // No dedicated required-metadata parser for this architecture (yet):
         // stay Ok() here, same as before this check existed. The executor
         // still fails closed at first load if the pack is incomplete.

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1439,6 +1439,19 @@ fn resolve_native_longform_policy_for_backend(
         }
     };
     let mut provenance = Vec::new();
+    // A self-chunking family (its dedicated executor ingests the full audio in
+    // one decode with globally continuous time anchors) must never be sliced by
+    // the native longform slicer -- per-window decoding would restart its time
+    // anchors at zero. Force Off even for an explicit longform request, since
+    // the executor never consults longform options.
+    if architecture_executor_consumes_full_audio(model_architecture)
+        && !matches!(options.mode, LongFormMode::Off)
+    {
+        provenance.push(format!(
+            "native longform disabled: '{model_architecture}' executor consumes the full audio in one decode"
+        ));
+        options.mode = LongFormMode::Off;
+    }
     if !matches!(options.mode, LongFormMode::Off) {
         apply_longform_safety_policy(model_architecture, &mut options, &mut provenance);
     }
@@ -1446,6 +1459,19 @@ fn resolve_native_longform_policy_for_backend(
         options,
         provenance,
     }
+}
+
+/// True when the architecture's dedicated executor ingests arbitrarily long
+/// audio in a single decode (its own internal window chunking), so the shared
+/// native longform slicer must stay off. Driven by the decode-policy descriptor
+/// (`BuiltinDecodePolicyLongformProfile::SelfChunkingExecutorV1`) so the fact
+/// lives with the family's other decode semantics, not as a magic string here.
+fn architecture_executor_consumes_full_audio(model_architecture: &str) -> bool {
+    resolve_builtin_decode_policy_for_architecture(model_architecture)
+        .map(|policy| {
+            policy.longform_profile == BuiltinDecodePolicyLongformProfile::SelfChunkingExecutorV1
+        })
+        .unwrap_or(false)
 }
 
 /// Applies every family-specific longform safety cap for `model_architecture`.
@@ -2583,6 +2609,32 @@ mod tests {
         let resolution =
             resolve_native_longform_policy_for_backend(None, 120.0, "", GgmlCpuGraphBackend::Cpu);
         assert_eq!(resolution.options.mode, LongFormMode::Auto);
+    }
+
+    #[test]
+    fn self_chunking_family_forces_longform_off_even_for_long_audio() {
+        // moss-transcribe-diarize ingests the full audio in one decode
+        // (`SelfChunkingExecutorV1`); the native slicer must stay off so its
+        // global time anchors are not restarted per VAD window.
+        let implicit = resolve_native_longform_policy_for_backend(
+            None,
+            180.0,
+            crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID,
+            GgmlCpuGraphBackend::Cpu,
+        );
+        assert_eq!(implicit.options.mode, LongFormMode::Off);
+        // Even an explicit longform request is overridden (the executor never
+        // consults longform options).
+        let explicit = resolve_native_longform_policy_for_backend(
+            Some(&crate::LongFormOptions {
+                mode: LongFormMode::Energy,
+                ..crate::LongFormOptions::default()
+            }),
+            180.0,
+            crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID,
+            GgmlCpuGraphBackend::Cpu,
+        );
+        assert_eq!(explicit.options.mode, LongFormMode::Off);
     }
 
     #[test]

--- a/crates/openasr-core/src/arch/hparams.rs
+++ b/crates/openasr-core/src/arch/hparams.rs
@@ -243,6 +243,30 @@ pub(crate) static FIRERED_LLM_HPARAM_SCHEMA: &[&str] = &[
     "firered_llm.llm.speech_token_id",
 ];
 
+// Keys mirror `models::moss_transcribe_diarize::runtime_contract`'s three
+// parsers.
+pub(crate) static MOSS_TD_HPARAM_SCHEMA: &[&str] = &[
+    "moss_td.encoder.n_layers",
+    "moss_td.encoder.d_model",
+    "moss_td.encoder.n_heads",
+    "moss_td.encoder.ffn_dim",
+    "moss_td.encoder.n_mels",
+    "moss_td.encoder.max_source_positions",
+    "moss_td.adaptor.merge_size",
+    "moss_td.adaptor.input_dim",
+    "moss_td.llm.n_layers",
+    "moss_td.llm.d_model",
+    "moss_td.llm.ffn_dim",
+    "moss_td.llm.n_heads",
+    "moss_td.llm.n_kv_heads",
+    "moss_td.llm.head_dim",
+    "moss_td.llm.vocab_size",
+    "moss_td.llm.max_positions",
+    "moss_td.llm.audio_start_token_id",
+    "moss_td.llm.audio_end_token_id",
+    "moss_td.llm.audio_pad_token_id",
+];
+
 // ── mimo-asr (XiaomiMiMo/MiMo-V2.5-ASR + MiMo-Audio-Tokenizer) hparam schema ─
 // Keys mirror `models::mimo_asr::runtime_contract`'s parsers. Deliberately
 // checks only the top-level presence gate (block counts + special-token ids);

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -325,7 +325,9 @@ pub(crate) struct OpenAsrArchitectureDescriptor {
     /// Silicon Metal specifically (a 29-frame chunk graph too small to
     /// amortize Metal's per-dispatch overhead) -- see
     /// `models::xasr_zipformer::graph_config::encoder_gpu_enabled` -- so it
-    /// is now the sole builtin `ExceptMetal`. That same audit also measured a
+    /// was for a time the sole builtin `ExceptMetal`; moss-transcribe-diarize
+    /// later joined it (Metal encoder-numeric divergence + per-step wired-memory
+    /// blow-up, documented on that descriptor). That same audit also measured a
     /// Metal slowdown for qwen and moonshine, but neither is gated: qwen's
     /// looks like a fixed size x quant platform trade-off rather than a code
     /// bug, and that read is left to a dedicated follow-up before being baked
@@ -1629,11 +1631,23 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: MOSS_TD_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
-        // Perf/backend tuning is explicitly out of scope for this stage (see
-        // `models::moss_transcribe_diarize::mod`'s stage-status note) --
-        // start un-gated like every other family's initial landing, revisit
-        // once a real Metal-vs-CPU measurement exists.
-        auto_gpu_policy: AutoGpuPolicy::AllBackends,
+        // Auto is pinned OFF Metal for this family until two Metal-specific
+        // defects are fixed (both measured on an M1, CPU parity confirmed; each
+        // is its own follow-up, out of scope for this landing):
+        //   1. Encoder numeric divergence: the Whisper encoder's deep layers
+        //      decorrelate on Metal (final-layer cosine ~0.20 vs the fp32 CPU
+        //      reference, which matches), collapsing decoding to an empty
+        //      `[..][S01][..]` shell. CPU produces the correct transcript.
+        //   2. Memory blow-up: the per-token decode rebuilds the whole 28-layer
+        //      ggml graph each step; on Metal the wired working set exhausts a
+        //      16 GB machine, while the same run peaks ~2.8 GB on CPU. (The KV
+        //      over-allocation half of this is already fixed via
+        //      `runtime_contract::moss_td_kv_cache_positions`; the remaining
+        //      per-step graph/wired behavior is Metal-only and still open.)
+        // `ExceptMetal` only steers Auto to CPU; an explicit
+        // `execution_target=accelerated` still gets Metal (and both defects),
+        // by design. Revisit -> `AllBackends` once 1 and 2 land.
+        auto_gpu_policy: AutoGpuPolicy::ExceptMetal,
         // The model is trained to emit `[S01]`/`[S02]`/... speaker labels
         // directly in its transcript text (see `decode_prompt`'s fixed
         // instruction), so this family diarizes itself -- there is no
@@ -1780,7 +1794,10 @@ mod tests {
             (FIRERED_AED_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
             (FIRERED_LLM_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
             (MIMO_ASR_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
-            (MOSS_TD_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
+            // Pinned off Metal until the family's Metal encoder-numeric and
+            // wired-memory defects are fixed (see the descriptor's
+            // `auto_gpu_policy` note).
+            (MOSS_TD_GGML_ARCHITECTURE_ID, AutoGpuPolicy::ExceptMetal),
         ];
         let registry = OpenAsrArchitectureRegistry::with_builtins();
         let mut seen = std::collections::BTreeSet::new();

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -22,10 +22,10 @@ use hparams::{
     COHERE_TRANSCRIBE_DECODER_LAYERS_KEY, COHERE_TRANSCRIBE_ENCODER_LAYERS_KEY,
     COHERE_TRANSCRIBE_HPARAM_SCHEMA, DOLPHIN_HPARAM_SCHEMA, FIRERED_AED_HPARAM_SCHEMA,
     FIRERED_LLM_HPARAM_SCHEMA, MIMO_ASR_HPARAM_SCHEMA, MOONSHINE_HPARAM_SCHEMA,
-    PARAKEET_CTC_HPARAM_SCHEMA, PARAKEET_TDT_HPARAM_SCHEMA, QWEN3_ARCHITECTURE_VALUE,
-    QWEN3_ASR_HPARAM_SCHEMA, QWEN3_AUDIO_LAYERS_KEY, QWEN3_LLM_LAYERS_KEY,
-    SENSEVOICE_HPARAM_SCHEMA, WAV2VEC2_CTC_HPARAM_SCHEMA, WHISPER_HPARAM_SCHEMA,
-    XASR_ZIPFORMER_HPARAM_SCHEMA,
+    MOSS_TD_HPARAM_SCHEMA, PARAKEET_CTC_HPARAM_SCHEMA, PARAKEET_TDT_HPARAM_SCHEMA,
+    QWEN3_ARCHITECTURE_VALUE, QWEN3_ASR_HPARAM_SCHEMA, QWEN3_AUDIO_LAYERS_KEY,
+    QWEN3_LLM_LAYERS_KEY, SENSEVOICE_HPARAM_SCHEMA, WAV2VEC2_CTC_HPARAM_SCHEMA,
+    WHISPER_HPARAM_SCHEMA, XASR_ZIPFORMER_HPARAM_SCHEMA,
 };
 
 pub(crate) const GENERAL_ARCHITECTURE_KEY: &str = "general.architecture";
@@ -186,6 +186,28 @@ pub(crate) const MIMO_ASR_TOKENIZER_ID: &str = "mimo-asr.gpt2-bpe.v0";
 pub(crate) const MIMO_ASR_DECODE_POLICY_ID: &str = "mimo-asr.greedy.seq2seq.v0";
 pub(crate) const MIMO_ASR_RUNTIME_TENSOR_CONTRACT_ID: &str = "mimo-asr.runtime-tensors.v0";
 pub(crate) const MIMO_ASR_EXECUTOR_COMPONENT_ID: &str = "mimo-asr.ggml-executor.v0";
+
+// moss-transcribe-diarize (OpenMOSS/MOSS-Transcribe-Diarize, 0.9B): a
+// Whisper-Medium-architecture audio encoder (standard HF `WhisperEncoder`,
+// reuses the shared `crate::nn::encoder::transformer_layer` "Whisper /
+// Qwen-audio encoder shape" primitive `qwen::audio_encoder` also builds on)
+// + a pure-reshape 4x time-merge + `VQAdaptor` (a plain 3-layer MLP+LayerNorm
+// despite the name -- no VQ codebook) + a genuinely Qwen3-0.6B-parameterized
+// decoder (QK-norm, no attention bias, GQA, tied embeddings), reusing
+// `qwen`'s family-agnostic decoder machinery byte-for-byte (see
+// `models::moss_transcribe_diarize::llm_decoder`'s module doc). Like
+// firered-llm/mimo-asr, decode runs on a hand-written dedicated executor
+// (block_stack: None) -- registered in `BUILTIN_COMPONENT_DESCRIPTORS` /
+// `BUILTIN_ARCHITECTURE_DESCRIPTORS` below.
+pub(crate) const MOSS_TD_GGML_ARCHITECTURE_ID: &str = "moss-transcribe-diarize-whisper-qwen3";
+pub(crate) const MOSS_TD_GGML_ADAPTER_ID: &str = "ggml-family-moss-transcribe-diarize-runtime-v1";
+pub(crate) const MOSS_TD_MODEL_FAMILY: &str = "moss-transcribe-diarize";
+pub(crate) const MOSS_TD_AUDIO_FRONTEND_ID: &str = "moss-transcribe-diarize.fbank80.16khz.mono.v0";
+pub(crate) const MOSS_TD_TOKENIZER_ID: &str = "moss-transcribe-diarize.qwen3-bpe.v0";
+pub(crate) const MOSS_TD_DECODE_POLICY_ID: &str = "moss-transcribe-diarize.greedy.seq2seq.v0";
+pub(crate) const MOSS_TD_RUNTIME_TENSOR_CONTRACT_ID: &str =
+    "moss-transcribe-diarize.runtime-tensors.v0";
+pub(crate) const MOSS_TD_EXECUTOR_COMPONENT_ID: &str = "moss-transcribe-diarize.ggml-executor.v0";
 
 // hymt2 (Tencent Hunyuan-MT2 subtitle translation, hunyuan-dense decoder-only
 // LLM). An auxiliary text-to-text family, NOT an ASR architecture: it is
@@ -1046,6 +1068,26 @@ const BUILTIN_COMPONENT_DESCRIPTORS: &[OpenAsrComponentDescriptor] = &[
         kind: OpenAsrComponentKind::Executor,
         id: MIMO_ASR_EXECUTOR_COMPONENT_ID,
     },
+    OpenAsrComponentDescriptor {
+        kind: OpenAsrComponentKind::AudioFrontend,
+        id: MOSS_TD_AUDIO_FRONTEND_ID,
+    },
+    OpenAsrComponentDescriptor {
+        kind: OpenAsrComponentKind::DecodePolicy,
+        id: MOSS_TD_DECODE_POLICY_ID,
+    },
+    OpenAsrComponentDescriptor {
+        kind: OpenAsrComponentKind::RuntimeTensorContract,
+        id: MOSS_TD_RUNTIME_TENSOR_CONTRACT_ID,
+    },
+    OpenAsrComponentDescriptor {
+        kind: OpenAsrComponentKind::Tokenizer,
+        id: MOSS_TD_TOKENIZER_ID,
+    },
+    OpenAsrComponentDescriptor {
+        kind: OpenAsrComponentKind::Executor,
+        id: MOSS_TD_EXECUTOR_COMPONENT_ID,
+    },
 ];
 
 const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
@@ -1567,6 +1609,54 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
         },
     },
+    OpenAsrArchitectureDescriptor {
+        runtime_architecture_aliases: &[MOSS_TD_GGML_ARCHITECTURE_ID],
+        model_family: MOSS_TD_MODEL_FAMILY,
+        model_architecture: MOSS_TD_GGML_ARCHITECTURE_ID,
+        adapter_id: MOSS_TD_GGML_ADAPTER_ID,
+        // The Qwen3 decoder auto-detects/produces the transcript language
+        // through free-text instruction-following (no dedicated language
+        // token in its vocab, same shape as qwen3-asr) -- until prompt-level
+        // language conditioning is wired and verified against a real pack, an
+        // explicit hint is rejected (not faked) rather than silently ignored.
+        language_family_hint: LanguageFamilyHint::SelfDetectsRejectsHint {
+            reject_reason: "MOSS-Transcribe-Diarize auto-detects the source language via its Qwen3 decoder and does not accept an explicit selection; use a multilingual Whisper pack to force or report a language.",
+        },
+        audio_frontend_id: MOSS_TD_AUDIO_FRONTEND_ID,
+        runtime_tensor_contract_id: MOSS_TD_RUNTIME_TENSOR_CONTRACT_ID,
+        tokenizer_id: MOSS_TD_TOKENIZER_ID,
+        decode_policy_id: MOSS_TD_DECODE_POLICY_ID,
+        executor_component_id: MOSS_TD_EXECUTOR_COMPONENT_ID,
+        execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
+        prefer_cpu_decoder_for_multichunk_metal: false,
+        // Perf/backend tuning is explicitly out of scope for this stage (see
+        // `models::moss_transcribe_diarize::mod`'s stage-status note) --
+        // start un-gated like every other family's initial landing, revisit
+        // once a real Metal-vs-CPU measurement exists.
+        auto_gpu_policy: AutoGpuPolicy::AllBackends,
+        // The model is trained to emit `[S01]`/`[S02]`/... speaker labels
+        // directly in its transcript text (see `decode_prompt`'s fixed
+        // instruction), so this family diarizes itself -- there is no
+        // separate diarization pass to compose.
+        self_diarizes: true,
+        // The fixed instruction asks for full punctuation-bearing prose
+        // segments; no characterized counter-example has been observed yet,
+        // but this has not been verified against enough real transcripts to
+        // assert as a capability -- leave unclaimed rather than guess.
+        emits_punctuation: None,
+        hparam_schema: MOSS_TD_HPARAM_SCHEMA,
+        // Whisper encoder + Qwen3 decoder-only decode both stay on the
+        // dedicated executor (neither shape is a composer block kind), so no
+        // data-driven block-stack descriptor.
+        block_stack: None,
+        // Whisper's own architecture-fixed 30s log-mel window: the encoder
+        // never attends past its own fixed 1500-position chunk no matter how
+        // long the total requested audio is (the executor loops the encoder
+        // over independent 30s windows and concatenates -- see `executor.rs`'s
+        // module doc), so this needs no additional longform safety cap --
+        // same classification as `whisper` itself.
+        encoder_attention_span: OpenAsrEncoderAttentionSpan::FixedWindow,
+    },
 ];
 
 #[cfg(test)]
@@ -1604,6 +1694,7 @@ mod tests {
             (FIRERED_AED_GGML_ARCHITECTURE_ID, false, Some(false)),
             (FIRERED_LLM_GGML_ARCHITECTURE_ID, false, None),
             (MIMO_ASR_GGML_ARCHITECTURE_ID, false, None),
+            (MOSS_TD_GGML_ARCHITECTURE_ID, true, None),
         ];
         let registry = OpenAsrArchitectureRegistry::with_builtins();
         let mut seen = std::collections::BTreeSet::new();
@@ -1689,6 +1780,7 @@ mod tests {
             (FIRERED_AED_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
             (FIRERED_LLM_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
             (MIMO_ASR_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
+            (MOSS_TD_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
         ];
         let registry = OpenAsrArchitectureRegistry::with_builtins();
         let mut seen = std::collections::BTreeSet::new();
@@ -1849,6 +1941,10 @@ mod tests {
                 OpenAsrEncoderAttentionSpan::GlobalQuadratic {
                     max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
                 },
+            ),
+            (
+                MOSS_TD_GGML_ARCHITECTURE_ID,
+                OpenAsrEncoderAttentionSpan::FixedWindow,
             ),
         ];
         let registry = OpenAsrArchitectureRegistry::with_builtins();

--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -34,6 +34,7 @@ pub(crate) mod local_source_import;
 pub(crate) mod lora_adapter;
 pub(crate) mod mimo_asr;
 pub mod moonshine;
+pub(crate) mod moss_transcribe_diarize;
 pub mod oasr_metadata;
 pub mod pack_quant;
 pub(crate) mod parakeet_ctc;

--- a/crates/openasr-core/src/models/builtin_execution_dispatch.rs
+++ b/crates/openasr-core/src/models/builtin_execution_dispatch.rs
@@ -17,6 +17,7 @@ use super::firered_llm::executor::FireRedLlmGgmlExecutor;
 use super::ggml_composed_executor::ComposedGgmlAsrExecutor;
 use super::ggml_family_adapter::GgmlExecutionCapability;
 use super::mimo_asr::executor::MimoAsrGgmlExecutor;
+use super::moss_transcribe_diarize::executor::MossTdGgmlExecutor;
 use super::parakeet_ctc::executor::ParakeetCtcGgmlExecutor;
 use super::parakeet_tdt::executor::ParakeetTdtGgmlExecutor;
 use super::sensevoice::executor::SenseVoiceGgmlExecutor;
@@ -203,6 +204,14 @@ pub(crate) fn build_builtin_ggml_streaming_execution_dispatch()
         )
         .with_streaming_partial_granularity_for_adapter(
             crate::arch::MIMO_ASR_GGML_ADAPTER_ID,
+            StreamingPartialGranularity::Buffered,
+        )
+        .with_streaming_executor_for_adapter(
+            crate::arch::MOSS_TD_GGML_ADAPTER_ID,
+            Arc::new(MossTdGgmlExecutor),
+        )
+        .with_streaming_partial_granularity_for_adapter(
+            crate::arch::MOSS_TD_GGML_ADAPTER_ID,
             StreamingPartialGranularity::Buffered,
         )
         .with_streaming_executor_for_adapter(

--- a/crates/openasr-core/src/models/decode_policy_component_registry.rs
+++ b/crates/openasr-core/src/models/decode_policy_component_registry.rs
@@ -249,6 +249,38 @@ const BUILTIN_DECODE_POLICY_COMPONENTS: &[BuiltinDecodePolicyComponentDescriptor
         ctc_blank_token_id: None,
     },
     BuiltinDecodePolicyComponentDescriptor {
+        // Source of truth is `crate::arch` (same staging precedent as
+        // firered-aed above): moss-transcribe-diarize has no crate-root
+        // re-export.
+        decode_policy_id: crate::arch::MOSS_TD_DECODE_POLICY_ID,
+        execution_kind: BuiltinDecodePolicyExecutionKind::Seq2SeqGreedyV0,
+        // eot (ChatML `<|im_end|>`) is supplied per-request via
+        // `BuiltinSeq2SeqDecodePolicyConfigInput.eot_token_id`; the audio-span
+        // placeholder/marker tokens are never emitted by the LLM itself (they
+        // only ever appear in the PROMPT, spliced in by the executor), so
+        // there is nothing else to strip -- Identity postprocess, same shape
+        // as firered-llm/mimo-asr.
+        seq2seq_text_postprocess_kind: BuiltinDecodePolicySeq2SeqTextPostprocessKind::Identity,
+        seq2seq_trace_kind: BuiltinDecodePolicySeq2SeqTraceKind::None,
+        seq2seq_stop_token_kind: BuiltinDecodePolicySeq2SeqStopTokenKind::None,
+        seq2seq_suppression_kind: BuiltinDecodePolicySeq2SeqSuppressionKind::None,
+        // This family's executor already folds arbitrarily long audio into
+        // ONE prompt/decode (chunked encoder concatenation, see
+        // `executor.rs`), so it never runs multiple ChatML-turn "chunks" the
+        // way firered-llm/mimo-asr's 30-40s hard caps do, and its encoder is
+        // `FixedWindow` (Whisper-Medium), not one of the small-context plain
+        // `<sos>`-prompted AED decoders `ConservativeSeq2SeqV1` guards
+        // against repeating on long pause-free audio -- same shape as
+        // `whisper` itself, which also pairs `FixedWindow` with `Default`
+        // (see that entry above). `ConservativeSeq2SeqV1` would additionally
+        // clamp the shared native longform slicer's chunk length even though
+        // this family's dedicated executor never consults it, so `Default`
+        // is the honest choice, not just an equivalent one.
+        longform_prompt_carry_mode: BuiltinDecodePolicyLongformPromptCarryMode::TokenHistory,
+        longform_profile: BuiltinDecodePolicyLongformProfile::Default,
+        ctc_blank_token_id: None,
+    },
+    BuiltinDecodePolicyComponentDescriptor {
         // hymt2 is an auxiliary translation family (no arch-registry entry, no
         // crate-root re-export); its runtime resolves this descriptor directly
         // by policy id. Source of truth for the id is `crate::arch`.
@@ -893,9 +925,9 @@ mod tests {
             checked += 1;
         }
         // cohere-transcribe + whisper + qwen3-asr + moonshine + firered-aed +
-        // firered-llm + mimo-asr.
+        // firered-llm + mimo-asr + moss-transcribe-diarize.
         assert_eq!(
-            checked, 7,
+            checked, 8,
             "expected exactly 7 greedy-seq2seq architectures to resolve"
         );
     }

--- a/crates/openasr-core/src/models/decode_policy_component_registry.rs
+++ b/crates/openasr-core/src/models/decode_policy_component_registry.rs
@@ -23,6 +23,17 @@ pub(crate) enum BuiltinDecodePolicyLongformPromptCarryMode {
 pub(crate) enum BuiltinDecodePolicyLongformProfile {
     Default,
     ConservativeSeq2SeqV1,
+    /// The family's dedicated executor ingests the FULL audio in a single
+    /// decode (it does its own internal 30s-window encoder chunking and folds
+    /// every chunk into ONE prompt with globally continuous time anchors --
+    /// see `moss_transcribe_diarize::executor`). The shared native longform
+    /// slicer must NOT run for such a family: slicing the audio into VAD
+    /// windows and decoding each independently would restart the model's time
+    /// anchors at zero per window (chunk-aligned timestamp resets) and defeat
+    /// the whole-audio design. `resolve_native_longform_policy_for_backend`
+    /// forces `LongFormMode::Off` for this profile, even for an explicit
+    /// longform request, because the executor never consults longform options.
+    SelfChunkingExecutorV1,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -264,20 +275,18 @@ const BUILTIN_DECODE_POLICY_COMPONENTS: &[BuiltinDecodePolicyComponentDescriptor
         seq2seq_trace_kind: BuiltinDecodePolicySeq2SeqTraceKind::None,
         seq2seq_stop_token_kind: BuiltinDecodePolicySeq2SeqStopTokenKind::None,
         seq2seq_suppression_kind: BuiltinDecodePolicySeq2SeqSuppressionKind::None,
-        // This family's executor already folds arbitrarily long audio into
-        // ONE prompt/decode (chunked encoder concatenation, see
-        // `executor.rs`), so it never runs multiple ChatML-turn "chunks" the
-        // way firered-llm/mimo-asr's 30-40s hard caps do, and its encoder is
-        // `FixedWindow` (Whisper-Medium), not one of the small-context plain
-        // `<sos>`-prompted AED decoders `ConservativeSeq2SeqV1` guards
-        // against repeating on long pause-free audio -- same shape as
-        // `whisper` itself, which also pairs `FixedWindow` with `Default`
-        // (see that entry above). `ConservativeSeq2SeqV1` would additionally
-        // clamp the shared native longform slicer's chunk length even though
-        // this family's dedicated executor never consults it, so `Default`
-        // is the honest choice, not just an equivalent one.
+        // This family's executor folds arbitrarily long audio into ONE
+        // prompt/decode (chunked encoder concatenation with globally
+        // continuous time anchors, see `executor.rs`), so the shared native
+        // longform slicer must NOT run: slicing into VAD windows and decoding
+        // each independently restarts the time anchors at zero per window
+        // (chunk-aligned timestamp resets). `SelfChunkingExecutorV1` forces
+        // `LongFormMode::Off` so the full audio reaches the executor in a
+        // single decode. (This differs from `whisper`, whose 30s executor
+        // genuinely needs the native slicer for long audio, and from
+        // firered-llm/mimo-asr, whose executors cap at 30-40s per ChatML turn.)
         longform_prompt_carry_mode: BuiltinDecodePolicyLongformPromptCarryMode::TokenHistory,
-        longform_profile: BuiltinDecodePolicyLongformProfile::Default,
+        longform_profile: BuiltinDecodePolicyLongformProfile::SelfChunkingExecutorV1,
         ctc_blank_token_id: None,
     },
     BuiltinDecodePolicyComponentDescriptor {

--- a/crates/openasr-core/src/models/executor_component_registry.rs
+++ b/crates/openasr-core/src/models/executor_component_registry.rs
@@ -8,11 +8,11 @@ use thiserror::Error;
 use crate::arch::{
     COHERE_TRANSCRIBE_EXECUTOR_COMPONENT_ID, DOLPHIN_EXECUTOR_COMPONENT_ID,
     FIRERED_AED_EXECUTOR_COMPONENT_ID, FIRERED_LLM_EXECUTOR_COMPONENT_ID,
-    MIMO_ASR_EXECUTOR_COMPONENT_ID, MOONSHINE_EXECUTOR_COMPONENT_ID, OpenAsrArchitectureRegistry,
-    PARAKEET_CTC_EXECUTOR_COMPONENT_ID, PARAKEET_TDT_EXECUTOR_COMPONENT_ID,
-    QWEN3_ASR_EXECUTOR_COMPONENT_ID, SENSEVOICE_EXECUTOR_COMPONENT_ID,
-    WAV2VEC2_CTC_EXECUTOR_COMPONENT_ID, WHISPER_EXECUTOR_COMPONENT_ID,
-    XASR_ZIPFORMER_EXECUTOR_COMPONENT_ID,
+    MIMO_ASR_EXECUTOR_COMPONENT_ID, MOONSHINE_EXECUTOR_COMPONENT_ID, MOSS_TD_EXECUTOR_COMPONENT_ID,
+    OpenAsrArchitectureRegistry, PARAKEET_CTC_EXECUTOR_COMPONENT_ID,
+    PARAKEET_TDT_EXECUTOR_COMPONENT_ID, QWEN3_ASR_EXECUTOR_COMPONENT_ID,
+    SENSEVOICE_EXECUTOR_COMPONENT_ID, WAV2VEC2_CTC_EXECUTOR_COMPONENT_ID,
+    WHISPER_EXECUTOR_COMPONENT_ID, XASR_ZIPFORMER_EXECUTOR_COMPONENT_ID,
 };
 
 use super::cohere::CohereTranscribeGgmlExecutor;
@@ -22,6 +22,7 @@ use super::firered_llm::executor::FireRedLlmGgmlExecutor;
 use super::ggml_asr_executor::GgmlAsrExecutor;
 use super::mimo_asr::executor::MimoAsrGgmlExecutor;
 use super::moonshine::MoonshineGgmlExecutor;
+use super::moss_transcribe_diarize::executor::MossTdGgmlExecutor;
 use super::parakeet_ctc::executor::ParakeetCtcGgmlExecutor;
 use super::parakeet_tdt::executor::ParakeetTdtGgmlExecutor;
 use super::qwen::Qwen3AsrGgmlExecutor;
@@ -93,6 +94,7 @@ fn materialize_builtin_executor_component(
         FIRERED_AED_EXECUTOR_COMPONENT_ID => Some(Arc::new(FireRedAedGgmlExecutor)),
         FIRERED_LLM_EXECUTOR_COMPONENT_ID => Some(Arc::new(FireRedLlmGgmlExecutor)),
         MIMO_ASR_EXECUTOR_COMPONENT_ID => Some(Arc::new(MimoAsrGgmlExecutor)),
+        MOSS_TD_EXECUTOR_COMPONENT_ID => Some(Arc::new(MossTdGgmlExecutor)),
         _ => None,
     }
 }
@@ -222,6 +224,7 @@ mod tests {
             (crate::arch::FIRERED_AED_MODEL_FAMILY, false),
             (crate::arch::FIRERED_LLM_MODEL_FAMILY, false),
             (crate::arch::MIMO_ASR_MODEL_FAMILY, false),
+            (crate::arch::MOSS_TD_MODEL_FAMILY, false),
         ]);
         let executors =
             materialize_builtin_executors_by_model_architecture().expect("executor map");

--- a/crates/openasr-core/src/models/ggml_family_registry.rs
+++ b/crates/openasr-core/src/models/ggml_family_registry.rs
@@ -299,6 +299,13 @@ pub fn mimo_asr_runtime_descriptor_v1() -> GgmlFamilyAdapterDescriptor {
         .ggml_family_adapter_descriptor()
 }
 
+pub fn moss_transcribe_diarize_runtime_descriptor_v1() -> GgmlFamilyAdapterDescriptor {
+    OpenAsrArchitectureRegistry::with_builtins()
+        .find_by_model_architecture(crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID)
+        .expect("builtin moss-transcribe-diarize architecture must exist")
+        .ggml_family_adapter_descriptor()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/crates/openasr-core/src/models/gpt2_bpe.rs
+++ b/crates/openasr-core/src/models/gpt2_bpe.rs
@@ -112,28 +112,7 @@ fn encode_plain_text_chunk(
     tokenizer_name: &str,
 ) -> Result<Vec<u32>, NativeAsrError> {
     let mut token_ids = Vec::new();
-    let mut cursor = 0usize;
-    while cursor < chunk.len() {
-        let start = cursor;
-        let Some(first_char) = chunk[cursor..].chars().next() else {
-            break;
-        };
-        if first_char.is_whitespace() {
-            cursor += first_char.len_utf8();
-        }
-        while cursor < chunk.len() {
-            let Some(ch) = chunk[cursor..].chars().next() else {
-                break;
-            };
-            if ch.is_whitespace() {
-                break;
-            }
-            cursor += ch.len_utf8();
-        }
-        if cursor == start {
-            cursor += first_char.len_utf8();
-        }
-        let piece = &chunk[start..cursor];
+    for piece in gpt2_style_pretokenize(chunk) {
         if piece.is_empty() {
             continue;
         }
@@ -145,6 +124,175 @@ fn encode_plain_text_chunk(
         )?);
     }
     Ok(token_ids)
+}
+
+/// Splits `text` into pretoken pieces per the standard "Qwen tokenizer"
+/// byte-level-BPE pretokenizer regex -- the exact pattern baked into every
+/// real checkpoint's `tokenizer.json` this crate has converted so far
+/// (`moss-transcribe-diarize`, the official Qwen2 tokenizer firered-llm/
+/// firered2-llm pack, and MiMo-V2.5-ASR all declare the byte-identical
+/// `Sequence[Split(<this regex>), ByteLevel]` pretokenizer), and the same
+/// pattern documented as `tiktoken`'s `cl100k_base` pretokenizer except this
+/// variant matches exactly one digit per number token (`\p{N}`) instead of
+/// `cl100k_base`'s up-to-three (`\p{N}{1,3}`):
+///
+/// ```text
+/// (?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+
+/// ```
+///
+/// This is hard-coded rather than read per-pack: every real pack observed
+/// declares the identical regex (there is no per-family variance to honor
+/// yet), `.oasr`'s `tokenizer.ggml.*` metadata contract has no slot for an
+/// arbitrary pretokenizer regex today, and running an attacker-supplied
+/// regex from a downloaded pack would need its own ReDoS/engine-parity
+/// review before it could join the trust boundary. If a future family's
+/// `tokenizer.json` ever declares a genuinely different pretokenizer, that
+/// is the point to add a per-family selector here (still not raw
+/// pack-supplied regex) -- see this module's doc for the exact evidence.
+///
+/// Implemented as a manual scanner (not a regex engine) to avoid a new
+/// dependency for one fixed pattern (`AGENTS.md`'s "reuse over invent").
+/// Uses `char::is_alphabetic`/`is_numeric`/`is_whitespace` as this crate's
+/// existing approximation of `\p{L}`/`\p{N}`/`\s` (matches `Regex`'s classes
+/// for every character this crate's real transcripts and ChatML templates
+/// use: ASCII, CJK, and common punctuation; combining marks and Nl-only
+/// letter-likes such as Roman numerals are out of scope).
+fn gpt2_style_pretokenize(text: &str) -> Vec<&str> {
+    let chars: Vec<(usize, char)> = text.char_indices().collect();
+    let n = chars.len();
+    let byte_end = |index: usize| -> usize {
+        if index < n {
+            chars[index].0
+        } else {
+            text.len()
+        }
+    };
+    let is_punct_class =
+        |ch: char| -> bool { !ch.is_whitespace() && !ch.is_alphabetic() && !ch.is_numeric() };
+
+    let mut pieces = Vec::new();
+    let mut i = 0usize;
+    while i < n {
+        let start_byte = chars[i].0;
+        let ch = chars[i].1;
+
+        // (?i:'s|'t|'re|'ve|'m|'ll|'d): contraction suffixes.
+        if ch == '\''
+            && let Some(end) = match_contraction(&chars, i)
+        {
+            pieces.push(&text[start_byte..byte_end(end)]);
+            i = end;
+            continue;
+        }
+
+        // [^\r\n\p{L}\p{N}]?\p{L}+: an optional single non-letter/number/CRLF
+        // char immediately followed by one-or-more letters.
+        if ch.is_alphabetic() {
+            let mut j = i + 1;
+            while j < n && chars[j].1.is_alphabetic() {
+                j += 1;
+            }
+            pieces.push(&text[start_byte..byte_end(j)]);
+            i = j;
+            continue;
+        }
+        if ch != '\r'
+            && ch != '\n'
+            && !ch.is_numeric()
+            && i + 1 < n
+            && chars[i + 1].1.is_alphabetic()
+        {
+            let mut j = i + 2;
+            while j < n && chars[j].1.is_alphabetic() {
+                j += 1;
+            }
+            pieces.push(&text[start_byte..byte_end(j)]);
+            i = j;
+            continue;
+        }
+
+        // \p{N}: exactly one digit (this variant never groups a number run).
+        if ch.is_numeric() {
+            pieces.push(&text[start_byte..byte_end(i + 1)]);
+            i += 1;
+            continue;
+        }
+
+        // ' '?[^\s\p{L}\p{N}]+[\r\n]*: an optional single leading space, then
+        // a greedy punctuation/symbol run, then any trailing CR/LF.
+        let punct_run_start = if ch == ' ' && i + 1 < n && is_punct_class(chars[i + 1].1) {
+            Some(i + 1)
+        } else if ch != ' ' && is_punct_class(ch) {
+            Some(i)
+        } else {
+            None
+        };
+        if let Some(run_start) = punct_run_start {
+            let mut j = run_start;
+            while j < n && is_punct_class(chars[j].1) {
+                j += 1;
+            }
+            while j < n && (chars[j].1 == '\r' || chars[j].1 == '\n') {
+                j += 1;
+            }
+            pieces.push(&text[start_byte..byte_end(j)]);
+            i = j;
+            continue;
+        }
+
+        // \s*[\r\n]+ | \s+(?!\S) | \s+: whitespace-run handling. By this
+        // point every non-whitespace case above has already failed to
+        // match, so `ch` is guaranteed whitespace.
+        debug_assert!(
+            ch.is_whitespace(),
+            "unclassified non-whitespace char '{ch}'"
+        );
+        let mut run_end = i;
+        while run_end < n && chars[run_end].1.is_whitespace() {
+            run_end += 1;
+        }
+        let last_newline = (i..run_end)
+            .rev()
+            .find(|&k| matches!(chars[k].1, '\r' | '\n'));
+        let consumed_end = if let Some(k) = last_newline {
+            // \s*[\r\n]+: consume through the last CR/LF in this run (any
+            // interior plain whitespace before it rides along with `\s*`).
+            k + 1
+        } else if run_end == n {
+            // End of chunk: `\s+(?!\S)`'s lookahead is trivially satisfied,
+            // equivalent to plain `\s+` here -- consume the whole run.
+            run_end
+        } else {
+            // `\s+(?!\S)` prefers to leave exactly one trailing whitespace
+            // char unconsumed (so it can prefix the following word via the
+            // letter-run branch above), unless the run is only one char
+            // long (nothing left to leave behind).
+            (run_end - 1).max(i + 1)
+        };
+        pieces.push(&text[start_byte..byte_end(consumed_end)]);
+        i = consumed_end;
+    }
+    pieces
+}
+
+/// Matches `(?i:'s|'t|'re|'ve|'m|'ll|'d)` starting at `chars[i]` (which must
+/// be `'`). Returns the end index (exclusive, in `chars`) on success.
+fn match_contraction(chars: &[(usize, char)], i: usize) -> Option<usize> {
+    const SUFFIXES: [&str; 7] = ["s", "t", "re", "ve", "m", "ll", "d"];
+    'outer: for suffix in SUFFIXES {
+        let mut j = i + 1;
+        for expected in suffix.chars() {
+            let Some(&(_, actual)) = chars.get(j) else {
+                continue 'outer;
+            };
+            if !actual.eq_ignore_ascii_case(&expected) {
+                continue 'outer;
+            }
+            j += 1;
+        }
+        return Some(j);
+    }
+    None
 }
 
 pub(crate) fn encode_byte_level_piece(
@@ -246,4 +394,139 @@ fn unicode_char_from_byte(byte: u8) -> char {
         extra_code += 1;
     }
     '?'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pretokenize_splits_letter_and_punctuation_runs_at_the_category_boundary() {
+        // "assistant." must NOT stay one pretoken piece: a letter run and a
+        // trailing punctuation char are different categories in the real
+        // regex, even with no whitespace between them.
+        assert_eq!(gpt2_style_pretokenize("assistant."), vec!["assistant", "."]);
+    }
+
+    #[test]
+    fn pretokenize_gives_each_digit_its_own_piece_not_a_run() {
+        // `\p{N}` (no `+`/`{1,3}`): this is the Qwen-specific single-digit
+        // variant, unlike GPT-2/cl100k's up-to-3-digit grouping.
+        assert_eq!(gpt2_style_pretokenize("101"), vec!["1", "0", "1"]);
+    }
+
+    #[test]
+    fn pretokenize_matches_the_real_moss_golden_bracket_sequence() {
+        // The exact fragment that exposed the original bug: real golden
+        // `prompt_input_ids` decode to "[" "S" "0" "1" "]" "、" "[" ... as
+        // separate tokens, never a merged "[S" -- letters/digits/punctuation
+        // are three different regex categories and a bracket immediately
+        // followed by a letter can never join it in one pretoken piece.
+        assert_eq!(
+            gpt2_style_pretokenize("（[S01]、[S02]、[S03]…）开头"),
+            vec![
+                "（[", "S", "0", "1", "]、[", "S", "0", "2", "]、[", "S", "0", "3", "]…）", "开头"
+            ]
+        );
+    }
+
+    #[test]
+    fn pretokenize_attaches_a_single_leading_space_to_the_following_word() {
+        assert_eq!(gpt2_style_pretokenize("You are"), vec!["You", " are"]);
+    }
+
+    #[test]
+    fn pretokenize_collapses_a_multi_space_run_leaving_one_space_for_the_next_word() {
+        // Three spaces before "b": `\s+(?!\S)` backtracks to leave exactly
+        // one trailing space, which then prefixes "b" as its own piece.
+        assert_eq!(gpt2_style_pretokenize("a   b"), vec!["a", "  ", " b"]);
+    }
+
+    #[test]
+    fn pretokenize_treats_a_newline_run_as_one_piece_separate_from_following_whitespace() {
+        assert_eq!(gpt2_style_pretokenize("a\n\nb"), vec!["a", "\n\n", "b"]);
+        // A newline followed by plain spaces before a word: the newline run
+        // stops at the last CR/LF; trailing spaces are handled separately.
+        assert_eq!(gpt2_style_pretokenize("a\n  b"), vec!["a", "\n", " ", " b"]);
+    }
+
+    #[test]
+    fn pretokenize_splits_contractions_from_the_preceding_word() {
+        assert_eq!(gpt2_style_pretokenize("don't"), vec!["don", "'t"]);
+        assert_eq!(
+            gpt2_style_pretokenize("we'REGOING"),
+            vec!["we", "'RE", "GOING"]
+        );
+    }
+
+    #[test]
+    fn pretokenize_glues_a_single_leading_cjk_punctuation_char_to_a_following_cjk_word() {
+        // Verified directly against the real checkpoint's
+        // `tokenizers::pre_tokenizer.pre_tokenize_str` output: a single
+        // punctuation char immediately followed by a letter is the SAME
+        // "optional leading char + word" shape as an ASCII space glued to a
+        // following English word (alt2 in this module's doc comment does
+        // not special-case CJK) -- "，" is not itself excluded, so it glues
+        // to "我打算" exactly like a leading space glues to " are".
+        assert_eq!(
+            gpt2_style_pretokenize("今天天气非常好，我打算"),
+            vec!["今天天气非常好", "，我打算"]
+        );
+    }
+
+    #[test]
+    fn pretokenize_whitespace_at_end_of_text_consumes_the_whole_run() {
+        assert_eq!(gpt2_style_pretokenize("hi  "), vec!["hi", "  "]);
+    }
+
+    #[test]
+    fn pretokenize_glues_a_lone_leading_bracket_to_a_following_letter() {
+        // Also verified against the real tokenizer: "[S01]" in ISOLATION
+        // (nothing punctuation-class immediately before the "[") DOES glue
+        // "[" to "S" into one pretoken piece -- alt2's "optional leading
+        // char" rule has no bracket/letter exception. This is the same rule
+        // that, in the real MOSS instruction text, does NOT fire for its
+        // "[S" occurrences, because there each "[" is immediately preceded
+        // by another punctuation-class char ("（" or "、") that greedily
+        // claims it into a punctuation run first (see the bracket-sequence
+        // test below) -- the bug this module fixes was letting that
+        // boundary get crossed even when nothing preceded the bracket.
+        assert_eq!(gpt2_style_pretokenize("[S01]"), vec!["[S", "0", "1", "]"]);
+    }
+
+    fn tiny_vocab_with_bracket_letter_merge() -> (BTreeMap<String, u32>, BTreeMap<String, usize>) {
+        // A synthetic vocab reproducing the real bug's shape: every raw
+        // byte-level char used below gets its own base token (all plain
+        // printable ASCII, so `bytes_to_unicode` maps each one to itself and
+        // the vocab entries can be written as literal chars), PLUS an
+        // anomalous "[S" entry (mirroring the real vocab's actual token
+        // 42474) reachable by one merge rule bridging punctuation and a
+        // letter.
+        let base_chars = ["(", "[", "S", "0", "1", "]"];
+        let mut tokens: Vec<String> = base_chars.iter().map(|s| s.to_string()).collect();
+        tokens.push("[S".to_string());
+        let token_to_id = build_token_to_id(&tokens, "test").expect("token_to_id");
+        let merge_rank = build_merge_rank(&["[ S".to_string()]);
+        (token_to_id, merge_rank)
+    }
+
+    #[test]
+    fn encode_prompt_text_never_lets_a_punctuation_letter_merge_cross_the_pretoken_boundary() {
+        // Unlike the isolated "[S01]" case above, a "(" immediately before
+        // "[" claims it into a punctuation-run pretoken first (the same
+        // shape as the real MOSS golden fixture's "（[" context), so "[" and
+        // "S" must land in different pretoken pieces and the "[S" merge
+        // rule must never get a chance to fire here even though the vocab
+        // has it.
+        let (token_to_id, merge_rank) = tiny_vocab_with_bracket_letter_merge();
+        let ids = encode_prompt_text("([S01]", &token_to_id, &merge_rank, "test").expect("encode");
+        let expected: Vec<u32> = ["(", "[", "S", "0", "1", "]"]
+            .iter()
+            .map(|token| *token_to_id.get(*token).unwrap())
+            .collect();
+        assert_eq!(
+            ids, expected,
+            "must never resolve to the anomalous merged '[S' token when a punctuation run claims '[' first"
+        );
+    }
 }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/adaptor_graph.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/adaptor_graph.rs
@@ -1,0 +1,264 @@
+//! The MOSS-Transcribe-Diarize `VQAdaptor` bridge: 4x time-merge (pure
+//! reshape, no weights) -> `Linear(4096 -> 1024) -> SiLU -> Linear(1024 ->
+//! 1024) -> LayerNorm(eps=1e-6)`. Despite the "VQ" name there is no
+//! vector-quantization codebook in this checkpoint (see `package_import`'s
+//! module doc) -- this is a plain 3-weighted-layer MLP.
+//!
+//! A plain host-side computation, not a ggml graph: mirrors
+//! `firered_llm::adapter_graph`'s precedent (small one-shot per-utterance
+//! projection, not a per-decode-step op) -- the weights here are smaller
+//! still (~9.4M params, ~19MB f32).
+
+use thiserror::Error;
+
+use crate::ggml_runtime::{GgufTensorDataReadError, GgufTensorDataReader};
+
+use super::tensor_names::{
+    ADAPTOR_LINEAR1_BIAS, ADAPTOR_LINEAR1_WEIGHT, ADAPTOR_LINEAR2_BIAS, ADAPTOR_LINEAR2_WEIGHT,
+    ADAPTOR_NORM_BIAS, ADAPTOR_NORM_WEIGHT,
+};
+
+#[derive(Debug, Error)]
+pub(crate) enum MossAdaptorError {
+    #[error("moss-transcribe-diarize adaptor tensor read failed: {0}")]
+    TensorRead(#[from] GgufTensorDataReadError),
+    #[error(
+        "moss-transcribe-diarize adaptor input shape is invalid: frame_count={frame_count} encoder_d_model={encoder_d_model} values_len={values_len}"
+    )]
+    InvalidInputShape {
+        frame_count: usize,
+        encoder_d_model: usize,
+        values_len: usize,
+    },
+    #[error("moss-transcribe-diarize adaptor output contains non-finite values")]
+    NonFiniteValues,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MossAdaptorWeights {
+    stacked_input_width: usize,
+    llm_dim: usize,
+    linear1_weight: Vec<f32>,
+    linear1_bias: Vec<f32>,
+    linear2_weight: Vec<f32>,
+    linear2_bias: Vec<f32>,
+    norm_weight: Vec<f32>,
+    norm_bias: Vec<f32>,
+    norm_epsilon: f32,
+}
+
+pub(crate) fn load_moss_adaptor_weights_from_reader(
+    reader: &GgufTensorDataReader,
+    encoder_d_model: usize,
+    merge_size: usize,
+    llm_dim: usize,
+    norm_epsilon: f32,
+) -> Result<MossAdaptorWeights, MossAdaptorError> {
+    let stacked_input_width = encoder_d_model * merge_size;
+    let linear1_weight = reader.host_tensor_f32_copy_dequantized_by_name(
+        ADAPTOR_LINEAR1_WEIGHT,
+        &[stacked_input_width as u64, llm_dim as u64],
+    )?;
+    let linear1_bias =
+        reader.host_tensor_f32_copy_dequantized_by_name(ADAPTOR_LINEAR1_BIAS, &[llm_dim as u64])?;
+    let linear2_weight = reader.host_tensor_f32_copy_dequantized_by_name(
+        ADAPTOR_LINEAR2_WEIGHT,
+        &[llm_dim as u64, llm_dim as u64],
+    )?;
+    let linear2_bias =
+        reader.host_tensor_f32_copy_dequantized_by_name(ADAPTOR_LINEAR2_BIAS, &[llm_dim as u64])?;
+    let norm_weight =
+        reader.host_tensor_f32_copy_dequantized_by_name(ADAPTOR_NORM_WEIGHT, &[llm_dim as u64])?;
+    let norm_bias =
+        reader.host_tensor_f32_copy_dequantized_by_name(ADAPTOR_NORM_BIAS, &[llm_dim as u64])?;
+    Ok(MossAdaptorWeights {
+        stacked_input_width,
+        llm_dim,
+        linear1_weight,
+        linear1_bias,
+        linear2_weight,
+        linear2_bias,
+        norm_weight,
+        norm_bias,
+        norm_epsilon,
+    })
+}
+
+/// `encoder_rows`: frame-major `[frame][encoder_d_model]`, already trimmed
+/// to a multiple of `merge_size` (the executor drops any remainder before
+/// calling this, matching upstream `time_merge`'s `T_trim = (T //
+/// merge_size) * merge_size` truncation). Returns (token-major output rows,
+/// output_token_count).
+pub(crate) fn run_moss_adaptor(
+    weights: &MossAdaptorWeights,
+    encoder_rows: &[f32],
+    frame_count: usize,
+    encoder_d_model: usize,
+    merge_size: usize,
+) -> Result<(Vec<f32>, usize), MossAdaptorError> {
+    let expected_len =
+        frame_count
+            .checked_mul(encoder_d_model)
+            .ok_or(MossAdaptorError::InvalidInputShape {
+                frame_count,
+                encoder_d_model,
+                values_len: encoder_rows.len(),
+            })?;
+    if encoder_rows.len() != expected_len {
+        return Err(MossAdaptorError::InvalidInputShape {
+            frame_count,
+            encoder_d_model,
+            values_len: encoder_rows.len(),
+        });
+    }
+    if !frame_count.is_multiple_of(merge_size.max(1)) {
+        return Err(MossAdaptorError::InvalidInputShape {
+            frame_count,
+            encoder_d_model,
+            values_len: encoder_rows.len(),
+        });
+    }
+    if encoder_rows.iter().any(|value| !value.is_finite()) {
+        return Err(MossAdaptorError::NonFiniteValues);
+    }
+
+    let output_token_count = frame_count / merge_size.max(1);
+    let stacked_width = encoder_d_model * merge_size;
+    if stacked_width != weights.stacked_input_width {
+        return Err(MossAdaptorError::InvalidInputShape {
+            frame_count,
+            encoder_d_model,
+            values_len: encoder_rows.len(),
+        });
+    }
+
+    let llm_dim = weights.llm_dim;
+    let mut output = Vec::with_capacity(output_token_count * llm_dim);
+    let mut stacked_row = vec![0.0_f32; stacked_width];
+    let mut hidden_row = vec![0.0_f32; llm_dim];
+    let mut linear2_row = vec![0.0_f32; llm_dim];
+    for out_token in 0..output_token_count {
+        let src_start = out_token * stacked_width;
+        stacked_row.copy_from_slice(&encoder_rows[src_start..src_start + stacked_width]);
+
+        matmul_row_output_by_input(
+            &stacked_row,
+            &weights.linear1_weight,
+            &weights.linear1_bias,
+            stacked_width,
+            &mut hidden_row,
+        );
+        // SiLU: x * sigmoid(x).
+        for value in hidden_row.iter_mut() {
+            *value *= 1.0 / (1.0 + (-*value).exp());
+        }
+
+        matmul_row_output_by_input(
+            &hidden_row,
+            &weights.linear2_weight,
+            &weights.linear2_bias,
+            llm_dim,
+            &mut linear2_row,
+        );
+
+        let mean = linear2_row.iter().sum::<f32>() / llm_dim as f32;
+        let variance = linear2_row
+            .iter()
+            .map(|v| (v - mean) * (v - mean))
+            .sum::<f32>()
+            / llm_dim as f32;
+        let inv_std = 1.0 / (variance + weights.norm_epsilon).sqrt();
+        for (idx, value) in linear2_row.iter().enumerate() {
+            let normalized = (value - mean) * inv_std;
+            output.push(normalized * weights.norm_weight[idx] + weights.norm_bias[idx]);
+        }
+    }
+    if output.iter().any(|value| !value.is_finite()) {
+        return Err(MossAdaptorError::NonFiniteValues);
+    }
+    Ok((output, output_token_count))
+}
+
+/// `out = W @ in + b`, where `weight` is `[input_width, output_width]`
+/// column-major-by-input (ggml `InputByOutput`-on-disk convention this
+/// family's `package_import` writes 2D linear weights in -- see that
+/// module's `reversed_dims`), i.e. row `out_idx` of the logical `[out, in]`
+/// matrix lives at `weight[out_idx * input_width .. +input_width]` exactly
+/// like `firered_llm::adapter_graph`'s host-side matmul.
+fn matmul_row_output_by_input(
+    input: &[f32],
+    weight: &[f32],
+    bias: &[f32],
+    input_width: usize,
+    out: &mut [f32],
+) {
+    for (out_idx, out_value) in out.iter_mut().enumerate() {
+        let row = &weight[out_idx * input_width..out_idx * input_width + input_width];
+        let mut acc = 0.0_f32;
+        for (input_value, weight_value) in input.iter().zip(row.iter()) {
+            acc += input_value * weight_value;
+        }
+        *out_value = acc + bias[out_idx];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn toy_weights() -> MossAdaptorWeights {
+        // encoder_d_model=2, merge_size=2 -> stacked_input_width=4, llm_dim=3.
+        MossAdaptorWeights {
+            stacked_input_width: 4,
+            llm_dim: 3,
+            linear1_weight: vec![
+                1.0, 1.0, 1.0, 1.0, //
+                0.5, 0.5, 0.5, 0.5, //
+                -1.0, -1.0, -1.0, -1.0,
+            ],
+            linear1_bias: vec![0.0, 0.0, 10.0],
+            linear2_weight: vec![
+                1.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, //
+                0.0, 0.0, 1.0,
+            ],
+            linear2_bias: vec![0.0, 0.0, 0.0],
+            norm_weight: vec![1.0, 1.0, 1.0],
+            norm_bias: vec![0.0, 0.0, 0.0],
+            norm_epsilon: 1e-6,
+        }
+    }
+
+    #[test]
+    fn adaptor_merges_two_frames_applies_silu_identity_linear2_then_layernorm() {
+        let weights = toy_weights();
+        let encoder_rows = [
+            1.0, 2.0, // frame 0
+            3.0, 4.0, // frame 1
+            100.0, 100.0, // frame 2 (dropped: frame_count must be a multiple of merge_size)
+        ];
+        // Only pass the first 2 (already-trimmed) frames, mirroring what the
+        // executor would hand in after its own truncation.
+        let (output, output_token_count) =
+            run_moss_adaptor(&weights, &encoder_rows[..4], 2, 2, 2).expect("adaptor");
+        assert_eq!(output_token_count, 1);
+        // stacked = [1,2,3,4]; linear1 -> [10, 5, 0] (relu-equivalent since all
+        // non-negative here except the last which SiLU(0)=0); SiLU(10)~=10,
+        // SiLU(5)~=5, SiLU(0)=0 -> linear2 identity -> layernorm(mean~=5,
+        // var>0) -- assert finiteness and the expected zero-mean/unit-ish
+        // shape rather than a brittle exact float chain.
+        assert_eq!(output.len(), 3);
+        let mean = output.iter().sum::<f32>() / 3.0;
+        assert!(
+            mean.abs() < 1e-3,
+            "layernorm output should be ~zero-mean: {output:?}"
+        );
+    }
+
+    #[test]
+    fn adaptor_rejects_frame_count_not_multiple_of_merge_size() {
+        let weights = toy_weights();
+        let error = run_moss_adaptor(&weights, &[0.0; 6], 3, 2, 2).expect_err("must fail");
+        assert!(matches!(error, MossAdaptorError::InvalidInputShape { .. }));
+    }
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/decode_prompt.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/decode_prompt.rs
@@ -292,4 +292,64 @@ mod tests {
         MossTdTokenizer::from_gguf_metadata(&GgufMetadata::from_values_for_test(values))
             .expect("tokenizer")
     }
+
+    /// Real converted dev pack (see `package_import`'s own
+    /// `golden_diff_converted_pack_tensors_match_source_checkpoint_bit_for_bit`
+    /// for the tensor-parity half of this pack's provenance), NOT committed
+    /// to the repo -- same dev-only-artifact convention as
+    /// `mimo_asr::executor::tests::dev_pack_path`.
+    fn dev_pack_path() -> std::path::PathBuf {
+        std::path::PathBuf::from(
+            "/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/moss-transcribe-diarize-fp16.oasr",
+        )
+    }
+
+    /// Regression test for the `models::gpt2_bpe` pretokenizer fix: builds
+    /// the real jfk.wav decode prompt against the real converted pack's real
+    /// vocab/merges and asserts it matches
+    /// `tmp/moss-td/golden/jfk.json`'s real `prompt_input_ids` token-for-
+    /// token (227 tokens: 14-token ChatML prefix + audio-start + 141-token
+    /// audio span + audio-end + 70-token instruction/ChatML suffix). Before
+    /// the pretokenizer fix this diverged at the instruction text's first
+    /// `"[S01]"` marker (index 22 of the suffix span: an anomalous merged
+    /// `"[S"` token instead of separate `"["`/`"S"` tokens).
+    #[test]
+    fn builds_the_real_golden_jfk_prompt_token_for_token() {
+        let pack_path = dev_pack_path();
+        if !pack_path.exists() {
+            eprintln!("skipping: {} not present", pack_path.display());
+            return;
+        }
+        let metadata = crate::ggml_runtime::read_gguf_metadata(&pack_path).expect("read metadata");
+        let tokenizer = MossTdTokenizer::from_gguf_metadata(&metadata).expect("tokenizer");
+        // jfk.wav is 11.0s @ 12.5 audio tokens/sec = 138 audio tokens (the
+        // real checkpoint's own `get_audio_features` output length,
+        // independently verified against the real encoder+adaptor forward
+        // pass -- see this module's own executor-level diagnostics).
+        let prompt = build_moss_td_decode_prompt(&tokenizer, 138).expect("prompt");
+        let golden_prompt_input_ids: Vec<u32> = vec![
+            151644, 8948, 198, 2610, 525, 264, 10950, 17847, 13, 151645, 198, 151644, 872, 198,
+            151669, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 20, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 16, 15, 151671, 151671, 151671, 151671, 151671,
+            151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151671, 151670, 198,
+            14880, 44063, 111268, 46670, 61443, 17714, 108704, 3837, 73157, 104383, 58362, 23031,
+            71618, 26606, 20450, 111420, 33108, 104283, 17340, 72640, 9909, 58, 50, 15, 16, 60,
+            5373, 58, 50, 15, 17, 60, 5373, 58, 50, 15, 18, 60, 1940, 7552, 111749, 3837, 110644,
+            17714, 110019, 105761, 43815, 90395, 18493, 37474, 100072, 111066, 80565, 20450,
+            111420, 3837, 23031, 104542, 117932, 75882, 37474, 105761, 101121, 1773, 151645, 198,
+            151644, 77091, 198,
+        ];
+        assert_eq!(prompt.token_ids.len(), golden_prompt_input_ids.len());
+        assert_eq!(prompt.token_ids, golden_prompt_input_ids);
+    }
 }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/decode_prompt.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/decode_prompt.rs
@@ -1,0 +1,295 @@
+//! ChatML decode prompt construction, ported one-for-one from upstream
+//! `processing_moss_transcribe_diarize.py`
+//! (`MossTranscribeDiarizeProcessor.__call__` / `expand_audio_token` /
+//! `_audio_span_ids`), verified against the real golden fixtures'
+//! `prompt_input_ids` (`tmp/moss-td/golden/*.json`) token-for-token
+//! (`jfk.json`/`en_zh_mixed.json`/`aishell4_multispeaker_3min.json`, decoded
+//! with the real tokenizer -- see this module's tests).
+//!
+//! Fixed literal template (verified against the golden fixtures' decoded
+//! text, not assumed):
+//!
+//! ```text
+//! <|im_start|>system\nYou are a helpful assistant.<|im_end|>\n
+//! <|im_start|>user\n<|audio_start|>{audio_span}<|audio_end|>\n{instruction}<|im_end|>\n
+//! <|im_start|>assistant\n
+//! ```
+//!
+//! `{audio_span}` is `<|audio_pad|>` repeated once per adaptor output token,
+//! with a numeric time anchor (the seconds elapsed, one BPE token per digit)
+//! spliced in every `time_marker_every_seconds` seconds -- NOT a contiguous
+//! run, so the audio-row splice (see `executor.rs`) must scatter by an
+//! explicit sparse position list, unlike `qwen::build_qwen3_prompt_embeddings_with_audio_splice`'s
+//! contiguous-range assumption (qwen3-asr's own `<|audio_pad|>` span has no
+//! markers interrupting it).
+//!
+//! No `enable_thinking` scaffold (`<think>...</think>`) -- verified absent
+//! from the golden fixtures' `prompt_input_ids` tail (`...<|im_start|>assistant\n`
+//! is the literal end of the prompt).
+
+use thiserror::Error;
+
+use super::tokenizer::MossTdTokenizer;
+
+/// `MossTranscribeDiarizeProcessor.__init__`'s defaults (`audio_tokens_per_second`,
+/// `time_marker_every_seconds`) and the checkpoint's own `processor_config.json`
+/// (`enable_time_marker: true`) -- not per-pack metadata, verified against the
+/// real checkpoint's `processor_config.json` rather than assumed. Not
+/// user-configurable: the LLM decoder was fine-tuned against this exact anchor
+/// cadence.
+const AUDIO_TOKENS_PER_SECOND: f32 = 12.5;
+const TIME_MARKER_EVERY_SECONDS: u32 = 5;
+
+/// Upstream's hard-coded ChatML system turn (`processing_moss_transcribe_diarize.py`
+/// has no system-prompt parameter; this is the literal text baked into every
+/// golden fixture's `prompt_input_ids`, verified by decoding them with the real
+/// tokenizer -- see this module's tests).
+const SYSTEM_TEXT: &str = "You are a helpful assistant.";
+/// The fixed instruction appended after `<|audio_end|>` in every golden
+/// fixture -- verified byte-for-byte by decoding `prompt_input_ids`, not
+/// guessed. Asks for per-segment `[S01]`/`[S02]`/... speaker labels and
+/// start/end timestamps around each segment's transcript.
+const INSTRUCTION_TEXT: &str = "请将音频转写为文本，每一段需以起始时间戳和说话人编号（[S01]、[S02]、[S03]…）开头，正文为对应的语音内容，并在段末标注结束时间戳，以清晰标明该段语音范围。";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MossTdDecodePrompt {
+    pub token_ids: Vec<u32>,
+    /// Positions in `token_ids` holding a literal `<|audio_pad|>` token, in
+    /// order -- the executor scatters adaptor output rows into exactly these
+    /// positions (never a contiguous range: `_audio_span_ids` interrupts the
+    /// run with digit-marker tokens).
+    pub audio_pad_positions: Vec<usize>,
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub(crate) enum MossTdDecodePromptError {
+    #[error("moss-transcribe-diarize decode prompt requires at least one audio token")]
+    EmptyAudioTokens,
+    #[error("moss-transcribe-diarize decode prompt tokenization failed: {reason}")]
+    TokenizationFailed { reason: String },
+}
+
+/// Port of `MossTranscribeDiarizeProcessor._audio_span_ids`: returns the
+/// full audio-span token id sequence (pad tokens interrupted by digit-token
+/// time anchors every `TIME_MARKER_EVERY_SECONDS` seconds) plus the list of
+/// indices (relative to the returned `Vec`'s start) holding a literal pad
+/// token.
+fn audio_span_ids(tokenizer: &MossTdTokenizer, audio_token_count: usize) -> (Vec<u32>, Vec<usize>) {
+    let tokens_per_marker = (AUDIO_TOKENS_PER_SECOND * TIME_MARKER_EVERY_SECONDS as f32) as i64;
+    if audio_token_count == 0 || tokens_per_marker <= 0 {
+        let ids = vec![tokenizer.audio_pad_token_id; audio_token_count];
+        let positions = (0..audio_token_count).collect();
+        return (ids, positions);
+    }
+
+    let duration = audio_token_count as f32 / AUDIO_TOKENS_PER_SECOND;
+    let mut ids = Vec::with_capacity(audio_token_count + audio_token_count / 40);
+    let mut pad_positions = Vec::with_capacity(audio_token_count);
+    let mut consumed: i64 = 0;
+    let mut sec = TIME_MARKER_EVERY_SECONDS as i64;
+    while sec <= duration as i64 {
+        let pos = (sec / TIME_MARKER_EVERY_SECONDS as i64) * tokens_per_marker;
+        let segment_len = pos - consumed;
+        if segment_len > 0 {
+            for _ in 0..segment_len {
+                pad_positions.push(ids.len());
+                ids.push(tokenizer.audio_pad_token_id);
+            }
+            consumed += segment_len;
+        }
+        for ch in sec.to_string().chars() {
+            let digit = ch.to_digit(10).expect("decimal digit") as usize;
+            ids.push(tokenizer.digit_token_ids[digit]);
+        }
+        sec += TIME_MARKER_EVERY_SECONDS as i64;
+    }
+    let remainder = audio_token_count as i64 - consumed;
+    if remainder > 0 {
+        for _ in 0..remainder {
+            pad_positions.push(ids.len());
+            ids.push(tokenizer.audio_pad_token_id);
+        }
+    }
+    (ids, pad_positions)
+}
+
+pub(crate) fn build_moss_td_decode_prompt(
+    tokenizer: &MossTdTokenizer,
+    audio_token_count: usize,
+) -> Result<MossTdDecodePrompt, MossTdDecodePromptError> {
+    if audio_token_count == 0 {
+        return Err(MossTdDecodePromptError::EmptyAudioTokens);
+    }
+    let encode = |text: &str| -> Result<Vec<u32>, MossTdDecodePromptError> {
+        tokenizer.encode_prompt_text(text).map_err(|error| {
+            MossTdDecodePromptError::TokenizationFailed {
+                reason: error.to_string(),
+            }
+        })
+    };
+
+    let prefix = format!("<|im_start|>system\n{SYSTEM_TEXT}<|im_end|>\n<|im_start|>user\n");
+    let suffix = format!("\n{INSTRUCTION_TEXT}<|im_end|>\n<|im_start|>assistant\n");
+
+    let prefix_ids = encode(&prefix)?;
+    let suffix_ids = encode(&suffix)?;
+    let (span_ids, span_pad_positions) = audio_span_ids(tokenizer, audio_token_count);
+
+    let mut token_ids =
+        Vec::with_capacity(prefix_ids.len() + 1 + span_ids.len() + 1 + suffix_ids.len());
+    token_ids.extend(prefix_ids.iter().copied());
+    token_ids.push(tokenizer.audio_start_token_id);
+    let span_start = token_ids.len();
+    token_ids.extend(span_ids.iter().copied());
+    token_ids.push(tokenizer.audio_end_token_id);
+    token_ids.extend(suffix_ids.iter().copied());
+
+    let audio_pad_positions = span_pad_positions
+        .into_iter()
+        .map(|position| span_start + position)
+        .collect();
+
+    Ok(MossTdDecodePrompt {
+        token_ids,
+        audio_pad_positions,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    use crate::models::moss_transcribe_diarize::runtime_contract::{
+        LLM_AUDIO_END_TOKEN_ID_KEY, LLM_AUDIO_PAD_TOKEN_ID_KEY, LLM_AUDIO_START_TOKEN_ID_KEY,
+        LLM_VOCAB_SIZE_KEY,
+    };
+    use crate::models::oasr_metadata::{
+        TOKENIZER_GGML_MERGES_KEY, TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_TOKENS_KEY,
+    };
+    use crate::{GgufMetadata, GgufMetadataValue};
+
+    #[test]
+    fn audio_span_matches_reference_marker_placement_for_short_clip() {
+        // 12.5 tokens/sec * 11s clip = 138 tokens (jfk.json's real
+        // audio_pad_count): TWO markers fire inside an 11s clip (5s and 10s,
+        // not just 10s -- verified directly against the real golden
+        // fixture's decoded `prompt_input_ids` span between `<|audio_start|>`
+        // and `<|audio_end|>`, which is 141 tokens long with non-pad values
+        // at span-relative positions 62 (single digit '5') and 125/126
+        // (digits '1'/'0' for "10"), not 140/a single marker).
+        let tokenizer = tokenizer_fixture();
+        let (ids, positions) = audio_span_ids(&tokenizer, 138);
+        assert_eq!(positions.len(), 138);
+        // Two markers: 3 extra (digit) tokens ('5', '1', '0') beyond the 138
+        // pad tokens.
+        assert_eq!(ids.len(), 141);
+        assert_eq!(ids[62], tokenizer.digit_token_ids[5]);
+        assert_eq!(ids[125], tokenizer.digit_token_ids[1]);
+        assert_eq!(ids[126], tokenizer.digit_token_ids[0]);
+        // The three non-pad ids are the digit tokens for '5', '1', and '0'.
+        let non_pad: Vec<u32> = ids
+            .iter()
+            .copied()
+            .filter(|id| *id != tokenizer.audio_pad_token_id)
+            .collect();
+        assert_eq!(
+            non_pad,
+            vec![
+                tokenizer.digit_token_ids[5],
+                tokenizer.digit_token_ids[1],
+                tokenizer.digit_token_ids[0],
+            ]
+        );
+    }
+
+    #[test]
+    fn builds_full_chatml_prompt_with_audio_span() {
+        let tokenizer = tokenizer_fixture();
+        let prompt = build_moss_td_decode_prompt(&tokenizer, 4).expect("prompt");
+        assert_eq!(prompt.audio_pad_positions.len(), 4);
+        for position in &prompt.audio_pad_positions {
+            assert_eq!(prompt.token_ids[*position], tokenizer.audio_pad_token_id);
+        }
+        assert_eq!(
+            prompt.token_ids[prompt.audio_pad_positions[0] - 1],
+            tokenizer.audio_start_token_id
+        );
+    }
+
+    #[test]
+    fn rejects_zero_audio_tokens() {
+        let tokenizer = tokenizer_fixture();
+        let error = build_moss_td_decode_prompt(&tokenizer, 0).expect_err("must fail");
+        assert_eq!(error, MossTdDecodePromptError::EmptyAudioTokens);
+    }
+
+    fn tokenizer_fixture() -> MossTdTokenizer {
+        let mut values = BTreeMap::new();
+        values.insert(
+            TOKENIZER_GGML_MODEL_KEY.to_string(),
+            GgufMetadataValue::String("gpt2".to_string()),
+        );
+        // Byte-level BPE with zero merges emits one token per raw UTF-8 byte
+        // for anything not covered by an explicit multi-char vocab entry, so
+        // this fixture only needs explicit entries for the literal
+        // multi-char tokens the prompt template inserts directly (ChatML
+        // control tokens, digits) -- system/instruction text falls back to
+        // per-byte tokens, which is fine since this test only checks the
+        // audio-span structure, not the surrounding prose's exact ids.
+        use crate::models::gpt2_bpe::bytes_to_unicode;
+        let mut tokens = vec![
+            "<|im_start|>".to_string(),
+            "<|im_end|>".to_string(),
+            "<|audio_start|>".to_string(),
+            "<|audio_end|>".to_string(),
+            "<|audio_pad|>".to_string(),
+        ];
+        for digit in "0123456789".chars() {
+            tokens.push(digit.to_string());
+        }
+        let mut seen_bytes = std::collections::BTreeSet::new();
+        let mut all_text = String::new();
+        all_text.push_str("system\nUser assistant\n");
+        all_text.push_str(SYSTEM_TEXT);
+        all_text.push_str(INSTRUCTION_TEXT);
+        for byte in all_text.as_bytes() {
+            if seen_bytes.insert(*byte) {
+                tokens.push(bytes_to_unicode(&[*byte]));
+            }
+        }
+        let vocab_size = tokens.len() as u32;
+        values.insert(
+            TOKENIZER_GGML_TOKENS_KEY.to_string(),
+            GgufMetadataValue::StringArray(tokens),
+        );
+        values.insert(
+            TOKENIZER_GGML_MERGES_KEY.to_string(),
+            // A real pack's merge list is never empty (byte-level BPE always
+            // has real merges); this fixture only needs one placeholder entry
+            // to satisfy `MossTdTokenizer::from_gguf_metadata`'s non-empty
+            // check, since byte-level encode with zero merges applied still
+            // falls back to per-byte tokens for anything this test's prose
+            // doesn't have an explicit multi-char vocab entry for.
+            GgufMetadataValue::StringArray(vec!["z z".to_string()]),
+        );
+        values.insert(
+            LLM_VOCAB_SIZE_KEY.to_string(),
+            GgufMetadataValue::U32(vocab_size),
+        );
+        values.insert(
+            LLM_AUDIO_START_TOKEN_ID_KEY.to_string(),
+            GgufMetadataValue::U32(2),
+        );
+        values.insert(
+            LLM_AUDIO_END_TOKEN_ID_KEY.to_string(),
+            GgufMetadataValue::U32(3),
+        );
+        values.insert(
+            LLM_AUDIO_PAD_TOKEN_ID_KEY.to_string(),
+            GgufMetadataValue::U32(4),
+        );
+        MossTdTokenizer::from_gguf_metadata(&GgufMetadata::from_values_for_test(values))
+            .expect("tokenizer")
+    }
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/encoder_graph.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/encoder_graph.rs
@@ -1,0 +1,583 @@
+//! MOSS-Transcribe-Diarize's Whisper-Medium-style audio encoder: conv1
+//! (kernel 3, stride 1, pad 1) -> GELU -> conv2 (kernel 3, stride 2, pad 1)
+//! -> GELU -> + fixed positional embedding -> 24 standard pre-norm
+//! Transformer encoder blocks (`crate::nn::encoder::transformer_layer`, the
+//! same "Whisper / Qwen-audio encoder shape" primitive `qwen::audio_encoder`
+//! already uses) -> final LayerNorm. Non-causal (full bidirectional
+//! self-attention over all 1500 positions, an all-zero additive mask) --
+//! this is standard upstream `transformers.WhisperEncoder`, verified against
+//! the checkpoint's tensor names and shapes (`package_import`'s module doc).
+//!
+//! Whisper's own `k_proj` carries no bias (only q/v do); `transformer_layer`
+//! requires a bias tensor for every projection, so this module supplies an
+//! all-zero one for K -- adding zero is an exact no-op, not an approximation.
+//!
+//! This always runs a fixed-size 30s chunk (3000 mel frames -> 1500 encoder
+//! output frames, `max_source_positions`); audio longer than 30s is chunked
+//! by the executor (see `executor.rs`), which trims each chunk's output to
+//! its own valid frame count before concatenating -- mirrors
+//! `MossTranscribeDiarizeModel.get_audio_features`'s
+//! `whisper_features[chunk_idx:chunk_idx+1, :token_len*4]` truncation.
+//!
+//! Deliberately skips the WEIGHTS-usage resident-arena optimization every
+//! other family's encoder uses for GPU offload (see `qwen::audio_encoder`'s
+//! module doc): correctness first, performance tuning is explicitly
+//! out-of-scope for this stage (see `mod.rs`'s stage-status note). Every
+//! weight is a genuine per-call graph input, which is correct on every
+//! backend, just not the fastest.
+
+use thiserror::Error;
+
+use crate::ggml_runtime::{
+    GgmlCpuGraphError, GgmlCpuGraphRunner, GgufTensorDataReadError, GgufTensorDataReader,
+};
+use crate::nn::conv::{
+    Conv1dParams, ConvActivation, ConvBlockSteps, apply_conv_1d_bias_activation,
+};
+use crate::nn::encoder::{
+    TransformerEncoderConfig, TransformerEncoderLayerWeights, transformer_layer,
+};
+
+use super::tensor_names::{
+    ENC_CONV1_BIAS, ENC_CONV1_WEIGHT, ENC_CONV2_BIAS, ENC_CONV2_WEIGHT, ENC_OUT_NORM_BIAS,
+    ENC_OUT_NORM_WEIGHT, ENC_POS_EMBD_WEIGHT, moss_encoder_layer_tensor_names,
+};
+
+/// `nn.LayerNorm`'s default epsilon -- verified against upstream
+/// `transformers.models.whisper.modeling_whisper.WhisperEncoderLayer`, which
+/// never overrides it (same value every Whisper size uses).
+const MOSS_ENCODER_LAYER_NORM_EPSILON: f32 = 1.0e-5;
+const CONV_KERNEL_SIZE: usize = 3;
+const CONV1_STRIDE: usize = 1;
+const CONV2_STRIDE: usize = 2;
+const CONV_PADDING: usize = 1;
+const CONV_DILATION: usize = 1;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MossEncoderConfig {
+    pub n_layers: usize,
+    pub d_model: usize,
+    pub n_heads: usize,
+    pub n_mels: usize,
+    pub max_source_positions: usize,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum MossEncoderError {
+    #[error("moss-transcribe-diarize encoder tensor read failed: {0}")]
+    TensorRead(#[from] GgufTensorDataReadError),
+    #[error("moss-transcribe-diarize encoder graph build failed at '{step}': {source}")]
+    GraphBuild {
+        step: &'static str,
+        source: GgmlCpuGraphError,
+    },
+    #[error("moss-transcribe-diarize encoder graph execution failed: {reason}")]
+    GraphExecution { reason: String },
+    #[error(
+        "moss-transcribe-diarize encoder mel input length {found} does not match expected {expected} for {n_mels} mels x {frames} frames"
+    )]
+    InvalidMelInputLength {
+        found: usize,
+        expected: usize,
+        n_mels: usize,
+        frames: usize,
+    },
+}
+
+fn map_graph_error(step: &'static str, source: GgmlCpuGraphError) -> MossEncoderError {
+    MossEncoderError::GraphBuild { step, source }
+}
+
+struct MossEncoderLayerWeights {
+    attn_norm_weight: Vec<f32>,
+    attn_norm_bias: Vec<f32>,
+    attn_q_weight: Vec<f32>,
+    attn_q_bias: Vec<f32>,
+    attn_k_weight: Vec<f32>,
+    attn_v_weight: Vec<f32>,
+    attn_v_bias: Vec<f32>,
+    attn_out_weight: Vec<f32>,
+    attn_out_bias: Vec<f32>,
+    ffn_norm_weight: Vec<f32>,
+    ffn_norm_bias: Vec<f32>,
+    ffn_up_weight: Vec<f32>,
+    ffn_up_bias: Vec<f32>,
+    ffn_down_weight: Vec<f32>,
+    ffn_down_bias: Vec<f32>,
+}
+
+pub(crate) struct MossEncoderWeights {
+    conv1_weight_f16_bits: Vec<u16>,
+    conv1_bias: Vec<f32>,
+    conv2_weight_f16_bits: Vec<u16>,
+    conv2_bias: Vec<f32>,
+    /// `[max_source_positions, d_model]` row-major (position-major,
+    /// dim-minor -- matches HF `embed_positions.weight`'s own layout, so no
+    /// transpose is needed before uploading as a `[d_model, positions]`
+    /// (ne0=d_model) ggml tensor).
+    pos_embd: Vec<f32>,
+    layers: Vec<MossEncoderLayerWeights>,
+    out_norm_weight: Vec<f32>,
+    out_norm_bias: Vec<f32>,
+}
+
+pub(crate) fn load_moss_encoder_weights_from_reader(
+    reader: &GgufTensorDataReader,
+    config: MossEncoderConfig,
+) -> Result<MossEncoderWeights, MossEncoderError> {
+    let conv1_weight_f16_bits = reader.host_tensor_f16_bits_copy_by_name(
+        ENC_CONV1_WEIGHT,
+        &[
+            CONV_KERNEL_SIZE as u64,
+            config.n_mels as u64,
+            config.d_model as u64,
+        ],
+    )?;
+    let conv1_bias = reader
+        .host_tensor_f32_copy_dequantized_by_name(ENC_CONV1_BIAS, &[config.d_model as u64])?;
+    let conv2_weight_f16_bits = reader.host_tensor_f16_bits_copy_by_name(
+        ENC_CONV2_WEIGHT,
+        &[
+            CONV_KERNEL_SIZE as u64,
+            config.d_model as u64,
+            config.d_model as u64,
+        ],
+    )?;
+    let conv2_bias = reader
+        .host_tensor_f32_copy_dequantized_by_name(ENC_CONV2_BIAS, &[config.d_model as u64])?;
+    let pos_embd = reader.host_tensor_f32_copy_dequantized_by_name(
+        ENC_POS_EMBD_WEIGHT,
+        &[config.max_source_positions as u64, config.d_model as u64],
+    )?;
+    let out_norm_weight = reader
+        .host_tensor_f32_copy_dequantized_by_name(ENC_OUT_NORM_WEIGHT, &[config.d_model as u64])?;
+    let out_norm_bias = reader
+        .host_tensor_f32_copy_dequantized_by_name(ENC_OUT_NORM_BIAS, &[config.d_model as u64])?;
+
+    let d = config.d_model as u64;
+    let mut layers = Vec::with_capacity(config.n_layers);
+    for layer_idx in 0..config.n_layers {
+        let names = moss_encoder_layer_tensor_names(layer_idx);
+        layers.push(MossEncoderLayerWeights {
+            attn_norm_weight: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.attn_norm_weight, &[d])?,
+            attn_norm_bias: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.attn_norm_bias, &[d])?,
+            attn_q_weight: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.attn_q_weight, &[d, d])?,
+            attn_q_bias: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.attn_q_bias, &[d])?,
+            attn_k_weight: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.attn_k_weight, &[d, d])?,
+            attn_v_weight: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.attn_v_weight, &[d, d])?,
+            attn_v_bias: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.attn_v_bias, &[d])?,
+            attn_out_weight: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.attn_out_weight, &[d, d])?,
+            attn_out_bias: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.attn_out_bias, &[d])?,
+            ffn_norm_weight: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.ffn_norm_weight, &[d])?,
+            ffn_norm_bias: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.ffn_norm_bias, &[d])?,
+            ffn_up_weight: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.ffn_up_weight, &[d, 4 * d])?,
+            ffn_up_bias: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.ffn_up_bias, &[4 * d])?,
+            ffn_down_weight: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.ffn_down_weight, &[4 * d, d])?,
+            ffn_down_bias: reader
+                .host_tensor_f32_copy_dequantized_by_name(&names.ffn_down_bias, &[d])?,
+        });
+    }
+
+    Ok(MossEncoderWeights {
+        conv1_weight_f16_bits,
+        conv1_bias,
+        conv2_weight_f16_bits,
+        conv2_bias,
+        pos_embd,
+        layers,
+        out_norm_weight,
+        out_norm_bias,
+    })
+}
+
+/// Run one 30s-chunk forward pass: `mel` is `[n_mels, mel_frames]` row-major
+/// (mel-major, frame-minor -- matches
+/// `whisper::whisper_log_mel_spectrogram_16khz_mono_v0`'s own output layout,
+/// so it uploads with zero reshaping). Always produces exactly
+/// `max_source_positions` output frames (a full un-trimmed 30s chunk); the
+/// caller trims to the chunk's own valid length (see `executor.rs`).
+///
+/// Returns frame-major rows: `[frame][d_model]`, `max_source_positions *
+/// d_model` values.
+pub(crate) fn run_moss_encoder_chunk(
+    runner: &mut GgmlCpuGraphRunner,
+    weights: &MossEncoderWeights,
+    config: MossEncoderConfig,
+    mel: &[f32],
+    mel_frames: usize,
+) -> Result<Vec<f32>, MossEncoderError> {
+    let expected_mel_len = config.n_mels * mel_frames;
+    if mel.len() != expected_mel_len {
+        return Err(MossEncoderError::InvalidMelInputLength {
+            found: mel.len(),
+            expected: expected_mel_len,
+            n_mels: config.n_mels,
+            frames: mel_frames,
+        });
+    }
+    if config.n_heads == 0 || !config.d_model.is_multiple_of(config.n_heads) {
+        return Err(MossEncoderError::GraphExecution {
+            reason: format!(
+                "d_model {} is not a multiple of n_heads {}",
+                config.d_model, config.n_heads
+            ),
+        });
+    }
+    let head_dim = config.d_model / config.n_heads;
+    let output_frames = config.max_source_positions;
+    let ffn_dim = 4 * config.d_model;
+
+    let mut graph = runner.start_graph();
+
+    let mel_tensor = graph
+        .new_tensor_2d_f32(mel_frames, config.n_mels, "moss_enc_mel")
+        .map_err(|source| map_graph_error("ggml_new_tensor_2d(mel)", source))?;
+    graph
+        .set_input(mel_tensor)
+        .map_err(|source| map_graph_error("ggml_set_input(mel)", source))?;
+
+    let conv1_w = graph
+        .new_tensor_3d_f16(
+            CONV_KERNEL_SIZE,
+            config.n_mels,
+            config.d_model,
+            "moss_enc_conv1_w",
+        )
+        .map_err(|source| map_graph_error("ggml_new_tensor_3d_f16(conv1_w)", source))?;
+    graph
+        .set_input(conv1_w)
+        .map_err(|source| map_graph_error("ggml_set_input(conv1_w)", source))?;
+    let conv1_b = graph
+        .new_tensor_2d_f32(1, config.d_model, "moss_enc_conv1_b")
+        .map_err(|source| map_graph_error("ggml_new_tensor_2d(conv1_b)", source))?;
+    graph
+        .set_input(conv1_b)
+        .map_err(|source| map_graph_error("ggml_set_input(conv1_b)", source))?;
+    let conv2_w = graph
+        .new_tensor_3d_f16(
+            CONV_KERNEL_SIZE,
+            config.d_model,
+            config.d_model,
+            "moss_enc_conv2_w",
+        )
+        .map_err(|source| map_graph_error("ggml_new_tensor_3d_f16(conv2_w)", source))?;
+    graph
+        .set_input(conv2_w)
+        .map_err(|source| map_graph_error("ggml_set_input(conv2_w)", source))?;
+    let conv2_b = graph
+        .new_tensor_2d_f32(1, config.d_model, "moss_enc_conv2_b")
+        .map_err(|source| map_graph_error("ggml_new_tensor_2d(conv2_b)", source))?;
+    graph
+        .set_input(conv2_b)
+        .map_err(|source| map_graph_error("ggml_set_input(conv2_b)", source))?;
+    let pos_embd = graph
+        .new_tensor_2d_f32(config.d_model, output_frames, "moss_enc_pos_embd")
+        .map_err(|source| map_graph_error("ggml_new_tensor_2d(pos_embd)", source))?;
+    graph
+        .set_input(pos_embd)
+        .map_err(|source| map_graph_error("ggml_set_input(pos_embd)", source))?;
+    let mask = graph
+        .new_tensor_2d_f32(output_frames, output_frames, "moss_enc_mask")
+        .map_err(|source| map_graph_error("ggml_new_tensor_2d(mask)", source))?;
+    graph
+        .set_input(mask)
+        .map_err(|source| map_graph_error("ggml_set_input(mask)", source))?;
+
+    let conv1 = apply_conv_1d_bias_activation(
+        &graph,
+        conv1_w,
+        mel_tensor,
+        conv1_b,
+        Conv1dParams {
+            stride: CONV1_STRIDE,
+            padding: CONV_PADDING,
+            dilation: CONV_DILATION,
+        },
+        ConvActivation::Gelu,
+        ConvBlockSteps {
+            conv: "ggml_conv_1d(conv1)",
+            bias: "ggml_add(conv1_bias)",
+            activation: "ggml_gelu(conv1)",
+        },
+        map_graph_error,
+    )?;
+    let conv2 = apply_conv_1d_bias_activation(
+        &graph,
+        conv2_w,
+        conv1,
+        conv2_b,
+        Conv1dParams {
+            stride: CONV2_STRIDE,
+            padding: CONV_PADDING,
+            dilation: CONV_DILATION,
+        },
+        ConvActivation::Gelu,
+        ConvBlockSteps {
+            conv: "ggml_conv_1d(conv2)",
+            bias: "ggml_add(conv2_bias)",
+            activation: "ggml_gelu(conv2)",
+        },
+        map_graph_error,
+    )?;
+    let conv2 = graph
+        .permute(conv2, 1, 0, 2, 3)
+        .map_err(|source| map_graph_error("ggml_permute(conv2)", source))?;
+    let conv2 = graph
+        .cont(conv2)
+        .map_err(|source| map_graph_error("ggml_cont(conv2)", source))?;
+    let mut state = graph
+        .add(conv2, pos_embd)
+        .map_err(|source| map_graph_error("ggml_add(pos_embd)", source))?;
+
+    let mut layer_uploads: Vec<(crate::ggml_runtime::GgmlCpuTensor<'_>, &[f32], &'static str)> =
+        Vec::new();
+    let zero_k_bias = vec![0.0_f32; config.d_model];
+
+    for (layer_idx, layer_weights) in weights.layers.iter().enumerate() {
+        let scope = format!("moss_enc_l{layer_idx}");
+        let attn_norm_weight = graph
+            .new_tensor_1d_f32(config.d_model, "attn_norm_w")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_norm_w)", source))?;
+        let attn_norm_bias = graph
+            .new_tensor_1d_f32(config.d_model, "attn_norm_b")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_norm_b)", source))?;
+        let attn_q_weight = graph
+            .new_tensor_2d_f32(config.d_model, config.d_model, "attn_q_w")
+            .map_err(|source| map_graph_error("ggml_new_tensor_2d(attn_q_w)", source))?;
+        let attn_q_bias = graph
+            .new_tensor_1d_f32(config.d_model, "attn_q_b")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_q_b)", source))?;
+        let attn_k_weight = graph
+            .new_tensor_2d_f32(config.d_model, config.d_model, "attn_k_w")
+            .map_err(|source| map_graph_error("ggml_new_tensor_2d(attn_k_w)", source))?;
+        let attn_k_bias = graph
+            .new_tensor_1d_f32(config.d_model, "attn_k_b_zero")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_k_b_zero)", source))?;
+        let attn_v_weight = graph
+            .new_tensor_2d_f32(config.d_model, config.d_model, "attn_v_w")
+            .map_err(|source| map_graph_error("ggml_new_tensor_2d(attn_v_w)", source))?;
+        let attn_v_bias = graph
+            .new_tensor_1d_f32(config.d_model, "attn_v_b")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_v_b)", source))?;
+        let attn_out_weight = graph
+            .new_tensor_2d_f32(config.d_model, config.d_model, "attn_out_w")
+            .map_err(|source| map_graph_error("ggml_new_tensor_2d(attn_out_w)", source))?;
+        let attn_out_bias = graph
+            .new_tensor_1d_f32(config.d_model, "attn_out_b")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_out_b)", source))?;
+        let ffn_norm_weight = graph
+            .new_tensor_1d_f32(config.d_model, "ffn_norm_w")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(ffn_norm_w)", source))?;
+        let ffn_norm_bias = graph
+            .new_tensor_1d_f32(config.d_model, "ffn_norm_b")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(ffn_norm_b)", source))?;
+        let ffn_up_weight = graph
+            .new_tensor_2d_f32(config.d_model, ffn_dim, "ffn_up_w")
+            .map_err(|source| map_graph_error("ggml_new_tensor_2d(ffn_up_w)", source))?;
+        let ffn_up_bias = graph
+            .new_tensor_1d_f32(ffn_dim, "ffn_up_b")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(ffn_up_b)", source))?;
+        let ffn_down_weight = graph
+            .new_tensor_2d_f32(ffn_dim, config.d_model, "ffn_down_w")
+            .map_err(|source| map_graph_error("ggml_new_tensor_2d(ffn_down_w)", source))?;
+        let ffn_down_bias = graph
+            .new_tensor_1d_f32(config.d_model, "ffn_down_b")
+            .map_err(|source| map_graph_error("ggml_new_tensor_1d(ffn_down_b)", source))?;
+
+        for tensor in [
+            attn_norm_weight,
+            attn_norm_bias,
+            attn_q_weight,
+            attn_q_bias,
+            attn_k_weight,
+            attn_k_bias,
+            attn_v_weight,
+            attn_v_bias,
+            attn_out_weight,
+            attn_out_bias,
+            ffn_norm_weight,
+            ffn_norm_bias,
+            ffn_up_weight,
+            ffn_up_bias,
+            ffn_down_weight,
+            ffn_down_bias,
+        ] {
+            graph.set_input(tensor).map_err(|source| {
+                map_graph_error("ggml_set_input(encoder_layer_weight)", source)
+            })?;
+        }
+
+        layer_uploads.push((
+            attn_norm_weight,
+            &layer_weights.attn_norm_weight,
+            "attn_norm_w",
+        ));
+        layer_uploads.push((attn_norm_bias, &layer_weights.attn_norm_bias, "attn_norm_b"));
+        layer_uploads.push((attn_q_weight, &layer_weights.attn_q_weight, "attn_q_w"));
+        layer_uploads.push((attn_q_bias, &layer_weights.attn_q_bias, "attn_q_b"));
+        layer_uploads.push((attn_k_weight, &layer_weights.attn_k_weight, "attn_k_w"));
+        layer_uploads.push((attn_k_bias, &zero_k_bias, "attn_k_b_zero"));
+        layer_uploads.push((attn_v_weight, &layer_weights.attn_v_weight, "attn_v_w"));
+        layer_uploads.push((attn_v_bias, &layer_weights.attn_v_bias, "attn_v_b"));
+        layer_uploads.push((
+            attn_out_weight,
+            &layer_weights.attn_out_weight,
+            "attn_out_w",
+        ));
+        layer_uploads.push((attn_out_bias, &layer_weights.attn_out_bias, "attn_out_b"));
+        layer_uploads.push((
+            ffn_norm_weight,
+            &layer_weights.ffn_norm_weight,
+            "ffn_norm_w",
+        ));
+        layer_uploads.push((ffn_norm_bias, &layer_weights.ffn_norm_bias, "ffn_norm_b"));
+        layer_uploads.push((ffn_up_weight, &layer_weights.ffn_up_weight, "ffn_up_w"));
+        layer_uploads.push((ffn_up_bias, &layer_weights.ffn_up_bias, "ffn_up_b"));
+        layer_uploads.push((
+            ffn_down_weight,
+            &layer_weights.ffn_down_weight,
+            "ffn_down_w",
+        ));
+        layer_uploads.push((ffn_down_bias, &layer_weights.ffn_down_bias, "ffn_down_b"));
+
+        state = transformer_layer(
+            &mut graph,
+            state,
+            mask,
+            TransformerEncoderConfig {
+                head_dim,
+                attention_heads: config.n_heads,
+                token_count: output_frames,
+                layer_norm_epsilon: MOSS_ENCODER_LAYER_NORM_EPSILON,
+                ffn_activation: crate::nn::ffn::FeedForwardActivation::Gelu,
+                use_flash_attention: false,
+            },
+            TransformerEncoderLayerWeights {
+                attn_norm_weight,
+                attn_norm_bias,
+                attn_q_weight,
+                attn_q_bias,
+                attn_k_weight,
+                attn_k_bias,
+                attn_v_weight,
+                attn_v_bias,
+                attn_out_weight,
+                attn_out_bias,
+                ffn_norm_weight,
+                ffn_norm_bias,
+                ffn_up_weight,
+                ffn_up_bias,
+                ffn_down_weight,
+                ffn_down_bias,
+            },
+            map_graph_error,
+        )?;
+        let _ = scope;
+    }
+
+    let out_norm_weight = graph
+        .new_tensor_1d_f32(config.d_model, "out_norm_w")
+        .map_err(|source| map_graph_error("ggml_new_tensor_1d(out_norm_w)", source))?;
+    graph
+        .set_input(out_norm_weight)
+        .map_err(|source| map_graph_error("ggml_set_input(out_norm_w)", source))?;
+    let out_norm_bias = graph
+        .new_tensor_1d_f32(config.d_model, "out_norm_b")
+        .map_err(|source| map_graph_error("ggml_new_tensor_1d(out_norm_b)", source))?;
+    graph
+        .set_input(out_norm_bias)
+        .map_err(|source| map_graph_error("ggml_set_input(out_norm_b)", source))?;
+
+    state = crate::nn::norm::apply_affine_layer_norm(
+        &graph,
+        state,
+        MOSS_ENCODER_LAYER_NORM_EPSILON,
+        out_norm_weight,
+        out_norm_bias,
+        crate::nn::norm::AffineLayerNormSteps {
+            norm: "ggml_norm(out_norm)",
+            scale: "out_norm",
+            bias: "out_norm",
+        },
+        map_graph_error,
+    )?;
+
+    graph
+        .set_output(state)
+        .map_err(|source| map_graph_error("ggml_set_output(encoder_out)", source))?;
+
+    graph
+        .set_f32_slice(mel_tensor, mel, "moss_enc_mel")
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("could not upload mel features: {source}"),
+        })?;
+    graph
+        .set_f16_bits_slice(conv1_w, &weights.conv1_weight_f16_bits, "moss_enc_conv1_w")
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("could not upload conv1 weight: {source}"),
+        })?;
+    graph
+        .set_f32_slice(conv1_b, &weights.conv1_bias, "moss_enc_conv1_b")
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("could not upload conv1 bias: {source}"),
+        })?;
+    graph
+        .set_f16_bits_slice(conv2_w, &weights.conv2_weight_f16_bits, "moss_enc_conv2_w")
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("could not upload conv2 weight: {source}"),
+        })?;
+    graph
+        .set_f32_slice(conv2_b, &weights.conv2_bias, "moss_enc_conv2_b")
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("could not upload conv2 bias: {source}"),
+        })?;
+    graph
+        .set_f32_slice(pos_embd, &weights.pos_embd, "moss_enc_pos_embd")
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("could not upload positional embedding: {source}"),
+        })?;
+    let mask_zeros = vec![0.0_f32; output_frames * output_frames];
+    graph
+        .set_f32_slice(mask, &mask_zeros, "moss_enc_mask")
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("could not upload attention mask: {source}"),
+        })?;
+    graph
+        .set_f32_slice(out_norm_weight, &weights.out_norm_weight, "out_norm_w")
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("could not upload out_norm weight: {source}"),
+        })?;
+    graph
+        .set_f32_slice(out_norm_bias, &weights.out_norm_bias, "out_norm_b")
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("could not upload out_norm bias: {source}"),
+        })?;
+    for (tensor, values, label) in layer_uploads {
+        graph
+            .set_f32_slice(tensor, values, label)
+            .map_err(|source| MossEncoderError::GraphExecution {
+                reason: format!("could not upload encoder layer weight '{label}': {source}"),
+            })?;
+    }
+
+    let values = graph
+        .compute_output_f32(state, output_frames * config.d_model)
+        .map_err(|source| MossEncoderError::GraphExecution {
+            reason: format!("encoder graph compute failed: {source}"),
+        })?;
+    Ok(values)
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/encoder_graph.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/encoder_graph.rs
@@ -19,17 +19,26 @@
 //! `MossTranscribeDiarizeModel.get_audio_features`'s
 //! `whisper_features[chunk_idx:chunk_idx+1, :token_len*4]` truncation.
 //!
-//! Deliberately skips the WEIGHTS-usage resident-arena optimization every
-//! other family's encoder uses for GPU offload (see `qwen::audio_encoder`'s
-//! module doc): correctness first, performance tuning is explicitly
-//! out-of-scope for this stage (see `mod.rs`'s stage-status note). Every
-//! weight is a genuine per-call graph input, which is correct on every
-//! backend, just not the fastest.
+//! Weights live resident across chunks instead of being re-declared as
+//! per-call graph inputs, mirroring `qwen::audio_encoder`'s
+//! `Qwen3AsrAudioEncoderRuntime` pattern: the six 2D projection weights per
+//! layer (`attn_{q,k,v,out}`, `ffn_{up,down}` -- by far the largest tensors,
+//! ~48 MiB/layer x 24 layers of host f32 if dequantized) bind zero-copy from
+//! the mmap'd pack's native f16 storage (see `load_moss_encoder_weights_from_reader`
+//! and `loaded_or_arena_2d` below), never touching host memory; everything
+//! else small (conv stem, every 1D norm/bias, the fixed positional embedding,
+//! the final LayerNorm) lives in a WEIGHTS-usage static-tensor arena uploaded
+//! once per `encode()` call. Only the per-chunk mel features and the (always
+//! all-zero, but genuinely re-uploaded per call for op-order clarity)
+//! attention mask stay real graph inputs.
+
+use std::path::Path;
 
 use thiserror::Error;
 
 use crate::ggml_runtime::{
-    GgmlCpuGraphError, GgmlCpuGraphRunner, GgufTensorDataReadError, GgufTensorDataReader,
+    GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlLoadedWeightContext,
+    GgmlStaticTensor, GgmlStaticTensorArena, GgufTensorDataReadError, GgufTensorDataReader,
 };
 use crate::nn::conv::{
     Conv1dParams, ConvActivation, ConvBlockSteps, apply_conv_1d_bias_activation,
@@ -88,21 +97,34 @@ fn map_graph_error(step: &'static str, source: GgmlCpuGraphError) -> MossEncoder
     MossEncoderError::GraphBuild { step, source }
 }
 
+/// A 2D projection weight's GGUF tensor name, with `values` always empty:
+/// this encoder never dequantizes these six per-layer weights to host f32
+/// (see `load_moss_encoder_weights_from_reader`), it only records the name so
+/// `loaded_or_arena_2d` can bind the mmap'd pack's native tensor zero-copy at
+/// `encode()` time. `values` exists (rather than dropping the field) so
+/// `loaded_or_arena_2d` has the same fail-closed shape as
+/// `qwen::audio_encoder`'s `F32Tensor`/`loaded_or_arena_2d`: an empty slice
+/// with no `loaded` bind is a hard error, never a silently-empty upload.
+struct MossProjectionTensor {
+    name: String,
+    values: Vec<f32>,
+}
+
 struct MossEncoderLayerWeights {
     attn_norm_weight: Vec<f32>,
     attn_norm_bias: Vec<f32>,
-    attn_q_weight: Vec<f32>,
+    attn_q_weight: MossProjectionTensor,
     attn_q_bias: Vec<f32>,
-    attn_k_weight: Vec<f32>,
-    attn_v_weight: Vec<f32>,
+    attn_k_weight: MossProjectionTensor,
+    attn_v_weight: MossProjectionTensor,
     attn_v_bias: Vec<f32>,
-    attn_out_weight: Vec<f32>,
+    attn_out_weight: MossProjectionTensor,
     attn_out_bias: Vec<f32>,
     ffn_norm_weight: Vec<f32>,
     ffn_norm_bias: Vec<f32>,
-    ffn_up_weight: Vec<f32>,
+    ffn_up_weight: MossProjectionTensor,
     ffn_up_bias: Vec<f32>,
-    ffn_down_weight: Vec<f32>,
+    ffn_down_weight: MossProjectionTensor,
     ffn_down_bias: Vec<f32>,
 }
 
@@ -163,30 +185,46 @@ pub(crate) fn load_moss_encoder_weights_from_reader(
                 .host_tensor_f32_copy_dequantized_by_name(&names.attn_norm_weight, &[d])?,
             attn_norm_bias: reader
                 .host_tensor_f32_copy_dequantized_by_name(&names.attn_norm_bias, &[d])?,
-            attn_q_weight: reader
-                .host_tensor_f32_copy_dequantized_by_name(&names.attn_q_weight, &[d, d])?,
+            // The four attention projections and the two FFN projections are
+            // never dequantized here -- `encode()` binds them zero-copy from
+            // the mmap'd pack via `loaded_or_arena_2d` (goals 7+8 Step 1b,
+            // mirrored from `qwen::audio_encoder`). Only the name is kept.
+            attn_q_weight: MossProjectionTensor {
+                name: names.attn_q_weight,
+                values: Vec::new(),
+            },
             attn_q_bias: reader
                 .host_tensor_f32_copy_dequantized_by_name(&names.attn_q_bias, &[d])?,
-            attn_k_weight: reader
-                .host_tensor_f32_copy_dequantized_by_name(&names.attn_k_weight, &[d, d])?,
-            attn_v_weight: reader
-                .host_tensor_f32_copy_dequantized_by_name(&names.attn_v_weight, &[d, d])?,
+            attn_k_weight: MossProjectionTensor {
+                name: names.attn_k_weight,
+                values: Vec::new(),
+            },
+            attn_v_weight: MossProjectionTensor {
+                name: names.attn_v_weight,
+                values: Vec::new(),
+            },
             attn_v_bias: reader
                 .host_tensor_f32_copy_dequantized_by_name(&names.attn_v_bias, &[d])?,
-            attn_out_weight: reader
-                .host_tensor_f32_copy_dequantized_by_name(&names.attn_out_weight, &[d, d])?,
+            attn_out_weight: MossProjectionTensor {
+                name: names.attn_out_weight,
+                values: Vec::new(),
+            },
             attn_out_bias: reader
                 .host_tensor_f32_copy_dequantized_by_name(&names.attn_out_bias, &[d])?,
             ffn_norm_weight: reader
                 .host_tensor_f32_copy_dequantized_by_name(&names.ffn_norm_weight, &[d])?,
             ffn_norm_bias: reader
                 .host_tensor_f32_copy_dequantized_by_name(&names.ffn_norm_bias, &[d])?,
-            ffn_up_weight: reader
-                .host_tensor_f32_copy_dequantized_by_name(&names.ffn_up_weight, &[d, 4 * d])?,
+            ffn_up_weight: MossProjectionTensor {
+                name: names.ffn_up_weight,
+                values: Vec::new(),
+            },
             ffn_up_bias: reader
                 .host_tensor_f32_copy_dequantized_by_name(&names.ffn_up_bias, &[4 * d])?,
-            ffn_down_weight: reader
-                .host_tensor_f32_copy_dequantized_by_name(&names.ffn_down_weight, &[4 * d, d])?,
+            ffn_down_weight: MossProjectionTensor {
+                name: names.ffn_down_weight,
+                values: Vec::new(),
+            },
             ffn_down_bias: reader
                 .host_tensor_f32_copy_dequantized_by_name(&names.ffn_down_bias, &[d])?,
         });
@@ -204,380 +242,541 @@ pub(crate) fn load_moss_encoder_weights_from_reader(
     })
 }
 
-/// Run one 30s-chunk forward pass: `mel` is `[n_mels, mel_frames]` row-major
-/// (mel-major, frame-minor -- matches
-/// `whisper::whisper_log_mel_spectrogram_16khz_mono_v0`'s own output layout,
-/// so it uploads with zero reshaping). Always produces exactly
-/// `max_source_positions` output frames (a full un-trimmed 30s chunk); the
-/// caller trims to the chunk's own valid length (see `executor.rs`).
-///
-/// Returns frame-major rows: `[frame][d_model]`, `max_source_positions *
-/// d_model` values.
-pub(crate) fn run_moss_encoder_chunk(
-    runner: &mut GgmlCpuGraphRunner,
-    weights: &MossEncoderWeights,
-    config: MossEncoderConfig,
-    mel: &[f32],
-    mel_frames: usize,
-) -> Result<Vec<f32>, MossEncoderError> {
-    let expected_mel_len = config.n_mels * mel_frames;
-    if mel.len() != expected_mel_len {
-        return Err(MossEncoderError::InvalidMelInputLength {
-            found: mel.len(),
-            expected: expected_mel_len,
-            n_mels: config.n_mels,
-            frames: mel_frames,
-        });
+/// Owns the encoder's graph runner plus the optional zero-copy weight
+/// context; both are expensive to rebuild per chunk (the loaded-weight
+/// context mmaps the whole pack), so callers build one runtime and call
+/// [`Self::encode`] once per 30s chunk. Mirrors
+/// `qwen::audio_encoder::Qwen3AsrAudioEncoderRuntime`.
+pub(crate) struct MossEncoderRuntime {
+    runner: GgmlCpuGraphRunner,
+    loaded: Option<GgmlLoadedWeightContext>,
+}
+
+impl MossEncoderRuntime {
+    pub(crate) fn new(
+        graph_config: GgmlCpuGraphConfig,
+        runtime_path: Option<&Path>,
+    ) -> Result<Self, MossEncoderError> {
+        let runner = GgmlCpuGraphRunner::new(graph_config)
+            .map_err(|source| map_graph_error("runner_init", source))?;
+        // `None` (no path) only happens off the production executor path; the
+        // only real caller (`executor.rs`) always resolves a concrete pack
+        // path through preflight first.
+        let loaded = runtime_path.and_then(|path| runner.load_gguf_weight_context(path).ok());
+        Ok(Self { runner, loaded })
     }
-    if config.n_heads == 0 || !config.d_model.is_multiple_of(config.n_heads) {
-        return Err(MossEncoderError::GraphExecution {
-            reason: format!(
-                "d_model {} is not a multiple of n_heads {}",
-                config.d_model, config.n_heads
-            ),
-        });
-    }
-    let head_dim = config.d_model / config.n_heads;
-    let output_frames = config.max_source_positions;
-    let ffn_dim = 4 * config.d_model;
 
-    let mut graph = runner.start_graph();
-
-    let mel_tensor = graph
-        .new_tensor_2d_f32(mel_frames, config.n_mels, "moss_enc_mel")
-        .map_err(|source| map_graph_error("ggml_new_tensor_2d(mel)", source))?;
-    graph
-        .set_input(mel_tensor)
-        .map_err(|source| map_graph_error("ggml_set_input(mel)", source))?;
-
-    let conv1_w = graph
-        .new_tensor_3d_f16(
-            CONV_KERNEL_SIZE,
-            config.n_mels,
-            config.d_model,
-            "moss_enc_conv1_w",
-        )
-        .map_err(|source| map_graph_error("ggml_new_tensor_3d_f16(conv1_w)", source))?;
-    graph
-        .set_input(conv1_w)
-        .map_err(|source| map_graph_error("ggml_set_input(conv1_w)", source))?;
-    let conv1_b = graph
-        .new_tensor_2d_f32(1, config.d_model, "moss_enc_conv1_b")
-        .map_err(|source| map_graph_error("ggml_new_tensor_2d(conv1_b)", source))?;
-    graph
-        .set_input(conv1_b)
-        .map_err(|source| map_graph_error("ggml_set_input(conv1_b)", source))?;
-    let conv2_w = graph
-        .new_tensor_3d_f16(
-            CONV_KERNEL_SIZE,
-            config.d_model,
-            config.d_model,
-            "moss_enc_conv2_w",
-        )
-        .map_err(|source| map_graph_error("ggml_new_tensor_3d_f16(conv2_w)", source))?;
-    graph
-        .set_input(conv2_w)
-        .map_err(|source| map_graph_error("ggml_set_input(conv2_w)", source))?;
-    let conv2_b = graph
-        .new_tensor_2d_f32(1, config.d_model, "moss_enc_conv2_b")
-        .map_err(|source| map_graph_error("ggml_new_tensor_2d(conv2_b)", source))?;
-    graph
-        .set_input(conv2_b)
-        .map_err(|source| map_graph_error("ggml_set_input(conv2_b)", source))?;
-    let pos_embd = graph
-        .new_tensor_2d_f32(config.d_model, output_frames, "moss_enc_pos_embd")
-        .map_err(|source| map_graph_error("ggml_new_tensor_2d(pos_embd)", source))?;
-    graph
-        .set_input(pos_embd)
-        .map_err(|source| map_graph_error("ggml_set_input(pos_embd)", source))?;
-    let mask = graph
-        .new_tensor_2d_f32(output_frames, output_frames, "moss_enc_mask")
-        .map_err(|source| map_graph_error("ggml_new_tensor_2d(mask)", source))?;
-    graph
-        .set_input(mask)
-        .map_err(|source| map_graph_error("ggml_set_input(mask)", source))?;
-
-    let conv1 = apply_conv_1d_bias_activation(
-        &graph,
-        conv1_w,
-        mel_tensor,
-        conv1_b,
-        Conv1dParams {
-            stride: CONV1_STRIDE,
-            padding: CONV_PADDING,
-            dilation: CONV_DILATION,
-        },
-        ConvActivation::Gelu,
-        ConvBlockSteps {
-            conv: "ggml_conv_1d(conv1)",
-            bias: "ggml_add(conv1_bias)",
-            activation: "ggml_gelu(conv1)",
-        },
-        map_graph_error,
-    )?;
-    let conv2 = apply_conv_1d_bias_activation(
-        &graph,
-        conv2_w,
-        conv1,
-        conv2_b,
-        Conv1dParams {
-            stride: CONV2_STRIDE,
-            padding: CONV_PADDING,
-            dilation: CONV_DILATION,
-        },
-        ConvActivation::Gelu,
-        ConvBlockSteps {
-            conv: "ggml_conv_1d(conv2)",
-            bias: "ggml_add(conv2_bias)",
-            activation: "ggml_gelu(conv2)",
-        },
-        map_graph_error,
-    )?;
-    let conv2 = graph
-        .permute(conv2, 1, 0, 2, 3)
-        .map_err(|source| map_graph_error("ggml_permute(conv2)", source))?;
-    let conv2 = graph
-        .cont(conv2)
-        .map_err(|source| map_graph_error("ggml_cont(conv2)", source))?;
-    let mut state = graph
-        .add(conv2, pos_embd)
-        .map_err(|source| map_graph_error("ggml_add(pos_embd)", source))?;
-
-    let mut layer_uploads: Vec<(crate::ggml_runtime::GgmlCpuTensor<'_>, &[f32], &'static str)> =
-        Vec::new();
-    let zero_k_bias = vec![0.0_f32; config.d_model];
-
-    for (layer_idx, layer_weights) in weights.layers.iter().enumerate() {
-        let scope = format!("moss_enc_l{layer_idx}");
-        let attn_norm_weight = graph
-            .new_tensor_1d_f32(config.d_model, "attn_norm_w")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_norm_w)", source))?;
-        let attn_norm_bias = graph
-            .new_tensor_1d_f32(config.d_model, "attn_norm_b")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_norm_b)", source))?;
-        let attn_q_weight = graph
-            .new_tensor_2d_f32(config.d_model, config.d_model, "attn_q_w")
-            .map_err(|source| map_graph_error("ggml_new_tensor_2d(attn_q_w)", source))?;
-        let attn_q_bias = graph
-            .new_tensor_1d_f32(config.d_model, "attn_q_b")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_q_b)", source))?;
-        let attn_k_weight = graph
-            .new_tensor_2d_f32(config.d_model, config.d_model, "attn_k_w")
-            .map_err(|source| map_graph_error("ggml_new_tensor_2d(attn_k_w)", source))?;
-        let attn_k_bias = graph
-            .new_tensor_1d_f32(config.d_model, "attn_k_b_zero")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_k_b_zero)", source))?;
-        let attn_v_weight = graph
-            .new_tensor_2d_f32(config.d_model, config.d_model, "attn_v_w")
-            .map_err(|source| map_graph_error("ggml_new_tensor_2d(attn_v_w)", source))?;
-        let attn_v_bias = graph
-            .new_tensor_1d_f32(config.d_model, "attn_v_b")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_v_b)", source))?;
-        let attn_out_weight = graph
-            .new_tensor_2d_f32(config.d_model, config.d_model, "attn_out_w")
-            .map_err(|source| map_graph_error("ggml_new_tensor_2d(attn_out_w)", source))?;
-        let attn_out_bias = graph
-            .new_tensor_1d_f32(config.d_model, "attn_out_b")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(attn_out_b)", source))?;
-        let ffn_norm_weight = graph
-            .new_tensor_1d_f32(config.d_model, "ffn_norm_w")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(ffn_norm_w)", source))?;
-        let ffn_norm_bias = graph
-            .new_tensor_1d_f32(config.d_model, "ffn_norm_b")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(ffn_norm_b)", source))?;
-        let ffn_up_weight = graph
-            .new_tensor_2d_f32(config.d_model, ffn_dim, "ffn_up_w")
-            .map_err(|source| map_graph_error("ggml_new_tensor_2d(ffn_up_w)", source))?;
-        let ffn_up_bias = graph
-            .new_tensor_1d_f32(ffn_dim, "ffn_up_b")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(ffn_up_b)", source))?;
-        let ffn_down_weight = graph
-            .new_tensor_2d_f32(ffn_dim, config.d_model, "ffn_down_w")
-            .map_err(|source| map_graph_error("ggml_new_tensor_2d(ffn_down_w)", source))?;
-        let ffn_down_bias = graph
-            .new_tensor_1d_f32(config.d_model, "ffn_down_b")
-            .map_err(|source| map_graph_error("ggml_new_tensor_1d(ffn_down_b)", source))?;
-
-        for tensor in [
-            attn_norm_weight,
-            attn_norm_bias,
-            attn_q_weight,
-            attn_q_bias,
-            attn_k_weight,
-            attn_k_bias,
-            attn_v_weight,
-            attn_v_bias,
-            attn_out_weight,
-            attn_out_bias,
-            ffn_norm_weight,
-            ffn_norm_bias,
-            ffn_up_weight,
-            ffn_up_bias,
-            ffn_down_weight,
-            ffn_down_bias,
-        ] {
-            graph.set_input(tensor).map_err(|source| {
-                map_graph_error("ggml_set_input(encoder_layer_weight)", source)
-            })?;
+    /// Run one 30s-chunk forward pass: `mel` is `[n_mels, mel_frames]`
+    /// row-major (mel-major, frame-minor -- matches
+    /// `whisper::whisper_log_mel_spectrogram_16khz_mono_v0`'s own output
+    /// layout, so it uploads with zero reshaping). Always produces exactly
+    /// `max_source_positions` output frames (a full un-trimmed 30s chunk);
+    /// the caller trims to the chunk's own valid length (see `executor.rs`).
+    ///
+    /// Returns frame-major rows: `[frame][d_model]`, `max_source_positions *
+    /// d_model` values.
+    pub(crate) fn encode(
+        &mut self,
+        weights: &MossEncoderWeights,
+        config: MossEncoderConfig,
+        mel: &[f32],
+        mel_frames: usize,
+    ) -> Result<Vec<f32>, MossEncoderError> {
+        let expected_mel_len = config.n_mels * mel_frames;
+        if mel.len() != expected_mel_len {
+            return Err(MossEncoderError::InvalidMelInputLength {
+                found: mel.len(),
+                expected: expected_mel_len,
+                n_mels: config.n_mels,
+                frames: mel_frames,
+            });
         }
+        if config.n_heads == 0 || !config.d_model.is_multiple_of(config.n_heads) {
+            return Err(MossEncoderError::GraphExecution {
+                reason: format!(
+                    "d_model {} is not a multiple of n_heads {}",
+                    config.d_model, config.n_heads
+                ),
+            });
+        }
+        let head_dim = config.d_model / config.n_heads;
+        let output_frames = config.max_source_positions;
 
-        layer_uploads.push((
-            attn_norm_weight,
-            &layer_weights.attn_norm_weight,
-            "attn_norm_w",
-        ));
-        layer_uploads.push((attn_norm_bias, &layer_weights.attn_norm_bias, "attn_norm_b"));
-        layer_uploads.push((attn_q_weight, &layer_weights.attn_q_weight, "attn_q_w"));
-        layer_uploads.push((attn_q_bias, &layer_weights.attn_q_bias, "attn_q_b"));
-        layer_uploads.push((attn_k_weight, &layer_weights.attn_k_weight, "attn_k_w"));
-        layer_uploads.push((attn_k_bias, &zero_k_bias, "attn_k_b_zero"));
-        layer_uploads.push((attn_v_weight, &layer_weights.attn_v_weight, "attn_v_w"));
-        layer_uploads.push((attn_v_bias, &layer_weights.attn_v_bias, "attn_v_b"));
-        layer_uploads.push((
-            attn_out_weight,
-            &layer_weights.attn_out_weight,
-            "attn_out_w",
-        ));
-        layer_uploads.push((attn_out_bias, &layer_weights.attn_out_bias, "attn_out_b"));
-        layer_uploads.push((
-            ffn_norm_weight,
-            &layer_weights.ffn_norm_weight,
-            "ffn_norm_w",
-        ));
-        layer_uploads.push((ffn_norm_bias, &layer_weights.ffn_norm_bias, "ffn_norm_b"));
-        layer_uploads.push((ffn_up_weight, &layer_weights.ffn_up_weight, "ffn_up_w"));
-        layer_uploads.push((ffn_up_bias, &layer_weights.ffn_up_bias, "ffn_up_b"));
-        layer_uploads.push((
-            ffn_down_weight,
-            &layer_weights.ffn_down_weight,
-            "ffn_down_w",
-        ));
-        layer_uploads.push((ffn_down_bias, &layer_weights.ffn_down_bias, "ffn_down_b"));
+        let loaded = self.loaded.as_ref();
 
-        state = transformer_layer(
-            &mut graph,
-            state,
-            mask,
-            TransformerEncoderConfig {
-                head_dim,
-                attention_heads: config.n_heads,
-                token_count: output_frames,
-                layer_norm_epsilon: MOSS_ENCODER_LAYER_NORM_EPSILON,
-                ffn_activation: crate::nn::ffn::FeedForwardActivation::Gelu,
-                use_flash_attention: false,
+        // Resident encoder weights (conv stem, every 1D norm/bias, the fixed
+        // positional embedding, the final LayerNorm) live in a WEIGHTS-usage
+        // arena buffer instead of per-call graph-input leaves; the six 2D
+        // projection weights per layer bind zero-copy from the mmap'd pack
+        // when bound. Only the mel input and the (per-call, always all-zero)
+        // attention mask stay genuine graph inputs. Mirrors
+        // `qwen::audio_encoder`'s `build_qwen_audio_resident_weights`.
+        let mut arena = self
+            .runner
+            .start_static_tensor_arena(moss_encoder_arena_context_bytes(weights))
+            .map_err(|source| map_graph_error("static_tensor_arena", source))?;
+        let resident = build_moss_encoder_resident_weights(&mut arena, weights, config, loaded)?;
+
+        let mut graph = self.runner.start_graph();
+
+        let mel_tensor = graph
+            .new_tensor_2d_f32(mel_frames, config.n_mels, "moss_enc_mel")
+            .map_err(|source| map_graph_error("ggml_new_tensor_2d(mel)", source))?;
+        graph
+            .set_input(mel_tensor)
+            .map_err(|source| map_graph_error("ggml_set_input(mel)", source))?;
+        let mask = graph
+            .new_tensor_2d_f32(output_frames, output_frames, "moss_enc_mask")
+            .map_err(|source| map_graph_error("ggml_new_tensor_2d(mask)", source))?;
+        graph
+            .set_input(mask)
+            .map_err(|source| map_graph_error("ggml_set_input(mask)", source))?;
+
+        let conv1 = apply_conv_1d_bias_activation(
+            &graph,
+            resident.conv1_weight,
+            mel_tensor,
+            resident.conv1_bias,
+            Conv1dParams {
+                stride: CONV1_STRIDE,
+                padding: CONV_PADDING,
+                dilation: CONV_DILATION,
             },
-            TransformerEncoderLayerWeights {
-                attn_norm_weight,
-                attn_norm_bias,
-                attn_q_weight,
-                attn_q_bias,
-                attn_k_weight,
-                attn_k_bias,
-                attn_v_weight,
-                attn_v_bias,
-                attn_out_weight,
-                attn_out_bias,
-                ffn_norm_weight,
-                ffn_norm_bias,
-                ffn_up_weight,
-                ffn_up_bias,
-                ffn_down_weight,
-                ffn_down_bias,
+            ConvActivation::Gelu,
+            ConvBlockSteps {
+                conv: "ggml_conv_1d(conv1)",
+                bias: "ggml_add(conv1_bias)",
+                activation: "ggml_gelu(conv1)",
             },
             map_graph_error,
         )?;
-        let _ = scope;
+        let conv2 = apply_conv_1d_bias_activation(
+            &graph,
+            resident.conv2_weight,
+            conv1,
+            resident.conv2_bias,
+            Conv1dParams {
+                stride: CONV2_STRIDE,
+                padding: CONV_PADDING,
+                dilation: CONV_DILATION,
+            },
+            ConvActivation::Gelu,
+            ConvBlockSteps {
+                conv: "ggml_conv_1d(conv2)",
+                bias: "ggml_add(conv2_bias)",
+                activation: "ggml_gelu(conv2)",
+            },
+            map_graph_error,
+        )?;
+        let conv2 = graph
+            .permute(conv2, 1, 0, 2, 3)
+            .map_err(|source| map_graph_error("ggml_permute(conv2)", source))?;
+        let conv2 = graph
+            .cont(conv2)
+            .map_err(|source| map_graph_error("ggml_cont(conv2)", source))?;
+        let mut state = graph
+            .add(conv2, resident.pos_embd)
+            .map_err(|source| map_graph_error("ggml_add(pos_embd)", source))?;
+
+        for tensors in &resident.layers {
+            state = transformer_layer(
+                &mut graph,
+                state,
+                mask,
+                TransformerEncoderConfig {
+                    head_dim,
+                    attention_heads: config.n_heads,
+                    token_count: output_frames,
+                    layer_norm_epsilon: MOSS_ENCODER_LAYER_NORM_EPSILON,
+                    ffn_activation: crate::nn::ffn::FeedForwardActivation::Gelu,
+                    use_flash_attention: true,
+                },
+                TransformerEncoderLayerWeights {
+                    attn_norm_weight: tensors.attn_norm_weight,
+                    attn_norm_bias: tensors.attn_norm_bias,
+                    attn_q_weight: tensors.attn_q_weight,
+                    attn_q_bias: tensors.attn_q_bias,
+                    attn_k_weight: tensors.attn_k_weight,
+                    attn_k_bias: tensors.attn_k_bias,
+                    attn_v_weight: tensors.attn_v_weight,
+                    attn_v_bias: tensors.attn_v_bias,
+                    attn_out_weight: tensors.attn_out_weight,
+                    attn_out_bias: tensors.attn_out_bias,
+                    ffn_norm_weight: tensors.ffn_norm_weight,
+                    ffn_norm_bias: tensors.ffn_norm_bias,
+                    ffn_up_weight: tensors.ffn_up_weight,
+                    ffn_up_bias: tensors.ffn_up_bias,
+                    ffn_down_weight: tensors.ffn_down_weight,
+                    ffn_down_bias: tensors.ffn_down_bias,
+                },
+                map_graph_error,
+            )?;
+        }
+
+        state = crate::nn::norm::apply_affine_layer_norm(
+            &graph,
+            state,
+            MOSS_ENCODER_LAYER_NORM_EPSILON,
+            resident.out_norm_weight,
+            resident.out_norm_bias,
+            crate::nn::norm::AffineLayerNormSteps {
+                norm: "ggml_norm(out_norm)",
+                scale: "out_norm",
+                bias: "out_norm",
+            },
+            map_graph_error,
+        )?;
+
+        graph
+            .set_output(state)
+            .map_err(|source| map_graph_error("ggml_set_output(encoder_out)", source))?;
+
+        // Peak-RSS lever: allocate the compute graph via the scheduler's
+        // gallocr (liveness-based buffer REUSE) before uploading inputs, so
+        // the per-layer intermediates collapse to the working-set peak
+        // instead of each getting its own buffer.
+        graph
+            .prepare_outputs_for_upload(&[state])
+            .map_err(|source| map_graph_error("ggml_prepare_outputs(encoder_out)", source))?;
+
+        // Only the genuine per-call inputs are uploaded here; every weight
+        // already resides in the arena's WEIGHTS-usage buffer (uploaded once
+        // in `build_moss_encoder_resident_weights`) or is bound zero-copy.
+        graph
+            .set_f32_slice(mel_tensor, mel, "moss_enc_mel")
+            .map_err(|source| MossEncoderError::GraphExecution {
+                reason: format!("could not upload mel features: {source}"),
+            })?;
+        let mask_zeros = vec![0.0_f32; output_frames * output_frames];
+        graph
+            .set_f32_slice(mask, &mask_zeros, "moss_enc_mask")
+            .map_err(|source| MossEncoderError::GraphExecution {
+                reason: format!("could not upload attention mask: {source}"),
+            })?;
+
+        let values = graph
+            .compute_output_f32(state, output_frames * config.d_model)
+            .map_err(|source| MossEncoderError::GraphExecution {
+                reason: format!("encoder graph compute failed: {source}"),
+            })?;
+        Ok(values)
+    }
+}
+
+/// Resident encoder graph tensors for one transformer layer, all living in
+/// the arena's WEIGHTS-usage backend buffer (the six 2D projections either
+/// bound zero-copy from the mmap'd pack or, when unbound, arena-f32-uploaded
+/// as a defensive fallback -- see `loaded_or_arena_2d`). Mirrors
+/// `qwen::audio_encoder`'s `AudioLayerGraphTensors`.
+#[derive(Clone, Copy)]
+struct MossEncoderLayerGraphTensors<'a> {
+    attn_norm_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    attn_norm_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    attn_q_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    attn_q_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    attn_k_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    attn_k_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    attn_v_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    attn_v_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    attn_out_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    attn_out_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    ffn_norm_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    ffn_norm_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    ffn_up_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    ffn_up_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    ffn_down_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    ffn_down_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+}
+
+/// Resident tensors shared by every chunk's forward pass. Only the mel input
+/// and the attention mask (built in [`MossEncoderRuntime::encode`]) are
+/// genuine per-call graph inputs.
+struct MossEncoderResidentTensors<'a> {
+    conv1_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    conv1_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    conv2_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    conv2_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    pos_embd: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    out_norm_weight: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    out_norm_bias: crate::ggml_runtime::GgmlCpuTensor<'a>,
+    layers: Vec<MossEncoderLayerGraphTensors<'a>>,
+}
+
+/// Upper bound on the arena's metadata context: the fixed conv-stem/pos-embd/
+/// out-norm tensors plus the worst-case per-layer tensor count (10 x 1D
+/// norm/bias that always land in the arena + up to 6 x 2D projection when the
+/// pack does not bind them for a zero-copy read). Over-counting only sizes the
+/// (cheap) tensor-overhead context; the real weight bytes land in a
+/// separately sized backend buffer. Mirrors
+/// `qwen::audio_encoder::qwen_audio_encoder_arena_context_bytes`.
+fn moss_encoder_arena_context_bytes(weights: &MossEncoderWeights) -> usize {
+    const FIXED_TENSORS: usize = 8;
+    const MAX_TENSORS_PER_LAYER: usize = 16;
+    let count =
+        FIXED_TENSORS.saturating_add(MAX_TENSORS_PER_LAYER.saturating_mul(weights.layers.len()));
+    GgmlCpuGraphConfig::metadata_context_bytes(count)
+}
+
+/// Collects `(arena handle, host slice, label)` uploads while every arena
+/// tensor is allocated, then flushes them once. Allocation MUST precede the
+/// arena's first upload (the first `set_*_slice` freezes further creation),
+/// so callers allocate every tensor first and call [`Self::upload`] last.
+/// Mirrors `qwen::audio_encoder`'s `QwenAudioArenaBuilder`.
+struct MossEncoderArenaBuilder<'w> {
+    f32_uploads: Vec<(GgmlStaticTensor, &'w [f32], &'static str)>,
+    f16_uploads: Vec<(GgmlStaticTensor, &'w [u16], &'static str)>,
+}
+
+impl<'w> MossEncoderArenaBuilder<'w> {
+    fn new() -> Self {
+        Self {
+            f32_uploads: Vec::new(),
+            f16_uploads: Vec::new(),
+        }
     }
 
-    let out_norm_weight = graph
-        .new_tensor_1d_f32(config.d_model, "out_norm_w")
-        .map_err(|source| map_graph_error("ggml_new_tensor_1d(out_norm_w)", source))?;
-    graph
-        .set_input(out_norm_weight)
-        .map_err(|source| map_graph_error("ggml_set_input(out_norm_w)", source))?;
-    let out_norm_bias = graph
-        .new_tensor_1d_f32(config.d_model, "out_norm_b")
-        .map_err(|source| map_graph_error("ggml_new_tensor_1d(out_norm_b)", source))?;
-    graph
-        .set_input(out_norm_bias)
-        .map_err(|source| map_graph_error("ggml_set_input(out_norm_b)", source))?;
+    /// A 1D norm/bias, or the fixed positional embedding treated as one flat
+    /// f32 slice: always an f32 arena tensor.
+    fn arena_1d<'a>(
+        &mut self,
+        arena: &GgmlStaticTensorArena,
+        values: &'w [f32],
+        step: &'static str,
+    ) -> Result<crate::ggml_runtime::GgmlCpuTensor<'a>, MossEncoderError> {
+        let handle = arena
+            .new_tensor_1d_f32(values.len(), step)
+            .map_err(|source| map_graph_error(step, source))?;
+        self.f32_uploads.push((handle, values, step));
+        Ok(arena.graph_tensor(handle))
+    }
 
-    state = crate::nn::norm::apply_affine_layer_norm(
-        &graph,
-        state,
-        MOSS_ENCODER_LAYER_NORM_EPSILON,
+    /// The fixed positional embedding: a 2D f32 arena tensor (constant across
+    /// every chunk, unlike qwen's per-call-derived positional embedding).
+    fn arena_2d_f32<'a>(
+        &mut self,
+        arena: &GgmlStaticTensorArena,
+        values: &'w [f32],
+        ne0: usize,
+        ne1: usize,
+        step: &'static str,
+    ) -> Result<crate::ggml_runtime::GgmlCpuTensor<'a>, MossEncoderError> {
+        let handle = arena
+            .new_tensor_2d_f32(ne0, ne1, step)
+            .map_err(|source| map_graph_error(step, source))?;
+        self.f32_uploads.push((handle, values, step));
+        Ok(arena.graph_tensor(handle))
+    }
+
+    /// A rank-3 conv kernel: always an f16 arena tensor (the conv stem's own
+    /// native storage type; unlike the 2D projections, small enough that
+    /// zero-copy binding buys nothing worth the extra code path).
+    fn arena_3d_f16<'a>(
+        &mut self,
+        arena: &GgmlStaticTensorArena,
+        values: &'w [u16],
+        ne0: usize,
+        ne1: usize,
+        ne2: usize,
+        step: &'static str,
+    ) -> Result<crate::ggml_runtime::GgmlCpuTensor<'a>, MossEncoderError> {
+        let handle = arena
+            .new_tensor_3d_f16(ne0, ne1, ne2, step)
+            .map_err(|source| map_graph_error(step, source))?;
+        self.f16_uploads.push((handle, values, step));
+        Ok(arena.graph_tensor(handle))
+    }
+
+    /// A 2D attention/FFN projection weight: bound zero-copy from the mmap'd
+    /// pack (`loaded`, native f16) when present. `load_moss_encoder_weights_from_reader`
+    /// never materializes a host f32 copy for these, so an unbound tensor
+    /// with an empty `values` means the pack lacks it -- better to error than
+    /// bind an empty buffer. Mirrors `qwen::audio_encoder`'s
+    /// `loaded_or_arena_2d`.
+    fn loaded_or_arena_2d<'a>(
+        &mut self,
+        arena: &GgmlStaticTensorArena,
+        loaded: Option<&GgmlLoadedWeightContext>,
+        tensor: &'w MossProjectionTensor,
+        ne0: usize,
+        ne1: usize,
+        step: &'static str,
+    ) -> Result<crate::ggml_runtime::GgmlCpuTensor<'a>, MossEncoderError> {
+        if let Some(loaded_tensor) = loaded.and_then(|context| context.tensor(&tensor.name)) {
+            return Ok(loaded_tensor.as_graph_tensor());
+        }
+        if tensor.values.is_empty() {
+            return Err(MossEncoderError::GraphExecution {
+                reason: format!(
+                    "encoder weight '{}' is neither bound zero-copy nor f32-materialized",
+                    tensor.name
+                ),
+            });
+        }
+        let handle = arena
+            .new_tensor_2d_f32(ne0, ne1, step)
+            .map_err(|source| map_graph_error(step, source))?;
+        self.f32_uploads.push((handle, &tensor.values, step));
+        Ok(arena.graph_tensor(handle))
+    }
+
+    /// Flush every collected upload into the arena's backend buffer. The
+    /// first upload allocates the buffer and freezes further tensor
+    /// creation, so this runs after all allocation.
+    fn upload(self, arena: &mut GgmlStaticTensorArena) -> Result<(), MossEncoderError> {
+        for (handle, values, step) in self.f32_uploads {
+            arena
+                .set_f32_slice(handle, values, step)
+                .map_err(|source| MossEncoderError::GraphExecution {
+                    reason: format!("could not upload arena weight '{step}': {source}"),
+                })?;
+        }
+        for (handle, values, step) in self.f16_uploads {
+            arena
+                .set_f16_bits_slice(handle, values, step)
+                .map_err(|source| MossEncoderError::GraphExecution {
+                    reason: format!("could not upload arena weight '{step}': {source}"),
+                })?;
+        }
+        Ok(())
+    }
+}
+
+/// Allocate every resident encoder weight in the arena and upload it once,
+/// returning the graph-tensor handles the forward graph references. Mirrors
+/// `qwen::audio_encoder`'s `build_qwen_audio_resident_weights`.
+fn build_moss_encoder_resident_weights<'a>(
+    arena: &mut GgmlStaticTensorArena,
+    weights: &MossEncoderWeights,
+    config: MossEncoderConfig,
+    loaded: Option<&GgmlLoadedWeightContext>,
+) -> Result<MossEncoderResidentTensors<'a>, MossEncoderError> {
+    let mut builder = MossEncoderArenaBuilder::new();
+    let ffn_dim = 4 * config.d_model;
+
+    let conv1_weight = builder.arena_3d_f16(
+        arena,
+        &weights.conv1_weight_f16_bits,
+        CONV_KERNEL_SIZE,
+        config.n_mels,
+        config.d_model,
+        "moss_enc_conv1_w",
+    )?;
+    // Conv bias tensors are `[1, d_model]` (ne0=1, ne1=d_model), NOT a flat 1D
+    // `[d_model]`: `ggml_add`'s broadcast against the conv output (ne0=out_len,
+    // ne1=d_model) needs ne0=1 to repeat across `out_len`, and ne1=d_model to
+    // match channel-for-channel -- a 1D tensor would instead broadcast across
+    // channels, corrupting the result. Preserves the original per-call-input
+    // shape exactly (this is a shape-only change, not a math change).
+    let conv1_bias = builder.arena_2d_f32(
+        arena,
+        &weights.conv1_bias,
+        1,
+        config.d_model,
+        "moss_enc_conv1_b",
+    )?;
+    let conv2_weight = builder.arena_3d_f16(
+        arena,
+        &weights.conv2_weight_f16_bits,
+        CONV_KERNEL_SIZE,
+        config.d_model,
+        config.d_model,
+        "moss_enc_conv2_w",
+    )?;
+    let conv2_bias = builder.arena_2d_f32(
+        arena,
+        &weights.conv2_bias,
+        1,
+        config.d_model,
+        "moss_enc_conv2_b",
+    )?;
+    let pos_embd = builder.arena_2d_f32(
+        arena,
+        &weights.pos_embd,
+        config.d_model,
+        config.max_source_positions,
+        "moss_enc_pos_embd",
+    )?;
+    let out_norm_weight = builder.arena_1d(arena, &weights.out_norm_weight, "out_norm_w")?;
+    let out_norm_bias = builder.arena_1d(arena, &weights.out_norm_bias, "out_norm_b")?;
+
+    // Whisper's own `k_proj` carries no bias; a fresh all-zero arena tensor
+    // per layer is the exact no-op the module doc describes, just resident
+    // instead of a per-call graph input.
+    let zero_k_bias = vec![0.0_f32; config.d_model];
+    let mut layers = Vec::with_capacity(weights.layers.len());
+    for layer in &weights.layers {
+        layers.push(MossEncoderLayerGraphTensors {
+            attn_norm_weight: builder.arena_1d(arena, &layer.attn_norm_weight, "attn_norm_w")?,
+            attn_norm_bias: builder.arena_1d(arena, &layer.attn_norm_bias, "attn_norm_b")?,
+            attn_q_weight: builder.loaded_or_arena_2d(
+                arena,
+                loaded,
+                &layer.attn_q_weight,
+                config.d_model,
+                config.d_model,
+                "attn_q_w",
+            )?,
+            attn_q_bias: builder.arena_1d(arena, &layer.attn_q_bias, "attn_q_b")?,
+            attn_k_weight: builder.loaded_or_arena_2d(
+                arena,
+                loaded,
+                &layer.attn_k_weight,
+                config.d_model,
+                config.d_model,
+                "attn_k_w",
+            )?,
+            attn_k_bias: builder.arena_1d(arena, &zero_k_bias, "attn_k_b_zero")?,
+            attn_v_weight: builder.loaded_or_arena_2d(
+                arena,
+                loaded,
+                &layer.attn_v_weight,
+                config.d_model,
+                config.d_model,
+                "attn_v_w",
+            )?,
+            attn_v_bias: builder.arena_1d(arena, &layer.attn_v_bias, "attn_v_b")?,
+            attn_out_weight: builder.loaded_or_arena_2d(
+                arena,
+                loaded,
+                &layer.attn_out_weight,
+                config.d_model,
+                config.d_model,
+                "attn_out_w",
+            )?,
+            attn_out_bias: builder.arena_1d(arena, &layer.attn_out_bias, "attn_out_b")?,
+            ffn_norm_weight: builder.arena_1d(arena, &layer.ffn_norm_weight, "ffn_norm_w")?,
+            ffn_norm_bias: builder.arena_1d(arena, &layer.ffn_norm_bias, "ffn_norm_b")?,
+            ffn_up_weight: builder.loaded_or_arena_2d(
+                arena,
+                loaded,
+                &layer.ffn_up_weight,
+                config.d_model,
+                ffn_dim,
+                "ffn_up_w",
+            )?,
+            ffn_up_bias: builder.arena_1d(arena, &layer.ffn_up_bias, "ffn_up_b")?,
+            ffn_down_weight: builder.loaded_or_arena_2d(
+                arena,
+                loaded,
+                &layer.ffn_down_weight,
+                ffn_dim,
+                config.d_model,
+                "ffn_down_w",
+            )?,
+            ffn_down_bias: builder.arena_1d(arena, &layer.ffn_down_bias, "ffn_down_b")?,
+        });
+    }
+
+    builder.upload(arena)?;
+
+    Ok(MossEncoderResidentTensors {
+        conv1_weight,
+        conv1_bias,
+        conv2_weight,
+        conv2_bias,
+        pos_embd,
         out_norm_weight,
         out_norm_bias,
-        crate::nn::norm::AffineLayerNormSteps {
-            norm: "ggml_norm(out_norm)",
-            scale: "out_norm",
-            bias: "out_norm",
-        },
-        map_graph_error,
-    )?;
-
-    graph
-        .set_output(state)
-        .map_err(|source| map_graph_error("ggml_set_output(encoder_out)", source))?;
-
-    graph
-        .set_f32_slice(mel_tensor, mel, "moss_enc_mel")
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("could not upload mel features: {source}"),
-        })?;
-    graph
-        .set_f16_bits_slice(conv1_w, &weights.conv1_weight_f16_bits, "moss_enc_conv1_w")
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("could not upload conv1 weight: {source}"),
-        })?;
-    graph
-        .set_f32_slice(conv1_b, &weights.conv1_bias, "moss_enc_conv1_b")
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("could not upload conv1 bias: {source}"),
-        })?;
-    graph
-        .set_f16_bits_slice(conv2_w, &weights.conv2_weight_f16_bits, "moss_enc_conv2_w")
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("could not upload conv2 weight: {source}"),
-        })?;
-    graph
-        .set_f32_slice(conv2_b, &weights.conv2_bias, "moss_enc_conv2_b")
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("could not upload conv2 bias: {source}"),
-        })?;
-    graph
-        .set_f32_slice(pos_embd, &weights.pos_embd, "moss_enc_pos_embd")
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("could not upload positional embedding: {source}"),
-        })?;
-    let mask_zeros = vec![0.0_f32; output_frames * output_frames];
-    graph
-        .set_f32_slice(mask, &mask_zeros, "moss_enc_mask")
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("could not upload attention mask: {source}"),
-        })?;
-    graph
-        .set_f32_slice(out_norm_weight, &weights.out_norm_weight, "out_norm_w")
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("could not upload out_norm weight: {source}"),
-        })?;
-    graph
-        .set_f32_slice(out_norm_bias, &weights.out_norm_bias, "out_norm_b")
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("could not upload out_norm bias: {source}"),
-        })?;
-    for (tensor, values, label) in layer_uploads {
-        graph
-            .set_f32_slice(tensor, values, label)
-            .map_err(|source| MossEncoderError::GraphExecution {
-                reason: format!("could not upload encoder layer weight '{label}': {source}"),
-            })?;
-    }
-
-    let values = graph
-        .compute_output_f32(state, output_frames * config.d_model)
-        .map_err(|source| MossEncoderError::GraphExecution {
-            reason: format!("encoder graph compute failed: {source}"),
-        })?;
-    Ok(values)
+        layers,
+    })
 }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -455,3 +455,127 @@ impl GgmlAsrStreamingExecutor for MossTdGgmlExecutor {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    use crate::ggml_runtime::install_request_backend_override;
+    use crate::models::ggml_asr_executor::{GgmlAsrBackendPreference, GgmlAsrPreparedAudio};
+    use crate::models::ggml_family_registry::moss_transcribe_diarize_runtime_descriptor_v1;
+
+    use super::*;
+
+    /// Real converted dev pack (fp16), NOT committed -- same dev-only-artifact
+    /// convention as `decode_prompt`'s own `dev_pack_path` and mimo-asr's
+    /// `mimo-v2.5-asr-q8_0.oasr`.
+    fn dev_pack_path() -> PathBuf {
+        PathBuf::from(
+            "/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/moss-transcribe-diarize-fp16.oasr",
+        )
+    }
+
+    fn dev_sample_path(name: &str) -> PathBuf {
+        PathBuf::from("/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/samples").join(name)
+    }
+
+    // Pinned to the real dev-pack CPU decode (fp16, backend forced to CPU
+    // below). Confirmed byte-for-byte equal to the HF fp32 reference stack's
+    // golden (`tmp/moss-td/golden/{jfk,en_zh_mixed}.json`'s `text`) -- the
+    // fp16-vs-fp32 numeric gap did not perturb the text OR the emitted time
+    // anchors for these clips (both matched to the hundredth of a second).
+    const GOLDEN_JFK_TEXT: &str = concat!(
+        "[0.28][S01] And so, my fellow Americans,[2.32][3.22][S01] ask not what your ",
+        "country can do for you,[7.71][8.12][S01] ask what you can do for your country.[10.59]",
+    );
+
+    // Code-switch coverage: `en_zh_mixed.wav` mixes English then Mandarin in a
+    // single utterance, exercising both tokenizer/decode paths plus a second
+    // speaker label (`[S02]`) in one prefill+decode. Byte-for-byte equal to the
+    // HF golden `en_zh_mixed.json`'s `text`.
+    const GOLDEN_EN_ZH_MIXED_TEXT: &str = concat!(
+        "[0.27][S01]And so, my fellow Americans,[2.34][3.21][S01]ask not.",
+        "[4.44][4.94][S02]今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去伊加新[12.88]",
+    );
+
+    fn transcribe_with_dev_pack(wav_path: PathBuf) -> Option<(String, std::time::Duration, f32)> {
+        let pack_path = dev_pack_path();
+        if !pack_path.exists() {
+            eprintln!("skipping: {} not present", pack_path.display());
+            return None;
+        }
+        if !wav_path.exists() {
+            eprintln!("skipping: {} not present", wav_path.display());
+            return None;
+        }
+        // Force CPU. This family's Metal path has two open defects (encoder
+        // numeric divergence -> empty-shell output, and a per-step wired-memory
+        // blow-up -- see the `arch` descriptor's `auto_gpu_policy` note), so the
+        // reference decode is CPU-only. `backend_preference` alone is inert on a
+        // direct `execute()` (it is only consulted via the thread-local override
+        // -- see `GgmlAsrExecutionRequest::backend_preference`'s doc), so install
+        // the override explicitly rather than relying on the ambient backend.
+        let backend_preference = GgmlAsrBackendPreference::CpuOnly;
+        // Hold the RAII guard for the whole decode: it restores the previous
+        // thread-local override on drop at the end of this function, after
+        // `execute()` below has run entirely on CPU.
+        let _backend_override_guard =
+            install_request_backend_override(backend_preference.request_backend_override());
+
+        let samples = crate::api::audio_io::load_wav_16khz_mono_f32_v0(
+            wav_path,
+            "moss-td e2e test",
+            "moss-td e2e test",
+        )
+        .expect("load wav fixture");
+        let audio_duration_seconds = samples.len() as f32 / 16_000.0;
+
+        let request = GgmlAsrExecutionRequest {
+            runtime_source_path: pack_path,
+            runtime_source_preflight: None,
+            selected_family: moss_transcribe_diarize_runtime_descriptor_v1(),
+            prepared_audio: GgmlAsrPreparedAudio::mono_16khz(samples),
+            request_options: Default::default(),
+            backend_preference,
+        };
+
+        let executor = MossTdGgmlExecutor;
+        let started_at = Instant::now();
+        let result = executor.execute(&request).expect("moss-td transcribe");
+        let elapsed = started_at.elapsed();
+        Some((result.transcription.text, elapsed, audio_duration_seconds))
+    }
+
+    #[test]
+    #[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack \
+                and tmp/moss-td/samples/*.wav; CPU-only (Metal path has known defects)"]
+    fn golden_diff_end_to_end_transcribe_jfk_wav() {
+        let Some((text, elapsed, audio_duration_seconds)) =
+            transcribe_with_dev_pack(dev_sample_path("jfk.wav"))
+        else {
+            return;
+        };
+        eprintln!(
+            "moss-td e2e [jfk.wav]: rtf={:.3} elapsed={elapsed:?} audio_duration={audio_duration_seconds:.2}s",
+            elapsed.as_secs_f32() / audio_duration_seconds.max(0.001)
+        );
+        assert_eq!(text, GOLDEN_JFK_TEXT);
+    }
+
+    #[test]
+    #[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack \
+                and tmp/moss-td/samples/*.wav; CPU-only (Metal path has known defects)"]
+    fn golden_diff_end_to_end_transcribe_en_zh_mixed_wav() {
+        let Some((text, elapsed, audio_duration_seconds)) =
+            transcribe_with_dev_pack(dev_sample_path("en_zh_mixed.wav"))
+        else {
+            return;
+        };
+        eprintln!(
+            "moss-td e2e [en_zh_mixed.wav]: rtf={:.3} elapsed={elapsed:?} audio_duration={audio_duration_seconds:.2}s",
+            elapsed.as_secs_f32() / audio_duration_seconds.max(0.001)
+        );
+        assert_eq!(text, GOLDEN_EN_ZH_MIXED_TEXT);
+    }
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -23,7 +23,6 @@ use thiserror::Error;
 
 use crate::NativeAsrError;
 use crate::api::backend::{Segment, Transcription};
-use crate::ggml_runtime::GgmlCpuGraphRunner;
 use crate::models::decode_policy_component_registry::{
     BuiltinDecodePolicyComponentRegistryError, BuiltinSeq2SeqDecodePolicyConfigInput,
     run_builtin_seq2seq_decode_policy,
@@ -46,7 +45,7 @@ use crate::models::whisper::whisper_log_mel_spectrogram_16khz_mono_v0;
 use super::adaptor_graph::{load_moss_adaptor_weights_from_reader, run_moss_adaptor};
 use super::decode_prompt::build_moss_td_decode_prompt;
 use super::encoder_graph::{
-    MossEncoderConfig, load_moss_encoder_weights_from_reader, run_moss_encoder_chunk,
+    MossEncoderConfig, MossEncoderRuntime, load_moss_encoder_weights_from_reader,
 };
 use super::graph_config::moss_td_encoder_graph_config;
 use super::llm_decoder::MossTdDecoderRuntime;
@@ -253,12 +252,17 @@ impl MossTdGgmlExecutor {
         // Upstream `_compute_audio_token_length`'s stride: hop_length * the
         // Whisper conv stem's 2x stride * audio_merge_size.
         let token_stride = HOP_LENGTH * WHISPER_ENCODER_CONV_STRIDE * adaptor_metadata.merge_size;
-        let mut encoder_runner =
-            GgmlCpuGraphRunner::new(moss_td_encoder_graph_config()).map_err(|error| {
-                MossTdExecutorError::EncoderFailed {
-                    reason: format!("could not initialize encoder graph runner: {error}"),
-                }
-            })?;
+        // Built once and reused across every chunk in the loop below: the
+        // loaded-weight context mmaps the whole pack once, and the six 2D
+        // projection weights per layer bind zero-copy from it on every
+        // `encode()` call (see `encoder_graph`'s module doc).
+        let mut encoder_runtime = MossEncoderRuntime::new(
+            moss_td_encoder_graph_config(),
+            Some(preflight.runtime_source.path()),
+        )
+        .map_err(|error| MossTdExecutorError::EncoderFailed {
+            reason: format!("could not initialize encoder runtime: {error}"),
+        })?;
 
         let mut concatenated_rows: Vec<f32> = Vec::new();
         let mut total_frames = 0usize;
@@ -271,16 +275,16 @@ impl MossTdGgmlExecutor {
             .map_err(|error| MossTdExecutorError::FrontendFailed {
                 reason: error.to_string(),
             })?;
-            let encoder_out = run_moss_encoder_chunk(
-                &mut encoder_runner,
-                &encoder_weights,
-                encoder_config,
-                mel.data(),
-                MEL_TARGET_FRAMES,
-            )
-            .map_err(|error| MossTdExecutorError::EncoderFailed {
-                reason: error.to_string(),
-            })?;
+            let encoder_out = encoder_runtime
+                .encode(
+                    &encoder_weights,
+                    encoder_config,
+                    mel.data(),
+                    MEL_TARGET_FRAMES,
+                )
+                .map_err(|error| MossTdExecutorError::EncoderFailed {
+                    reason: error.to_string(),
+                })?;
             let token_length = (chunk.len() - 1) / token_stride.max(1) + 1;
             let keep_frames = (token_length * adaptor_metadata.merge_size)
                 .min(encoder_metadata.max_source_positions);
@@ -515,11 +519,18 @@ mod tests {
         PathBuf::from("/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/samples").join(name)
     }
 
-    // Pinned to the real dev-pack CPU decode (fp16, backend forced to CPU
-    // below). Confirmed byte-for-byte equal to the HF fp32 reference stack's
-    // golden (`tmp/moss-td/golden/{jfk,en_zh_mixed}.json`'s `text`) -- the
-    // fp16-vs-fp32 numeric gap did not perturb the text OR the emitted time
-    // anchors for these clips (both matched to the hundredth of a second).
+    // Pinned to the real dev-pack CPU decode (backend forced to CPU below).
+    // The encoder binds its 2D projection weights zero-copy as native f16 and
+    // runs flash attention (see `encoder_graph`), so this decode path is f16
+    // weights + flash, NOT the f32-naive path -- do not assert flash == naive or
+    // f16 == f32 bit-for-bit. What IS asserted, matching the reference-platform
+    // golden policy: the transcript is text-level identical to the HF fp32
+    // reference (`tmp/moss-td/golden/*.json`'s `text`), including speaker labels,
+    // and every emitted time anchor is within 0.05s of it. In practice jfk and
+    // the 3-minute aishell clip come out byte-for-byte equal to the HF golden
+    // (time anchors included); en_zh_mixed matches the HF text exactly with two
+    // anchors shifted by 0.02s ([2.34]->[2.32], [4.94]->[4.96]), the f16+flash
+    // numeric delta.
     const GOLDEN_JFK_TEXT: &str = concat!(
         "[0.28][S01] And so, my fellow Americans,[2.32][3.22][S01] ask not what your ",
         "country can do for you,[7.71][8.12][S01] ask what you can do for your country.[10.59]",
@@ -527,11 +538,12 @@ mod tests {
 
     // Code-switch coverage: `en_zh_mixed.wav` mixes English then Mandarin in a
     // single utterance, exercising both tokenizer/decode paths plus a second
-    // speaker label (`[S02]`) in one prefill+decode. Byte-for-byte equal to the
-    // HF golden `en_zh_mixed.json`'s `text`.
+    // speaker label (`[S02]`) in one prefill+decode. Text identical to the HF
+    // golden `en_zh_mixed.json`'s `text`; two time anchors sit 0.02s off (see the
+    // pinning note above).
     const GOLDEN_EN_ZH_MIXED_TEXT: &str = concat!(
-        "[0.27][S01]And so, my fellow Americans,[2.34][3.21][S01]ask not.",
-        "[4.44][4.94][S02]今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去伊加新[12.88]",
+        "[0.27][S01]And so, my fellow Americans,[2.32][3.21][S01]ask not.",
+        "[4.44][4.96][S02]今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去伊加新[12.88]",
     );
 
     fn transcribe_with_dev_pack(wav_path: PathBuf) -> Option<(String, std::time::Duration, f32)> {

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -52,8 +52,8 @@ use super::graph_config::moss_td_encoder_graph_config;
 use super::llm_decoder::MossTdDecoderRuntime;
 use super::prompt_embedding::build_moss_td_prompt_embeddings_with_audio_splice;
 use super::runtime_contract::{
-    MOSS_TD_ADAPTOR_NORM_EPSILON, parse_adaptor_metadata, parse_decoder_metadata,
-    parse_encoder_metadata,
+    MOSS_TD_ADAPTOR_NORM_EPSILON, moss_td_kv_cache_positions, parse_adaptor_metadata,
+    parse_decoder_metadata, parse_encoder_metadata,
 };
 use super::tokenizer::MossTdTokenizer;
 
@@ -73,6 +73,11 @@ const HOP_LENGTH: usize = 160;
 /// `tmp/moss-td/golden/*.json`'s `max_new_tokens`). Only the fail-closed
 /// backstop against a runaway (non-terminating) decode.
 const MOSS_TD_MAX_GENERATED_TOKENS: usize = 4096;
+/// Audio tokens per second the adaptor emits (`audio_tokens_per_second` in
+/// `processing_moss_transcribe_diarize.py`, same value `decode_prompt`'s marker
+/// cadence uses). Only used to render the `AudioExceedsContext` limit as an
+/// approximate minutes figure; not part of any decode math.
+const AUDIO_TOKENS_PER_SECOND_FOR_LIMIT: f32 = 12.5;
 
 #[derive(Debug, Error)]
 enum MossTdExecutorError {
@@ -89,6 +94,16 @@ enum MossTdExecutorError {
     TokenizerBuildFailed { reason: String },
     #[error("moss-transcribe-diarize requires non-empty audio")]
     EmptyAudio,
+    #[error(
+        "moss-transcribe-diarize audio is too long: its {prompt_tokens}-token audio prompt \
+         needs at least one free position within the {kv_capacity}-position decoder context \
+         (about {max_minutes:.0} min of audio); split the input into shorter files"
+    )]
+    AudioExceedsContext {
+        prompt_tokens: usize,
+        kv_capacity: usize,
+        max_minutes: f32,
+    },
     #[error("moss-transcribe-diarize mel frontend failed: {reason}")]
     FrontendFailed { reason: String },
     #[error("moss-transcribe-diarize encoder failed: {reason}")]
@@ -298,6 +313,26 @@ impl MossTdGgmlExecutor {
                     reason: error.to_string(),
                 }
             })?;
+
+        // Fail closed up front when the whole-audio prompt cannot fit the
+        // decoder's KV context. This family ingests the full audio in one
+        // decode (native longform slicing is disabled for it, see the
+        // decode-policy `SelfChunkingExecutorV1`), so a very long file grows
+        // the prompt until it exceeds the KV-cache capacity. `kv_capacity`
+        // positions (~one every 12.5 audio tokens/sec plus the fixed template
+        // and generated tokens) works out to roughly 7-10 minutes of audio;
+        // beyond that, fail with a clear message instead of a cryptic mid-
+        // decode KV-bounds error (or worse, silent truncation).
+        let kv_capacity = moss_td_kv_cache_positions(decoder_metadata.max_positions);
+        if decode_prompt.token_ids.len() >= kv_capacity {
+            let max_minutes =
+                (kv_capacity as f32 / AUDIO_TOKENS_PER_SECOND_FOR_LIMIT / 60.0).max(0.0);
+            return Err(MossTdExecutorError::AudioExceedsContext {
+                prompt_tokens: decode_prompt.token_ids.len(),
+                kv_capacity,
+                max_minutes,
+            });
+        }
 
         let runtime_path = preflight.runtime_source.path();
         let mut decoder =

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -1,0 +1,457 @@
+//! moss-transcribe-diarize dedicated executor: chunked Whisper-Medium
+//! encoder (30s windows, each trimmed to its own valid frame count before
+//! concatenation -- mirrors upstream `get_audio_features`'s
+//! `whisper_features[chunk_idx:chunk_idx+1, :token_len*4]`) -> [`adaptor_graph`]
+//! (4x merge + VQAdaptor over the FULL concatenated sequence, numerically
+//! identical to merging per-chunk-then-concatenating since each kept
+//! chunk length is already a multiple of the merge size) -> ChatML+audio-span
+//! prompt ([`decode_prompt`] + [`prompt_embedding`]'s sparse splice, since
+//! digit time-anchor tokens interrupt the `<|audio_pad|>` run) -> Qwen3-0.6B
+//! [`llm_decoder`] prefill/decode, driven through the ONE shared greedy
+//! decode loop (`models::decode_policy_component_registry::
+//! run_builtin_seq2seq_decode_policy`) via a [`Seq2SeqGreedyDecodeStepExecutor`]
+//! impl below -- never a hand-rolled argmax loop (this repo's
+//! `model-integration-shared-driver` invariant, see `AGENTS.md`).
+//!
+//! File-transcribe only: no streaming/realtime session (this family's
+//! architecture always needs the full audio to compute time-anchor markers
+//! ahead of the prompt, so there is no meaningful "partial" mode yet).
+
+#![allow(dead_code)]
+
+use thiserror::Error;
+
+use crate::NativeAsrError;
+use crate::api::backend::{Segment, Transcription};
+use crate::ggml_runtime::GgmlCpuGraphRunner;
+use crate::models::decode_policy_component_registry::{
+    BuiltinDecodePolicyComponentRegistryError, BuiltinSeq2SeqDecodePolicyConfigInput,
+    run_builtin_seq2seq_decode_policy,
+};
+use crate::models::ggml_asr_executor::{
+    GgmlAsrExecutionError, GgmlAsrExecutionRequest, GgmlAsrExecutionResult, GgmlAsrExecutor,
+    GgmlAsrStreamingExecutor, GgmlAsrStreamingSessionRequest,
+};
+use crate::models::incremental_streaming_driver::{
+    STREAMING_PARTIAL_TUNING_HEAVY_SNAPSHOT, build_seq2seq_streaming_session,
+};
+use crate::models::qwen::{Qwen3AsrLayerKvCacheState, Qwen3AsrPromptEmbeddings};
+use crate::models::runtime_preflight::build_runtime_tensor_reader_from_preflight;
+use crate::models::seq2seq_greedy_decode::{
+    Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeStepExecutor, Seq2SeqGreedyDecodeStepInput,
+    Seq2SeqGreedyDecodeStepLogitsOutput,
+};
+use crate::models::whisper::whisper_log_mel_spectrogram_16khz_mono_v0;
+
+use super::adaptor_graph::{load_moss_adaptor_weights_from_reader, run_moss_adaptor};
+use super::decode_prompt::build_moss_td_decode_prompt;
+use super::encoder_graph::{
+    MossEncoderConfig, load_moss_encoder_weights_from_reader, run_moss_encoder_chunk,
+};
+use super::graph_config::moss_td_encoder_graph_config;
+use super::llm_decoder::MossTdDecoderRuntime;
+use super::prompt_embedding::build_moss_td_prompt_embeddings_with_audio_splice;
+use super::runtime_contract::{
+    MOSS_TD_ADAPTOR_NORM_EPSILON, parse_adaptor_metadata, parse_decoder_metadata,
+    parse_encoder_metadata,
+};
+use super::tokenizer::MossTdTokenizer;
+
+/// `WhisperFeatureExtractor`'s `chunk_length=30` @ 16kHz (`preprocessor_config.json`,
+/// verified against the real checkpoint).
+const CHUNK_SAMPLES: usize = 480_000;
+const MEL_TARGET_FRAMES: usize = 3000;
+const SAMPLE_RATE_HZ: usize = 16_000;
+/// `WhisperFeatureExtractor.hop_length` (160) * the Whisper conv stem's 2x
+/// stride * `audio_merge_size` -- upstream's
+/// `_compute_audio_token_length`'s `stride` (`processing_moss_transcribe_diarize.py`).
+const WHISPER_ENCODER_CONV_STRIDE: usize = 2;
+const HOP_LENGTH: usize = 160;
+/// Generous upper bound on generated tokens; greedy decode stops at
+/// `<|im_end|>` well before this in practice (the real checkpoint's own
+/// reference generation config used this exact cap -- verified against
+/// `tmp/moss-td/golden/*.json`'s `max_new_tokens`). Only the fail-closed
+/// backstop against a runaway (non-terminating) decode.
+const MOSS_TD_MAX_GENERATED_TOKENS: usize = 4096;
+
+#[derive(Debug, Error)]
+enum MossTdExecutorError {
+    #[error("moss-transcribe-diarize executor requires adapter '{expected}', got '{found}'")]
+    AdapterMismatch {
+        expected: &'static str,
+        found: String,
+    },
+    #[error("moss-transcribe-diarize executor runtime preflight failed: {reason}")]
+    RuntimePreflightFailed { reason: String },
+    #[error("moss-transcribe-diarize runtime metadata contract failed: {reason}")]
+    RuntimeContractViolation { reason: String },
+    #[error("moss-transcribe-diarize tokenizer materialization failed: {reason}")]
+    TokenizerBuildFailed { reason: String },
+    #[error("moss-transcribe-diarize requires non-empty audio")]
+    EmptyAudio,
+    #[error("moss-transcribe-diarize mel frontend failed: {reason}")]
+    FrontendFailed { reason: String },
+    #[error("moss-transcribe-diarize encoder failed: {reason}")]
+    EncoderFailed { reason: String },
+    #[error("moss-transcribe-diarize adaptor failed: {reason}")]
+    AdaptorFailed { reason: String },
+    #[error("moss-transcribe-diarize decode prompt failed: {reason}")]
+    DecodePromptFailed { reason: String },
+    #[error("moss-transcribe-diarize decoder failed: {reason}")]
+    DecoderFailed { reason: String },
+    #[error("moss-transcribe-diarize prompt embedding splice failed: {reason}")]
+    PromptEmbeddingFailed { reason: String },
+    #[error("moss-transcribe-diarize greedy decode failed: {reason}")]
+    GreedyDecodeFailed { reason: String },
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct MossTdGgmlExecutor;
+
+const MOSS_TD_EXECUTOR_ID: &str = "moss-transcribe-diarize-ggml-executor-v1";
+const MOSS_TD_STREAMING_EXECUTOR_ID: &str =
+    "moss-transcribe-diarize-ggml-snapshot-streaming-executor-v1";
+
+struct MossTdGreedyStepExecutor<'a> {
+    decoder: &'a mut MossTdDecoderRuntime,
+    layer_kv_caches: Vec<Qwen3AsrLayerKvCacheState>,
+    prompt_embeddings: Option<Qwen3AsrPromptEmbeddings>,
+    cache_prompt_tokens: usize,
+}
+
+impl Seq2SeqGreedyDecodeStepExecutor for MossTdGreedyStepExecutor<'_> {
+    fn decode_step_logits(
+        &mut self,
+        input: Seq2SeqGreedyDecodeStepInput<'_>,
+    ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyDecodeError> {
+        if let Some(prompt_embeddings) = self.prompt_embeddings.take() {
+            self.cache_prompt_tokens = prompt_embeddings.token_count;
+            let logits = self
+                .decoder
+                .prefill(&prompt_embeddings, &mut self.layer_kv_caches)
+                .map_err(|error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                    reason: error.to_string(),
+                })?;
+            return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits,
+                greedy_token_hint: None,
+            });
+        }
+        let last_token = input.generated_tokens.last().copied().ok_or_else(|| {
+            Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                reason: "moss-transcribe-diarize generated token history is unexpectedly empty"
+                    .to_string(),
+            }
+        })?;
+        let cache_position = self
+            .cache_prompt_tokens
+            .checked_add(input.generated_tokens.len())
+            .and_then(|total| total.checked_sub(1))
+            .ok_or_else(|| Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                reason: "moss-transcribe-diarize decode cache position underflowed".to_string(),
+            })?;
+        let logits = self
+            .decoder
+            .decode_step(last_token, cache_position, &mut self.layer_kv_caches)
+            .map_err(|error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                reason: error.to_string(),
+            })?;
+        Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+            logits,
+            greedy_token_hint: None,
+        })
+    }
+}
+
+impl MossTdGgmlExecutor {
+    fn execute_inner(
+        &self,
+        request: &GgmlAsrExecutionRequest,
+    ) -> Result<GgmlAsrExecutionResult, MossTdExecutorError> {
+        let expected_adapter = crate::arch::MOSS_TD_GGML_ADAPTER_ID;
+        if request.selected_family.adapter_id != expected_adapter {
+            return Err(MossTdExecutorError::AdapterMismatch {
+                expected: expected_adapter,
+                found: request.selected_family.adapter_id.to_string(),
+            });
+        }
+        let preflight = request
+            .resolve_runtime_source_preflight()
+            .map_err(|error| MossTdExecutorError::RuntimePreflightFailed {
+                reason: error.to_string(),
+            })?;
+
+        let encoder_metadata = parse_encoder_metadata(&*preflight.metadata).map_err(|error| {
+            MossTdExecutorError::RuntimeContractViolation {
+                reason: error.to_string(),
+            }
+        })?;
+        let adaptor_metadata = parse_adaptor_metadata(&*preflight.metadata).map_err(|error| {
+            MossTdExecutorError::RuntimeContractViolation {
+                reason: error.to_string(),
+            }
+        })?;
+        let decoder_metadata = parse_decoder_metadata(&*preflight.metadata).map_err(|error| {
+            MossTdExecutorError::RuntimeContractViolation {
+                reason: error.to_string(),
+            }
+        })?;
+        let tokenizer = MossTdTokenizer::from_gguf_metadata(&preflight.metadata).map_err(
+            |error: NativeAsrError| MossTdExecutorError::TokenizerBuildFailed {
+                reason: error.to_string(),
+            },
+        )?;
+
+        let samples = &request.prepared_audio.samples_f32;
+        if samples.is_empty() {
+            return Err(MossTdExecutorError::EmptyAudio);
+        }
+        let audio_duration_seconds = samples.len() as f32 / SAMPLE_RATE_HZ as f32;
+
+        let reader = build_runtime_tensor_reader_from_preflight(&preflight).map_err(|error| {
+            MossTdExecutorError::RuntimeContractViolation {
+                reason: error.to_string(),
+            }
+        })?;
+        let encoder_config = MossEncoderConfig {
+            n_layers: encoder_metadata.n_layers,
+            d_model: encoder_metadata.d_model,
+            n_heads: encoder_metadata.n_heads,
+            n_mels: encoder_metadata.n_mels,
+            max_source_positions: encoder_metadata.max_source_positions,
+        };
+        let encoder_weights = load_moss_encoder_weights_from_reader(&reader, encoder_config)
+            .map_err(|error| MossTdExecutorError::EncoderFailed {
+                reason: error.to_string(),
+            })?;
+        let adaptor_weights = load_moss_adaptor_weights_from_reader(
+            &reader,
+            encoder_metadata.d_model,
+            adaptor_metadata.merge_size,
+            decoder_metadata.d_model,
+            MOSS_TD_ADAPTOR_NORM_EPSILON,
+        )
+        .map_err(|error| MossTdExecutorError::AdaptorFailed {
+            reason: error.to_string(),
+        })?;
+
+        // Upstream `_compute_audio_token_length`'s stride: hop_length * the
+        // Whisper conv stem's 2x stride * audio_merge_size.
+        let token_stride = HOP_LENGTH * WHISPER_ENCODER_CONV_STRIDE * adaptor_metadata.merge_size;
+        let mut encoder_runner =
+            GgmlCpuGraphRunner::new(moss_td_encoder_graph_config()).map_err(|error| {
+                MossTdExecutorError::EncoderFailed {
+                    reason: format!("could not initialize encoder graph runner: {error}"),
+                }
+            })?;
+
+        let mut concatenated_rows: Vec<f32> = Vec::new();
+        let mut total_frames = 0usize;
+        for chunk in samples.chunks(CHUNK_SAMPLES) {
+            let mel = whisper_log_mel_spectrogram_16khz_mono_v0(
+                chunk,
+                encoder_metadata.n_mels,
+                MEL_TARGET_FRAMES,
+            )
+            .map_err(|error| MossTdExecutorError::FrontendFailed {
+                reason: error.to_string(),
+            })?;
+            let encoder_out = run_moss_encoder_chunk(
+                &mut encoder_runner,
+                &encoder_weights,
+                encoder_config,
+                mel.data(),
+                MEL_TARGET_FRAMES,
+            )
+            .map_err(|error| MossTdExecutorError::EncoderFailed {
+                reason: error.to_string(),
+            })?;
+            let token_length = (chunk.len() - 1) / token_stride.max(1) + 1;
+            let keep_frames = (token_length * adaptor_metadata.merge_size)
+                .min(encoder_metadata.max_source_positions);
+            let keep_values = keep_frames * encoder_metadata.d_model;
+            concatenated_rows.extend_from_slice(&encoder_out[..keep_values]);
+            total_frames += keep_frames;
+        }
+        // Upstream's `time_merge` truncates any remainder below a full
+        // merge-size group; concatenating already-merge-size-aligned
+        // per-chunk lengths (see above) means the total is already aligned,
+        // so this is a no-op guard, not a silent frame drop.
+        let aligned_frames =
+            (total_frames / adaptor_metadata.merge_size) * adaptor_metadata.merge_size;
+        concatenated_rows.truncate(aligned_frames * encoder_metadata.d_model);
+
+        let (audio_rows, audio_token_count) = run_moss_adaptor(
+            &adaptor_weights,
+            &concatenated_rows,
+            aligned_frames,
+            encoder_metadata.d_model,
+            adaptor_metadata.merge_size,
+        )
+        .map_err(|error| MossTdExecutorError::AdaptorFailed {
+            reason: error.to_string(),
+        })?;
+
+        let decode_prompt =
+            build_moss_td_decode_prompt(&tokenizer, audio_token_count).map_err(|error| {
+                MossTdExecutorError::DecodePromptFailed {
+                    reason: error.to_string(),
+                }
+            })?;
+
+        let runtime_path = preflight.runtime_source.path();
+        let mut decoder =
+            MossTdDecoderRuntime::new(runtime_path, decoder_metadata).map_err(|error| {
+                MossTdExecutorError::DecoderFailed {
+                    reason: error.to_string(),
+                }
+            })?;
+        if std::env::var_os("OPENASR_MOSS_TD_PROFILE").is_some() {
+            eprintln!(
+                "OPENASR_MOSS_TD_PROFILE decoder_backend={}",
+                decoder.backend_label()
+            );
+        }
+
+        let token_rows_len = decode_prompt.token_ids.len() * decoder_metadata.d_model;
+        let mut token_rows = Vec::with_capacity(token_rows_len);
+        for &token_id in &decode_prompt.token_ids {
+            let row = decoder.gather_token_embedding(token_id).map_err(|error| {
+                MossTdExecutorError::DecoderFailed {
+                    reason: error.to_string(),
+                }
+            })?;
+            token_rows.extend_from_slice(&row);
+        }
+        let spliced = build_moss_td_prompt_embeddings_with_audio_splice(
+            decode_prompt.token_ids.len(),
+            &decode_prompt.audio_pad_positions,
+            decoder_metadata.d_model,
+            &token_rows,
+            &audio_rows,
+        )
+        .map_err(|error| MossTdExecutorError::PromptEmbeddingFailed {
+            reason: error.to_string(),
+        })?;
+        let prompt_embeddings = Qwen3AsrPromptEmbeddings {
+            hidden_size: spliced.hidden_size,
+            token_count: spliced.token_count,
+            token_major_values: spliced.token_major_values,
+        };
+
+        let layer_kv_caches = decoder.new_kv_caches();
+        let mut step_executor = MossTdGreedyStepExecutor {
+            decoder: &mut decoder,
+            layer_kv_caches,
+            prompt_embeddings: Some(prompt_embeddings),
+            cache_prompt_tokens: 0,
+        };
+        let config = BuiltinSeq2SeqDecodePolicyConfigInput {
+            initial_prompt_tokens: decode_prompt.token_ids.clone(),
+            eot_token_id: tokenizer.im_end_token_id,
+            vocab_size: decoder_metadata.vocab_size,
+            max_generated_tokens: MOSS_TD_MAX_GENERATED_TOKENS,
+        };
+        let result = run_builtin_seq2seq_decode_policy(
+            crate::arch::MOSS_TD_DECODE_POLICY_ID,
+            &config,
+            &tokenizer,
+            None,
+            &mut step_executor,
+            &|token_ids: &[u32]| {
+                tokenizer.decode_text_token_ids(token_ids).map_err(|error| {
+                    Seq2SeqGreedyDecodeError::TokenizerDecodeFailed {
+                        reason: error.to_string(),
+                    }
+                })
+            },
+            |error: Seq2SeqGreedyDecodeError| error,
+            |error: Seq2SeqGreedyDecodeError| error,
+            map_registry_error,
+        )
+        .map_err(|error| MossTdExecutorError::GreedyDecodeFailed {
+            reason: error.to_string(),
+        })?;
+
+        let text = result.text.trim().to_string();
+        let transcription = Transcription {
+            segments: vec![Segment {
+                start: 0.0,
+                end: audio_duration_seconds.max(0.0),
+                text: text.clone(),
+                speaker: None,
+                speaker_label: None,
+                speaker_profile_id: None,
+                words: Vec::new(),
+            }],
+            text,
+            longform: None,
+            language: None,
+        };
+        Ok(GgmlAsrExecutionResult {
+            transcription,
+            carry_context: None,
+        })
+    }
+}
+
+fn map_registry_error(
+    error: BuiltinDecodePolicyComponentRegistryError,
+) -> Seq2SeqGreedyDecodeError {
+    Seq2SeqGreedyDecodeError::DecoderStepFailed {
+        reason: error.to_string(),
+    }
+}
+
+impl GgmlAsrExecutor for MossTdGgmlExecutor {
+    fn executor_id(&self) -> &'static str {
+        MOSS_TD_EXECUTOR_ID
+    }
+
+    fn supports_phrase_bias(&self) -> bool {
+        false
+    }
+
+    fn execute(
+        &self,
+        request: &GgmlAsrExecutionRequest,
+    ) -> Result<GgmlAsrExecutionResult, GgmlAsrExecutionError> {
+        self.execute_inner(request)
+            .map_err(|error| GgmlAsrExecutionError::ExecutorFailed {
+                executor_id: GgmlAsrExecutor::executor_id(self),
+                adapter_id: request.selected_family.adapter_id,
+                reason: error.to_string(),
+            })
+    }
+}
+
+/// Not a true incremental streaming session -- this family's architecture
+/// needs the full audio up front to place its numeric time-anchor markers
+/// (see `decode_prompt`'s module doc), so there is no meaningful "partial"
+/// mode yet (matches the top-of-file doc's "file-transcribe only" note).
+/// Still registers a buffered snapshot-streaming session (mirrors
+/// `firered_llm`'s identical precedent: a family with no real partial path
+/// still needs SOME streaming executor, or the builtin dispatch's
+/// fail-fast completeness gate rejects the whole registry at startup) so a
+/// live-caption request degrades to "one final result at end of audio"
+/// instead of silently falling back to a broken cadence.
+impl GgmlAsrStreamingExecutor for MossTdGgmlExecutor {
+    fn executor_id(&self) -> &'static str {
+        MOSS_TD_STREAMING_EXECUTOR_ID
+    }
+
+    fn start_streaming_session(
+        &self,
+        request: &GgmlAsrStreamingSessionRequest,
+    ) -> Result<Box<dyn crate::NativeAsrSession>, GgmlAsrExecutionError> {
+        build_seq2seq_streaming_session(
+            self.clone(),
+            MOSS_TD_STREAMING_EXECUTOR_ID,
+            crate::arch::MOSS_TD_GGML_ADAPTER_ID,
+            "moss-transcribe-diarize",
+            request,
+            STREAMING_PARTIAL_TUNING_HEAVY_SNAPSHOT,
+            MossTdGgmlExecutor::execute,
+        )
+    }
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/graph_config.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/graph_config.rs
@@ -1,0 +1,34 @@
+//! moss-transcribe-diarize ggml graph backend/threading policy. Correctness-
+//! first: no per-stage GPU opt-out gating yet (perf tuning is out of scope
+//! this stage, see `mod.rs`'s stage-status note) -- just the shared
+//! env-driven backend resolution every other family's runtime graph config
+//! uses (`AutoGpuPolicy::AllBackends`, mirrors this family's arch-descriptor
+//! entry).
+
+use crate::ggml_runtime::GgmlCpuGraphConfig;
+use crate::models::graph_runtime_config::{
+    ModelMetalRuntimeOverrides, configure_model_runtime_graph_config_from_env,
+};
+
+const MOSS_TD_ENCODER_GRAPH_SIZE: usize = 16_384;
+
+pub(crate) fn moss_td_runtime_graph_config() -> GgmlCpuGraphConfig {
+    configure_model_runtime_graph_config_from_env(
+        GgmlCpuGraphConfig::default(),
+        ModelMetalRuntimeOverrides {
+            default_use_scheduler_when_unset: Some(true),
+            default_n_threads_when_unset: Some(1),
+        },
+    )
+}
+
+pub(crate) fn moss_td_encoder_graph_config() -> GgmlCpuGraphConfig {
+    let mut config = moss_td_runtime_graph_config();
+    config.graph_size = config.graph_size.max(MOSS_TD_ENCODER_GRAPH_SIZE);
+    config.context_bytes = config
+        .context_bytes
+        .max(GgmlCpuGraphConfig::metadata_context_bytes(
+            config.graph_size,
+        ));
+    config
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -191,28 +191,55 @@ impl MossTdDecoderRuntime {
     }
 
     /// Run the entire ChatML+audio prompt as one causal prefill pass, seeding
-    /// `layer_kv_caches` with every prompt token's K/V, and return the logits
-    /// row for the token immediately following the prompt.
+    /// the decoder's KV history with every prompt token's K/V, and return the
+    /// logits row for the token immediately following the prompt.
     ///
-    /// A single-shot prefill graph materializes a `token_count x token_count`
-    /// attention working set, which for a multi-minute clip's few-thousand-token
-    /// prompt is the dominant memory spike (measured: it is what pushes a
-    /// 3-minute decode past a 6 GB budget, while the encoder itself peaks around
-    /// 3 GB). On the host path this splits the prompt into
-    /// `MOSS_TD_PREFILL_CHUNK_TOKENS`-token segments fed in KV order, so the
-    /// attention working set stays `chunk x total` instead of `total x total`.
-    /// Numerically identical to the single-shot pass -- causal attention over
-    /// the same KV history, just in segments (mirrors qwen3-asr's own
-    /// `ggml_executor` prefill-chunking). Prompts at or below the chunk size
-    /// (every sub-40s clip, including jfk/en_zh) take the single-shot path
-    /// unchanged, and the GPU path (`safe_host_cache_prefill_chunk_size_for`
-    /// returns `None`) is likewise left single-shot.
+    /// Three paths, all numerically equivalent (causal attention over the same
+    /// KV order):
+    /// - Metal/single-GPU reuse: `run_prefill_auto_last_hidden` seeds the
+    ///   persistent decode graph's resident-KV arena in one batched compute so
+    ///   `decode_step`'s reused graph can attend over the prompt (see the branch
+    ///   below).
+    /// - Host path, long prompt: split into `MOSS_TD_PREFILL_CHUNK_TOKENS`-token
+    ///   segments fed in KV order, so the single-shot graph's
+    ///   `token_count x token_count` attention working set stays `chunk x total`
+    ///   -- a secondary memory lever for multi-minute clips (mirrors qwen3-asr's
+    ///   own `ggml_executor` prefill-chunking).
+    /// - Host path, short prompt (every sub-40s clip, incl. jfk/en_zh): a single
+    ///   bulk `run_prefill`.
     pub(crate) fn prefill(
         &mut self,
         prompt_embeddings: &Qwen3AsrPromptEmbeddings,
         layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
     ) -> Result<Vec<f32>, MossTdDecoderError> {
         let token_count = prompt_embeddings.token_count;
+        // On a backend with persistent decode-graph reuse (Metal/single-GPU),
+        // seed the resident-KV arena in one batched compute instead of the bulk
+        // host-cache `run_prefill` below. `decode_step` reuses that same
+        // persistent graph and can only see a prompt token's K/V if the prompt
+        // flowed through it too (see `run_prefill_auto_last_hidden`'s doc), so
+        // mixing bulk prefill with reuse decode would attend over an empty KV
+        // history for the whole prompt span. Returns `None` on the host/CPU
+        // path, which falls through to the chunked/single-shot prefill.
+        if let Some(final_hidden) = self
+            .whole_decoder
+            .run_prefill_auto_last_hidden(
+                &prompt_embeddings.token_major_values,
+                token_count,
+                layer_kv_caches,
+                MOSS_TD_ROPE_THETA,
+            )
+            .map_err(|error| MossTdDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?
+        {
+            return self
+                .logits_head
+                .compute_logits_for_last_hidden(&final_hidden)
+                .map_err(|error| MossTdDecoderError::LogitsHeadFailed {
+                    reason: error.to_string(),
+                });
+        }
         let host_chunked = self
             .whole_decoder
             .safe_host_cache_prefill_chunk_size_for(token_count)
@@ -302,9 +329,16 @@ impl MossTdDecoderRuntime {
         layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
     ) -> Result<Vec<f32>, MossTdDecoderError> {
         let hidden = self.gather_token_embedding(token_id)?;
+        // `run_step_auto` transparently reuses the persistent decode graph on
+        // the Metal/single-GPU lane (avoiding the per-token graph rebuild whose
+        // growing-KV re-upload exhausts the Metal command buffer on long
+        // decodes); CPU stays on the per-token `run_step` rebuild, byte-
+        // identical to before. The host KV write below keeps the host cache in
+        // sync for the CPU path and is a harmless no-op-equivalent on the
+        // reuse path (whose KV lives resident in the decode graph's arena).
         let step = self
             .whole_decoder
-            .run_step(&hidden, cache_position, layer_kv_caches, MOSS_TD_ROPE_THETA)
+            .run_step_auto(&hidden, cache_position, layer_kv_caches, MOSS_TD_ROPE_THETA)
             .map_err(|error| MossTdDecoderError::GraphFailed {
                 reason: error.to_string(),
             })?;

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -29,6 +29,15 @@ use super::tensor_names::{
     LLM_OUTPUT_NORM_WEIGHT, LLM_TOKEN_EMBD_WEIGHT, moss_llm_layer_tensor_names,
 };
 
+/// Host-path prefill segment width (see [`MossTdDecoderRuntime::prefill`]). A
+/// prompt longer than this is fed to the decoder in segments of this many
+/// tokens so the attention working set stays `chunk x total` instead of
+/// `total x total`. Chosen above every sub-40s clip's prompt length so short
+/// audio (jfk/en_zh and the 40s regression clip) keeps the byte-for-byte
+/// single-shot path, while a multi-minute prompt still splits into a handful of
+/// segments that fit a modest memory budget.
+const MOSS_TD_PREFILL_CHUNK_TOKENS: usize = 512;
+
 #[derive(Debug, Error)]
 pub(crate) enum MossTdDecoderError {
     #[error("moss-transcribe-diarize decoder tensor read failed: {reason}")]
@@ -184,28 +193,99 @@ impl MossTdDecoderRuntime {
     /// Run the entire ChatML+audio prompt as one causal prefill pass, seeding
     /// `layer_kv_caches` with every prompt token's K/V, and return the logits
     /// row for the token immediately following the prompt.
+    ///
+    /// A single-shot prefill graph materializes a `token_count x token_count`
+    /// attention working set, which for a multi-minute clip's few-thousand-token
+    /// prompt is the dominant memory spike (measured: it is what pushes a
+    /// 3-minute decode past a 6 GB budget, while the encoder itself peaks around
+    /// 3 GB). On the host path this splits the prompt into
+    /// `MOSS_TD_PREFILL_CHUNK_TOKENS`-token segments fed in KV order, so the
+    /// attention working set stays `chunk x total` instead of `total x total`.
+    /// Numerically identical to the single-shot pass -- causal attention over
+    /// the same KV history, just in segments (mirrors qwen3-asr's own
+    /// `ggml_executor` prefill-chunking). Prompts at or below the chunk size
+    /// (every sub-40s clip, including jfk/en_zh) take the single-shot path
+    /// unchanged, and the GPU path (`safe_host_cache_prefill_chunk_size_for`
+    /// returns `None`) is likewise left single-shot.
     pub(crate) fn prefill(
         &mut self,
         prompt_embeddings: &Qwen3AsrPromptEmbeddings,
         layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
     ) -> Result<Vec<f32>, MossTdDecoderError> {
         let token_count = prompt_embeddings.token_count;
-        let step = self
+        let host_chunked = self
             .whole_decoder
-            .run_prefill(
-                &prompt_embeddings.token_major_values,
-                token_count,
-                MOSS_TD_ROPE_THETA,
-            )
-            .map_err(|error| MossTdDecoderError::GraphFailed {
-                reason: error.to_string(),
-            })?;
-        let final_hidden = self.write_prefill_outputs(0, token_count, &step, layer_kv_caches)?;
+            .safe_host_cache_prefill_chunk_size_for(token_count)
+            .is_some();
+        let final_hidden = if host_chunked && token_count > MOSS_TD_PREFILL_CHUNK_TOKENS {
+            self.prefill_chunked(prompt_embeddings, layer_kv_caches)?
+        } else {
+            let step = self
+                .whole_decoder
+                .run_prefill(
+                    &prompt_embeddings.token_major_values,
+                    token_count,
+                    MOSS_TD_ROPE_THETA,
+                )
+                .map_err(|error| MossTdDecoderError::GraphFailed {
+                    reason: error.to_string(),
+                })?;
+            self.write_prefill_outputs(0, token_count, &step, layer_kv_caches)?
+        };
         self.logits_head
             .compute_logits_for_last_hidden(&final_hidden)
             .map_err(|error| MossTdDecoderError::LogitsHeadFailed {
                 reason: error.to_string(),
             })
+    }
+
+    /// Segmented prefill (see [`Self::prefill`]): feed the prompt to the decoder
+    /// in `MOSS_TD_PREFILL_CHUNK_TOKENS`-token segments, each attending to the
+    /// KV history the prior segments wrote, and return the final segment's last
+    /// hidden state. Every segment's K/V is written into `layer_kv_caches`
+    /// before the next segment runs, exactly reproducing the single-shot pass's
+    /// KV order.
+    fn prefill_chunked(
+        &mut self,
+        prompt_embeddings: &Qwen3AsrPromptEmbeddings,
+        layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
+    ) -> Result<Vec<f32>, MossTdDecoderError> {
+        let token_count = prompt_embeddings.token_count;
+        let hidden_size = self.metadata.d_model;
+        let mut position_offset = 0usize;
+        let mut final_hidden: Option<Vec<f32>> = None;
+        while position_offset < token_count {
+            let chunk_len = (token_count - position_offset).min(MOSS_TD_PREFILL_CHUNK_TOKENS);
+            let hidden_start = position_offset
+                .checked_mul(hidden_size)
+                .ok_or(MossTdDecoderError::EmptyPrefillOutput)?;
+            let hidden_end = position_offset
+                .checked_add(chunk_len)
+                .and_then(|end| end.checked_mul(hidden_size))
+                .ok_or(MossTdDecoderError::EmptyPrefillOutput)?;
+            let total_token_count = position_offset + chunk_len;
+            let chunk_values = prompt_embeddings
+                .token_major_values
+                .get(hidden_start..hidden_end)
+                .ok_or(MossTdDecoderError::EmptyPrefillOutput)?;
+            let step = self
+                .whole_decoder
+                .run_prefill_chunk(
+                    chunk_values,
+                    chunk_len,
+                    position_offset,
+                    total_token_count,
+                    layer_kv_caches,
+                    MOSS_TD_ROPE_THETA,
+                )
+                .map_err(|error| MossTdDecoderError::GraphFailed {
+                    reason: error.to_string(),
+                })?;
+            final_hidden =
+                Some(self.write_prefill_outputs(position_offset, chunk_len, &step, layer_kv_caches)?);
+            position_offset = total_token_count;
+        }
+        final_hidden.ok_or(MossTdDecoderError::EmptyPrefillOutput)
     }
 
     /// Run one incremental decode step for `token_id` at `cache_position`,

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -281,8 +281,12 @@ impl MossTdDecoderRuntime {
                 .map_err(|error| MossTdDecoderError::GraphFailed {
                     reason: error.to_string(),
                 })?;
-            final_hidden =
-                Some(self.write_prefill_outputs(position_offset, chunk_len, &step, layer_kv_caches)?);
+            final_hidden = Some(self.write_prefill_outputs(
+                position_offset,
+                chunk_len,
+                &step,
+                layer_kv_caches,
+            )?);
             position_offset = total_token_count;
         }
         final_hidden.ok_or(MossTdDecoderError::EmptyPrefillOutput)

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -1,0 +1,303 @@
+//! The Qwen3-0.6B decoder-only LLM stage, reusing `qwen`'s family-agnostic
+//! decoder machinery byte-for-byte: `qwen::load_qwen_family_llm_layer_attention_projection_generic`
+//! for layer projections (QK-norm present, no attention bias -- the inverse
+//! of `firered_llm`'s Qwen2 parameterization, but the SAME shared loader,
+//! just with the `Option` fields flipped), `qwen::Qwen3AsrLlmWholeDecoderGraphExecutor`
+//! for the whole-decoder ggml graph, `qwen::Qwen3AsrLayerKvCacheState` for the
+//! host-side per-layer GQA KV cache, and `qwen::Qwen3AsrLlmLogitsHead` /
+//! `qwen::Qwen3AsrTokenEmbeddingTable` for the output/embedding stage.
+//! Mirrors `firered_llm::llm_transformer`'s exact shape (see that module's
+//! doc comment for why this crate does not replicate qwen's GPU-tuned
+//! prefill-chunk/persistent-session machinery here: correctness-first single-
+//! shot decode, GPU perf tuning is out of scope this stage).
+
+use thiserror::Error;
+
+use crate::ggml_runtime::GgufTensorDataReadError;
+use crate::models::qwen::{
+    Qwen3AsrLayerKvCacheState, Qwen3AsrLlmLayerAttentionProjection, Qwen3AsrLlmLogitsHead,
+    Qwen3AsrLlmWholeDecoderGraphExecutor, Qwen3AsrPromptEmbeddings, Qwen3AsrTokenEmbeddingTable,
+    QwenFamilyLlmLayerTensorNames, load_llm_logits_head_from_reader_with_tensor_names,
+    load_qwen_family_llm_layer_attention_projection_generic,
+    load_token_embedding_table_from_reader_with_tensor_name,
+};
+
+use super::runtime_contract::{
+    MOSS_TD_RMS_NORM_EPSILON, MOSS_TD_ROPE_THETA, MossTdDecoderMetadata,
+};
+use super::tensor_names::{
+    LLM_OUTPUT_NORM_WEIGHT, LLM_TOKEN_EMBD_WEIGHT, moss_llm_layer_tensor_names,
+};
+
+#[derive(Debug, Error)]
+pub(crate) enum MossTdDecoderError {
+    #[error("moss-transcribe-diarize decoder tensor read failed: {reason}")]
+    TensorReadFailed { reason: String },
+    #[error("moss-transcribe-diarize decoder graph failed: {reason}")]
+    GraphFailed { reason: String },
+    #[error("moss-transcribe-diarize decoder token-embedding gather failed: {reason}")]
+    TokenEmbeddingFailed { reason: String },
+    #[error("moss-transcribe-diarize decoder logits head failed: {reason}")]
+    LogitsHeadFailed { reason: String },
+    #[error("moss-transcribe-diarize decoder KV cache write failed: {reason}")]
+    KvCacheFailed { reason: String },
+    #[error("moss-transcribe-diarize decoder prefill produced no final hidden state")]
+    EmptyPrefillOutput,
+}
+
+fn load_moss_layer_projections(
+    reader: &crate::ggml_runtime::GgufTensorDataReader,
+    metadata: &MossTdDecoderMetadata,
+) -> Result<Vec<Qwen3AsrLlmLayerAttentionProjection>, MossTdDecoderError> {
+    let mut projections = Vec::with_capacity(metadata.n_layers);
+    for layer_index in 0..metadata.n_layers {
+        let names = moss_llm_layer_tensor_names(layer_index);
+        let generic = load_qwen_family_llm_layer_attention_projection_generic(
+            reader,
+            QwenFamilyLlmLayerTensorNames {
+                attn_norm_name: names.attn_norm_weight,
+                attn_q_name: names.attn_q_weight,
+                attn_k_name: names.attn_k_weight,
+                attn_v_name: names.attn_v_weight,
+                attn_output_name: names.attn_output_weight,
+                // Qwen3 has QK-norm (unlike Qwen2/firered-llm).
+                q_norm_name: Some(names.attn_q_norm_weight),
+                k_norm_name: Some(names.attn_k_norm_weight),
+                // Qwen3 has no attention bias (unlike Qwen2/firered-llm).
+                q_bias_name: None,
+                k_bias_name: None,
+                v_bias_name: None,
+                ffn_norm_name: names.ffn_norm_weight,
+                ffn_gate_name: names.ffn_gate_weight,
+                ffn_up_name: names.ffn_up_weight,
+                ffn_down_name: names.ffn_down_weight,
+            },
+            metadata.d_model,
+            metadata.n_heads,
+            metadata.n_kv_heads,
+            metadata.head_dim,
+            false,
+        )
+        .map_err(|error| MossTdDecoderError::TensorReadFailed {
+            reason: error.to_string(),
+        })?;
+        projections.push(Qwen3AsrLlmLayerAttentionProjection::Generic(generic));
+    }
+    Ok(projections)
+}
+
+/// The Qwen3-0.6B decoder-only stack for one loaded pack: layer weights +
+/// logits head + token embedding table (tied to the same tensor as the
+/// logits head's output weight -- `config.tie_word_embeddings=true`, see
+/// `package_import`'s module doc), ready to prefill/decode against a fresh
+/// set of per-utterance KV caches (`new_kv_caches`).
+pub(crate) struct MossTdDecoderRuntime {
+    whole_decoder: Qwen3AsrLlmWholeDecoderGraphExecutor,
+    logits_head: Qwen3AsrLlmLogitsHead,
+    token_embedding: Qwen3AsrTokenEmbeddingTable,
+    metadata: MossTdDecoderMetadata,
+}
+
+impl MossTdDecoderRuntime {
+    pub(crate) fn new(
+        runtime_path: &std::path::Path,
+        metadata: MossTdDecoderMetadata,
+    ) -> Result<Self, MossTdDecoderError> {
+        let reader = crate::ggml_runtime::GgufTensorDataReader::from_path(runtime_path)
+            .map_err(map_tensor_read_error)?;
+        let projections = load_moss_layer_projections(&reader, &metadata)?;
+        let whole_decoder =
+            Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_rms_norm_epsilon_and_fused_logits_head(
+                &projections,
+                Some(runtime_path),
+                MOSS_TD_RMS_NORM_EPSILON,
+                None,
+            )
+            .map_err(|error| MossTdDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?;
+        let logits_head = load_llm_logits_head_from_reader_with_tensor_names(
+            &reader,
+            metadata.d_model,
+            metadata.vocab_size,
+            LLM_OUTPUT_NORM_WEIGHT,
+            // Tied embeddings: the output projection reuses the token
+            // embedding tensor -- no separate lm_head tensor exists in the
+            // pack (see `package_import`).
+            LLM_TOKEN_EMBD_WEIGHT,
+            MOSS_TD_RMS_NORM_EPSILON,
+        )
+        .map_err(|error| MossTdDecoderError::LogitsHeadFailed {
+            reason: error.to_string(),
+        })?;
+        let token_embedding = load_token_embedding_table_from_reader_with_tensor_name(
+            &reader,
+            LLM_TOKEN_EMBD_WEIGHT,
+            metadata.d_model,
+            metadata.vocab_size,
+        )
+        .map_err(|error| MossTdDecoderError::TokenEmbeddingFailed {
+            reason: error.to_string(),
+        })?;
+        Ok(Self {
+            whole_decoder,
+            logits_head,
+            token_embedding,
+            metadata,
+        })
+    }
+
+    pub(crate) fn backend_label(&self) -> String {
+        self.whole_decoder.backend_label()
+    }
+
+    pub(crate) fn new_kv_caches(&self) -> Vec<Qwen3AsrLayerKvCacheState> {
+        (0..self.metadata.n_layers)
+            .map(|_| {
+                Qwen3AsrLayerKvCacheState::new(
+                    self.metadata.max_positions,
+                    self.metadata.n_kv_heads,
+                    self.metadata.head_dim,
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn gather_token_embedding(
+        &self,
+        token_id: u32,
+    ) -> Result<Vec<f32>, MossTdDecoderError> {
+        self.token_embedding
+            .gather_rows(&[token_id])
+            .map_err(|error| MossTdDecoderError::TokenEmbeddingFailed {
+                reason: error.to_string(),
+            })
+    }
+
+    /// Run the entire ChatML+audio prompt as one causal prefill pass, seeding
+    /// `layer_kv_caches` with every prompt token's K/V, and return the logits
+    /// row for the token immediately following the prompt.
+    pub(crate) fn prefill(
+        &mut self,
+        prompt_embeddings: &Qwen3AsrPromptEmbeddings,
+        layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
+    ) -> Result<Vec<f32>, MossTdDecoderError> {
+        let token_count = prompt_embeddings.token_count;
+        let step = self
+            .whole_decoder
+            .run_prefill(
+                &prompt_embeddings.token_major_values,
+                token_count,
+                MOSS_TD_ROPE_THETA,
+            )
+            .map_err(|error| MossTdDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?;
+        let final_hidden = self.write_prefill_outputs(0, token_count, &step, layer_kv_caches)?;
+        self.logits_head
+            .compute_logits_for_last_hidden(&final_hidden)
+            .map_err(|error| MossTdDecoderError::LogitsHeadFailed {
+                reason: error.to_string(),
+            })
+    }
+
+    /// Run one incremental decode step for `token_id` at `cache_position`,
+    /// updating `layer_kv_caches`, and return the logits row for the NEXT
+    /// token.
+    pub(crate) fn decode_step(
+        &mut self,
+        token_id: u32,
+        cache_position: usize,
+        layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
+    ) -> Result<Vec<f32>, MossTdDecoderError> {
+        let hidden = self.gather_token_embedding(token_id)?;
+        let step = self
+            .whole_decoder
+            .run_step(&hidden, cache_position, layer_kv_caches, MOSS_TD_ROPE_THETA)
+            .map_err(|error| MossTdDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?;
+        write_layer_kv(
+            cache_position,
+            1,
+            &step.layer_kv,
+            self.metadata.n_kv_heads * self.metadata.head_dim,
+            layer_kv_caches,
+        )?;
+        self.logits_head
+            .compute_logits_for_last_hidden(&step.hidden)
+            .map_err(|error| MossTdDecoderError::LogitsHeadFailed {
+                reason: error.to_string(),
+            })
+    }
+
+    fn write_prefill_outputs(
+        &self,
+        position_offset: usize,
+        token_count: usize,
+        step: &crate::models::qwen::Qwen3AsrLlmWholeStepOutput,
+        layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
+    ) -> Result<Vec<f32>, MossTdDecoderError> {
+        let kv_row_width = self.metadata.n_kv_heads * self.metadata.head_dim;
+        write_layer_kv(
+            position_offset,
+            token_count,
+            &step.layer_kv,
+            kv_row_width,
+            layer_kv_caches,
+        )?;
+        let hidden_size = self.metadata.d_model;
+        let final_hidden_start = token_count
+            .checked_sub(1)
+            .and_then(|position| position.checked_mul(hidden_size))
+            .ok_or(MossTdDecoderError::EmptyPrefillOutput)?;
+        let final_hidden_end = final_hidden_start
+            .checked_add(hidden_size)
+            .ok_or(MossTdDecoderError::EmptyPrefillOutput)?;
+        step.hidden
+            .get(final_hidden_start..final_hidden_end)
+            .map(<[f32]>::to_vec)
+            .ok_or(MossTdDecoderError::EmptyPrefillOutput)
+    }
+}
+
+fn write_layer_kv(
+    position_offset: usize,
+    token_count: usize,
+    layer_kv: &[(Vec<f32>, Vec<f32>)],
+    kv_row_width: usize,
+    layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
+) -> Result<(), MossTdDecoderError> {
+    if layer_kv.len() != layer_kv_caches.len() {
+        return Err(MossTdDecoderError::KvCacheFailed {
+            reason: "layer-KV count mismatch".to_string(),
+        });
+    }
+    for token_position in 0..token_count {
+        let absolute_position = position_offset + token_position;
+        let row_start = token_position * kv_row_width;
+        let row_end = row_start + kv_row_width;
+        for (layer_index, (projected_k, projected_v)) in layer_kv.iter().enumerate() {
+            let key_row = projected_k.get(row_start..row_end).ok_or_else(|| {
+                MossTdDecoderError::KvCacheFailed {
+                    reason: "K row out of bounds".to_string(),
+                }
+            })?;
+            let value_row = projected_v.get(row_start..row_end).ok_or_else(|| {
+                MossTdDecoderError::KvCacheFailed {
+                    reason: "V row out of bounds".to_string(),
+                }
+            })?;
+            layer_kv_caches[layer_index]
+                .write(absolute_position, key_row, value_row)
+                .map_err(|reason| MossTdDecoderError::KvCacheFailed { reason })?;
+        }
+    }
+    Ok(())
+}
+
+fn map_tensor_read_error(error: GgufTensorDataReadError) -> MossTdDecoderError {
+    MossTdDecoderError::TensorReadFailed {
+        reason: error.to_string(),
+    }
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -23,7 +23,7 @@ use crate::models::qwen::{
 };
 
 use super::runtime_contract::{
-    MOSS_TD_RMS_NORM_EPSILON, MOSS_TD_ROPE_THETA, MossTdDecoderMetadata,
+    MOSS_TD_RMS_NORM_EPSILON, MOSS_TD_ROPE_THETA, MossTdDecoderMetadata, moss_td_kv_cache_positions,
 };
 use super::tensor_names::{
     LLM_OUTPUT_NORM_WEIGHT, LLM_TOKEN_EMBD_WEIGHT, moss_llm_layer_tensor_names,
@@ -152,10 +152,17 @@ impl MossTdDecoderRuntime {
     }
 
     pub(crate) fn new_kv_caches(&self) -> Vec<Qwen3AsrLayerKvCacheState> {
+        // Clamp the RoPE context limit (`max_positions`, up to 131072) down to
+        // the KV-cache preallocation cap: `Qwen3AsrLayerKvCacheState::new`
+        // eagerly allocates the full `max_positions` span on first write, so an
+        // uncapped 131072 reserves ~30 GB across the 28 layers (see
+        // `moss_td_kv_cache_positions`). This makes packs built before the cap
+        // (131072 baked into the GGUF) allocate the same ~1.9 GB as fresh ones.
+        let cache_positions = moss_td_kv_cache_positions(self.metadata.max_positions);
         (0..self.metadata.n_layers)
             .map(|_| {
                 Qwen3AsrLayerKvCacheState::new(
-                    self.metadata.max_positions,
+                    cache_positions,
                     self.metadata.n_kv_heads,
                     self.metadata.head_dim,
                 )

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/mod.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/mod.rs
@@ -1,0 +1,32 @@
+//! MOSS-Transcribe-Diarize (`OpenMOSS/MOSS-Transcribe-Diarize`, 0.9B) model
+//! family: a joint transcription + speaker-diarization ASR model built from
+//! a Whisper-Medium-architecture audio encoder, a small `VQAdaptor` bridge
+//! (a plain 3-layer MLP+LayerNorm despite the "VQ" name -- there is no
+//! vector-quantization codebook in this checkpoint), and a Qwen3-0.6B
+//! decoder. `[S01]`-style speaker labels and inline timestamps are ordinary
+//! BPE tokens the Qwen3 decoder emits freely as part of its transcript text;
+//! this family does not parse or structure them (that is a product-layer
+//! concern, out of scope for the core engine).
+//!
+//! Stage status: only the checkpoint-to-GGUF importer
+//! ([`package_import`]) exists so far -- see that module's doc comment for
+//! the full tensor-mapping contract and exactly what is and is not wired up
+//! yet. The ggml execution graph (Whisper encoder reuse, the adaptor
+//! bridge, Qwen3 decoder reuse, decode-policy registration) has not been
+//! implemented; a pack produced by this importer is not yet runnable by
+//! `openasr transcribe`.
+
+pub(crate) mod package_import;
+pub(crate) mod tensor_names;
+
+// Not yet consumed by any CLI/tooling entry point (see the module doc above
+// for stage status) -- re-exported now so the runtime-wiring follow-up and a
+// future CLI `model-pack import` case can reach these without touching this
+// file again. Matches every other family module's `pub use` shape in this
+// crate (e.g. `firered_llm`, `mimo_asr`), which stay unused the same way
+// until their own executor/CLI wiring lands.
+#[allow(unused_imports)]
+pub use package_import::{
+    MossTdImportRequest, MossTdImportResult, MossTdQuantizationMode,
+    convert_local_moss_transcribe_diarize_source_to_runtime_pack,
+};

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/mod.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/mod.rs
@@ -16,15 +16,24 @@
 //! implemented; a pack produced by this importer is not yet runnable by
 //! `openasr transcribe`.
 
+mod adaptor_graph;
+mod decode_prompt;
+mod encoder_graph;
+pub(crate) mod executor;
+mod graph_config;
+mod llm_decoder;
 pub(crate) mod package_import;
+mod prompt_embedding;
+pub(crate) mod runtime_contract;
 pub(crate) mod tensor_names;
+mod tokenizer;
 
 // Not yet consumed by any CLI/tooling entry point (see the module doc above
-// for stage status) -- re-exported now so the runtime-wiring follow-up and a
-// future CLI `model-pack import` case can reach these without touching this
-// file again. Matches every other family module's `pub use` shape in this
-// crate (e.g. `firered_llm`, `mimo_asr`), which stay unused the same way
-// until their own executor/CLI wiring lands.
+// for stage status) -- re-exported now so a future CLI `model-pack import`
+// case can reach these without touching this file again. Matches every
+// other family module's `pub use` shape in this crate (e.g. `firered_llm`,
+// `mimo_asr`), which stay unused the same way until their own CLI wiring
+// lands.
 #[allow(unused_imports)]
 pub use package_import::{
     MossTdImportRequest, MossTdImportResult, MossTdQuantizationMode,

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
@@ -1,0 +1,1287 @@
+//! Convert a local MOSS-Transcribe-Diarize (`OpenMOSS/MOSS-Transcribe-Diarize`,
+//! 0.9B) source checkpoint into an OpenASR `.oasr` (GGUF-v0) runtime pack.
+//!
+//! MOSS-Transcribe-Diarize is an Encoder-Adaptor-LLM ASR+diarization model:
+//! a Whisper-Medium-architecture audio encoder (80-mel, `d_model=1024`, 24
+//! layers, 16 heads, `max_source_positions=1500`) feeds a pure-reshape 4x
+//! time-merge (`(B,T,1024) -> (B,T/4,4096)`, no learned weights) into the
+//! `VQAdaptor` bridge (`Linear(4096->1024) -> SiLU -> Linear(1024->1024) ->
+//! LayerNorm`, the only weighted bridge layer despite the "VQ" name -- there
+//! is no vector-quantization codebook in this checkpoint), whose output rows
+//! get `masked_scatter`-spliced into a Qwen3-0.6B decoder's prompt embedding
+//! stream at `<|audio_pad|>` (token id 151671) positions, bracketed by
+//! `<|audio_start|>` (151669) / `<|audio_end|>` (151670). `[S01]`-style
+//! speaker labels and inline timestamps are ordinary BPE tokens the Qwen3
+//! decoder emits freely -- this importer treats them as opaque text, same as
+//! every other token.
+//!
+//! This importer combines the checkpoint's three parameter groups (single
+//! safetensors shard, `model.safetensors.index.json` names one shard) into
+//! one GGUF:
+//!
+//!  1. **Encoder** (`model.whisper_encoder.*`, 367 tensors): standard HF
+//!     `WhisperEncoder` naming (`conv1`/`conv2`/`embed_positions`/
+//!     `layers.N.*`/`layer_norm`) -- verified against the checkpoint's own
+//!     `config.json` `audio_config` (`model_type: "whisper"`) and a byte
+//!     inspection of the safetensors header. This importer keeps its own
+//!     `moss.enc.*` tensor namespace (see `tensor_names.rs`'s module doc for
+//!     why) rather than whisper.cpp's `model.encoder.*` names, since this
+//!     pack carries no whisper decoder branch for a shared binding contract
+//!     to apply to.
+//!  2. **VQAdaptor** (`model.vq_adaptor.layers.{0,2,3}.*`, 6 tensors):
+//!     `layers.0` = Linear(4096->1024), `layers.1` = SiLU (no weights),
+//!     `layers.2` = Linear(1024->1024), `layers.3` = LayerNorm(1024,
+//!     `eps=1e-6`).
+//!  3. **Qwen3-0.6B decoder** (`model.language_model.*`, 310 tensors):
+//!     standard un-prefixed `Qwen3ForCausalLM` naming, QK-norm present
+//!     (`self_attn.{q,k}_norm.weight`), no attention bias tensors (matches
+//!     `config.json`'s `text_config.attention_bias: false`),
+//!     `tie_word_embeddings: true` (no separate `lm_head.weight` tensor --
+//!     verified absent from the safetensors header).
+//!
+//! Tokenizer: standard Qwen `vocab.json` + `merges.txt` GPT-2-style BPE, plus
+//! `tokenizer.json`'s `added_tokens` array (29 entries, ids 151643..151671
+//! contiguous, verified against the checkpoint's own file), which is where
+//! the ChatML control tokens AND the three audio tokens
+//! (`<|audio_start|>`=151669 / `<|audio_end|>`=151670 / `<|audio_pad|>`=151671)
+//! live -- none of the three audio tokens are exposed via `vocab.json` or
+//! `added_tokens.json` alone, only in `tokenizer.json`.
+//!
+//! **Stage status**: this importer produces a well-formed, self-describing
+//! GGUF with every tensor this family needs and full tokenizer metadata. It
+//! is NOT yet wired into `arch/mod.rs`'s family-descriptor table (no
+//! `MOSS_TRANSCRIBE_DIARIZE_*` architecture/decode-policy/executor-component
+//! registration exists yet), so a pack produced here is not yet runnable by
+//! `openasr transcribe` -- the ggml execution graph (Whisper encoder reuse +
+//! adaptor + Qwen3 decoder + decode-policy registration) is follow-up work.
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::ggml_runtime::{
+    GgufWriteTensor, GgufWriteTensorType, GgufWriteValue, quantize_f32_to_ggml_tensor_data,
+    read_gguf_tensor_index, write_gguf_file_v0,
+};
+use crate::models::ggml_family_adapter::GGML_TOKENIZER_ID_KEY;
+use crate::models::local_source_import::{
+    LocalSourceImportError, SafetensorsFile, SafetensorsTensorHeader,
+    decode_safetensors_payload_as_f16_bits, decode_safetensors_payload_as_f32, encode_f16_bits_le,
+    read_source_file_bytes, read_source_json_file, tensor_element_count, validate_error,
+    validate_output_pack_extension,
+};
+use crate::models::oasr_metadata::{
+    OASR_METADATA_KEY_AUDIO_FRONTEND, OASR_METADATA_KEY_DECODE_POLICY,
+    OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
+    OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1, OasrMetadataBuilder,
+    TOKENIZER_GGML_MERGES_KEY, TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_TOKENS_KEY,
+};
+use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+
+use super::tensor_names::{
+    ADAPTOR_LINEAR1_BIAS, ADAPTOR_LINEAR1_WEIGHT, ADAPTOR_LINEAR2_BIAS, ADAPTOR_LINEAR2_WEIGHT,
+    ADAPTOR_NORM_BIAS, ADAPTOR_NORM_WEIGHT, ENC_CONV1_BIAS, ENC_CONV1_WEIGHT, ENC_CONV2_BIAS,
+    ENC_CONV2_WEIGHT, ENC_OUT_NORM_BIAS, ENC_OUT_NORM_WEIGHT, ENC_POS_EMBD_WEIGHT,
+    LLM_OUTPUT_NORM_WEIGHT, LLM_TOKEN_EMBD_WEIGHT, moss_encoder_layer_tensor_names,
+    moss_llm_layer_tensor_names,
+};
+
+pub(crate) const MOSS_TD_MODEL_FAMILY: &str = "moss-transcribe-diarize";
+pub(crate) const MOSS_TD_GGML_ARCHITECTURE_ID: &str = "moss-transcribe-diarize-whisper-qwen3";
+/// Not yet registered in `arch/mod.rs` (see this module's doc comment) --
+/// kept here as the value this importer stamps into the pack so the runtime
+/// wiring stage can adopt it verbatim without an on-disk format change.
+pub(crate) const MOSS_TD_AUDIO_FRONTEND_ID: &str = "moss-transcribe-diarize.fbank80.16khz.mono.v0";
+pub(crate) const MOSS_TD_TOKENIZER_ID: &str = "moss-transcribe-diarize.qwen3-bpe.v0";
+pub(crate) const MOSS_TD_DECODE_POLICY_ID: &str = "moss-transcribe-diarize.greedy.seq2seq.v0";
+
+const SOURCE_CONFIG_JSON: &str = "config.json";
+const SOURCE_VOCAB_JSON: &str = "vocab.json";
+const SOURCE_MERGES_TXT: &str = "merges.txt";
+const SOURCE_TOKENIZER_JSON: &str = "tokenizer.json";
+
+const TOKENIZER_GGML_MODEL_VALUE_GPT2: &str = "gpt2";
+const OPENASR_MODEL_ID_KEY: &str = "openasr.model.id";
+const GENERAL_ARCHITECTURE_KEY: &str = "general.architecture";
+
+const WHISPER_ENCODER_PREFIX: &str = "model.whisper_encoder.";
+const VQ_ADAPTOR_PREFIX: &str = "model.vq_adaptor.";
+const LANGUAGE_MODEL_PREFIX: &str = "model.language_model.";
+
+/// `config.json`'s `audio_token_id` (the `<|audio_pad|>` id the model was
+/// trained against) and `audio_merge_size` (the 4x reshape factor) are
+/// checkpoint-declared, not hardcoded -- this importer cross-checks them
+/// against the tokenizer's own `<|audio_pad|>` entry and fails closed on a
+/// mismatch rather than silently trusting one source.
+#[derive(Debug, Deserialize)]
+struct MossConfigJson {
+    audio_token_id: u32,
+    audio_merge_size: u32,
+    adaptor_input_dim: u32,
+    tie_word_embeddings: bool,
+    text_config: MossTextConfigJson,
+    audio_config: MossAudioConfigJson,
+}
+
+#[derive(Debug, Deserialize)]
+struct MossTextConfigJson {
+    vocab_size: usize,
+    hidden_size: usize,
+    intermediate_size: usize,
+    num_hidden_layers: usize,
+    num_attention_heads: usize,
+    num_key_value_heads: usize,
+    head_dim: usize,
+    rms_norm_eps: f32,
+    rope_theta: f32,
+    max_position_embeddings: usize,
+    attention_bias: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct MossAudioConfigJson {
+    num_mel_bins: usize,
+    d_model: usize,
+    encoder_layers: usize,
+    encoder_attention_heads: usize,
+    encoder_ffn_dim: usize,
+    max_source_positions: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenizerJsonAddedToken {
+    id: u32,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenizerJson {
+    #[serde(default)]
+    added_tokens: Vec<TokenizerJsonAddedToken>,
+}
+
+pub type MossTdQuantizationMode = PackQuant;
+
+#[derive(Debug, Clone)]
+pub struct MossTdImportRequest {
+    /// Directory containing the checkpoint's `config.json`, safetensors
+    /// shard(s), `vocab.json`, `merges.txt` and `tokenizer.json`.
+    pub source_root: PathBuf,
+    pub output_root: PathBuf,
+    pub model_id: String,
+    pub quantization: MossTdQuantizationMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MossTdImportResult {
+    pub output_path: PathBuf,
+    pub tensor_count: usize,
+    pub vocab_size: usize,
+}
+
+pub fn convert_local_moss_transcribe_diarize_source_to_runtime_pack(
+    request: &MossTdImportRequest,
+) -> Result<MossTdImportResult, LocalSourceImportError> {
+    validate_request(request)?;
+    let config: MossConfigJson = read_source_json_file(&request.source_root, SOURCE_CONFIG_JSON)?;
+    validate_moss_config(&config)?;
+
+    let safetensors = open_safetensors_shard(&request.source_root)?;
+
+    let mut tensors =
+        build_encoder_runtime_tensors(&safetensors, &config.audio_config, request.quantization)?;
+    tensors.extend(build_adaptor_runtime_tensors(
+        &safetensors,
+        &config,
+        request.quantization,
+    )?);
+    tensors.extend(build_llm_runtime_tensors(
+        &safetensors,
+        &config.text_config,
+        config.tie_word_embeddings,
+        request.quantization,
+    )?);
+
+    let mut tokens = load_vocab_tokens(&request.source_root)?;
+    let merges = load_merges(&request.source_root)?;
+    let audio_token_ids =
+        patch_added_tokens_and_find_audio_tokens(&request.source_root, &mut tokens)?;
+    if audio_token_ids.pad != config.audio_token_id {
+        return Err(validate_error(format!(
+            "moss-transcribe-diarize tokenizer.json '<|audio_pad|>' id {} != \
+             config.json audio_token_id {}",
+            audio_token_ids.pad, config.audio_token_id
+        )));
+    }
+    if tokens.len() < config.text_config.vocab_size {
+        tokens.resize_with(config.text_config.vocab_size, String::new);
+    }
+    for (index, token) in tokens.iter_mut().enumerate() {
+        if token.is_empty() {
+            *token = format!("<unused_{index}>");
+        }
+    }
+
+    let metadata =
+        moss_td_runtime_gguf_metadata(&config, request, &tokens, &merges, audio_token_ids);
+    write_gguf_file_v0(&request.output_root, &metadata, &tensors).map_err(|error| {
+        validate_error(format!(
+            "moss-transcribe-diarize GGUF writer failed for '{}': {error}",
+            request.output_root.display()
+        ))
+    })?;
+
+    let index = read_gguf_tensor_index(&request.output_root).map_err(|error| {
+        validate_error(format!(
+            "moss-transcribe-diarize import produced an unreadable tensor index: {error}"
+        ))
+    })?;
+    Ok(MossTdImportResult {
+        output_path: request.output_root.clone(),
+        tensor_count: index.tensors().len(),
+        vocab_size: tokens.len(),
+    })
+}
+
+fn validate_request(request: &MossTdImportRequest) -> Result<(), LocalSourceImportError> {
+    if request.model_id.trim().is_empty() {
+        return Err(validate_error(
+            "moss-transcribe-diarize local-source converter requires non-empty model_id",
+        ));
+    }
+    validate_output_pack_extension(&request.output_root)
+}
+
+fn validate_moss_config(config: &MossConfigJson) -> Result<(), LocalSourceImportError> {
+    let text = &config.text_config;
+    if text.num_attention_heads == 0
+        || !text
+            .num_attention_heads
+            .is_multiple_of(text.num_key_value_heads.max(1))
+        || text.num_key_value_heads == 0
+    {
+        return Err(validate_error(format!(
+            "moss-transcribe-diarize text_config num_attention_heads {} is not a multiple of \
+             num_key_value_heads {}",
+            text.num_attention_heads, text.num_key_value_heads
+        )));
+    }
+    if text.attention_bias {
+        return Err(validate_error(
+            "moss-transcribe-diarize text_config.attention_bias=true is not the verified \
+             Qwen3 (no-bias) parameterization this importer targets",
+        ));
+    }
+    if !config.tie_word_embeddings {
+        return Err(validate_error(
+            "moss-transcribe-diarize config.tie_word_embeddings=false is unsupported: this \
+             importer expects no separate lm_head.weight tensor",
+        ));
+    }
+    let audio = &config.audio_config;
+    if audio.d_model == 0
+        || !audio
+            .d_model
+            .is_multiple_of(audio.encoder_attention_heads.max(1))
+    {
+        return Err(validate_error(format!(
+            "moss-transcribe-diarize audio_config d_model {} is not a multiple of \
+             encoder_attention_heads {}",
+            audio.d_model, audio.encoder_attention_heads
+        )));
+    }
+    if config.audio_merge_size == 0 {
+        return Err(validate_error(
+            "moss-transcribe-diarize config.audio_merge_size must be > 0",
+        ));
+    }
+    let expected_adaptor_input = audio.d_model * config.audio_merge_size as usize;
+    if config.adaptor_input_dim as usize != expected_adaptor_input {
+        return Err(validate_error(format!(
+            "moss-transcribe-diarize config.adaptor_input_dim {} != d_model {} * \
+             audio_merge_size {} ({})",
+            config.adaptor_input_dim,
+            audio.d_model,
+            config.audio_merge_size,
+            expected_adaptor_input
+        )));
+    }
+    Ok(())
+}
+
+fn open_safetensors_shard(source_root: &Path) -> Result<SafetensorsFile, LocalSourceImportError> {
+    // The published checkpoint ships a single shard
+    // (`model-00000-of-00001.safetensors`); rather than hardcode that exact
+    // filename (a re-shard would silently break this), resolve it the same
+    // way `model.safetensors.index.json` would: pick the sole `*.safetensors`
+    // file in the source root.
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(source_root)
+        .map_err(|error| {
+            validate_error(format!(
+                "moss-transcribe-diarize import cannot list '{}': {error}",
+                source_root.display()
+            ))
+        })?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "safetensors"))
+        .collect();
+    candidates.sort();
+    match candidates.as_slice() {
+        [single] => SafetensorsFile::open(single),
+        [] => Err(validate_error(format!(
+            "moss-transcribe-diarize import found no '*.safetensors' file under '{}'",
+            source_root.display()
+        ))),
+        multiple => Err(validate_error(format!(
+            "moss-transcribe-diarize import found {} '*.safetensors' shards under '{}'; \
+             multi-shard checkpoints are not supported yet",
+            multiple.len(),
+            source_root.display()
+        ))),
+    }
+}
+
+// --- shared tensor materialization helpers ---------------------------------
+
+fn f32_tensor(name: &str, dims: Vec<u64>, values: &[f32]) -> GgufWriteTensor {
+    let mut bytes = Vec::with_capacity(values.len() * 4);
+    for value in values {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+    GgufWriteTensor {
+        name: name.to_string(),
+        dims,
+        tensor_type: GgufWriteTensorType::F32,
+        data: bytes,
+    }
+}
+
+fn f16_tensor_from_source(
+    tensor: &SafetensorsTensorHeader,
+    data: &[u8],
+    target_name: &str,
+    target_dims: Vec<u64>,
+) -> Result<GgufWriteTensor, LocalSourceImportError> {
+    let bits = decode_safetensors_payload_as_f16_bits(&tensor.name, &tensor.dtype, data)?;
+    let expected = tensor_element_count(&tensor.name, &target_dims)?;
+    if bits.len() != expected {
+        return Err(validate_error(format!(
+            "moss-transcribe-diarize tensor '{}' decoded {} values but expected {} for dims {:?}",
+            tensor.name,
+            bits.len(),
+            expected,
+            target_dims
+        )));
+    }
+    Ok(GgufWriteTensor {
+        name: target_name.to_string(),
+        dims: target_dims,
+        tensor_type: GgufWriteTensorType::F16,
+        data: encode_f16_bits_le(bits),
+    })
+}
+
+fn f32_tensor_from_source(
+    tensor: &SafetensorsTensorHeader,
+    data: &[u8],
+    target_name: &str,
+    target_dims: Vec<u64>,
+) -> Result<GgufWriteTensor, LocalSourceImportError> {
+    let values = decode_safetensors_payload_as_f32(&tensor.name, &tensor.dtype, data)?;
+    let expected = tensor_element_count(&tensor.name, &target_dims)?;
+    if values.len() != expected {
+        return Err(validate_error(format!(
+            "moss-transcribe-diarize tensor '{}' decoded {} values but expected {} for dims {:?}",
+            tensor.name,
+            values.len(),
+            expected,
+            target_dims
+        )));
+    }
+    Ok(f32_tensor(target_name, target_dims, &values))
+}
+
+/// `[out, in]` safetensors row-major -> ggml's `[in, out]` (OutputByInput)
+/// on-disk convention: reverse the dims, keep the flat byte layout (a
+/// row-major `[out, in]` buffer IS a row-major `[in, out]`-shaped ggml tensor
+/// read back with `ne0=in, ne1=out` -- this is the same "just relabel dims,
+/// don't transpose bytes" convention every other importer in this crate
+/// uses for 2D `Linear` weights).
+fn reversed_dims(shape: &[u64]) -> Vec<u64> {
+    let mut dims = shape.to_vec();
+    dims.reverse();
+    dims
+}
+
+fn quantized_linear_tensor_type(
+    dims: &[u64],
+    quantization: MossTdQuantizationMode,
+) -> Option<GgufWriteTensorType> {
+    if quantization == MossTdQuantizationMode::Fp16 {
+        return None;
+    }
+    let ne0 = dims.first().copied()?;
+    classify_quant_tensor(ne0, quantization)
+}
+
+fn maybe_quantized_linear_tensor(
+    tensor: &SafetensorsTensorHeader,
+    data: &[u8],
+    target_name: &str,
+    target_dims: Vec<u64>,
+    quantization: MossTdQuantizationMode,
+) -> Result<GgufWriteTensor, LocalSourceImportError> {
+    match quantized_linear_tensor_type(&target_dims, quantization) {
+        Some(tensor_type) => {
+            let values = decode_safetensors_payload_as_f32(&tensor.name, &tensor.dtype, data)?;
+            let expected = tensor_element_count(&tensor.name, &target_dims)?;
+            if values.len() != expected {
+                return Err(validate_error(format!(
+                    "moss-transcribe-diarize tensor '{}' decoded {} values but expected {} for \
+                     dims {:?}",
+                    tensor.name,
+                    values.len(),
+                    expected,
+                    target_dims
+                )));
+            }
+            let quantized = quantize_f32_to_ggml_tensor_data(tensor_type, &target_dims, &values)
+                .map_err(|error| {
+                    validate_error(format!(
+                        "moss-transcribe-diarize quantization failed for '{}' -> '{target_name}' \
+                     ({tensor_type:?}): {error}",
+                        tensor.name
+                    ))
+                })?;
+            Ok(GgufWriteTensor {
+                name: target_name.to_string(),
+                dims: target_dims,
+                tensor_type,
+                data: quantized,
+            })
+        }
+        None => f16_tensor_from_source(tensor, data, target_name, target_dims),
+    }
+}
+
+fn tensor_by_name<'a>(
+    safetensors: &'a SafetensorsFile,
+    name: &str,
+) -> Result<(&'a SafetensorsTensorHeader, &'a [u8]), LocalSourceImportError> {
+    let tensor = safetensors.tensor(name).ok_or_else(|| {
+        validate_error(format!(
+            "moss-transcribe-diarize source is missing tensor '{name}'"
+        ))
+    })?;
+    let data = safetensors.tensor_data(tensor)?;
+    Ok((tensor, data))
+}
+
+// --- Whisper-Medium-style encoder ------------------------------------------
+
+fn build_encoder_runtime_tensors(
+    safetensors: &SafetensorsFile,
+    audio: &MossAudioConfigJson,
+    quantization: MossTdQuantizationMode,
+) -> Result<Vec<GgufWriteTensor>, LocalSourceImportError> {
+    let mut out = Vec::new();
+
+    let (conv1_w, conv1_w_data) = tensor_by_name(
+        safetensors,
+        &format!("{WHISPER_ENCODER_PREFIX}conv1.weight"),
+    )?;
+    out.push(f16_tensor_from_source(
+        conv1_w,
+        conv1_w_data,
+        ENC_CONV1_WEIGHT,
+        reversed_dims(&conv1_w.shape),
+    )?);
+    let (conv1_b, conv1_b_data) =
+        tensor_by_name(safetensors, &format!("{WHISPER_ENCODER_PREFIX}conv1.bias"))?;
+    out.push(f32_tensor_from_source(
+        conv1_b,
+        conv1_b_data,
+        ENC_CONV1_BIAS,
+        conv1_b.shape.clone(),
+    )?);
+    let (conv2_w, conv2_w_data) = tensor_by_name(
+        safetensors,
+        &format!("{WHISPER_ENCODER_PREFIX}conv2.weight"),
+    )?;
+    out.push(f16_tensor_from_source(
+        conv2_w,
+        conv2_w_data,
+        ENC_CONV2_WEIGHT,
+        reversed_dims(&conv2_w.shape),
+    )?);
+    let (conv2_b, conv2_b_data) =
+        tensor_by_name(safetensors, &format!("{WHISPER_ENCODER_PREFIX}conv2.bias"))?;
+    out.push(f32_tensor_from_source(
+        conv2_b,
+        conv2_b_data,
+        ENC_CONV2_BIAS,
+        conv2_b.shape.clone(),
+    )?);
+    let (pos_embd, pos_embd_data) = tensor_by_name(
+        safetensors,
+        &format!("{WHISPER_ENCODER_PREFIX}embed_positions.weight"),
+    )?;
+    out.push(f16_tensor_from_source(
+        pos_embd,
+        pos_embd_data,
+        ENC_POS_EMBD_WEIGHT,
+        pos_embd.shape.clone(),
+    )?);
+    let (norm_w, norm_w_data) = tensor_by_name(
+        safetensors,
+        &format!("{WHISPER_ENCODER_PREFIX}layer_norm.weight"),
+    )?;
+    out.push(f32_tensor_from_source(
+        norm_w,
+        norm_w_data,
+        ENC_OUT_NORM_WEIGHT,
+        norm_w.shape.clone(),
+    )?);
+    let (norm_b, norm_b_data) = tensor_by_name(
+        safetensors,
+        &format!("{WHISPER_ENCODER_PREFIX}layer_norm.bias"),
+    )?;
+    out.push(f32_tensor_from_source(
+        norm_b,
+        norm_b_data,
+        ENC_OUT_NORM_BIAS,
+        norm_b.shape.clone(),
+    )?);
+
+    for layer in 0..audio.encoder_layers {
+        let names = moss_encoder_layer_tensor_names(layer);
+        let src = |suffix: &str| format!("{WHISPER_ENCODER_PREFIX}layers.{layer}.{suffix}");
+
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn_layer_norm.weight"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.attn_norm_weight,
+            t.shape.clone(),
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn_layer_norm.bias"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.attn_norm_bias,
+            t.shape.clone(),
+        )?);
+
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.q_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.attn_q_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.q_proj.bias"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.attn_q_bias,
+            t.shape.clone(),
+        )?);
+
+        // Whisper's key projection has no bias (upstream `WhisperAttention`
+        // only sets `bias=False` on `k_proj`, matching the safetensors
+        // header this importer verified).
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.k_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.attn_k_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.v_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.attn_v_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.v_proj.bias"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.attn_v_bias,
+            t.shape.clone(),
+        )?);
+
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.out_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.attn_out_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.out_proj.bias"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.attn_out_bias,
+            t.shape.clone(),
+        )?);
+
+        let (t, d) = tensor_by_name(safetensors, &src("final_layer_norm.weight"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.ffn_norm_weight,
+            t.shape.clone(),
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("final_layer_norm.bias"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.ffn_norm_bias,
+            t.shape.clone(),
+        )?);
+
+        let (t, d) = tensor_by_name(safetensors, &src("fc1.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.ffn_up_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("fc1.bias"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.ffn_up_bias,
+            t.shape.clone(),
+        )?);
+
+        let (t, d) = tensor_by_name(safetensors, &src("fc2.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.ffn_down_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("fc2.bias"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.ffn_down_bias,
+            t.shape.clone(),
+        )?);
+    }
+
+    Ok(out)
+}
+
+// --- VQAdaptor bridge -------------------------------------------------------
+
+fn build_adaptor_runtime_tensors(
+    safetensors: &SafetensorsFile,
+    config: &MossConfigJson,
+    quantization: MossTdQuantizationMode,
+) -> Result<Vec<GgufWriteTensor>, LocalSourceImportError> {
+    let mut out = Vec::new();
+
+    let (t, d) = tensor_by_name(safetensors, &format!("{VQ_ADAPTOR_PREFIX}layers.0.weight"))?;
+    if t.shape.as_slice()
+        != [
+            config.text_config.hidden_size as u64,
+            config.adaptor_input_dim as u64,
+        ]
+    {
+        return Err(validate_error(format!(
+            "moss-transcribe-diarize adaptor linear1 weight shape {:?} != expected [{}, {}]",
+            t.shape, config.text_config.hidden_size, config.adaptor_input_dim
+        )));
+    }
+    out.push(maybe_quantized_linear_tensor(
+        t,
+        d,
+        ADAPTOR_LINEAR1_WEIGHT,
+        reversed_dims(&t.shape),
+        quantization,
+    )?);
+    let (t, d) = tensor_by_name(safetensors, &format!("{VQ_ADAPTOR_PREFIX}layers.0.bias"))?;
+    out.push(f32_tensor_from_source(
+        t,
+        d,
+        ADAPTOR_LINEAR1_BIAS,
+        t.shape.clone(),
+    )?);
+
+    let (t, d) = tensor_by_name(safetensors, &format!("{VQ_ADAPTOR_PREFIX}layers.2.weight"))?;
+    out.push(maybe_quantized_linear_tensor(
+        t,
+        d,
+        ADAPTOR_LINEAR2_WEIGHT,
+        reversed_dims(&t.shape),
+        quantization,
+    )?);
+    let (t, d) = tensor_by_name(safetensors, &format!("{VQ_ADAPTOR_PREFIX}layers.2.bias"))?;
+    out.push(f32_tensor_from_source(
+        t,
+        d,
+        ADAPTOR_LINEAR2_BIAS,
+        t.shape.clone(),
+    )?);
+
+    let (t, d) = tensor_by_name(safetensors, &format!("{VQ_ADAPTOR_PREFIX}layers.3.weight"))?;
+    out.push(f32_tensor_from_source(
+        t,
+        d,
+        ADAPTOR_NORM_WEIGHT,
+        t.shape.clone(),
+    )?);
+    let (t, d) = tensor_by_name(safetensors, &format!("{VQ_ADAPTOR_PREFIX}layers.3.bias"))?;
+    out.push(f32_tensor_from_source(
+        t,
+        d,
+        ADAPTOR_NORM_BIAS,
+        t.shape.clone(),
+    )?);
+
+    Ok(out)
+}
+
+// --- Qwen3-0.6B decoder ------------------------------------------------------
+
+fn build_llm_runtime_tensors(
+    safetensors: &SafetensorsFile,
+    text: &MossTextConfigJson,
+    tie_word_embeddings: bool,
+    quantization: MossTdQuantizationMode,
+) -> Result<Vec<GgufWriteTensor>, LocalSourceImportError> {
+    let mut out = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+
+    let (t, d) = tensor_by_name(
+        safetensors,
+        &format!("{LANGUAGE_MODEL_PREFIX}embed_tokens.weight"),
+    )?;
+    if t.shape.as_slice() != [text.vocab_size as u64, text.hidden_size as u64] {
+        return Err(validate_error(format!(
+            "moss-transcribe-diarize embed_tokens shape {:?} != expected [{}, {}]",
+            t.shape, text.vocab_size, text.hidden_size
+        )));
+    }
+    // Embedding table: same "just relabel dims, gather is column-major
+    // either way" convention as every other family's token-embedding tensor
+    // in this crate (rows stay contiguous per-token; ggml reads it back as
+    // `[hidden, vocab]`).
+    out.push(f16_tensor_from_source(
+        t,
+        d,
+        LLM_TOKEN_EMBD_WEIGHT,
+        vec![text.hidden_size as u64, text.vocab_size as u64],
+    )?);
+    seen.insert(LLM_TOKEN_EMBD_WEIGHT.to_string());
+    if !tie_word_embeddings {
+        // Guarded by `validate_moss_config` above; defensive redundancy so a
+        // future caller that skips validation still fails closed instead of
+        // silently dropping the lm_head branch.
+        return Err(validate_error(
+            "moss-transcribe-diarize untied embeddings are not supported by this importer",
+        ));
+    }
+
+    let (t, d) = tensor_by_name(safetensors, &format!("{LANGUAGE_MODEL_PREFIX}norm.weight"))?;
+    out.push(f32_tensor_from_source(
+        t,
+        d,
+        LLM_OUTPUT_NORM_WEIGHT,
+        t.shape.clone(),
+    )?);
+
+    for layer in 0..text.num_hidden_layers {
+        let names = moss_llm_layer_tensor_names(layer);
+        let src = |suffix: &str| format!("{LANGUAGE_MODEL_PREFIX}layers.{layer}.{suffix}");
+
+        let (t, d) = tensor_by_name(safetensors, &src("input_layernorm.weight"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.attn_norm_weight,
+            t.shape.clone(),
+        )?);
+
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.q_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.attn_q_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.k_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.attn_k_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.v_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.attn_v_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.o_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.attn_output_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.q_norm.weight"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.attn_q_norm_weight,
+            t.shape.clone(),
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("self_attn.k_norm.weight"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.attn_k_norm_weight,
+            t.shape.clone(),
+        )?);
+
+        let (t, d) = tensor_by_name(safetensors, &src("post_attention_layernorm.weight"))?;
+        out.push(f32_tensor_from_source(
+            t,
+            d,
+            &names.ffn_norm_weight,
+            t.shape.clone(),
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("mlp.gate_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.ffn_gate_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("mlp.up_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.ffn_up_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+        let (t, d) = tensor_by_name(safetensors, &src("mlp.down_proj.weight"))?;
+        out.push(maybe_quantized_linear_tensor(
+            t,
+            d,
+            &names.ffn_down_weight,
+            reversed_dims(&t.shape),
+            quantization,
+        )?);
+    }
+
+    Ok(out)
+}
+
+// --- Qwen-style tokenizer (vocab.json + merges.txt + tokenizer.json added) -
+
+fn load_vocab_tokens(source_root: &Path) -> Result<Vec<String>, LocalSourceImportError> {
+    let vocab: BTreeMap<String, usize> = read_source_json_file(source_root, SOURCE_VOCAB_JSON)?;
+    if vocab.is_empty() {
+        return Err(validate_error(
+            "moss-transcribe-diarize vocab.json cannot be empty",
+        ));
+    }
+    let mut pairs = vocab.into_iter().collect::<Vec<_>>();
+    pairs.sort_by_key(|(_, token_id)| *token_id);
+    let max_id = pairs.last().map(|(_, token_id)| *token_id).ok_or_else(|| {
+        validate_error("moss-transcribe-diarize vocab.json cannot determine max token id")
+    })?;
+    let mut tokens = vec![String::new(); max_id + 1];
+    for (token, token_id) in pairs {
+        tokens[token_id] = token;
+    }
+    Ok(tokens)
+}
+
+fn load_merges(source_root: &Path) -> Result<Vec<String>, LocalSourceImportError> {
+    let bytes = read_source_file_bytes(source_root, SOURCE_MERGES_TXT)?;
+    let text = std::str::from_utf8(&bytes).map_err(|error| {
+        validate_error(format!(
+            "moss-transcribe-diarize merges.txt is not valid UTF-8: {error}"
+        ))
+    })?;
+    Ok(text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MossTdAudioTokenIds {
+    pub start: u32,
+    pub end: u32,
+    pub pad: u32,
+}
+
+/// Reads `tokenizer.json`'s `added_tokens` array (ids 151643..151671 in the
+/// verified checkpoint -- ChatML control tokens plus the three audio
+/// tokens), patches them into `tokens`, and resolves the three audio token
+/// ids by their literal content string (never assumed contiguous /
+/// offset-derived from each other) so the caller can cross-check
+/// `<|audio_pad|>` against `config.json`'s `audio_token_id`.
+fn patch_added_tokens_and_find_audio_tokens(
+    source_root: &Path,
+    tokens: &mut Vec<String>,
+) -> Result<MossTdAudioTokenIds, LocalSourceImportError> {
+    let parsed: TokenizerJson = read_source_json_file(source_root, SOURCE_TOKENIZER_JSON)?;
+    if parsed.added_tokens.is_empty() {
+        return Err(validate_error(
+            "moss-transcribe-diarize tokenizer.json has an empty 'added_tokens' array",
+        ));
+    }
+    let mut start = None;
+    let mut end = None;
+    let mut pad = None;
+    for entry in &parsed.added_tokens {
+        let token_id = entry.id as usize;
+        if token_id >= tokens.len() {
+            tokens.resize_with(token_id + 1, String::new);
+        }
+        tokens[token_id] = entry.content.clone();
+        match entry.content.as_str() {
+            "<|audio_start|>" => start = Some(entry.id),
+            "<|audio_end|>" => end = Some(entry.id),
+            "<|audio_pad|>" => pad = Some(entry.id),
+            _ => {}
+        }
+    }
+    let missing = |name: &str| {
+        validate_error(format!(
+            "moss-transcribe-diarize tokenizer.json 'added_tokens' has no '{name}' entry"
+        ))
+    };
+    Ok(MossTdAudioTokenIds {
+        start: start.ok_or_else(|| missing("<|audio_start|>"))?,
+        end: end.ok_or_else(|| missing("<|audio_end|>"))?,
+        pad: pad.ok_or_else(|| missing("<|audio_pad|>"))?,
+    })
+}
+
+// --- metadata ---------------------------------------------------------
+
+fn moss_td_runtime_gguf_metadata(
+    config: &MossConfigJson,
+    request: &MossTdImportRequest,
+    tokens: &[String],
+    merges: &[String],
+    audio_token_ids: MossTdAudioTokenIds,
+) -> BTreeMap<String, GgufWriteValue> {
+    let text = &config.text_config;
+    let audio = &config.audio_config;
+    OasrMetadataBuilder::new()
+        .str(GENERAL_ARCHITECTURE_KEY, MOSS_TD_GGML_ARCHITECTURE_ID)
+        .str(OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1)
+        .str(OASR_METADATA_KEY_MODEL_FAMILY, MOSS_TD_MODEL_FAMILY)
+        .str(
+            OASR_METADATA_KEY_MODEL_ARCHITECTURE,
+            MOSS_TD_GGML_ARCHITECTURE_ID,
+        )
+        .str(OASR_METADATA_KEY_AUDIO_FRONTEND, MOSS_TD_AUDIO_FRONTEND_ID)
+        .str(OASR_METADATA_KEY_DECODE_POLICY, MOSS_TD_DECODE_POLICY_ID)
+        .str(GGML_TOKENIZER_ID_KEY, MOSS_TD_TOKENIZER_ID)
+        .str(OPENASR_MODEL_ID_KEY, &request.model_id)
+        .str(TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_MODEL_VALUE_GPT2)
+        .string_array(TOKENIZER_GGML_TOKENS_KEY, tokens)
+        .string_array(TOKENIZER_GGML_MERGES_KEY, merges)
+        .u32("moss_td.encoder.n_layers", audio.encoder_layers as u32)
+        .u32("moss_td.encoder.d_model", audio.d_model as u32)
+        .u32(
+            "moss_td.encoder.n_heads",
+            audio.encoder_attention_heads as u32,
+        )
+        .u32("moss_td.encoder.ffn_dim", audio.encoder_ffn_dim as u32)
+        .u32("moss_td.encoder.n_mels", audio.num_mel_bins as u32)
+        .u32(
+            "moss_td.encoder.max_source_positions",
+            audio.max_source_positions as u32,
+        )
+        .u32("moss_td.adaptor.merge_size", config.audio_merge_size)
+        .u32("moss_td.adaptor.input_dim", config.adaptor_input_dim)
+        .u32("moss_td.llm.n_layers", text.num_hidden_layers as u32)
+        .u32("moss_td.llm.d_model", text.hidden_size as u32)
+        .u32("moss_td.llm.ffn_dim", text.intermediate_size as u32)
+        .u32("moss_td.llm.n_heads", text.num_attention_heads as u32)
+        .u32("moss_td.llm.n_kv_heads", text.num_key_value_heads as u32)
+        .u32("moss_td.llm.head_dim", text.head_dim as u32)
+        .u32("moss_td.llm.vocab_size", tokens.len() as u32)
+        .u32(
+            "moss_td.llm.max_positions",
+            text.max_position_embeddings as u32,
+        )
+        .u32("moss_td.llm.audio_start_token_id", audio_token_ids.start)
+        .u32("moss_td.llm.audio_end_token_id", audio_token_ids.end)
+        .u32("moss_td.llm.audio_pad_token_id", audio_token_ids.pad)
+        .str("moss_td.llm.rms_norm_eps", text.rms_norm_eps)
+        .str("moss_td.llm.rope_theta", text.rope_theta)
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_json(dir: &Path, name: &str, value: &serde_json::Value) {
+        let mut file = std::fs::File::create(dir.join(name)).expect("create json fixture");
+        file.write_all(serde_json::to_string(value).unwrap().as_bytes())
+            .expect("write json fixture");
+    }
+
+    #[test]
+    fn validate_moss_config_accepts_the_real_checkpoint_shape() {
+        let config = MossConfigJson {
+            audio_token_id: 151_671,
+            audio_merge_size: 4,
+            adaptor_input_dim: 4096,
+            tie_word_embeddings: true,
+            text_config: MossTextConfigJson {
+                vocab_size: 151_936,
+                hidden_size: 1024,
+                intermediate_size: 3072,
+                num_hidden_layers: 28,
+                num_attention_heads: 16,
+                num_key_value_heads: 8,
+                head_dim: 128,
+                rms_norm_eps: 1e-6,
+                rope_theta: 1_000_000.0,
+                max_position_embeddings: 131_072,
+                attention_bias: false,
+            },
+            audio_config: MossAudioConfigJson {
+                num_mel_bins: 80,
+                d_model: 1024,
+                encoder_layers: 24,
+                encoder_attention_heads: 16,
+                encoder_ffn_dim: 4096,
+                max_source_positions: 1500,
+            },
+        };
+        assert!(validate_moss_config(&config).is_ok());
+    }
+
+    #[test]
+    fn validate_moss_config_rejects_attention_bias() {
+        let mut config = base_config_for_test();
+        config.text_config.attention_bias = true;
+        assert!(validate_moss_config(&config).is_err());
+    }
+
+    #[test]
+    fn validate_moss_config_rejects_untied_embeddings() {
+        let mut config = base_config_for_test();
+        config.tie_word_embeddings = false;
+        assert!(validate_moss_config(&config).is_err());
+    }
+
+    #[test]
+    fn validate_moss_config_rejects_adaptor_input_dim_mismatch() {
+        let mut config = base_config_for_test();
+        config.adaptor_input_dim = 999;
+        assert!(validate_moss_config(&config).is_err());
+    }
+
+    fn base_config_for_test() -> MossConfigJson {
+        MossConfigJson {
+            audio_token_id: 151_671,
+            audio_merge_size: 4,
+            adaptor_input_dim: 4096,
+            tie_word_embeddings: true,
+            text_config: MossTextConfigJson {
+                vocab_size: 151_936,
+                hidden_size: 1024,
+                intermediate_size: 3072,
+                num_hidden_layers: 28,
+                num_attention_heads: 16,
+                num_key_value_heads: 8,
+                head_dim: 128,
+                rms_norm_eps: 1e-6,
+                rope_theta: 1_000_000.0,
+                max_position_embeddings: 131_072,
+                attention_bias: false,
+            },
+            audio_config: MossAudioConfigJson {
+                num_mel_bins: 80,
+                d_model: 1024,
+                encoder_layers: 24,
+                encoder_attention_heads: 16,
+                encoder_ffn_dim: 4096,
+                max_source_positions: 1500,
+            },
+        }
+    }
+
+    #[test]
+    fn load_merges_skips_comments_and_blank_lines() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("merges.txt"), "#version: 0.2\na b\n\nc d\n")
+            .expect("write merges.txt");
+        let merges = load_merges(dir.path()).expect("load merges");
+        assert_eq!(merges, vec!["a b".to_string(), "c d".to_string()]);
+    }
+
+    #[test]
+    fn patch_added_tokens_resolves_audio_pad_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_json(
+            dir.path(),
+            "tokenizer.json",
+            &serde_json::json!({
+                "added_tokens": [
+                    {"id": 151643, "content": "<|endoftext|>"},
+                    {"id": 151669, "content": "<|audio_start|>"},
+                    {"id": 151670, "content": "<|audio_end|>"},
+                    {"id": 151671, "content": "<|audio_pad|>"},
+                ]
+            }),
+        );
+        let mut tokens = vec![String::new(); 151_643];
+        let audio_ids = patch_added_tokens_and_find_audio_tokens(dir.path(), &mut tokens)
+            .expect("patch added tokens");
+        assert_eq!(audio_ids.pad, 151_671);
+        assert_eq!(audio_ids.start, 151_669);
+        assert_eq!(audio_ids.end, 151_670);
+        assert_eq!(tokens[151_669], "<|audio_start|>");
+        assert_eq!(tokens[151_671], "<|audio_pad|>");
+    }
+
+    #[test]
+    fn patch_added_tokens_rejects_missing_audio_pad() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_json(
+            dir.path(),
+            "tokenizer.json",
+            &serde_json::json!({
+                "added_tokens": [
+                    {"id": 151643, "content": "<|endoftext|>"},
+                ]
+            }),
+        );
+        let mut tokens = vec![String::new(); 151_643];
+        assert!(patch_added_tokens_and_find_audio_tokens(dir.path(), &mut tokens).is_err());
+    }
+
+    // --- Real-checkpoint conversion + tensor parity ------------------------
+    //
+    // Points at the private dev-only checkpoint download (~1.7GB bf16
+    // safetensors, NOT committed -- same convention as every other family's
+    // real-dev-pack test in this crate, e.g. `firered_llm::executor`'s
+    // `dev_pack_path()`). Skips silently when absent so this stays runnable
+    // without the multi-GB download.
+    fn dev_checkpoint_root() -> PathBuf {
+        PathBuf::from("/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/model")
+    }
+
+    #[test]
+    fn golden_diff_converted_pack_tensors_match_source_checkpoint_bit_for_bit() {
+        let source_root = dev_checkpoint_root();
+        if !source_root.exists() {
+            eprintln!("skipping: {} not present", source_root.display());
+            return;
+        }
+        let output_dir = tempfile::tempdir().expect("tempdir");
+        let output_root = output_dir.path().join("moss-transcribe-diarize-fp16.oasr");
+        let request = MossTdImportRequest {
+            source_root: source_root.clone(),
+            output_root: output_root.clone(),
+            model_id: "moss-transcribe-diarize-test".to_string(),
+            quantization: MossTdQuantizationMode::Fp16,
+        };
+        let result = convert_local_moss_transcribe_diarize_source_to_runtime_pack(&request)
+            .expect("moss-transcribe-diarize conversion");
+        // Encoder (367) + adaptor (6) + llm embed+norm (2) + llm 28 layers x
+        // 11 tensors (308) = 683, matching the source safetensors tensor
+        // count exactly (no tensor dropped, none duplicated).
+        assert_eq!(result.tensor_count, 683);
+        assert_eq!(result.vocab_size, 151_936);
+
+        // Spot-check tensor-value parity on a representative sample from
+        // each of the three branches: fp16 conversion is lossy relative to
+        // the source bf16 (both are 16-bit but with different
+        // mantissa/exponent splits), so this asserts closeness, not bit
+        // equality -- the golden-diff test at the ggml-execution layer
+        // (follow-up work, see this module's doc comment) is where
+        // token-level parity against the reference PyTorch forward pass
+        // gets checked.
+        let safetensors = open_safetensors_shard(&source_root).expect("open safetensors");
+        let reader = crate::ggml_runtime::GgufTensorDataReader::from_path(&output_root)
+            .expect("open converted pack for parity read");
+        assert_tensor_close(
+            &safetensors,
+            &reader,
+            "model.whisper_encoder.conv1.bias",
+            ENC_CONV1_BIAS,
+            &[1024],
+        );
+        assert_tensor_close(
+            &safetensors,
+            &reader,
+            "model.vq_adaptor.layers.3.weight",
+            ADAPTOR_NORM_WEIGHT,
+            &[1024],
+        );
+        assert_tensor_close(
+            &safetensors,
+            &reader,
+            "model.language_model.norm.weight",
+            LLM_OUTPUT_NORM_WEIGHT,
+            &[1024],
+        );
+    }
+
+    fn assert_tensor_close(
+        safetensors: &SafetensorsFile,
+        reader: &crate::ggml_runtime::GgufTensorDataReader,
+        source_name: &str,
+        target_name: &str,
+        dims: &[u64],
+    ) {
+        let (tensor, data) = tensor_by_name(safetensors, source_name).expect("source tensor");
+        let expected = decode_safetensors_payload_as_f32(&tensor.name, &tensor.dtype, data)
+            .expect("decode source f32");
+        let actual = reader
+            .host_tensor_f32_copy_dequantized_by_name(target_name, dims)
+            .expect("read converted tensor");
+        assert_eq!(
+            expected.len(),
+            actual.len(),
+            "{target_name} length mismatch"
+        );
+        for (index, (want, got)) in expected.iter().zip(actual.iter()).enumerate() {
+            let diff = (want - got).abs();
+            assert!(
+                diff <= 1e-2 * want.abs().max(1.0),
+                "{target_name}[{index}] parity mismatch: source(bf16)={want} converted(f16)={got}"
+            );
+        }
+    }
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
@@ -88,14 +88,10 @@ use super::tensor_names::{
     moss_llm_layer_tensor_names,
 };
 
-pub(crate) const MOSS_TD_MODEL_FAMILY: &str = "moss-transcribe-diarize";
-pub(crate) const MOSS_TD_GGML_ARCHITECTURE_ID: &str = "moss-transcribe-diarize-whisper-qwen3";
-/// Not yet registered in `arch/mod.rs` (see this module's doc comment) --
-/// kept here as the value this importer stamps into the pack so the runtime
-/// wiring stage can adopt it verbatim without an on-disk format change.
-pub(crate) const MOSS_TD_AUDIO_FRONTEND_ID: &str = "moss-transcribe-diarize.fbank80.16khz.mono.v0";
-pub(crate) const MOSS_TD_TOKENIZER_ID: &str = "moss-transcribe-diarize.qwen3-bpe.v0";
-pub(crate) const MOSS_TD_DECODE_POLICY_ID: &str = "moss-transcribe-diarize.greedy.seq2seq.v0";
+use crate::arch::{
+    MOSS_TD_AUDIO_FRONTEND_ID, MOSS_TD_DECODE_POLICY_ID, MOSS_TD_GGML_ARCHITECTURE_ID,
+    MOSS_TD_MODEL_FAMILY, MOSS_TD_TOKENIZER_ID,
+};
 
 const SOURCE_CONFIG_JSON: &str = "config.json";
 const SOURCE_VOCAB_JSON: &str = "vocab.json";

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
@@ -80,6 +80,7 @@ use crate::models::oasr_metadata::{
 };
 use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
 
+use super::runtime_contract::moss_td_kv_cache_positions;
 use super::tensor_names::{
     ADAPTOR_LINEAR1_BIAS, ADAPTOR_LINEAR1_WEIGHT, ADAPTOR_LINEAR2_BIAS, ADAPTOR_LINEAR2_WEIGHT,
     ADAPTOR_NORM_BIAS, ADAPTOR_NORM_WEIGHT, ENC_CONV1_BIAS, ENC_CONV1_WEIGHT, ENC_CONV2_BIAS,
@@ -1030,9 +1031,15 @@ fn moss_td_runtime_gguf_metadata(
         .u32("moss_td.llm.n_kv_heads", text.num_key_value_heads as u32)
         .u32("moss_td.llm.head_dim", text.head_dim as u32)
         .u32("moss_td.llm.vocab_size", tokens.len() as u32)
+        // Write a pragmatic KV-cache capacity, NOT the raw RoPE context limit
+        // (`max_position_embeddings` = 131072). The runtime caps this again on
+        // load (`llm_decoder::new_kv_caches`), so this keeps freshly built packs
+        // self-describing with the same value the runtime will use, rather than
+        // baking in a 131072 that would (uncapped) reserve ~30 GB of KV cache.
+        // See `runtime_contract::moss_td_kv_cache_positions`.
         .u32(
             "moss_td.llm.max_positions",
-            text.max_position_embeddings as u32,
+            moss_td_kv_cache_positions(text.max_position_embeddings) as u32,
         )
         .u32("moss_td.llm.audio_start_token_id", audio_token_ids.start)
         .u32("moss_td.llm.audio_end_token_id", audio_token_ids.end)

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/prompt_embedding.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/prompt_embedding.rs
@@ -1,0 +1,166 @@
+//! Splice adaptor output rows into the token embedding sequence at the exact
+//! (possibly non-contiguous) `<|audio_pad|>` positions
+//! `decode_prompt::build_moss_td_decode_prompt` records. Cannot reuse
+//! `qwen::build_qwen3_prompt_embeddings_with_audio_splice` (that function
+//! assumes one contiguous pad run; MOSS's audio span is interrupted by
+//! digit-marker tokens -- see `decode_prompt`'s module doc), so this is the
+//! sparse-position generalization of the same "replace embedding rows at
+//! placeholder positions" idea upstream implements via `masked_scatter`
+//! (`modeling_moss_transcribe_diarize.py`'s `inject_audio_features`).
+
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MossTdPromptEmbeddings {
+    pub hidden_size: usize,
+    pub token_count: usize,
+    /// Token-major, row-contiguous ([token][hidden]) f32.
+    pub token_major_values: Vec<f32>,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(crate) enum MossTdPromptEmbeddingError {
+    #[error(
+        "moss-transcribe-diarize prompt embedding token rows shape is invalid: token_count={token_count} hidden_size={hidden_size} values_len={values_len}"
+    )]
+    InvalidTokenRowsShape {
+        token_count: usize,
+        hidden_size: usize,
+        values_len: usize,
+    },
+    #[error(
+        "moss-transcribe-diarize prompt embedding audio rows shape is invalid: audio_row_count={audio_row_count} hidden_size={hidden_size} values_len={values_len}"
+    )]
+    InvalidAudioRowsShape {
+        audio_row_count: usize,
+        hidden_size: usize,
+        values_len: usize,
+    },
+    #[error(
+        "moss-transcribe-diarize prompt embedding audio_pad_positions length {positions_len} != audio row count {audio_row_count}"
+    )]
+    AudioRowCountMismatch {
+        positions_len: usize,
+        audio_row_count: usize,
+    },
+    #[error(
+        "moss-transcribe-diarize prompt embedding audio_pad position {position} is out of range for token_count {token_count}"
+    )]
+    PositionOutOfRange { position: usize, token_count: usize },
+    #[error("moss-transcribe-diarize prompt embedding values contain non-finite elements")]
+    NonFiniteValues,
+}
+
+pub(crate) fn build_moss_td_prompt_embeddings_with_audio_splice(
+    token_ids_len: usize,
+    audio_pad_positions: &[usize],
+    hidden_size: usize,
+    token_rows: &[f32],
+    audio_rows: &[f32],
+) -> Result<MossTdPromptEmbeddings, MossTdPromptEmbeddingError> {
+    if hidden_size == 0 {
+        return Err(MossTdPromptEmbeddingError::InvalidTokenRowsShape {
+            token_count: token_ids_len,
+            hidden_size,
+            values_len: token_rows.len(),
+        });
+    }
+    let expected_token_values = token_ids_len.checked_mul(hidden_size).ok_or(
+        MossTdPromptEmbeddingError::InvalidTokenRowsShape {
+            token_count: token_ids_len,
+            hidden_size,
+            values_len: token_rows.len(),
+        },
+    )?;
+    if token_rows.len() != expected_token_values {
+        return Err(MossTdPromptEmbeddingError::InvalidTokenRowsShape {
+            token_count: token_ids_len,
+            hidden_size,
+            values_len: token_rows.len(),
+        });
+    }
+    if token_rows.iter().any(|value| !value.is_finite()) {
+        return Err(MossTdPromptEmbeddingError::NonFiniteValues);
+    }
+
+    let audio_row_count = audio_pad_positions.len();
+    let expected_audio_values = audio_row_count.checked_mul(hidden_size).ok_or(
+        MossTdPromptEmbeddingError::InvalidAudioRowsShape {
+            audio_row_count,
+            hidden_size,
+            values_len: audio_rows.len(),
+        },
+    )?;
+    if audio_rows.len() != expected_audio_values {
+        return Err(MossTdPromptEmbeddingError::AudioRowCountMismatch {
+            positions_len: audio_row_count,
+            audio_row_count: audio_rows.len() / hidden_size.max(1),
+        });
+    }
+    if audio_rows.iter().any(|value| !value.is_finite()) {
+        return Err(MossTdPromptEmbeddingError::NonFiniteValues);
+    }
+
+    let mut combined = token_rows.to_vec();
+    for (row_idx, &position) in audio_pad_positions.iter().enumerate() {
+        if position >= token_ids_len {
+            return Err(MossTdPromptEmbeddingError::PositionOutOfRange {
+                position,
+                token_count: token_ids_len,
+            });
+        }
+        let src_start = row_idx * hidden_size;
+        let dst_start = position * hidden_size;
+        combined[dst_start..dst_start + hidden_size]
+            .copy_from_slice(&audio_rows[src_start..src_start + hidden_size]);
+    }
+
+    Ok(MossTdPromptEmbeddings {
+        hidden_size,
+        token_count: token_ids_len,
+        token_major_values: combined,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splice_replaces_only_the_listed_positions() {
+        let token_rows = vec![
+            10.0, 11.0, //
+            20.0, 21.0, //
+            30.0, 31.0, //
+            40.0, 41.0,
+        ];
+        let audio_rows = vec![
+            100.0, 101.0, //
+            200.0, 201.0,
+        ];
+        // Positions 1 and 3 (non-contiguous, position 2 stays a real token).
+        let spliced = build_moss_td_prompt_embeddings_with_audio_splice(
+            4,
+            &[1, 3],
+            2,
+            &token_rows,
+            &audio_rows,
+        )
+        .expect("splice");
+        assert_eq!(
+            spliced.token_major_values,
+            vec![10.0, 11.0, 100.0, 101.0, 30.0, 31.0, 200.0, 201.0]
+        );
+    }
+
+    #[test]
+    fn splice_rejects_position_out_of_range() {
+        let error =
+            build_moss_td_prompt_embeddings_with_audio_splice(2, &[5], 2, &[0.0; 4], &[0.0; 2])
+                .expect_err("must fail");
+        assert!(matches!(
+            error,
+            MossTdPromptEmbeddingError::PositionOutOfRange { .. }
+        ));
+    }
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/runtime_contract.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/runtime_contract.rs
@@ -1,0 +1,268 @@
+//! moss-transcribe-diarize execution metadata parsed from the `.oasr` GGUF
+//! header. Key names match exactly what `package_import` writes.
+
+use crate::models::runtime_contract::{
+    MetadataContractError, ScalarMetadataView, required_u64_scalar, u64_to_u32, u64_to_usize,
+    validate_positive_usize,
+};
+
+pub(crate) const ENCODER_N_LAYERS_KEY: &str = "moss_td.encoder.n_layers";
+pub(crate) const ENCODER_D_MODEL_KEY: &str = "moss_td.encoder.d_model";
+pub(crate) const ENCODER_N_HEADS_KEY: &str = "moss_td.encoder.n_heads";
+pub(crate) const ENCODER_FFN_DIM_KEY: &str = "moss_td.encoder.ffn_dim";
+pub(crate) const ENCODER_N_MELS_KEY: &str = "moss_td.encoder.n_mels";
+pub(crate) const ENCODER_MAX_SOURCE_POSITIONS_KEY: &str = "moss_td.encoder.max_source_positions";
+pub(crate) const ADAPTOR_MERGE_SIZE_KEY: &str = "moss_td.adaptor.merge_size";
+pub(crate) const ADAPTOR_INPUT_DIM_KEY: &str = "moss_td.adaptor.input_dim";
+pub(crate) const LLM_N_LAYERS_KEY: &str = "moss_td.llm.n_layers";
+pub(crate) const LLM_D_MODEL_KEY: &str = "moss_td.llm.d_model";
+pub(crate) const LLM_FFN_DIM_KEY: &str = "moss_td.llm.ffn_dim";
+pub(crate) const LLM_N_HEADS_KEY: &str = "moss_td.llm.n_heads";
+pub(crate) const LLM_N_KV_HEADS_KEY: &str = "moss_td.llm.n_kv_heads";
+pub(crate) const LLM_HEAD_DIM_KEY: &str = "moss_td.llm.head_dim";
+pub(crate) const LLM_VOCAB_SIZE_KEY: &str = "moss_td.llm.vocab_size";
+pub(crate) const LLM_MAX_POSITIONS_KEY: &str = "moss_td.llm.max_positions";
+pub(crate) const LLM_AUDIO_START_TOKEN_ID_KEY: &str = "moss_td.llm.audio_start_token_id";
+pub(crate) const LLM_AUDIO_END_TOKEN_ID_KEY: &str = "moss_td.llm.audio_end_token_id";
+pub(crate) const LLM_AUDIO_PAD_TOKEN_ID_KEY: &str = "moss_td.llm.audio_pad_token_id";
+
+/// `rope_theta` (1e6) and RMSNorm epsilon (1e-6) are fixed properties of the
+/// checkpoint's Qwen3-0.6B decoder (`config.json`'s `text_config.rope_theta`
+/// / `rms_norm_eps`, verified against the real checkpoint), not per-pack
+/// metadata -- the same "family constant, not a GGUF key" convention
+/// `firered_llm::runtime_contract`'s `FIRERED_LLM_ROPE_THETA` uses.
+pub(crate) const MOSS_TD_ROPE_THETA: f32 = 1_000_000.0;
+pub(crate) const MOSS_TD_RMS_NORM_EPSILON: f32 = 1e-6;
+/// `nn.LayerNorm`'s `eps` in `VQAdaptor.__init__` (`config.py`:
+/// `norm_eps=config.text_config.rms_norm_eps`) -- same value as the decoder's
+/// RMSNorm epsilon, verified against the real checkpoint's `config.json`.
+pub(crate) const MOSS_TD_ADAPTOR_NORM_EPSILON: f32 = 1e-6;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MossTdEncoderMetadata {
+    pub n_layers: usize,
+    pub d_model: usize,
+    pub n_heads: usize,
+    pub ffn_dim: usize,
+    pub n_mels: usize,
+    pub max_source_positions: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MossTdAdaptorMetadata {
+    pub merge_size: usize,
+    pub input_dim: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MossTdDecoderMetadata {
+    pub n_layers: usize,
+    pub d_model: usize,
+    pub ffn_dim: usize,
+    pub n_heads: usize,
+    pub n_kv_heads: usize,
+    pub head_dim: usize,
+    pub vocab_size: usize,
+    pub max_positions: usize,
+    pub audio_start_token_id: u32,
+    pub audio_end_token_id: u32,
+    pub audio_pad_token_id: u32,
+}
+
+pub(crate) fn parse_encoder_metadata<M: ScalarMetadataView>(
+    metadata: &M,
+) -> Result<MossTdEncoderMetadata, MetadataContractError> {
+    let usize_key = |key: &'static str| -> Result<usize, MetadataContractError> {
+        u64_to_usize(required_u64_scalar(metadata, key)?, key)
+    };
+    let n_layers = usize_key(ENCODER_N_LAYERS_KEY)?;
+    let d_model = usize_key(ENCODER_D_MODEL_KEY)?;
+    let n_heads = usize_key(ENCODER_N_HEADS_KEY)?;
+    let ffn_dim = usize_key(ENCODER_FFN_DIM_KEY)?;
+    let n_mels = usize_key(ENCODER_N_MELS_KEY)?;
+    let max_source_positions = usize_key(ENCODER_MAX_SOURCE_POSITIONS_KEY)?;
+    for (key, value) in [
+        (ENCODER_N_LAYERS_KEY, n_layers),
+        (ENCODER_D_MODEL_KEY, d_model),
+        (ENCODER_N_HEADS_KEY, n_heads),
+        (ENCODER_FFN_DIM_KEY, ffn_dim),
+        (ENCODER_N_MELS_KEY, n_mels),
+        (ENCODER_MAX_SOURCE_POSITIONS_KEY, max_source_positions),
+    ] {
+        validate_positive_usize(value, key)?;
+    }
+    if n_heads == 0 || !d_model.is_multiple_of(n_heads) {
+        return Err(MetadataContractError::InvalidValue {
+            key: ENCODER_N_HEADS_KEY,
+            reason: format!("d_model {d_model} is not a multiple of n_heads {n_heads}"),
+        });
+    }
+    Ok(MossTdEncoderMetadata {
+        n_layers,
+        d_model,
+        n_heads,
+        ffn_dim,
+        n_mels,
+        max_source_positions,
+    })
+}
+
+pub(crate) fn parse_adaptor_metadata<M: ScalarMetadataView>(
+    metadata: &M,
+) -> Result<MossTdAdaptorMetadata, MetadataContractError> {
+    let usize_key = |key: &'static str| -> Result<usize, MetadataContractError> {
+        u64_to_usize(required_u64_scalar(metadata, key)?, key)
+    };
+    let merge_size = usize_key(ADAPTOR_MERGE_SIZE_KEY)?;
+    let input_dim = usize_key(ADAPTOR_INPUT_DIM_KEY)?;
+    validate_positive_usize(merge_size, ADAPTOR_MERGE_SIZE_KEY)?;
+    validate_positive_usize(input_dim, ADAPTOR_INPUT_DIM_KEY)?;
+    Ok(MossTdAdaptorMetadata {
+        merge_size,
+        input_dim,
+    })
+}
+
+pub(crate) fn parse_decoder_metadata<M: ScalarMetadataView>(
+    metadata: &M,
+) -> Result<MossTdDecoderMetadata, MetadataContractError> {
+    let usize_key = |key: &'static str| -> Result<usize, MetadataContractError> {
+        u64_to_usize(required_u64_scalar(metadata, key)?, key)
+    };
+    let u32_key = |key: &'static str| -> Result<u32, MetadataContractError> {
+        u64_to_u32(required_u64_scalar(metadata, key)?, key)
+    };
+    let n_layers = usize_key(LLM_N_LAYERS_KEY)?;
+    let d_model = usize_key(LLM_D_MODEL_KEY)?;
+    let ffn_dim = usize_key(LLM_FFN_DIM_KEY)?;
+    let n_heads = usize_key(LLM_N_HEADS_KEY)?;
+    let n_kv_heads = usize_key(LLM_N_KV_HEADS_KEY)?;
+    let head_dim = usize_key(LLM_HEAD_DIM_KEY)?;
+    let vocab_size = usize_key(LLM_VOCAB_SIZE_KEY)?;
+    let max_positions = usize_key(LLM_MAX_POSITIONS_KEY)?;
+    let audio_start_token_id = u32_key(LLM_AUDIO_START_TOKEN_ID_KEY)?;
+    let audio_end_token_id = u32_key(LLM_AUDIO_END_TOKEN_ID_KEY)?;
+    let audio_pad_token_id = u32_key(LLM_AUDIO_PAD_TOKEN_ID_KEY)?;
+
+    for (key, value) in [
+        (LLM_N_LAYERS_KEY, n_layers),
+        (LLM_D_MODEL_KEY, d_model),
+        (LLM_FFN_DIM_KEY, ffn_dim),
+        (LLM_N_HEADS_KEY, n_heads),
+        (LLM_N_KV_HEADS_KEY, n_kv_heads),
+        (LLM_HEAD_DIM_KEY, head_dim),
+        (LLM_VOCAB_SIZE_KEY, vocab_size),
+        (LLM_MAX_POSITIONS_KEY, max_positions),
+    ] {
+        validate_positive_usize(value, key)?;
+    }
+    // Unlike Qwen2/firered-llm, Qwen3 decouples the per-head projection width
+    // from `d_model / n_heads`: the real checkpoint's `head_dim` (128) times
+    // `n_heads` (16) is 2048, not `d_model`'s 1024 -- `q_proj`/`k_proj`/
+    // `v_proj` project to `n_heads * head_dim` and `attn_output` projects
+    // back down to `d_model` (verified against the real checkpoint's
+    // `config.json`). So there is no `n_heads * head_dim == d_model`
+    // invariant to enforce here (matches `qwen::runtime_contract`, which
+    // never asserts one either).
+    if n_kv_heads == 0 || !n_heads.is_multiple_of(n_kv_heads) {
+        return Err(MetadataContractError::InvalidValue {
+            key: LLM_N_KV_HEADS_KEY,
+            reason: format!("n_heads {n_heads} is not a multiple of n_kv_heads {n_kv_heads}"),
+        });
+    }
+    for (key, id) in [
+        (LLM_AUDIO_START_TOKEN_ID_KEY, audio_start_token_id),
+        (LLM_AUDIO_END_TOKEN_ID_KEY, audio_end_token_id),
+        (LLM_AUDIO_PAD_TOKEN_ID_KEY, audio_pad_token_id),
+    ] {
+        if (id as usize) >= vocab_size {
+            return Err(MetadataContractError::InvalidValue {
+                key,
+                reason: format!("token id {id} out of range for vocab_size {vocab_size}"),
+            });
+        }
+    }
+
+    Ok(MossTdDecoderMetadata {
+        n_layers,
+        d_model,
+        ffn_dim,
+        n_heads,
+        n_kv_heads,
+        head_dim,
+        vocab_size,
+        max_positions,
+        audio_start_token_id,
+        audio_end_token_id,
+        audio_pad_token_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn full_metadata() -> BTreeMap<String, String> {
+        [
+            (ENCODER_N_LAYERS_KEY, "24"),
+            (ENCODER_D_MODEL_KEY, "1024"),
+            (ENCODER_N_HEADS_KEY, "16"),
+            (ENCODER_FFN_DIM_KEY, "4096"),
+            (ENCODER_N_MELS_KEY, "80"),
+            (ENCODER_MAX_SOURCE_POSITIONS_KEY, "1500"),
+            (ADAPTOR_MERGE_SIZE_KEY, "4"),
+            (ADAPTOR_INPUT_DIM_KEY, "4096"),
+            (LLM_N_LAYERS_KEY, "28"),
+            (LLM_D_MODEL_KEY, "1024"),
+            (LLM_FFN_DIM_KEY, "3072"),
+            (LLM_N_HEADS_KEY, "16"),
+            (LLM_N_KV_HEADS_KEY, "8"),
+            (LLM_HEAD_DIM_KEY, "128"),
+            (LLM_VOCAB_SIZE_KEY, "151936"),
+            (LLM_MAX_POSITIONS_KEY, "131072"),
+            (LLM_AUDIO_START_TOKEN_ID_KEY, "151669"),
+            (LLM_AUDIO_END_TOKEN_ID_KEY, "151670"),
+            (LLM_AUDIO_PAD_TOKEN_ID_KEY, "151671"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+    }
+
+    #[test]
+    fn parses_encoder_metadata_matching_real_checkpoint() {
+        let parsed = parse_encoder_metadata(&full_metadata()).expect("parse");
+        assert_eq!(parsed.n_layers, 24);
+        assert_eq!(parsed.d_model, 1024);
+        assert_eq!(parsed.max_source_positions, 1500);
+    }
+
+    #[test]
+    fn parses_adaptor_metadata_matching_real_checkpoint() {
+        let parsed = parse_adaptor_metadata(&full_metadata()).expect("parse");
+        assert_eq!(parsed.merge_size, 4);
+        assert_eq!(parsed.input_dim, 4096);
+    }
+
+    #[test]
+    fn parses_decoder_metadata_matching_real_checkpoint() {
+        let parsed = parse_decoder_metadata(&full_metadata()).expect("parse");
+        assert_eq!(parsed.n_kv_heads, 8);
+        assert_eq!(parsed.audio_pad_token_id, 151_671);
+    }
+
+    #[test]
+    fn rejects_kv_heads_not_dividing_heads() {
+        let mut metadata = full_metadata();
+        metadata.insert(LLM_N_KV_HEADS_KEY.to_string(), "3".to_string());
+        assert!(parse_decoder_metadata(&metadata).is_err());
+    }
+
+    #[test]
+    fn rejects_audio_token_id_out_of_vocab() {
+        let mut metadata = full_metadata();
+        metadata.insert(LLM_AUDIO_PAD_TOKEN_ID_KEY.to_string(), "999999".to_string());
+        assert!(parse_decoder_metadata(&metadata).is_err());
+    }
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/runtime_contract.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/runtime_contract.rs
@@ -38,6 +38,35 @@ pub(crate) const MOSS_TD_RMS_NORM_EPSILON: f32 = 1e-6;
 /// RMSNorm epsilon, verified against the real checkpoint's `config.json`.
 pub(crate) const MOSS_TD_ADAPTOR_NORM_EPSILON: f32 = 1e-6;
 
+/// KV-cache preallocation cap for this family's Qwen3 decoder.
+///
+/// The checkpoint's `text_config.max_position_embeddings` is 131072 -- the
+/// decoder's *RoPE context limit*, NOT a sane KV-cache capacity. But
+/// `Qwen3AsrLayerKvCacheState` eagerly allocates `max_positions * n_kv_heads *
+/// head_dim` f32 for K and V on first write, so feeding 131072 straight through
+/// reserves ~30 GB of address space (28 layers x 2 x 131072 x 8 x 128 x 4 B).
+/// That reservation is lazy-zeroed and harmless on the CPU backend (only the
+/// touched prefix is resident), but the Metal backend physically wires the
+/// buffers and exhausts a 16 GB machine. Cap the preallocation at a pragmatic
+/// ASR context length -- 8192 mirrors qwen3-asr's own audio-encoder value -- so
+/// real utterances (audio tokens + prompt + generated tokens) stay comfortably
+/// under it while the reservation drops to ~1.9 GB. A sequence longer than the
+/// cap fails closed at the cache's own bounds check, never by over-allocating.
+///
+/// Lesson, recorded so it does not recur: `max_position_embeddings` is an
+/// attention/positional-encoding ceiling, not a working-set size; the two must
+/// not be conflated when sizing runtime buffers.
+pub(crate) const MOSS_TD_MAX_KV_CACHE_POSITIONS: usize = 8192;
+
+/// Clamp a decoder `max_positions` value (which may be the raw RoPE context
+/// limit) to the KV-cache preallocation cap. Both the runtime decoder
+/// (`llm_decoder::new_kv_caches`) and the pack importer
+/// (`package_import`) route through this so a pack built before the cap (with
+/// 131072 baked in) and a freshly built pack allocate identically.
+pub(crate) fn moss_td_kv_cache_positions(max_positions: usize) -> usize {
+    max_positions.min(MOSS_TD_MAX_KV_CACHE_POSITIONS)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct MossTdEncoderMetadata {
     pub n_layers: usize,
@@ -264,5 +293,18 @@ mod tests {
         let mut metadata = full_metadata();
         metadata.insert(LLM_AUDIO_PAD_TOKEN_ID_KEY.to_string(), "999999".to_string());
         assert!(parse_decoder_metadata(&metadata).is_err());
+    }
+
+    #[test]
+    fn kv_cache_positions_caps_the_rope_context_limit() {
+        // A pack with the raw RoPE ceiling (131072) baked in clamps down to the
+        // pragmatic cap, so the KV cache preallocates ~1.9 GB, not ~30 GB.
+        assert_eq!(
+            moss_td_kv_cache_positions(131_072),
+            MOSS_TD_MAX_KV_CACHE_POSITIONS
+        );
+        assert_eq!(moss_td_kv_cache_positions(8_192), 8_192);
+        // A short-enough value passes through untouched.
+        assert_eq!(moss_td_kv_cache_positions(300), 300);
     }
 }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/tensor_names.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/tensor_names.rs
@@ -1,0 +1,111 @@
+//! `.oasr` tensor-name constants for the moss-transcribe-diarize family
+//! (Whisper-Medium-style encoder -> VQAdaptor bridge -> Qwen3-0.6B decoder).
+//!
+//! The encoder is architecturally a standard HF `WhisperEncoder` (see
+//! `package_import`'s module doc for the upstream tensor names this maps
+//! from), but this family does not reuse `whisper::package_import`'s tensor
+//! names directly: that importer writes verbatim HF names
+//! (`model.encoder.*`) into a GGUF that also always carries a whisper
+//! *decoder* branch, which this family has none of. Scoping this family's
+//! own `moss.enc.*` namespace (mirroring the `firered_llm` vs `firered_aed`
+//! precedent: architecturally identical encoder, independent tensor
+//! namespace because the owning pack has a different tensor-name contract)
+//! keeps this pack self-describing without depending on whisper's
+//! decoder-inclusive binding contract.
+//!
+//! The decoder branch is genuinely Qwen3-parameterized (QK-norm, no
+//! attention bias, GQA) -- the same LLM parameter family `qwen3-asr`
+//! already uses -- so this reuses `qwen3-asr`'s exact per-layer tensor slot
+//! names (`attn_q_norm`/`attn_k_norm`, no `*_bias` slots) under this
+//! family's own `moss.llm.blk.N.*` scope, so a runtime loader written
+//! against `qwen::QwenFamilyLlmLayerTensorNames`'s generic tensor-name-driven
+//! loaders can consume this pack's decoder branch without modification.
+
+use crate::models::tensor_schema::layer_tensor_names;
+
+// --- Whisper-Medium-style encoder (24 layers, d_model=1024, 16 heads) ------
+
+pub(crate) const ENC_CONV1_WEIGHT: &str = "moss.enc.conv1.weight";
+pub(crate) const ENC_CONV1_BIAS: &str = "moss.enc.conv1.bias";
+pub(crate) const ENC_CONV2_WEIGHT: &str = "moss.enc.conv2.weight";
+pub(crate) const ENC_CONV2_BIAS: &str = "moss.enc.conv2.bias";
+pub(crate) const ENC_POS_EMBD_WEIGHT: &str = "moss.enc.pos_embd.weight";
+pub(crate) const ENC_OUT_NORM_WEIGHT: &str = "moss.enc.out_norm.weight";
+pub(crate) const ENC_OUT_NORM_BIAS: &str = "moss.enc.out_norm.bias";
+
+layer_tensor_names! {
+    pub(crate) struct MossEncoderLayerTensorNames;
+    pub(crate) fn moss_encoder_layer_tensor_names @ "moss.enc.blk";
+    {
+        attn_norm_weight => "attn_norm.weight",
+        attn_norm_bias => "attn_norm.bias",
+        attn_q_weight => "attn_q.weight",
+        attn_q_bias => "attn_q.bias",
+        attn_k_weight => "attn_k.weight",
+        attn_v_weight => "attn_v.weight",
+        attn_v_bias => "attn_v.bias",
+        attn_out_weight => "attn_out.weight",
+        attn_out_bias => "attn_out.bias",
+        ffn_norm_weight => "ffn_norm.weight",
+        ffn_norm_bias => "ffn_norm.bias",
+        ffn_up_weight => "ffn_up.weight",
+        ffn_up_bias => "ffn_up.bias",
+        ffn_down_weight => "ffn_down.weight",
+        ffn_down_bias => "ffn_down.bias",
+    }
+}
+
+// --- VQAdaptor bridge (4x time-merge is a pure reshape; only these 3 -----
+// --- weighted layers exist: Linear -> SiLU -> Linear -> LayerNorm) --------
+
+pub(crate) const ADAPTOR_LINEAR1_WEIGHT: &str = "moss.adaptor.linear1.weight";
+pub(crate) const ADAPTOR_LINEAR1_BIAS: &str = "moss.adaptor.linear1.bias";
+pub(crate) const ADAPTOR_LINEAR2_WEIGHT: &str = "moss.adaptor.linear2.weight";
+pub(crate) const ADAPTOR_LINEAR2_BIAS: &str = "moss.adaptor.linear2.bias";
+pub(crate) const ADAPTOR_NORM_WEIGHT: &str = "moss.adaptor.norm.weight";
+pub(crate) const ADAPTOR_NORM_BIAS: &str = "moss.adaptor.norm.bias";
+
+// --- Qwen3-0.6B decoder (tied embeddings: no separate lm_head tensor) -----
+
+pub(crate) const LLM_TOKEN_EMBD_WEIGHT: &str = "moss.llm.tok_embd.weight";
+pub(crate) const LLM_OUTPUT_NORM_WEIGHT: &str = "moss.llm.out_norm.weight";
+
+layer_tensor_names! {
+    pub(crate) struct MossLlmLayerTensorNames;
+    pub(crate) fn moss_llm_layer_tensor_names @ "moss.llm.blk";
+    {
+        attn_norm_weight => "attn_norm.weight",
+        attn_q_weight => "attn_q.weight",
+        attn_k_weight => "attn_k.weight",
+        attn_v_weight => "attn_v.weight",
+        attn_output_weight => "attn_output.weight",
+        attn_q_norm_weight => "attn_q_norm.weight",
+        attn_k_norm_weight => "attn_k_norm.weight",
+        ffn_norm_weight => "ffn_norm.weight",
+        ffn_gate_weight => "ffn_gate.weight",
+        ffn_up_weight => "ffn_up.weight",
+        ffn_down_weight => "ffn_down.weight",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encoder_layer_tensor_names_match_runtime_convention() {
+        let names = moss_encoder_layer_tensor_names(3);
+        assert_eq!(names.attn_q_weight, "moss.enc.blk.3.attn_q.weight");
+        assert_eq!(names.ffn_down_bias, "moss.enc.blk.3.ffn_down.bias");
+    }
+
+    #[test]
+    fn llm_layer_tensor_names_match_runtime_convention() {
+        let names = moss_llm_layer_tensor_names(5);
+        assert_eq!(
+            names.attn_q_norm_weight,
+            "moss.llm.blk.5.attn_q_norm.weight"
+        );
+        assert_eq!(names.ffn_gate_weight, "moss.llm.blk.5.ffn_gate.weight");
+    }
+}

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/tokenizer.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/tokenizer.rs
@@ -1,0 +1,347 @@
+//! moss-transcribe-diarize tokenizer: the official Qwen3 byte-level BPE
+//! vocabulary (`tokenizer.ggml.{model,tokens,merges}`, baked in verbatim by
+//! `package_import`, including the `<|audio_start|>` / `<|audio_end|>` /
+//! `<|audio_pad|>` special tokens from `tokenizer.json`'s `added_tokens`),
+//! reusing the same shared `models::gpt2_bpe` engine every other BPE family
+//! in this crate uses (there is nothing MOSS-specific about byte-level BPE
+//! encode/decode).
+
+use std::collections::BTreeMap;
+
+use crate::NativeAsrError;
+use crate::ggml_runtime::GgufMetadata;
+use crate::models::decode_policy_component_registry::BuiltinSeq2SeqDecodePolicyTokenSource;
+use crate::models::gpt2_bpe::{
+    build_merge_rank, build_token_to_id, encode_prompt_text, token_to_bytes,
+};
+use crate::models::oasr_metadata::{
+    TOKENIZER_GGML_MERGES_KEY, TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_TOKENS_KEY,
+    required_metadata_string, required_metadata_string_array, required_metadata_u32,
+};
+use crate::models::phrase_bias_decode::{PhraseBiasTokenEncoder, encode_bpe_phrase_bias_variants};
+
+use super::runtime_contract::{
+    LLM_AUDIO_END_TOKEN_ID_KEY, LLM_AUDIO_PAD_TOKEN_ID_KEY, LLM_AUDIO_START_TOKEN_ID_KEY,
+    LLM_VOCAB_SIZE_KEY,
+};
+
+const MOSS_TD_TOKENIZER_FAMILY: &str = "MOSS-Transcribe-Diarize";
+const TOKENIZER_GGML_MODEL_VALUE_GPT2: &str = "gpt2";
+
+#[derive(Debug, Clone)]
+pub(crate) struct MossTdTokenizer {
+    id_to_token: Vec<Option<String>>,
+    token_to_id: BTreeMap<String, u32>,
+    merge_rank: BTreeMap<String, usize>,
+    pub audio_start_token_id: u32,
+    pub audio_end_token_id: u32,
+    pub audio_pad_token_id: u32,
+    /// `im_start`/`im_end` (Qwen ChatML turn delimiters) resolved by literal
+    /// text lookup rather than a dedicated metadata key -- both are ordinary
+    /// vocab entries already present in `tokenizer.ggml.tokens`. The decoder
+    /// never actually emits `im_start` mid-generation, but
+    /// `decode_text_token_ids` strips it defensively anyway, same precedent
+    /// as `firered_llm::tokenizer`'s `chatml_im_start_token_id`.
+    pub im_start_token_id: u32,
+    pub im_end_token_id: u32,
+    /// Single-token ids for `'0'..'9'`, used by `decode_prompt`'s time-anchor
+    /// markers (mirrors upstream `MossTranscribeDiarizeProcessor::_get_digit_token_ids`).
+    pub digit_token_ids: [u32; 10],
+}
+
+impl MossTdTokenizer {
+    pub fn from_gguf_metadata(metadata: &GgufMetadata) -> Result<Self, NativeAsrError> {
+        let tokenizer_model =
+            required_metadata_string(metadata, TOKENIZER_GGML_MODEL_KEY, MOSS_TD_TOKENIZER_FAMILY)?;
+        if !tokenizer_model.eq_ignore_ascii_case(TOKENIZER_GGML_MODEL_VALUE_GPT2) {
+            return Err(NativeAsrError::UnsupportedModelPack {
+                reason: format!(
+                    "moss-transcribe-diarize GGUF tokenizer key '{}' must be '{}', got '{}'",
+                    TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_MODEL_VALUE_GPT2, tokenizer_model
+                ),
+            });
+        }
+
+        let tokens = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_TOKENS_KEY,
+            MOSS_TD_TOKENIZER_FAMILY,
+        )?;
+        if tokens.is_empty() {
+            return Err(NativeAsrError::UnsupportedModelPack {
+                reason: format!(
+                    "moss-transcribe-diarize GGUF tokenizer key '{}' cannot be empty",
+                    TOKENIZER_GGML_TOKENS_KEY
+                ),
+            });
+        }
+        let merges = required_metadata_string_array(
+            metadata,
+            TOKENIZER_GGML_MERGES_KEY,
+            MOSS_TD_TOKENIZER_FAMILY,
+        )?;
+        if merges.is_empty() {
+            return Err(NativeAsrError::UnsupportedModelPack {
+                reason: format!(
+                    "moss-transcribe-diarize GGUF tokenizer key '{}' cannot be empty",
+                    TOKENIZER_GGML_MERGES_KEY
+                ),
+            });
+        }
+
+        let vocab_size =
+            required_metadata_u32(metadata, LLM_VOCAB_SIZE_KEY, MOSS_TD_TOKENIZER_FAMILY)?;
+        let token_count =
+            u32::try_from(tokens.len()).map_err(|_| NativeAsrError::UnsupportedModelPack {
+                reason: format!(
+                    "moss-transcribe-diarize GGUF tokenizer token count {} exceeds u32",
+                    tokens.len()
+                ),
+            })?;
+        if token_count != vocab_size {
+            return Err(NativeAsrError::UnsupportedModelPack {
+                reason: format!(
+                    "moss-transcribe-diarize GGUF tokenizer token count {} does not match '{}'={}",
+                    token_count, LLM_VOCAB_SIZE_KEY, vocab_size
+                ),
+            });
+        }
+
+        let audio_start_token_id = required_metadata_u32(
+            metadata,
+            LLM_AUDIO_START_TOKEN_ID_KEY,
+            MOSS_TD_TOKENIZER_FAMILY,
+        )?;
+        let audio_end_token_id = required_metadata_u32(
+            metadata,
+            LLM_AUDIO_END_TOKEN_ID_KEY,
+            MOSS_TD_TOKENIZER_FAMILY,
+        )?;
+        let audio_pad_token_id = required_metadata_u32(
+            metadata,
+            LLM_AUDIO_PAD_TOKEN_ID_KEY,
+            MOSS_TD_TOKENIZER_FAMILY,
+        )?;
+
+        let id_to_token = tokens
+            .iter()
+            .map(|token| Some(token.clone()))
+            .collect::<Vec<_>>();
+        let token_to_id = build_token_to_id(tokens, MOSS_TD_TOKENIZER_FAMILY)?;
+        let merge_rank = build_merge_rank(merges);
+
+        let im_start_token_id = *token_to_id.get("<|im_start|>").ok_or_else(|| {
+            NativeAsrError::UnsupportedModelPack {
+                reason: "moss-transcribe-diarize tokenizer vocab has no '<|im_start|>' entry"
+                    .to_string(),
+            }
+        })?;
+        let im_end_token_id =
+            *token_to_id
+                .get("<|im_end|>")
+                .ok_or_else(|| NativeAsrError::UnsupportedModelPack {
+                    reason: "moss-transcribe-diarize tokenizer vocab has no '<|im_end|>' entry"
+                        .to_string(),
+                })?;
+
+        let mut digit_token_ids = [0u32; 10];
+        for (digit, slot) in "0123456789".chars().zip(digit_token_ids.iter_mut()) {
+            *slot = *token_to_id.get(digit.encode_utf8(&mut [0; 4]) as &str).ok_or_else(|| {
+                NativeAsrError::UnsupportedModelPack {
+                    reason: format!(
+                        "moss-transcribe-diarize tokenizer vocab is missing a single-token entry for digit '{digit}'"
+                    ),
+                }
+            })?;
+        }
+
+        for token_id in [
+            audio_start_token_id,
+            audio_end_token_id,
+            audio_pad_token_id,
+            im_start_token_id,
+            im_end_token_id,
+        ] {
+            validate_token_id_in_range(&id_to_token, token_id)?;
+        }
+
+        Ok(Self {
+            id_to_token,
+            token_to_id,
+            merge_rank,
+            audio_start_token_id,
+            audio_end_token_id,
+            audio_pad_token_id,
+            im_start_token_id,
+            im_end_token_id,
+            digit_token_ids,
+        })
+    }
+
+    pub fn decode_text_token_ids(&self, token_ids: &[u32]) -> Result<String, NativeAsrError> {
+        let mut bytes = Vec::new();
+        for token_id in token_ids {
+            if *token_id == self.audio_start_token_id
+                || *token_id == self.audio_end_token_id
+                || *token_id == self.audio_pad_token_id
+                || *token_id == self.im_start_token_id
+                || *token_id == self.im_end_token_id
+            {
+                continue;
+            }
+            let index = usize::try_from(*token_id).map_err(|_| NativeAsrError::SessionFailed {
+                message: format!(
+                    "moss-transcribe-diarize tokenizer id {token_id} does not fit into usize"
+                ),
+            })?;
+            let Some(Some(token)) = self.id_to_token.get(index) else {
+                return Err(NativeAsrError::SessionFailed {
+                    message: format!(
+                        "moss-transcribe-diarize tokenizer id {token_id} is not in vocab"
+                    ),
+                });
+            };
+            bytes.extend(token_to_bytes(token));
+        }
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    pub fn encode_prompt_text(&self, text: &str) -> Result<Vec<u32>, NativeAsrError> {
+        encode_prompt_text(
+            text,
+            &self.token_to_id,
+            &self.merge_rank,
+            MOSS_TD_TOKENIZER_FAMILY,
+        )
+    }
+}
+
+impl BuiltinSeq2SeqDecodePolicyTokenSource for MossTdTokenizer {}
+
+impl PhraseBiasTokenEncoder for MossTdTokenizer {
+    fn encode_phrase_bias_tokens(&self, phrase: &str) -> Result<Option<Vec<u32>>, String> {
+        self.encode_prompt_text(phrase)
+            .map(Some)
+            .map_err(|error| error.to_string())
+    }
+
+    fn encode_phrase_bias_variants(&self, phrase: &str) -> Result<Option<Vec<Vec<u32>>>, String> {
+        encode_bpe_phrase_bias_variants(phrase, |text| self.encode_prompt_text(text)).map(Some)
+    }
+}
+
+fn validate_token_id_in_range(
+    id_to_token: &[Option<String>],
+    token_id: u32,
+) -> Result<(), NativeAsrError> {
+    let index = usize::try_from(token_id).map_err(|_| NativeAsrError::UnsupportedModelPack {
+        reason: format!(
+            "moss-transcribe-diarize tokenizer token id {token_id} does not fit into usize"
+        ),
+    })?;
+    if index < id_to_token.len() {
+        return Ok(());
+    }
+    Err(NativeAsrError::UnsupportedModelPack {
+        reason: format!(
+            "moss-transcribe-diarize tokenizer token id {token_id} is out of range for vocab size {}",
+            id_to_token.len()
+        ),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::{GgufMetadata, GgufMetadataValue};
+
+    use super::*;
+
+    fn base_metadata() -> GgufMetadata {
+        let mut values = BTreeMap::new();
+        values.insert(
+            TOKENIZER_GGML_MODEL_KEY.to_string(),
+            GgufMetadataValue::String(TOKENIZER_GGML_MODEL_VALUE_GPT2.to_string()),
+        );
+        let mut tokens: Vec<String> = "0123456789".chars().map(|c| c.to_string()).collect();
+        tokens.extend([
+            "<|im_start|>".to_string(),
+            "user".to_string(),
+            "assistant".to_string(),
+            "\u{0120}hi".to_string(),
+            "\u{010A}".to_string(),
+            "<|audio_start|>".to_string(),
+            "<|audio_end|>".to_string(),
+            "<|audio_pad|>".to_string(),
+            "<|im_end|>".to_string(),
+            "<|endoftext|>".to_string(),
+        ]);
+        let vocab_size = tokens.len() as u32;
+        values.insert(
+            TOKENIZER_GGML_TOKENS_KEY.to_string(),
+            GgufMetadataValue::StringArray(tokens),
+        );
+        values.insert(
+            TOKENIZER_GGML_MERGES_KEY.to_string(),
+            // A real pack's merge list is never empty (byte-level BPE always
+            // has real merges); this fixture only needs one placeholder entry
+            // to satisfy `MossTdTokenizer::from_gguf_metadata`'s non-empty
+            // check, not the actual pairing behavior these tests exercise.
+            GgufMetadataValue::StringArray(vec!["\u{0120} \u{010A}".to_string()]),
+        );
+        values.insert(
+            LLM_VOCAB_SIZE_KEY.to_string(),
+            GgufMetadataValue::U32(vocab_size),
+        );
+        // Indices into the 20-entry `tokens` vec above: 0-9=digits,
+        // 10=<|im_start|>, 11=user, 12=assistant, 13=hi, 14=\n,
+        // 15=<|audio_start|>, 16=<|audio_end|>, 17=<|audio_pad|>,
+        // 18=<|im_end|>, 19=<|endoftext|>.
+        values.insert(
+            LLM_AUDIO_START_TOKEN_ID_KEY.to_string(),
+            GgufMetadataValue::U32(15),
+        );
+        values.insert(
+            LLM_AUDIO_END_TOKEN_ID_KEY.to_string(),
+            GgufMetadataValue::U32(16),
+        );
+        values.insert(
+            LLM_AUDIO_PAD_TOKEN_ID_KEY.to_string(),
+            GgufMetadataValue::U32(17),
+        );
+        GgufMetadata::from_values_for_test(values)
+    }
+
+    #[test]
+    fn tokenizer_resolves_digit_ids_and_audio_ids() {
+        let metadata = base_metadata();
+        let tokenizer = MossTdTokenizer::from_gguf_metadata(&metadata).expect("load tokenizer");
+        assert_eq!(tokenizer.digit_token_ids, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(tokenizer.audio_start_token_id, 15);
+        assert_eq!(tokenizer.audio_pad_token_id, 17);
+        assert_eq!(tokenizer.im_end_token_id, 18);
+    }
+
+    #[test]
+    fn tokenizer_decodes_skipping_control_tokens() {
+        let metadata = base_metadata();
+        let tokenizer = MossTdTokenizer::from_gguf_metadata(&metadata).expect("load tokenizer");
+        // 10=<|im_start|>, 13=hi, 15=<|audio_start|>, 18=<|im_end|>
+        let text = tokenizer
+            .decode_text_token_ids(&[10, 13, 15, 18])
+            .expect("decode");
+        assert_eq!(text, " hi");
+    }
+
+    #[test]
+    fn tokenizer_rejects_vocab_size_mismatch() {
+        let mut values = base_metadata().values().clone();
+        values.insert(LLM_VOCAB_SIZE_KEY.to_string(), GgufMetadataValue::U32(3));
+        let metadata = GgufMetadata::from_values_for_test(values);
+        let error = MossTdTokenizer::from_gguf_metadata(&metadata)
+            .expect_err("mismatch should fail")
+            .to_string();
+        assert!(error.contains("token count"), "{error}");
+    }
+}

--- a/crates/openasr-core/src/models/runtime_tensor_contract_registry.rs
+++ b/crates/openasr-core/src/models/runtime_tensor_contract_registry.rs
@@ -73,6 +73,7 @@ pub(crate) enum DedicatedRuntimeTensorContractFamily {
     FireRedAed,
     FireRedLlm,
     MimoAsr,
+    MossTd,
 }
 
 impl DedicatedRuntimeTensorContractFamily {
@@ -87,6 +88,7 @@ impl DedicatedRuntimeTensorContractFamily {
             Self::FireRedAed => "firered-aed",
             Self::FireRedLlm => "firered-llm",
             Self::MimoAsr => "mimo-asr",
+            Self::MossTd => "moss-transcribe-diarize",
         }
     }
 }
@@ -256,6 +258,9 @@ fn dedicated_runtime_tensor_contract_family(
         }
         crate::arch::MIMO_ASR_RUNTIME_TENSOR_CONTRACT_ID => {
             Some(DedicatedRuntimeTensorContractFamily::MimoAsr)
+        }
+        crate::arch::MOSS_TD_RUNTIME_TENSOR_CONTRACT_ID => {
+            Some(DedicatedRuntimeTensorContractFamily::MossTd)
         }
         _ => None,
     }


### PR DESCRIPTION
## Summary

Integrate OpenMOSS MOSS-Transcribe-Diarize (0.9B, Apache-2.0): joint transcription + anonymous speaker labels + timestamps as a new model family, end to end (importer -> .oasr -> native execution through the shared decode driver).

## Why

First speaker-attributed model in the catalog pipeline: one checkpoint, one forward pass, structured `[time][Sxx]text` output. Architecture reuses the whisper-class encoder and the qwen3 LLM decoder paradigm already in-tree.

## Changes

- Importer: safetensors -> GGUF-backed .oasr (683 tensors, Whisper-Medium encoder / VQAdaptor bridge / Qwen3-0.6B decoder), tokenizer carried in-pack.
- Family runtime: encoder graph with resident f16 weights + flash attention (single 30s chunk peak 9.19GB -> 3.43GB), adaptor graph, prompt assembly replicating the official processor (audio-pad expansion, 5s digit time anchors, ChatML), decode via the shared `run_step_auto`/`run_prefill_auto_last_hidden` path. KV preallocation capped to a pragmatic context (131072 -> 8192; ~30GB virtual reservation removed).
- Long audio: whole-clip single decode per the official semantics (new `SelfChunkingExecutorV1` longform profile keeps the generic VAD slicer off this family); fail-closed `AudioExceedsContext` beyond ~10 minutes. 3-minute meeting sample: timestamps continuous to 179.99s, byte-identical to the HF reference.
- Shared fix: gpt2_bpe pretokenizer now enforces real GPT-2/Qwen category boundaries (letter/digit/punct runs). Existing qwen3/firered/mimo goldens verified unchanged; new unit tests pin the behavior.
- Metal: short-sample output is byte-correct after the resident-f16 rework; long-audio Metal remains gated by `ExceptMetal` pending the shared GPU prefill flash-attention work (tracked separately). Catalog publication is NOT part of this PR (release audit form + peer bench + Metal unlock are the release gates).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2727 passed)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (no dependency changes)

## Manual smoke checks

- CPU end-to-end goldens (dev-gated, real fp16 pack): jfk and en-zh-mixed byte-identical to the HF fp32 reference including timestamps and speaker labels; 3-min AISHELL-4 sample text-identical with continuous timestamps.
- Peak-memory curves recorded (0.2s sampling): 3.4-5.9GB across samples on a 16GB M1.

## Docs updated

- [x] Family/module docs inline; catalog entry intentionally not public in this PR.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

No catalog publication, no quant tiers yet (q8_0/q4_k follow with the release-audit work), Metal long-audio unlock tracked separately.

## AI usage disclosure

YES