### PR TITLE
perf(firered-aed): drop the k_heads/r_heads cont copies after the metal a-b check

### DIFF
--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -522,6 +522,11 @@ fn firered_conformer_block<'a>(
         },
         map_err,
     )?;
+    // No `ggml_cont` on `k_heads`/`r_heads`: both feed `mul_mat` as src0 (the
+    // `attn_ac`/`attn_bd_raw` score matmuls below), which only requires its src0
+    // contiguous on the first (head) dim -- already satisfied by the permuted
+    // reshape view, the same strided-src0 form `q_u`/`q_v` above already use. The
+    // extra materialization was pure copy work (~11.5 MB/layer transient).
     let k_heads = reshape_projection_to_attention_heads(
         graph,
         k,

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -527,7 +527,7 @@ fn firered_conformer_block<'a>(
         k,
         attention_layout,
         STANDARD_HEAD_PERMUTE_AXES,
-        true,
+        false,
         AttentionReshapeSteps {
             reshape: "ggml_reshape_3d(attn_k)",
             permute: "ggml_permute(attn_k)",
@@ -543,7 +543,7 @@ fn firered_conformer_block<'a>(
             ..attention_layout
         },
         STANDARD_HEAD_PERMUTE_AXES,
-        true,
+        false,
         AttentionReshapeSteps {
             reshape: "ggml_reshape_3d(attn_r)",
             permute: "ggml_permute(attn_r)",


### PR DESCRIPTION
## Summary

Flips the `contiguous` argument to `false` for the `k_heads`/`r_heads` head-split projections in the firered-aed production conformer block, removing the last two cont copies that the contiguity sweep had parked behind a Metal timing check.

## Why

The sweep proved removal correctness-safe on both backends (mul_mat accepts a first-dim-contiguous strided src0, same as the existing q_u/q_v calls) but flagged a possible Metal matmul throughput cost for strided rows. A quiet-window A/B (release binaries, ABAB alternation, medians of 3, thermal-throttle round discarded and re-run with cooldown) measured the variant faster or neutral in every cell: metal jfk -2.7%, metal 300s -6.0%, cpu jfk -1.0%, cpu 300s -7.0%; peak footprint neutral within noise. Raw data: tmp/perf-fraed-ab/ (summary.txt, raw.csv, raw_long_cooldown.csv).

## Tests run

- cargo fmt --check; cargo clippy --all-targets -- -D warnings
- golden_diff jfk/zh byte-identical; longform CLI golden byte-identical
- models::firered_aed full module with --include-ignored: 46 passed (isolated OPENASR_HOME, real fp16 pack)

## Scope

Two call-site argument flips in `firered_conformer_block` only; the diagnostic taps variant and all other families untouched.

AI usage disclosure: YES