### PR TITLE
fix(core): prefer the discrete GPU on hybrid-graphics hosts

### DIFF
--- a/crates/openasr-core/src/device/compute_devices.rs
+++ b/crates/openasr-core/src/device/compute_devices.rs
@@ -13,7 +13,7 @@
 
 use serde::Serialize;
 
-use crate::ggml_runtime::{GgmlBackendKind, GgmlRuntimeInfo};
+use crate::ggml_runtime::{GgmlBackendKind, GgmlRuntimeInfo, preferred_accelerated_device};
 
 const BYTES_PER_GIB: f64 = 1024.0 * 1024.0 * 1024.0;
 
@@ -50,11 +50,11 @@ pub struct ComputeDevice {
 /// `Auto` + `CPU`.
 pub fn compute_devices_from_runtime(runtime: &GgmlRuntimeInfo) -> Vec<ComputeDevice> {
     let cpu_name = cpu_device_name(runtime);
-    let accelerated = runtime
-        .devices
-        .iter()
-        .find(|device| device.kind.is_gpu())
-        .map(|device| {
+    // On a hybrid-graphics host (Optimus-style: an integrated + a discrete
+    // GPU both surfaced by the same Vulkan backend), prefer the discrete GPU
+    // -- see `preferred_accelerated_device`'s doc comment for the ranking.
+    let accelerated =
+        preferred_accelerated_device(&runtime.devices, GgmlBackendKind::is_gpu).map(|device| {
             let name = non_empty_device_label(&device.description, &device.name, "Accelerated");
             ComputeDevice {
                 id: "accelerated".to_string(),
@@ -225,6 +225,43 @@ mod tests {
         // Auto mirrors the accelerated device's label so the picker's default
         // reads as the GPU, not a bare "CPU".
         assert_eq!(devices[0].name, "NVIDIA GeForce RTX 4070");
+    }
+
+    #[test]
+    fn hybrid_graphics_runtime_surfaces_discrete_gpu_not_integrated() {
+        // Optimus-style laptop: Intel UHD (integrated) enumerates before the
+        // NVIDIA discrete GPU. The picker's "accelerated" entry (and Auto,
+        // which mirrors it) must still be the discrete GPU, not whichever
+        // device the registry happened to list first.
+        let runtime = runtime_with(
+            vec![
+                GgmlBackendDevice::for_test("CPU", "Intel Core i7", GgmlBackendKind::Cpu, None),
+                GgmlBackendDevice::for_test(
+                    "Vulkan0",
+                    "Intel(R) UHD Graphics 630",
+                    GgmlBackendKind::IntegratedGpu,
+                    None,
+                ),
+                GgmlBackendDevice::for_test(
+                    "Vulkan1",
+                    "NVIDIA GeForce RTX 4070",
+                    GgmlBackendKind::Gpu,
+                    Some(GgmlDeviceMemory {
+                        free_bytes: 8 * 1024 * 1024 * 1024,
+                        total_bytes: 12 * 1024 * 1024 * 1024,
+                    }),
+                ),
+            ],
+            "Intel Core i7",
+        );
+        let devices = compute_devices_from_runtime(&runtime);
+        let accelerated = devices.iter().find(|d| d.id == "accelerated").unwrap();
+        assert_eq!(accelerated.name, "NVIDIA GeForce RTX 4070");
+        assert_eq!(accelerated.meta, "GPU backend");
+        assert_eq!(
+            devices[0].name, "NVIDIA GeForce RTX 4070",
+            "Auto mirrors it"
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/ggml_runtime/backend.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend.rs
@@ -221,6 +221,47 @@ impl GgmlBackendKind {
     }
 }
 
+/// Priority for picking among several simultaneously-available accelerated
+/// devices (the Optimus/hybrid-graphics case: a Vulkan-capable laptop
+/// enumerates both its Intel integrated GPU and its NVIDIA/AMD discrete GPU
+/// as separate devices through the same backend). Lower ranks first.
+///
+/// A discrete GPU (`Gpu`, `ggml`'s `VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU` on
+/// the Vulkan backend) has its own VRAM and is essentially always the
+/// faster, less contended choice, so it ranks first. An `Accelerator`
+/// (NPU-class device) also has dedicated silicon and ranks second. An
+/// integrated GPU (`IntegratedGpu`) shares system RAM and memory bandwidth
+/// with the CPU and ranks last among the "accelerated" kinds -- it should
+/// only be picked when nothing better is present. Devices that tie on rank
+/// (e.g. two discrete GPUs) keep the registry's original enumeration order:
+/// we have no other signal to break that tie, and
+/// [`preferred_accelerated_device`] relies on `Iterator::min_by_key`
+/// returning the first minimal element to preserve it.
+pub(crate) fn accelerated_device_rank(kind: GgmlBackendKind) -> u8 {
+    match kind {
+        GgmlBackendKind::Gpu => 0,
+        GgmlBackendKind::Accelerator => 1,
+        GgmlBackendKind::IntegratedGpu => 2,
+        _ => 3,
+    }
+}
+
+/// Pick the device to prefer when more than one accelerated device is
+/// available, per [`accelerated_device_rank`]. `is_accelerated` lets each
+/// caller keep its own notion of "counts as an accelerated device" (some
+/// only want `Gpu`/`IntegratedGpu`, `init_gpu_backend` also folds in
+/// `Accelerator`), while the tie-break/ranking logic stays in one place so
+/// device selection can never drift from the diagnostics that describe it.
+pub(crate) fn preferred_accelerated_device(
+    devices: &[GgmlBackendDevice],
+    is_accelerated: impl Fn(GgmlBackendKind) -> bool,
+) -> Option<&GgmlBackendDevice> {
+    devices
+        .iter()
+        .filter(|device| is_accelerated(device.kind))
+        .min_by_key(|device| accelerated_device_rank(device.kind))
+}
+
 /// Register backend plugin DLLs once per process before the first registry
 /// query. Under `GGML_BACKEND_DL` the static `GGML_USE_*` backend registration
 /// is compiled out, so without this the registry is empty and every
@@ -381,6 +422,14 @@ pub fn ggml_runtime_info() -> GgmlRuntimeInfo {
 /// reports) where the reporter's misfiled "backend used" field left the
 /// actually-selected backend and device unknown; this makes it recoverable
 /// from `daemon.log` alone.
+///
+/// When more than one accelerated-kind device is present (an Optimus/hybrid-
+/// graphics host exposing both an integrated and a discrete GPU through the
+/// same Vulkan backend), the summary also appends
+/// `gpu_selection=discrete_over_integrated` naming the device
+/// [`preferred_accelerated_device`] picked and why -- so a "wrong GPU used"
+/// report is diagnosable from the boot log alone (see the discrete-GPU
+/// preference fix that added this).
 pub fn ggml_runtime_boot_summary(info: &GgmlRuntimeInfo) -> String {
     let best = info.best_backend_name.as_deref().unwrap_or("unavailable");
     let mut summary = format!("best_backend={best} cpu_backend={}", info.cpu_backend_name);
@@ -410,6 +459,21 @@ pub fn ggml_runtime_boot_summary(info: &GgmlRuntimeInfo) -> String {
     summary.push_str(" devices=[");
     summary.push_str(&devices);
     summary.push(']');
+
+    let accelerated_kinds = info
+        .devices
+        .iter()
+        .filter(|device| device.kind.is_gpu())
+        .count();
+    if accelerated_kinds > 1
+        && let Some(preferred) =
+            preferred_accelerated_device(&info.devices, GgmlBackendKind::is_gpu)
+    {
+        summary.push_str(&format!(
+            " gpu_selection={{picked={:?} kind={:?} rule=discrete_over_integrated}}",
+            preferred.name, preferred.kind
+        ));
+    }
     summary
 }
 
@@ -521,9 +585,7 @@ pub fn ggml_hip_tuning_summary() -> Option<&'static str> {
 }
 
 fn best_device_name(devices: &[GgmlBackendDevice]) -> Option<String> {
-    devices
-        .iter()
-        .find(|device| device.kind.is_gpu())
+    preferred_accelerated_device(devices, GgmlBackendKind::is_gpu)
         .or_else(|| {
             devices
                 .iter()
@@ -534,10 +596,7 @@ fn best_device_name(devices: &[GgmlBackendDevice]) -> Option<String> {
 
 #[cfg(target_os = "macos")]
 fn metal_device_name(devices: &[GgmlBackendDevice]) -> Option<String> {
-    devices
-        .iter()
-        .find(|device| device.kind.is_gpu())
-        .map(|device| device.name.clone())
+    preferred_accelerated_device(devices, GgmlBackendKind::is_gpu).map(|device| device.name.clone())
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -621,6 +680,96 @@ mod tests {
             summary,
             "best_backend=unavailable cpu_backend=CPU devices=none"
         );
+    }
+
+    fn test_device(name: &str, kind: GgmlBackendKind) -> GgmlBackendDevice {
+        GgmlBackendDevice::for_test(name, name, kind, None)
+    }
+
+    #[test]
+    fn preferred_accelerated_device_picks_discrete_over_integrated() {
+        // The Optimus/hybrid-graphics case (issue: "double GPU picks the
+        // wrong one"): an Intel integrated GPU enumerated ahead of the
+        // NVIDIA discrete GPU must still yield the discrete GPU.
+        let devices = vec![
+            test_device("Vulkan0", GgmlBackendKind::IntegratedGpu),
+            test_device("Vulkan1", GgmlBackendKind::Gpu),
+        ];
+        let picked = preferred_accelerated_device(&devices, GgmlBackendKind::is_gpu)
+            .expect("a device is picked");
+        assert_eq!(picked.name, "Vulkan1");
+        assert_eq!(picked.kind, GgmlBackendKind::Gpu);
+    }
+
+    #[test]
+    fn preferred_accelerated_device_falls_back_to_integrated_when_no_discrete_present() {
+        let devices = vec![test_device("Vulkan0", GgmlBackendKind::IntegratedGpu)];
+        let picked = preferred_accelerated_device(&devices, GgmlBackendKind::is_gpu)
+            .expect("integrated GPU is picked");
+        assert_eq!(picked.name, "Vulkan0");
+    }
+
+    #[test]
+    fn preferred_accelerated_device_picks_discrete_when_only_discrete_present() {
+        let devices = vec![test_device("Vulkan0", GgmlBackendKind::Gpu)];
+        let picked = preferred_accelerated_device(&devices, GgmlBackendKind::is_gpu)
+            .expect("discrete GPU is picked");
+        assert_eq!(picked.name, "Vulkan0");
+    }
+
+    #[test]
+    fn preferred_accelerated_device_keeps_enumeration_order_between_two_discrete_gpus() {
+        // No further signal to break the tie between two discrete GPUs; the
+        // first one the registry enumerated is kept (matches
+        // `Iterator::min_by_key`'s documented first-minimum behavior).
+        let devices = vec![
+            test_device("Vulkan0", GgmlBackendKind::Gpu),
+            test_device("Vulkan1", GgmlBackendKind::Gpu),
+        ];
+        let picked = preferred_accelerated_device(&devices, GgmlBackendKind::is_gpu)
+            .expect("a discrete GPU is picked");
+        assert_eq!(picked.name, "Vulkan0");
+    }
+
+    #[test]
+    fn preferred_accelerated_device_none_when_no_accelerated_device_present() {
+        let devices = vec![test_device("CPU", GgmlBackendKind::Cpu)];
+        assert!(preferred_accelerated_device(&devices, GgmlBackendKind::is_gpu).is_none());
+    }
+
+    #[test]
+    fn best_device_name_prefers_discrete_gpu_on_hybrid_graphics_host() {
+        let devices = vec![
+            test_device("Vulkan0", GgmlBackendKind::IntegratedGpu),
+            test_device("Vulkan1", GgmlBackendKind::Gpu),
+        ];
+        assert_eq!(best_device_name(&devices).as_deref(), Some("Vulkan1"));
+    }
+
+    #[test]
+    fn boot_summary_reports_gpu_selection_only_with_multiple_accelerated_devices() {
+        let single = GgmlRuntimeInfo {
+            cpu_backend_name: "CPU".to_string(),
+            best_backend_name: Some("Vulkan0".to_string()),
+            metal_backend_name: None,
+            devices: vec![test_device("Vulkan0", GgmlBackendKind::Gpu)],
+            cpu_features: GgmlCpuFeatures::default(),
+        };
+        assert!(!ggml_runtime_boot_summary(&single).contains("gpu_selection="));
+
+        let hybrid = GgmlRuntimeInfo {
+            cpu_backend_name: "CPU".to_string(),
+            best_backend_name: Some("Vulkan1".to_string()),
+            metal_backend_name: None,
+            devices: vec![
+                test_device("Vulkan0", GgmlBackendKind::IntegratedGpu),
+                test_device("Vulkan1", GgmlBackendKind::Gpu),
+            ],
+            cpu_features: GgmlCpuFeatures::default(),
+        };
+        let summary = ggml_runtime_boot_summary(&hybrid);
+        assert!(summary.contains("gpu_selection={picked=\"Vulkan1\" kind=Gpu"));
+        assert!(summary.contains("rule=discrete_over_integrated"));
     }
 
     #[test]

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 use super::ffi;
 use super::{
     GgmlBackendKind, GgmlRuntimeError, GgufTensorDataReader, GgufWeightTensorPayload,
-    ensure_backends_loaded, ggml_available_devices,
+    accelerated_device_rank, ensure_backends_loaded, ggml_available_devices,
 };
 
 const F32_WIDTH_BYTES: usize = std::mem::size_of::<f32>();
@@ -4962,10 +4962,21 @@ impl GgmlBackendGuard {
     }
 
     fn init_gpu_backend() -> Result<NonNull<c_void>, GgmlCpuGraphError> {
-        for device in ggml_available_devices()
+        // Rank candidates so a hybrid-graphics host (Optimus-style laptop
+        // exposing both an Intel integrated GPU and an NVIDIA/AMD discrete GPU
+        // through the same Vulkan backend) tries the discrete GPU first,
+        // falling through to lower-ranked devices only if a higher-ranked one
+        // fails to initialize -- see `accelerated_device_rank`. A plain
+        // registry-order scan here (the previous behavior) picked whichever
+        // device the platform/driver happened to enumerate first, which on
+        // several reported Optimus setups was the integrated GPU, leaving the
+        // discrete GPU idle even though it is almost always the better choice.
+        let mut candidates: Vec<_> = ggml_available_devices()
             .into_iter()
             .filter(|device| backend_kind_is_accelerated(device.kind))
-        {
+            .collect();
+        candidates.sort_by_key(|device| accelerated_device_rank(device.kind));
+        for device in candidates {
             match device.initialize() {
                 Ok(backend) => return Ok(backend.into_raw()),
                 Err(GgmlRuntimeError::BackendUnavailable(_)) => continue,

--- a/crates/openasr-core/src/ggml_runtime/mod.rs
+++ b/crates/openasr-core/src/ggml_runtime/mod.rs
@@ -15,11 +15,13 @@ pub(crate) use arena_weight_pipeline::{
     ArenaAllocError, WeightSlot, alloc_static_f16, alloc_static_f32, bind_loaded,
     upload_static_f16, upload_static_f32,
 };
-pub(crate) use backend::ensure_backends_loaded;
 pub use backend::{
     GgmlBackend, GgmlBackendDevice, GgmlBackendKind, GgmlCpuFeatures, GgmlDeviceMemory,
     GgmlRuntimeError, GgmlRuntimeInfo, ggml_available_devices, ggml_hip_tuning_summary,
     ggml_native_build_enabled, ggml_runtime_boot_summary, ggml_runtime_info,
+};
+pub(crate) use backend::{
+    accelerated_device_rank, ensure_backends_loaded, preferred_accelerated_device,
 };
 pub use cpu_graph::{
     AutoGpuPolicy, GgmlCpuBinaryOp, GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphError,

--- a/crates/openasr-core/src/models/serve_batch_env.rs
+++ b/crates/openasr-core/src/models/serve_batch_env.rs
@@ -6,7 +6,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::ggml_runtime::{
-    GgmlBackendKind, GgmlCpuGraphBackend, GgmlDeviceMemory, ggml_available_devices,
+    GgmlBackendKind, GgmlCpuGraphBackend, GgmlDeviceMemory, accelerated_device_rank,
+    ggml_available_devices,
 };
 use crate::models::seq2seq_greedy_decode::{
     MAX_CONSECUTIVE_NGRAM_REPEATS, MAX_REPEAT_NGRAM, Seq2SeqGreedyDecodeConfig,
@@ -427,7 +428,15 @@ fn selected_gpu_memory_sample() -> Option<ServeBatchGpuMemorySample> {
 fn selected_gpu_memory_sample_from_device_infos(
     devices: &[(String, GgmlBackendKind, Option<GgmlDeviceMemory>)],
 ) -> Option<ServeBatchGpuMemorySample> {
-    let (name, kind, memory) = devices.iter().find(|(_, kind, _)| kind.is_gpu())?;
+    // Same discrete-over-integrated preference as `init_gpu_backend` /
+    // `preferred_accelerated_device`: on a hybrid-graphics host the VRAM cap
+    // must be sized off the discrete GPU actually selected for inference, not
+    // whichever device the registry happens to enumerate first (which could
+    // be a small-memory integrated GPU).
+    let (name, kind, memory) = devices
+        .iter()
+        .filter(|(_, kind, _)| kind.is_gpu())
+        .min_by_key(|(_, kind, _)| accelerated_device_rank(*kind))?;
     memory.map(|memory| ServeBatchGpuMemorySample {
         device_name: name.clone(),
         device_kind: *kind,
@@ -847,6 +856,37 @@ mod tests {
 
         assert_eq!(sample.device_name, "first-gpu");
         assert_eq!(sample.memory.free_bytes, 4 * MIB_BYTES);
+    }
+
+    #[test]
+    fn serve_batch_vram_sample_prefers_discrete_gpu_over_integrated() {
+        // Optimus-style host: the integrated GPU enumerates first but must
+        // not be the one the VRAM cap is sized against.
+        let devices = vec![
+            (
+                "integrated".to_string(),
+                GgmlBackendKind::IntegratedGpu,
+                Some(GgmlDeviceMemory {
+                    free_bytes: 512 * MIB_BYTES,
+                    total_bytes: 1024 * MIB_BYTES,
+                }),
+            ),
+            (
+                "discrete".to_string(),
+                GgmlBackendKind::Gpu,
+                Some(GgmlDeviceMemory {
+                    free_bytes: 8 * 1024 * MIB_BYTES,
+                    total_bytes: 12 * 1024 * MIB_BYTES,
+                }),
+            ),
+        ];
+
+        let sample =
+            selected_gpu_memory_sample_from_device_infos(&devices).expect("gpu memory sample");
+
+        assert_eq!(sample.device_name, "discrete");
+        assert_eq!(sample.device_kind, GgmlBackendKind::Gpu);
+        assert_eq!(sample.memory.free_bytes, 8 * 1024 * MIB_BYTES);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

On Optimus/hybrid-graphics hosts, Auto/Accelerated now resolves to the discrete GPU instead of whichever device the Vulkan ICD happens to enumerate first.

## Why

User report (dual-GPU laptop, Intel UHD + RTX 4070): inference silently ran on the iGPU; the user had to disable hybrid graphics in BIOS to reach the dGPU. ggml already distinguishes discrete vs integrated (GGML_BACKEND_DEVICE_TYPE_GPU vs _IGPU); our selection layer ignored it in four independent first-found-wins call sites - including the VRAM budget sampler, which could read the iGPU's shared memory instead of the dGPU's VRAM.

## Changes

- backend.rs: accelerated_device_rank (discrete < accelerator < integrated) + preferred_accelerated_device; applied to init_gpu_backend (with init-failure fallthrough), best_device_name, compute_devices_from_runtime, and the serve-batch VRAM sampler.
- Boot summary appends gpu_selection={picked=... rule=discrete_over_integrated} only when multiple accelerated devices exist; single-device hosts unchanged.
- GGML_VK_VISIBLE_DEVICES and explicit backend preferences unaffected.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (openasr-core)
- [x] targeted suites: backend 17, compute_devices 5, serve_batch_env 28, cpu_graph 77 - all passed (includes real single-device Metal init: zero behavior change)
- [ ] `cargo nextest run --workspace` (queued pre-merge)
- [ ] `cargo deny check` (no dependency changes)

## Manual smoke checks

Mock hybrid-device tests; end-to-end confirmation on a real Optimus laptop depends on the reporter (or a future Windows leg) - the new gpu_selection boot-log line is the field signal.

## Scope / non-goals

Desktop-side NVIDIA detection (DXGI enumeration for the CUDA-kernel offer) is a separate app-repo change in flight.

## AI usage disclosure

YES