### PR TITLE
fix(core): wire RequestSource for segment CLI, bench-suite, and FFI entry points

### DIFF
--- a/crates/openasr-cli/src/bench_suite_cli.rs
+++ b/crates/openasr-cli/src/bench_suite_cli.rs
@@ -158,6 +158,27 @@ fn bench_execution_target() -> Option<ExecutionTarget> {
     }
 }
 
+/// Builds one suite entry's [`TranscriptionRequest`]. Split out from
+/// [`run_entry`] so the `RequestSource` wiring is unit-testable without a
+/// real model pack.
+fn suite_entry_transcription_request(
+    entry: &SuiteEntry,
+    validated_pack: &Path,
+    prepared: &openasr_core::PreparedAudioInput,
+) -> TranscriptionRequest {
+    TranscriptionRequest::new(prepared.path(), NATIVE_RUNTIME_MODEL_ID_AUTO)
+        .with_source(openasr_core::RequestSource::CliBenchSuite)
+        .with_model_pack_path(Some(validated_pack.to_path_buf()))
+        .with_language(entry.language.clone())
+        .with_task(entry.task)
+        .with_execution_target(bench_execution_target())
+        // The perf suite measures ASR decode RTF/RSS; an optional
+        // post-process stage running when a FireRedPunc pack happens to be
+        // installed would skew both, so it stays off for every entry.
+        .with_punctuation(false)
+        .with_prepared_samples(prepared.shared_samples())
+}
+
 fn run_entry(
     entry: &SuiteEntry,
     ffmpeg_bin: Option<PathBuf>,
@@ -201,16 +222,7 @@ fn run_entry(
     let mut transcription_text = String::new();
     let mut segment_count = 0;
     for run_index in 0..runs.max(1) {
-        let request = TranscriptionRequest::new(prepared.path(), NATIVE_RUNTIME_MODEL_ID_AUTO)
-            .with_model_pack_path(Some(validated_pack.clone()))
-            .with_language(entry.language.clone())
-            .with_task(entry.task)
-            .with_execution_target(bench_execution_target())
-            // The perf suite measures ASR decode RTF/RSS; an optional
-            // post-process stage running when a FireRedPunc pack happens to be
-            // installed would skew both, so it stays off for every entry.
-            .with_punctuation(false)
-            .with_prepared_samples(prepared.shared_samples());
+        let request = suite_entry_transcription_request(entry, &validated_pack, &prepared);
         configure_native_cpu_inference_threads();
         let started = Instant::now();
         let transcription = transcribe_with_backend(BackendKind::Native, request)?;
@@ -496,4 +508,53 @@ fn host_note() -> String {
 
 fn host_slug() -> String {
     format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_wav_fixture_path() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../fixtures/jfk.wav")
+            .canonicalize()
+            .expect("sample wav fixture path must exist")
+    }
+
+    fn sample_suite_entry() -> SuiteEntry {
+        SuiteEntry {
+            id: "test-entry".to_string(),
+            family: "whisper".to_string(),
+            quant: "q4_k".to_string(),
+            pack_path: PathBuf::from("/nonexistent/pack.oasr"),
+            audio_path: sample_wav_fixture_path(),
+            language: None,
+            task: None,
+            reference: None,
+            reference_text_path: None,
+            optional: true,
+            gating: None,
+            ordering_group: None,
+            cpp_binary: None,
+            cpp_model: None,
+        }
+    }
+
+    // Regression guard for the `openasr bench-suite` entry point: its
+    // `TranscriptionRequest` must log `RequestSource::CliBenchSuite`, distinct
+    // from `transcribe --benchmark`'s `CliTranscribe` -- see
+    // `RequestSource::CliBenchSuite`'s doc comment for why the two CLI timing
+    // paths must not collapse to the same `daemon.log` label.
+    #[test]
+    fn suite_entry_transcription_request_labels_source_as_cli_bench_suite() {
+        let entry = sample_suite_entry();
+        let prepared = prepare_audio_input(
+            &entry.audio_path,
+            &audio_preparation_options(BackendKind::Native, None, false),
+        )
+        .expect("fixture wav must prepare");
+        let validated_pack = PathBuf::from("/nonexistent/pack.oasr");
+        let request = suite_entry_transcription_request(&entry, &validated_pack, &prepared);
+        assert_eq!(request.source, openasr_core::RequestSource::CliBenchSuite);
+    }
 }

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -122,20 +122,7 @@ pub(super) fn transcribe_batch_item(
     )?;
     print_audio_input_notes(prepared.original());
     print_audio_preparation_notes(&prepared);
-    let request = TranscriptionRequest::new(prepared.path(), context.model_id)
-        .with_model_pack_path(context.model_pack_path.clone())
-        .with_language(context.language.clone())
-        .with_task(context.task)
-        .with_longform(context.longform.clone())
-        .with_display_file_name(
-            input_path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(str::to_string),
-        )
-        .with_diarization(context.diarize)
-        .with_diarize_speakers(context.speakers)
-        .with_prepared_samples(prepared.shared_samples());
+    let request = batch_item_transcription_request(input_path, context, &prepared);
     let transcription = transcribe_with_backend(context.backend_kind, request)?;
     let written = write_rendered_formats(
         &transcription,
@@ -151,6 +138,35 @@ pub(super) fn transcribe_batch_item(
             .next()
             .unwrap_or_else(|| context.output_dir.to_path_buf()),
     })
+}
+
+/// Builds one batch item's [`TranscriptionRequest`]. Split out from
+/// [`transcribe_batch_item`] so the `RequestSource` wiring is unit-testable
+/// without a real model pack (`prepared_run.backend_kind`'s decode path is not
+/// exercised here).
+fn batch_item_transcription_request(
+    input_path: &Path,
+    context: &BatchRunContext<'_>,
+    prepared: &openasr_core::PreparedAudioInput,
+) -> TranscriptionRequest {
+    TranscriptionRequest::new(prepared.path(), context.model_id)
+        // Per-file item of a multi-input `openasr transcribe` run (directory
+        // or several explicit files) -- same command/source as the
+        // single-input path in `main.rs`, just batched.
+        .with_source(openasr_core::RequestSource::CliTranscribe)
+        .with_model_pack_path(context.model_pack_path.clone())
+        .with_language(context.language.clone())
+        .with_task(context.task)
+        .with_longform(context.longform.clone())
+        .with_display_file_name(
+            input_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string),
+        )
+        .with_diarization(context.diarize)
+        .with_diarize_speakers(context.speakers)
+        .with_prepared_samples(prepared.shared_samples())
 }
 
 pub(super) fn ensure_batch_output_dir(output_dir: &Path) -> Result<()> {
@@ -209,22 +225,7 @@ pub(super) fn run_benchmark(
     } else {
         None
     };
-    let request =
-        TranscriptionRequest::new(prepared.path(), prepared_run.model_source.model_id.clone())
-            .with_model_pack_path(prepared_run.model_source.model_pack_path.clone())
-            .with_longform(longform)
-            .with_display_file_name(
-                file.file_name()
-                    .and_then(|name| name.to_str())
-                    .map(str::to_string),
-            )
-            // `--benchmark` measures plain ASR decode timing; punctuation
-            // restoration is an optional post-process (like diarization and
-            // word-timestamp alignment, neither of which this request enables
-            // either) and would silently skew the real-time factor for an
-            // unpunctuated model with the FireRedPunc pack installed.
-            .with_punctuation(false)
-            .with_prepared_samples(prepared.shared_samples());
+    let request = benchmark_transcription_request(prepared_run, file, longform, &prepared);
     let started = Instant::now();
     let transcription = transcribe_with_backend(prepared_run.backend_kind, request)?;
     let elapsed = started.elapsed();
@@ -255,6 +256,37 @@ pub(super) fn run_benchmark(
         render_benchmark(&result, bench_format).context("Could not render benchmark output")?;
     write_rendered_output(&rendered, output)?;
     Ok(())
+}
+
+/// Builds `transcribe --benchmark`'s [`TranscriptionRequest`]. Split out from
+/// [`run_benchmark`] so the `RequestSource` wiring is unit-testable without a
+/// real model pack.
+fn benchmark_transcription_request(
+    prepared_run: &PreparedBackendRun,
+    file: &Path,
+    longform: Option<openasr_core::LongFormOptions>,
+    prepared: &openasr_core::PreparedAudioInput,
+) -> TranscriptionRequest {
+    TranscriptionRequest::new(prepared.path(), prepared_run.model_source.model_id.clone())
+        // `transcribe --benchmark` is a mode of the interactive `transcribe`
+        // command, not the separate `bench-suite` CI/perf gate (which logs
+        // `RequestSource::CliBenchSuite` instead) -- see that variant's doc
+        // comment for the distinction.
+        .with_source(openasr_core::RequestSource::CliTranscribe)
+        .with_model_pack_path(prepared_run.model_source.model_pack_path.clone())
+        .with_longform(longform)
+        .with_display_file_name(
+            file.file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string),
+        )
+        // `--benchmark` measures plain ASR decode timing; punctuation
+        // restoration is an optional post-process (like diarization and
+        // word-timestamp alignment, neither of which this request enables
+        // either) and would silently skew the real-time factor for an
+        // unpunctuated model with the FireRedPunc pack installed.
+        .with_punctuation(false)
+        .with_prepared_samples(prepared.shared_samples())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1248,6 +1280,72 @@ mod tests {
     use std::ffi::{OsStr, OsString};
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use tower::ServiceExt;
+
+    fn sample_wav_fixture_path() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../fixtures/jfk.wav")
+            .canonicalize()
+            .expect("sample wav fixture path must exist")
+    }
+
+    fn sample_prepared_audio() -> openasr_core::PreparedAudioInput {
+        openasr_core::prepare_audio_input(
+            sample_wav_fixture_path(),
+            &audio_preparation_options(BackendKind::Native, None, false),
+        )
+        .expect("fixture wav must prepare")
+    }
+
+    // Regression guard for the batch (`transcribe --output <dir>` on a
+    // directory/multiple files) entry point: it must log the same
+    // `RequestSource::CliTranscribe` as the single-input path in `main.rs`,
+    // since both are the same `transcribe` command.
+    #[test]
+    fn batch_item_transcription_request_labels_source_as_cli_transcribe() {
+        let prepared = sample_prepared_audio();
+        let output_dir = PathBuf::from("/tmp/openasr-test-output");
+        let context = BatchRunContext {
+            output_dir: &output_dir,
+            formats: &[ResponseFormat::Text],
+            model_id: "whisper-small",
+            model_pack_path: None,
+            backend_kind: BackendKind::Native,
+            ffmpeg_bin: None,
+            ffmpeg_bin_explicit: false,
+            longform: None,
+            diarize: false,
+            speakers: None,
+            language: None,
+            task: None,
+        };
+        let request =
+            batch_item_transcription_request(&sample_wav_fixture_path(), &context, &prepared);
+        assert_eq!(request.source, openasr_core::RequestSource::CliTranscribe);
+    }
+
+    // Regression guard for `transcribe --benchmark`: it must log
+    // `RequestSource::CliTranscribe`, not the separate `bench-suite` gate's
+    // `CliBenchSuite` -- the two must stay distinguishable in `daemon.log`.
+    #[test]
+    fn benchmark_transcription_request_labels_source_as_cli_transcribe() {
+        let prepared = sample_prepared_audio();
+        let prepared_run = PreparedBackendRun {
+            backend_kind: BackendKind::Native,
+            model_source: ResolvedModelSource {
+                model_id: "whisper-small".to_string(),
+                model_pack_path: None,
+            },
+            ffmpeg_bin: None,
+            ffmpeg_bin_explicit: false,
+        };
+        let request = benchmark_transcription_request(
+            &prepared_run,
+            &sample_wav_fixture_path(),
+            None,
+            &prepared,
+        );
+        assert_eq!(request.source, openasr_core::RequestSource::CliTranscribe);
+    }
 
     struct EnvVarRestore {
         name: &'static str,

--- a/crates/openasr-core/src/api/backend/request_context.rs
+++ b/crates/openasr-core/src/api/backend/request_context.rs
@@ -37,6 +37,23 @@ pub enum RequestSource {
     /// finalized utterance. Covers both the desktop's dictation and
     /// live-captions features -- see the type-level doc above.
     ServerRealtime,
+    /// `openasr bench-suite` (CLI, `crates/openasr-cli/src/bench_suite_cli.rs`),
+    /// the committed performance regression gate that replays `perf/suite.toml`
+    /// through the real native backend. Distinct from `CliTranscribe` even
+    /// though `transcribe --benchmark` also measures timing: that flag is a
+    /// mode of the interactive `transcribe` command (see
+    /// `crates/openasr-cli/src/native_segment_cli.rs::run_benchmark`, which
+    /// logs `CliTranscribe`), while `bench-suite` is a separate, CI/perf-only
+    /// subcommand a human never runs to get a transcript.
+    CliBenchSuite,
+    /// `openasr_transcribe_pcm` (the `openasr-ffi` C ABI, embedded in a host
+    /// app such as the iOS app via the xcframework -- see
+    /// `crates/openasr-ffi/src/lib.rs`). The C ABI carries no field
+    /// distinguishing which host feature/screen made the call, so every FFI
+    /// caller logs this one label -- the same "can't observe a finer
+    /// distinction, so don't fabricate one" tradeoff `ServerRealtime` makes
+    /// for its two desktop features.
+    Ffi,
     /// The request was built without an explicit source (a test helper, or a
     /// caller that has not been updated yet). Never intentionally emitted by
     /// a real entry point; exists so adding this field did not require
@@ -54,6 +71,8 @@ impl RequestSource {
             Self::ServerTranscribe => "server_transcribe",
             Self::ServerTranslate => "server_translate",
             Self::ServerRealtime => "server_realtime",
+            Self::CliBenchSuite => "cli_bench_suite",
+            Self::Ffi => "ffi",
             Self::Unspecified => "unspecified",
         }
     }
@@ -351,6 +370,8 @@ mod tests {
             RequestSource::ServerTranscribe,
             RequestSource::ServerTranslate,
             RequestSource::ServerRealtime,
+            RequestSource::CliBenchSuite,
+            RequestSource::Ffi,
             RequestSource::Unspecified,
         ];
         let mut labels: Vec<&'static str> =
@@ -359,6 +380,35 @@ mod tests {
         labels.sort_unstable();
         labels.dedup();
         assert_eq!(labels.len(), original_len, "duplicate RequestSource labels");
+    }
+
+    #[test]
+    fn cli_bench_suite_source_label_is_distinct_from_cli_transcribe() {
+        // Regression guard for the two CLI timing paths' distinction: `openasr
+        // bench-suite` (the CI/perf regression gate) must never collapse to
+        // the same label as `transcribe --benchmark`, or a `daemon.log`
+        // reader could not tell a human-triggered benchmark run from the
+        // committed perf gate replaying `perf/suite.toml`.
+        assert_ne!(
+            RequestSource::CliBenchSuite.as_log_label(),
+            RequestSource::CliTranscribe.as_log_label()
+        );
+        assert_eq!(
+            RequestSource::CliBenchSuite.as_log_label(),
+            "cli_bench_suite"
+        );
+    }
+
+    #[test]
+    fn ffi_source_label_is_distinct_from_unspecified() {
+        // Regression guard: the FFI entry point's label is a real,
+        // intentional source (not a placeholder for "caller not wired yet"),
+        // so it must never collide with `Unspecified`'s label.
+        assert_ne!(
+            RequestSource::Ffi.as_log_label(),
+            RequestSource::Unspecified.as_log_label()
+        );
+        assert_eq!(RequestSource::Ffi.as_log_label(), "ffi");
     }
 
     #[test]

--- a/crates/openasr-ffi/src/lib.rs
+++ b/crates/openasr-ffi/src/lib.rs
@@ -352,6 +352,20 @@ pub unsafe extern "C" fn openasr_model_close(model: *mut OpenAsrModel) {
 /// buffer. Read the result with the `openasr_result_*` accessors, then free it
 /// with [`openasr_result_free`].
 ///
+/// Builds the [`TranscriptionRequest`] for one `openasr_transcribe_pcm` call.
+/// Split out from that function so the `RequestSource` wiring is
+/// unit-testable without a real model pack (this never touches the
+/// filesystem or a backend).
+fn ffi_transcription_request(staging_path: PathBuf, pack_path: PathBuf) -> TranscriptionRequest {
+    TranscriptionRequest::new(staging_path, NATIVE_RUNTIME_MODEL_ID_AUTO)
+        // The C ABI carries no field distinguishing which host feature called
+        // in, so every embedder logs this one label -- see
+        // `RequestSource::Ffi`'s doc comment.
+        .with_source(openasr_core::RequestSource::Ffi)
+        .with_model_pack_path(Some(pack_path))
+        .with_word_timestamps(false)
+}
+
 /// # Safety
 /// `model` must be a live handle from [`openasr_model_open`]. `pcm` must
 /// point to at least `pcm_len_samples` samples of the given `format` (4 bytes
@@ -438,9 +452,7 @@ pub unsafe extern "C" fn openasr_transcribe_pcm(
             return OpenAsrStatus::IoError;
         }
 
-        let request = TranscriptionRequest::new(staging_path, NATIVE_RUNTIME_MODEL_ID_AUTO)
-            .with_model_pack_path(Some(model_ref.pack_path.clone()))
-            .with_word_timestamps(false);
+        let request = ffi_transcription_request(staging_path, model_ref.pack_path.clone());
 
         match NativeBackend.transcribe(request) {
             Ok(transcription) => {
@@ -1154,6 +1166,20 @@ mod tests {
         unsafe { CStr::from_ptr(ptr) }
             .to_string_lossy()
             .into_owned()
+    }
+
+    // Regression guard for the FFI entry point: the request built from a
+    // `openasr_transcribe_pcm` call must log `RequestSource::Ffi`, not
+    // `Unspecified` -- see that variant's doc comment for why the C ABI
+    // still gets an intentional, non-default label despite carrying no
+    // finer-grained caller context.
+    #[test]
+    fn ffi_transcription_request_labels_source_as_ffi() {
+        let request = ffi_transcription_request(
+            PathBuf::from("/tmp/openasr-ffi-staging.wav"),
+            PathBuf::from("/nonexistent/model.oasr"),
+        );
+        assert_eq!(request.source, openasr_core::RequestSource::Ffi);
     }
 
     #[test]

--- a/crates/openasr-ffi/src/lib.rs
+++ b/crates/openasr-ffi/src/lib.rs
@@ -344,14 +344,6 @@ pub unsafe extern "C" fn openasr_model_close(model: *mut OpenAsrModel) {
     });
 }
 
-/// Transcribes one whole in-memory 16 kHz mono PCM buffer and writes a result
-/// through `out_result`. `pcm_len_samples` counts samples (not bytes/frames).
-/// Only mono 16 kHz input is accepted in v1 -- resampling/downmixing is the
-/// caller's responsibility; anything else fails closed with
-/// [`OpenAsrStatus::InvalidArgument`] rather than silently reinterpreting the
-/// buffer. Read the result with the `openasr_result_*` accessors, then free it
-/// with [`openasr_result_free`].
-///
 /// Builds the [`TranscriptionRequest`] for one `openasr_transcribe_pcm` call.
 /// Split out from that function so the `RequestSource` wiring is
 /// unit-testable without a real model pack (this never touches the
@@ -366,6 +358,14 @@ fn ffi_transcription_request(staging_path: PathBuf, pack_path: PathBuf) -> Trans
         .with_word_timestamps(false)
 }
 
+/// Transcribes one whole in-memory 16 kHz mono PCM buffer and writes a result
+/// through `out_result`. `pcm_len_samples` counts samples (not bytes/frames).
+/// Only mono 16 kHz input is accepted in v1 -- resampling/downmixing is the
+/// caller's responsibility; anything else fails closed with
+/// [`OpenAsrStatus::InvalidArgument`] rather than silently reinterpreting the
+/// buffer. Read the result with the `openasr_result_*` accessors, then free it
+/// with [`openasr_result_free`].
+///
 /// # Safety
 /// `model` must be a live handle from [`openasr_model_open`]. `pcm` must
 /// point to at least `pcm_len_samples` samples of the given `format` (4 bytes


### PR DESCRIPTION
## Summary

Wires `RequestSource` (introduced in #166's `daemon.log` request-context line) into the three entry points that were left logging `source=unspecified`: `transcribe --benchmark` / batch transcribe (the `native_segment_cli.rs` module), `openasr bench-suite`, and the `openasr-ffi` C ABI (`openasr_transcribe_pcm`).

## Why

#166 added the `RequestSource` enum for `stage=request_context` diagnostics but only wired the CLI single-file transcribe, CLI live, and server transcribe/translate/realtime paths, leaving these three as a known non-blocking gap.

## Changes

- `RequestSource`: added `CliBenchSuite` (the `openasr bench-suite` CI/perf regression gate, distinct from `transcribe --benchmark`'s `CliTranscribe`) and `Ffi` (the C ABI, which carries no finer-grained caller context, so it gets one intentional label rather than fabricating one).
- Wired `.with_source(...)` at the batch-transcribe path, the `--benchmark` path, `bench-suite`'s per-entry request, and the FFI transcribe call.
- Confirmed by `rg` that no other `TranscriptionRequest::new` call site in the workspace was still unwired outside test helpers.
- Split each entry point's request-building into a small pure function so the `RequestSource` wiring is unit-testable without a real model pack.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

## Manual smoke checks

N/A (request-context logging change; covered by unit tests below).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Only wires the `source` field for these three entry points; does not add the audio-format/container wiring (`with_source_audio_format`/`with_source_container`) that the single-file transcribe and server paths already have, which is out of scope for this fix.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — implementation drafted with AI assistance, reviewed and verified by me.
