### PR TITLE
fix(diarize): derive ReDimNet2-B6 calibration from measured voice-id eval

### DIFF
--- a/crates/openasr-core/src/diarize/calibration.rs
+++ b/crates/openasr-core/src/diarize/calibration.rs
@@ -7,6 +7,11 @@
 pub struct SpeakerCalibrationProfile {
     pub(crate) clustering: ClusteringCalibrationProfile,
     pub(crate) streaming: StreamingCalibrationProfile,
+    /// Default cosine-similarity floor for a newly enrolled voice-match
+    /// profile (`SpeakerProfile::match_similarity`) in this embedder's cosine
+    /// space, used when the caller does not supply an explicit override. See
+    /// `enrollment::DEFAULT_MATCH_SIMILARITY` for how this is consumed.
+    pub(crate) enrollment_default_match_similarity: f32,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -85,51 +90,99 @@ pub(crate) const WESPEAKER_CALIBRATION: SpeakerCalibrationProfile = SpeakerCalib
         native_profile_anchor_similarity: 0.50,
         speaker_change_max_cosine: 0.42,
     },
+    enrollment_default_match_similarity: 0.5,
 };
 
 /// ReDimNet2-B6 calibration (192-dim cosine space), distinct from
 /// `WESPEAKER_CALIBRATION` -- the two embedders' cosine distributions are not
 /// comparable, so nothing here is copied from the WeSpeaker profile above.
 ///
-/// TODO(voice-id-eval): every threshold below is a conservative placeholder,
-/// not yet measured against real enrollment data. A separate task is
-/// producing a LibriSpeech/AISHELL-4 same-speaker/cross-speaker cosine
-/// distribution to calibrate these for real; until that lands, values are
-/// picked to fail toward "no match" (stricter than a tuned profile would be)
-/// rather than risk false speaker merges.
+/// The batch-pipeline (clustering) thresholds below are derived from a real
+/// voice-id evaluation: LibriSpeech `test-clean`, 40 speakers, 42,960 trials
+/// across enrolled-library sizes of 5/10/20/40 speakers and 5-20 s enrollment
+/// clips (`tmp/voiceid-eval/results/{summary_metrics,threshold_curves,
+/// margin_distributions}.csv`, not checked into this repo). Headline findings:
+/// - A cosine match threshold of 0.55 keeps FAR at 0-1.3% with 98.7-100% hit
+///   rate across 5-20 speaker libraries (`threshold_curves.csv`); a 20-speaker
+///   library shows roughly an order of magnitude more false accepts than a
+///   5-speaker library at the same threshold, so 0.55 is the floor, not a
+///   number to relax as libraries grow.
+/// - The top1-vs-top2 similarity margin cleanly separates registered speakers
+///   from strangers: enrolled-speaker margins have p10 > 0.3, impostor margins
+///   have p90 < 0.17, so >= 0.15 margin is a reasonable "safe to display a
+///   name with high confidence" bar (`margin_distributions.csv`). Nothing in
+///   this crate currently gates the batch match on a runner-up margin (see
+///   `SpeakerProfileMatcher::best_match`, margin = 0.0) -- that is a
+///   deliberately separate change, not folded into this calibration pass.
+///
+/// Caveat: the eval is a clean, single-speaker-per-file, native-microphone
+/// read-speech corpus (LibriSpeech). It calibrates the acoustic same/
+/// different-speaker cosine floor well but says nothing about cross-device
+/// recording conditions, noisy/far-field capture, or multi-speaker
+/// segmentation quality; those need a dedicated Challenge Set pass before the
+/// thresholds below can be trusted outside this scenario.
+///
+/// This version ships batch file-transcription support for ReDimNet2 only;
+/// the streaming (realtime) fields further down have no equivalent streaming
+/// trial data yet and stay conservative TODO placeholders.
 pub(crate) const REDIMNET_CALIBRATION: SpeakerCalibrationProfile = SpeakerCalibrationProfile {
     clustering: ClusteringCalibrationProfile {
-        // TODO(voice-id-eval): placeholder, needs real calibration.
-        plain_merge_threshold: 0.50,
-        // TODO(voice-id-eval): placeholder, needs real calibration.
-        context_auto_merge_threshold: 0.75,
+        // Measured: LibriSpeech eval's 0.55 cosine main match threshold,
+        // expressed as `1 - cosine` dissimilarity (0.45). Clean read-speech
+        // only; see module-level caveat above.
+        plain_merge_threshold: 0.45,
+        // Not independently measured -- no multi-speaker segmentation corpus
+        // in the LibriSpeech eval to calibrate the context-assisted merge
+        // gate. Extrapolated by applying WeSpeaker's own
+        // context_auto_merge_threshold / plain_merge_threshold ratio
+        // (0.73 / 0.43 ~= 1.70) to the measured plain threshold above
+        // (0.45 * 1.70 ~= 0.76). Needs a real multi-speaker meeting-style
+        // corpus (e.g. AISHELL-4) before this can be called calibrated.
+        context_auto_merge_threshold: 0.76,
         dense_context_min_embeddings: 30,
-        // TODO(voice-id-eval): placeholder, needs real calibration.
-        dense_context_merge_threshold: 0.50,
+        // Same reasoning as `plain_merge_threshold`: WeSpeaker keeps this
+        // equal to its plain threshold, and the measured 0.55 main match
+        // threshold gives no separate signal for dense-meeting behavior.
+        dense_context_merge_threshold: 0.45,
         context_gap: Some(ContextGapCalibrationProfile {
             min_gap: 0.05,
             max_speakers: 4,
             fallback_speakers: 3,
         }),
     },
+    // Streaming (realtime registry consolidation) is out of scope for this
+    // calibration pass: the LibriSpeech eval only exercised batch-style
+    // enrollment/matching trials, not the incremental same-turn-vs-new-turn
+    // decisions streaming makes. Values below stay the original conservative,
+    // fail-toward-"no match" placeholders (distinct from WeSpeaker's tuned
+    // numbers) until a dedicated streaming/Challenge Set pass calibrates them
+    // for real; this crate does not ship streaming support for ReDimNet2 yet.
     streaming: StreamingCalibrationProfile {
-        // TODO(voice-id-eval): placeholder, needs real calibration.
+        // TODO(voice-id-eval): placeholder, needs streaming/Challenge Set calibration.
         match_similarity: 0.60,
-        // TODO(voice-id-eval): placeholder, needs real calibration.
+        // TODO(voice-id-eval): placeholder, needs streaming/Challenge Set calibration.
         strong_existing_match_similarity: 0.70,
-        // TODO(voice-id-eval): placeholder, needs real calibration.
+        // TODO(voice-id-eval): placeholder, needs streaming/Challenge Set calibration.
         relaxed_match_similarity: 0.40,
+        // TODO(voice-id-eval): placeholder, needs streaming/Challenge Set calibration.
         relaxed_match_margin: 0.20,
+        // TODO(voice-id-eval): placeholder, needs streaming/Challenge Set calibration.
         relaxed_reuse_max_weight: 3.0,
-        // TODO(voice-id-eval): placeholder, needs real calibration.
+        // TODO(voice-id-eval): placeholder, needs streaming/Challenge Set calibration.
         new_speaker_max_existing_similarity: 0.50,
-        // TODO(voice-id-eval): placeholder, needs real calibration.
+        // TODO(voice-id-eval): placeholder, needs streaming/Challenge Set calibration.
         profile_anchor_similarity: 0.80,
-        // TODO(voice-id-eval): placeholder, needs real calibration.
+        // TODO(voice-id-eval): placeholder, needs streaming/Challenge Set calibration.
         native_profile_anchor_similarity: 0.55,
-        // TODO(voice-id-eval): placeholder, needs real calibration.
+        // TODO(voice-id-eval): placeholder, needs streaming/Challenge Set calibration.
         speaker_change_max_cosine: 0.45,
     },
+    // Measured: LibriSpeech eval's 0.55 cosine main match threshold. This is
+    // the default floor for a newly enrolled `SpeakerProfile` in ReDimNet2's
+    // cosine space (batch file-transcription enrollment/matching), up from
+    // WeSpeaker's unrelated 0.5 default -- the two embedders' cosine spaces
+    // are not comparable, see module doc.
+    enrollment_default_match_similarity: 0.55,
 };
 
 #[cfg(test)]
