### PR TITLE
perf(audio): decode non-WAV input straight to memory, skip the temp-WAV round trip

### DIFF
--- a/crates/openasr-cli/src/bench_suite_cli.rs
+++ b/crates/openasr-cli/src/bench_suite_cli.rs
@@ -17,8 +17,7 @@ use openasr_core::{
     BackendKind, ExecutionTarget, NATIVE_RUNTIME_MODEL_ID_AUTO, SuiteBaseline, SuiteConfig,
     SuiteEntry, SuiteEntryMetrics, TranscriptionRequest, check_quant_ordering, check_vs_cpp,
     compare_to_baseline, load_config, openasr_home, peak_rss_bytes, prepare_audio_input,
-    probe_wav_duration, render_suite_json, render_suite_markdown,
-    validate_local_native_model_pack_path, wer_counts,
+    render_suite_json, render_suite_markdown, validate_local_native_model_pack_path, wer_counts,
 };
 
 use crate::cli_args::BenchSuiteCommandOptions;
@@ -183,10 +182,7 @@ fn run_entry(
     )
     .with_context(|| format!("Could not prepare audio: {}", entry.audio_path.display()))?;
 
-    let audio_seconds = prepared
-        .original()
-        .duration_seconds
-        .or_else(|| probe_wav_duration(prepared.path()));
+    let audio_seconds = prepared.duration_seconds();
     let reference = resolve_reference(entry)?;
 
     // Best-of-N: keep the fastest wall-clock sample so a single noisy run
