### PR TITLE
fix(moss): accept the reuse path's empty layer-KV contract so Metal decode reuses its graph

### DIFF
--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -1631,22 +1631,31 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         executor_component_id: MOSS_TD_EXECUTOR_COMPONENT_ID,
         execution_capability: GgmlExecutionCapability::DedicatedRuntimeExecutorV1,
         prefer_cpu_decoder_for_multichunk_metal: false,
-        // Auto is pinned OFF Metal for this family until two Metal-specific
-        // defects are fixed (both measured on an M1, CPU parity confirmed; each
-        // is its own follow-up, out of scope for this landing):
+        // Auto is pinned OFF Metal for this family until its Metal-specific
+        // defect is fixed (measured on an M1, CPU parity confirmed; its own
+        // follow-up, out of scope for this landing):
         //   1. Encoder numeric divergence: the Whisper encoder's deep layers
         //      decorrelate on Metal (final-layer cosine ~0.20 vs the fp32 CPU
         //      reference, which matches), collapsing decoding to an empty
         //      `[..][S01][..]` shell. CPU produces the correct transcript.
-        //   2. Memory blow-up: the per-token decode rebuilds the whole 28-layer
-        //      ggml graph each step; on Metal the wired working set exhausts a
-        //      16 GB machine, while the same run peaks ~2.8 GB on CPU. (The KV
-        //      over-allocation half of this is already fixed via
-        //      `runtime_contract::moss_td_kv_cache_positions`; the remaining
-        //      per-step graph/wired behavior is Metal-only and still open.)
+        // A second defect that used to live here -- the per-token decode
+        // rebuilding the whole 28-layer ggml graph each step and exhausting
+        // Metal's wired working set -- is fixed: `llm_decoder`'s decode step
+        // already called the shared executor's `run_step_auto`, which reuses
+        // a persistent decode graph on Metal (`supports_graph_reuse`), but
+        // the KV-cache write-back after it unconditionally asserted a
+        // full per-layer K/V count, which the reuse path legitimately never
+        // produces (its K/V stays resident in the decode graph's own arena),
+        // so every Metal decode step failed closed on that mismatch before
+        // the reuse graph could actually amortize anything. `write_layer_kv`
+        // now treats an empty layer-KV slice as the reuse path's no-op
+        // contract instead of a count error (see its doc comment) --
+        // measured end-to-end on the real dev pack: decode now builds the
+        // reused graph once and revisits it every subsequent token instead of
+        // rebuilding, with no other per-step allocation growth.
         // `ExceptMetal` only steers Auto to CPU; an explicit
-        // `execution_target=accelerated` still gets Metal (and both defects),
-        // by design. Revisit -> `AllBackends` once 1 and 2 land.
+        // `execution_target=accelerated` still gets Metal (and the remaining
+        // encoder defect), by design. Revisit -> `AllBackends` once 1 lands.
         auto_gpu_policy: AutoGpuPolicy::ExceptMetal,
         // The model is trained to emit `[S01]`/`[S02]`/... speaker labels
         // directly in its transcript text (see `decode_prompt`'s fixed

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -331,11 +331,14 @@ impl MossTdDecoderRuntime {
         let hidden = self.gather_token_embedding(token_id)?;
         // `run_step_auto` transparently reuses the persistent decode graph on
         // the Metal/single-GPU lane (avoiding the per-token graph rebuild whose
-        // growing-KV re-upload exhausts the Metal command buffer on long
-        // decodes); CPU stays on the per-token `run_step` rebuild, byte-
-        // identical to before. The host KV write below keeps the host cache in
-        // sync for the CPU path and is a harmless no-op-equivalent on the
-        // reuse path (whose KV lives resident in the decode graph's arena).
+        // growing-KV re-upload and re-allocation is what exhausts Metal's
+        // wired memory over a long decode); CPU stays on the per-token
+        // `run_step` rebuild, byte-identical to before. The host KV write
+        // below keeps the host cache in sync for the CPU (and any non-reuse)
+        // path; on the reuse path `step.layer_kv` comes back empty by design
+        // (see `write_layer_kv`'s doc) and the write below is a real no-op,
+        // not merely a harmless-looking one -- `write_layer_kv` must treat an
+        // empty slice as intentional rather than a count-mismatch error.
         let step = self
             .whole_decoder
             .run_step_auto(&hidden, cache_position, layer_kv_caches, MOSS_TD_ROPE_THETA)
@@ -393,6 +396,22 @@ fn write_layer_kv(
     kv_row_width: usize,
     layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
 ) -> Result<(), MossTdDecoderError> {
+    // `run_step_reused` (the Metal/single-GPU decode-graph-reuse path) returns
+    // an intentionally EMPTY `layer_kv`: its K/V lives resident in the
+    // persistent decode graph's device-side arena, never read back to the
+    // host, so there is nothing to mirror into `layer_kv_caches` -- exactly
+    // mirroring qwen3-asr's own decode step, whose `step.layer_kv.iter()`
+    // loop (`qwen::ggml_executor`'s `decode_step`) simply iterates zero times
+    // on that path instead of asserting a count. Treating empty as a no-op
+    // here (rather than failing the strict count check below) is what makes
+    // `decode_step`'s call into this function byte-for-byte the same
+    // reuse-tolerant contract; every OTHER caller (prefill, and decode's own
+    // non-reuse `run_step` rebuild) always produces one entry per layer, so a
+    // non-empty-but-wrong count still fails closed instead of silently
+    // dropping/misaligning KV writes.
+    if layer_kv.is_empty() {
+        return Ok(());
+    }
     if layer_kv.len() != layer_kv_caches.len() {
         return Err(MossTdDecoderError::KvCacheFailed {
             reason: "layer-KV count mismatch".to_string(),


### PR DESCRIPTION
## Summary

MOSS decode already routed through the shared executor's run_step_auto, whose Metal reuse path legitimately returns an empty layer_kv (K/V stays resident in the device-side arena, mirroring qwen). MOSS's write_layer_kv rejected the empty slice with a strict count-mismatch guard, so every GPU-class decode step hard-errored before the reused graph could run -- this is also why plain `openasr transcribe` (Auto) fails on MOSS with "layer-KV count mismatch" today. The guard now treats the empty slice as the reuse-path no-op contract and still fails closed on any non-empty wrong count. Stale docs in llm_decoder.rs and arch/mod.rs updated to reflect what is fixed (defect 2) vs still open (defect 1, encoder divergence).

## Why

Unblocks the standard CLI path for MOSS and makes the Metal decode graph actually amortize (single build, ~300 reuse steps measured on jfk).

## Changes

- `llm_decoder.rs`: empty layer_kv = Ok (reuse contract); non-empty mismatch still errors.
- `arch/mod.rs`: doc comment updated.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

2779 passed / 0 failed; golden_diff 4/4; catalog signature test green.

## Manual smoke checks

Real fp16 dev pack: CPU goldens byte-identical (jfk, en_zh_mixed); Metal (forced accelerated) decodes end-to-end with transcripts matching the CPU goldens (one time anchor within the documented 0.02s f16/flash delta), graph built once and reused across ~300 steps.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not lift the ExceptMetal gate (encoder defect 1 pending); no cap re-tuning (resident reuse arena ~896MB at the 8192 cap is fine).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES