### PR TITLE
publish(catalog): stage moss-transcribe-diarize publish metadata

### DIFF
--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -879,6 +879,81 @@ fn firered_aed_golden_diff_longform_cli_transcribe_matches_reference_decode() {
     );
 }
 
+// moss-transcribe-diarize longform golden: this family's other golden_diff
+// cases (`moss_transcribe_diarize::executor::tests`) call the low-level
+// `MossTdGgmlExecutor` directly on single-utterance fixtures and never
+// exercise the longform/auto-VAD slicing orchestrator, so unlike those, this
+// one drives the real `openasr` binary on `fixtures/longform_en_zh.wav` (same
+// already-committed ~69s, 5-clip EN/ZH/EN/ZH/EN fixture the firered-llm/
+// mimo-asr/firered-aed longform goldens use) to pin the actual user-facing
+// multi-slice path. moss-transcribe-diarize's `FixedWindow` encoder span
+// (Whisper's own architecture-fixed 30s log-mel window) means the executor
+// loops the encoder over independent windows and concatenates, same as
+// `whisper` itself -- unlike the other three families' longform goldens, this
+// fixture's assembled transcript shows no chunk-seam artifacts (no duplicated
+// word, no missing inter-token space): each of the three encoder passes ends
+// on a clean sentence boundary for this particular fixture. The family's own
+// `[start][Sxx]text[end]` tagged output (self_diarizes = true) comes through
+// unmodified in the assembled text -- core does not parse or restructure
+// those tags (see the family's module doc comment). Pinned against
+// `OPENASR_GGML_BACKEND=cpu` (this family's Metal path has a known encoder
+// numerics defect, see the arch descriptor's `auto_gpu_policy` doc).
+fn moss_transcribe_diarize_dev_pack_path() -> PathBuf {
+    PathBuf::from(
+        "/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/moss-transcribe-diarize-fp16.oasr",
+    )
+}
+
+const GOLDEN_MOSS_TRANSCRIBE_DIARIZE_LONGFORM_EN_ZH_TEXT: &str = concat!(
+    "[0.27][S01]And so, my fellow Americans,[2.34][3.21][S01]ask not[4.44][5.31][S01]what your ",
+    "country can do for you,[7.64][8.11][S01]ask what you can do for your country.",
+    "[10.54][10.94][S02]今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的",
+    "川菜馆吃饭，听说那里的麻婆豆腐特别正宗。周末的时候，我通常会读书或者看一部电影放松一下。",
+    "[29.14][29.41][S01]And so, my fellow Americans,[31.54][32.34][S01]ask not",
+    "[33.64][34.44][S01]what your country can do for you,[36.84][37.24][S01]ask what you can ",
+    "do for your country.",
+    "[39.74][40.11][S02]今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的",
+    "川菜馆吃饭，听说那里的麻婆豆腐特别正宗。周末的时候，我通常会读书或者看一部电影放松一下。",
+    "[58.34][58.61][S01]And so, my fellow Americans,[60.64][61.54][S01]ask not",
+    "[62.84][63.64][S01]what your country can do for you,[66.04][66.44][S01]ask what you can ",
+    "do for your country.[68.94]",
+);
+
+#[test]
+#[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack; runs the real \
+            longform-chunked CLI transcribe path on a ~69s fixture, OPENASR_GGML_BACKEND=cpu"]
+fn moss_transcribe_diarize_golden_diff_longform_cli_transcribe_matches_reference_decode() {
+    let pack_path = moss_transcribe_diarize_dev_pack_path();
+    if !pack_path.exists() {
+        eprintln!("skipping: {} not present", pack_path.display());
+        return;
+    }
+    let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures/longform_en_zh.wav")
+        .canonicalize()
+        .expect("longform_en_zh.wav fixture must exist");
+
+    let assert = openasr()
+        .env("OPENASR_GGML_BACKEND", "cpu")
+        .args([
+            "transcribe",
+            &input.display().to_string(),
+            "--model-pack",
+            &pack_path.display().to_string(),
+            "--format",
+            "text",
+        ])
+        .assert()
+        .success();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    eprintln!("moss-transcribe-diarize longform CLI transcript: {output:?}");
+    assert_eq!(
+        output.trim_end(),
+        GOLDEN_MOSS_TRANSCRIBE_DIARIZE_LONGFORM_EN_ZH_TEXT,
+        "unexpected longform CLI transcript"
+    );
+}
+
 #[test]
 fn transcribe_native_requires_local_model_pack_path() {
     let input = temp_input_wav();

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/mod.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/mod.rs
@@ -8,13 +8,20 @@
 //! this family does not parse or structure them (that is a product-layer
 //! concern, out of scope for the core engine).
 //!
-//! Stage status: only the checkpoint-to-GGUF importer
-//! ([`package_import`]) exists so far -- see that module's doc comment for
-//! the full tensor-mapping contract and exactly what is and is not wired up
-//! yet. The ggml execution graph (Whisper encoder reuse, the adaptor
-//! bridge, Qwen3 decoder reuse, decode-policy registration) has not been
-//! implemented; a pack produced by this importer is not yet runnable by
-//! `openasr transcribe`.
+//! Stage status: the checkpoint-to-GGUF importer ([`package_import`]) and the
+//! full ggml execution graph (Whisper encoder reuse via [`encoder_graph`],
+//! the [`adaptor_graph`] bridge, Qwen3 decoder reuse via [`llm_decoder`], and
+//! decode-policy/executor/tensor-contract registration in [`executor`] and
+//! `arch/mod.rs`) are both implemented and registered as a builtin
+//! architecture -- a pack produced by this importer runs end-to-end through
+//! `openasr transcribe --model-pack <pack>` (CPU; the Metal path has a known
+//! encoder-numerics defect, see the arch descriptor's `auto_gpu_policy`
+//! doc). What is NOT yet wired: a public `openasr model-pack import`
+//! subcommand (the importer above is reachable only from Rust/tests, same
+//! pre-CLI-wiring stage `qwen3-forced-aligner` was at) and publication to
+//! the model catalog/registry (see `tooling/publish-model/models-core.toml`'s
+//! `moss-transcribe-diarize` entry, staged `release_public` but not yet
+//! public).
 
 mod adaptor_graph;
 mod decode_prompt;

--- a/crates/openasr-core/src/registry/tests/schema_validation.rs
+++ b/crates/openasr-core/src/registry/tests/schema_validation.rs
@@ -229,6 +229,7 @@ fn bundled_registry_ordering_is_deterministic() {
             "hymt2-1.8b",
             "mimo-v2.5-asr",
             "moonshine-tiny",
+            "moss-transcribe-diarize",
             "parakeet-tdt-0.6b-v3",
             "pyannote-segmentation-3.0",
             "qwen3-asr-1.7b",

--- a/model-registry/models/moss-transcribe-diarize.toml
+++ b/model-registry/models/moss-transcribe-diarize.toml
@@ -1,0 +1,10 @@
+id = "moss-transcribe-diarize"
+default_variant = "published"
+display_name = "MOSS-Transcribe-Diarize (OpenASR pack)"
+languages = ["de", "en", "es", "fr", "it", "ja", "ko", "pt", "ru", "th", "tl", "tr", "ur", "vi", "zh"]
+size = "0.9b"
+license = "Apache-2.0"
+source = "Published OpenASR packs: https://huggingface.co/OpenASR/moss-transcribe-diarize"
+
+[variant]
+quantization = "q8_0"

--- a/tooling/publish-model/cards/moss-transcribe-diarize.toml
+++ b/tooling/publish-model/cards/moss-transcribe-diarize.toml
@@ -1,0 +1,26 @@
+# Per-model card prose for openasr/moss-transcribe-diarize.
+#
+# PLACEHOLDER: every user-facing marketing string below is intentionally set to
+# "TODO-COPY". Final prose (tagline/highlights/intro/acknowledgement, and any
+# zh-CN locale block) is authored separately and must not be drafted here. Fill
+# these in before the model is flipped public (--public requires a non-empty
+# tagline + intro; see _manifest.validate_public_prose). Keep every factual
+# claim to what the upstream OpenMOSS-Team/MOSS-Transcribe-Diarize model card
+# actually states (0.9B joint transcription + diarization model, Whisper-Medium
+# encoder + Qwen3-0.6B-style decoder, `[start][Sxx]text[end]` output format);
+# do not conflate it with the larger "MOSS-Transcribe-Diarize Pro" variant the
+# upstream card mentions as API-only and not part of this pack.
+
+tagline = "TODO-COPY"
+
+highlights = [
+  "TODO-COPY",
+]
+
+intro = """
+TODO-COPY
+"""
+
+acknowledgement = """
+TODO-COPY
+"""

--- a/tooling/publish-model/models-core.toml
+++ b/tooling/publish-model/models-core.toml
@@ -751,3 +751,46 @@ min_cli_version = "0.1.11"
 ["firered-punc".capability]
 feature = "punctuation"
 role = "punctuation-restorer"
+
+# MOSS-Transcribe-Diarize (OpenMOSS-Team/MOSS-Transcribe-Diarize, 0.9B): a
+# Whisper-Medium-configuration audio encoder + a small MLP/LayerNorm adaptor
+# bridge feeding a Qwen3-0.6B-style decoder. Its own runtime family/
+# architecture (`moss-transcribe-diarize` in arch/mod.rs). The decoder emits
+# `[start][Sxx]text[end]` transcript text directly (self_diarizes = true in
+# the arch descriptor) via free-text instruction-following, with no
+# language-selection prompt token (LanguageFamilyHint::SelfDetectsRejectsHint,
+# same shape as qwen3-asr) -- language_mode is therefore "detect_implicit".
+# Staged PRIVATE like firered2-llm/mimo-asr were in c847ae2: release_public
+# only gates the eventual `--public` flip (which also needs a completed
+# docs/model-audits/moss-transcribe-diarize.md form -- see _manifest.py's
+# ensure_release_audit_form); the catalog entry itself stays absent until a
+# deliberate later publish step, so this staging is not itself a release.
+["moss-transcribe-diarize"]
+family = "moss-transcribe-diarize"
+hf_repo = "OpenASR/moss-transcribe-diarize"
+release_public = true
+size = "0.9b"
+registry_id = "moss-transcribe-diarize"
+display_name = "MOSS-Transcribe-Diarize"
+license_name = "Apache-2.0"
+license_source = "https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize/blob/main/LICENSE"
+license_class = "permissive"
+aliases = ["moss", "moss-td"]
+pull_alias = "moss-transcribe-diarize"
+# Explicit override, deliberately conservative: the upstream model card only
+# claims "50+ languages" without enumerating them. The only languages with a
+# concrete upstream evidentiary source are (a) Mandarin Chinese, from the
+# model's own primary objective-evaluation benchmarks (AISHELL-4, Alimeeting
+# -- both Mandarin meeting corpora) and this repo's own dev-pack golden
+# transcripts, and (b) the 14 languages the upstream README names by name for
+# the model's 1st-place 2nd MLC-SLM Challenge result (English, French,
+# German, Italian, Portuguese, Spanish, Japanese, Korean, Russian, Thai,
+# Vietnamese, Tagalog, Urdu, Turkish). Do not expand this list to the
+# unenumerated "50+" claim without a concrete per-language source.
+languages = [
+    "de", "en", "es", "fr", "it", "ja", "ko", "pt", "ru", "th", "tl", "tr",
+    "ur", "vi", "zh",
+]
+quants = ["fp16", "q8_0", "q4_k"]
+recommended_quant = "q8_0"
+upstream_release_date = "2026-07-09"

--- a/tooling/publish-model/models-publish.toml
+++ b/tooling/publish-model/models-publish.toml
@@ -238,3 +238,13 @@ import_subcommand = "import firered-punc"
 upstream_repo = "FireRedTeam/FireRedPunc"
 source_revision = "e448fd967f44182a1c323cc30f5d89f2400c28da"
 needs_license_flags = false
+
+# MOSS-Transcribe-Diarize: not yet wired to a public `openasr model-pack
+# import` subcommand (the crate-internal importer
+# `moss_transcribe_diarize::package_import` exists but has no CLI entry
+# point yet, same pre-CLI-wiring stage qwen3-forced-aligner-0.6b was at).
+["moss-transcribe-diarize"]
+import_subcommand = "not yet a public model-pack import subcommand"
+upstream_repo = "OpenMOSS-Team/MOSS-Transcribe-Diarize"
+source_revision = "main"
+needs_license_flags = false

--- a/tooling/publish-model/scripts/_catalog.py
+++ b/tooling/publish-model/scripts/_catalog.py
@@ -314,6 +314,11 @@ LANG_BY_FAMILY = {
     # &["zh", "en", "yue"] } arch descriptor). "yue" is a base ISO 639-3 code
     # (Cantonese), not a dialect subtag.
     "mimo-asr": ["en", "yue", "zh"],
+    # moss-transcribe-diarize is intentionally NOT listed here (its entry
+    # carries an explicit `languages` override instead) so the user-facing "N
+    # model families" doc counts (check_family_count_strings) do not move
+    # before this family's public flip -- same staging convention used for
+    # firered2-llm/mimo-asr in c847ae2.
 }
 
 # Per-family source-language parameter policy for the catalog's `language_mode`
@@ -366,6 +371,10 @@ LANGUAGE_MODE_BY_FAMILY = {
     # FixedMultilingual LanguageFamilyHint on both arch descriptors).
     "firered2-llm": "fixed_multilingual",
     "mimo-asr": "fixed_multilingual",
+    # MOSS-Transcribe-Diarize: SelfDetectsRejectsHint -- the Qwen3-style
+    # decoder auto-detects/produces the transcript language through free-text
+    # instruction-following (no dedicated language token), same shape as qwen.
+    "moss-transcribe-diarize": "detect_implicit",
 }
 
 # SpecifyOnly's conditioned default, mirroring the `default_language` literal
@@ -491,6 +500,11 @@ PUNCTUATION_BY_FAMILY = {
     # than assert an unverified True/False (mirrors Option<bool>::None).
     "firered2-llm": None,
     "mimo-asr": None,
+    # moss-transcribe-diarize: the fixed instruction prompts for full
+    # punctuation-bearing prose, but this has not been verified against
+    # enough real transcripts to assert as a capability yet (arch descriptor
+    # declares emits_punctuation: None -- see arch/mod.rs) -- unclaimed.
+    "moss-transcribe-diarize": None,
 }
 
 

--- a/tooling/publish-model/scripts/publish_model_targets.py
+++ b/tooling/publish-model/scripts/publish_model_targets.py
@@ -75,6 +75,7 @@ RELEASE_LANE_MODELS = (
     "firered-punc",
     "firered2-llm",
     "mimo-v2.5-asr",
+    "moss-transcribe-diarize",
 )
 GGUF_GENERAL_ARCHITECTURE_KEY = b"general.architecture"
 


### PR DESCRIPTION
## Summary

Registers the moss-transcribe-diarize family in the publish-tooling metadata layer (catalog/registry-card/model-card plumbing) and closes a couple of small gaps in the already-landed runtime wiring. No publish, upload, or catalog-public-listing action is included or intended by this PR.

## Why

The moss-transcribe-diarize runtime (importer, ggml execution graph, decode policy, executor, arch descriptor) already landed in earlier PRs. What was missing was the publish-tooling side: a models-core.toml/models-publish.toml entry, a regenerated local registry card, and a longform CLI golden test bringing this family to parity with the other LLM-decoder families (firered2-llm, mimo-asr).

## Changes

- `tooling/publish-model/models-core.toml` / `models-publish.toml`: new `moss-transcribe-diarize` entry, staged private the same way firered2-llm/mimo-asr were staged before their own public flip. `release_public = true` only gates the eventual `--public` flip; the catalog entry itself is intentionally **not** added in this PR (catalog.json requires real publish evidence -- HF revision, benchmarked metrics -- that only exists once this model is actually published, and `--public` additionally fails closed without a completed `docs/model-audits/moss-transcribe-diarize.md` form, which this PR does not add).
- `tooling/publish-model/scripts/_catalog.py`: added the family to `LANGUAGE_MODE_BY_FAMILY` (`detect_implicit`, mirroring the `SelfDetectsRejectsHint` arch descriptor) and `PUNCTUATION_BY_FAMILY` (`None` = unclaimed, mirroring `emits_punctuation: None`). Deliberately **not** added to `LANG_BY_FAMILY` yet, so the user-facing "N model families" doc-count checks do not move before the public flip (same convention used when firered2-llm/mimo-asr were staged).
- `tooling/publish-model/scripts/publish_model_targets.py`: added to the release-lane allowlist.
- `model-registry/models/moss-transcribe-diarize.toml`: local dev registry card, regenerated via `_registry.py` from the new catalog entry (dev-only convenience path; not part of the release runtime).
- `tooling/publish-model/cards/moss-transcribe-diarize.toml`: `TODO-COPY` prose placeholder -- marketing copy is intentionally not authored here and must be filled in separately before any `--public` flip.
- `crates/openasr-core/src/models/moss_transcribe_diarize/mod.rs`: corrected the module doc, which was stale (it still said the ggml execution graph "has not been implemented," but the encoder/adaptor/decoder graph, decode policy, and executor registration all already landed and are wired as a builtin architecture).
- `crates/openasr-cli/tests/cli.rs`: added a longform CLI golden test on the shared `fixtures/longform_en_zh.wav` fixture, `#[ignore]`-gated on the private dev-only pack, matching the firered-aed/firered-llm/mimo-asr longform golden pattern (text-equality assertion, no hash pinning).
- `crates/openasr-core/src/registry/tests/schema_validation.rs`: updated the bundled-registry ordering pin to include the new card.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2795 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'` (188 passed)
- [x] `tooling/publish-model/scripts/regenerate_all.sh --check`
- [x] New longform golden test run explicitly against the private dev pack (`--ignored`): passes byte-for-byte against the real decode.

## Manual smoke checks

Ran against local dev packs (not committed) with an isolated `OPENASR_HOME`:
- `openasr transcribe <fixture> --model-pack <fp16 pack> --format text` and `--format verbose_json`: correct joint transcription + inline `[Sxx]`/timestamp diarization output.
- `openasr serve --model-pack <q8_0 pack>` + `POST /v1/audio/transcriptions` (`response_format=verbose_json`): works end-to-end.
- `openasr transcribe <fixture> --model-pack <q8_0 pack> --format srt --output <file>`: renders correctly.

Note: `verbose_json`/`srt` segmentation is a generic word-count-based re-split independent of this family's own `[Sxx]` tags -- core does not parse or restructure those tags into a separate structured speaker field (this is documented, by-design scope, per the family's own module doc, not a gap this PR introduces or fixes).

## Docs updated

- [x] Module doc comment corrected to match current implementation state.
- [x] No README/FAQ/ACKNOWLEDGMENTS changes -- intentionally deferred, since this family is not catalog-public yet (adding it there now would move the "N model families" count ahead of the public flip).

## Scope / non-goals

This PR explicitly does **not**: publish to Hugging Face, flip any catalog entry public, add a `docs/model-audits/moss-transcribe-diarize.md` audit form, write final marketing prose, or add a public `openasr model-pack import` CLI subcommand. All of those remain later, separately-authorized steps.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — used as an accelerant for research (upstream model-card language enumeration, repo-convention discovery) and drafting; all catalog/metadata decisions and verification were reviewed and are owned by the submitter.