@@ -213,7 +209,8 @@ fn run_entry(
             // The perf suite measures ASR decode RTF/RSS; an optional
             // post-process stage running when a FireRedPunc pack happens to be
             // installed would skew both, so it stays off for every entry.
-            .with_punctuation(false);
+            .with_punctuation(false)
+            .with_prepared_samples(prepared.shared_samples());
         configure_native_cpu_inference_threads();
         let started = Instant::now();
         let transcription = transcribe_with_backend(BackendKind::Native, request)?;
@@ -245,8 +242,19 @@ fn run_entry(
         .map(|seconds| elapsed.as_secs_f64() / seconds);
 
     // "Beat comparable open source": time the same-model whisper.cpp baseline.
+    // whisper.cpp is an external process that needs a real WAV file path --
+    // it cannot take the in-memory samples the symphonia decode path now
+    // hands back for non-WAV/non-conformant-WAV entries (`prepared.path()`
+    // there is only the *original* source file, not a WAV; see
+    // `PreparedAudioInput::path`'s doc comment). Every entry in
+    // `perf/suite.toml` today is already a conformant WAV (the passthrough
+    // path, always a real file), so this only ever skips the comparison for a
+    // hypothetical future non-WAV entry rather than handing whisper.cpp a
+    // path it cannot read.
     let cpp_best_ms = match (&entry.cpp_binary, &entry.cpp_model) {
-        (Some(binary), Some(model)) if binary.exists() && model.exists() => {
+        (Some(binary), Some(model))
+            if binary.exists() && model.exists() && prepared.samples().is_none() =>
+        {
             time_whisper_cpp(binary, model, prepared.path(), runs.max(1))
         }
         _ => None,

--- a/crates/openasr-cli/src/live.rs
+++ b/crates/openasr-cli/src/live.rs
@@ -397,6 +397,18 @@ fn prepare_input_file_samples_pcm16_mono_16khz(
             .with_ffmpeg_bin_explicit(options.runtime_paths.ffmpeg_bin.is_some())
             .with_native_non_wav_conversion(true),
     )?;
+    // The in-process symphonia decode path hands back f32 samples already
+    // resident in memory (see `PreparedAudioInput::samples`): convert those
+    // straight to i16 instead of writing a prepared WAV to disk and
+    // re-reading it back through `hound`. The WAV-passthrough and external
+    // ffmpeg/afconvert conversion paths still hand back a real file, which
+    // `hound` reads exactly as before.
+    if let Some(samples) = prepared.samples() {
+        return Ok(samples
+            .iter()
+            .map(|&sample| (sample.clamp(-1.0, 1.0) * i16::MAX as f32).round() as i16)
+            .collect());
+    }
     let mut reader = hound::WavReader::open(prepared.path()).with_context(|| {
         format!(
             "Could not open prepared WAV audio at {}",

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -1256,7 +1256,8 @@ fn transcribe(options: TranscribeCommandOptions<'_>) -> Result<()> {
         .with_word_timestamps_refine(matches!(
             options.word_timestamps_mode,
             Some(WordTimestampsMode::Aligned)
-        ));
+        ))
+        .with_prepared_samples(prepared.shared_samples());
     let transcription =
         transcribe_with_backend(prepared_run.backend_kind, request).map_err(|error| {
             consent::CliExit::new(consent::ExitCode::RuntimeFailed, error.to_string())

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -134,7 +134,8 @@ pub(super) fn transcribe_batch_item(
                 .map(str::to_string),
         )
         .with_diarization(context.diarize)
-        .with_diarize_speakers(context.speakers);
+        .with_diarize_speakers(context.speakers)
+        .with_prepared_samples(prepared.shared_samples());
     let transcription = transcribe_with_backend(context.backend_kind, request)?;
     let written = write_rendered_formats(
         &transcription,
@@ -222,17 +223,13 @@ pub(super) fn run_benchmark(
             // word-timestamp alignment, neither of which this request enables
             // either) and would silently skew the real-time factor for an
             // unpunctuated model with the FireRedPunc pack installed.
-            .with_punctuation(false);
+            .with_punctuation(false)
+            .with_prepared_samples(prepared.shared_samples());
     let started = Instant::now();
     let transcription = transcribe_with_backend(prepared_run.backend_kind, request)?;
     let elapsed = started.elapsed();
 
-    let audio_duration_seconds = prepared.original().duration_seconds.or_else(|| {
-        prepared
-            .is_converted()
-            .then(|| openasr_core::probe_wav_duration(prepared.path()))
-            .flatten()
-    });
+    let audio_duration_seconds = prepared.duration_seconds();
     let real_time_factor = audio_duration_seconds
         .filter(|duration| *duration > 0.0)
         .map(|duration| elapsed.as_secs_f64() / duration);
@@ -1142,7 +1139,12 @@ pub(super) fn print_audio_input_notes(info: &AudioInputInfo) {
 }
 
 pub(super) fn print_audio_preparation_notes(prepared: &PreparedAudioInput) {
-    if prepared.is_converted() {
+    if prepared.samples().is_some() {
+        eprintln!(
+            "Note: decoded {} to 16 kHz mono in memory for the selected backend.",
+            prepared.original().path.display()
+        );
+    } else if prepared.is_converted() {
         eprintln!(
             "Note: prepared {} as temporary 16 kHz mono PCM WAV for the selected backend.",
             prepared.original().path.display()

--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -413,7 +413,7 @@ pub struct TranscriptionRequest {
     /// decode source. `None` for the WAV-passthrough and external
     /// ffmpeg/afconvert conversion paths, and for any caller that built this
     /// request without going through `prepare_audio_input` at all.
-    pub prepared_samples: Option<Arc<[f32]>>,
+    pub prepared_samples: Option<Arc<Vec<f32>>>,
 }
 
 impl TranscriptionRequest {
@@ -446,7 +446,7 @@ impl TranscriptionRequest {
 
     /// Attaches in-memory samples so the native backend can skip re-reading
     /// `input_path` from disk -- see the field's doc comment.
-    pub fn with_prepared_samples(mut self, prepared_samples: Option<Arc<[f32]>>) -> Self {
+    pub fn with_prepared_samples(mut self, prepared_samples: Option<Arc<Vec<f32>>>) -> Self {
         self.prepared_samples = prepared_samples;
         self
     }

--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt, str::FromStr};
+use std::{fmt, str::FromStr, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -403,6 +403,17 @@ pub struct TranscriptionRequest {
     /// genuinely unknown, never guessed, and never the *file name* or any
     /// other path component -- extension only.
     pub source_container: Option<String>,
+    /// Ready-to-decode 16 kHz mono f32 samples already resident in memory,
+    /// set when `prepare_audio_input`'s in-process symphonia decode path
+    /// produced them directly (see `crate::audio::PreparedAudioInput::
+    /// shared_samples`). When `Some`, the native backend decodes straight
+    /// from these samples instead of re-reading `input_path` from disk --
+    /// `input_path` is still populated in that case (for display/logging and
+    /// the mock backend's placeholder text), it just is not the actual
+    /// decode source. `None` for the WAV-passthrough and external
+    /// ffmpeg/afconvert conversion paths, and for any caller that built this
+    /// request without going through `prepare_audio_input` at all.
+    pub prepared_samples: Option<Arc<[f32]>>,
 }
 
 impl TranscriptionRequest {
@@ -429,7 +440,15 @@ impl TranscriptionRequest {
             source_sample_rate_hz: None,
             source_channels: None,
             source_container: None,
+            prepared_samples: None,
         }
+    }
+
+    /// Attaches in-memory samples so the native backend can skip re-reading
+    /// `input_path` from disk -- see the field's doc comment.
+    pub fn with_prepared_samples(mut self, prepared_samples: Option<Arc<[f32]>>) -> Self {
+        self.prepared_samples = prepared_samples;
+        self
     }
 
     pub fn with_source(mut self, source: RequestSource) -> Self {

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -556,6 +556,7 @@ fn native_offline_request_to_transcription_request(
         .with_source(request.source)
         .with_source_audio_format(request.source_sample_rate_hz, request.source_channels)
         .with_source_container(request.source_container)
+        .with_prepared_samples(request.prepared_samples)
 }
 
 fn native_backend_error_to_asr(error: BackendError) -> NativeAsrError {

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1,4 +1,9 @@
-use std::{collections::BTreeMap, path::Path, sync::OnceLock, time::Instant};
+use std::{
+    collections::BTreeMap,
+    path::Path,
+    sync::{Arc, OnceLock},
+    time::Instant,
+};
 
 use crate::NATIVE_RUNTIME_MODEL_ID_AUTO;
 use crate::api::audio_io::load_wav_16khz_mono_f32_v0;
@@ -810,6 +815,7 @@ fn run_native_transcription_fallible(
     // rather than running uncounted.
     let _progress = NativeProgressGuard::new();
     let input_path = request.input_path.clone();
+    let prepared_samples = request.prepared_samples.clone();
     let language_hint = request.language.clone();
     let model_pack_path = request.model_pack_path.clone();
     let punctuate = request.punctuate;
@@ -836,6 +842,7 @@ fn run_native_transcription_fallible(
         refine_transcription_word_timestamps_with_forced_aligner(
             transcription,
             &input_path,
+            prepared_samples.as_ref(),
             language_hint.as_deref(),
         )
     } else {
@@ -921,28 +928,48 @@ fn punctuate_transcription_segments(
     transcription
 }
 
-/// Re-decodes `input_path` and calls the installed Qwen3-ForcedAligner pack
-/// once over the whole finished transcript, then reassigns each segment's
-/// `words` from the aligner's own per-word spans (dropping the family's
-/// approximate per-word confidence -- the aligner does not produce one; never
-/// inventing a value is preferred to fabricating one). Segments/text/speaker
-/// attribution from the ordinary decode path are left untouched; only `words`
-/// changes.
-fn refine_transcription_word_timestamps_with_forced_aligner(
-    mut transcription: Transcription,
+/// Returns `request`'s audio as 16 kHz mono f32 samples, preferring
+/// `prepared_samples` -- already resident in memory when
+/// `prepare_audio_input`'s in-process symphonia decode path produced them
+/// (see `crate::audio::PreparedAudioInput::samples`) -- over re-reading
+/// `input_path` from disk. The WAV-passthrough and external ffmpeg/afconvert
+/// conversion paths leave `prepared_samples` unset, so this falls back to the
+/// WAV load exactly as before for those.
+fn resolve_prepared_audio_samples(
     input_path: &Path,
-    language_hint: Option<&str>,
-) -> Result<Transcription, BackendError> {
-    let pack_path = forced_aligner_pack::resolve_forced_aligner_pack_path()
-        .ok_or(BackendError::WordTimestampAlignmentPackMissing { backend: "native" })?;
-    let prepared_audio = load_wav_16khz_mono_f32_v0(
+    prepared_samples: Option<&Arc<[f32]>>,
+) -> Result<Vec<f32>, crate::NativeAsrError> {
+    if let Some(samples) = prepared_samples {
+        return Ok(samples.to_vec());
+    }
+    load_wav_16khz_mono_f32_v0(
         input_path,
         "Native ASR Core backend",
         "Native ASR Core backend",
     )
-    .map_err(|error| BackendError::NativeUnsupportedInputFormat {
-        reason: error.to_string(),
-    })?;
+}
+
+/// Re-decodes `input_path` (or reuses `prepared_samples` when already
+/// resident in memory) and calls the installed Qwen3-ForcedAligner pack once
+/// over the whole finished transcript, then reassigns each segment's `words`
+/// from the aligner's own per-word spans (dropping the family's approximate
+/// per-word confidence -- the aligner does not produce one; never inventing a
+/// value is preferred to fabricating one). Segments/text/speaker attribution
+/// from the ordinary decode path are left untouched; only `words` changes.
+fn refine_transcription_word_timestamps_with_forced_aligner(
+    mut transcription: Transcription,
+    input_path: &Path,
+    prepared_samples: Option<&Arc<[f32]>>,
+    language_hint: Option<&str>,
+) -> Result<Transcription, BackendError> {
+    let pack_path = forced_aligner_pack::resolve_forced_aligner_pack_path()
+        .ok_or(BackendError::WordTimestampAlignmentPackMissing { backend: "native" })?;
+    let prepared_audio =
+        resolve_prepared_audio_samples(input_path, prepared_samples).map_err(|error| {
+            BackendError::NativeUnsupportedInputFormat {
+                reason: error.to_string(),
+            }
+        })?;
     let language = transcription
         .language
         .clone()
@@ -1084,14 +1111,11 @@ fn run_native_transcription_impl(
         model_resolve_started.elapsed(),
     );
     let audio_prep_started = Instant::now();
-    let prepared_audio = load_wav_16khz_mono_f32_v0(
-        &request.input_path,
-        "Native ASR Core backend",
-        "Native ASR Core backend",
-    )
-    .map_err(|error| BackendError::NativeUnsupportedInputFormat {
-        reason: error.to_string(),
-    })?;
+    let prepared_audio =
+        resolve_prepared_audio_samples(&request.input_path, request.prepared_samples.as_ref())
+            .map_err(|error| BackendError::NativeUnsupportedInputFormat {
+                reason: error.to_string(),
+            })?;
     crate::stage_timing::log_stage(
         "native_transcribe",
         "audio_prep",

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -815,7 +815,14 @@ fn run_native_transcription_fallible(
     // rather than running uncounted.
     let _progress = NativeProgressGuard::new();
     let input_path = request.input_path.clone();
-    let prepared_samples = request.prepared_samples.clone();
+    // Only clone the in-memory samples' `Arc` when the (opt-in, uncommon)
+    // forced-aligner refine stage will actually need to re-read them after
+    // the main decode below has consumed `request`: cloning unconditionally
+    // would keep a second strong reference alive for the whole decode,
+    // permanently defeating the zero-copy `Arc::try_unwrap` reclaim in
+    // `resolve_prepared_audio_samples` (see its doc comment) for every
+    // request, not just refine ones.
+    let prepared_samples_for_refine = refine.then(|| request.prepared_samples.clone()).flatten();
     let language_hint = request.language.clone();
     let model_pack_path = request.model_pack_path.clone();
     let punctuate = request.punctuate;
@@ -842,7 +849,7 @@ fn run_native_transcription_fallible(
         refine_transcription_word_timestamps_with_forced_aligner(
             transcription,
             &input_path,
-            prepared_samples.as_ref(),
+            prepared_samples_for_refine,
             language_hint.as_deref(),
         )
     } else {
@@ -928,19 +935,29 @@ fn punctuate_transcription_segments(
     transcription
 }
 
-/// Returns `request`'s audio as 16 kHz mono f32 samples, preferring
+/// Returns the audio at `input_path` as 16 kHz mono f32 samples, preferring
 /// `prepared_samples` -- already resident in memory when
 /// `prepare_audio_input`'s in-process symphonia decode path produced them
 /// (see `crate::audio::PreparedAudioInput::samples`) -- over re-reading
 /// `input_path` from disk. The WAV-passthrough and external ffmpeg/afconvert
 /// conversion paths leave `prepared_samples` unset, so this falls back to the
 /// WAV load exactly as before for those.
+///
+/// Takes `prepared_samples` by value (not by reference) so that when the
+/// caller passes its *only* remaining `Arc` handle, `Arc::try_unwrap` below
+/// reclaims the underlying `Vec<f32>` with zero copy instead of cloning it
+/// out from behind a shared reference -- avoiding the double-memory window
+/// (the `Arc`'s buffer plus a freshly cloned `Vec` of the same audio) this
+/// would otherwise cost for the whole decode. Only falls back to an actual
+/// clone when another reference is still alive (the opt-in forced-aligner
+/// refine path, which legitimately needs the samples a second time after the
+/// main decode has consumed them -- see `run_native_transcription_fallible`).
 fn resolve_prepared_audio_samples(
     input_path: &Path,
-    prepared_samples: Option<&Arc<[f32]>>,
+    prepared_samples: Option<Arc<Vec<f32>>>,
 ) -> Result<Vec<f32>, crate::NativeAsrError> {
     if let Some(samples) = prepared_samples {
-        return Ok(samples.to_vec());
+        return Ok(Arc::try_unwrap(samples).unwrap_or_else(|shared| (*shared).clone()));
     }
     load_wav_16khz_mono_f32_v0(
         input_path,
@@ -959,7 +976,7 @@ fn resolve_prepared_audio_samples(
 fn refine_transcription_word_timestamps_with_forced_aligner(
     mut transcription: Transcription,
     input_path: &Path,
-    prepared_samples: Option<&Arc<[f32]>>,
+    prepared_samples: Option<Arc<Vec<f32>>>,
     language_hint: Option<&str>,
 ) -> Result<Transcription, BackendError> {
     let pack_path = forced_aligner_pack::resolve_forced_aligner_pack_path()
@@ -1020,8 +1037,15 @@ fn assign_aligned_words_to_segments(segments: &mut [Segment], items: &[ForcedAli
 }
 
 fn run_native_transcription_impl(
-    request: TranscriptionRequest,
+    mut request: TranscriptionRequest,
 ) -> Result<Transcription, BackendError> {
+    // Taken up front (before `requested_model_id` below borrows `request` for
+    // the rest of this function): leaves `request.prepared_samples` as
+    // `None` and hands `resolve_prepared_audio_samples` the only `Arc`
+    // strong reference in the common (non-refine) case, so it can reclaim
+    // the underlying `Vec<f32>` with zero copy instead of cloning it -- see
+    // that function's doc comment.
+    let prepared_samples = request.prepared_samples.take();
     let model_resolve_started = Instant::now();
     let requested_model_id = normalize_and_validate_model_id(&request)?;
     let model_pack_path = request
@@ -1111,11 +1135,10 @@ fn run_native_transcription_impl(
         model_resolve_started.elapsed(),
     );
     let audio_prep_started = Instant::now();
-    let prepared_audio =
-        resolve_prepared_audio_samples(&request.input_path, request.prepared_samples.as_ref())
-            .map_err(|error| BackendError::NativeUnsupportedInputFormat {
-                reason: error.to_string(),
-            })?;
+    let prepared_audio = resolve_prepared_audio_samples(&request.input_path, prepared_samples)
+        .map_err(|error| BackendError::NativeUnsupportedInputFormat {
+            reason: error.to_string(),
+        })?;
     crate::stage_timing::log_stage(
         "native_transcribe",
         "audio_prep",

--- a/crates/openasr-core/src/api/native/types.rs
+++ b/crates/openasr-core/src/api/native/types.rs
@@ -1,4 +1,4 @@
-use std::{fmt, path::PathBuf};
+use std::{fmt, path::PathBuf, sync::Arc};
 
 use crate::realtime::RealtimeSessionId;
 use crate::{LongFormOptions, PhraseBiasConfig, RequestSource, TranscriptionTask};
@@ -306,6 +306,11 @@ pub struct NativeAsrOfflineRequest {
     /// [`crate::TranscriptionRequest::source_container`], which this carries
     /// through to.
     pub source_container: Option<String>,
+    /// Ready-to-decode 16 kHz mono f32 samples already resident in memory --
+    /// same "prefer this over re-reading `input_path`" contract as
+    /// [`crate::TranscriptionRequest::prepared_samples`], which this carries
+    /// through to via `native_offline_request_to_transcription_request`.
+    pub prepared_samples: Option<Arc<[f32]>>,
 }
 
 impl NativeAsrOfflineRequest {
@@ -319,7 +324,15 @@ impl NativeAsrOfflineRequest {
             source_sample_rate_hz: None,
             source_channels: None,
             source_container: None,
+            prepared_samples: None,
         }
+    }
+
+    /// Attaches in-memory samples so the native backend can skip re-reading
+    /// `input_path` from disk -- see the field's doc comment.
+    pub fn with_prepared_samples(mut self, prepared_samples: Option<Arc<[f32]>>) -> Self {
+        self.prepared_samples = prepared_samples;
+        self
     }
 
     pub fn with_options(mut self, options: NativeAsrRequestOptions) -> Self {

--- a/crates/openasr-core/src/api/native/types.rs
+++ b/crates/openasr-core/src/api/native/types.rs
@@ -310,7 +310,7 @@ pub struct NativeAsrOfflineRequest {
     /// same "prefer this over re-reading `input_path`" contract as
     /// [`crate::TranscriptionRequest::prepared_samples`], which this carries
     /// through to via `native_offline_request_to_transcription_request`.
-    pub prepared_samples: Option<Arc<[f32]>>,
+    pub prepared_samples: Option<Arc<Vec<f32>>>,
 }
 
 impl NativeAsrOfflineRequest {
@@ -330,7 +330,7 @@ impl NativeAsrOfflineRequest {
 
     /// Attaches in-memory samples so the native backend can skip re-reading
     /// `input_path` from disk -- see the field's doc comment.
-    pub fn with_prepared_samples(mut self, prepared_samples: Option<Arc<[f32]>>) -> Self {
+    pub fn with_prepared_samples(mut self, prepared_samples: Option<Arc<Vec<f32>>>) -> Self {
         self.prepared_samples = prepared_samples;
         self
     }

--- a/crates/openasr-core/src/audio.rs
+++ b/crates/openasr-core/src/audio.rs
@@ -39,7 +39,7 @@ pub fn prepare_audio_input(
             let prepared_path = info.path.clone();
             Ok(PreparedAudioInput {
                 original: info,
-                prepared_path,
+                samples: types::PreparedAudioSamples::Path(prepared_path),
                 temp_dir: None,
             })
         }

--- a/crates/openasr-core/src/audio/prepare.rs
+++ b/crates/openasr-core/src/audio/prepare.rs
@@ -4,23 +4,30 @@ use crate::{
     BackendKind,
     audio::{
         AudioInputInfo, AudioPreparationError, AudioPreparationOptions, PreparedAudioInput,
-        RECOGNIZED_EXTENSIONS, decode, symphonia_decode,
+        RECOGNIZED_EXTENSIONS, decode, symphonia_decode, types::PreparedAudioSamples,
     },
 };
 
 const CONVERSION_STDERR_LIMIT: usize = 800;
+
+/// A pass-through `PreparedAudioInput` that hands back `info`'s own path
+/// unmodified (the WAV-passthrough branches below): no conversion, no temp
+/// dir, no in-memory samples.
+fn passthrough(info: AudioInputInfo) -> PreparedAudioInput {
+    let prepared_path = info.path.clone();
+    PreparedAudioInput {
+        original: info,
+        samples: PreparedAudioSamples::Path(prepared_path),
+        temp_dir: None,
+    }
+}
 
 pub(crate) fn prepare_external_input(
     info: AudioInputInfo,
     options: &AudioPreparationOptions,
 ) -> Result<PreparedAudioInput, AudioPreparationError> {
     if options.backend == BackendKind::Native && !options.native_non_wav_requires_conversion {
-        let prepared_path = info.path.clone();
-        return Ok(PreparedAudioInput {
-            original: info,
-            prepared_path,
-            temp_dir: None,
-        });
+        return Ok(passthrough(info));
     }
 
     let is_wav = info.extension.as_deref() == Some("wav");
@@ -28,12 +35,7 @@ pub(crate) fn prepare_external_input(
         // Already matches the 16 kHz mono PCM16/float32 shape the rest of the
         // pipeline expects: pass it through untouched (cheap, and preserves
         // today's behavior for already-conformant recordings).
-        let prepared_path = info.path.clone();
-        return Ok(PreparedAudioInput {
-            original: info,
-            prepared_path,
-            temp_dir: None,
-        });
+        return Ok(passthrough(info));
     }
     if is_wav && !options.ffmpeg_bin_explicit {
         // Non-conformant (other sample rate, stereo, ...) and no explicit
@@ -49,12 +51,7 @@ pub(crate) fn prepare_external_input(
         // preserve today's leniency and pass the original bytes through
         // untouched rather than hard-failing here -- downstream rejects it
         // with a precise WAV-format error if it truly isn't valid input.
-        let prepared_path = info.path.clone();
-        return Ok(PreparedAudioInput {
-            original: info,
-            prepared_path,
-            temp_dir: None,
-        });
+        return Ok(passthrough(info));
     }
     // A non-conformant wav with an *explicit* ffmpeg configured falls through
     // to the general external-tool conversion below instead of returning here,
@@ -133,7 +130,7 @@ pub(crate) fn prepare_external_input(
     match fs::metadata(&prepared_path) {
         Ok(metadata) if metadata.is_file() => Ok(PreparedAudioInput {
             original: info,
-            prepared_path,
+            samples: PreparedAudioSamples::Path(prepared_path),
             temp_dir: Some(temp_dir),
         }),
         _ => Err(AudioPreparationError::PreparedFileMissing {
@@ -153,7 +150,7 @@ fn wav_is_already_conformant(path: &std::path::Path) -> bool {
 
 /// Outcome of [`try_symphonia_prepare`].
 enum SymphoniaAttempt {
-    /// Decoded and written to a temporary WAV; ready to use.
+    /// Decoded straight to memory; ready to use.
     Prepared(PreparedAudioInput),
     /// Not decodable in-process; fall back to the external converter chain.
     /// `codec_label` is the codec name the demuxer identified, if any (see
@@ -170,30 +167,27 @@ enum SymphoniaAttempt {
 /// Tries the in-process symphonia decode path for `info`. Never a hard error
 /// on an unsupported/malformed/panicking input -- the caller falls back to
 /// the external converter chain in every such case (see [`SymphoniaAttempt`]).
+///
+/// On success the decoded samples stay resident in memory
+/// (`PreparedAudioSamples::InMemory`) instead of being encoded to a WAV,
+/// written to a temp file, and immediately re-read + re-parsed back into the
+/// exact same samples by the downstream consumer -- the write-then-reread
+/// round trip this used to always pay for every non-WAV (and non-conformant
+/// WAV) input.
 fn try_symphonia_prepare(info: &AudioInputInfo) -> Result<SymphoniaAttempt, AudioPreparationError> {
-    let (wav_bytes, source_format) = match symphonia_decode::try_decode_to_pcm16_mono_16k_wav(
-        &info.path,
-        info.extension.as_deref(),
-    ) {
-        symphonia_decode::SymphoniaOutcome::Decoded(bytes, source_format) => (bytes, source_format),
-        symphonia_decode::SymphoniaOutcome::Unsupported { codec_label } => {
-            return Ok(SymphoniaAttempt::NotHandled { codec_label });
-        }
-        symphonia_decode::SymphoniaOutcome::ParserPanicked => {
-            return Ok(SymphoniaAttempt::ParserPanicked);
-        }
-    };
-
-    let temp_dir = tempfile::Builder::new()
-        .prefix("openasr-audio-")
-        .tempdir()
-        .map_err(|source| AudioPreparationError::TempDir { source })?;
-    let prepared_path = temp_dir.path().join("prepared.wav");
-    fs::write(&prepared_path, &wav_bytes).map_err(|_source| {
-        AudioPreparationError::PreparedFileMissing {
-            path: prepared_path.clone(),
-        }
-    })?;
+    let (samples, source_format) =
+        match symphonia_decode::try_decode_to_pcm16_mono_16k(&info.path, info.extension.as_deref())
+        {
+            symphonia_decode::SymphoniaOutcome::Decoded(samples, source_format) => {
+                (samples, source_format)
+            }
+            symphonia_decode::SymphoniaOutcome::Unsupported { codec_label } => {
+                return Ok(SymphoniaAttempt::NotHandled { codec_label });
+            }
+            symphonia_decode::SymphoniaOutcome::ParserPanicked => {
+                return Ok(SymphoniaAttempt::ParserPanicked);
+            }
+        };
 
     // The probe stage (`probe::probe_audio_details`) only reads source
     // format off WAV's fmt chunk; for the non-wav formats that land here it
@@ -205,8 +199,8 @@ fn try_symphonia_prepare(info: &AudioInputInfo) -> Result<SymphoniaAttempt, Audi
 
     Ok(SymphoniaAttempt::Prepared(PreparedAudioInput {
         original,
-        prepared_path,
-        temp_dir: Some(temp_dir),
+        samples: PreparedAudioSamples::InMemory(samples.into()),
+        temp_dir: None,
     }))
 }
 

--- a/crates/openasr-core/src/audio/prepare.rs
+++ b/crates/openasr-core/src/audio/prepare.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf, process::Command};
+use std::{fs, path::PathBuf, process::Command, sync::Arc};
 
 use crate::{
     BackendKind,
@@ -199,7 +199,10 @@ fn try_symphonia_prepare(info: &AudioInputInfo) -> Result<SymphoniaAttempt, Audi
 
     Ok(SymphoniaAttempt::Prepared(PreparedAudioInput {
         original,
-        samples: PreparedAudioSamples::InMemory(samples.into()),
+        // `Arc::new` (not `.into()`/`Arc::from`): wraps the already-allocated
+        // `Vec<f32>` in a new refcount header without copying its samples --
+        // see `PreparedAudioSamples`'s doc comment for why this matters.
+        samples: PreparedAudioSamples::InMemory(Arc::new(samples)),
         temp_dir: None,
     }))
 }

--- a/crates/openasr-core/src/audio/symphonia_decode.rs
+++ b/crates/openasr-core/src/audio/symphonia_decode.rs
@@ -48,7 +48,7 @@ use symphonia::core::{
     probe::Hint,
 };
 
-const TARGET_SAMPLE_RATE: u32 = 16_000;
+pub(crate) const TARGET_SAMPLE_RATE_HZ: u32 = 16_000;
 // FFT resampler chunk size: large enough to amortize FFT overhead, small
 // enough to keep peak memory low for long recordings.
 const RESAMPLE_CHUNK_FRAMES: usize = 4096;
@@ -67,10 +67,12 @@ pub(crate) struct DecodedAudioSourceFormat {
 
 /// Result of attempting the in-process symphonia decode path.
 pub(crate) enum SymphoniaOutcome {
-    /// Decoded successfully: ready-to-use 16 kHz mono PCM16 WAV bytes, plus
-    /// the file's true source format (sample rate/channels, before this
-    /// module's downmix/resample) for diagnostics.
-    Decoded(Vec<u8>, DecodedAudioSourceFormat),
+    /// Decoded successfully: ready-to-use 16 kHz mono f32 samples, plus the
+    /// file's true source format (sample rate/channels, before this module's
+    /// downmix/resample) for diagnostics. Callers hand these samples
+    /// straight to the rest of the pipeline in memory -- no WAV encode, disk
+    /// write, or re-read/re-parse round trip.
+    Decoded(Vec<f32>, DecodedAudioSourceFormat),
     /// Not decodable in-process (unsupported codec, malformed stream, or an
     /// otherwise-empty result) -- fall back to the external converter chain.
     /// `codec_label` is populated whenever the demuxer identified the track's
@@ -85,11 +87,11 @@ pub(crate) enum SymphoniaOutcome {
     ParserPanicked,
 }
 
-/// Attempt to decode `path` to a 16 kHz mono PCM16 WAV entirely in-process.
+/// Attempt to decode `path` to 16 kHz mono f32 samples entirely in-process.
 /// Never panics, even on adversarial input (see module docs): a panic inside
 /// the underlying symphonia demuxer/decoder is caught and reported as
 /// [`SymphoniaOutcome::ParserPanicked`].
-pub(crate) fn try_decode_to_pcm16_mono_16k_wav(
+pub(crate) fn try_decode_to_pcm16_mono_16k(
     path: &Path,
     extension: Option<&str>,
 ) -> SymphoniaOutcome {
@@ -118,7 +120,7 @@ pub(crate) fn try_decode_to_pcm16_mono_16k_wav(
         sample_rate_hz: mono.sample_rate,
         channels: mono.channels,
     };
-    let resampled = if mono.sample_rate == TARGET_SAMPLE_RATE {
+    let resampled = if mono.sample_rate == TARGET_SAMPLE_RATE_HZ {
         mono.samples
     } else {
         match resample_mono_to_16k(&mono.samples, mono.sample_rate) {
@@ -130,7 +132,7 @@ pub(crate) fn try_decode_to_pcm16_mono_16k_wav(
             }
         }
     };
-    SymphoniaOutcome::Decoded(encode_pcm16_mono_16k_wav(&resampled), source_format)
+    SymphoniaOutcome::Decoded(resampled, source_format)
 }
 
 /// Result of [`probe_codec_label`]: names the codec of a file's first real
@@ -155,7 +157,7 @@ pub(crate) enum ProbeOutcome {
 /// letting callers report a precise "this codec is unsupported" error instead
 /// of an opaque conversion failure. Never panics (see module docs).
 pub(crate) fn probe_codec_label(path: &Path, extension: Option<&str>) -> ProbeOutcome {
-    // Same `UnwindSafe` reasoning as `try_decode_to_pcm16_mono_16k_wav` above:
+    // Same `UnwindSafe` reasoning as `try_decode_to_pcm16_mono_16k` above:
     // both captured arguments are plain shared references with no interior
     // mutability.
     match catch_unwind(|| probe_codec_label_inner(path, extension)) {
@@ -219,7 +221,7 @@ struct DecodedMono {
 /// so a caller reporting a failed decode doesn't need to re-open and re-probe
 /// the file just to name the codec (see `codec_label` on the returned
 /// struct). Never itself panics on symphonia's behalf -- run this through
-/// `catch_unwind` (as `try_decode_to_pcm16_mono_16k_wav` does), not directly.
+/// `catch_unwind` (as `try_decode_to_pcm16_mono_16k` does), not directly.
 struct DecodeAttempt {
     /// Populated as soon as a real (non-null) track is found, even if
     /// decoding it then fails -- see [`codec_type_label`].
@@ -406,7 +408,7 @@ where
 fn resample_mono_to_16k(input: &[f32], input_rate: u32) -> Option<Vec<f32>> {
     let mut resampler = FftFixedIn::<f32>::new(
         input_rate as usize,
-        TARGET_SAMPLE_RATE as usize,
+        TARGET_SAMPLE_RATE_HZ as usize,
         RESAMPLE_CHUNK_FRAMES,
         RESAMPLE_SUB_CHUNKS,
         1,
@@ -414,7 +416,7 @@ fn resample_mono_to_16k(input: &[f32], input_rate: u32) -> Option<Vec<f32>> {
     .ok()?;
 
     let mut output: Vec<f32> = Vec::with_capacity(
-        input.len() * TARGET_SAMPLE_RATE as usize / input_rate.max(1) as usize
+        input.len() * TARGET_SAMPLE_RATE_HZ as usize / input_rate.max(1) as usize
             + RESAMPLE_CHUNK_FRAMES,
     );
     let mut position = 0usize;
@@ -455,51 +457,9 @@ fn resample_mono_to_16k(input: &[f32], input_rate: u32) -> Option<Vec<f32>> {
     Some(output)
 }
 
-/// Encodes mono f32 samples (expected in `[-1.0, 1.0]`) as a canonical PCM16
-/// mono 16 kHz WAV file, matching the format `api::audio_io` expects.
-fn encode_pcm16_mono_16k_wav(samples: &[f32]) -> Vec<u8> {
-    let data_size = (samples.len() * 2) as u32;
-    let mut bytes = Vec::with_capacity(44 + data_size as usize);
-    bytes.extend_from_slice(b"RIFF");
-    bytes.extend_from_slice(&(36 + data_size).to_le_bytes());
-    bytes.extend_from_slice(b"WAVE");
-    bytes.extend_from_slice(b"fmt ");
-    bytes.extend_from_slice(&16_u32.to_le_bytes());
-    bytes.extend_from_slice(&1_u16.to_le_bytes()); // PCM
-    bytes.extend_from_slice(&1_u16.to_le_bytes()); // mono
-    bytes.extend_from_slice(&TARGET_SAMPLE_RATE.to_le_bytes());
-    let byte_rate = TARGET_SAMPLE_RATE * 2;
-    bytes.extend_from_slice(&byte_rate.to_le_bytes());
-    bytes.extend_from_slice(&2_u16.to_le_bytes()); // block align
-    bytes.extend_from_slice(&16_u16.to_le_bytes()); // bits per sample
-    bytes.extend_from_slice(b"data");
-    bytes.extend_from_slice(&data_size.to_le_bytes());
-    for &sample in samples {
-        let clamped = sample.clamp(-1.0, 1.0);
-        let quantized = (clamped * i16::MAX as f32).round() as i16;
-        bytes.extend_from_slice(&quantized.to_le_bytes());
-    }
-    bytes
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn wav_encoder_round_trips_through_audio_io_reader() {
-        let samples = vec![0.0_f32, 0.5, -0.5, 1.0, -1.0];
-        let bytes = encode_pcm16_mono_16k_wav(&samples);
-
-        let parsed =
-            crate::api::audio_io::load_wav_16khz_mono_f32_v0(write_temp(&bytes), "test", "test")
-                .unwrap();
-
-        assert_eq!(parsed.len(), samples.len());
-        for (expected, actual) in samples.iter().zip(parsed.iter()) {
-            assert!((expected - actual).abs() < 0.001, "{expected} vs {actual}");
-        }
-    }
 
     #[test]
     fn resample_preserves_frame_count_ratio() {
@@ -517,13 +477,6 @@ mod tests {
             "expected ~{expected} samples, got {}",
             output.len()
         );
-    }
-
-    fn write_temp(bytes: &[u8]) -> std::path::PathBuf {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.keep().join("out.wav");
-        std::fs::write(&path, bytes).unwrap();
-        path
     }
 
     /// A minimal webm/mkv EBML header whose size vint is the single byte
@@ -552,7 +505,7 @@ mod tests {
         // must now report `ParserPanicked` and let the caller fall back to
         // the external converter chain instead of crashing the process.
         assert!(matches!(
-            try_decode_to_pcm16_mono_16k_wav(&path, Some("webm")),
+            try_decode_to_pcm16_mono_16k(&path, Some("webm")),
             SymphoniaOutcome::ParserPanicked
         ));
         assert!(matches!(

--- a/crates/openasr-core/src/audio/tests.rs
+++ b/crates/openasr-core/src/audio/tests.rs
@@ -298,10 +298,27 @@ fn native_m4a_input_converts_via_afconvert_without_ffmpeg() {
     )
     .expect("decoding a real m4a without ffmpeg configured should succeed");
 
+    assert_prepared_16k_mono_audio(&prepared);
+}
+
+/// The in-process symphonia decode path (the one this m4a/AAC-LC fixture
+/// takes, see the test above) hands back samples already resident in memory
+/// instead of writing a prepared WAV to a temp dir and immediately
+/// re-reading it back -- assert both halves of that contract directly.
+#[test]
+fn symphonia_in_memory_decode_never_writes_a_temp_wav_to_disk() {
+    let prepared = prepare_native_conversion(&crate_fixture("tone_mono.m4a"))
+        .expect("m4a/AAC-LC should decode via the in-process symphonia path");
+
+    assert!(
+        prepared.temp_dir.is_none(),
+        "the in-memory decode path must not create a temp dir"
+    );
+    let samples = prepared
+        .samples()
+        .expect("in-process symphonia decode should hand back in-memory samples");
+    assert!(!samples.is_empty());
     assert!(prepared.is_converted());
-    let bytes = fs::read(prepared.path()).unwrap();
-    assert_eq!(&bytes[0..4], b"RIFF");
-    assert_eq!(&bytes[8..12], b"WAVE");
 }
 
 /// `tests/fixtures/*.{m4a,mp3,flac,ogg,webm,qta}` are all synthesized, not
@@ -333,13 +350,23 @@ fn prepare_native_conversion(path: &Path) -> Result<PreparedAudioInput, AudioPre
     )
 }
 
-fn assert_prepared_16k_mono_wav(prepared: &PreparedAudioInput) {
+/// Asserts `prepared` is a converted, non-empty 16 kHz mono decode,
+/// regardless of which conversion path produced it: the in-process symphonia
+/// path hands back samples already resident in memory
+/// ([`PreparedAudioInput::samples`]), while the external ffmpeg/afconvert
+/// conversion path still writes a real prepared WAV to disk.
+fn assert_prepared_16k_mono_audio(prepared: &PreparedAudioInput) {
     assert!(prepared.is_converted());
-    let bytes = fs::read(prepared.path()).unwrap();
-    let samples = crate::api::audio_io::load_wav_16khz_mono_f32_v0(prepared.path(), "test", "test")
-        .expect("prepared output must be a valid 16 kHz mono WAV");
-    assert_eq!(&bytes[0..4], b"RIFF");
-    assert_eq!(&bytes[8..12], b"WAVE");
+    let samples: Vec<f32> = match prepared.samples() {
+        Some(samples) => samples.to_vec(),
+        None => {
+            let bytes = fs::read(prepared.path()).unwrap();
+            assert_eq!(&bytes[0..4], b"RIFF");
+            assert_eq!(&bytes[8..12], b"WAVE");
+            crate::api::audio_io::load_wav_16khz_mono_f32_v0(prepared.path(), "test", "test")
+                .expect("prepared output must be a valid 16 kHz mono WAV")
+        }
+    };
     assert!(!samples.is_empty());
 }
 
@@ -347,49 +374,49 @@ fn assert_prepared_16k_mono_wav(prepared: &PreparedAudioInput) {
 fn symphonia_decodes_m4a_aac_lc_in_process() {
     let prepared = prepare_native_conversion(&crate_fixture("tone_mono.m4a"))
         .expect("m4a/AAC-LC should decode via the in-process symphonia path");
-    assert_prepared_16k_mono_wav(&prepared);
+    assert_prepared_16k_mono_audio(&prepared);
 }
 
 #[test]
 fn symphonia_decodes_qta_container_in_process() {
     let prepared = prepare_native_conversion(&crate_fixture("tone_mono.qta"))
         .expect(".qta (mov/m4a container) should decode via the in-process symphonia path");
-    assert_prepared_16k_mono_wav(&prepared);
+    assert_prepared_16k_mono_audio(&prepared);
 }
 
 #[test]
 fn symphonia_decodes_mp3_in_process() {
     let prepared = prepare_native_conversion(&crate_fixture("tone_mono.mp3"))
         .expect("mp3 should decode via the in-process symphonia path");
-    assert_prepared_16k_mono_wav(&prepared);
+    assert_prepared_16k_mono_audio(&prepared);
 }
 
 #[test]
 fn symphonia_decodes_flac_in_process() {
     let prepared = prepare_native_conversion(&crate_fixture("tone_mono.flac"))
         .expect("flac should decode via the in-process symphonia path");
-    assert_prepared_16k_mono_wav(&prepared);
+    assert_prepared_16k_mono_audio(&prepared);
 }
 
 #[test]
 fn symphonia_decodes_ogg_vorbis_in_process() {
     let prepared = prepare_native_conversion(&crate_fixture("tone_stereo.ogg"))
         .expect("ogg/vorbis should decode (and downmix) via the in-process symphonia path");
-    assert_prepared_16k_mono_wav(&prepared);
+    assert_prepared_16k_mono_audio(&prepared);
 }
 
 #[test]
 fn symphonia_decodes_webm_vorbis_in_process() {
     let prepared = prepare_native_conversion(&crate_fixture("tone_stereo.webm"))
         .expect("webm/vorbis should decode via the in-process symphonia mkv path");
-    assert_prepared_16k_mono_wav(&prepared);
+    assert_prepared_16k_mono_audio(&prepared);
 }
 
 #[test]
 fn symphonia_decodes_m4a_alac_in_process() {
     let prepared = prepare_native_conversion(&crate_fixture("tone_mono_alac.m4a"))
         .expect("m4a/ALAC should decode via the in-process symphonia alac path");
-    assert_prepared_16k_mono_wav(&prepared);
+    assert_prepared_16k_mono_audio(&prepared);
 }
 
 #[test]
@@ -476,7 +503,7 @@ fn symphonia_decodes_and_resamples_non_conformant_wav() {
     // and resampled via the same symphonia path as the other formats.
     let prepared = prepare_native_conversion(&crate_fixture("tone_stereo_44100.wav"))
         .expect("non-conformant wav should decode via the in-process symphonia path");
-    assert_prepared_16k_mono_wav(&prepared);
+    assert_prepared_16k_mono_audio(&prepared);
 }
 
 #[test]
@@ -488,7 +515,7 @@ fn he_aac_falls_back_to_afconvert_when_symphonia_cannot_decode_it() {
     // silently emitting bandwidth-limited audio.
     let prepared = prepare_native_conversion(&crate_fixture("tone_heaac.m4a"))
         .expect("HE-AAC should fall back to afconvert and still succeed");
-    assert_prepared_16k_mono_wav(&prepared);
+    assert_prepared_16k_mono_audio(&prepared);
 }
 
 #[test]

--- a/crates/openasr-core/src/audio/types.rs
+++ b/crates/openasr-core/src/audio/types.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use crate::BackendKind;
 
@@ -86,23 +89,91 @@ impl AudioPreparationOptions {
     }
 }
 
+/// The decoded/prepared audio a [`PreparedAudioInput`] hands to downstream
+/// consumers. The WAV-passthrough and external ffmpeg/afconvert conversion
+/// paths (`audio::prepare`) still route through a real file on disk -- either
+/// the untouched original or the external tool's output -- because that is
+/// the cheapest or only option there. The in-process symphonia decode path
+/// (the default for m4a/mp3/flac/ogg/webm/non-conformant wav) instead hands
+/// back the fully-decoded 16 kHz mono f32 samples it already has resident in
+/// memory, so callers never have to write them to a temporary WAV and
+/// immediately re-read + re-parse it back into the exact same samples.
+#[derive(Debug)]
+pub(crate) enum PreparedAudioSamples {
+    Path(PathBuf),
+    InMemory(Arc<[f32]>),
+}
+
 #[derive(Debug)]
 pub struct PreparedAudioInput {
     pub(crate) original: AudioInputInfo,
-    pub(crate) prepared_path: PathBuf,
+    pub(crate) samples: PreparedAudioSamples,
     pub(crate) temp_dir: Option<tempfile::TempDir>,
 }
 
 impl PreparedAudioInput {
+    /// A path identifying this prepared input: the real WAV to read bytes
+    /// from for the WAV-passthrough and external-conversion paths (see
+    /// [`Self::samples`]), or -- for the in-process symphonia decode path,
+    /// which writes nothing to disk -- the *original* source file, purely
+    /// for display/logging. Callers that need the decoded audio itself
+    /// should prefer [`Self::samples`] and only fall back to reading this
+    /// path when it returns `None`.
     pub fn path(&self) -> &Path {
-        &self.prepared_path
+        match &self.samples {
+            PreparedAudioSamples::Path(path) => path,
+            PreparedAudioSamples::InMemory(_) => &self.original.path,
+        }
     }
 
     pub fn original(&self) -> &AudioInputInfo {
         &self.original
     }
 
+    /// Ready-to-decode 16 kHz mono f32 samples already resident in memory,
+    /// when the in-process symphonia decode path produced them directly.
+    /// `None` for the WAV-passthrough and external ffmpeg/afconvert
+    /// conversion paths, which hand back a file via [`Self::path`] instead.
+    pub fn samples(&self) -> Option<&[f32]> {
+        match &self.samples {
+            PreparedAudioSamples::InMemory(samples) => Some(samples),
+            PreparedAudioSamples::Path(_) => None,
+        }
+    }
+
+    /// Cheap `Arc` clone of [`Self::samples`], for attaching to a
+    /// [`crate::TranscriptionRequest`]/`NativeAsrOfflineRequest` so the
+    /// native backend can decode straight from memory instead of re-reading
+    /// [`Self::path`] from disk.
+    pub fn shared_samples(&self) -> Option<Arc<[f32]>> {
+        match &self.samples {
+            PreparedAudioSamples::InMemory(samples) => Some(Arc::clone(samples)),
+            PreparedAudioSamples::Path(_) => None,
+        }
+    }
+
     pub fn is_converted(&self) -> bool {
-        self.temp_dir.is_some()
+        self.temp_dir.is_some() || matches!(self.samples, PreparedAudioSamples::InMemory(_))
+    }
+
+    /// Best-effort duration of the prepared audio in seconds. Prefers the
+    /// cheap probed source-file duration (wav's fmt/data chunk sizes,
+    /// `original().duration_seconds`); falls back to counting the in-memory
+    /// samples for the symphonia decode path, or re-probing the prepared WAV
+    /// on disk for the external-conversion path. `None` only when nothing
+    /// here can determine it (e.g. an unrecognized-extension passthrough).
+    pub fn duration_seconds(&self) -> Option<f64> {
+        if let Some(duration) = self.original.duration_seconds {
+            return Some(duration);
+        }
+        match &self.samples {
+            PreparedAudioSamples::InMemory(samples) => Some(
+                samples.len() as f64 / f64::from(super::symphonia_decode::TARGET_SAMPLE_RATE_HZ),
+            ),
+            PreparedAudioSamples::Path(path) if self.temp_dir.is_some() => {
+                super::probe_wav_duration(path)
+            }
+            PreparedAudioSamples::Path(_) => None,
+        }
     }
 }

--- a/crates/openasr-core/src/audio/types.rs
+++ b/crates/openasr-core/src/audio/types.rs
@@ -98,10 +98,19 @@ impl AudioPreparationOptions {
 /// back the fully-decoded 16 kHz mono f32 samples it already has resident in
 /// memory, so callers never have to write them to a temporary WAV and
 /// immediately re-read + re-parse it back into the exact same samples.
+///
+/// Deliberately `Arc<Vec<f32>>`, not `Arc<[f32]>`: wrapping the already-owned
+/// `Vec<f32>` the symphonia decode produced is a plain pointer move (`Arc::new`
+/// only allocates the small refcount header), whereas `Arc<[f32]>::from(vec)`
+/// would copy every sample into a new combined allocation. It also lets the
+/// sole consumer (`native_transcribe::resolve_prepared_audio_samples`) reclaim
+/// the exact same `Vec<f32>` via `Arc::try_unwrap` with zero copy whenever it
+/// is the last handle, instead of always cloning the samples out from behind
+/// a shared reference.
 #[derive(Debug)]
 pub(crate) enum PreparedAudioSamples {
     Path(PathBuf),
-    InMemory(Arc<[f32]>),
+    InMemory(Arc<Vec<f32>>),
 }
 
 #[derive(Debug)]
@@ -136,16 +145,17 @@ impl PreparedAudioInput {
     /// conversion paths, which hand back a file via [`Self::path`] instead.
     pub fn samples(&self) -> Option<&[f32]> {
         match &self.samples {
-            PreparedAudioSamples::InMemory(samples) => Some(samples),
+            PreparedAudioSamples::InMemory(samples) => Some(samples.as_slice()),
             PreparedAudioSamples::Path(_) => None,
         }
     }
 
-    /// Cheap `Arc` clone of [`Self::samples`], for attaching to a
+    /// Cheap `Arc` clone (a refcount bump, not a data copy) of
+    /// [`Self::samples`], for attaching to a
     /// [`crate::TranscriptionRequest`]/`NativeAsrOfflineRequest` so the
     /// native backend can decode straight from memory instead of re-reading
     /// [`Self::path`] from disk.
-    pub fn shared_samples(&self) -> Option<Arc<[f32]>> {
+    pub fn shared_samples(&self) -> Option<Arc<Vec<f32>>> {
         match &self.samples {
             PreparedAudioSamples::InMemory(samples) => Some(Arc::clone(samples)),
             PreparedAudioSamples::Path(_) => None,

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1391,7 +1391,13 @@ pub(crate) async fn transcribe_with_runtime(
                 // preserves the client's original extension via
                 // `safe_extension_suffix` -- see `ingest_field` above); never
                 // the client-supplied file name/stem itself.
-                .with_source_container(prepared.original().extension.clone());
+                .with_source_container(prepared.original().extension.clone())
+                // Lets the native backend decode straight from the in-process
+                // symphonia decode's in-memory samples (uploads are almost
+                // always a non-WAV/non-conformant container) instead of
+                // re-reading `input_path` from disk -- see
+                // `PreparedAudioInput::shared_samples`.
+                .with_prepared_samples(prepared.shared_samples());
             let executor = NativeBackendExecutor;
             let mut transcription = NativeAsrExecutor::transcribe(
                 &executor,


### PR DESCRIPTION
## Summary

Non-WAV audio input (m4a/mp3/flac/ogg/webm, and non-conformant wav) no longer pays a write-then-reread disk round trip between decode and transcription: the in-process symphonia decode path now hands its f32 samples straight to the native backend in memory.

## Why

`prepare_audio_input`'s symphonia decode path used to encode its already-decoded f32 samples to a PCM16 WAV, write that to a temp file, and hand back a path -- which every downstream consumer (native decode, the forced-aligner refine stage, the CLI live file-simulation path) immediately reopened and re-parsed back into f32. That is a full disk write + read + WAV re-parse, plus a lossy f32->i16->f32 quantization hop, for every non-WAV transcription (CLI, server uploads, desktop).

## Changes

- `PreparedAudioInput` carries either a `Path` (WAV passthrough and the external ffmpeg/afconvert conversion fallback, unchanged) or `InMemory` f32 samples (the symphonia decode path); added `samples()`/`shared_samples()`/`duration_seconds()` accessors.
- `symphonia_decode` returns f32 samples directly instead of encoding a WAV byte buffer; dropped the now-unused WAV encoder.
- `TranscriptionRequest` and `NativeAsrOfflineRequest` gained an optional `prepared_samples` field; `native_transcribe`'s main decode and its forced-aligner refine stage both prefer it over re-reading `input_path`.
- Wired through the CLI single-file/batch/benchmark transcribe paths, the `live --input-file` simulation path (converts samples to i16 directly, skipping `hound` entirely for in-memory input), the server's upload transcription route, and the offline perf-suite CLI (`bench_suite_cli.rs`).
- **Memory:** the in-memory samples are `Arc<Vec<f32>>`, not `Arc<[f32]>` -- wrapping the already-allocated `Vec<f32>` the decode produced is a plain pointer move (`Arc::new`), not a copy (`Arc<[f32]>::from(vec)` would copy every sample into a new combined allocation). The native decode reclaims that `Vec<f32>` via `Arc::try_unwrap` with zero copy whenever it holds the only strong reference -- the common case, since the request no longer keeps its own reference alive past that point. Peak memory for the common (non-refine) path is therefore the same as before this PR, not doubled. The only place a real clone still happens is the opt-in, uncommon forced-aligner refine stage, which legitimately needs the samples a second time after the main decode has consumed them -- one clone, bounded to that stage, matching what the pre-PR code already paid (it decoded the file twice from disk).
- Updated the audio module's unit tests for the new in-memory contract, including a new test asserting the symphonia path creates no temp file.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`

## Manual smoke checks

N/A (unit/integration coverage above exercises every conversion path; no committed golden fixture takes non-WAV input, see below).

## Docs updated

- [x] No behavior/limitations change requiring doc updates.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- The external ffmpeg/afconvert conversion fallback still writes a real prepared WAV to disk (unchanged) -- only the in-process symphonia path goes fully in-memory.
- Realtime/live-mic capture is unaffected: it already produces 16 kHz WAV directly and never calls `prepare_audio_input`.
- Non-WAV input now keeps full f32 precision instead of the prior lossy PCM16 round trip. No committed `golden_diff` fixture exercises the symphonia decode path (they are all `.wav`), so nothing here changes committed golden output.
- `bench_suite_cli.rs`'s whisper.cpp comparison baseline is an external process that needs a real WAV file path; it explicitly skips (rather than silently failing) for a hypothetical future non-WAV suite entry that takes the in-memory decode path. Every entry in `perf/suite.toml` today is already a conformant WAV, so this is unreachable in practice right now.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — AI-assisted implementation, human-reviewed and tested per the checklist above.

