### PR TITLE
docs(release): call out the CLI nature of core releases and point to the desktop app

### DIFF
--- a/scripts/render-install-verify.sh
+++ b/scripts/render-install-verify.sh
@@ -53,6 +53,12 @@ label_for_target() {
 }
 
 echo "<!-- install-verify:start -->"
+echo "> [!NOTE]"
+echo "> **This release is the OpenASR engine and command-line tool.** Looking for"
+echo "> the desktop app (dictation, live captions, GUI)? Download it from"
+echo "> [openasr.org/download](https://openasr.org/download) or the"
+echo "> [\`desktop-vX.Y.Z\` releases](https://github.com/${repo}/releases?q=desktop&expanded=true)."
+echo
 echo "## Install & Verify"
 echo
 echo "Download the archive for your platform from the assets below, extract it,"


### PR DESCRIPTION
## Summary

Core vX.Y.Z releases now open with a prominent note that this is the engine/CLI release, linking desktop users to openasr.org/download and the desktop-vX.Y.Z releases.

## Why

Desktop users landing on core releases see a wall of CLI archives and no pointer to the app they actually want.

## Changes

- scripts/render-install-verify.sh: GitHub NOTE admonition rendered at the top of the install-verify block (inside the splice markers, so re-splicing replaces it atomically).

## Tests run

- [x] Manual render smoke (output verified, markers intact)
- [x] splice compatibility confirmed (block lives inside start/end markers)
- [ ] cargo suites N/A (shell script only)

## Manual smoke checks

Rendered sample verified locally.

## Docs updated

- [x] This is the doc change.

## Scope / non-goals

No workflow YAML changes; takes effect from the next core release.

## AI usage disclosure

YES