### PR TITLE
feat(core): add host system, request, and failure context to daemon.log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cpal = { version = "0.17.3", default-features = false }
 ed25519-dalek = { version = "2.2", default-features = false, features = ["std"] }
 futures-util = "0.3"
 libc = "0.2"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_System_SystemInformation", "Win32_System_ProcessStatus", "Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_System_SystemInformation", "Win32_System_ProcessStatus", "Win32_Storage_FileSystem", "Win32_System_Registry"] }
 matrixmultiply = "0.3"
 memmap2 = "0.9"
 metal = "0.33"

--- a/crates/openasr-cli/src/live.rs
+++ b/crates/openasr-cli/src/live.rs
@@ -1114,6 +1114,7 @@ impl LiveTranscriptionWorker {
                 let result = transcribe_with_backend(
                     backend,
                     TranscriptionRequest::new(job.temp_wav.path(), job.model_id)
+                        .with_source(openasr_core::RequestSource::CliLive)
                         .with_model_pack_path(
                             job.model_pack_path.or_else(|| model_pack_path.clone()),
                         )

--- a/crates/openasr-cli/src/live.rs
+++ b/crates/openasr-cli/src/live.rs
@@ -1115,6 +1115,11 @@ impl LiveTranscriptionWorker {
                     backend,
                     TranscriptionRequest::new(job.temp_wav.path(), job.model_id)
                         .with_source(openasr_core::RequestSource::CliLive)
+                        // Not a normalization-pipeline guess: `write_temp_utterance_wav`
+                        // above always writes PCM16 mono 16 kHz -- this *is* the
+                        // mic capture's real captured format, unlike an uploaded file
+                        // whose source format is unknown until probed/decoded.
+                        .with_source_audio_format(Some(16_000), Some(1))
                         .with_model_pack_path(
                             job.model_pack_path.or_else(|| model_pack_path.clone()),
                         )

--- a/crates/openasr-cli/src/live.rs
+++ b/crates/openasr-cli/src/live.rs
@@ -1116,10 +1116,12 @@ impl LiveTranscriptionWorker {
                     TranscriptionRequest::new(job.temp_wav.path(), job.model_id)
                         .with_source(openasr_core::RequestSource::CliLive)
                         // Not a normalization-pipeline guess: `write_temp_utterance_wav`
-                        // above always writes PCM16 mono 16 kHz -- this *is* the
-                        // mic capture's real captured format, unlike an uploaded file
-                        // whose source format is unknown until probed/decoded.
+                        // above always writes PCM16 mono 16 kHz WAV -- this *is*
+                        // the mic capture's real captured format/container,
+                        // unlike an uploaded file whose source format is
+                        // unknown until probed/decoded.
                         .with_source_audio_format(Some(16_000), Some(1))
+                        .with_source_container(Some("wav".to_string()))
                         .with_model_pack_path(
                             job.model_pack_path.or_else(|| model_pack_path.clone()),
                         )

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -1224,6 +1224,7 @@ fn transcribe(options: TranscribeCommandOptions<'_>) -> Result<()> {
     print_audio_preparation_notes(&prepared);
 
     let request = TranscriptionRequest::new(prepared.path(), prepared_run.model_source.model_id)
+        .with_source(openasr_core::RequestSource::CliTranscribe)
         .with_model_pack_path(prepared_run.model_source.model_pack_path)
         // OADP Phase 0: the adapter rides the request options into the native
         // executor (the OPENASR_ADAPTER env var stays a server-side surface;

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -1225,6 +1225,10 @@ fn transcribe(options: TranscribeCommandOptions<'_>) -> Result<()> {
 
     let request = TranscriptionRequest::new(prepared.path(), prepared_run.model_source.model_id)
         .with_source(openasr_core::RequestSource::CliTranscribe)
+        .with_source_audio_format(
+            prepared.original().sample_rate_hz,
+            prepared.original().channels,
+        )
         .with_model_pack_path(prepared_run.model_source.model_pack_path)
         // OADP Phase 0: the adapter rides the request options into the native
         // executor (the OPENASR_ADAPTER env var stays a server-side surface;

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -1229,6 +1229,7 @@ fn transcribe(options: TranscribeCommandOptions<'_>) -> Result<()> {
             prepared.original().sample_rate_hz,
             prepared.original().channels,
         )
+        .with_source_container(prepared.original().extension.clone())
         .with_model_pack_path(prepared_run.model_source.model_pack_path)
         // OADP Phase 0: the adapter rides the request options into the native
         // executor (the OPENASR_ADAPTER env var stays a server-side surface;

--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -396,6 +396,13 @@ pub struct TranscriptionRequest {
     /// [`crate::api::backend::request_context`]'s honesty contract.
     pub source_sample_rate_hz: Option<u32>,
     pub source_channels: Option<u16>,
+    /// The *source* file's container/codec extension (e.g. `"m4a"`,
+    /// `"mp3"`), lowercased, with no leading dot -- before any conversion
+    /// this pipeline performs to reach the normalized WAV it actually
+    /// decodes. Same honesty contract as `source_sample_rate_hz`: `None` when
+    /// genuinely unknown, never guessed, and never the *file name* or any
+    /// other path component -- extension only.
+    pub source_container: Option<String>,
 }
 
 impl TranscriptionRequest {
@@ -421,6 +428,7 @@ impl TranscriptionRequest {
             source: RequestSource::default(),
             source_sample_rate_hz: None,
             source_channels: None,
+            source_container: None,
         }
     }
 
@@ -440,6 +448,15 @@ impl TranscriptionRequest {
     ) -> Self {
         self.source_sample_rate_hz = sample_rate_hz;
         self.source_channels = channels;
+        self
+    }
+
+    /// Sets the source file's container/codec extension for the
+    /// `stage=request_context` log line. Pass the raw extension (e.g.
+    /// `"m4a"`) or `None` when genuinely unknown -- never the file name; see
+    /// this field's doc comment.
+    pub fn with_source_container(mut self, container: Option<String>) -> Self {
+        self.source_container = container;
         self
     }
 

--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -7,6 +7,7 @@ use crate::models::language::LanguageMode;
 
 mod mock;
 mod native;
+mod request_context;
 
 pub use mock::transcribe_with_mock_backend;
 pub use native::{
@@ -19,6 +20,10 @@ pub use native::{
     native_runtime_transcription_capabilities_for_path, native_transcription_progress,
     resolve_local_native_runtime_model_identity, unload_idle_native_model_runtime_caches,
     validate_local_native_model_pack_path, validate_native_runtime_model_pack_contract,
+};
+pub use request_context::{
+    FailureCategory, RequestSource, format_failure_context_line, format_request_context_line,
+    log_failure_context, log_request_context,
 };
 
 pub const NATIVE_RUNTIME_MODEL_ID_AUTO: &str = "__openasr_native_runtime_model_id_auto__";
@@ -373,6 +378,12 @@ pub struct TranscriptionRequest {
     /// preference toggle), not the primary gate. Never triggers a download --
     /// same fail-closed contract as `word_timestamps_refine`.
     pub punctuate: bool,
+    /// Which call path built this request (CLI transcribe/live, server
+    /// transcribe/translate/realtime) -- diagnostics only, logged verbatim
+    /// into the `stage=request_context` `daemon.log` line so a bug report is
+    /// self-describing. Defaults to [`RequestSource::Unspecified`]; real
+    /// entry points set it via [`Self::with_source`].
+    pub source: RequestSource,
 }
 
 impl TranscriptionRequest {
@@ -395,7 +406,13 @@ impl TranscriptionRequest {
             diarize: false,
             diarize_speakers: None,
             punctuate: true,
+            source: RequestSource::default(),
         }
+    }
+
+    pub fn with_source(mut self, source: RequestSource) -> Self {
+        self.source = source;
+        self
     }
 
     pub fn with_language(mut self, language: Option<String>) -> Self {

--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -384,6 +384,18 @@ pub struct TranscriptionRequest {
     /// self-describing. Defaults to [`RequestSource::Unspecified`]; real
     /// entry points set it via [`Self::with_source`].
     pub source: RequestSource,
+    /// The *source* audio's real sample rate/channel count (before this
+    /// crate's normalization pipeline resamples/downmixes to 16 kHz mono) --
+    /// diagnostics only, logged verbatim into the `stage=request_context`
+    /// line. `None` when the caller has no source format to report (a
+    /// synthesized-format realtime utterance request sets these explicitly to
+    /// its true captured format instead of leaving them `None`; a file
+    /// request sets them from [`crate::audio::AudioInputInfo`] once
+    /// `prepare_audio_input` has probed/decoded the file). Never a
+    /// normalization-pipeline constant -- see
+    /// [`crate::api::backend::request_context`]'s honesty contract.
+    pub source_sample_rate_hz: Option<u32>,
+    pub source_channels: Option<u16>,
 }
 
 impl TranscriptionRequest {
@@ -407,11 +419,27 @@ impl TranscriptionRequest {
             diarize_speakers: None,
             punctuate: true,
             source: RequestSource::default(),
+            source_sample_rate_hz: None,
+            source_channels: None,
         }
     }
 
     pub fn with_source(mut self, source: RequestSource) -> Self {
         self.source = source;
+        self
+    }
+
+    /// Sets the source audio's real sample rate/channel count for the
+    /// `stage=request_context` log line. Pass `None` for either when it is
+    /// genuinely unknown -- never a normalization constant; see this field's
+    /// doc comment.
+    pub fn with_source_audio_format(
+        mut self,
+        sample_rate_hz: Option<u32>,
+        channels: Option<u16>,
+    ) -> Self {
+        self.source_sample_rate_hz = sample_rate_hz;
+        self.source_channels = channels;
         self
     }
 

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -553,6 +553,8 @@ fn native_offline_request_to_transcription_request(
         .with_diarization(request.options.diarize)
         .with_longform(request.longform)
         .with_display_file_name(request.display_file_name)
+        .with_source(request.source)
+        .with_source_audio_format(request.source_sample_rate_hz, request.source_channels)
 }
 
 fn native_backend_error_to_asr(error: BackendError) -> NativeAsrError {

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -555,6 +555,7 @@ fn native_offline_request_to_transcription_request(
         .with_display_file_name(request.display_file_name)
         .with_source(request.source)
         .with_source_audio_format(request.source_sample_rate_hz, request.source_channels)
+        .with_source_container(request.source_container)
 }
 
 fn native_backend_error_to_asr(error: BackendError) -> NativeAsrError {

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -28,6 +28,8 @@ use crate::{
     GgmlFamilyRegistrySelectionError, OasrV1MetadataError, parse_model_ref,
 };
 
+use crate::api::backend::{FailureCategory, log_failure_context, log_request_context};
+
 use super::{BackendError, Transcription, TranscriptionRequest};
 use crate::Segment;
 use crate::WordTimestamp;
@@ -745,7 +747,57 @@ struct NativeLongformPolicyResolution {
 /// state that function computes. Punctuation runs before the forced-aligner
 /// refine so the aligner (and every other downstream consumer) sees the
 /// punctuated text.
+/// Thin wrapper over [`run_native_transcription_fallible`] that adds exactly
+/// one thing: a `stage=transcribe_failure` `daemon.log` line on the `Err`
+/// path, carrying the failure's category and the process's current
+/// available-memory (and, if applicable, VRAM) reading. Kept as a separate
+/// wrapper rather than folding the logging into the fallible function itself
+/// so every one of that function's many early-return `?` sites (model
+/// resolve, audio prep, capability rejection, decode dispatch, ...) is
+/// covered by one log site instead of needing its own.
 pub(super) fn run_native_transcription(
+    request: TranscriptionRequest,
+) -> Result<Transcription, BackendError> {
+    run_native_transcription_fallible(request).inspect_err(|error| {
+        log_failure_context(classify_backend_error_for_failure_log(error));
+    })
+}
+
+/// Coarse [`FailureCategory`] bucket for a `BackendError`, reusing its
+/// existing variants (and, for the variants that flatten internal detail
+/// into a `NativeFailClosed` reason string, the same allocation-failure
+/// marker-text sniffing `gpu_buffer_allocation_failure_backend` already
+/// relies on above) rather than introducing a second, parallel error
+/// taxonomy just for logging.
+fn classify_backend_error_for_failure_log(error: &BackendError) -> FailureCategory {
+    match error {
+        BackendError::NativeUnsupportedInputFormat { .. } => FailureCategory::AudioIo,
+        BackendError::NativeModelPackPathRequired
+        | BackendError::NativeModelPackPathRejected { .. }
+        | BackendError::NativeModelSelectionMismatch { .. } => FailureCategory::ModelResolve,
+        BackendError::DiarizationNotSupported { .. }
+        | BackendError::DiarizeSpeakersRequiresDiarization
+        | BackendError::PhraseBiasNotSupported { .. }
+        | BackendError::AdapterNotSupported { .. }
+        | BackendError::PhraseBiasUnsupportedByModel { .. }
+        | BackendError::RequestOptionUnsupportedByModel { .. }
+        | BackendError::WordTimestampAlignmentRequiresWordTimestamps
+        | BackendError::WordTimestampAlignmentPackMissing { .. } => {
+            FailureCategory::UnsupportedCapability
+        }
+        BackendError::TranscriptionCanceled => FailureCategory::Canceled,
+        BackendError::ServeBatchUnavailable { .. } => FailureCategory::Transient,
+        BackendError::NativeFailClosed { .. }
+            if gpu_buffer_allocation_failure_backend(error).is_some() =>
+        {
+            FailureCategory::Alloc
+        }
+        BackendError::NativeFailClosed { .. }
+        | BackendError::WordTimestampAlignmentFailed { .. } => FailureCategory::Decode,
+    }
+}
+
+fn run_native_transcription_fallible(
     request: TranscriptionRequest,
 ) -> Result<Transcription, BackendError> {
     let refine = request.word_timestamps_refine;
@@ -1123,6 +1175,22 @@ fn run_native_transcription_impl(
     // executor used (see `native_runtime_backend_label`'s doc comment).
     let auto_gpu_policy = crate::arch::family_auto_gpu_policy_for_model_architecture(
         selected_family.model_architecture,
+    );
+    // Per-request diagnostics line (source/model/quant/backend/audio shape) --
+    // logged once here, after model resolution and audio prep have both
+    // succeeded and the backend label is resolvable, and before decode
+    // dispatch. Deliberately excludes `request.input_path`/
+    // `request.display_file_name` and any decoded/transcribed text: see
+    // `request_context`'s module doc for the privacy contract.
+    log_request_context(
+        request.source,
+        requested_model_id,
+        &quant_tag_for_log(requested_model_id, runtime_source.path()),
+        native_runtime_backend_label(auto_gpu_policy),
+        audio_duration_seconds,
+        input_container_tag(&request.input_path),
+        16_000,
+        1,
     );
     let mut longform_metadata: Option<TranscriptionLongFormMetadata> = None;
     if run_longform {
@@ -2330,6 +2398,38 @@ fn native_runtime_backend_label(
         GgmlCpuGraphBackend::Metal => "metal",
         GgmlCpuGraphBackend::Gpu => "gpu",
     }
+}
+
+/// Best-effort quant tag for the `stage=request_context` log line: installed
+/// packs live at `<home>/models/<model>/<quant>/<model>-<quant>.oasr` (see
+/// `pull.rs`'s `InstalledPack` layout), so the runtime pack path's *parent
+/// directory name* already is the quant tag -- no second GGUF/metadata read
+/// needed. Falls back to the tag parsed off the request's own model ref
+/// (`family:quant`) for a pack laid out outside that convention (e.g.
+/// `--model-pack` pointed at an arbitrary file), and finally to `"unknown"`
+/// rather than fabricating a value.
+fn quant_tag_for_log(requested_model_id: &str, runtime_pack_path: &Path) -> String {
+    let from_parent_dir = runtime_pack_path
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str());
+    let from_request_tag = parse_model_ref(requested_model_id)
+        .ok()
+        .and_then(|reference| reference.tag);
+    match from_parent_dir.or(from_request_tag.as_deref()) {
+        Some(tag) => crate::canonical_quant_tag(tag).to_string(),
+        None => "unknown".to_string(),
+    }
+}
+
+/// Codec/container tag for the `stage=request_context` log line: the input
+/// path's extension only (e.g. `"wav"`, `"mp3"`) -- never the file name or
+/// any other path component, per this module's privacy contract.
+fn input_container_tag(input_path: &Path) -> &str {
+    input_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or("unknown")
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1188,7 +1188,7 @@ fn run_native_transcription_impl(
         &quant_tag_for_log(requested_model_id, runtime_source.path()),
         native_runtime_backend_label(auto_gpu_policy),
         audio_duration_seconds,
-        input_container_tag(&request.input_path),
+        request.source_container.as_deref(),
         request.source_sample_rate_hz,
         request.source_channels,
     );
@@ -2420,16 +2420,6 @@ fn quant_tag_for_log(requested_model_id: &str, runtime_pack_path: &Path) -> Stri
         Some(tag) => crate::canonical_quant_tag(tag).to_string(),
         None => "unknown".to_string(),
     }
-}
-
-/// Codec/container tag for the `stage=request_context` log line: the input
-/// path's extension only (e.g. `"wav"`, `"mp3"`) -- never the file name or
-/// any other path component, per this module's privacy contract.
-fn input_container_tag(input_path: &Path) -> &str {
-    input_path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .unwrap_or("unknown")
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1189,8 +1189,8 @@ fn run_native_transcription_impl(
         native_runtime_backend_label(auto_gpu_policy),
         audio_duration_seconds,
         input_container_tag(&request.input_path),
-        16_000,
-        1,
+        request.source_sample_rate_hz,
+        request.source_channels,
     );
     let mut longform_metadata: Option<TranscriptionLongFormMetadata> = None;
     if run_longform {

--- a/crates/openasr-core/src/api/backend/request_context.rs
+++ b/crates/openasr-core/src/api/backend/request_context.rs
@@ -68,6 +68,12 @@ impl RequestSource {
 /// `"whisper-small"`), never a file path; `quant_tag` and `backend_label` are
 /// short fixed-vocabulary tokens (`"q4_k"`, `"metal"`, ...); `container` is a
 /// codec/extension tag (e.g. `"wav"`), not a file name.
+///
+/// `sample_rate_hz`/`channels` are the *source* audio's real format (before
+/// this crate's normalization pipeline resamples/downmixes), not the
+/// normalized-pipeline constants -- print `"unknown"` (matching
+/// [`format_failure_context_line`]'s degrade style) rather than a fabricated
+/// number when the caller could not determine them.
 #[allow(clippy::too_many_arguments)]
 pub fn format_request_context_line(
     source: RequestSource,
@@ -76,9 +82,11 @@ pub fn format_request_context_line(
     backend_label: &str,
     audio_duration_seconds: f32,
     container: &str,
-    sample_rate_hz: u32,
-    channels: u16,
+    sample_rate_hz: Option<u32>,
+    channels: Option<u16>,
 ) -> String {
+    let sample_rate_hz = sample_rate_hz.map_or_else(|| "unknown".to_string(), |hz| hz.to_string());
+    let channels = channels.map_or_else(|| "unknown".to_string(), |count| count.to_string());
     format!(
         "stage=request_context source={} model={model_id} quant={quant_tag} backend={backend_label} audio_duration_s={audio_duration_seconds:.2} container={container} sample_rate_hz={sample_rate_hz} channels={channels}",
         source.as_log_label(),
@@ -97,8 +105,8 @@ pub fn log_request_context(
     backend_label: &str,
     audio_duration_seconds: f32,
     container: &str,
-    sample_rate_hz: u32,
-    channels: u16,
+    sample_rate_hz: Option<u32>,
+    channels: Option<u16>,
 ) {
     stage_timing::log_event(
         "native_transcribe",
@@ -240,8 +248,8 @@ mod tests {
             "metal",
             12.34,
             "wav",
-            16_000,
-            1,
+            Some(16_000),
+            Some(1),
         );
         // Regression guard for the privacy contract: no field named
         // path/file/input in the formatted line, and no path separators that
@@ -260,6 +268,47 @@ mod tests {
         assert!(line.contains("container=wav"));
         assert!(line.contains("sample_rate_hz=16000"));
         assert!(line.contains("channels=1"));
+    }
+
+    #[test]
+    fn request_context_line_reports_the_true_source_format_not_a_normalized_constant() {
+        // Regression guard for the field's honesty contract: a non-16 kHz,
+        // non-mono source (e.g. a 44.1 kHz stereo m4a export) must show up as
+        // its own real numbers, not silently collapse to the normalization
+        // pipeline's 16000/1 constants.
+        let line = format_request_context_line(
+            RequestSource::ServerTranscribe,
+            "whisper-small",
+            "q4_k",
+            "metal",
+            12.34,
+            "m4a",
+            Some(44_100),
+            Some(2),
+        );
+        assert!(line.contains("sample_rate_hz=44100"));
+        assert!(line.contains("channels=2"));
+        assert!(!line.contains("sample_rate_hz=16000"));
+        assert!(!line.contains("channels=1"));
+    }
+
+    #[test]
+    fn request_context_line_degrades_to_unknown_when_source_format_is_unavailable() {
+        // Honesty contract, the other direction: a caller with no probed
+        // source format passes `None`, which must render as `unknown`, never
+        // a fabricated/default number.
+        let line = format_request_context_line(
+            RequestSource::CliTranscribe,
+            "whisper-small",
+            "q4_k",
+            "cpu",
+            5.0,
+            "wav",
+            None,
+            None,
+        );
+        assert!(line.contains("sample_rate_hz=unknown"));
+        assert!(line.contains("channels=unknown"));
     }
 
     #[test]

--- a/crates/openasr-core/src/api/backend/request_context.rs
+++ b/crates/openasr-core/src/api/backend/request_context.rs
@@ -1,0 +1,322 @@
+//! Structured, privacy-safe `daemon.log` lines for one transcription
+//! request's context (what kind of request, which model/quant/backend, how
+//! much audio) and, on failure, why it failed. Companion to
+//! [`crate::host::host_system_boot_summary`] and the existing
+//! `stage=ggml_backend` boot line: together they let a bug report's
+//! `daemon.log` (plus the desktop's `desktop.log`) stand on its own for
+//! triage, without asking the reporter what model/OS/RAM they were on.
+//!
+//! **Privacy contract**: neither line here may ever include a file name, a
+//! file path, or any audio/transcript content -- only request *shape*
+//! (source, model, backend, audio duration/format) and host resource
+//! counters. [`format_request_context_line`] is covered by a regression test
+//! asserting this.
+
+use crate::stage_timing;
+
+/// Which call path originated a native transcription request. Named after
+/// the concrete entry points that exist today (see `rg
+/// "TranscriptionRequest::new"`), not an aspirational taxonomy: the realtime
+/// websocket path serves both the desktop's dictation and live-captions
+/// features through the same per-utterance native request, and the wire
+/// protocol carries no field distinguishing them, so both log as
+/// `server_realtime` rather than fabricating a distinction this crate cannot
+/// actually observe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RequestSource {
+    /// `openasr transcribe` (CLI, one-shot local file).
+    CliTranscribe,
+    /// `openasr live` (CLI, mic capture loop), one request per utterance.
+    CliLive,
+    /// `POST /v1/audio/transcriptions` (server, uploaded file).
+    ServerTranscribe,
+    /// `POST /v1/audio/translations` (server, uploaded file, forced
+    /// `task=translate`).
+    ServerTranslate,
+    /// `/v1/audio/realtime` websocket session (server), one request per
+    /// finalized utterance. Covers both the desktop's dictation and
+    /// live-captions features -- see the type-level doc above.
+    ServerRealtime,
+    /// The request was built without an explicit source (a test helper, or a
+    /// caller that has not been updated yet). Never intentionally emitted by
+    /// a real entry point; exists so adding this field did not require
+    /// touching every one of this crate's existing `TranscriptionRequest`
+    /// construction sites.
+    #[default]
+    Unspecified,
+}
+
+impl RequestSource {
+    pub fn as_log_label(self) -> &'static str {
+        match self {
+            Self::CliTranscribe => "cli_transcribe",
+            Self::CliLive => "cli_live",
+            Self::ServerTranscribe => "server_transcribe",
+            Self::ServerTranslate => "server_translate",
+            Self::ServerRealtime => "server_realtime",
+            Self::Unspecified => "unspecified",
+        }
+    }
+}
+
+/// Formats the per-request context line's payload (everything after the
+/// `stage_timing` prefix and component name). Pure formatting, no I/O --
+/// separated from [`log_request_context`] so the "no filename field" privacy
+/// contract can be regression-tested without capturing stderr.
+///
+/// `model_id` must already be the resolved bare model id (e.g.
+/// `"whisper-small"`), never a file path; `quant_tag` and `backend_label` are
+/// short fixed-vocabulary tokens (`"q4_k"`, `"metal"`, ...); `container` is a
+/// codec/extension tag (e.g. `"wav"`), not a file name.
+#[allow(clippy::too_many_arguments)]
+pub fn format_request_context_line(
+    source: RequestSource,
+    model_id: &str,
+    quant_tag: &str,
+    backend_label: &str,
+    audio_duration_seconds: f32,
+    container: &str,
+    sample_rate_hz: u32,
+    channels: u16,
+) -> String {
+    format!(
+        "stage=request_context source={} model={model_id} quant={quant_tag} backend={backend_label} audio_duration_s={audio_duration_seconds:.2} container={container} sample_rate_hz={sample_rate_hz} channels={channels}",
+        source.as_log_label(),
+    )
+}
+
+/// Logs [`format_request_context_line`]'s output as an unconditional (not
+/// `OPENASR_TIMING`-gated) `daemon.log` line -- request-context is baseline
+/// observability, not opt-in profiling, matching `stage=ggml_backend` and
+/// `stage=host_system`'s always-on posture.
+#[allow(clippy::too_many_arguments)]
+pub fn log_request_context(
+    source: RequestSource,
+    model_id: &str,
+    quant_tag: &str,
+    backend_label: &str,
+    audio_duration_seconds: f32,
+    container: &str,
+    sample_rate_hz: u32,
+    channels: u16,
+) {
+    stage_timing::log_event(
+        "native_transcribe",
+        format_request_context_line(
+            source,
+            model_id,
+            quant_tag,
+            backend_label,
+            audio_duration_seconds,
+            container,
+            sample_rate_hz,
+            channels,
+        ),
+    );
+}
+
+/// Coarse failure-category buckets a `BackendError` collapses into for the
+/// failure-context log line. Reuses `BackendError`'s existing variants (and,
+/// for the variants that flatten internal detail into a `NativeFailClosed`
+/// reason string, the same marker-text sniffing
+/// `gpu_buffer_allocation_failure_backend` already relies on) rather than
+/// introducing a second, parallel error taxonomy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureCategory {
+    /// A compute-buffer/GPU allocation failed (ggml
+    /// `BackendBufferAllocationFailed`, surfaced as `NativeFailClosed`).
+    Alloc,
+    /// The input audio file/container could not be read or normalized.
+    AudioIo,
+    /// The requested model/pack path/id could not be resolved or did not
+    /// match the loaded runtime source.
+    ModelResolve,
+    /// The request asked for a capability (diarization, phrase bias,
+    /// adapter, word-timestamp alignment, ...) the resolved backend/model
+    /// does not support; rejected before any decode ran.
+    UnsupportedCapability,
+    /// The request was canceled by the caller at a slice boundary.
+    Canceled,
+    /// A transient, retryable condition (e.g. serve-batch decode busy).
+    Transient,
+    /// Any other fail-closed decode/dispatch error not covered above.
+    Decode,
+}
+
+impl FailureCategory {
+    pub fn as_log_label(self) -> &'static str {
+        match self {
+            Self::Alloc => "alloc",
+            Self::AudioIo => "audio_io",
+            Self::ModelResolve => "model_resolve",
+            Self::UnsupportedCapability => "unsupported_capability",
+            Self::Canceled => "canceled",
+            Self::Transient => "transient",
+            Self::Decode => "decode",
+        }
+    }
+}
+
+/// Formats the failure-context line's payload. `available_memory_mib` and
+/// `gpu_memory_mib` (`(free, total)`) are `None` when the corresponding probe
+/// is unavailable (unsupported platform, no GPU-class device) -- the field is
+/// then omitted entirely rather than printed as a sentinel, matching this
+/// crate's other best-effort diagnostic lines (e.g. `ggml_runtime_boot_summary`
+/// omitting `gpu_selection=` when there is nothing to disambiguate).
+pub fn format_failure_context_line(
+    category: FailureCategory,
+    available_memory_mib: Option<u64>,
+    gpu_memory_mib: Option<(u64, u64)>,
+) -> String {
+    let mut line = format!(
+        "stage=transcribe_failure error_category={}",
+        category.as_log_label()
+    );
+    match available_memory_mib {
+        Some(mib) => line.push_str(&format!(" mem_available_mib={mib}")),
+        None => line.push_str(" mem_available_mib=unknown"),
+    }
+    if let Some((free_mib, total_mib)) = gpu_memory_mib {
+        line.push_str(&format!(
+            " gpu_mem_free_mib={free_mib} gpu_mem_total_mib={total_mib}"
+        ));
+    }
+    line
+}
+
+/// Logs [`format_failure_context_line`]'s output at the moment a native
+/// transcription request fails, using the process's current best-effort
+/// available-memory reading (and, if a GPU-class device is present, its
+/// free/total VRAM from the same device enumeration `stage=ggml_backend`
+/// logs at boot) -- never re-probing anything expensive, and never a hard
+/// dependency: a probe returning `None` just narrows the logged line.
+pub fn log_failure_context(category: FailureCategory) {
+    let available_memory_mib =
+        crate::host_available_memory_bytes().map(|bytes| bytes / (1024 * 1024));
+    let gpu_memory_mib = first_gpu_class_device_memory_mib();
+    stage_timing::log_event(
+        "native_transcribe",
+        format_failure_context_line(category, available_memory_mib, gpu_memory_mib),
+    );
+}
+
+/// Best-effort `(free_mib, total_mib)` for the first GPU-class device ggml's
+/// device registry reports memory for. Reuses the same
+/// `ggml_runtime_info()`/`GgmlBackendDevice` enumeration the boot-time
+/// `stage=ggml_backend` line already walks, rather than a second device
+/// probe -- this is a point-in-time snapshot at failure time, not the boot
+/// snapshot, so it can catch VRAM pressure that developed since boot.
+fn first_gpu_class_device_memory_mib() -> Option<(u64, u64)> {
+    use crate::ggml_runtime::GgmlBackendKind;
+
+    crate::ggml_runtime_info()
+        .devices
+        .iter()
+        .find_map(|device| {
+            let is_gpu_class = matches!(
+                device.kind,
+                GgmlBackendKind::Gpu
+                    | GgmlBackendKind::IntegratedGpu
+                    | GgmlBackendKind::Accelerator
+            );
+            let memory = device.memory?;
+            is_gpu_class.then_some((
+                (memory.free_bytes as u64) / (1024 * 1024),
+                (memory.total_bytes as u64) / (1024 * 1024),
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_context_line_has_no_filename_or_path_field() {
+        let line = format_request_context_line(
+            RequestSource::ServerTranscribe,
+            "whisper-small",
+            "q4_k",
+            "metal",
+            12.34,
+            "wav",
+            16_000,
+            1,
+        );
+        // Regression guard for the privacy contract: no field named
+        // path/file/input in the formatted line, and no path separators that
+        // would suggest one snuck in through another field.
+        for forbidden in ["path=", "file=", "filename=", "input_path", "/", "\\"] {
+            assert!(
+                !line.contains(forbidden),
+                "request context line unexpectedly contains {forbidden:?}: {line}"
+            );
+        }
+        assert!(line.contains("source=server_transcribe"));
+        assert!(line.contains("model=whisper-small"));
+        assert!(line.contains("quant=q4_k"));
+        assert!(line.contains("backend=metal"));
+        assert!(line.contains("audio_duration_s=12.34"));
+        assert!(line.contains("container=wav"));
+        assert!(line.contains("sample_rate_hz=16000"));
+        assert!(line.contains("channels=1"));
+    }
+
+    #[test]
+    fn request_source_labels_are_stable_and_distinct() {
+        let all = [
+            RequestSource::CliTranscribe,
+            RequestSource::CliLive,
+            RequestSource::ServerTranscribe,
+            RequestSource::ServerTranslate,
+            RequestSource::ServerRealtime,
+            RequestSource::Unspecified,
+        ];
+        let mut labels: Vec<&'static str> =
+            all.iter().map(|source| source.as_log_label()).collect();
+        let original_len = labels.len();
+        labels.sort_unstable();
+        labels.dedup();
+        assert_eq!(labels.len(), original_len, "duplicate RequestSource labels");
+    }
+
+    #[test]
+    fn failure_context_line_reports_unknown_when_probes_are_absent() {
+        let line = format_failure_context_line(FailureCategory::Alloc, None, None);
+        assert_eq!(
+            line,
+            "stage=transcribe_failure error_category=alloc mem_available_mib=unknown"
+        );
+    }
+
+    #[test]
+    fn failure_context_line_includes_gpu_memory_when_present() {
+        let line =
+            format_failure_context_line(FailureCategory::Alloc, Some(2048), Some((512, 8192)));
+        assert!(line.contains("mem_available_mib=2048"));
+        assert!(line.contains("gpu_mem_free_mib=512"));
+        assert!(line.contains("gpu_mem_total_mib=8192"));
+    }
+
+    #[test]
+    fn failure_category_labels_are_distinct() {
+        let all = [
+            FailureCategory::Alloc,
+            FailureCategory::AudioIo,
+            FailureCategory::ModelResolve,
+            FailureCategory::UnsupportedCapability,
+            FailureCategory::Canceled,
+            FailureCategory::Transient,
+            FailureCategory::Decode,
+        ];
+        let mut labels: Vec<&'static str> = all.iter().map(|c| c.as_log_label()).collect();
+        let original_len = labels.len();
+        labels.sort_unstable();
+        labels.dedup();
+        assert_eq!(
+            labels.len(),
+            original_len,
+            "duplicate FailureCategory labels"
+        );
+    }
+}

--- a/crates/openasr-core/src/api/backend/request_context.rs
+++ b/crates/openasr-core/src/api/backend/request_context.rs
@@ -66,14 +66,17 @@ impl RequestSource {
 ///
 /// `model_id` must already be the resolved bare model id (e.g.
 /// `"whisper-small"`), never a file path; `quant_tag` and `backend_label` are
-/// short fixed-vocabulary tokens (`"q4_k"`, `"metal"`, ...); `container` is a
-/// codec/extension tag (e.g. `"wav"`), not a file name.
+/// short fixed-vocabulary tokens (`"q4_k"`, `"metal"`, ...).
 ///
-/// `sample_rate_hz`/`channels` are the *source* audio's real format (before
-/// this crate's normalization pipeline resamples/downmixes), not the
-/// normalized-pipeline constants -- print `"unknown"` (matching
+/// `container`, `sample_rate_hz`, and `channels` are all the *source* file's
+/// real, pre-conversion/pre-normalization properties -- `container` is the
+/// original upload/input's extension only (e.g. `"m4a"`), never the file
+/// name or any other path component; `sample_rate_hz`/`channels` are the
+/// source audio's real format, not this pipeline's normalized-output
+/// constants. All three print `"unknown"` (matching
 /// [`format_failure_context_line`]'s degrade style) rather than a fabricated
-/// number when the caller could not determine them.
+/// value when the caller could not determine them -- never derive any of the
+/// three from the *normalized/converted* temp file this crate decodes.
 #[allow(clippy::too_many_arguments)]
 pub fn format_request_context_line(
     source: RequestSource,
@@ -81,10 +84,11 @@ pub fn format_request_context_line(
     quant_tag: &str,
     backend_label: &str,
     audio_duration_seconds: f32,
-    container: &str,
+    container: Option<&str>,
     sample_rate_hz: Option<u32>,
     channels: Option<u16>,
 ) -> String {
+    let container = container.unwrap_or("unknown");
     let sample_rate_hz = sample_rate_hz.map_or_else(|| "unknown".to_string(), |hz| hz.to_string());
     let channels = channels.map_or_else(|| "unknown".to_string(), |count| count.to_string());
     format!(
@@ -104,7 +108,7 @@ pub fn log_request_context(
     quant_tag: &str,
     backend_label: &str,
     audio_duration_seconds: f32,
-    container: &str,
+    container: Option<&str>,
     sample_rate_hz: Option<u32>,
     channels: Option<u16>,
 ) {
@@ -247,7 +251,7 @@ mod tests {
             "q4_k",
             "metal",
             12.34,
-            "wav",
+            Some("wav"),
             Some(16_000),
             Some(1),
         );
@@ -271,23 +275,50 @@ mod tests {
     }
 
     #[test]
-    fn request_context_line_reports_the_true_source_format_not_a_normalized_constant() {
-        // Regression guard for the field's honesty contract: a non-16 kHz,
-        // non-mono source (e.g. a 44.1 kHz stereo m4a export) must show up as
-        // its own real numbers, not silently collapse to the normalization
-        // pipeline's 16000/1 constants.
+    fn request_context_line_container_is_extension_only_never_a_filename_stem() {
+        // Regression guard specific to `container`: even if a caller passed
+        // a whole file name or a dotted/multi-segment string by mistake, the
+        // formatter must not be the thing that makes a leaked stem look
+        // innocuous. This asserts the *contract* callers must uphold (see
+        // `TranscriptionRequest::source_container`'s doc comment) by checking
+        // a real extension renders as itself with no separators, matching
+        // the general no-path-separator guard above but scoped to this one
+        // field so a future regression here fails on its own.
         let line = format_request_context_line(
             RequestSource::ServerTranscribe,
             "whisper-small",
             "q4_k",
             "metal",
             12.34,
-            "m4a",
+            Some("m4a"),
             Some(44_100),
             Some(2),
         );
+        assert!(line.contains("container=m4a"));
+        assert!(!line.contains('/'));
+        assert!(!line.contains('\\'));
+    }
+
+    #[test]
+    fn request_context_line_reports_the_true_source_format_not_a_normalized_constant() {
+        // Regression guard for the field's honesty contract: a non-16 kHz,
+        // non-mono, non-wav source (e.g. a 44.1 kHz stereo m4a export) must
+        // show up as its own real values, not silently collapse to the
+        // normalization pipeline's wav/16000/1 constants.
+        let line = format_request_context_line(
+            RequestSource::ServerTranscribe,
+            "whisper-small",
+            "q4_k",
+            "metal",
+            12.34,
+            Some("m4a"),
+            Some(44_100),
+            Some(2),
+        );
+        assert!(line.contains("container=m4a"));
         assert!(line.contains("sample_rate_hz=44100"));
         assert!(line.contains("channels=2"));
+        assert!(!line.contains("container=wav"));
         assert!(!line.contains("sample_rate_hz=16000"));
         assert!(!line.contains("channels=1"));
     }
@@ -295,18 +326,19 @@ mod tests {
     #[test]
     fn request_context_line_degrades_to_unknown_when_source_format_is_unavailable() {
         // Honesty contract, the other direction: a caller with no probed
-        // source format passes `None`, which must render as `unknown`, never
-        // a fabricated/default number.
+        // source format/container passes `None`, which must render as
+        // `unknown`, never a fabricated/default value.
         let line = format_request_context_line(
             RequestSource::CliTranscribe,
             "whisper-small",
             "q4_k",
             "cpu",
             5.0,
-            "wav",
+            None,
             None,
             None,
         );
+        assert!(line.contains("container=unknown"));
         assert!(line.contains("sample_rate_hz=unknown"));
         assert!(line.contains("channels=unknown"));
     }

--- a/crates/openasr-core/src/api/native/types.rs
+++ b/crates/openasr-core/src/api/native/types.rs
@@ -301,6 +301,11 @@ pub struct NativeAsrOfflineRequest {
     /// carries through to.
     pub source_sample_rate_hz: Option<u32>,
     pub source_channels: Option<u16>,
+    /// The source file's container/codec extension, same
+    /// "probed/known, never fabricated" contract as
+    /// [`crate::TranscriptionRequest::source_container`], which this carries
+    /// through to.
+    pub source_container: Option<String>,
 }
 
 impl NativeAsrOfflineRequest {
@@ -313,6 +318,7 @@ impl NativeAsrOfflineRequest {
             source: RequestSource::default(),
             source_sample_rate_hz: None,
             source_channels: None,
+            source_container: None,
         }
     }
 
@@ -346,6 +352,14 @@ impl NativeAsrOfflineRequest {
     ) -> Self {
         self.source_sample_rate_hz = sample_rate_hz;
         self.source_channels = channels;
+        self
+    }
+
+    /// Sets the source file's container/codec extension. Pass the raw
+    /// extension (e.g. `"m4a"`) or `None` when genuinely unknown -- never
+    /// the file name.
+    pub fn with_source_container(mut self, container: Option<String>) -> Self {
+        self.source_container = container;
         self
     }
 }

--- a/crates/openasr-core/src/api/native/types.rs
+++ b/crates/openasr-core/src/api/native/types.rs
@@ -1,7 +1,7 @@
 use std::{fmt, path::PathBuf};
 
 use crate::realtime::RealtimeSessionId;
-use crate::{LongFormOptions, PhraseBiasConfig, TranscriptionTask};
+use crate::{LongFormOptions, PhraseBiasConfig, RequestSource, TranscriptionTask};
 
 macro_rules! impl_enum_str_display {
     ($name:ident { $($variant:ident => $value:literal),+ $(,)? }) => {
@@ -288,6 +288,19 @@ pub struct NativeAsrOfflineRequest {
     pub options: NativeAsrRequestOptions,
     pub longform: Option<LongFormOptions>,
     pub display_file_name: Option<String>,
+    /// Which call path built this request -- carried through to
+    /// [`crate::TranscriptionRequest::source`] by
+    /// `native_offline_request_to_transcription_request` for the
+    /// `stage=request_context` `daemon.log` line. Defaults to
+    /// [`RequestSource::Unspecified`]; callers set it via [`Self::with_source`].
+    pub source: RequestSource,
+    /// The *source* audio's real sample rate/channel count, before this
+    /// crate's normalization pipeline resamples/downmixes -- same
+    /// "probed/known, never fabricated" contract as
+    /// [`crate::TranscriptionRequest::source_sample_rate_hz`], which this
+    /// carries through to.
+    pub source_sample_rate_hz: Option<u32>,
+    pub source_channels: Option<u16>,
 }
 
 impl NativeAsrOfflineRequest {
@@ -297,6 +310,9 @@ impl NativeAsrOfflineRequest {
             options: NativeAsrRequestOptions::default(),
             longform: None,
             display_file_name: None,
+            source: RequestSource::default(),
+            source_sample_rate_hz: None,
+            source_channels: None,
         }
     }
 
@@ -312,6 +328,24 @@ impl NativeAsrOfflineRequest {
 
     pub fn with_display_file_name(mut self, display_file_name: Option<String>) -> Self {
         self.display_file_name = display_file_name;
+        self
+    }
+
+    pub fn with_source(mut self, source: RequestSource) -> Self {
+        self.source = source;
+        self
+    }
+
+    /// Sets the source audio's real sample rate/channel count. Pass `None`
+    /// for either when it is genuinely unknown -- never a normalization
+    /// constant; see this field's doc comment.
+    pub fn with_source_audio_format(
+        mut self,
+        sample_rate_hz: Option<u32>,
+        channels: Option<u16>,
+    ) -> Self {
+        self.source_sample_rate_hz = sample_rate_hz;
+        self.source_channels = channels;
         self
     }
 }

--- a/crates/openasr-core/src/audio/prepare.rs
+++ b/crates/openasr-core/src/audio/prepare.rs
@@ -138,7 +138,7 @@ fn wav_is_already_conformant(path: &std::path::Path) -> bool {
 fn try_symphonia_prepare(
     info: &AudioInputInfo,
 ) -> Result<Option<PreparedAudioInput>, AudioPreparationError> {
-    let Some(wav_bytes) =
+    let Some((wav_bytes, source_format)) =
         symphonia_decode::try_decode_to_pcm16_mono_16k_wav(&info.path, info.extension.as_deref())
     else {
         return Ok(None);
@@ -155,8 +155,16 @@ fn try_symphonia_prepare(
         }
     })?;
 
+    // The probe stage (`probe::probe_audio_details`) only reads source
+    // format off WAV's fmt chunk; for the non-wav formats that land here it
+    // could not have known this yet, so fill it in now from the decode that
+    // just ran -- the true source format, not a second separate probe.
+    let mut original = info.clone();
+    original.sample_rate_hz = Some(source_format.sample_rate_hz);
+    original.channels = Some(source_format.channels);
+
     Ok(Some(PreparedAudioInput {
-        original: info.clone(),
+        original,
         prepared_path,
         temp_dir: Some(temp_dir),
     }))

--- a/crates/openasr-core/src/audio/probe.rs
+++ b/crates/openasr-core/src/audio/probe.rs
@@ -1,17 +1,26 @@
 use std::path::Path;
 
-use super::{AudioInputInfo, AudioInputIssue, RECOGNIZED_EXTENSIONS, probe_wav_duration};
+use super::{AudioInputInfo, AudioInputIssue, RECOGNIZED_EXTENSIONS, decode, probe_wav_duration};
 
 pub(super) fn probe_audio_details(path: &Path) -> AudioInputInfo {
     let extension = normalized_extension(path);
     let recognized_extension = is_recognized_extension(extension.as_deref());
     let duration_seconds = wav_duration_if_supported(path, extension.as_deref());
+    // WAV's fmt chunk names the source sample rate/channel count directly, no
+    // decode needed. Other recognized formats (m4a/mp3/flac/ogg/...) only
+    // reveal their true source format once actually decoded -- see
+    // `prepare::try_symphonia_prepare`, which fills these fields in on this
+    // same `AudioInputInfo` after a successful in-process decode. Left `None`
+    // here for anything this probe cannot cheaply determine, never guessed.
+    let (sample_rate_hz, channels) = wav_source_format_if_supported(path, extension.as_deref());
 
     AudioInputInfo {
         path: path.to_path_buf(),
         extension: extension.clone(),
         recognized_extension,
         duration_seconds,
+        sample_rate_hz,
+        channels,
         issues: collect_issues(extension, recognized_extension),
     }
 }
@@ -32,6 +41,19 @@ fn wav_duration_if_supported(path: &Path, extension: Option<&str>) -> Option<f64
         probe_wav_duration(path)
     } else {
         None
+    }
+}
+
+fn wav_source_format_if_supported(
+    path: &Path,
+    extension: Option<&str>,
+) -> (Option<u32>, Option<u16>) {
+    if extension != Some("wav") {
+        return (None, None);
+    }
+    match decode::probe_wav_pcm_shape(path) {
+        Ok(Some(fmt)) => (Some(fmt.sample_rate), Some(fmt.channels)),
+        _ => (None, None),
     }
 }
 

--- a/crates/openasr-core/src/audio/symphonia_decode.rs
+++ b/crates/openasr-core/src/audio/symphonia_decode.rs
@@ -30,6 +30,17 @@ const TARGET_SAMPLE_RATE: u32 = 16_000;
 const RESAMPLE_CHUNK_FRAMES: usize = 4096;
 const RESAMPLE_SUB_CHUNKS: usize = 2;
 
+/// The decoded file's *source* format, before this module's mono-downmix and
+/// 16 kHz resample -- e.g. `{ sample_rate_hz: 44100, channels: 2 }` for a
+/// typical music-app m4a export. Surfaced so callers (see
+/// `prepare::try_symphonia_prepare`) can report the true source format for
+/// diagnostics without a second, separate probe of the same file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DecodedAudioSourceFormat {
+    pub(crate) sample_rate_hz: u32,
+    pub(crate) channels: u16,
+}
+
 /// Attempt to decode `path` to a 16 kHz mono PCM16 WAV entirely in-process.
 /// Returns `None` (never an error) if the container/codec is not supported
 /// by the enabled symphonia features, or if decoding otherwise fails --
@@ -37,22 +48,31 @@ const RESAMPLE_SUB_CHUNKS: usize = 2;
 pub(crate) fn try_decode_to_pcm16_mono_16k_wav(
     path: &Path,
     extension: Option<&str>,
-) -> Option<Vec<u8>> {
+) -> Option<(Vec<u8>, DecodedAudioSourceFormat)> {
     let mono = decode_to_mono_f32(path, extension)?;
     if mono.samples.is_empty() {
         return None;
     }
+    let source_format = DecodedAudioSourceFormat {
+        sample_rate_hz: mono.sample_rate,
+        channels: mono.channels,
+    };
     let resampled = if mono.sample_rate == TARGET_SAMPLE_RATE {
         mono.samples
     } else {
         resample_mono_to_16k(&mono.samples, mono.sample_rate)?
     };
-    Some(encode_pcm16_mono_16k_wav(&resampled))
+    Some((encode_pcm16_mono_16k_wav(&resampled), source_format))
 }
 
 struct DecodedMono {
     samples: Vec<f32>,
     sample_rate: u32,
+    /// The source track's channel count *before* this function's mono
+    /// downmix (which always collapses to 1) -- captured from the first
+    /// successfully decoded packet's `AudioBufferRef::spec()`, same as
+    /// `sample_rate` below.
+    channels: u16,
 }
 
 fn decode_to_mono_f32(path: &Path, extension: Option<&str>) -> Option<DecodedMono> {
@@ -92,6 +112,7 @@ fn decode_to_mono_f32(path: &Path, extension: Option<&str>) -> Option<DecodedMon
 
     let mut samples: Vec<f32> = Vec::new();
     let mut sample_rate: Option<u32> = None;
+    let mut channels: Option<u16> = None;
 
     loop {
         let packet = match format.next_packet() {
@@ -109,8 +130,9 @@ fn decode_to_mono_f32(path: &Path, extension: Option<&str>) -> Option<DecodedMon
 
         match decoder.decode(&packet) {
             Ok(decoded) => {
-                let rate = decoded.spec().rate;
-                sample_rate.get_or_insert(rate);
+                let spec = decoded.spec();
+                sample_rate.get_or_insert(spec.rate);
+                channels.get_or_insert(spec.channels.count() as u16);
                 push_downmixed_samples(&decoded, &mut samples);
             }
             // A single corrupt/undecodable packet does not doom the whole
@@ -128,10 +150,15 @@ fn decode_to_mono_f32(path: &Path, extension: Option<&str>) -> Option<DecodedMon
     if sample_rate == 0 {
         return None;
     }
+    // `.max(1)` mirrors `push_downmixed_samples`'s own floor: a spec reporting
+    // zero channels is nonsensical, so treat it the same as "unknown" rather
+    // than surfacing an impossible `0` in a diagnostics field.
+    let channels = channels.unwrap_or(1).max(1);
 
     Some(DecodedMono {
         samples,
         sample_rate,
+        channels,
     })
 }
 

--- a/crates/openasr-core/src/audio/types.rs
+++ b/crates/openasr-core/src/audio/types.rs
@@ -15,6 +15,17 @@ pub struct AudioInputInfo {
     pub extension: Option<String>,
     pub recognized_extension: bool,
     pub duration_seconds: Option<f64>,
+    /// The *source* file's sample rate in Hz, before any resampling this
+    /// crate's normalization pipeline applies -- e.g. `8000` for a phone-call
+    /// recording or `44100`/`48000` for a typical music-app export. `None`
+    /// when the source rate could not be determined (an unrecognized
+    /// extension, or a format this crate does not decode in-process --
+    /// callers must not fabricate a value in that case; see
+    /// `crate::api::backend::request_context`'s privacy/honesty contract).
+    pub sample_rate_hz: Option<u32>,
+    /// The source file's channel count, before this pipeline's mono downmix.
+    /// Same "probed, never fabricated" contract as `sample_rate_hz`.
+    pub channels: Option<u16>,
     pub issues: Vec<AudioInputIssue>,
 }
 

--- a/crates/openasr-core/src/host.rs
+++ b/crates/openasr-core/src/host.rs
@@ -64,3 +64,391 @@ pub fn host_quant_recommendation_profile() -> CatalogQuantRecommendationProfile 
         memory_budget_bytes: host_total_memory_bytes().map(|total| total / 4 * 3),
     }
 }
+
+/// Best-effort memory currently available to new allocations, in bytes (i.e.
+/// free-or-reclaimable-without-swapping), or `None` on platforms without a
+/// probe. Used only for local diagnostics -- the daemon-log system line and
+/// the failure-context line's "how much headroom was left" field -- never for
+/// admission control, so an occasional `None` (unsupported platform, a failed
+/// syscall) degrading to an absent log field is acceptable.
+pub fn host_available_memory_bytes() -> Option<u64> {
+    #[cfg(target_os = "macos")]
+    // `libc::mach_host_self` is marked deprecated upstream in favor of the
+    // separate `mach2` crate; pulling in another crate for one function this
+    // narrow does not fit this workspace's dependency-trimming posture (see
+    // this module's and `stage_timing`'s doc comments), so the deprecation is
+    // acknowledged here rather than by adding a dependency.
+    #[allow(deprecated)]
+    {
+        // Mach's `host_statistics64(HOST_VM_INFO64)` reports page *counts*, not
+        // bytes; the host's own page size (16 KiB on Apple Silicon, 4 KiB on
+        // Intel Macs -- never assume either) comes from `sysconf(_SC_PAGESIZE)`.
+        // "Available" is approximated as free + inactive pages: inactive pages
+        // are clean and reclaimable without swapping, which is the same rough
+        // notion Activity Monitor and `vm_stat` use, and closer to "can a new
+        // allocation land here" than `free_count` alone (which undercounts by
+        // excluding easily-reclaimable file-backed pages).
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if page_size <= 0 {
+            return None;
+        }
+        let mut info: libc::vm_statistics64 = unsafe { std::mem::zeroed() };
+        let mut count = libc::HOST_VM_INFO64_COUNT;
+        // SAFETY: `mach_host_self` returns a borrowed (no-release-needed) host
+        // port; `host_statistics64` fills the caller-owned `info`, sized via
+        // `count` set to the flavor's expected word count as the API requires.
+        let ret = unsafe {
+            libc::host_statistics64(
+                libc::mach_host_self(),
+                libc::HOST_VM_INFO64,
+                (&mut info as *mut libc::vm_statistics64).cast::<libc::integer_t>(),
+                &mut count,
+            )
+        };
+        if ret != 0 {
+            return None;
+        }
+        let available_pages = u64::from(info.free_count) + u64::from(info.inactive_count);
+        Some(available_pages.saturating_mul(page_size as u64))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // The kernel-computed `MemAvailable` estimate (present since Linux
+        // 3.14) already accounts for reclaimable caches/slabs; prefer it over
+        // hand-rolling `MemFree + Cached` from the same file.
+        let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+        meminfo.lines().find_map(|line| {
+            line.strip_prefix("MemAvailable:")?
+                .split_whitespace()
+                .next()?
+                .parse::<u64>()
+                .ok()
+                .map(|kb| kb.saturating_mul(1024))
+        })
+    }
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+
+        // SAFETY: same contract as `host_total_memory_bytes`'s Windows arm.
+        let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+        status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+        let ok = unsafe { GlobalMemoryStatusEx(&mut status) };
+        (ok != 0).then_some(status.ullAvailPhys)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    {
+        None
+    }
+}
+
+/// Best-effort human-readable CPU model string (e.g. `"Apple M1"` /
+/// `"Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz"` / `"AMD Ryzen 9 7950X"`),
+/// or `None` on platforms without a probe. Diagnostics only, never parsed
+/// back by this codebase -- format is whatever the OS reports.
+pub fn host_cpu_model() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        sysctl_string("machdep.cpu.brand_string")
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+        // x86 reports "model name"; some ARM boards report "Hardware" or
+        // "Model" instead (no "model name" key at all) -- try each in turn
+        // rather than assuming x86's key exists on every kernel.
+        for key in ["model name", "Model", "Hardware"] {
+            if let Some(value) = cpuinfo.lines().find_map(|line| {
+                let (line_key, value) = line.split_once(':')?;
+                (line_key.trim() == key).then(|| value.trim().to_string())
+            }) && !value.is_empty()
+            {
+                return Some(value);
+            }
+        }
+        None
+    }
+    #[cfg(windows)]
+    {
+        registry_string_value(
+            c"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+            c"ProcessorNameString",
+        )
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    {
+        None
+    }
+}
+
+/// `(os_name, os_version)` best-effort pair, e.g. `("macOS", "15.5")` /
+/// `("Linux", "Ubuntu 24.04.1 LTS")` / `("Windows", "Windows 11 Pro (build
+/// 26100)")`. `os_name` is always a fixed literal per platform (never
+/// `None`); `os_version` is `None` only when the platform-specific probe
+/// fails.
+pub fn host_os_name_and_version() -> (&'static str, Option<String>) {
+    #[cfg(target_os = "macos")]
+    {
+        // `kern.osproductversion` is the user-facing marketing version (e.g.
+        // "15.5"); it has existed since 10.13.4, which is far below this
+        // workspace's realistic support floor. `kern.osrelease` (the Darwin
+        // kernel version, e.g. "24.5.0") is appended for precise bug-report
+        // correlation, matching Apple's own "macOS 15.5 (24F74)"-style
+        // reporting convention without needing the private build-number API.
+        let product_version = sysctl_string("kern.osproductversion");
+        let darwin_release = sysctl_string("kern.osrelease");
+        let version = match (product_version, darwin_release) {
+            (Some(product), Some(darwin)) => Some(format!("{product} (Darwin {darwin})")),
+            (Some(product), None) => Some(product),
+            (None, Some(darwin)) => Some(format!("Darwin {darwin}")),
+            (None, None) => None,
+        };
+        ("macOS", version)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // `/etc/os-release`'s `PRETTY_NAME` is the de-facto standard
+        // distro-identification file (systemd spec, but honored far beyond
+        // systemd distros); falls back to the raw kernel release
+        // (`uname -r` equivalent) via `/proc/sys/kernel/osrelease` when the
+        // distro file is missing (minimal/embedded images).
+        let pretty_name = std::fs::read_to_string("/etc/os-release")
+            .ok()
+            .and_then(|contents| {
+                contents.lines().find_map(|line| {
+                    let value = line.strip_prefix("PRETTY_NAME=")?;
+                    Some(value.trim_matches('"').to_string())
+                })
+            });
+        let version = pretty_name.or_else(|| {
+            std::fs::read_to_string("/proc/sys/kernel/osrelease")
+                .ok()
+                .map(|release| format!("kernel {}", release.trim()))
+        });
+        ("Linux", version)
+    }
+    #[cfg(windows)]
+    {
+        let product_name = registry_string_value(
+            c"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+            c"ProductName",
+        );
+        let build_number = registry_string_value(
+            c"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+            c"CurrentBuildNumber",
+        );
+        let version = match (product_name, build_number) {
+            (Some(name), Some(build)) => Some(format!("{name} (build {build})")),
+            (Some(name), None) => Some(name),
+            (None, Some(build)) => Some(format!("Windows (build {build})")),
+            (None, None) => None,
+        };
+        ("Windows", version)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    {
+        ("Unknown", None)
+    }
+}
+
+/// Reads a string-valued `sysctlbyname` key (macOS only): a null-terminated C
+/// string whose length is not known ahead of time, so this probes the
+/// required buffer size with a `NULL` output pointer first (the documented
+/// `sysctlbyname` idiom), allocates exactly that much, then reads the value.
+#[cfg(target_os = "macos")]
+fn sysctl_string(name: &str) -> Option<String> {
+    let name = std::ffi::CString::new(name).ok()?;
+    let mut size = 0usize;
+    // SAFETY: a null oldp/oldlenp-only call is the documented way to query
+    // the required buffer size without writing through a null pointer.
+    let probe = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            std::ptr::null_mut(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if probe != 0 || size == 0 {
+        return None;
+    }
+    let mut buffer = vec![0u8; size];
+    // SAFETY: `buffer` is exactly `size` bytes as just reported by the probe
+    // call above; `size` is passed back in as the buffer's capacity.
+    let ret = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            buffer.as_mut_ptr().cast::<libc::c_void>(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret != 0 {
+        return None;
+    }
+    // `size` may include the trailing NUL; strip any trailing NUL bytes
+    // before lossily decoding (sysctl string values are not guaranteed UTF-8,
+    // though in practice CPU brand strings and OS version strings are ASCII).
+    while buffer.last() == Some(&0) {
+        buffer.pop();
+    }
+    Some(String::from_utf8_lossy(&buffer).into_owned())
+}
+
+/// Reads a single `REG_SZ` value under `HKEY_LOCAL_MACHINE\{subkey}` (Windows
+/// only). Returns `None` on any failure (key/value missing, wrong type,
+/// permission denied) -- this is a best-effort diagnostics probe, never a
+/// hard dependency.
+#[cfg(windows)]
+fn registry_string_value(subkey: &std::ffi::CStr, value_name: &std::ffi::CStr) -> Option<String> {
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::System::Registry::{
+        HKEY, HKEY_LOCAL_MACHINE, KEY_READ, REG_SZ, RegCloseKey, RegOpenKeyExA, RegQueryValueExA,
+    };
+
+    // The wide (`*W`) registry APIs are the normal Rust-on-Windows idiom, but
+    // every key/value name this module reads is ASCII, so the simpler `*A`
+    // (ANSI) entry points avoid a UTF-16 round trip for no behavioral
+    // difference here.
+    let mut key: HKEY = std::ptr::null_mut();
+    // SAFETY: `subkey` and `value_name` are caller-provided, NUL-terminated
+    // `&CStr`s (guaranteed by the type); `key` is an out-pointer this call
+    // fills on success.
+    let open_status = unsafe {
+        RegOpenKeyExA(
+            HKEY_LOCAL_MACHINE,
+            subkey.as_ptr().cast(),
+            0,
+            KEY_READ,
+            &mut key,
+        )
+    };
+    if open_status != ERROR_SUCCESS {
+        return None;
+    }
+
+    let mut value_type: u32 = 0;
+    let mut data_len: u32 = 0;
+    // First call with a null data buffer to discover the required length
+    // (the documented `RegQueryValueEx` idiom), matching `sysctl_string`'s
+    // two-call shape above.
+    // SAFETY: all out-pointers are valid locals; the data buffer pointer is
+    // null, which `RegQueryValueExA` accepts to mean "size query only".
+    let probe_status = unsafe {
+        RegQueryValueExA(
+            key,
+            value_name.as_ptr().cast(),
+            std::ptr::null_mut(),
+            &mut value_type,
+            std::ptr::null_mut(),
+            &mut data_len,
+        )
+    };
+    if probe_status != ERROR_SUCCESS || value_type != REG_SZ || data_len == 0 {
+        // SAFETY: `key` was successfully opened above.
+        unsafe { RegCloseKey(key) };
+        return None;
+    }
+
+    let mut buffer = vec![0u8; data_len as usize];
+    // SAFETY: `buffer` is exactly `data_len` bytes as just reported by the
+    // probe call; `data_len` is passed back in as the buffer's capacity.
+    let read_status = unsafe {
+        RegQueryValueExA(
+            key,
+            value_name.as_ptr().cast(),
+            std::ptr::null_mut(),
+            &mut value_type,
+            buffer.as_mut_ptr(),
+            &mut data_len,
+        )
+    };
+    // SAFETY: `key` was successfully opened above.
+    unsafe { RegCloseKey(key) };
+    if read_status != ERROR_SUCCESS {
+        return None;
+    }
+    while buffer.last() == Some(&0) {
+        buffer.pop();
+    }
+    Some(String::from_utf8_lossy(&buffer).into_owned())
+}
+
+/// One-line, structured `daemon.log` summary of host system facts: OS
+/// name+version, CPU model, and total/available physical RAM. Logged once at
+/// daemon boot right next to the existing `stage=ggml_backend` device
+/// enumeration line, so a support bundle of `daemon.log` + `desktop.log`
+/// alone (no separate "what's your OS/CPU/RAM" back-and-forth) is enough to
+/// start triaging a report. Deliberately host-hardware-only: no user data, no
+/// file paths, no network calls (matches this crate's no-telemetry contract).
+pub fn host_system_boot_summary() -> String {
+    let (os_name, os_version) = host_os_name_and_version();
+    let os_version = os_version.as_deref().unwrap_or("unknown");
+    let cpu_model = host_cpu_model();
+    let cpu_model = cpu_model.as_deref().unwrap_or("unknown");
+    let mem_total_mib = host_total_memory_bytes().map(bytes_to_mib);
+    let mem_available_mib = host_available_memory_bytes().map(bytes_to_mib);
+    format!(
+        "os={os_name} os_version=\"{os_version}\" cpu=\"{cpu_model}\" mem_total_mib={} mem_available_mib={}",
+        mem_total_mib.map_or_else(|| "unknown".to_string(), |mib| mib.to_string()),
+        mem_available_mib.map_or_else(|| "unknown".to_string(), |mib| mib.to_string()),
+    )
+}
+
+fn bytes_to_mib(bytes: u64) -> u64 {
+    bytes / (1024 * 1024)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_available_memory_is_plausible_on_supported_platforms() {
+        if cfg!(any(target_os = "macos", target_os = "linux", windows)) {
+            let available = host_available_memory_bytes()
+                .expect("supported platform should return an available-memory probe");
+            assert!(available > 0, "implausible zero available memory");
+            if let Some(total) = host_total_memory_bytes() {
+                assert!(
+                    available <= total,
+                    "available ({available}) must not exceed total ({total})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn host_cpu_model_is_nonempty_on_supported_platforms() {
+        if cfg!(any(target_os = "macos", target_os = "linux", windows)) {
+            let model = host_cpu_model();
+            // Best-effort: still allow `None` (e.g. a locked-down /proc on an
+            // exotic Linux sandbox), but if present it must not be blank.
+            if let Some(model) = model {
+                assert!(!model.trim().is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn host_os_name_and_version_reports_a_fixed_nonempty_name() {
+        let (name, _version) = host_os_name_and_version();
+        assert!(!name.is_empty());
+    }
+
+    #[test]
+    fn host_system_boot_summary_has_expected_keys() {
+        let summary = host_system_boot_summary();
+        for key in [
+            "os=",
+            "os_version=",
+            "cpu=",
+            "mem_total_mib=",
+            "mem_available_mib=",
+        ] {
+            assert!(summary.contains(key), "missing {key} in {summary:?}");
+        }
+    }
+}

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -53,11 +53,12 @@ pub mod testing;
 pub(crate) mod translation;
 
 pub use api::backend::{
-    ActiveTranscriptionControlGuard, BackendError, BackendKind, ExecutionTarget,
+    ActiveTranscriptionControlGuard, BackendError, BackendKind, ExecutionTarget, FailureCategory,
     NATIVE_RUNTIME_MODEL_ID_AUTO, NativeBackend, NativeBackendExecutor, NativeRuntimeModelAdapter,
     NativeRuntimeModelIdSource, NativeRuntimeModelIdentity, NativeRuntimeModelIdentityError,
-    Segment, SliceBoundaryControl, Transcription, TranscriptionBackend, TranscriptionControl,
-    TranscriptionRequest, TranscriptionTask, WordTimestamp, add_segment_word_timestamps,
+    RequestSource, Segment, SliceBoundaryControl, Transcription, TranscriptionBackend,
+    TranscriptionControl, TranscriptionRequest, TranscriptionTask, WordTimestamp,
+    add_segment_word_timestamps, format_failure_context_line, format_request_context_line,
     install_active_transcription_control, native_adapter_supports_source_language_hint,
     native_runtime_model_adapter_for_path, native_runtime_model_refs_match,
     native_runtime_realtime_capabilities_for_path,
@@ -144,7 +145,10 @@ pub use ggml_runtime::{
     validate_ggml_runtime_source_path,
 };
 pub use home::{OpenAsrHomeError, openasr_home, resolve_openasr_home};
-pub use host::{host_quant_recommendation_profile, host_total_memory_bytes};
+pub use host::{
+    host_available_memory_bytes, host_cpu_model, host_os_name_and_version,
+    host_quant_recommendation_profile, host_system_boot_summary, host_total_memory_bytes,
+};
 pub use hotword::{
     DEFAULT_PHRASE_BIAS_BOOST, MAX_PHRASE_BIAS_BOOST, MAX_PHRASE_BIAS_ENTRIES,
     MAX_PHRASE_BIAS_PHRASE_CHARS, MAX_PHRASE_BIAS_TOTAL_CHARS, PhraseBiasConfig, PhraseBiasEntry,

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -240,6 +240,16 @@ pub async fn serve_with_launch_options(
             openasr_core::ggml_runtime_boot_summary(&openasr_core::ggml_runtime_info())
         ),
     );
+    // Host system facts (OS/CPU/RAM) -- diagnostics only, no user data -- so a
+    // bug report's `daemon.log` + the desktop's `desktop.log` are enough to
+    // triage without asking the reporter for their OS/CPU/RAM by hand.
+    openasr_core::stage_timing::log_event(
+        "server_boot",
+        format_args!(
+            "stage=host_system {}",
+            openasr_core::host_system_boot_summary()
+        ),
+    );
     validate_listen_security(addr, &launch_options)?;
     openasr_core::stage_timing::log_stage(
         "server_boot",

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -1255,6 +1255,11 @@ async fn run_realtime_backend_job(runtime: ServerRuntime, job: BackendJob) -> Ba
     let response_language = job.language.clone();
     let request = openasr_core::TranscriptionRequest::new(job.temp_wav.path(), job.model_id)
         .with_source(openasr_core::RequestSource::ServerRealtime)
+        // Not a normalization-pipeline guess: `write_temp_utterance_wav`
+        // (see `realtime/mod.rs`) always writes PCM16 mono 16 kHz -- this is
+        // the realtime session's real fixed capture format, unlike an
+        // uploaded file whose source format is unknown until probed/decoded.
+        .with_source_audio_format(Some(16_000), Some(1))
         .with_language(job.language)
         .with_task(job.task)
         .with_prompt(job.prompt)

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -1256,10 +1256,12 @@ async fn run_realtime_backend_job(runtime: ServerRuntime, job: BackendJob) -> Ba
     let request = openasr_core::TranscriptionRequest::new(job.temp_wav.path(), job.model_id)
         .with_source(openasr_core::RequestSource::ServerRealtime)
         // Not a normalization-pipeline guess: `write_temp_utterance_wav`
-        // (see `realtime/mod.rs`) always writes PCM16 mono 16 kHz -- this is
-        // the realtime session's real fixed capture format, unlike an
-        // uploaded file whose source format is unknown until probed/decoded.
+        // (see `realtime/mod.rs`) always writes PCM16 mono 16 kHz WAV -- this
+        // is the realtime session's real fixed capture format/container,
+        // unlike an uploaded file whose source format is unknown until
+        // probed/decoded.
         .with_source_audio_format(Some(16_000), Some(1))
+        .with_source_container(Some("wav".to_string()))
         .with_language(job.language)
         .with_task(job.task)
         .with_prompt(job.prompt)

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -1254,6 +1254,7 @@ async fn run_realtime_backend_job(runtime: ServerRuntime, job: BackendJob) -> Ba
     // only source. Capture it before job.language is moved into the builder.
     let response_language = job.language.clone();
     let request = openasr_core::TranscriptionRequest::new(job.temp_wav.path(), job.model_id)
+        .with_source(openasr_core::RequestSource::ServerRealtime)
         .with_language(job.language)
         .with_task(job.task)
         .with_prompt(job.prompt)

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -284,6 +284,11 @@ async fn run_offline_transcription(
     if let Some(task) = task_override {
         parsed.request.task = Some(task);
     }
+    parsed.request.source = if task_override == Some(TranscriptionTask::Translate) {
+        openasr_core::RequestSource::ServerTranslate
+    } else {
+        openasr_core::RequestSource::ServerTranscribe
+    };
     let history_request = parsed.request.clone();
     if runtime.backend == BackendKind::Native {
         validate_native_request_model(&runtime, &parsed.request.model_id)

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1384,7 +1384,12 @@ pub(crate) async fn transcribe_with_runtime(
                 .with_source_audio_format(
                     prepared.original().sample_rate_hz,
                     prepared.original().channels,
-                );
+                )
+                // Extension only, off the upload's own temp file (which
+                // preserves the client's original extension via
+                // `safe_extension_suffix` -- see `ingest_field` above); never
+                // the client-supplied file name/stem itself.
+                .with_source_container(prepared.original().extension.clone());
             let executor = NativeBackendExecutor;
             let mut transcription = NativeAsrExecutor::transcribe(
                 &executor,

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1373,7 +1373,18 @@ pub(crate) async fn transcribe_with_runtime(
                         .with_word_timestamps_refine(request.word_timestamps_refine),
                 )
                 .with_longform(request.longform.clone())
-                .with_display_file_name(request.display_file_name.clone());
+                .with_display_file_name(request.display_file_name.clone())
+                .with_source(request.source)
+                // The source audio's real format for the `stage=request_context`
+                // log line -- `prepared.original()` is the pre-normalization
+                // probe (WAV fmt chunk) or decode (other recognized formats)
+                // result; `None` when this pipeline could not determine it
+                // (unrecognized extension, or a format only the external
+                // ffmpeg/afconvert fallback handles).
+                .with_source_audio_format(
+                    prepared.original().sample_rate_hz,
+                    prepared.original().channels,
+                );
             let executor = NativeBackendExecutor;
             let mut transcription = NativeAsrExecutor::transcribe(
                 &executor,


### PR DESCRIPTION
## Summary

- Adds a `stage=host_system` line at daemon boot (OS name+version, CPU model, total/available RAM), right next to the existing `stage=ggml_backend` device-enumeration line.
- Adds a `stage=request_context` line per transcription request (call-path source, model id, quant tag, execution backend, audio duration/container/sample rate/channels).
- Adds a `stage=transcribe_failure` line on any native transcription error (coarse failure category, available RAM, and GPU free/total memory when a GPU-class device is present).

## Why

The desktop side already logs host/request/error context in `desktop.log`. `daemon.log` had none of this, so triaging a bug report needed asking the reporter for their OS/CPU/RAM and model setup by hand. These three lines make `daemon.log` self-sufficient for that.

## Changes

- `crates/openasr-core/src/host.rs`: adds `host_available_memory_bytes`, `host_cpu_model`, `host_os_name_and_version`, and `host_system_boot_summary` (macOS via `sysctlbyname`/Mach `host_statistics64`, Linux via `/proc/meminfo`+`/proc/cpuinfo`+`/etc/os-release`, Windows via `GlobalMemoryStatusEx`+registry reads).
- `crates/openasr-core/src/api/backend/request_context.rs` (new): `RequestSource` (which call path built the request), `FailureCategory` (coarse `BackendError` bucket), and the pure line-formatting functions plus their `daemon.log` loggers.
- `crates/openasr-core/src/api/backend/mod.rs`: adds `TranscriptionRequest::source` (defaults to `Unspecified`) and `.with_source(...)`.
- `crates/openasr-core/src/api/backend/native_transcribe.rs`: logs the request-context line after model resolution + audio prep succeed (before decode dispatch), and wraps the top-level entry point to log the failure-context line on any `Err`.
- `crates/openasr-server/src/lib.rs`: logs `stage=host_system` at boot.
- `crates/openasr-server/src/routes/transcription.rs`, `crates/openasr-server/src/realtime/native_worker.rs`, `crates/openasr-cli/src/main.rs`, `crates/openasr-cli/src/live.rs`: set `RequestSource` at each of the four real `TranscriptionRequest` construction call sites (server transcribe/translate/realtime, CLI transcribe/live).
- `Cargo.toml`: enables `windows-sys`'s `Win32_System_Registry` feature (needed for the Windows CPU-model/OS-version reads). No new crate dependency -- reuses `libc`/`windows-sys`, both already workspace dependencies, matching this crate's existing dependency-free-by-default posture for host probes (see `host_total_memory_bytes` and `metrics::peak_rss`).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2759 passed, 128 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check` (pre-existing duplicate-dependency warnings only, unrelated to this change)

New unit tests: `host::tests::*` (available-memory/CPU-model/OS-version probes return plausible non-empty values, and the boot summary contains the expected keys) and `api::backend::request_context::tests::*` (the request-context line contains no `path=`/`file=`/path-separator field -- a regression guard for the privacy contract -- plus label-uniqueness checks for both new enums and a failure-line formatting check).

## Manual smoke checks

Ran with an isolated `OPENASR_HOME` (copied model pack, never the real home):

```
$ openasr serve --backend native
[... +0ms] server_boot: stage=ggml_backend best_backend=MTL0 cpu_backend=CPU devices=[...]
[... +0ms] server_boot: stage=host_system os=macOS os_version="26.5.2 (Darwin 25.5.0)" cpu="Apple M1" mem_total_mib=16384 mem_available_mib=7023

$ openasr transcribe fixtures/jfk.wav --backend native --model moonshine-tiny --model-pack .../moonshine-tiny-q8_0.oasr
[...] native_transcribe: stage=request_context source=cli_transcribe model=moonshine-tiny:q8_0 quant=q8_0 backend=cpu audio_duration_s=11.00 container=wav sample_rate_hz=16000 channels=1

$ openasr transcribe bad.wav --backend native --model moonshine-tiny --model-pack ...
[...] native_transcribe: stage=transcribe_failure error_category=audio_io mem_available_mib=7735 gpu_mem_free_mib=12123 gpu_mem_total_mib=12124
```

No file name or path appears in either new per-request line.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed. -- not needed; this is additive, internal `daemon.log` observability with no user-facing behavior or config change.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- The execution-backend label reuses the existing `cpu`/`metal`/`gpu` categorization (`native_runtime_backend_label`); it does not further distinguish Vulkan/CUDA/HIP within the generic `gpu` bucket, since that finer distinction is not reliably resolvable per-request today.
- The realtime websocket path (dictation and live-captions in the desktop UI) shares one server-side session type with no wire-level field distinguishing the two features, so both log as `source=server_realtime` rather than fabricating a distinction the wire protocol does not carry.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
