### PR TITLE
test(firered-aed): add committed longform and fbank golden regressions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,7 +8,8 @@
 # Scope: this applies to processes CARGO spawns (cargo test / nextest / cargo
 # run). The shipped release binary (run directly, and what the bench-suite
 # times) is UNAFFECTED and still defaults to Metal-when-available. CI runs on
-# Linux ARM64 (no Metal) so it already used CPU — this just matches it locally.
+# Linux x86_64 (`ubuntu-latest`, no Metal) so it already used CPU — this just
+# matches it locally.
 [env]
 OPENASR_GGML_BACKEND = { value = "cpu", force = false }
 # ts-rs (realtime wire-type TS codegen, see crates/openasr-core/tests/realtime_wire_bindings.rs)

--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -812,6 +812,73 @@ fn mimo_asr_golden_diff_longform_cli_transcribe_matches_reference_decode() {
     );
 }
 
+// firered-aed longform golden: firered-aed's other golden_diff cases
+// (`firered_aed::executor::tests`) call the low-level `FireRedAedGgmlExecutor`
+// directly on the single-utterance `jfk.wav`/`zh_sample.wav` fixtures and
+// never exercise the longform/auto-VAD slicing orchestrator, so unlike those,
+// this one drives the real `openasr` binary on `fixtures/longform_en_zh.wav`
+// (same already-committed ~69s, 5-clip EN/ZH/EN/ZH/EN fixture the
+// firered-llm and mimo-asr longform goldens use) to pin the actual
+// user-facing multi-slice path. firered-aed's `GlobalQuadratic` encoder caps
+// the longform chunk length to the shared 30s default (see
+// `encoder_attention_span_caps_every_builtin_architecture_on_the_production_path`
+// in `native_transcribe.rs`), so this 69s input forces the auto energy-VAD
+// slicer to split -- confirmed 3 chunks via `--format verbose_json`'s
+// `longform.chunk_count`. Pinned against `OPENASR_GGML_BACKEND=cpu`. The two
+// chunk seams show up as the golden's two textual artifacts: a duplicated "我"
+// at the first seam (VAD overlap re-transcribing the boundary word) and a
+// missing space between "COUNTRY" and "今天" / "ANDSO" run together at chunk
+// boundaries where the assembler's join lands between two tokens with no SPM
+// space marker between them -- both present in the real committed pack's
+// output, not smoothed over.
+fn firered_aed_dev_pack_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp/firered-out/firered-aed-l-fp16.oasr")
+}
+
+const GOLDEN_FIRERED_AED_LONGFORM_EN_ZH_TEXT: &str = concat!(
+    "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO ",
+    "FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 我通常会读书或者看一部电影放松一下 ",
+    "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO ",
+    "FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗 周末的时候我通常会读书或者看一部电影放松一下 ",
+    "ANDSO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR ",
+    "YOUR COUNTRY",
+);
+
+#[test]
+#[ignore = "requires the private dev-only firered-aed-l-fp16.oasr pack; runs the real \
+            longform-chunked CLI transcribe path on a ~69s fixture, OPENASR_GGML_BACKEND=cpu"]
+fn firered_aed_golden_diff_longform_cli_transcribe_matches_reference_decode() {
+    let pack_path = firered_aed_dev_pack_path();
+    if !pack_path.exists() {
+        eprintln!("skipping: {} not present", pack_path.display());
+        return;
+    }
+    let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures/longform_en_zh.wav")
+        .canonicalize()
+        .expect("longform_en_zh.wav fixture must exist");
+
+    let assert = openasr()
+        .env("OPENASR_GGML_BACKEND", "cpu")
+        .args([
+            "transcribe",
+            &input.display().to_string(),
+            "--model-pack",
+            &pack_path.display().to_string(),
+            "--format",
+            "text",
+        ])
+        .assert()
+        .success();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    eprintln!("firered-aed longform CLI transcript: {output:?}");
+    assert_eq!(
+        output.trim_end(),
+        GOLDEN_FIRERED_AED_LONGFORM_EN_ZH_TEXT,
+        "unexpected longform CLI transcript"
+    );
+}
+
 #[test]
 fn transcribe_native_requires_local_model_pack_path() {
     let input = temp_input_wav();

--- a/crates/openasr-core/src/models/firered_aed/frontend.rs
+++ b/crates/openasr-core/src/models/firered_aed/frontend.rs
@@ -180,4 +180,53 @@ mod tests {
         let mut feats = vec![0.0; 4];
         assert!(apply_cmvn(&mut feats, 2, &[0.0], &[1.0, 1.0]).is_err());
     }
+
+    // Weight-free, committable regression net for the fbank math itself
+    // (windowing / FFT / mel filterbank / log-energy): the two tests above
+    // only feed a constant-DC signal, which is degenerate -- pre-emphasis and
+    // the FFT collapse it to (near-)zero magnitude in every bin except the
+    // log-energy floor, so a bug in the mel filterbank weights or the window
+    // function would not move the output at all. A synthetic 440 Hz sine
+    // (generated in-code, no fixture file, no model weights) actually
+    // exercises the frequency response, so a SHA-256 pin over the computed
+    // pre-CMVN log-mel values catches silent drift in the shared
+    // `kaldi_fbank` engine or this family's `FRONTEND_CONFIG` without ever
+    // needing a committed `.oasr` pack.
+    fn synthetic_sine_wave_samples(duration_seconds: f32, frequency_hz: f32) -> Vec<f32> {
+        let n = (SAMPLE_RATE_HZ as f32 * duration_seconds) as usize;
+        (0..n)
+            .map(|i| {
+                let t = i as f32 / SAMPLE_RATE_HZ as f32;
+                0.5 * (2.0 * std::f32::consts::PI * frequency_hz * t).sin()
+            })
+            .collect()
+    }
+
+    fn sha256_f32_le(values: &[f32]) -> String {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        for value in values {
+            hasher.update(value.to_le_bytes());
+        }
+        format!("{:x}", hasher.finalize())
+    }
+
+    const GOLDEN_FIRERED_FBANK_440HZ_SINE_SHA256: &str =
+        "01f3d6d729de5703297275d8fb96280354214bde032eb4cfb783e1a1464dad25";
+
+    #[test]
+    fn golden_diff_fbank_matches_pinned_hash_for_synthetic_440hz_sine() {
+        let samples = synthetic_sine_wave_samples(1.0, 440.0);
+        let features = FireRedFbankFrontend::new()
+            .compute(&samples)
+            .expect("fbank");
+        assert_eq!(features.n_mels, 80);
+        assert_eq!(features.n_frames, 98);
+        assert!(features.data.iter().all(|v| v.is_finite()));
+        let digest = sha256_f32_le(&features.data);
+        assert_eq!(
+            digest, GOLDEN_FIRERED_FBANK_440HZ_SINE_SHA256,
+            "fbank output for the synthetic 440 Hz sine drifted from the pinned golden hash"
+        );
+    }
 }

