### PR TITLE
perf(firered-aed): drop four statically-proven-redundant cont copies

### DIFF
--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -748,9 +748,9 @@ fn view_last_token_state<'a>(
     hidden: usize,
     prefix_len: usize,
 ) -> Result<GgmlCpuTensor<'a>, FireRedDecoderError> {
-    let contiguous_state = graph
-        .cont(state)
-        .map_err(|source| map_err("last_token_cont", source))?;
+    // No `ggml_cont` needed: `state` is the output of the final affine
+    // layer_norm (an `ggml_add` of scale and bias), which is always a freshly
+    // allocated contiguous tensor, so `ggml_view_2d` can slice it directly.
     let row_stride = hidden
         .checked_mul(std::mem::size_of::<f32>())
         .ok_or(FireRedDecoderError::ShapeOverflow)?;
@@ -759,7 +759,7 @@ fn view_last_token_state<'a>(
         .and_then(|index| index.checked_mul(row_stride))
         .ok_or(FireRedDecoderError::ShapeOverflow)?;
     graph
-        .view_2d(contiguous_state, hidden, 1, row_stride, offset)
+        .view_2d(state, hidden, 1, row_stride, offset)
         .map_err(|source| map_err("last_token_view", source))
 }
 

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -586,12 +586,16 @@ fn firered_conformer_block<'a>(
     let scores = graph
         .soft_max(scores)
         .map_err(|source| map_err("ggml_soft_max(attn_scores)", source))?;
+    // No `ggml_cont` here: `attention_context_from_probs` immediately re-permutes
+    // this tensor (its own `value_permute` step) before the value_cont that
+    // materializes it, so the two permutes compose into one and only the final
+    // `ggml_cont` needs to run.
     let v_heads = reshape_projection_to_attention_heads(
         graph,
         v,
         attention_layout,
         STANDARD_HEAD_PERMUTE_AXES,
-        true,
+        false,
         AttentionReshapeSteps {
             reshape: "ggml_reshape_3d(attn_v)",
             permute: "ggml_permute(attn_v)",
@@ -659,12 +663,10 @@ fn firered_conformer_block<'a>(
             glu_half_width * element,
         )
         .map_err(|source| map_err("ggml_view_2d(conv_gate)", source))?;
-    let conv_main = graph
-        .cont(conv_main)
-        .map_err(|source| map_err("ggml_cont(conv_main)", source))?;
-    let conv_gate = graph
-        .cont(conv_gate)
-        .map_err(|source| map_err("ggml_cont(conv_gate)", source))?;
+    // No `ggml_cont` needed for either GLU half: `ggml_sigmoid` is elementwise and
+    // only requires `is_contiguous_rows` (satisfied here since nb0 on both views is
+    // still the element size), and `ggml_mul` accepts a strided src0 against a
+    // freshly-allocated (contiguous) dst.
     conv = graph
         .mul(
             conv_main,


### PR DESCRIPTION
## Summary

Removes four `ggml_cont` calls in the firered-aed graph that a static analysis
of ggml's operator contiguity requirements showed are redundant:

- Encoder GLU: `cont(conv_main)` / `cont(conv_gate)` before the sigmoid+mul.
- Encoder attention: the `cont` on `v_heads` (the reshape/permute helper's
  `contiguous` flag, firered's call site only).
- Decoder: the `cont(state)` inside `view_last_token_state`.

## Why

`ggml_mul_mat` only requires its operands contiguous on the first dimension
(`ggml-cpu.c`), and elementwise ops only require `is_contiguous_rows`; `cont`/
`dup` themselves accept arbitrary-stride sources. Each of the four sites was
materializing a tensor that the very next op already accepts as a view:

- `sigmoid(conv_gate)` is elementwise (`is_contiguous_rows` holds: nb0 is
  still the element size on the GLU half-views) and `mul(conv_main, ...)`
  accepts a strided src0 against a freshly-allocated dst.
- `v_heads`'s cont was immediately followed by another permute
  (`attention_context_from_probs`'s `value_permute` step) before *its own*
  cont, so the two permutes now compose into a single view and only the
  final cont materializes it.
- `state` going into `view_last_token_state` is already the contiguous output
  of the decoder's final affine layer_norm, so the view can slice it
  directly without an extra copy.

`k_heads`/`r_heads` cont calls are intentionally left in place -- they are
also statically removable but their effect on Metal matmul throughput needs
a separate A/B measurement, out of scope here.

## Changes

- `crates/openasr-core/src/models/firered_aed/encoder_graph.rs`: drop the
  GLU-half conts and flip `v_heads`'s `contiguous` argument to `false`.
- `crates/openasr-core/src/models/firered_aed/decoder_graph.rs`: drop the
  `cont` in `view_last_token_state`.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture`
- [x] `cargo test -p openasr-core firered_aed` (default suite, 39 passed / 8 ignored)
- [x] `cargo test --workspace --doc`
- [x] firered-aed `#[ignore]` e2e goldens (jfk + zh) against the private dev pack --
      transcripts unchanged
- [x] firered-aed encoder parity test against the pinned PyTorch reference --
      `max_abs_diff`/`mean_abs_diff` unchanged (0.3315 / 0.0758, matching the
      committed pin exactly)
- [ ] `cargo nextest run --workspace` (ran the scoped `firered_aed` + `golden_diff`
      subsets above instead, per reviewer request for this change)
- [ ] `cargo deny check`

No firered-aed CPU-vs-Metal parity harness exists yet (that pattern is currently
implemented only for `moss_transcribe_diarize`, see #182); nothing to run there.

## Manual smoke checks

N/A -- covered by the golden/parity tests above.

## Docs updated

- [x] No behavior or limitations changed; no docs update needed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not touch `k_heads`/`r_heads` conts (separate perf decision pending
Metal throughput measurement), does not touch any other model family, and
does not touch the `with_taps` diagnostic variant of the conformer block
(test-only tooling, not part of the production graph).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- used AI-assisted tooling for the static ggml-contiguity analysis and to draft/apply this diff, based on a prior offline static review the author performed.