### PR TITLE
fix(core): bound longform chunk cuts and padding by max_chunk_seconds

### DIFF
--- a/crates/openasr-core/src/longform/slicing.rs
+++ b/crates/openasr-core/src/longform/slicing.rs
@@ -248,11 +248,16 @@ fn plan_fixed_slices(
     // span with no extra margin, e.g. `mimo_asr`, it clamps to *exactly* the
     // executor's hard per-chunk cap). Merging a short tail into the previous
     // chunk below must never be allowed to push that chunk past this ceiling
-    // -- doing so silently produced an over-cap slice that the mimo-asr /
-    // firered-llm executors then rejected with a fail-closed 400 (a 30.2s
-    // clip: one 30.0s chunk plus a 0.2s tail below `min_chunk_seconds`
-    // merged straight into the 30.0s chunk, exceeding mimo-asr's 30.0s cap
-    // with zero headroom).
+    // -- doing so silently produced an over-cap slice that mimo-asr's
+    // executor then rejected with a fail-closed 400 (a 30.2s clip: one 30.0s
+    // chunk plus a 0.2s tail below `min_chunk_seconds` merged straight into
+    // the 30.0s chunk, exceeding mimo-asr's 30.0s cap with zero headroom).
+    // firered-llm shares this same encoder-attention-span clamp (also 30.0s)
+    // but keeps 10s of margin below its own executor's separate 40.0s hard
+    // cap, so this exact 30.2s shape would not have tripped its fail-closed
+    // check -- it is bound here anyway because the ceiling this clamps to is
+    // the encoder-memory guidance span, not just "whatever the executor
+    // happens to still tolerate".
     let max_chunk_samples =
         seconds_to_samples(options.max_chunk_seconds, sample_rate_hz).max(chunk_samples);
     let step = chunk_samples.saturating_sub(overlap_samples).max(1);

--- a/crates/openasr-core/src/longform/slicing.rs
+++ b/crates/openasr-core/src/longform/slicing.rs
@@ -174,6 +174,7 @@ pub fn plan_longform_slices(
                 total_samples,
                 sample_rate_hz,
                 options.padding_seconds,
+                options.max_chunk_seconds,
             );
         }
     }
