### PR TITLE
docs(release): source B2 sync credentials from ~/.openasr/b2-release.env (#184)

### DIFF
--- a/tooling/release-manifest/README.md
+++ b/tooling/release-manifest/README.md
@@ -180,11 +180,12 @@ Run all three steps from a maintainer machine; none of this runs in CI.
    (`b2_sync.py sync --version <version>`, uploading the Windows sidecar
    archives -- `-vulkan`, `-cuda-sidecar`, `-rocm-sidecar` -- plus
    `backends-manifest.json` and `backends-manifest.signature.json` to
-   `core/v<version>/` in the shared `openasr-releases` B2 bucket. The B2 vars
-   (`B2_S3_ENDPOINT` / `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`) come
-   from `source ~/.openasr/b2-release.env` in the running shell -- never repo
-   secrets, never a shell-profile export). `sync-vendor` for the vendor_layers archives is
-   OPTIONAL (see above) and not part of this release-blocking checklist --
+   `core/v<version>/` in the shared `openasr-releases` B2 bucket). The B2
+   vars (`B2_S3_ENDPOINT` / `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`)
+   come from `source ~/.openasr/b2-release.env` in the running shell -- never
+   repo secrets, never a shell-profile export. `sync-vendor` for the
+   vendor_layers archives is OPTIONAL (see above) and not part of this
+   release-blocking checklist --
    GitHub Releases (already populated by `release-binaries.yml`) is enough.
    `b2_sync.py` is the ONLY thing that syncs to B2/dl.openasr.org -- step 1's
    script deliberately does not touch B2 at all, so run this step after step

--- a/tooling/release-manifest/README.md
+++ b/tooling/release-manifest/README.md
@@ -107,10 +107,15 @@ plus `release-publish.mjs`'s upload-with-immutability-check logic --
 cross-validated against AWS's published SigV4 worked example in
 `b2_sync_test.py`, no network required to test.
 
