### PR TITLE
chore(publish): graduate firered2-llm out of the pre-audit exemption set

### DIFF
--- a/tooling/publish-model/scripts/audit_form.py
+++ b/tooling/publish-model/scripts/audit_form.py
@@ -51,7 +51,6 @@ PRE_AUDIT_FAMILIES = frozenset(
         "dolphin",
         "firered-aed",
         "firered-punc",
-        "firered2-llm",
         "hymt2",
         "mimo-asr",
         "moonshine",


### PR DESCRIPTION
## Summary

Removes `firered2-llm` from `PRE_AUDIT_FAMILIES` now that its release audit form is complete on main (#165): the family is henceforth held to the full fail-closed audit gate.

## Why

The exemption set is shrink-only by policy; a family graduates the moment its form lands complete. firered2-llm is the first.

## Changes

- `tooling/publish-model/scripts/audit_form.py`: drop one entry from `PRE_AUDIT_FAMILIES`.

## Tests run

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Python-only: `python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'` -> 188 tests OK (gate validated against the live form in-tree).

## Manual smoke checks

`audit_form.validate_family_audit_form("firered2-llm")` passes against `docs/model-audits/firered2-llm.md` on this branch.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

No other family graduates in this PR.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES