### PR TITLE
feat(moss-td): parse inline speaker/timestamp tags into real segments

### DIFF
--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -413,8 +413,19 @@ impl MossTdGgmlExecutor {
         })?;
 
         let text = result.text.trim().to_string();
-        let transcription = Transcription {
-            segments: vec![Segment {
+        // Parse the model's own inline `[start][end][SNN]` markup into real
+        // speaker segments (see `speaker_segments`'s module doc for the
+        // grammar and fail-closed policy). Both a parse error and a
+        // well-formed-but-empty result (no speaker tags at all) degrade the
+        // same way: keep the single, speaker-less segment carrying the
+        // untouched raw text rather than fabricate structure this decode did
+        // not actually assert. `text` itself is never rewritten either way.
+        let segments = match super::speaker_segments::parse_moss_td_speaker_segments(
+            &text,
+            audio_duration_seconds,
+        ) {
+            Ok(segments) if !segments.is_empty() => segments,
+            _ => vec![Segment {
                 start: 0.0,
                 end: audio_duration_seconds.max(0.0),
                 text: text.clone(),
@@ -423,6 +434,9 @@ impl MossTdGgmlExecutor {
                 speaker_profile_id: None,
                 words: Vec::new(),
             }],
+        };
+        let transcription = Transcription {
+            segments,
             text,
             longform: None,
             language: None,
@@ -504,6 +518,7 @@ mod tests {
     use crate::models::ggml_asr_executor::{GgmlAsrBackendPreference, GgmlAsrPreparedAudio};
     use crate::models::ggml_family_registry::moss_transcribe_diarize_runtime_descriptor_v1;
 
+    use super::super::speaker_segments::parse_moss_td_speaker_segments;
     use super::*;
 
     /// Real converted dev pack (fp16), NOT committed -- same dev-only-artifact
@@ -606,6 +621,43 @@ mod tests {
         let result = executor.execute(&request).expect("moss-td transcribe");
         let elapsed = started_at.elapsed();
         Some((result.transcription.text, elapsed, audio_duration_seconds))
+    }
+
+    /// Same dev-pack e2e path as [`transcribe_with_dev_pack`], but returns the
+    /// full [`Segment`] list instead of only the flat text -- used to check
+    /// that the real decode's speaker/time-anchor markup round-trips through
+    /// `speaker_segments::parse_moss_td_speaker_segments` (as wired into the
+    /// executor) into the same structure the golden `[Sxx]`/`[t]` tags encode.
+    fn transcribe_with_dev_pack_segments(wav_path: PathBuf) -> Option<Vec<Segment>> {
+        let pack_path = dev_pack_path();
+        if !pack_path.exists() {
+            eprintln!("skipping: {} not present", pack_path.display());
+            return None;
+        }
+        if !wav_path.exists() {
+            eprintln!("skipping: {} not present", wav_path.display());
+            return None;
+        }
+        let _backend_override_guard = install_request_backend_override(
+            GgmlAsrBackendPreference::CpuOnly.request_backend_override(),
+        );
+        let samples = crate::api::audio_io::load_wav_16khz_mono_f32_v0(
+            wav_path,
+            "moss-td e2e test",
+            "moss-td e2e test",
+        )
+        .expect("load wav fixture");
+        let request = GgmlAsrExecutionRequest {
+            runtime_source_path: pack_path,
+            runtime_source_preflight: None,
+            selected_family: moss_transcribe_diarize_runtime_descriptor_v1(),
+            prepared_audio: GgmlAsrPreparedAudio::mono_16khz(samples),
+            request_options: Default::default(),
+            backend_preference: GgmlAsrBackendPreference::CpuOnly,
+        };
+        let executor = MossTdGgmlExecutor;
+        let result = executor.execute(&request).expect("moss-td transcribe");
+        Some(result.transcription.segments)
     }
 
     /// Splits a moss-td transcript into (a) its "skeleton" -- every literal
@@ -722,6 +774,103 @@ mod tests {
             elapsed.as_secs_f32() / audio_duration_seconds.max(0.001)
         );
         assert_eq!(text, GOLDEN_EN_ZH_MIXED_TEXT);
+    }
+
+    #[test]
+    #[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack \
+                and tmp/moss-td/samples/*.wav; CPU-only (Metal path has known defects)"]
+    fn golden_diff_end_to_end_transcribe_jfk_wav_speaker_segments() {
+        let Some(segments) = transcribe_with_dev_pack_segments(dev_sample_path("jfk.wav")) else {
+            return;
+        };
+        // Same three speaker turns the flat-text golden's `[Sxx]`/`[t]` tags
+        // encode (see `golden_diff_end_to_end_transcribe_jfk_wav` and
+        // `GOLDEN_JFK_TEXT`) -- this asserts the executor's real dev-pack
+        // decode round-trips through `speaker_segments` into that same
+        // structure, not just that the flat string matches.
+        let expected = parse_moss_td_speaker_segments(GOLDEN_JFK_TEXT, 10.59)
+            .expect("golden text itself must parse");
+        assert_eq!(segments, expected);
+    }
+
+    #[test]
+    #[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack \
+                and tmp/moss-td/samples/*.wav; CPU-only (Metal path has known defects)"]
+    fn golden_diff_end_to_end_transcribe_en_zh_mixed_wav_speaker_segments() {
+        let Some(segments) = transcribe_with_dev_pack_segments(dev_sample_path("en_zh_mixed.wav"))
+        else {
+            return;
+        };
+        let expected = parse_moss_td_speaker_segments(GOLDEN_EN_ZH_MIXED_TEXT, 12.88)
+            .expect("golden text itself must parse");
+        assert_eq!(segments, expected);
+    }
+
+    /// Snapshot of the shape `speaker_segments` produces for the two golden
+    /// transcripts pinned above, independent of any dev-pack decode -- pins
+    /// the exact segment count/speaker-label/start/end/text tuple this PR's
+    /// parser derives from the reference HF text, so a future edit to the
+    /// grammar (e.g. changing how a back-to-back closing/opening anchor pair
+    /// is split) shows up as a diff here even without the private pack.
+    #[test]
+    fn snapshot_jfk_and_en_zh_mixed_golden_speaker_segments() {
+        let jfk = parse_moss_td_speaker_segments(GOLDEN_JFK_TEXT, 10.59).expect("jfk parses");
+        let jfk_snapshot: Vec<(&str, f32, f32, &str)> = jfk
+            .iter()
+            .map(|segment| {
+                (
+                    segment.speaker.as_deref().unwrap_or(""),
+                    segment.start,
+                    segment.end,
+                    segment.text.as_str(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            jfk_snapshot,
+            vec![
+                ("SPEAKER_01", 0.28, 2.32, "And so, my fellow Americans,"),
+                (
+                    "SPEAKER_01",
+                    3.22,
+                    7.71,
+                    "ask not what your country can do for you,"
+                ),
+                (
+                    "SPEAKER_01",
+                    8.12,
+                    10.59,
+                    "ask what you can do for your country."
+                ),
+            ]
+        );
+
+        let en_zh_mixed =
+            parse_moss_td_speaker_segments(GOLDEN_EN_ZH_MIXED_TEXT, 12.88).expect("parses");
+        let en_zh_mixed_snapshot: Vec<(&str, f32, f32, &str)> = en_zh_mixed
+            .iter()
+            .map(|segment| {
+                (
+                    segment.speaker.as_deref().unwrap_or(""),
+                    segment.start,
+                    segment.end,
+                    segment.text.as_str(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            en_zh_mixed_snapshot,
+            vec![
+                ("SPEAKER_01", 0.27, 2.32, "And so, my fellow Americans,"),
+                ("SPEAKER_01", 3.21, 4.44, "ask not."),
+                (
+                    "SPEAKER_02",
+                    4.96,
+                    12.88,
+                    "今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去伊加新"
+                ),
+            ]
+        );
     }
 
     /// Time anchors are floating-point-derived (see

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -22,7 +22,7 @@
 use thiserror::Error;
 
 use crate::NativeAsrError;
-use crate::api::backend::{Segment, Transcription};
+use crate::api::backend::Transcription;
 use crate::models::decode_policy_component_registry::{
     BuiltinDecodePolicyComponentRegistryError, BuiltinSeq2SeqDecodePolicyConfigInput,
     run_builtin_seq2seq_decode_policy,
@@ -414,27 +414,13 @@ impl MossTdGgmlExecutor {
 
         let text = result.text.trim().to_string();
         // Parse the model's own inline `[start][end][SNN]` markup into real
-        // speaker segments (see `speaker_segments`'s module doc for the
-        // grammar and fail-closed policy). Both a parse error and a
-        // well-formed-but-empty result (no speaker tags at all) degrade the
-        // same way: keep the single, speaker-less segment carrying the
-        // untouched raw text rather than fabricate structure this decode did
-        // not actually assert. `text` itself is never rewritten either way.
-        let segments = match super::speaker_segments::parse_moss_td_speaker_segments(
-            &text,
-            audio_duration_seconds,
-        ) {
-            Ok(segments) if !segments.is_empty() => segments,
-            _ => vec![Segment {
-                start: 0.0,
-                end: audio_duration_seconds.max(0.0),
-                text: text.clone(),
-                speaker: None,
-                speaker_label: None,
-                speaker_profile_id: None,
-                words: Vec::new(),
-            }],
-        };
+        // speaker segments, degrading fail-closed to the single speaker-less
+        // segment carrying the untouched raw text when the tag stream is
+        // malformed or empty (see `speaker_segments`'s module doc for the
+        // grammar, the fail-closed policy, and the degrade shape's tests).
+        // `text` itself is never rewritten either way.
+        let segments =
+            super::speaker_segments::moss_td_segments_or_degrade(&text, audio_duration_seconds);
         let transcription = Transcription {
             segments,
             text,
@@ -517,6 +503,8 @@ mod tests {
     use crate::ggml_runtime::install_request_backend_override;
     use crate::models::ggml_asr_executor::{GgmlAsrBackendPreference, GgmlAsrPreparedAudio};
     use crate::models::ggml_family_registry::moss_transcribe_diarize_runtime_descriptor_v1;
+
+    use crate::api::backend::Segment;
 
     use super::super::speaker_segments::parse_moss_td_speaker_segments;
     use super::*;

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/mod.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/mod.rs
@@ -5,8 +5,13 @@
 //! vector-quantization codebook in this checkpoint), and a Qwen3-0.6B
 //! decoder. `[S01]`-style speaker labels and inline timestamps are ordinary
 //! BPE tokens the Qwen3 decoder emits freely as part of its transcript text;
-//! this family does not parse or structure them (that is a product-layer
-//! concern, out of scope for the core engine).
+//! [`speaker_segments`] parses that markup, fail-closed, into the shared
+//! `Segment` speaker-turn shape so `verbose_json`/SRT/VTT get real per-speaker
+//! segments (see its module doc for the grammar and the fail-closed policy).
+//! The executor's top-level `Transcription::text` stays the raw, tag-included
+//! decode -- unlike cohere, whose diarization markers are non-printing
+//! special tokens, moss-td's tags are literal characters, so stripping them
+//! from the plain/CLI text output would rewrite what the model actually said.
 //!
 //! Stage status: the checkpoint-to-GGUF importer ([`package_import`]) and the
 //! full ggml execution graph (Whisper encoder reuse via [`encoder_graph`],
@@ -32,6 +37,7 @@ mod llm_decoder;
 pub(crate) mod package_import;
 mod prompt_embedding;
 pub(crate) mod runtime_contract;
+mod speaker_segments;
 pub(crate) mod tensor_names;
 mod tokenizer;
 

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
@@ -20,6 +20,35 @@
 //! "in-decoder self-diarization tags" as two producers of one interface
 //! without reshaping either family's output again.
 //!
+//! That future two-producer interface will, however, want fields neither
+//! source populates today: a per-turn confidence (cf.
+//! [`crate::api::backend::WordTimestamp::confidence`], already an `Option`) and
+//! an `overlap` flag (cf. [`crate::diarize::contract::SpeakerTurn::overlap`],
+//! which the VAD path sets but this in-decoder path has no signal for).
+//! [`Segment`] carries neither, and moss-td asserts neither, so nothing is lost
+//! now -- but a `DiarizerBackend` extraction that wants to keep the VAD path's
+//! overlap/confidence must grow [`Segment`] additively (a new
+//! `Option`/`#[serde(default)]` field) rather than reshape it. Flagged here so
+//! that growth stays a conscious additive step, not a breaking change.
+//!
+//! # Tags are ordinary characters: an inherent ambiguity
+//!
+//! Because moss-td's `[t]`/`[Sxx]` markers are ordinary transcript characters
+//! rather than reserved control tokens, this parser cannot tell a structural
+//! tag apart from transcript content that merely *looks* like one. If the
+//! decoded text itself contains a bracketed number (say the model wrote
+//! `meeting at [3.30] pm`) that span is consumed as a time anchor and the
+//! segment splits there; a bracketed `[Sxx]` sitting inside content is likewise
+//! read as a speaker change and absorbed. This is unavoidable given the format
+//! and is deliberately accepted: the worst case is a mis-split or an absorbed
+//! bracket, never a panic and never a dropped transcript -- and if such a stray
+//! bracket makes time run backwards or strands text before an anchor, the
+//! fail-closed policy below degrades the whole decode back to the untouched raw
+//! text. The reference decode does not emit bracketed numerics as free text, so
+//! this stays a theoretical edge, but callers must treat the segment overlay as
+//! best-effort structure over a plain-text signal, not a guaranteed lossless
+//! parse of arbitrary transcript content.
+//!
 //! # Grammar
 //!
 //! Observed from the reference HF decode (`docs/model-audits/
@@ -223,6 +252,29 @@ pub(crate) fn parse_moss_td_speaker_segments(
     Ok(segments)
 }
 
+/// The executor's segment-overlay decision, centralized next to the parser it
+/// guards instead of inlined in `executor.rs`. Returns the parsed per-speaker
+/// segments when the decode's tag stream is well formed AND carried at least
+/// one attributable turn; otherwise -- a typed parse error, or a well-formed
+/// stream with no speaker tags/text at all -- returns the single, speaker-less
+/// segment carrying the untouched raw `text` (tags included, verbatim), i.e.
+/// the exact shape that existed before inline-tag structuring. Structure is
+/// never fabricated for a decode that did not assert it.
+pub(crate) fn moss_td_segments_or_degrade(text: &str, audio_duration_seconds: f32) -> Vec<Segment> {
+    match parse_moss_td_speaker_segments(text, audio_duration_seconds) {
+        Ok(segments) if !segments.is_empty() => segments,
+        _ => vec![Segment {
+            start: 0.0,
+            end: audio_duration_seconds.max(0.0),
+            text: text.to_string(),
+            speaker: None,
+            speaker_label: None,
+            speaker_profile_id: None,
+            words: Vec::new(),
+        }],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -332,5 +384,68 @@ mod tests {
         let error = parse_moss_td_speaker_segments("[0.0]hello[1.0]", 5.0)
             .expect_err("text before the first speaker tag must fail closed");
         assert_eq!(error, MossTdSpeakerSegmentParseError::TextBeforeSpeaker);
+    }
+
+    /// The degrade shape the executor keeps for a malformed decode: exactly one
+    /// speaker-less segment spanning the whole clip, carrying the raw text
+    /// verbatim with its tags still in it -- never empty, never rewritten. This
+    /// is the verbose_json/SRT/VTT overlay-withheld case (a single unattributed
+    /// cue), asserted here so it cannot silently regress into an empty segment
+    /// list or a stripped transcript.
+    #[test]
+    fn malformed_decode_degrades_to_one_raw_speaker_less_segment() {
+        // Time runs backwards -> a typed parse error -> degrade.
+        let raw = "[2.0][S01]hi[1.0][S01]bye";
+        let segments = moss_td_segments_or_degrade(raw, 5.0);
+        assert_eq!(
+            segments,
+            vec![Segment {
+                start: 0.0,
+                end: 5.0,
+                text: raw.to_string(),
+                speaker: None,
+                speaker_label: None,
+                speaker_profile_id: None,
+                words: Vec::new(),
+            }]
+        );
+    }
+
+    /// A well-formed decode that simply carried no speaker tags/text degrades
+    /// the same way (single speaker-less segment), not to an empty list.
+    #[test]
+    fn tag_skeleton_with_no_text_degrades_to_one_speaker_less_segment() {
+        let raw = "[0.0][1.0][2.0]";
+        let segments = moss_td_segments_or_degrade(raw, 4.0);
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].speaker, None);
+        assert_eq!(segments[0].text, raw);
+        assert_eq!(segments[0].start, 0.0);
+        assert_eq!(segments[0].end, 4.0);
+    }
+
+    /// A well-formed decode keeps its structured per-speaker turns (the happy
+    /// path the degrade helper must NOT swallow).
+    #[test]
+    fn well_formed_decode_keeps_structured_segments() {
+        let segments = moss_td_segments_or_degrade("[0.0][S01]hello[1.0][2.0][S02]world[3.0]", 3.0);
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].speaker.as_deref(), Some("SPEAKER_01"));
+        assert_eq!(segments[1].speaker.as_deref(), Some("SPEAKER_02"));
+    }
+
+    /// Documented inherent ambiguity (see the module doc's "Tags are ordinary
+    /// characters" section): a bracketed numeric that is really transcript
+    /// content is indistinguishable from a time anchor and splits the segment.
+    /// Pinned so the behavior is a conscious, reviewed contract rather than a
+    /// surprise -- the fail-closed worst case is a mis-split, never a panic.
+    #[test]
+    fn bracketed_numeric_content_is_consumed_as_an_anchor_by_design() {
+        let segments = parse_moss_td_speaker_segments("[0.0][S01]meeting at [3.30] pm[5.0]", 6.0)
+            .expect("well-formed once the stray bracket is read as an anchor");
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].text, "meeting at");
+        assert_eq!(segments[0].end, 3.30);
+        assert_eq!(segments[1].text, "pm");
     }
 }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
@@ -1,0 +1,336 @@
+//! Parses moss-transcribe-diarize's inline `[start][end][SNN]text` speaker /
+//! time-anchor markup -- ordinary BPE tokens the Qwen3 decoder emits as
+//! literal transcript *characters* (see the module doc) -- into the shared
+//! [`Segment`] speaker-turn shape (`speaker`/`start`/`end`/`text`) the rest of
+//! the engine already understands.
+//!
+//! This mirrors the one existing precedent for turning a family's own inline
+//! diarization markup into `Segment`s:
+//! `cohere::decoder_graph::cohere_diarized_segments_from_generated_tokens`.
+//! The shapes differ because the underlying signal differs -- cohere's
+//! `<|spltoken0|>` / `<|t:2.4|>` are dedicated vocabulary entries the tokenizer
+//! can recognize by token id before any text decode, so a malformed stream is
+//! not really reachable; moss-td's tags are ordinary characters the model
+//! free-generates as part of its text, so a malformed tag stream is a real,
+//! reachable failure mode this parser must handle without guessing. Both
+//! parsers make the same "never invent a speaker" call (see
+//! [`parse_moss_td_speaker_segments`]'s fail-closed policy below) and both
+//! produce the same `Segment` shape, which is what will let a future
+//! `DiarizerBackend` trait extraction treat "VAD+embedder turns" and
+//! "in-decoder self-diarization tags" as two producers of one interface
+//! without reshaping either family's output again.
+//!
+//! # Grammar
+//!
+//! Observed from the reference HF decode (`docs/model-audits/
+//! moss-transcribe-diarize.md`, pinned in `executor.rs`'s golden fixtures): a
+//! segment opens with a numeric time anchor `[t]`, a speaker tag `[Sxx]`, then
+//! free text. The anchor that closes one segment doubles as the opener of the
+//! next, so two anchors appear back to back between segments, e.g.
+//! `...for you,[7.71][8.12][S01] ask what...`. A final trailing anchor closes
+//! the last segment.
+//!
+//! # Fail-closed policy
+//!
+//! Any deviation from that grammar -- an unterminated `[`, a tag that is
+//! neither a finite non-negative float nor `Sxx`, a time anchor that goes
+//! backwards, or text/a speaker change emitted before the first anchor or
+//! speaker tag has ever appeared -- returns a typed
+//! [`MossTdSpeakerSegmentParseError`] instead of guessing at a boundary or
+//! silently dropping the offending span. The caller (`executor.rs`) treats
+//! any such error, and the "well-formed but zero speaker tags found" case, the
+//! same way: this decode's tag structure is not trustworthy, so it falls back
+//! to the pre-existing single speaker-less segment carrying the untouched raw
+//! text. The transcript text itself is never dropped or rewritten -- only the
+//! speaker/segment overlay is withheld -- which mirrors this crate's existing
+//! diarization degrade path (`SpeakerAttribution` with empty turns is a
+//! silent no-op, never an error surfaced to the caller).
+//!
+//! A speaker-number *gap* (e.g. `S01` then `S05` with no `S02`-`S04` in
+//! between) is deliberately NOT an error: the model's own numbering is passed
+//! through verbatim, on the same "never invent speakers" principle as
+//! `cohere_diarized_segments_from_generated_tokens`'s
+//! `does_not_invent_speakers` test -- renumbering to close the gap would
+//! fabricate an ordering/count the model never asserted.
+
+use crate::api::backend::Segment;
+
+/// Why [`parse_moss_td_speaker_segments`] gave up rather than guess. See the
+/// module doc's "Fail-closed policy" for how each variant is triggered and
+/// what the caller does with it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum MossTdSpeakerSegmentParseError {
+    /// A `[` was never followed by a matching `]`.
+    UnclosedTag,
+    /// A bracketed tag's content was neither a finite, non-negative time
+    /// value nor an `Sxx` speaker marker.
+    UnknownTag { raw: String },
+    /// A later time anchor is smaller than an earlier one, e.g.
+    /// `[2.0]...[1.0]`.
+    TimeWentBackwards { previous: f32, next: f32 },
+    /// Text (or a speaker tag) appeared before the stream ever produced an
+    /// opening time anchor, so no `start` value exists to attribute it to.
+    TextBeforeTimestamp,
+    /// Text appeared before any `[Sxx]` speaker tag was seen, so there is no
+    /// speaker to attribute it to.
+    TextBeforeSpeaker,
+}
+
+impl std::fmt::Display for MossTdSpeakerSegmentParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnclosedTag => write!(f, "unterminated '[' in moss-td tag stream"),
+            Self::UnknownTag { raw } => write!(f, "unrecognized moss-td tag content '{raw}'"),
+            Self::TimeWentBackwards { previous, next } => write!(
+                f,
+                "moss-td time anchor went backwards: {previous} -> {next}"
+            ),
+            Self::TextBeforeTimestamp => {
+                write!(f, "moss-td text appeared before any time anchor")
+            }
+            Self::TextBeforeSpeaker => {
+                write!(f, "moss-td text appeared before any speaker tag")
+            }
+        }
+    }
+}
+
+impl std::error::Error for MossTdSpeakerSegmentParseError {}
+
+enum MossTdTag {
+    Anchor(f32),
+    Speaker(String),
+}
+
+/// Parses one bracketed tag's inner content (without the `[`/`]`). Speaker
+/// tags are tried first since `"S01"` would otherwise also fail the float
+/// parse and fall through anyway; trying it first just avoids the wasted
+/// `parse::<f32>()` call on the common case.
+fn parse_tag_content(raw: &str) -> Result<MossTdTag, MossTdSpeakerSegmentParseError> {
+    if let Some(digits) = raw.strip_prefix('S')
+        && !digits.is_empty()
+        && digits.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        // Digits are ASCII-checked above, so this only fails on overflow of a
+        // number no real pack would ever emit; treat that the same as any
+        // other unrecognized tag rather than panicking.
+        return digits
+            .parse::<u32>()
+            .map(|number| MossTdTag::Speaker(format!("SPEAKER_{number:02}")))
+            .map_err(|_| MossTdSpeakerSegmentParseError::UnknownTag {
+                raw: raw.to_string(),
+            });
+    }
+    if let Ok(value) = raw.trim().parse::<f32>()
+        && value.is_finite()
+        && value >= 0.0
+    {
+        return Ok(MossTdTag::Anchor(value));
+    }
+    Err(MossTdSpeakerSegmentParseError::UnknownTag {
+        raw: raw.to_string(),
+    })
+}
+
+fn plain_segment(speaker: String, start: f32, end: f32, text: String) -> Segment {
+    Segment {
+        start,
+        end: end.max(start),
+        text,
+        speaker: Some(speaker),
+        speaker_label: None,
+        speaker_profile_id: None,
+        words: Vec::new(),
+    }
+}
+
+/// Parses a moss-transcribe-diarize decoded transcript's inline
+/// `[start][end][SNN]text` markup into ordered, non-overlapping [`Segment`]s.
+/// `audio_duration_seconds` closes a final segment that never received a
+/// trailing anchor (premature EOS), the same permissive end-of-stream
+/// handling as the cohere parser this mirrors.
+///
+/// Returns `Ok(vec![])` (never an error) when the stream is empty or well
+/// formed but carries no speaker tags/text at all -- e.g. a bare anchor/tag
+/// skeleton with no free text -- since there is nothing to invent a segment
+/// from. See the module doc for the fail-closed policy on genuinely malformed
+/// input.
+pub(crate) fn parse_moss_td_speaker_segments(
+    text: &str,
+    audio_duration_seconds: f32,
+) -> Result<Vec<Segment>, MossTdSpeakerSegmentParseError> {
+    let mut segments = Vec::new();
+    let mut pending_start: Option<f32> = None;
+    let mut last_anchor: Option<f32> = None;
+    let mut current_speaker: Option<String> = None;
+    let mut buffer = String::new();
+    let mut rest = text;
+
+    while let Some(open_rel) = rest.find('[') {
+        buffer.push_str(&rest[..open_rel]);
+        let after_open = &rest[open_rel + 1..];
+        let Some(close_rel) = after_open.find(']') else {
+            return Err(MossTdSpeakerSegmentParseError::UnclosedTag);
+        };
+        let raw_tag = &after_open[..close_rel];
+        rest = &after_open[close_rel + 1..];
+
+        match parse_tag_content(raw_tag)? {
+            MossTdTag::Anchor(timestamp) => {
+                if let Some(previous) = last_anchor
+                    && timestamp < previous
+                {
+                    return Err(MossTdSpeakerSegmentParseError::TimeWentBackwards {
+                        previous,
+                        next: timestamp,
+                    });
+                }
+                last_anchor = Some(timestamp);
+                let trimmed = buffer.trim();
+                if !trimmed.is_empty() {
+                    let speaker = current_speaker
+                        .clone()
+                        .ok_or(MossTdSpeakerSegmentParseError::TextBeforeSpeaker)?;
+                    let start =
+                        pending_start.ok_or(MossTdSpeakerSegmentParseError::TextBeforeTimestamp)?;
+                    segments.push(plain_segment(
+                        speaker,
+                        start,
+                        timestamp,
+                        trimmed.to_string(),
+                    ));
+                }
+                buffer.clear();
+                pending_start = Some(timestamp);
+            }
+            MossTdTag::Speaker(label) => {
+                current_speaker = Some(label);
+            }
+        }
+    }
+    buffer.push_str(rest);
+    let trimmed = buffer.trim();
+    if !trimmed.is_empty() {
+        let speaker = current_speaker.ok_or(MossTdSpeakerSegmentParseError::TextBeforeSpeaker)?;
+        let start = pending_start.ok_or(MossTdSpeakerSegmentParseError::TextBeforeTimestamp)?;
+        segments.push(plain_segment(
+            speaker,
+            start,
+            audio_duration_seconds.max(start),
+            trimmed.to_string(),
+        ));
+    }
+    Ok(segments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_stream_yields_no_segments() {
+        assert_eq!(parse_moss_td_speaker_segments("", 5.0), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn tags_only_with_no_text_yields_no_segments() {
+        let segments = parse_moss_td_speaker_segments("[0.0][S01][1.0][S02][2.0]", 5.0)
+            .expect("well-formed tag-only stream parses");
+        assert!(segments.is_empty());
+    }
+
+    #[test]
+    fn parses_the_jfk_golden_shape() {
+        let text = concat!(
+            "[0.28][S01] And so, my fellow Americans,[2.32][3.22][S01] ask not what your ",
+            "country can do for you,[7.71][8.12][S01] ask what you can do for your country.[10.59]",
+        );
+        let segments = parse_moss_td_speaker_segments(text, 10.59).expect("jfk golden parses");
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[0].speaker.as_deref(), Some("SPEAKER_01"));
+        assert_eq!(segments[0].start, 0.28);
+        assert_eq!(segments[0].end, 2.32);
+        assert_eq!(segments[0].text, "And so, my fellow Americans,");
+        assert_eq!(segments[1].start, 3.22);
+        assert_eq!(segments[1].end, 7.71);
+        assert_eq!(segments[2].start, 8.12);
+        assert_eq!(segments[2].end, 10.59);
+        assert_eq!(segments[2].text, "ask what you can do for your country.");
+    }
+
+    #[test]
+    fn parses_a_speaker_change() {
+        let text = "[0.0][S01]hello[1.0][2.0][S02]world[3.0]";
+        let segments =
+            parse_moss_td_speaker_segments(text, 3.0).expect("two-speaker stream parses");
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].speaker.as_deref(), Some("SPEAKER_01"));
+        assert_eq!(segments[0].text, "hello");
+        assert_eq!(segments[1].speaker.as_deref(), Some("SPEAKER_02"));
+        assert_eq!(segments[1].text, "world");
+    }
+
+    #[test]
+    fn speaker_number_gap_is_accepted_verbatim() {
+        let text = "[0.0][S01]hello[1.0][2.0][S05]world[3.0]";
+        let segments =
+            parse_moss_td_speaker_segments(text, 3.0).expect("a numbering gap is not malformed");
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].speaker.as_deref(), Some("SPEAKER_01"));
+        assert_eq!(segments[1].speaker.as_deref(), Some("SPEAKER_05"));
+    }
+
+    #[test]
+    fn trailing_text_without_a_closing_anchor_uses_audio_duration() {
+        let segments = parse_moss_td_speaker_segments("[0.0][S01]hello", 4.5)
+            .expect("premature EOS still parses");
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].end, 4.5);
+    }
+
+    #[test]
+    fn unclosed_tag_is_rejected() {
+        let error = parse_moss_td_speaker_segments("[0.0][S01]hello[1.0", 5.0)
+            .expect_err("unterminated '[' must fail closed");
+        assert_eq!(error, MossTdSpeakerSegmentParseError::UnclosedTag);
+    }
+
+    #[test]
+    fn unknown_tag_content_is_rejected() {
+        let error = parse_moss_td_speaker_segments("[0.0][S01]hello[oops]", 5.0)
+            .expect_err("a tag that is neither a timestamp nor Sxx must fail closed");
+        assert_eq!(
+            error,
+            MossTdSpeakerSegmentParseError::UnknownTag {
+                raw: "oops".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn time_reversal_is_rejected() {
+        let error = parse_moss_td_speaker_segments("[2.0][S01]hi[1.0]", 5.0)
+            .expect_err("a time anchor going backwards must fail closed");
+        assert_eq!(
+            error,
+            MossTdSpeakerSegmentParseError::TimeWentBackwards {
+                previous: 2.0,
+                next: 1.0
+            }
+        );
+    }
+
+    #[test]
+    fn text_before_any_timestamp_is_rejected() {
+        let error = parse_moss_td_speaker_segments("[S01]hello", 5.0)
+            .expect_err("text before the first anchor must fail closed");
+        assert_eq!(error, MossTdSpeakerSegmentParseError::TextBeforeTimestamp);
+    }
+
+    #[test]
+    fn text_before_any_speaker_tag_is_rejected() {
+        let error = parse_moss_td_speaker_segments("[0.0]hello[1.0]", 5.0)
+            .expect_err("text before the first speaker tag must fail closed");
+        assert_eq!(error, MossTdSpeakerSegmentParseError::TextBeforeSpeaker);
+    }
+}


### PR DESCRIPTION
## Summary

moss-transcribe-diarize's decoder emits its own diarization as literal
`[start][end][SNN] text` markup, but the executor previously discarded that
structure into one monolithic speaker-less segment. This adds a fail-closed
parser that turns the markup into the shared `Segment` speaker-turn shape,
so `verbose_json`/SRT/VTT get real per-speaker segments for this family.

## Why

The module doc explicitly flagged this as unimplemented: the model's
diarization tags were passed through as opaque text, and `verbose_json`'s
segments were generic word-count re-chunks with no real speaker/time
attribution. Anonymous structured speaker turns (speaker id + time range)
are already a first-class concept elsewhere in the engine (the VAD +
speaker-embedder pipeline, and cohere's own inline-tag parser); moss-td just
never plugged into that shape.

## Changes

- `crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs`
  (new): parses `[start][end][SNN]text` markup into `Segment`s. Fail-closed on
  an unterminated tag, an unrecognized tag, a time anchor going backwards, or
  text/speaker-tag content appearing before the stream has produced an
  opening anchor/speaker tag -- any of these degrades to the pre-existing
  single speaker-less segment rather than guessing. A speaker-number gap
  (e.g. `S01` then `S05`) is accepted verbatim, matching the "never invent a
  speaker" policy the cohere parser already established.
- `executor.rs`: wires the parser into the real decode path. Top-level
  `Transcription::text` stays the raw, tag-included decode (moss-td's tags
  are ordinary characters the model free-generates, unlike cohere's
  non-printing control tokens, so stripping them would rewrite what the
  model actually said); only `Transcription::segments` becomes structured.
  That flows through the existing cue-segmentation pass and format
  renderers with no further per-format wiring.
- `mod.rs`: updated the stale module doc that said this family does not
  parse its own tags.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

Also ran directly: `cargo test -p openasr-core golden_diff -- --nocapture`,
`cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch -- --nocapture`,
`cargo nextest run -p openasr-server` -- all green, no regressions.

New coverage: a parser unit-test suite in `speaker_segments.rs` covering
malformed input (empty stream, tags-only-no-text, unterminated tag, unknown
tag content, time going backwards, text before a timestamp/speaker tag, a
speaker-number gap) plus the two golden transcripts; a snapshot test pinning
the exact segment shape derived from the golden text; and two `#[ignore]`
end-to-end tests (require the private dev-pack) asserting the real decode's
segments match what the parser derives from the golden text.

## Manual smoke checks

None beyond the tests above (no CLI/API-surface change; same request/response
shape, just populated).

## Docs updated

- [x] No README/limitations doc changes needed -- the module doc comment
      (code-level, not `docs/`) was updated in place.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not touch speaker enrollment/voiceprint matching (a separate,
  unrelated feature line).
- Does not extract a `DiarizerBackend` trait -- this only makes moss-td
  produce the same `Segment` shape the VAD pipeline and cohere already do,
  which is what such a future extraction would sit on top of.
- Does not change the CLI plain-text output (unchanged, tag-included).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- used AI assistance to draft the parser implementation and tests.