+The B2 write credentials are kept **only** in `~/.openasr/b2-release.env`
+(chmod 600, outside the repo) -- never in `~/.zshrc` / `~/.bashrc` or any
+long-lived shell profile (a release-bucket write key must not be inherited by
+every terminal process), and never as a CI secret / repository variable /
+workflow literal for this script (core's sync is a local, human-run step).
+`source` that file in the shell that runs the sync, then run the command:
+
 ```bash
-export B2_S3_ENDPOINT=https://s3.us-east-005.backblazeb2.com   # confirm the real value with whoever owns the B2 account
-export B2_APPLICATION_KEY_ID=...
-export B2_APPLICATION_KEY=...                                   # never logged
+source ~/.openasr/b2-release.env   # provides B2_S3_ENDPOINT / B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY (and optional B2_BUCKET / B2_S3_REGION); never logged
 
 python3 tooling/release-manifest/b2_sync.py sync --version 0.1.20 \
   dist/openasr-0.1.20-windows-x86_64-vulkan.zip \
@@ -146,8 +151,9 @@ is always a local, human-run step:
   key prefix (`B2_BUCKET` defaults to `openasr-releases`; override only if the
   bucket is ever split). Credentials (`B2_APPLICATION_KEY_ID` /
   `B2_APPLICATION_KEY`) stay out of CI -- this sync always runs from a
-  maintainer's machine using the same local env vars desktop releases use, not
-  a repo secret.
+  maintainer's machine, with the B2 vars provided by `source
+  ~/.openasr/b2-release.env` in that shell (the same credential file desktop
+  releases use), not a repo secret and not a long-lived shell-profile export.
 - `openasr-app`'s own `release-desktop.yml` only runs this kind of publish
   from a `workflow_dispatch` with an explicit `publish: true` input, gated by
   repo secrets on the app repo -- i.e. even there, publishing to
@@ -174,9 +180,10 @@ Run all three steps from a maintainer machine; none of this runs in CI.
    (`b2_sync.py sync --version <version>`, uploading the Windows sidecar
    archives -- `-vulkan`, `-cuda-sidecar`, `-rocm-sidecar` -- plus
    `backends-manifest.json` and `backends-manifest.signature.json` to
-   `core/v<version>/` in the shared `openasr-releases` B2 bucket, using local
-   `B2_S3_ENDPOINT` / `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` env vars
-   -- never repo secrets). `sync-vendor` for the vendor_layers archives is
+   `core/v<version>/` in the shared `openasr-releases` B2 bucket. The B2 vars
+   (`B2_S3_ENDPOINT` / `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`) come
+   from `source ~/.openasr/b2-release.env` in the running shell -- never repo
+   secrets, never a shell-profile export). `sync-vendor` for the vendor_layers archives is
    OPTIONAL (see above) and not part of this release-blocking checklist --
    GitHub Releases (already populated by `release-binaries.yml`) is enough.
    `b2_sync.py` is the ONLY thing that syncs to B2/dl.openasr.org -- step 1's

--- a/tooling/release-manifest/b2_sync.py
+++ b/tooling/release-manifest/b2_sync.py
@@ -37,6 +37,16 @@ Both subcommands use THE SAME environment variable names as
   B2_BUCKET             Default: openasr-releases
   B2_S3_REGION          Override if it cannot be inferred from B2_S3_ENDPOINT.
 
+Credential source: these write credentials live ONLY in
+`~/.openasr/b2-release.env` (chmod 600, outside the repo). `source` that file
+in the shell that runs this script, e.g. `source ~/.openasr/b2-release.env`
+immediately before the command. Do NOT export them from a long-lived shell
+profile (~/.zshrc, ~/.bashrc, ...): a release-bucket write key must not be
+inherited by every terminal process. They are also never CI secrets /
+repository variables / workflow literals for this script -- core's B2 sync is
+a local, human-run step (see README). Missing vars fail closed below with a
+message pointing at the `source` step.
+
 Immutability, same policy as the desktop publish script: before uploading a
 key, HEAD it. If an object already exists there with a DIFFERENT sha256, this
 aborts rather than silently overwriting a shipped release asset -- bump the
@@ -193,12 +203,18 @@ class B2Credentials:
         secret_access_key = env.get("B2_APPLICATION_KEY")
         if not endpoint:
             raise B2SyncError(
-                "B2_S3_ENDPOINT is not set. The bucket's region/cluster is not known until it's "
-                "created; set this to the bucket's S3-compatible endpoint, e.g. "
-                "https://s3.us-east-005.backblazeb2.com."
+                "B2_S3_ENDPOINT is not set. These B2 write credentials are kept only in "
+                "~/.openasr/b2-release.env (not in any shell profile and not in CI); run "
+                "`source ~/.openasr/b2-release.env` in this shell and retry. The endpoint is "
+                "the bucket's S3-compatible URL, e.g. https://s3.us-east-005.backblazeb2.com "
+                "(the region/cluster is not known until the bucket is created)."
             )
         if not access_key_id or not secret_access_key:
-            raise B2SyncError("B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY must both be set to sync.")
+            raise B2SyncError(
+                "B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY must both be set to sync. They "
+                "live only in ~/.openasr/b2-release.env; run `source ~/.openasr/b2-release.env` "
+                "in this shell and retry (do not export them from ~/.zshrc or any login profile)."
+            )
         return cls(
             endpoint=endpoint,
             access_key_id=access_key_id,

--- a/tooling/release-manifest/b2_sync_test.py
+++ b/tooling/release-manifest/b2_sync_test.py
@@ -154,6 +154,61 @@ class RegionFromEndpointTest(unittest.TestCase):
             region_from_endpoint("https://example.com", None)
 
 
+# Complete, obviously-fake credential set for the from_env tests below. Every
+# case passes an explicit env dict, so these never read or mutate the real
+# os.environ.
+_COMPLETE_ENV = {
+    "B2_S3_ENDPOINT": "https://s3.us-east-005.backblazeb2.com",
+    "B2_APPLICATION_KEY_ID": "fake-key-id",
+    "B2_APPLICATION_KEY": "fake-secret",
+}
+
+
+class FromEnvCredentialGateTest(unittest.TestCase):
+    """B2Credentials.from_env must fail closed on incomplete credentials."""
+
+    def test_missing_endpoint_raises(self) -> None:
+        env = {name: value for name, value in _COMPLETE_ENV.items() if name != "B2_S3_ENDPOINT"}
+        with self.assertRaises(B2SyncError) as ctx:
+            B2Credentials.from_env(env=env)
+        self.assertIn("source ~/.openasr/b2-release.env", str(ctx.exception))
+
+    def test_missing_application_key_id_raises(self) -> None:
+        env = {
+            name: value for name, value in _COMPLETE_ENV.items() if name != "B2_APPLICATION_KEY_ID"
+        }
+        with self.assertRaises(B2SyncError) as ctx:
+            B2Credentials.from_env(env=env)
+        message = str(ctx.exception)
+        self.assertIn("must both be set", message)
+        self.assertIn("source ~/.openasr/b2-release.env", message)
+
+    def test_missing_application_key_raises(self) -> None:
+        env = {name: value for name, value in _COMPLETE_ENV.items() if name != "B2_APPLICATION_KEY"}
+        with self.assertRaises(B2SyncError) as ctx:
+            B2Credentials.from_env(env=env)
+        message = str(ctx.exception)
+        self.assertIn("must both be set", message)
+        self.assertIn("source ~/.openasr/b2-release.env", message)
+
+    def test_empty_string_values_raise(self) -> None:
+        for unset in _COMPLETE_ENV:
+            with self.subTest(unset=unset):
+                env = dict(_COMPLETE_ENV)
+                env[unset] = ""
+                with self.assertRaises(B2SyncError):
+                    B2Credentials.from_env(env=env)
+
+    def test_complete_env_builds_credentials_with_optional_overrides(self) -> None:
+        env = dict(_COMPLETE_ENV, B2_BUCKET="other-bucket", B2_S3_REGION="us-east-005")
+        credentials = B2Credentials.from_env(env=env)
+        self.assertEqual(credentials.endpoint, _COMPLETE_ENV["B2_S3_ENDPOINT"])
+        self.assertEqual(credentials.access_key_id, _COMPLETE_ENV["B2_APPLICATION_KEY_ID"])
+        self.assertEqual(credentials.secret_access_key, _COMPLETE_ENV["B2_APPLICATION_KEY"])
+        self.assertEqual(credentials.bucket, "other-bucket")
+        self.assertEqual(credentials.region, "us-east-005")
+
+
 class DecideImmutabilityActionTest(unittest.TestCase):
     def test_put_when_nothing_remote(self) -> None:
         self.assertEqual(decide_immutability_action(None, 10, "abc"), "put")


### PR DESCRIPTION
## Summary

The B2 release-bucket write credentials (B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY / B2_S3_ENDPOINT, optional B2_BUCKET / B2_S3_REGION) moved out of ~/.zshrc into ~/.openasr/b2-release.env (chmod 600, outside the repo), sourced per-shell on demand so a write key is no longer inherited by every terminal process. This adapts core's local B2 sync tooling (tooling/release-manifest/b2_sync.py + README) to that model.

## Why

A production write key exported from a login profile leaks into every shell/process; keeping it in a 600-mode file sourced only when syncing is the safer posture. The script and docs previously implied the vars were always present in the environment (an inline `export ... = ...` example block, and "local env vars" wording), which no longer holds for a fresh shell.

## Changes

- `b2_sync.py`: missing-var errors now fail closed (unchanged behavior) but the message tells the operator to `source ~/.openasr/b2-release.env` and retry, and notes the vars must not live in a shell profile or CI. Module docstring gains a "Credential source" paragraph stating the same. No dotenv / repo-file loading added; no hardcoded values.
- `README.md`: the inline `export B2_...` example is replaced by `source ~/.openasr/b2-release.env`; the "Decided policy" and post-release-checklist bullets now say the vars come from sourcing that file, never a repo secret and never a long-lived profile export. Post-release step 2 also had a sentence-with-period split out of its parenthetical for readability.
- `b2_sync_test.py`: adds five from_env credential-gate tests (explicit env dicts, never os.environ): missing B2_S3_ENDPOINT / B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY each raise B2SyncError, empty-string values raise, and a complete env builds credentials with the optional B2_BUCKET / B2_S3_REGION overrides. Error-message assertions pin the stable `source ~/.openasr/b2-release.env` wording.
- CI: verified `.github/` has zero references to these B2 vars -- core's sync is intentionally a local, human-run step, so there was nothing to migrate to secrets (confirming requirement 4 by absence).

## Tests run

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Python-only change: `python3 -m unittest discover -s tooling/release-manifest -p 'b2_sync_test.py'` -> 25 tests OK (the pre-existing B2SyncError tests covered region inference / immutability / overwrite / missing-local-file, NOT from_env; this PR adds the missing from_env credential-gate tests).

## Manual smoke checks

Repo-wide grep confirms no remaining "store B2 in zshrc/profile" wording, no bare `export B2_` example, no hardcoded key, and no new dotenv/repo-file credential loading. Did not read ~/.openasr/b2-release.env or ~/.zshrc.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

No behavior change to the sync itself (SigV4 signing, immutability gate, upload logic untouched); this is credential-provenance messaging + runbook wording only. Does not touch the app repo's B2 client (separate owner).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
