### PR TITLE
fix(firered-aed): enforce the PE capacity limit and name the real backend in OOM errors

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -643,8 +643,16 @@ pub enum GgmlCpuGraphError {
     TensorAllocationFailed { tensor: &'static str },
     #[error("ggml cpu graph construction failed at '{step}'")]
     GraphBuildFailed { step: &'static str },
-    #[error("ggml cpu graph backend buffer allocation failed")]
-    BackendBufferAllocationFailed,
+    /// Backend-agnostic wording deliberately avoids "cpu graph backend" (an
+    /// internal ggml scheduler-plumbing term, not a statement about which
+    /// physical device ran out of memory): `backend` names the actual device
+    /// (e.g. "Vulkan0", "Metal", "CPU") the allocation targeted, so a
+    /// downstream translation layer or user-facing error can say plainly
+    /// which backend was out of memory instead of surfacing ggml jargon
+    /// (issue #158's report showed a Vulkan OOM misread as a generic "cpu
+    /// graph backend" failure).
+    #[error("compute buffer allocation failed (backend: {backend})")]
+    BackendBufferAllocationFailed { backend: String },
     #[error(
         "ggml cpu graph backend has no device (backend outlived the thread-local \
          backend that owns it); refusing to allocate against a dangling backend"
@@ -4976,9 +4984,11 @@ impl GgmlBackendBufferGuard {
         ensure_backend_device_present(backend)?;
         let raw =
             unsafe { ffi::ggml_backend_alloc_ctx_tensors(context.as_ptr(), backend.as_ptr()) };
-        NonNull::new(raw)
-            .map(|raw| Self { raw })
-            .ok_or(GgmlCpuGraphError::BackendBufferAllocationFailed)
+        NonNull::new(raw).map(|raw| Self { raw }).ok_or_else(|| {
+            GgmlCpuGraphError::BackendBufferAllocationFailed {
+                backend: backend_name(backend),
+            }
+        })
     }
 
     fn allocate_with_usage(
@@ -4990,7 +5000,9 @@ impl GgmlBackendBufferGuard {
         let raw =
             unsafe { ffi::ggml_backend_alloc_ctx_tensors(context.as_ptr(), backend.as_ptr()) };
         let Some(raw) = NonNull::new(raw) else {
-            return Err(GgmlCpuGraphError::BackendBufferAllocationFailed);
+            return Err(GgmlCpuGraphError::BackendBufferAllocationFailed {
+                backend: backend_name(backend),
+            });
         };
         unsafe { ffi::ggml_backend_buffer_set_usage(raw.as_ptr(), usage) };
         Ok(Self { raw })

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -139,6 +139,25 @@ impl FireRedEncoderGraphRuntime {
     }
 }
 
+/// Post-subsampling encoder time-frame count the 2x Conv2d(k3,s2) stem
+/// produces for `n_frames` raw (pre-context-pad) fbank frames -- the same
+/// time-axis arithmetic `encode_firered_aed_audio_embeddings` runs, factored
+/// out so a caller can predict the frame count a window will encode to
+/// *before* building the graph (see `FireRedAedGgmlExecutor`'s PE-capacity
+/// preflight check, which must reject an oversized window with a typed error
+/// rather than let it reach `ggml_prepare_outputs` and fail on an opaque
+/// allocation error).
+pub(crate) fn predicted_encoder_time_frames(n_frames: usize) -> Result<usize, FireRedEncoderError> {
+    if n_frames == 0 {
+        return Err(FireRedEncoderError::EmptyInput);
+    }
+    let padded_frames = n_frames
+        .checked_add(SUBSAMPLE_CONTEXT_PAD_FRAMES)
+        .ok_or(FireRedEncoderError::ShapeOverflow)?;
+    let conv1_time = conv_out_dim(padded_frames, 3, 2)?;
+    conv_out_dim(conv1_time, 3, 2)
+}
+
 /// Run the full encoder forward pass in a single ggml graph (no incremental
 /// reuse -- matches cohere's/parakeet's single-shot encoder shape) against an
 /// already-loaded runner/weights pair.
@@ -167,13 +186,11 @@ fn encode_firered_aed_audio_embeddings(
     padded[..cmvn_features.len()].copy_from_slice(cmvn_features);
 
     let conv1_freq = conv_out_dim(feature_dim, 3, 2)?;
-    let conv1_time = conv_out_dim(padded_frames, 3, 2)?;
     let conv2_freq = conv_out_dim(conv1_freq, 3, 2)?;
-    let conv2_time = conv_out_dim(conv1_time, 3, 2)?;
     if conv2_freq * metadata.subsample_channels != metadata.subsample_out_dim {
         return Err(FireRedEncoderError::ShapeOverflow);
     }
-    let frame_count = conv2_time;
+    let frame_count = predicted_encoder_time_frames(n_frames)?;
     // Valid (unpadded) frame count: computed from the ORIGINAL (pre-context-pad)
     // frame count via the same subsampling arithmetic the upstream uses for
     // `input_lengths` (`(L-3)//2+1` twice) -- NOT from `padded_frames`. Frames
@@ -776,6 +793,52 @@ fn firered_conformer_block<'a>(
         },
         map_err,
     )
+}
+
+#[cfg(test)]
+mod frame_count_tests {
+    use super::predicted_encoder_time_frames;
+
+    #[test]
+    fn zero_frames_is_empty_input_error() {
+        assert!(matches!(
+            predicted_encoder_time_frames(0),
+            Err(super::FireRedEncoderError::EmptyInput)
+        ));
+    }
+
+    #[test]
+    fn matches_the_inline_arithmetic_encode_used_before_extraction() {
+        // Same conv_out_dim(conv_out_dim(n+6,3,2),3,2) the encoder forward
+        // itself runs; regression-pins the extraction in
+        // `predicted_encoder_time_frames` against silent drift.
+        for n_frames in [1usize, 10, 273, 1000, 20_000] {
+            let padded = n_frames + 6;
+            let conv1 = (padded - 3) / 2 + 1;
+            let expected = (conv1 - 3) / 2 + 1;
+            assert_eq!(
+                predicted_encoder_time_frames(n_frames).unwrap(),
+                expected,
+                "mismatch for n_frames={n_frames}"
+            );
+        }
+    }
+
+    /// A 210s window (16 kHz mono, 10ms fbank hop) predicts an encoder frame
+    /// count comfortably past the `pe_len=9999` -> 5000-frame capacity
+    /// (~200s) declared in `runtime_contract`'s parsed-metadata test --
+    /// this is the exact shape `FireRedAedGgmlExecutor::execute_inner`'s
+    /// PE-capacity preflight check (issue #158) must catch before ever
+    /// building the encoder graph.
+    #[test]
+    fn oversized_window_predicts_past_pe_capacity() {
+        let raw_fbank_frames = 210 * 100; // 10ms hop => 100 frames/sec
+        let predicted = predicted_encoder_time_frames(raw_fbank_frames).unwrap();
+        assert!(
+            predicted > 5000,
+            "expected a 210s window to predict past the 5000-frame PE capacity, got {predicted}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/firered_aed/executor.rs
+++ b/crates/openasr-core/src/models/firered_aed/executor.rs
@@ -1,9 +1,21 @@
 //! firered-aed dedicated executor (Stage 4): fbank+CMVN [`frontend`] -> the
 //! parity-verified Conformer [`encoder_graph`] -> greedy attention
 //! [`decoder_graph`] -> char+SPM [`tokenizer`] detokenize. No CTC branch, no
-//! phrase bias (pure autoregressive attention decode), single-segment plain
-//! transcription. The executor fails closed with typed errors on a bad pack
-//! and never fabricates a transcript.
+//! phrase bias (pure autoregressive attention decode). The executor fails
+//! closed with typed errors on a bad pack and never fabricates a transcript.
+//!
+//! Each call here encodes/decodes exactly one audio window ("single-segment"
+//! in that sense -- there is no internal multi-slice batching, unlike
+//! cohere's `batched_decode`). Long-file transcription is NOT single-shot,
+//! though: the architecture-agnostic longform slicer in
+//! `api::backend::native_transcribe` calls this executor once per slice for
+//! every builtin family, firered-aed included, with each window pre-capped to
+//! this architecture's `GlobalQuadratic` safety ceiling (issue #68) -- well
+//! under the encoder's PE-table capacity. `execute_inner` still checks that
+//! capacity itself and fails closed with a typed error if a window ever
+//! arrives oversized (issue #158's defense-in-depth: a caller that bypasses
+//! longform, or a future regression in the slicing wiring, must not reach an
+//! opaque graph-allocation failure or a silently degraded transcript).
 //!
 //! [`frontend`]: super::frontend
 //! [`encoder_graph`]: super::encoder_graph
@@ -37,7 +49,9 @@ use crate::models::thread_local_runtime_cache::{
 use super::decoder_graph::{
     FireRedDecoderGraphRuntime, run_firered_aed_decoder_greedy_with_runtime,
 };
-use super::encoder_graph::{FireRedEncoderGraphRuntime, FireRedEncoderOutput};
+use super::encoder_graph::{
+    FireRedEncoderGraphRuntime, FireRedEncoderOutput, predicted_encoder_time_frames,
+};
 use super::frontend::{FireRedFbankFrontend, apply_cmvn};
 use super::graph_config::{firered_decoder_graph_config, firered_encoder_graph_config};
 use super::runtime_contract::{FireRedAedExecutionMetadata, parse_firered_aed_execution_metadata};
@@ -135,6 +149,12 @@ enum FireRedAedExecutorError {
     EncoderFailed { reason: String },
     #[error("firered-aed decoder failed: {reason}")]
     DecoderFailed { reason: String },
+    #[error("firered-aed audio window ({window_seconds:.1}s) is too long for this pack: {reason}")]
+    AudioWindowTooLong { window_seconds: f32, reason: String },
+}
+
+fn window_seconds(n_samples: usize, sample_rate_hz: u32) -> f32 {
+    n_samples as f32 / sample_rate_hz.max(1) as f32
 }
 
 #[derive(Debug, Default, Clone)]
@@ -201,6 +221,45 @@ impl FireRedAedGgmlExecutor {
                 reason: error.to_string(),
             },
         )?;
+
+        // Defense in depth (issue #158): the generic longform slicer in
+        // `native_transcribe` already caps every window at this architecture's
+        // declared `GlobalQuadratic` safety ceiling (issue #68), which is well
+        // inside the encoder's baked rel-pos-table capacity below -- so this
+        // should never trip in the normal request path. But this executor is
+        // also reachable directly (a caller that skips longform, a future
+        // regression in the slicing wiring, an oversized fixed/manual chunk
+        // request), and a window past the PE table's capacity is a quality/
+        // correctness problem even when it happens to fit in memory: reject it
+        // with a typed, actionable error up front rather than let a caller
+        // silently degrade or hit an opaque graph-allocation failure deep in
+        // `encoder_graph`.
+        let predicted_encoder_frames =
+            predicted_encoder_time_frames(features.n_frames).map_err(|error| {
+                FireRedAedExecutorError::AudioWindowTooLong {
+                    window_seconds: window_seconds(
+                        samples.len(),
+                        request.prepared_audio.sample_rate_hz,
+                    ),
+                    reason: error.to_string(),
+                }
+            })?;
+        let max_encoder_frames = metadata.encoder_max_frames();
+        if predicted_encoder_frames > max_encoder_frames {
+            return Err(FireRedAedExecutorError::AudioWindowTooLong {
+                window_seconds: window_seconds(
+                    samples.len(),
+                    request.prepared_audio.sample_rate_hz,
+                ),
+                reason: format!(
+                    "encoder frame count {predicted_encoder_frames} exceeds this pack's \
+                     positional-encoding capacity of {max_encoder_frames} frames \
+                     (~{:.0}s at 25 fps); this window should already be capped by \
+                     longform slicing before reaching the executor",
+                    max_encoder_frames as f32 / 25.0
+                ),
+            });
+        }
 
         let runtime_path = preflight.runtime_source.path();
         let encoder_output =
@@ -419,6 +478,47 @@ mod tests {
         assert!(
             second_elapsed < first_elapsed,
             "expected cached (second) transcribe to be faster: first={first_elapsed:?} second={second_elapsed:?}"
+        );
+    }
+
+    /// Issue #158 defense-in-depth: a single window past the pack's
+    /// PE-table capacity (~200s for this dev pack's `pe_len=9999`) must fail
+    /// closed with a typed `AudioWindowTooLong` error instead of reaching
+    /// `encoder_graph`'s allocation and either OOM-ing or (on a machine with
+    /// enough memory to actually build the graph) silently degrading past
+    /// the model's trained/positional-encoding range. This should never
+    /// happen on the real request path (the outer longform slicer already
+    /// caps every window to the architecture's 30s safety ceiling), so this
+    /// constructs an oversized window directly against the executor,
+    /// bypassing the slicer, to prove the guard is load-bearing on its own.
+    #[test]
+    #[ignore = "requires the private dev-only firered-aed-l-fp16.oasr pack; see module docs"]
+    fn oversized_window_fails_closed_with_typed_error_instead_of_reaching_the_encoder_graph() {
+        let pack_path = dev_pack_path();
+        if !pack_path.exists() {
+            eprintln!("skipping: {} not present", pack_path.display());
+            return;
+        }
+        // 210s of silence at 16 kHz: cheap to construct, and content does not
+        // matter -- the guard trips on shape (predicted encoder frame count)
+        // before any real encoding is attempted.
+        let samples = vec![0.0_f32; 210 * 16_000];
+        let request = GgmlAsrExecutionRequest {
+            runtime_source_path: pack_path,
+            runtime_source_preflight: None,
+            selected_family: firered_aed_runtime_descriptor_v1(),
+            prepared_audio: GgmlAsrPreparedAudio::mono_16khz(samples),
+            request_options: Default::default(),
+            backend_preference: GgmlAsrBackendPreference::CpuOnly,
+        };
+        let executor = FireRedAedGgmlExecutor;
+        let error = executor
+            .execute(&request)
+            .expect_err("a 210s window must fail closed, not transcribe");
+        let message = error.to_string();
+        assert!(
+            message.contains("too long") || message.contains("positional-encoding capacity"),
+            "expected a PE-capacity typed error, got: {message}"
         );
     }
 }

--- a/crates/openasr-core/src/models/firered_aed/graph_config.rs
+++ b/crates/openasr-core/src/models/firered_aed/graph_config.rs
@@ -8,10 +8,22 @@
 //! mirrors the cohere/moonshine template -- dynamic backend resolution via
 //! [`configure_model_runtime_graph_config_from_env`] (Metal auto-selected
 //! through `GgmlCpuGraphConfig::resolve_runtime_backend()`), with an explicit
-//! per-stage opt-out that falls back to CPU. Unlike cohere, firered-aed never
-//! does multi-chunk longform batching (the executor is single-segment plain
-//! transcription -- see `executor.rs` module docs), so there is no
-//! `prefer_cpu_backend` request-level override to thread through here.
+//! per-stage opt-out that falls back to CPU.
+//!
+//! Note this is narrower than it may read: firered-aed's own executor never
+//! batches *multiple* longform slices into one graph call the way cohere's
+//! `batched_decode` can (each call here still encodes/decodes exactly one
+//! window -- see `executor.rs` module docs), so there is no
+//! `prefer_cpu_backend` request-level override to thread through here. That
+//! is NOT the same claim as "firered-aed has no longform support" (issue
+//! #158's actual bug, and easy to misread this comment as): the *outer*
+//! per-file longform slicer in `native_transcribe` is architecture-agnostic
+//! and already calls this executor once per slice for every builtin family,
+//! firered-aed included, with its window length capped to this
+//! architecture's declared `GlobalQuadratic` safety ceiling (issue #68's
+//! `encoder_attention_span`) and, defensively, to the encoder's baked
+//! rel-pos-table capacity (`FireRedAedExecutionMetadata::encoder_max_frames`,
+//! enforced in `executor.rs`).
 
 use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphThreadingWorkload};
 use crate::models::graph_runtime_config::{


### PR DESCRIPTION
## Summary

Two hardening fixes from the issue #158 investigation, plus doc corrections.

## Why

Investigating #158 showed (a) the family's PE capacity (~200s) was parsed but never enforced, and (b) allocation failures always said 'ggml cpu graph backend buffer allocation failed' even when the failing backend was Vulkan/Metal - which misdirected the diagnosis. Note: generic longform slicing already covers firered-aed (since #68); the module docs claiming otherwise were stale and are corrected here. The remaining #158 root cause (per-slice VRAM pressure on 8GB GPUs) is tracked separately.

## Changes

- firered_aed executor: predict post-subsampling frame count before graph build; fail closed with a typed AudioWindowTooLong when a window exceeds encoder_max_frames (defense-in-depth; normal path stays under it via slicing).
- ggml_runtime: BackendBufferAllocationFailed now names the actual backend device (Vulkan0/Metal/CPU).
- Stale module docs corrected (graph_config.rs / executor.rs).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2689 passed)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (no dependency changes)

## Manual smoke checks

- Real-pack 16-minute continuous-speech run on CPU: 35 slices, coherent transcript, peak RSS ~5.6GB; 150s Metal smoke clean.
- Existing goldens byte-identical; a pre-existing unrelated parity test failure reproduces identically on clean main.
- Real-pack gated test: a 210s window fails closed with the typed error.

## Scope / non-goals

Per-slice VRAM-pressure handling (retry a failed slice on CPU) is follow-up work, not in this PR.

## AI usage disclosure

YES