@@ -237,13 +238,33 @@ fn plan_fixed_slices(
     let chunk_samples = seconds_to_samples(options.chunk_seconds, sample_rate_hz);
     let overlap_samples = seconds_to_samples(options.overlap_seconds, sample_rate_hz);
     let min_chunk_samples = seconds_to_samples(options.min_chunk_seconds, sample_rate_hz);
+    // The true ceiling a chunk may never cross -- same `max_chunk_seconds`
+    // reading the energy/VAD planners already bound their forced cuts to
+    // (`extend_energy_slices_for_span`'s `hard_end`,
+    // `extend_vad_slices_for_span`'s `hard_end`). `options.max_chunk_seconds`
+    // is what `apply_encoder_attention_span_longform_safety_policy` clamps
+    // down to a `GlobalQuadratic` architecture's declared safe span (and, for
+    // families whose dedicated executor also fails closed above that same
+    // span with no extra margin, e.g. `mimo_asr`, it clamps to *exactly* the
+    // executor's hard per-chunk cap). Merging a short tail into the previous
+    // chunk below must never be allowed to push that chunk past this ceiling
+    // -- doing so silently produced an over-cap slice that the mimo-asr /
+    // firered-llm executors then rejected with a fail-closed 400 (a 30.2s
+    // clip: one 30.0s chunk plus a 0.2s tail below `min_chunk_seconds`
+    // merged straight into the 30.0s chunk, exceeding mimo-asr's 30.0s cap
+    // with zero headroom).
+    let max_chunk_samples =
+        seconds_to_samples(options.max_chunk_seconds, sample_rate_hz).max(chunk_samples);
     let step = chunk_samples.saturating_sub(overlap_samples).max(1);
     let mut start = 0usize;
     let mut slices: Vec<AudioSlice> = Vec::new();
     while start < total_samples {
         let end = (start + chunk_samples).min(total_samples);
-        if end.saturating_sub(start) < min_chunk_samples && !slices.is_empty() {
-            let last = slices.last_mut().expect("non-empty");
+        if end.saturating_sub(start) < min_chunk_samples
+            && let Some(last) = slices.last()
+            && total_samples.saturating_sub(last.content_start_sample) <= max_chunk_samples
+        {
+            let last = slices.last_mut().expect("checked Some above");
             last.content_end_sample = total_samples;
             break;
         }
@@ -886,6 +907,7 @@ fn build_auto_plan_candidate(
         total_samples,
         sample_rate_hz,
         options.padding_seconds,
+        options.max_chunk_seconds,
     );
     let short_slice_penalty = estimate_short_slice_penalty(&layout.slices, sample_rate_hz, options);
     let boundary_penalty = estimate_boundary_penalty(samples, &layout, sample_rate_hz, options);
@@ -1499,6 +1521,7 @@ fn estimate_layout_processed_samples(
     total_samples: usize,
     sample_rate_hz: u32,
     padding_seconds: f32,
+    max_chunk_seconds: f32,
 ) -> usize {
     if let Some(processed_audio) = layout.processed_audio.as_ref() {
         return processed_audio.len();
@@ -1514,6 +1537,7 @@ fn estimate_layout_processed_samples(
             total_samples,
             sample_rate_hz,
             padding_seconds,
+            max_chunk_seconds,
         );
         estimated.iter().map(AudioSlice::duration_samples).sum()
     }
@@ -1626,6 +1650,13 @@ fn pack_processed_spans_into_windows(
     }
     let target_chunk_samples = seconds_to_samples(options.chunk_seconds, sample_rate_hz).max(1);
     let min_chunk_samples = seconds_to_samples(options.min_chunk_seconds, sample_rate_hz).max(1);
+    // The hard ceiling: unlike `target_chunk_samples` (a soft target the loop
+    // below normally cuts at once `current_len >= min_chunk_samples`), this
+    // must never be crossed regardless of how small `current_len` still is --
+    // mirrors the same `max_chunk_samples` ceiling `subdivide_processed_spans_silence_aware`
+    // just bounded the individual subdivided spans by.
+    let max_chunk_samples =
+        seconds_to_samples(options.max_chunk_seconds, sample_rate_hz).max(target_chunk_samples);
     let overlap_samples = seconds_to_samples(options.overlap_seconds, sample_rate_hz)
         .min(target_chunk_samples.saturating_sub(1));
     // A single processed span longer than one chunk (a continuous-speech region
@@ -1642,7 +1673,9 @@ fn pack_processed_spans_into_windows(
         let prospective_end = span.end_sample;
         let prospective_len = prospective_end.saturating_sub(current_start);
         let current_len = current_end.saturating_sub(current_start);
-        if prospective_len > target_chunk_samples && current_len >= min_chunk_samples {
+        if prospective_len > target_chunk_samples
+            && (current_len >= min_chunk_samples || prospective_len > max_chunk_samples)
+        {
             windows.push(LongFormVadSlice {
                 start_sample: current_start,
                 end_sample: current_end,
@@ -1916,14 +1949,34 @@ fn apply_padding(
     total_samples: usize,
     sample_rate_hz: u32,
     padding_seconds: f32,
+    max_chunk_seconds: f32,
 ) {
     if slices.is_empty() {
         return;
     }
     let pad = seconds_to_samples(padding_seconds, sample_rate_hz);
+    // The true ceiling the *padded* window (what actually gets fed to the
+    // executor -- `AudioSlice::duration_samples`, not the narrower `content_*`
+    // range) may never cross. Every content-producing planner already bounds
+    // its `content_end_sample` by this same `max_chunk_seconds` (see
+    // `extend_energy_slices_for_span` / `extend_vad_slices_for_span` /
+    // `plan_fixed_slices`'s `hard_end`/`max_chunk_samples`), but padding used
+    // to add a flat `padding_seconds` on top unconditionally: a chunk whose
+    // content already sat at (or right up against) the cap got pushed past
+    // it by padding alone, reproducing the exact "30.2s exceeds the 30s
+    // per-chunk cap" shape (a 30.0s content chunk plus 0.25s padding,
+    // clamped by `total_samples` down to a 0.2s overshoot when little audio
+    // remained past it) even after the content-side merge bug is fixed.
+    // Shrink padding, never content, to keep the fed window inside the cap.
+    let max_chunk_samples = seconds_to_samples(max_chunk_seconds, sample_rate_hz).max(1);
     for slice in slices.iter_mut() {
-        slice.start_sample = slice.content_start_sample.saturating_sub(pad);
-        slice.end_sample = (slice.content_end_sample + pad).min(total_samples);
+        let content_len = slice
+            .content_end_sample
+            .saturating_sub(slice.content_start_sample);
+        let pad_budget = max_chunk_samples.saturating_sub(content_len);
+        let side_pad = pad.min(pad_budget / 2);
+        slice.start_sample = slice.content_start_sample.saturating_sub(side_pad);
+        slice.end_sample = (slice.content_end_sample + side_pad).min(total_samples);
     }
 }
 
@@ -3595,7 +3648,7 @@ mod tests {
             selection_provenance: Vec::new(),
         };
 
-        let estimated = estimate_layout_processed_samples(&layout, 16_000 * 40, 16_000, 0.0);
+        let estimated = estimate_layout_processed_samples(&layout, 16_000 * 40, 16_000, 0.0, 120.0);
         assert_eq!(estimated, 16_000 * 40 + 16_000 / 2);
     }
 
@@ -3760,5 +3813,82 @@ mod tests {
         assert_eq!(slices.len(), 1);
         assert_eq!(slices[0].content_start_sample, 0);
         assert_eq!(slices[0].content_end_sample, samples.len());
+    }
+
+    /// Regression for the mimo-asr/firered-llm "30.2s per-chunk cap" bug: a
+    /// `GlobalQuadratic` family whose dedicated executor fails closed at
+    /// exactly its declared `max_safe_chunk_seconds` (zero extra margin, the
+    /// `mimo_asr` shape) gets `chunk_seconds == max_chunk_seconds == 30.0`
+    /// from `apply_encoder_attention_span_longform_safety_policy`. Before the
+    /// fix, `plan_fixed_slices` merged any tail shorter than
+    /// `min_chunk_seconds` (default 1.0s) straight into the previous 30.0s
+    /// chunk with no cap check, so a 30.2s clip (30.0s chunk + a 0.2s tail)
+    /// produced a single 30.2s slice -- past the 30.0s executor cap with zero
+    /// tolerance. Matrix covers the exact reported duration (30.2s) plus its
+    /// neighbors: comfortably under cap (29.9s), exactly at cap (30.0s), and
+    /// a case requiring a real second chunk regardless (60.0s).
+    #[test]
+    fn fixed_mode_never_exceeds_zero_margin_family_chunk_cap() {
+        let sample_rate_hz = 16_000u32;
+        let max_chunk_seconds = 30.0f32;
+        for total_seconds in [29.9f32, 30.0, 30.2, 60.0] {
+            let mut options = options_with_mode(LongFormMode::Fixed);
+            options.chunk_seconds = max_chunk_seconds;
+            options.max_chunk_seconds = max_chunk_seconds;
+            let total_samples = (total_seconds * sample_rate_hz as f32).round() as usize;
+            let samples = tone(total_samples);
+            let plan = plan_longform_slices(&samples, sample_rate_hz, &options, None).unwrap();
+            let max_chunk_samples = (max_chunk_seconds * sample_rate_hz as f32).round() as usize;
+            for slice in &plan.slices {
+                assert!(
+                    slice.duration_samples() <= max_chunk_samples,
+                    "total_seconds={total_seconds}: slice {slice:?} exceeds the \
+                     {max_chunk_seconds}s zero-margin cap"
+                );
+            }
+            // Full coverage must still hold: nothing gets silently dropped by
+            // refusing to merge the short tail into the previous chunk.
+            assert_eq!(
+                plan.slices
+                    .last()
+                    .expect("non-empty plan")
+                    .content_end_sample,
+                total_samples,
+                "total_seconds={total_seconds}: plan must still cover the full clip"
+            );
+        }
+    }
+
+    /// Same zero-margin family shape, but through `LongFormMode::Auto`'s
+    /// multi-candidate selection: a continuous, pause-free 30.2s tone (no
+    /// clean silence point for the energy/VAD planners to land on) is exactly
+    /// the shape that let the defective `Fixed` candidate look best (full
+    /// coverage, single chunk, no wasted overlap) and win selection, handing
+    /// the mimo-asr executor an over-cap slice.
+    #[test]
+    fn auto_mode_never_exceeds_zero_margin_family_chunk_cap_on_pauseless_audio() {
+        let sample_rate_hz = 16_000u32;
+        let max_chunk_seconds = 30.0f32;
+        let mut options = options_with_mode(LongFormMode::Auto);
+        options.chunk_seconds = max_chunk_seconds;
+        options.max_chunk_seconds = max_chunk_seconds;
+        let total_samples = (30.2f32 * sample_rate_hz as f32).round() as usize;
+        let samples = tone(total_samples);
+        let plan = plan_longform_slices(&samples, sample_rate_hz, &options, None).unwrap();
+        let max_chunk_samples = (max_chunk_seconds * sample_rate_hz as f32).round() as usize;
+        for slice in &plan.slices {
+            assert!(
+                slice.duration_samples() <= max_chunk_samples,
+                "auto-selected slice {slice:?} exceeds the {max_chunk_seconds}s zero-margin cap"
+            );
+        }
+        assert_eq!(
+            plan.slices
+                .last()
+                .expect("non-empty plan")
+                .content_end_sample,
+            total_samples,
+            "auto-selected plan must still cover the full clip"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`plan_fixed_slices` merged any tail shorter than `min_chunk_seconds` straight into
the previous chunk with no upper-bound check, and `apply_padding` added a flat
`padding_seconds` on top of every slice's content regardless of how close that
content already sat to the family's chunk cap. Energy/VAD planners already bounded
their forced cuts by `max_chunk_seconds`; Fixed-mode and the shared padding step
did not.

## Why

For a `GlobalQuadratic` family whose dedicated executor fails closed at exactly its
declared safe chunk span with no extra margin (mimo-asr: `chunk_seconds ==
max_chunk_seconds == 30.0` after the encoder-attention-span clamp), either gap
alone reproduces the reported bug: a 30.2s clip becomes one 30.0s Fixed-mode chunk
plus a 0.2s tail merged into it, or a 30.0s content chunk padded out to the file's
true end -- in both cases yielding a single 30.2s slice that the executor's 30.0s
per-chunk cap then rejects with HTTP 400 and no partial output (`mimo-asr audio
duration 30.2s exceeds the 30s per-chunk cap`).

## Changes

- `plan_fixed_slices`: refuse the short-tail merge into the previous chunk when
  doing so would push it past `max_chunk_seconds`; the tail becomes its own
  (short) slice instead, matching how Energy/VAD already leave short trailing
  slices when unavoidable.
- `apply_padding`: shrink per-side padding (never content) so the padded window
  never crosses `max_chunk_seconds`, instead of adding a flat pad unconditionally.
- `pack_processed_spans_into_windows`: force a cut once accumulated length would
  cross `max_chunk_seconds`, even if `current_len < min_chunk_seconds` (same
  unbounded-merge shape as `plan_fixed_slices`, in the packed VAD/energy path).
- Threaded `max_chunk_seconds` through the two `apply_padding` call sites and
  `estimate_layout_processed_samples`.
- Regression tests: a boundary matrix (29.9/30.0/30.2/60.0s) for both `Fixed` and
  `Auto` mode against a zero-margin chunk cap (`chunk_seconds == max_chunk_seconds
  == 30.0`, the exact mimo-asr/firered-llm shape), asserting no emitted slice
  exceeds the cap and full audio coverage is preserved.

This fixes the whole class of per-chunk-cap executors (not just mimo-asr): any
family where `apply_encoder_attention_span_longform_safety_policy` clamps
`chunk_seconds` and `max_chunk_seconds` to the same value now gets a slicing
guarantee that structurally cannot exceed it, rather than raising the executor's
cap to paper over the gap.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-core longform mimo_asr firered_llm` (133 passed)
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (4 passed, 14 ignored -- private packs)
- [x] `cargo test -p openasr-core bundled_catalog_signature_verifies_committed_catalog_and_epoch`
- [x] `cargo test -p openasr-core --doc`

Full-workspace `cargo nextest run --workspace` not run (scope is `openasr-core`
longform/mimo/firered-llm only); real `.oasr`-pack end-to-end repro was not run in
this environment (no mimo-asr pack available locally) -- the unit-level boundary
matrix reproduces the exact reported numeric shape (30.2s) against the same
`LongFormOptions` mimo-asr resolves to.

## Manual smoke checks

N/A (no local mimo-asr pack to drive an HTTP/CLI smoke check in this environment).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not raise any executor's per-chunk cap.
- Does not touch VAD/energy planners themselves (already correctly bounded).
- Does not add a real-pack `#[ignore]`-gated integration test (no mimo-asr pack
  available in this environment to validate one against).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- root-cause investigation, fix implementation, and regression tests were done with AI (Claude) assistance under human direction and review.