--- a/crates/openasr-core/src/models/firered_aed/frontend.rs
+++ b/crates/openasr-core/src/models/firered_aed/frontend.rs
@@ -188,10 +188,21 @@ mod tests {
     // log-energy floor, so a bug in the mel filterbank weights or the window
     // function would not move the output at all. A synthetic 440 Hz sine
     // (generated in-code, no fixture file, no model weights) actually
-    // exercises the frequency response, so a SHA-256 pin over the computed
-    // pre-CMVN log-mel values catches silent drift in the shared
-    // `kaldi_fbank` engine or this family's `FRONTEND_CONFIG` without ever
-    // needing a committed `.oasr` pack.
+    // exercises the frequency response.
+    //
+    // This does NOT pin a bit-exact hash of the full output: `rustfft` (the
+    // shared `kaldi_fbank` engine's FFT) dispatches to different SIMD kernels
+    // per target architecture, and a cross-arch check found up to 0.017 max
+    // absolute difference per log-mel value between this repo's aarch64 dev
+    // host and CI's `ubuntu-latest` (x86_64) runner for this exact synthetic
+    // input -- a real, expected floating-point-reduction-order difference,
+    // not a bug. So every numeric assertion below is a `< TOLERANCE`
+    // (2e-2, comfortably above that measured 0.017 spread) comparison against
+    // reference values captured on this repo's aarch64 dev host, plus a small
+    // number of topology-level exact assertions (frame/bin counts, the peak
+    // mel bin) that a bit-exact FFT reduction order cannot move.
+    const CROSS_ARCH_TOLERANCE: f32 = 2e-2;
+
     fn synthetic_sine_wave_samples(duration_seconds: f32, frequency_hz: f32) -> Vec<f32> {
         let n = (SAMPLE_RATE_HZ as f32 * duration_seconds) as usize;
         (0..n)
@@ -202,31 +213,77 @@ mod tests {
             .collect()
     }
 
-    fn sha256_f32_le(values: &[f32]) -> String {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        for value in values {
-            hasher.update(value.to_le_bytes());
-        }
-        format!("{:x}", hasher.finalize())
-    }
-
-    const GOLDEN_FIRERED_FBANK_440HZ_SINE_SHA256: &str =
-        "01f3d6d729de5703297275d8fb96280354214bde032eb4cfb783e1a1464dad25";
+    // Reference-platform (macOS aarch64) pre-CMVN log-mel row for frame 49
+    // (the temporal midpoint of the 98-frame output) of a 1s/440Hz synthetic
+    // sine, captured via `FireRedFbankFrontend::compute`.
+    const REFERENCE_MID_FRAME_INDEX: usize = 49;
+    const REFERENCE_MID_FRAME_MEL: [f32; 80] = [
+        9.15403, 9.707858, 9.0794, 8.10379, 10.367656, 11.684205, 12.609817, 13.0649605,
+        12.0948515, 13.158659, 16.220291, 18.155163, 21.218346, 24.451693, 25.201832, 24.18605,
+        20.647932, 17.800747, 14.544067, 13.942957, 13.465343, 11.708978, 10.721327, 11.125276,
+        9.636799, 9.035014, 9.323213, 7.888769, 8.032621, 7.8527403, 6.703881, 7.238613, 5.9116964,
+        6.362684, 5.814136, 5.619769, 5.7077184, 5.0359716, 4.839378, 4.5809956, 4.500667,
+        5.9902954, 6.2484126, 5.969748, 4.3605266, 3.8930109, 4.786309, 4.589755, 3.3749213,
+        3.2095275, 5.80585, 6.5169654, 5.7522435, 5.657481, 5.732948, 4.62743, 4.8528843,
+        5.7505183, 5.0832577, 6.365632, 6.578811, 5.2467036, 5.3258343, 6.3744135, 6.318425,
+        7.2973347, 5.370094, 5.7292542, 6.311184, 7.035475, 7.1788545, 6.216628, 6.36065, 8.939394,
+        7.266076, 5.47633, 6.591452, 9.103914, 7.3653455, 7.268999,
+    ];
+    // The 440 Hz fundamental's log-mel peak, at reference-platform mel bin
+    // 14 -- topology, not float magnitude, so it must hold exactly across
+    // architectures regardless of FFT reduction order.
+    const REFERENCE_PEAK_MEL_BIN: usize = 14;
+    // Reference-platform total log-mel energy (sum over all 98*80 values);
+    // a wide-but-bounded absolute tolerance (well under 0.1% relative) so a
+    // real regression (wrong filterbank weights, dropped frames, mis-scaled
+    // window) still trips this even though per-value cross-arch FFT noise
+    // does not.
+    const REFERENCE_TOTAL_ENERGY: f64 = 65021.198688641656;
+    const TOTAL_ENERGY_TOLERANCE: f64 = 50.0;
 
     #[test]
-    fn golden_diff_fbank_matches_pinned_hash_for_synthetic_440hz_sine() {
+    fn golden_diff_fbank_matches_pinned_reference_for_synthetic_440hz_sine() {
         let samples = synthetic_sine_wave_samples(1.0, 440.0);
         let features = FireRedFbankFrontend::new()
             .compute(&samples)
             .expect("fbank");
+
+        // Exact, architecture-independent topology.
         assert_eq!(features.n_mels, 80);
         assert_eq!(features.n_frames, 98);
         assert!(features.data.iter().all(|v| v.is_finite()));
-        let digest = sha256_f32_le(&features.data);
+
+        let mid = features.n_frames / 2;
+        assert_eq!(mid, REFERENCE_MID_FRAME_INDEX);
+        let row = &features.data[mid * features.n_mels..(mid + 1) * features.n_mels];
+
+        let peak_bin = row
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map(|(i, _)| i)
+            .expect("mid frame is non-empty");
         assert_eq!(
-            digest, GOLDEN_FIRERED_FBANK_440HZ_SINE_SHA256,
-            "fbank output for the synthetic 440 Hz sine drifted from the pinned golden hash"
+            peak_bin, REFERENCE_PEAK_MEL_BIN,
+            "440 Hz fundamental's peak mel bin moved"
+        );
+
+        for (bin, (actual, expected)) in row.iter().zip(REFERENCE_MID_FRAME_MEL).enumerate() {
+            let diff = (actual - expected).abs();
+            assert!(
+                diff < CROSS_ARCH_TOLERANCE,
+                "mid-frame mel bin {bin} drifted past cross-arch tolerance: \
+                 actual={actual} expected={expected} diff={diff} tolerance={CROSS_ARCH_TOLERANCE}"
+            );
+        }
+
+        let total_energy: f64 = features.data.iter().map(|v| *v as f64).sum();
+        let energy_diff = (total_energy - REFERENCE_TOTAL_ENERGY).abs();
+        assert!(
+            energy_diff < TOTAL_ENERGY_TOLERANCE,
+            "total fbank log-mel energy drifted: actual={total_energy} \
+             expected={REFERENCE_TOTAL_ENERGY} diff={energy_diff} \
+             tolerance={TOTAL_ENERGY_TOLERANCE}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds two committed, non-ignored golden regression tests for firered-aed, closing
gaps found by auditing the family's existing golden coverage against the other
seq2seq families (firered-llm, mimo-asr, whisper).

## Why

firered-aed's `golden_diff_*` tests are all `#[ignore]`d and require the private,
non-committed fp16 dev pack, so `cargo nextest run --workspace` (default CI) has
zero firered-aed-specific correctness coverage today. Model weights cannot be
committed (repo artifact policy), so a bit-exact end-to-end transcript golden
cannot run in CI for this family, same as every other native family. This PR adds
the two things that are both (a) genuinely missing and (b) achievable without
committing any weights:

- firered-aed had no longform/auto-VAD-slicing golden at all, unlike firered-llm
  and mimo-asr, which already pin the real CLI transcribe path on the shared
  `fixtures/longform_en_zh.wav` fixture (~69s, forces the `GlobalQuadratic` 30s
  chunk cap to split into multiple slices).
- The fbank frontend's existing tests only fed a degenerate constant-DC signal,
  which collapses through pre-emphasis/FFT and would not catch a windowing or
  mel-filterbank regression.

## Changes

- `crates/openasr-cli/tests/cli.rs`: add
  `firered_aed_golden_diff_longform_cli_transcribe_matches_reference_decode`,
  mirroring the existing firered-llm/mimo-asr longform CLI goldens. `#[ignore]`d
  (needs the private dev-only `firered-aed-l-fp16.oasr` pack), captured and
  verified against the real pack locally; text pinned includes the two chunk-seam
  artifacts (a duplicated "我" and missing spaces at slice boundaries) present in
  the real output, not smoothed over.
- `crates/openasr-core/src/models/firered_aed/frontend.rs`: add
  `golden_diff_fbank_matches_pinned_reference_for_synthetic_440hz_sine`, a
  weight-free, always-on test against an in-code synthetic 440 Hz sine (no
  fixture file, no model weights). Runs in the default workspace test pass.
  This does **not** pin a bit-exact hash of the output: the shared fbank
  engine's FFT (`rustfft`) dispatches to different SIMD kernels per target
  architecture, and a cross-arch check found up to 0.017 max absolute
  difference per log-mel value between aarch64 and CI's `ubuntu-latest`
  (x86_64) runner for this exact input -- a real floating-point
  reduction-order difference, not a bug, that would have made a bit-exact
  hash fail closed on every CI run. Instead it asserts exact
  architecture-independent topology (frame/mel counts, the 440 Hz peak mel
  bin) plus a `< 2e-2` per-element tolerance (above the measured 0.017
  spread) against a reference mid-frame row and total log-mel energy
  captured on the aarch64 dev host.
- `.cargo/config.toml`: fix a stale comment describing CI as running on Linux
  ARM64; `ci.yml` actually uses `ubuntu-latest` (x86_64).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2777 passed, 131 skipped/ignored; new fbank
      golden runs and passes in this default pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] Locally, against the real private fp16 pack: all 3 previously-ignored
      firered-aed `golden_diff_*` end-to-end tests plus the new longform CLI
      golden pass; confirmed deterministic across two runs.

## Manual smoke checks

Ran the real `openasr transcribe` CLI against `fixtures/longform_en_zh.wav` with
the local fp16 dev pack (`OPENASR_GGML_BACKEND=cpu`), confirmed via
`--format verbose_json` that the auto energy-VAD slicer picks 3 chunks for this
input, then pinned the resulting text as the new golden.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not attempt to make any firered-aed golden run un-ignored in CI -- that
  would require committing model weights, which the artifact policy forbids.
  This mirrors the existing house pattern for firered-llm/mimo-asr/whisper.
- Does not touch the pre-existing low-level
  `encoder_matches_reference_pytorch_output_on_jfk_wav` parity test, which is
  currently failing against the local dev pack (actual encoder output far from
  the pinned reference values) -- that looks like a pre-existing bug unrelated to
  this change; flagging separately rather than fixing here to keep this PR
  scoped to adding coverage.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts,
      secrets, or private audio.
- [x] I did not add vendored runtime sources outside
      `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage
      policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI
      assistance, and I own its maintenance.
- AI usage disclosure: YES -- used AI assistance to audit existing golden-test
  conventions across model families and draft these tests, including a
  cross-architecture review that caught and fixed a hash-pin portability bug
  before merge.