@@ -138,10 +191,16 @@ mod tests {
 
     #[test]
     fn redimnet_calibration_profile_is_pinned_and_distinct_from_wespeaker() {
-        assert_eq!(REDIMNET_CALIBRATION.clustering.plain_merge_threshold, 0.50);
+        assert_eq!(REDIMNET_CALIBRATION.clustering.plain_merge_threshold, 0.45);
         assert_eq!(
             REDIMNET_CALIBRATION.clustering.context_auto_merge_threshold,
-            0.75
+            0.76
+        );
+        assert_eq!(
+            REDIMNET_CALIBRATION
+                .clustering
+                .dense_context_merge_threshold,
+            0.45
         );
         assert_eq!(REDIMNET_CALIBRATION.streaming.match_similarity, 0.60);
         assert_eq!(
@@ -149,6 +208,10 @@ mod tests {
                 .streaming
                 .strong_existing_match_similarity,
             0.70
+        );
+        assert_eq!(
+            REDIMNET_CALIBRATION.enrollment_default_match_similarity,
+            0.55
         );
         assert_ne!(
             REDIMNET_CALIBRATION.clustering.plain_merge_threshold,
@@ -159,6 +222,64 @@ mod tests {
             REDIMNET_CALIBRATION.streaming.match_similarity,
             WESPEAKER_CALIBRATION.streaming.match_similarity,
             "redimnet calibration must not be copied verbatim from wespeaker's tuned values"
+        );
+        assert_ne!(
+            REDIMNET_CALIBRATION.enrollment_default_match_similarity,
+            WESPEAKER_CALIBRATION.enrollment_default_match_similarity,
+            "redimnet calibration must not be copied verbatim from wespeaker's tuned values"
+        );
+    }
+
+    /// The clustering thresholds must stay internally consistent with the
+    /// measured 0.55 cosine main match threshold: `plain_merge_threshold` and
+    /// `dense_context_merge_threshold` are both `1 - 0.55` dissimilarity, and
+    /// the context-assisted threshold must loosen (not tighten) relative to
+    /// the plain one, matching WeSpeaker's own merge-threshold ordering.
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn redimnet_clustering_thresholds_are_self_consistent_with_measured_main_threshold() {
+        const MEASURED_MAIN_MATCH_COSINE: f32 = 0.55;
+        let expected_dissimilarity = 1.0 - MEASURED_MAIN_MATCH_COSINE;
+        assert!(
+            (REDIMNET_CALIBRATION.clustering.plain_merge_threshold - expected_dissimilarity).abs()
+                < 1e-6
+        );
+        assert_eq!(
+            REDIMNET_CALIBRATION.clustering.plain_merge_threshold,
+            REDIMNET_CALIBRATION
+                .clustering
+                .dense_context_merge_threshold,
+            "dense-context merge threshold should match the plain threshold, as in WeSpeaker's profile"
+        );
+        assert!(
+            REDIMNET_CALIBRATION.clustering.context_auto_merge_threshold
+                > REDIMNET_CALIBRATION.clustering.plain_merge_threshold,
+            "context-assisted merging must stay looser than the acoustic-only floor"
+        );
+        assert!(
+            (REDIMNET_CALIBRATION.enrollment_default_match_similarity - MEASURED_MAIN_MATCH_COSINE)
+                .abs()
+                < 1e-6,
+            "enrollment default should track the measured main match threshold"
+        );
+    }
+
+    /// The per-embedder enrollment default must actually diverge: WeSpeaker
+    /// keeps its historical 0.5 default (`enrollment::DEFAULT_MATCH_SIMILARITY`)
+    /// while ReDimNet2 uses the measured 0.55 floor.
+    #[test]
+    fn enrollment_default_match_similarity_is_embedder_specific() {
+        assert_eq!(
+            WESPEAKER_CALIBRATION.enrollment_default_match_similarity,
+            0.5
+        );
+        assert_eq!(
+            REDIMNET_CALIBRATION.enrollment_default_match_similarity,
+            0.55
+        );
+        assert_ne!(
+            WESPEAKER_CALIBRATION.enrollment_default_match_similarity,
+            REDIMNET_CALIBRATION.enrollment_default_match_similarity
         );
     }
 
@@ -225,6 +346,10 @@ mod tests {
         assert_eq!(
             WESPEAKER_CALIBRATION.streaming.speaker_change_max_cosine,
             0.42
+        );
+        assert_eq!(
+            WESPEAKER_CALIBRATION.enrollment_default_match_similarity,
+            0.5
         );
     }
 }

--- a/crates/openasr-core/src/diarize/calibration.rs
+++ b/crates/openasr-core/src/diarize/calibration.rs
@@ -102,11 +102,15 @@ pub(crate) const WESPEAKER_CALIBRATION: SpeakerCalibrationProfile = SpeakerCalib
 /// across enrolled-library sizes of 5/10/20/40 speakers and 5-20 s enrollment
 /// clips (`tmp/voiceid-eval/results/{summary_metrics,threshold_curves,
 /// margin_distributions}.csv`, not checked into this repo). Headline findings:
-/// - A cosine match threshold of 0.55 keeps FAR at 0-1.3% with 98.7-100% hit
-///   rate across 5-20 speaker libraries (`threshold_curves.csv`); a 20-speaker
-///   library shows roughly an order of magnitude more false accepts than a
-///   5-speaker library at the same threshold, so 0.55 is the floor, not a
-///   number to relax as libraries grow.
+/// - A cosine match threshold of 0.55 keeps FAR at 0-1.5% with 99.4-100% hit
+///   rate across 5-20 speaker libraries (`threshold_curves.csv`, worst case
+///   is the 20-speaker `multi3_12s` config at FAR 1.53% / hit 99.76%); a
+///   20-speaker library shows roughly an order of magnitude more false
+///   accepts than a 5-speaker library at the same threshold, so 0.55 is the
+///   floor, not a number to relax as libraries grow. Per-scenario thresholds
+///   that hit the tighter FAR < 1% bar range 0.43-0.57
+///   (`summary_metrics.csv` `rec_threshold_far_lt_1pct`); 0.55 is a
+///   reasonable single cutover value but is not FAR < 1% for every scenario.
 /// - The top1-vs-top2 similarity margin cleanly separates registered speakers
 ///   from strangers: enrolled-speaker margins have p10 > 0.3, impostor margins
 ///   have p90 < 0.17, so >= 0.15 margin is a reasonable "safe to display a

--- a/crates/openasr-core/src/diarize/enrollment.rs
+++ b/crates/openasr-core/src/diarize/enrollment.rs
@@ -22,7 +22,12 @@ use super::embed::{EmbedError, SpeakerEmbedder, SpeakerEmbedderIdentity, shared_
 /// CLI. The REST API accepts any non-empty display name.
 pub const DEFAULT_ENROLLED_NAME: &str = "SPEAKER_ME";
 /// Default cosine-similarity floor for matching a diarized speaker to a stored
-/// voice-match profile.
+/// voice-match profile, in the legacy WeSpeaker cosine space. Kept as the
+/// WeSpeaker-specific constant it always was; the actual default applied at
+/// enrollment time is per-embedder (see
+/// `SpeakerCalibrationProfile::enrollment_default_match_similarity` and
+/// `create_profile_from_samples_with_embedder_and_seconds`), since ReDimNet2
+/// and WeSpeaker cosine spaces are not comparable.
 pub const DEFAULT_MATCH_SIMILARITY: f32 = 0.5;
 /// Version of the on-disk multi-profile voiceprint store.
 pub const VOICEPRINT_STORE_VERSION: u32 = 1;
@@ -511,8 +516,9 @@ fn create_profile_from_samples_with_embedder_and_seconds(
     identity: &SpeakerEmbedderIdentity,
 ) -> Result<SpeakerProfile, SpeakerEnrollmentError> {
     let name = normalize_profile_name(name.into())?;
-    let match_similarity =
-        validate_match_similarity(match_similarity.unwrap_or(DEFAULT_MATCH_SIMILARITY))?;
+    let match_similarity = validate_match_similarity(
+        match_similarity.unwrap_or_else(|| default_match_similarity_for(embedder)),
+    )?;
     let embedding = embedding_from_enrollment_audio(embedder, samples)?;
     Ok(profile_from_embedding(
         name,
@@ -692,6 +698,17 @@ fn validate_profile_id(id: &str) -> Result<(), VoiceprintStoreError> {
     }
 }
 
+/// The cosine-similarity floor applied to a newly enrolled `SpeakerProfile`
+/// when the caller does not supply an explicit `--match-similarity` override.
+/// Sourced from the active embedder's own calibration profile so ReDimNet2
+/// and WeSpeaker enrollments never share a threshold across their
+/// (non-comparable) cosine spaces.
+fn default_match_similarity_for(embedder: &dyn SpeakerEmbedder) -> f32 {
+    embedder
+        .calibration_profile()
+        .enrollment_default_match_similarity
+}
+
 fn validate_match_similarity(value: f32) -> Result<f32, VoiceprintStoreError> {
     if (0.0..=1.0).contains(&value) {
         Ok(value)
@@ -799,6 +816,46 @@ mod tests {
             embedding_dim: dim,
             pack_fingerprint: fingerprint.to_string(),
         }
+    }
+
+    /// Trait-default calibration (WeSpeaker), standing in for the real
+    /// `WeSpeakerEmbedder` without needing loaded weights.
+    struct StubWeSpeakerEmbedder;
+    impl SpeakerEmbedder for StubWeSpeakerEmbedder {
+        fn embed(&self, _samples: &[f32], _sr: u32) -> Result<SpeakerEmbedding, EmbedError> {
+            unimplemented!("not needed for calibration-default tests")
+        }
+        fn embedding_dim(&self) -> usize {
+            256
+        }
+    }
+
+    /// Overrides `calibration_profile` the same way `RedimNet2Embedder` does,
+    /// standing in for it without needing loaded weights.
+    struct StubRedimNetEmbedder;
+    impl SpeakerEmbedder for StubRedimNetEmbedder {
+        fn embed(&self, _samples: &[f32], _sr: u32) -> Result<SpeakerEmbedding, EmbedError> {
+            unimplemented!("not needed for calibration-default tests")
+        }
+        fn embedding_dim(&self) -> usize {
+            192
+        }
+        fn calibration_profile(&self) -> crate::diarize::calibration::SpeakerCalibrationProfile {
+            crate::diarize::calibration::REDIMNET_CALIBRATION
+        }
+    }
+
+    #[test]
+    fn default_match_similarity_is_embedder_specific() {
+        assert_eq!(
+            default_match_similarity_for(&StubWeSpeakerEmbedder),
+            DEFAULT_MATCH_SIMILARITY
+        );
+        assert_eq!(default_match_similarity_for(&StubRedimNetEmbedder), 0.55);
+        assert_ne!(
+            default_match_similarity_for(&StubWeSpeakerEmbedder),
+            default_match_similarity_for(&StubRedimNetEmbedder)
+        );
     }
 
     fn profile(id: &str, dim: usize, fingerprint: &str, embedding: Vec<f32>) -> SpeakerProfile {


### PR DESCRIPTION
## Summary

Replace the ReDimNet2-B6 calibration TODO placeholders in
`crates/openasr-core/src/diarize/calibration.rs` with values derived from a
real voice-id evaluation, and make the default `SpeakerProfile.match_similarity`
applied at enrollment time embedder-specific instead of a single shared
constant.

## Why

`REDIMNET_CALIBRATION` shipped in #197 as a conservative, unmeasured
placeholder. A voice-id evaluation has since run against real ReDimNet2-B6
embeddings, so the batch-pipeline thresholds can now be pinned to measured
numbers instead of guesses.

## Changes

- `calibration.rs`: `plain_merge_threshold` / `dense_context_merge_threshold`
  now derive from the measured 0.55 cosine main match threshold
  (`1 - 0.55 = 0.45` dissimilarity); `context_auto_merge_threshold` is
  extrapolated from WeSpeaker's own context/plain ratio (no multi-speaker
  segmentation corpus was evaluated) and documented as such. Streaming-only
  fields keep their conservative placeholders with comments explaining why
  (no streaming trial data yet; this release ships batch file transcription
  only for ReDimNet2).
- Added `SpeakerCalibrationProfile::enrollment_default_match_similarity`
  (0.55 for ReDimNet2, 0.5 for WeSpeaker, unchanged) and wired
  `create_profile_from_samples` to source the default from the active
  embedder's calibration profile instead of a single shared constant.
- Tests: clustering-threshold self-consistency with the measured main
  threshold, ReDimNet2 vs WeSpeaker constants remain distinct, and the
  enrollment default resolves correctly per embedder.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

None; no runtime-facing behavior change beyond the calibration constants.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Streaming (realtime) calibration for ReDimNet2 is out of scope; those fields
are unchanged placeholders pending a dedicated Challenge Set / streaming
evaluation. No margin-gating change to the batch match path.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — AI assistance was used to draft the calibration derivation and tests.