### PR TITLE
fix(pull): abandon low-speed chunked segments onto a fresh connection

### DIFF
--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc,
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -64,6 +64,26 @@ const PULL_CONNECTIONS_ENV_VAR: &str = "OPENASR_PULL_CONNECTIONS";
 /// persistently broken likely reflects a source-wide problem the outer loop
 /// is already positioned to retry or fall back away from.
 const SEGMENT_MAX_RETRIES: usize = 3;
+/// Per-segment low-speed floor for the concurrent chunked-download path.
+/// Deliberately shorter and stricter than the whole-file
+/// `DOWNLOAD_LOW_SPEED_*` pair used by the single-stream path: that guard is
+/// tuned to catch only a connection that is *effectively dead* (its 60s / 64
+/// KiB pair is a floor of roughly 1 KB/s), because abandoning it discards the
+/// whole download so far. A segment fetch has no such cost -- the other
+/// segments already on disk or in flight are untouched -- so it can afford to
+/// give up on a merely *slow* connection and try a fresh one instead of
+/// riding it out. 15s / 3 MiB is a ~205 KB/s floor, chosen to actually catch
+/// the reported real-world failure mode: a lone tail segment stuck on one
+/// degraded connection at ~90 KB/s, which would otherwise take the full 64
+/// MiB segment (~12 minutes) to finish with nothing else to fall back on.
+/// Reconnecting is cheap here (see `fetch_segment_with_retries` and the
+/// requeue-to-tail handling in `run_segment_worker`), and CDNs commonly
+/// resolve a degraded edge by simply routing a new connection differently,
+/// so this floor favors giving a fresh connection a chance over waiting out
+/// a bad one. Exposed via `PullOptions` (like the whole-file pair) so tests
+/// can force a deterministic trip.
+const SEGMENT_LOW_SPEED_TIMEOUT: Duration = Duration::from_secs(15);
+const SEGMENT_LOW_SPEED_MIN_BYTES: u64 = 3 * 1024 * 1024;
 /// Discriminator stamped into the segmented-download partial-meta file so a
 /// resume never misreads a legacy (pre-chunking) `PartialMeta` -- or a future
 /// incompatible format -- as a valid segment bitmap. Bumping the segment size
@@ -228,6 +248,15 @@ pub enum PullError {
         "Concurrent chunk fetch for '{url}' returned a Content-Range starting at a different offset than requested"
     )]
     SegmentRangeMismatch { url: String },
+    #[error(
+        "Concurrent chunk fetch for '{url}' segment [{start}-{end}] stayed below the per-segment low-speed floor across {attempts} connection attempts; giving up on this segment"
+    )]
+    SegmentLowSpeed {
+        url: String,
+        start: u64,
+        end: u64,
+        attempts: usize,
+    },
     #[error("Downloaded pack failed Rust-only GGUF preflight for '{path}': {reason}")]
     GgufPreflight { path: PathBuf, reason: String },
     #[error("Downloaded backend file failed binary preflight for '{path}': {reason}")]
@@ -293,6 +322,13 @@ struct PullOptions {
     available_space_override: Option<u64>,
     low_speed_timeout: Duration,
     low_speed_min_bytes: u64,
+    /// Per-segment low-speed floor for the concurrent chunked-download path;
+    /// see `SEGMENT_LOW_SPEED_TIMEOUT`/`SEGMENT_LOW_SPEED_MIN_BYTES` for the
+    /// production defaults and the rationale for why they're stricter than
+    /// the whole-file pair above. Overridable (like that pair) so tests can
+    /// force a deterministic trip without waiting out a real window.
+    segment_low_speed_timeout: Duration,
+    segment_low_speed_min_bytes: u64,
     /// Test-only override for `DOWNLOAD_SEGMENT_BYTES`, so unit tests can
     /// exercise multi-segment concurrent download logic (splitting, resume
     /// bitmap, ETag invalidation, ...) against small in-memory fixtures
@@ -307,6 +343,8 @@ impl PullOptions {
             available_space_override: None,
             low_speed_timeout: DOWNLOAD_LOW_SPEED_TIMEOUT,
             low_speed_min_bytes: DOWNLOAD_LOW_SPEED_MIN_BYTES,
+            segment_low_speed_timeout: SEGMENT_LOW_SPEED_TIMEOUT,
+            segment_low_speed_min_bytes: SEGMENT_LOW_SPEED_MIN_BYTES,
             parallel_segment_bytes_override: None,
         }
     }
@@ -378,6 +416,7 @@ struct ParallelDownloadConfig<'a> {
     factory: &'a dyn Fn() -> Result<BoxedDownloadClient, PullError>,
 }
 
+#[derive(Debug)]
 struct DownloadedPartial {
     bytes_done: u64,
     sha256: String,
@@ -1406,6 +1445,7 @@ fn load_segmented_meta(
 }
 
 /// Outcome of one concurrent chunked-download attempt.
+#[derive(Debug)]
 enum ParallelAttemptOutcome {
     /// Every segment verified complete; the caller feeds this straight into
     /// `verify_partial_and_install` exactly like the single-stream path.
@@ -1555,21 +1595,6 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
                 path: paths.partial_path.clone(),
                 source,
             })?;
-        let written = write_segment_body(
-            &mut file,
-            &paths.partial_path,
-            probe_start,
-            probe_end,
-            probe_response.reader,
-            |delta| {
-                bytes_done = bytes_done.saturating_add(delta);
-                progress(PullProgress::Downloading {
-                    bytes_done,
-                    bytes_total: target.size_bytes,
-                });
-            },
-            &|| should_cancel() || should_pause(),
-        )?;
         // The probe segment downloads synchronously on this orchestrating
         // thread, before any worker thread exists to poll the controls, so it
         // must honor cancel/pause itself -- otherwise a cancel issued while the
@@ -1578,20 +1603,85 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
         // for seconds. `write_segment_body` stops early on the predicate above,
         // leaving a short segment, so these checks must come before the
         // size-mismatch check below (an intentional stop is not a mismatch).
-        if should_cancel() {
-            cleanup_partial(paths);
-            return Err(PullError::Canceled {
-                reference: target.pull.clone(),
-            });
-        }
-        if should_pause() {
-            // Keep the partial file and segment bitmap (segment not marked
-            // done) so a later resume re-probes and refetches this segment
-            // cleanly, exactly like a pause caught by the worker loop below.
-            return Err(PullError::Paused {
-                reference: target.pull.clone(),
-            });
-        }
+        //
+        // The probe also carries its own low-speed guard: it runs before any
+        // worker exists and can just as easily land on a degraded connection
+        // as a worker-fetched segment can. Unlike the worker path there's no
+        // shared queue to requeue into here (there's exactly one prober), so
+        // a low-speed trip just re-opens a fresh request for the same range
+        // and retries in place, bounded by the same `SEGMENT_MAX_RETRIES` cap
+        // every other segment failure mode uses.
+        let mut probe_reader = probe_response.reader;
+        let mut probe_attempts = 1_usize;
+        let written = loop {
+            let mut low_speed = SegmentLowSpeedWindow::new(options);
+            let outcome = write_segment_body(
+                &mut file,
+                &paths.partial_path,
+                probe_start,
+                probe_end,
+                probe_reader,
+                |delta| {
+                    bytes_done = bytes_done.saturating_add(delta);
+                    progress(PullProgress::Downloading {
+                        bytes_done,
+                        bytes_total: target.size_bytes,
+                    });
+                },
+                &|| should_cancel() || should_pause(),
+                &mut low_speed,
+            )?;
+            match outcome {
+                SegmentWriteOutcome::Completed(written) => break written,
+                SegmentWriteOutcome::AbortedByControl => {
+                    if should_cancel() {
+                        cleanup_partial(paths);
+                        return Err(PullError::Canceled {
+                            reference: target.pull.clone(),
+                        });
+                    }
+                    // Keep the partial file and segment bitmap (segment not
+                    // marked done) so a later resume re-probes and refetches
+                    // this segment cleanly, exactly like a pause caught by
+                    // the worker loop below.
+                    return Err(PullError::Paused {
+                        reference: target.pull.clone(),
+                    });
+                }
+                SegmentWriteOutcome::LowSpeed(partial_written) => {
+                    // Roll back the progress already reported for this
+                    // abandoned attempt so bytes_done never double-counts
+                    // once the retry below re-downloads the same range from
+                    // scratch.
+                    bytes_done = bytes_done.saturating_sub(partial_written);
+                    progress(PullProgress::Downloading {
+                        bytes_done,
+                        bytes_total: target.size_bytes,
+                    });
+                    if probe_attempts > SEGMENT_MAX_RETRIES {
+                        cleanup_partial(paths);
+                        return Err(PullError::SegmentLowSpeed {
+                            url: target.url.clone(),
+                            start: probe_start,
+                            end: probe_end,
+                            attempts: probe_attempts,
+                        });
+                    }
+                    let retry_response = probe_client.open(
+                        &target.url,
+                        Some(ByteRange::bounded(probe_start, probe_end)),
+                    )?;
+                    if retry_response.status != 206 {
+                        return Err(PullError::UnexpectedStatus {
+                            url: target.url.clone(),
+                            status: retry_response.status,
+                        });
+                    }
+                    probe_reader = retry_response.reader;
+                    probe_attempts += 1;
+                }
+            }
+        };
         let expected = probe_end - probe_start + 1;
         if written != expected {
             cleanup_partial(paths);
@@ -1631,6 +1721,14 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
     let remaining_count = remaining.len();
     let queue = Arc::new(Mutex::new(remaining));
     let abort = Arc::new(AtomicBool::new(false));
+    // One low-speed abandon counter per segment index, shared across every
+    // worker: a segment can be requeued and picked up by a *different*
+    // worker than the one that abandoned it, so the retry cap has to live
+    // outside any single worker's local state (unlike the generic
+    // `SEGMENT_MAX_RETRIES` loop in `fetch_segment_with_retries`, which stays
+    // on one worker/connection because it isn't requeuing).
+    let low_speed_abandon_counts: Arc<Vec<AtomicUsize>> =
+        Arc::new((0..total_segments).map(|_| AtomicUsize::new(0)).collect());
     let (sender, receiver) = mpsc::channel::<SegmentEvent>();
     // No lock needed yet: no worker thread exists before the spawn loop
     // below, so `remaining_count` (captured before `remaining` moved into
@@ -1646,6 +1744,8 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
         let worker_path = paths.partial_path.clone();
         let worker_url = target.url.clone();
         let worker_reference_etag = reference_etag.clone();
+        let worker_options = options.clone();
+        let worker_low_speed_abandon_counts = low_speed_abandon_counts.clone();
         handles.push(std::thread::spawn(move || {
             run_segment_worker(
                 worker_client,
@@ -1657,6 +1757,8 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
                 size_bytes,
                 segment_bytes,
                 worker_reference_etag,
+                worker_options,
+                worker_low_speed_abandon_counts,
             );
         }));
     }
@@ -1669,6 +1771,17 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
         match receiver.recv_timeout(Duration::from_millis(100)) {
             Ok(SegmentEvent::Progress(delta)) => {
                 bytes_done = bytes_done.saturating_add(delta);
+                progress(PullProgress::Downloading {
+                    bytes_done,
+                    bytes_total: target.size_bytes,
+                });
+            }
+            Ok(SegmentEvent::ProgressRollback(delta)) => {
+                // A worker abandoned a low-speed attempt after already
+                // reporting some of its bytes via `Progress` above; undo
+                // that now so the retry (which re-downloads the same range
+                // from scratch) doesn't double-count them.
+                bytes_done = bytes_done.saturating_sub(delta);
                 progress(PullProgress::Downloading {
                     bytes_done,
                     bytes_total: target.size_bytes,
@@ -1768,6 +1881,26 @@ fn sync_partial_file(path: &Path) -> Result<(), PullError> {
     })
 }
 
+/// How [`write_segment_body`] stopped before reaching `expected_len`. The
+/// `Completed` case is the only one where the caller may mark the segment
+/// done; `LowSpeed` carries the partial byte count so the caller can roll
+/// back whatever progress it already reported for this (now-discarded)
+/// attempt before retrying. `AbortedByControl` needs no such rollback: a
+/// cancel discards the whole partial download and a pause preserves it
+/// on-disk exactly as-is (no retry follows), so there's nothing to correct.
+enum SegmentWriteOutcome {
+    /// Read exactly `expected_len` bytes (the size check against
+    /// `end_inclusive - start + 1` still happens at the call site, matching
+    /// the pre-existing contract).
+    Completed(u64),
+    /// `should_abort` tripped (pause/cancel): stop silently, same as before.
+    AbortedByControl,
+    /// The per-segment low-speed window tripped: this attempt's connection
+    /// is judged too slow to keep riding out; the caller should abandon it
+    /// and get a fresh connection rather than treat this as a hard error.
+    LowSpeed(u64),
+}
+
 /// Stream `reader` (already capped to the segment's expected length by the
 /// caller's use of `.take`, applied inside this function) into `file` at
 /// `[start, end_inclusive]`, calling `on_progress` with each chunk's byte
@@ -1779,7 +1912,11 @@ fn sync_partial_file(path: &Path) -> Result<(), PullError> {
 /// probe-segment write (main thread, whose predicate polls the pull's
 /// cancel/pause controls directly) and every worker's per-segment fetch
 /// (`fetch_segment_once`, whose predicate reads the shared `abort` flag), so
-/// both paths write segments identically and stop identically.
+/// both paths write segments identically and stop identically. Also shared:
+/// the per-segment low-speed guard (`low_speed`), so a lone tail segment
+/// stuck on a degraded connection is caught the same way regardless of which
+/// of the two call sites is currently downloading it (see
+/// `SEGMENT_LOW_SPEED_TIMEOUT`).
 fn write_segment_body(
     file: &mut File,
     path_for_errors: &Path,
@@ -1788,7 +1925,8 @@ fn write_segment_body(
     reader: Box<dyn Read>,
     mut on_progress: impl FnMut(u64),
     should_abort: &dyn Fn() -> bool,
-) -> Result<u64, PullError> {
+    low_speed: &mut SegmentLowSpeedWindow,
+) -> Result<SegmentWriteOutcome, PullError> {
     file.seek(SeekFrom::Start(start))
         .map_err(|source| PullError::Io {
             path: path_for_errors.to_path_buf(),
@@ -1800,7 +1938,7 @@ fn write_segment_body(
     let mut written = 0_u64;
     loop {
         if should_abort() {
-            break;
+            return Ok(SegmentWriteOutcome::AbortedByControl);
         }
         let read = reader.read(&mut buffer).map_err(|source| PullError::Io {
             path: path_for_errors.to_path_buf(),
@@ -1816,26 +1954,60 @@ fn write_segment_body(
             })?;
         written = written.saturating_add(read as u64);
         on_progress(read as u64);
+        if low_speed.observe(read as u64) {
+            return Ok(SegmentWriteOutcome::LowSpeed(written));
+        }
     }
-    Ok(written)
+    Ok(SegmentWriteOutcome::Completed(written))
 }
 
 /// Events a segment worker thread reports back to the orchestrating thread
 /// over the `mpsc` channel. Kept intentionally minimal: only the
 /// orchestrating thread touches `should_cancel`/`should_pause`, the segment
 /// bitmap, and the `progress` callback, so workers never need anything more
-/// than "here is a byte delta" / "this segment index is done" / "this
-/// segment failed".
+/// than "here is a byte delta" / "undo this many previously-reported bytes"
+/// / "this segment index is done" / "this segment failed".
 enum SegmentEvent {
     Progress(u64),
+    /// A worker abandoned a low-speed attempt after already reporting
+    /// `Progress` for some of its bytes; the orchestrator subtracts this
+    /// from `bytes_done` so the (from-scratch) retry doesn't double-count
+    /// them. See `run_segment_worker`'s `SegmentFetchOutcome::LowSpeed` arm.
+    ProgressRollback(u64),
     Done(usize),
     Failed(PullError),
+}
+
+/// Outcome of one segment fetch attempt (one `client.open` + body read).
+/// Distinguished from a hard `Err` because a low-speed trip is not a fatal
+/// condition -- it means "this connection is bad, get a new one" -- so it is
+/// handled by `run_segment_worker` requeuing the segment instead of by
+/// `fetch_segment_with_retries`'s same-connection retry loop.
+enum SegmentFetchOutcome {
+    Done,
+    /// Aborted mid-segment by cancel/pause; no event needed, the
+    /// orchestrator already knows.
+    AbortedByControl,
+    /// The per-segment low-speed window tripped; carries the bytes written
+    /// (and already reported via `SegmentEvent::Progress`) so the caller can
+    /// roll that progress back before abandoning the connection.
+    LowSpeed(u64),
 }
 
 /// One worker thread's loop: pop segment indices off the shared `queue`
 /// until it's empty or `abort` is set, fetching and writing each with
 /// `fetch_segment_with_retries`. Never panics on I/O failure -- every error
 /// path reports a `SegmentEvent::Failed` and returns instead.
+///
+/// A segment that trips the per-segment low-speed guard is not retried
+/// in place: it's pushed back onto the tail of the shared `queue` so the
+/// next `client.open()` call for it (by this worker or another, once its
+/// current segment finishes) starts a genuinely fresh connection rather than
+/// riding out the same degraded one. `low_speed_abandon_counts` bounds how
+/// many times any single segment index can be abandoned this way before it
+/// falls through to the same fail-closed path every other segment failure
+/// mode uses (`PullError::SegmentLowSpeed`, retried at the whole-attempt
+/// level by `download_with_retries` like any other retryable pull error).
 #[allow(clippy::too_many_arguments)]
 fn run_segment_worker(
     mut client: BoxedDownloadClient,
@@ -1847,6 +2019,8 @@ fn run_segment_worker(
     size_bytes: u64,
     segment_bytes: u64,
     reference_etag: Option<String>,
+    options: PullOptions,
+    low_speed_abandon_counts: Arc<Vec<AtomicUsize>>,
 ) {
     let mut file = match OpenOptions::new().write(true).open(&path) {
         Ok(file) => file,
@@ -1880,13 +2054,40 @@ fn run_segment_worker(
             reference_etag.as_deref(),
             &abort,
             &sender,
+            &options,
         ) {
-            Ok(true) => {
+            Ok(SegmentFetchOutcome::Done) => {
                 if sender.send(SegmentEvent::Done(index)).is_err() {
                     return;
                 }
             }
-            Ok(false) => return, // aborted mid-segment; no event, orchestrator already knows
+            Ok(SegmentFetchOutcome::AbortedByControl) => return,
+            Ok(SegmentFetchOutcome::LowSpeed(partial_written)) => {
+                if sender
+                    .send(SegmentEvent::ProgressRollback(partial_written))
+                    .is_err()
+                {
+                    return;
+                }
+                // SeqCst: every worker reads-then-writes this same counter,
+                // so ordering must be total across threads, not just
+                // per-worker-relative -- the usual case for a shared cap.
+                let attempts = low_speed_abandon_counts[index].fetch_add(1, Ordering::SeqCst) + 1;
+                if attempts > SEGMENT_MAX_RETRIES {
+                    let _ = sender.send(SegmentEvent::Failed(PullError::SegmentLowSpeed {
+                        url: url.clone(),
+                        start,
+                        end,
+                        attempts,
+                    }));
+                    return;
+                }
+                // Back of the queue, not the front: give any segments still
+                // untouched a chance first, so a persistently bad source
+                // doesn't get to monopolize every worker retrying the same
+                // handful of unlucky indices in a tight loop.
+                queue.lock().unwrap().push_back(index);
+            }
             Err(error) => {
                 let _ = sender.send(SegmentEvent::Failed(error));
                 return;
@@ -1897,6 +2098,11 @@ fn run_segment_worker(
 
 /// Retry one segment fetch up to `SEGMENT_MAX_RETRIES` times, backing off
 /// between attempts exactly like the single-stream path's outer retry loop.
+/// This loop only ever retries a hard `Err` (I/O, unexpected status, ...) on
+/// the *same* connection -- a low-speed trip is a `SegmentFetchOutcome::
+/// LowSpeed`, not an `Err`, so it passes straight back to the caller
+/// (`run_segment_worker`) untouched, which is what routes it to the
+/// requeue-for-a-new-connection handling instead.
 #[allow(clippy::too_many_arguments)]
 fn fetch_segment_with_retries(
     client: &mut dyn DownloadClient,
@@ -1908,11 +2114,12 @@ fn fetch_segment_with_retries(
     reference_etag: Option<&str>,
     abort: &AtomicBool,
     sender: &mpsc::Sender<SegmentEvent>,
-) -> Result<bool, PullError> {
+    options: &PullOptions,
+) -> Result<SegmentFetchOutcome, PullError> {
     let mut attempt = 0_usize;
     loop {
         if abort.load(Ordering::SeqCst) {
-            return Ok(false);
+            return Ok(SegmentFetchOutcome::AbortedByControl);
         }
         match fetch_segment_once(
             client,
@@ -1924,6 +2131,7 @@ fn fetch_segment_with_retries(
             reference_etag,
             abort,
             sender,
+            options,
         ) {
             Ok(outcome) => return Ok(outcome),
             Err(error) if attempt < SEGMENT_MAX_RETRIES && is_retryable_download_error(&error) => {
@@ -1946,7 +2154,8 @@ fn fetch_segment_once(
     reference_etag: Option<&str>,
     abort: &AtomicBool,
     sender: &mpsc::Sender<SegmentEvent>,
-) -> Result<bool, PullError> {
+    options: &PullOptions,
+) -> Result<SegmentFetchOutcome, PullError> {
     let response = client.open(url, Some(ByteRange::bounded(start, end)))?;
     if response.status != 206 {
         return Err(PullError::UnexpectedStatus {
@@ -1973,7 +2182,8 @@ fn fetch_segment_once(
             url: url.to_string(),
         });
     }
-    let written = write_segment_body(
+    let mut low_speed = SegmentLowSpeedWindow::new(options);
+    let write_outcome = write_segment_body(
         file,
         path,
         start,
@@ -1983,10 +2193,15 @@ fn fetch_segment_once(
             let _ = sender.send(SegmentEvent::Progress(delta));
         },
         &|| abort.load(Ordering::SeqCst),
+        &mut low_speed,
     )?;
-    if abort.load(Ordering::SeqCst) {
-        return Ok(false);
-    }
+    let written = match write_outcome {
+        SegmentWriteOutcome::Completed(written) => written,
+        SegmentWriteOutcome::AbortedByControl => return Ok(SegmentFetchOutcome::AbortedByControl),
+        SegmentWriteOutcome::LowSpeed(partial_written) => {
+            return Ok(SegmentFetchOutcome::LowSpeed(partial_written));
+        }
+    };
     let expected = end - start + 1;
     if written != expected {
         return Err(PullError::SegmentSizeMismatch {
@@ -1997,7 +2212,7 @@ fn fetch_segment_once(
             actual: written,
         });
     }
-    Ok(true)
+    Ok(SegmentFetchOutcome::Done)
 }
 
 fn verify_partial_and_install(
@@ -2488,6 +2703,58 @@ impl LowSpeedWindow {
         self.started_at = Instant::now();
         self.bytes_read = 0;
         Ok(())
+    }
+}
+
+/// Per-segment counterpart to [`LowSpeedWindow`], used by the concurrent
+/// chunked-download path (see `SEGMENT_LOW_SPEED_TIMEOUT` /
+/// `SEGMENT_LOW_SPEED_MIN_BYTES` for why it's a stricter floor). Deliberately
+/// a separate, smaller type rather than a generalization of `LowSpeedWindow`:
+/// the whole-file guard's job is "fail the pull with a typed error", while
+/// this one's job is "tell the caller whether to give up on *this attempt*"
+/// -- the caller (`write_segment_body`) then decides whether that means
+/// requeuing the segment for a fresh connection or, past
+/// `SEGMENT_MAX_RETRIES`, surfacing `PullError::SegmentLowSpeed`. Sharing one
+/// type across both call shapes would need the error-vs-bool branching to
+/// live inside the window itself, which is more indirection than the two
+/// call sites justify.
+struct SegmentLowSpeedWindow {
+    started_at: Instant,
+    bytes_read: u64,
+    timeout: Duration,
+    min_bytes: u64,
+}
+
+impl SegmentLowSpeedWindow {
+    fn new(options: &PullOptions) -> Self {
+        Self {
+            started_at: Instant::now(),
+            bytes_read: 0,
+            timeout: options.segment_low_speed_timeout,
+            min_bytes: options.segment_low_speed_min_bytes,
+        }
+    }
+
+    /// Rolling-window check: returns `true` once a full `timeout` window has
+    /// elapsed without `min_bytes` worth of reads landing in it. Resets the
+    /// window on every window that *does* clear the floor, so a segment that
+    /// starts fast and later degrades is still caught rather than being
+    /// judged once over its whole lifetime. `min_bytes == 0` disables the
+    /// guard entirely (matches `LowSpeedWindow::observe`'s escape hatch).
+    fn observe(&mut self, bytes_read: u64) -> bool {
+        if self.min_bytes == 0 {
+            return false;
+        }
+        self.bytes_read = self.bytes_read.saturating_add(bytes_read);
+        if self.started_at.elapsed() < self.timeout {
+            return false;
+        }
+        if self.bytes_read < self.min_bytes {
+            return true;
+        }
+        self.started_at = Instant::now();
+        self.bytes_read = 0;
+        false
     }
 }
 
@@ -3072,7 +3339,8 @@ fn is_retryable_download_error(error: &PullError) -> bool {
         | PullError::SizeMismatch { .. }
         | PullError::EtagChanged { .. }
         | PullError::SegmentSizeMismatch { .. }
-        | PullError::SegmentRangeMismatch { .. } => true,
+        | PullError::SegmentRangeMismatch { .. }
+        | PullError::SegmentLowSpeed { .. } => true,
         // Only 5xx here: a 4xx from the currently open source is not a
         // transient fault of *this* request, so retrying the same source
         // again would just repeat it (see `is_source_fallback_error`, which
@@ -3094,7 +3362,8 @@ fn is_source_fallback_error(error: &PullError) -> bool {
         | PullError::RuntimeValidation { .. }
         | PullError::EtagChanged { .. }
         | PullError::SegmentSizeMismatch { .. }
-        | PullError::SegmentRangeMismatch { .. } => true,
+        | PullError::SegmentRangeMismatch { .. }
+        | PullError::SegmentLowSpeed { .. } => true,
         // 5xx: this source's own infra failed -- try the next one. 403/404:
         // this source does not have (or will not serve) the requested object,
         // which is a per-source availability gap, not a global failure -- e.g.

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -2772,9 +2772,11 @@ impl LowSpeedWindow {
 }
 
 /// Per-segment counterpart to [`LowSpeedWindow`], used by the concurrent
-/// chunked-download path (see `SEGMENT_LOW_SPEED_TIMEOUT` /
-/// `SEGMENT_LOW_SPEED_MIN_BYTES` for why it's a stricter floor). Deliberately
-/// a separate, smaller type rather than a generalization of `LowSpeedWindow`:
+/// chunked-download path (see `SEGMENT_LOW_SPEED_TIMEOUT`,
+/// `SEGMENT_LOW_SPEED_RELATIVE_RATIO`, and
+/// `SEGMENT_LOW_SPEED_ABSOLUTE_FLOOR_BYTES` for the relative-judgment
+/// rationale). Deliberately a separate, smaller type rather than a
+/// generalization of `LowSpeedWindow`:
 /// the whole-file guard's job is "fail the pull with a typed error", while
 /// this one's job is "tell the caller whether to give up on *this attempt*"
 /// -- the caller (`write_segment_body`) then decides whether that means

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -64,26 +64,57 @@ const PULL_CONNECTIONS_ENV_VAR: &str = "OPENASR_PULL_CONNECTIONS";
 /// persistently broken likely reflects a source-wide problem the outer loop
 /// is already positioned to retry or fall back away from.
 const SEGMENT_MAX_RETRIES: usize = 3;
-/// Per-segment low-speed floor for the concurrent chunked-download path.
-/// Deliberately shorter and stricter than the whole-file
-/// `DOWNLOAD_LOW_SPEED_*` pair used by the single-stream path: that guard is
-/// tuned to catch only a connection that is *effectively dead* (its 60s / 64
-/// KiB pair is a floor of roughly 1 KB/s), because abandoning it discards the
-/// whole download so far. A segment fetch has no such cost -- the other
-/// segments already on disk or in flight are untouched -- so it can afford to
-/// give up on a merely *slow* connection and try a fresh one instead of
-/// riding it out. 15s / 3 MiB is a ~205 KB/s floor, chosen to actually catch
-/// the reported real-world failure mode: a lone tail segment stuck on one
-/// degraded connection at ~90 KB/s, which would otherwise take the full 64
-/// MiB segment (~12 minutes) to finish with nothing else to fall back on.
-/// Reconnecting is cheap here (see `fetch_segment_with_retries` and the
-/// requeue-to-tail handling in `run_segment_worker`), and CDNs commonly
-/// resolve a degraded edge by simply routing a new connection differently,
-/// so this floor favors giving a fresh connection a chance over waiting out
-/// a bad one. Exposed via `PullOptions` (like the whole-file pair) so tests
-/// can force a deterministic trip.
+/// Window length for the per-segment low-speed guard's rolling check (see
+/// `SegmentLowSpeedWindow`). Shorter than the whole-file single-stream guard
+/// (60s): abandoning a segment only discards that segment's in-flight bytes,
+/// not the whole download, so it can afford to reevaluate more often.
 const SEGMENT_LOW_SPEED_TIMEOUT: Duration = Duration::from_secs(15);
-const SEGMENT_LOW_SPEED_MIN_BYTES: u64 = 3 * 1024 * 1024;
+/// Outlier threshold for the per-segment low-speed guard: a segment is only
+/// a candidate for abandonment once a window reads under this fraction of
+/// the download session's own current reference throughput (see
+/// `SegmentThroughputReference`). This is a *relative* judgment, not a fixed
+/// floor -- a session where every connection tops out around, say, 200 KB/s
+/// (a real, working, if modest network) must never trip this guard just
+/// because 200 KB/s is a small number in absolute terms: no segment in that
+/// session is an outlier relative to the others, so the ratio test alone
+/// already never fires. Picked from a defensible "meaningfully behind its
+/// siblings" range (roughly a seventh to a tenth of the reference) and
+/// biased toward the lenient end to keep false positives rare.
+const SEGMENT_LOW_SPEED_RELATIVE_RATIO: f64 = 0.15;
+/// Second half of the low-speed AND, in absolute terms: bytes expected
+/// within one `SEGMENT_LOW_SPEED_TIMEOUT` window, roughly a 273 KB/s floor.
+/// Without this, the relative test alone could abandon a segment that's
+/// merely somewhat slower than an *unusually fast* reference (say 300-400
+/// KB/s in a session whose other segments hit several MB/s) even though
+/// that speed is still a perfectly normal, working connection -- just not
+/// this session's best. Requiring both conditions means only a segment that
+/// is genuinely slow in real terms *and* a clear outlier among its own
+/// siblings gets abandoned; this is what actually catches the reported
+/// failure mode (a lone tail segment at ~90 KB/s while the rest of the
+/// download ran at several MB/s) without ever penalizing a uniformly slow
+/// session.
+const SEGMENT_LOW_SPEED_ABSOLUTE_FLOOR_BYTES: u64 = 4 * 1024 * 1024;
+/// Cooldown after a segment is abandoned for low speed, before it's eligible
+/// to be judged low-speed again: twice the window length, so a freshly
+/// reconnected attempt gets at least two full observation windows before
+/// being re-evaluated. Without this, a segment sitting right at the ratio
+/// boundary could thrash -- reconnect, immediately look slow again next
+/// window, reconnect again -- burning through `SEGMENT_MAX_RETRIES` on
+/// connection churn instead of giving each fresh connection a fair chance.
+const SEGMENT_LOW_SPEED_COOLDOWN: Duration = Duration::from_secs(30);
+/// Minimum recorded windows before the session reference is trusted enough
+/// to judge outliers against. Below this, a single (possibly unlucky) early
+/// sample would effectively become "the reference", which can never
+/// correctly identify an outlier -- it would just compare a segment against
+/// itself. `SegmentThroughputReference::median` returns `None` (never judge
+/// low-speed yet) until this many samples exist, which is also what keeps a
+/// download's very first segments from ever being penalized cold.
+const SEGMENT_LOW_SPEED_MIN_REFERENCE_SAMPLES: usize = 3;
+/// Bounds how many recent per-window byte counts the session reference
+/// keeps: large enough for a stable median, small enough that the reference
+/// tracks *current* conditions on a long, many-segment download rather than
+/// staying anchored to however the first few segments happened to perform.
+const SEGMENT_LOW_SPEED_REFERENCE_CAPACITY: usize = 64;
 /// Discriminator stamped into the segmented-download partial-meta file so a
 /// resume never misreads a legacy (pre-chunking) `PartialMeta` -- or a future
 /// incompatible format -- as a valid segment bitmap. Bumping the segment size
@@ -248,15 +279,6 @@ pub enum PullError {
         "Concurrent chunk fetch for '{url}' returned a Content-Range starting at a different offset than requested"
     )]
     SegmentRangeMismatch { url: String },
-    #[error(
-        "Concurrent chunk fetch for '{url}' segment [{start}-{end}] stayed below the per-segment low-speed floor across {attempts} connection attempts; giving up on this segment"
-    )]
-    SegmentLowSpeed {
-        url: String,
-        start: u64,
-        end: u64,
-        attempts: usize,
-    },
     #[error("Downloaded pack failed Rust-only GGUF preflight for '{path}': {reason}")]
     GgufPreflight { path: PathBuf, reason: String },
     #[error("Downloaded backend file failed binary preflight for '{path}': {reason}")]
@@ -322,13 +344,16 @@ struct PullOptions {
     available_space_override: Option<u64>,
     low_speed_timeout: Duration,
     low_speed_min_bytes: u64,
-    /// Per-segment low-speed floor for the concurrent chunked-download path;
-    /// see `SEGMENT_LOW_SPEED_TIMEOUT`/`SEGMENT_LOW_SPEED_MIN_BYTES` for the
-    /// production defaults and the rationale for why they're stricter than
-    /// the whole-file pair above. Overridable (like that pair) so tests can
+    /// Relative per-segment low-speed guard for the concurrent
+    /// chunked-download path; see `SEGMENT_LOW_SPEED_TIMEOUT` and friends for
+    /// the production defaults and the rationale for judging a segment
+    /// against this download session's own throughput rather than a fixed
+    /// floor. All overridable (like the whole-file pair above) so tests can
     /// force a deterministic trip without waiting out a real window.
     segment_low_speed_timeout: Duration,
-    segment_low_speed_min_bytes: u64,
+    segment_low_speed_relative_ratio: f64,
+    segment_low_speed_absolute_floor_bytes: u64,
+    segment_low_speed_cooldown: Duration,
     /// Test-only override for `DOWNLOAD_SEGMENT_BYTES`, so unit tests can
     /// exercise multi-segment concurrent download logic (splitting, resume
     /// bitmap, ETag invalidation, ...) against small in-memory fixtures
@@ -344,7 +369,9 @@ impl PullOptions {
             low_speed_timeout: DOWNLOAD_LOW_SPEED_TIMEOUT,
             low_speed_min_bytes: DOWNLOAD_LOW_SPEED_MIN_BYTES,
             segment_low_speed_timeout: SEGMENT_LOW_SPEED_TIMEOUT,
-            segment_low_speed_min_bytes: SEGMENT_LOW_SPEED_MIN_BYTES,
+            segment_low_speed_relative_ratio: SEGMENT_LOW_SPEED_RELATIVE_RATIO,
+            segment_low_speed_absolute_floor_bytes: SEGMENT_LOW_SPEED_ABSOLUTE_FLOOR_BYTES,
+            segment_low_speed_cooldown: SEGMENT_LOW_SPEED_COOLDOWN,
             parallel_segment_bytes_override: None,
         }
     }
@@ -1524,6 +1551,19 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
         options.clone(),
     )?;
 
+    // Shared low-speed guard state for this attempt, used by both the probe
+    // (below) and every worker spawned later: one session-wide throughput
+    // reference (see `SegmentThroughputReference`), one low-speed abandon
+    // counter per segment index (a segment can be requeued and picked up by
+    // a *different* worker than the one that abandoned it, so this can't
+    // live in any single worker's local state), and one cooldown timestamp
+    // per segment index (see `SEGMENT_LOW_SPEED_COOLDOWN`).
+    let throughput_reference = Arc::new(SegmentThroughputReference::new());
+    let low_speed_abandon_counts: Arc<Vec<AtomicUsize>> =
+        Arc::new((0..total_segments).map(|_| AtomicUsize::new(0)).collect());
+    let low_speed_cooldowns: Arc<Vec<Mutex<Option<Instant>>>> =
+        Arc::new((0..total_segments).map(|_| Mutex::new(None)).collect());
+
     // Probe the first still-missing segment with a real, bounded Range
     // request before committing to concurrency. A single request both (a)
     // confirms the source honors Range (206) rather than ignoring it (200 --
@@ -1610,11 +1650,21 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
         // shared queue to requeue into here (there's exactly one prober), so
         // a low-speed trip just re-opens a fresh request for the same range
         // and retries in place, bounded by the same `SEGMENT_MAX_RETRIES` cap
-        // every other segment failure mode uses.
+        // every other segment failure mode uses -- past that cap, evaluation
+        // is disabled and the probe simply finishes on its current
+        // connection (see `SegmentLowSpeedWindow::disabled`), never a hard
+        // failure.
         let mut probe_reader = probe_response.reader;
-        let mut probe_attempts = 1_usize;
+        let mut probe_abandon_count = 0_usize;
+        let probe_cooldown = &low_speed_cooldowns[probe_index];
         let written = loop {
-            let mut low_speed = SegmentLowSpeedWindow::new(options);
+            let disabled = probe_abandon_count >= SEGMENT_MAX_RETRIES;
+            let mut low_speed = SegmentLowSpeedWindow::new(
+                options,
+                &throughput_reference,
+                probe_cooldown,
+                disabled,
+            );
             let outcome = write_segment_body(
                 &mut file,
                 &paths.partial_path,
@@ -1658,14 +1708,14 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
                         bytes_done,
                         bytes_total: target.size_bytes,
                     });
-                    if probe_attempts > SEGMENT_MAX_RETRIES {
-                        cleanup_partial(paths);
-                        return Err(PullError::SegmentLowSpeed {
-                            url: target.url.clone(),
-                            start: probe_start,
-                            end: probe_end,
-                            attempts: probe_attempts,
-                        });
+                    probe_abandon_count += 1;
+                    if probe_abandon_count == SEGMENT_MAX_RETRIES {
+                        eprintln!(
+                            "openasr: warning: probe segment [{probe_start}-{probe_end}] for \
+                             '{}' stayed a relative low-speed outlier after {probe_abandon_count} \
+                             reconnect attempts; accepting it on its current connection",
+                            target.url
+                        );
                     }
                     let retry_response = probe_client.open(
                         &target.url,
@@ -1678,7 +1728,6 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
                         });
                     }
                     probe_reader = retry_response.reader;
-                    probe_attempts += 1;
                 }
             }
         };
@@ -1721,14 +1770,6 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
     let remaining_count = remaining.len();
     let queue = Arc::new(Mutex::new(remaining));
     let abort = Arc::new(AtomicBool::new(false));
-    // One low-speed abandon counter per segment index, shared across every
-    // worker: a segment can be requeued and picked up by a *different*
-    // worker than the one that abandoned it, so the retry cap has to live
-    // outside any single worker's local state (unlike the generic
-    // `SEGMENT_MAX_RETRIES` loop in `fetch_segment_with_retries`, which stays
-    // on one worker/connection because it isn't requeuing).
-    let low_speed_abandon_counts: Arc<Vec<AtomicUsize>> =
-        Arc::new((0..total_segments).map(|_| AtomicUsize::new(0)).collect());
     let (sender, receiver) = mpsc::channel::<SegmentEvent>();
     // No lock needed yet: no worker thread exists before the spawn loop
     // below, so `remaining_count` (captured before `remaining` moved into
@@ -1746,6 +1787,8 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
         let worker_reference_etag = reference_etag.clone();
         let worker_options = options.clone();
         let worker_low_speed_abandon_counts = low_speed_abandon_counts.clone();
+        let worker_throughput_reference = throughput_reference.clone();
+        let worker_low_speed_cooldowns = low_speed_cooldowns.clone();
         handles.push(std::thread::spawn(move || {
             run_segment_worker(
                 worker_client,
@@ -1759,6 +1802,8 @@ fn download_parallel_attempt<C: DownloadClient + ?Sized>(
                 worker_reference_etag,
                 worker_options,
                 worker_low_speed_abandon_counts,
+                worker_throughput_reference,
+                worker_low_speed_cooldowns,
             );
         }));
     }
@@ -2004,10 +2049,11 @@ enum SegmentFetchOutcome {
 /// next `client.open()` call for it (by this worker or another, once its
 /// current segment finishes) starts a genuinely fresh connection rather than
 /// riding out the same degraded one. `low_speed_abandon_counts` bounds how
-/// many times any single segment index can be abandoned this way before it
-/// falls through to the same fail-closed path every other segment failure
-/// mode uses (`PullError::SegmentLowSpeed`, retried at the whole-attempt
-/// level by `download_with_retries` like any other retryable pull error).
+/// many times any single segment index can be abandoned this way; past
+/// `SEGMENT_MAX_RETRIES`, the *next* attempt on that index is constructed
+/// with its low-speed guard disabled (see `SegmentLowSpeedWindow::disabled`),
+/// so it can no longer trip -- the worst case degrades to "just let it
+/// finish on whatever connection it's on", never a hard failure.
 #[allow(clippy::too_many_arguments)]
 fn run_segment_worker(
     mut client: BoxedDownloadClient,
@@ -2021,6 +2067,8 @@ fn run_segment_worker(
     reference_etag: Option<String>,
     options: PullOptions,
     low_speed_abandon_counts: Arc<Vec<AtomicUsize>>,
+    throughput_reference: Arc<SegmentThroughputReference>,
+    low_speed_cooldowns: Arc<Vec<Mutex<Option<Instant>>>>,
 ) {
     let mut file = match OpenOptions::new().write(true).open(&path) {
         Ok(file) => file,
@@ -2044,6 +2092,11 @@ fn run_segment_worker(
             }
         };
         let (start, end) = segment_range(index, size_bytes, segment_bytes);
+        // SeqCst: read-then-later-write of this same counter happens across
+        // worker threads, so ordering must be total, not just
+        // per-worker-relative.
+        let disabled =
+            low_speed_abandon_counts[index].load(Ordering::SeqCst) >= SEGMENT_MAX_RETRIES;
         match fetch_segment_with_retries(
             client.as_mut(),
             &mut file,
@@ -2055,6 +2108,9 @@ fn run_segment_worker(
             &abort,
             &sender,
             &options,
+            &throughput_reference,
+            &low_speed_cooldowns[index],
+            disabled,
         ) {
             Ok(SegmentFetchOutcome::Done) => {
                 if sender.send(SegmentEvent::Done(index)).is_err() {
@@ -2069,18 +2125,13 @@ fn run_segment_worker(
                 {
                     return;
                 }
-                // SeqCst: every worker reads-then-writes this same counter,
-                // so ordering must be total across threads, not just
-                // per-worker-relative -- the usual case for a shared cap.
                 let attempts = low_speed_abandon_counts[index].fetch_add(1, Ordering::SeqCst) + 1;
-                if attempts > SEGMENT_MAX_RETRIES {
-                    let _ = sender.send(SegmentEvent::Failed(PullError::SegmentLowSpeed {
-                        url: url.clone(),
-                        start,
-                        end,
-                        attempts,
-                    }));
-                    return;
+                if attempts == SEGMENT_MAX_RETRIES {
+                    eprintln!(
+                        "openasr: warning: segment [{start}-{end}] for '{url}' stayed a \
+                         relative low-speed outlier after {attempts} reconnect attempts; \
+                         accepting it on its current connection"
+                    );
                 }
                 // Back of the queue, not the front: give any segments still
                 // untouched a chance first, so a persistently bad source
@@ -2115,6 +2166,9 @@ fn fetch_segment_with_retries(
     abort: &AtomicBool,
     sender: &mpsc::Sender<SegmentEvent>,
     options: &PullOptions,
+    throughput_reference: &SegmentThroughputReference,
+    cooldown_slot: &Mutex<Option<Instant>>,
+    low_speed_disabled: bool,
 ) -> Result<SegmentFetchOutcome, PullError> {
     let mut attempt = 0_usize;
     loop {
@@ -2132,6 +2186,9 @@ fn fetch_segment_with_retries(
             abort,
             sender,
             options,
+            throughput_reference,
+            cooldown_slot,
+            low_speed_disabled,
         ) {
             Ok(outcome) => return Ok(outcome),
             Err(error) if attempt < SEGMENT_MAX_RETRIES && is_retryable_download_error(&error) => {
@@ -2155,6 +2212,9 @@ fn fetch_segment_once(
     abort: &AtomicBool,
     sender: &mpsc::Sender<SegmentEvent>,
     options: &PullOptions,
+    throughput_reference: &SegmentThroughputReference,
+    cooldown_slot: &Mutex<Option<Instant>>,
+    low_speed_disabled: bool,
 ) -> Result<SegmentFetchOutcome, PullError> {
     let response = client.open(url, Some(ByteRange::bounded(start, end)))?;
     if response.status != 206 {
@@ -2182,7 +2242,12 @@ fn fetch_segment_once(
             url: url.to_string(),
         });
     }
-    let mut low_speed = SegmentLowSpeedWindow::new(options);
+    let mut low_speed = SegmentLowSpeedWindow::new(
+        options,
+        throughput_reference,
+        cooldown_slot,
+        low_speed_disabled,
+    );
     let write_outcome = write_segment_body(
         file,
         path,
@@ -2713,48 +2778,148 @@ impl LowSpeedWindow {
 /// the whole-file guard's job is "fail the pull with a typed error", while
 /// this one's job is "tell the caller whether to give up on *this attempt*"
 /// -- the caller (`write_segment_body`) then decides whether that means
-/// requeuing the segment for a fresh connection or, past
-/// `SEGMENT_MAX_RETRIES`, surfacing `PullError::SegmentLowSpeed`. Sharing one
-/// type across both call shapes would need the error-vs-bool branching to
-/// live inside the window itself, which is more indirection than the two
-/// call sites justify.
-struct SegmentLowSpeedWindow {
+/// requeuing the segment for a fresh connection. Unlike the whole-file guard,
+/// abandoning a segment is never a hard failure: past `SEGMENT_MAX_RETRIES`,
+/// further evaluation is simply disabled for that segment's final attempt
+/// (see `disabled`), so the worst case is identical to not having this guard
+/// at all -- the segment just finishes on whatever connection it's on.
+///
+/// Session-wide shared state, cloned/threaded into every worker and the
+/// probe:
+/// - [`SegmentThroughputReference`] -- the rolling median every segment is
+///   judged against (see its doc comment for why this is relative, not an
+///   absolute floor).
+/// - `cooldown_slot` -- this specific segment index's last-trip timestamp,
+///   damping requeue churn for a segment sitting right at the outlier
+///   boundary (see `SEGMENT_LOW_SPEED_COOLDOWN`).
+struct SegmentLowSpeedWindow<'a> {
     started_at: Instant,
     bytes_read: u64,
     timeout: Duration,
-    min_bytes: u64,
+    reference: &'a SegmentThroughputReference,
+    cooldown_slot: &'a Mutex<Option<Instant>>,
+    relative_ratio: f64,
+    absolute_floor_bytes: u64,
+    cooldown: Duration,
+    /// Set once this segment index has already been abandoned
+    /// `SEGMENT_MAX_RETRIES` times: this attempt is its last chance, so
+    /// evaluation is skipped entirely and it's simply allowed to finish
+    /// (see `download_parallel_attempt`'s degrade-and-log handling).
+    disabled: bool,
 }
 
-impl SegmentLowSpeedWindow {
-    fn new(options: &PullOptions) -> Self {
+impl<'a> SegmentLowSpeedWindow<'a> {
+    fn new(
+        options: &PullOptions,
+        reference: &'a SegmentThroughputReference,
+        cooldown_slot: &'a Mutex<Option<Instant>>,
+        disabled: bool,
+    ) -> Self {
         Self {
             started_at: Instant::now(),
             bytes_read: 0,
             timeout: options.segment_low_speed_timeout,
-            min_bytes: options.segment_low_speed_min_bytes,
+            reference,
+            cooldown_slot,
+            relative_ratio: options.segment_low_speed_relative_ratio,
+            absolute_floor_bytes: options.segment_low_speed_absolute_floor_bytes,
+            cooldown: options.segment_low_speed_cooldown,
+            disabled,
         }
     }
 
-    /// Rolling-window check: returns `true` once a full `timeout` window has
-    /// elapsed without `min_bytes` worth of reads landing in it. Resets the
-    /// window on every window that *does* clear the floor, so a segment that
-    /// starts fast and later degrades is still caught rather than being
-    /// judged once over its whole lifetime. `min_bytes == 0` disables the
-    /// guard entirely (matches `LowSpeedWindow::observe`'s escape hatch).
+    /// Rolling-window check: once a full `timeout` window elapses, records
+    /// its byte count into the shared reference and decides whether this
+    /// window was a low-speed outlier (see `SegmentThroughputReference` and
+    /// the module-level constants for the two-part AND condition). Resets on
+    /// every window regardless of the outcome, so a segment that starts fast
+    /// and later degrades is still caught (or one that recovers stops being
+    /// flagged). `disabled` skips everything -- this segment already used up
+    /// its reconnect budget, so its last attempt is allowed to run to
+    /// completion unconditionally.
+    ///
+    /// Note this compares raw per-window *byte counts*, never a computed
+    /// bytes/sec rate: every window shares the same configured `timeout`, so
+    /// byte counts are already directly comparable as a throughput proxy,
+    /// without ever dividing by a measured elapsed time (which would be
+    /// unstable for very short or test-forced windows).
     fn observe(&mut self, bytes_read: u64) -> bool {
-        if self.min_bytes == 0 {
+        if self.disabled {
             return false;
         }
         self.bytes_read = self.bytes_read.saturating_add(bytes_read);
         if self.started_at.elapsed() < self.timeout {
             return false;
         }
-        if self.bytes_read < self.min_bytes {
-            return true;
-        }
+        let window_bytes = self.bytes_read;
         self.started_at = Instant::now();
         self.bytes_read = 0;
-        false
+        // Compare against the reference as it stood *before* this window is
+        // folded in, so a slow window never gets to (even slightly) pull
+        // down the baseline it is itself being judged against.
+        let median = self.reference.median();
+        self.reference.record(window_bytes);
+        let Some(median) = median else {
+            return false; // cold start: no reference yet, never judge
+        };
+        let relative_floor = (median as f64 * self.relative_ratio) as u64;
+        let is_outlier = window_bytes < relative_floor && window_bytes < self.absolute_floor_bytes;
+        if !is_outlier {
+            return false;
+        }
+        let mut cooldown_slot = self.cooldown_slot.lock().unwrap();
+        let now = Instant::now();
+        if let Some(last_trip) = *cooldown_slot
+            && now.duration_since(last_trip) < self.cooldown
+        {
+            return false; // still cooling down from the last trip
+        }
+        *cooldown_slot = Some(now);
+        true
+    }
+}
+
+/// Session-wide reference for the concurrent chunked-download path's
+/// relative low-speed guard: a bounded rolling window of per-segment-window
+/// byte counts (see [`SegmentLowSpeedWindow`]), shared across every worker
+/// and the probe so a segment is judged against what *this* download
+/// session is actually achieving right now -- never a fixed absolute number,
+/// which would misjudge a uniformly slow-but-working network as broken (see
+/// `SEGMENT_LOW_SPEED_RELATIVE_RATIO`'s doc comment for the full rationale).
+struct SegmentThroughputReference {
+    samples: Mutex<VecDeque<u64>>,
+}
+
+impl SegmentThroughputReference {
+    fn new() -> Self {
+        Self {
+            samples: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// The median of every recorded window's byte count. Requires at least
+    /// `SEGMENT_LOW_SPEED_MIN_REFERENCE_SAMPLES` samples; `None` (fewer than
+    /// that) means "cold start: never judge a segment low-speed yet" -- see
+    /// that constant's doc comment for why.
+    fn median(&self) -> Option<u64> {
+        let samples = self.samples.lock().unwrap();
+        if samples.len() < SEGMENT_LOW_SPEED_MIN_REFERENCE_SAMPLES {
+            return None;
+        }
+        let mut sorted: Vec<u64> = samples.iter().copied().collect();
+        sorted.sort_unstable();
+        Some(sorted[sorted.len() / 2])
+    }
+
+    /// Records one window's byte count, bounding the reference to the most
+    /// recent `SEGMENT_LOW_SPEED_REFERENCE_CAPACITY` samples (see that
+    /// constant's doc comment).
+    fn record(&self, bytes_in_window: u64) {
+        let mut samples = self.samples.lock().unwrap();
+        samples.push_back(bytes_in_window);
+        while samples.len() > SEGMENT_LOW_SPEED_REFERENCE_CAPACITY {
+            samples.pop_front();
+        }
     }
 }
 
@@ -3339,8 +3504,7 @@ fn is_retryable_download_error(error: &PullError) -> bool {
         | PullError::SizeMismatch { .. }
         | PullError::EtagChanged { .. }
         | PullError::SegmentSizeMismatch { .. }
-        | PullError::SegmentRangeMismatch { .. }
-        | PullError::SegmentLowSpeed { .. } => true,
+        | PullError::SegmentRangeMismatch { .. } => true,
         // Only 5xx here: a 4xx from the currently open source is not a
         // transient fault of *this* request, so retrying the same source
         // again would just repeat it (see `is_source_fallback_error`, which
@@ -3362,8 +3526,7 @@ fn is_source_fallback_error(error: &PullError) -> bool {
         | PullError::RuntimeValidation { .. }
         | PullError::EtagChanged { .. }
         | PullError::SegmentSizeMismatch { .. }
-        | PullError::SegmentRangeMismatch { .. }
-        | PullError::SegmentLowSpeed { .. } => true,
+        | PullError::SegmentRangeMismatch { .. } => true,
         // 5xx: this source's own infra failed -- try the next one. 403/404:
         // this source does not have (or will not serve) the requested object,
         // which is a per-source availability gap, not a global failure -- e.g.

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::Cell,
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     fs,
     io::{self, Cursor, Read, Write},
     net::TcpListener,
@@ -1546,6 +1546,57 @@ fn pull_retries_low_speed_body_and_restarts_safely() {
 
     assert_eq!(installed.pull, "moonshine-tiny:q8");
     assert_eq!(client.ranges(), vec![None, None]);
+}
+
+#[test]
+fn segment_low_speed_window_trips_when_a_window_clears_without_the_byte_floor() {
+    // `Duration::ZERO` makes every `observe` call judge its window
+    // immediately (matches the same zero-timeout trick the whole-file
+    // `pull_retries_low_speed_body_and_restarts_safely` test above uses),
+    // so this is deterministic without any real sleep.
+    let options = PullOptions {
+        segment_low_speed_timeout: Duration::ZERO,
+        segment_low_speed_min_bytes: 10,
+        ..PullOptions::default()
+    };
+    let mut window = SegmentLowSpeedWindow::new(&options);
+    assert!(
+        window.observe(1),
+        "1 byte is below the 10-byte floor and the window already elapsed"
+    );
+}
+
+#[test]
+fn segment_low_speed_window_disabled_when_min_bytes_is_zero() {
+    let options = PullOptions {
+        segment_low_speed_timeout: Duration::ZERO,
+        segment_low_speed_min_bytes: 0,
+        ..PullOptions::default()
+    };
+    let mut window = SegmentLowSpeedWindow::new(&options);
+    assert!(!window.observe(0));
+    assert!(!window.observe(1));
+}
+
+#[test]
+fn segment_low_speed_window_resets_after_a_window_clears_the_floor() {
+    // A segment that starts out fast and later degrades must still be
+    // caught: clearing the floor once must reset the window rather than
+    // permanently disabling the guard for the rest of the segment.
+    let options = PullOptions {
+        segment_low_speed_timeout: Duration::ZERO,
+        segment_low_speed_min_bytes: 5,
+        ..PullOptions::default()
+    };
+    let mut window = SegmentLowSpeedWindow::new(&options);
+    assert!(
+        !window.observe(5),
+        "5 bytes clears the 5-byte floor; must reset, not trip"
+    );
+    assert!(
+        window.observe(1),
+        "the next window starts fresh at 0 bytes, so 1 byte must trip again"
+    );
 }
 
 #[test]
@@ -3246,6 +3297,330 @@ fn parallel_download_sha_mismatch_deletes_partial() {
     assert!(!paths.partial_path.exists());
     assert!(!paths.partial_segments_meta_path.exists());
     assert!(!paths.final_path.exists());
+}
+
+/// Yields exactly one byte per `read()` call, regardless of the caller's
+/// buffer size -- used to guarantee the very first chunk `write_segment_body`
+/// observes is smaller than any realistic low-speed floor, without depending
+/// on real wall-clock timing (paired with `segment_low_speed_timeout:
+/// Duration::ZERO` in the tests below, which makes `SegmentLowSpeedWindow`
+/// judge the very first observed chunk instead of waiting out a real window).
+struct OneByteAtATimeReader {
+    remaining: VecDeque<u8>,
+}
+
+impl OneByteAtATimeReader {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            remaining: bytes.into(),
+        }
+    }
+}
+
+impl Read for OneByteAtATimeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self.remaining.pop_front() {
+            Some(byte) => {
+                buf[0] = byte;
+                Ok(1)
+            }
+            None => Ok(0),
+        }
+    }
+}
+
+/// A `RangeServerClient`-alike whose responses for one specific segment
+/// (`flaky_start`) trickle one byte at a time -- tripping a zero-timeout
+/// `SegmentLowSpeedWindow` on the very first chunk -- while every other
+/// segment (and, if `always_flaky` is `false`, every attempt after the
+/// first on the flaky segment too) is served normally in one read. Models
+/// "one connection to this source is bad; a fresh one for the same range is
+/// fine" without needing a real slow socket.
+#[derive(Clone)]
+struct FlakySegmentRangeClient {
+    bytes: Arc<Vec<u8>>,
+    attempts_by_start: Arc<Mutex<HashMap<u64, usize>>>,
+    flaky_start: u64,
+    always_flaky: bool,
+}
+
+impl FlakySegmentRangeClient {
+    fn new(bytes: Vec<u8>, flaky_start: u64, always_flaky: bool) -> Self {
+        Self {
+            bytes: Arc::new(bytes),
+            attempts_by_start: Arc::new(Mutex::new(HashMap::new())),
+            flaky_start,
+            always_flaky,
+        }
+    }
+
+    fn attempts_on_flaky_segment(&self) -> usize {
+        self.attempts_by_start
+            .lock()
+            .unwrap()
+            .get(&self.flaky_start)
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
+impl DownloadClient for FlakySegmentRangeClient {
+    fn open(
+        &mut self,
+        _url: &str,
+        range: Option<ByteRange>,
+    ) -> Result<DownloadResponse, PullError> {
+        let range = range.expect("the segmented download path always sends a bounded Range");
+        let start = range.start;
+        let end = range.end.expect("segment fetches always bound the end");
+        let total = self.bytes.len() as u64;
+        let slice = self.bytes[start as usize..=end as usize].to_vec();
+        let attempt = {
+            let mut attempts = self.attempts_by_start.lock().unwrap();
+            let counter = attempts.entry(start).or_insert(0);
+            *counter += 1;
+            *counter
+        };
+        let is_flaky_now = start == self.flaky_start && (self.always_flaky || attempt == 1);
+        let reader: Box<dyn Read> = if is_flaky_now {
+            Box::new(OneByteAtATimeReader::new(slice))
+        } else {
+            Box::new(Cursor::new(slice))
+        };
+        Ok(DownloadResponse {
+            status: 206,
+            content_length: Some(end - start + 1),
+            content_range: Some(format!("bytes {start}-{end}/{total}")),
+            etag: Some("etag-a".to_string()),
+            reader,
+        })
+    }
+}
+
+/// Builds the `PullTarget`/`PullPaths` pair `download_parallel_attempt` needs,
+/// without going through the outer `download_with_retries` retry loop (whose
+/// real `std::thread::sleep` backoff would make a deliberately-exhausted
+/// low-speed test slow for no reason -- these tests call the segmented
+/// attempt directly so the requeue/cap logic under test is exercised without
+/// any unrelated timing).
+fn parallel_attempt_paths(home: &Path, resolved: &ResolvedCatalogPull) -> (PullTarget, PullPaths) {
+    let target = PullTarget::from_resolved(resolved).unwrap();
+    let paths = pull_paths(home, &target).unwrap();
+    ensure_storage_dir_within_root(home, &paths).unwrap();
+    (target, paths)
+}
+
+#[test]
+fn parallel_download_low_speed_segment_requeues_onto_fresh_connection_and_recovers() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let total_segments = segment_count(bytes.len() as u64, segment_bytes);
+    assert!(
+        total_segments >= 3,
+        "fixture too small to give the flaky segment (index 1, not the probe) \
+         siblings to run alongside"
+    );
+    // Index 1, not 0: segment 0 is always the synchronous probe segment, and
+    // this test targets the worker-queue requeue path in `run_segment_worker`
+    // specifically (the probe has its own low-speed retry loop, covered by
+    // the probe-path test below).
+    let (flaky_start, _) = segment_range(1, bytes.len() as u64, segment_bytes);
+
+    let mut probe_client = FlakySegmentRangeClient::new(bytes.clone(), flaky_start, false);
+    let factory_client = probe_client.clone();
+    let factory: Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>> =
+        Box::new(move || Ok(Box::new(factory_client.clone()) as BoxedDownloadClient));
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    let options = PullOptions {
+        segment_low_speed_timeout: Duration::ZERO,
+        segment_low_speed_min_bytes: 2,
+        ..parallel_test_options(segment_bytes)
+    };
+
+    let progress_events = Arc::new(Mutex::new(Vec::<(u64, u64)>::new()));
+    let progress_sink = progress_events.clone();
+    let (target, paths) = parallel_attempt_paths(temp.path(), &resolved);
+
+    let outcome = download_parallel_attempt(
+        &target,
+        &paths,
+        &mut probe_client,
+        &parallel,
+        segment_bytes,
+        &options,
+        &mut |event| {
+            if let PullProgress::Downloading {
+                bytes_done,
+                bytes_total,
+            } = event
+            {
+                progress_sink
+                    .lock()
+                    .unwrap()
+                    .push((bytes_done, bytes_total));
+            }
+        },
+        &|| false,
+        &|| false,
+    )
+    .unwrap();
+
+    let downloaded = match outcome {
+        ParallelAttemptOutcome::Completed(downloaded) => downloaded,
+        ParallelAttemptOutcome::RangeNotSupported => {
+            panic!("this mock always honors Range with 206")
+        }
+    };
+    assert_eq!(downloaded.bytes_done, bytes.len() as u64);
+    assert_eq!(downloaded.sha256, sha256_hex(&bytes));
+    assert_eq!(fs::read(&paths.partial_path).unwrap(), bytes);
+
+    // Exactly one abandoned attempt, then one successful retry -- proof the
+    // segment was requeued and refetched (on what this mock models as a
+    // fresh connection) rather than either silently corrupting the file or
+    // hanging on the first bad connection.
+    assert_eq!(probe_client.attempts_on_flaky_segment(), 2);
+
+    // The low-speed rollback must keep `bytes_done` from ever being reported
+    // past the true total: without it, the abandoned attempt's partial bytes
+    // would still be counted once the retry re-downloads the same range from
+    // scratch, double-counting them.
+    for (bytes_done, bytes_total) in progress_events.lock().unwrap().iter().copied() {
+        assert!(
+            bytes_done <= bytes_total,
+            "progress double-counted: reported {bytes_done} of {bytes_total} total bytes"
+        );
+    }
+}
+
+#[test]
+fn parallel_download_probe_segment_low_speed_retries_in_place_and_recovers() {
+    // Same recovery contract as the worker-side test above, but for the
+    // probe segment (always index 0), which runs synchronously before any
+    // worker thread exists and so has its own retry loop in
+    // `download_parallel_attempt` instead of the shared work queue.
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let (flaky_start, _) = segment_range(0, bytes.len() as u64, segment_bytes);
+
+    let mut probe_client = FlakySegmentRangeClient::new(bytes.clone(), flaky_start, false);
+    let factory_client = probe_client.clone();
+    let factory: Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>> =
+        Box::new(move || Ok(Box::new(factory_client.clone()) as BoxedDownloadClient));
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    let options = PullOptions {
+        segment_low_speed_timeout: Duration::ZERO,
+        segment_low_speed_min_bytes: 2,
+        ..parallel_test_options(segment_bytes)
+    };
+    let (target, paths) = parallel_attempt_paths(temp.path(), &resolved);
+
+    let outcome = download_parallel_attempt(
+        &target,
+        &paths,
+        &mut probe_client,
+        &parallel,
+        segment_bytes,
+        &options,
+        &mut |_| {},
+        &|| false,
+        &|| false,
+    )
+    .unwrap();
+
+    match outcome {
+        ParallelAttemptOutcome::Completed(downloaded) => {
+            assert_eq!(downloaded.sha256, sha256_hex(&bytes));
+        }
+        ParallelAttemptOutcome::RangeNotSupported => {
+            panic!("this mock always honors Range with 206")
+        }
+    }
+    assert_eq!(probe_client.attempts_on_flaky_segment(), 2);
+}
+
+#[test]
+fn parallel_download_low_speed_segment_gives_up_after_max_abandons() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let total_segments = segment_count(bytes.len() as u64, segment_bytes);
+    assert!(
+        total_segments >= 3,
+        "fixture too small to give the flaky segment (index 1) siblings"
+    );
+    let (flaky_start, flaky_end) = segment_range(1, bytes.len() as u64, segment_bytes);
+
+    // `always_flaky: true` -- this segment never recovers, no matter how
+    // many fresh connections it gets, exercising the bounded give-up path.
+    let mut probe_client = FlakySegmentRangeClient::new(bytes.clone(), flaky_start, true);
+    let factory_client = probe_client.clone();
+    let factory: Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>> =
+        Box::new(move || Ok(Box::new(factory_client.clone()) as BoxedDownloadClient));
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    let options = PullOptions {
+        segment_low_speed_timeout: Duration::ZERO,
+        segment_low_speed_min_bytes: 2,
+        ..parallel_test_options(segment_bytes)
+    };
+    let (target, paths) = parallel_attempt_paths(temp.path(), &resolved);
+
+    let error = download_parallel_attempt(
+        &target,
+        &paths,
+        &mut probe_client,
+        &parallel,
+        segment_bytes,
+        &options,
+        &mut |_| {},
+        &|| false,
+        &|| false,
+    )
+    .unwrap_err();
+
+    match error {
+        PullError::SegmentLowSpeed {
+            start,
+            end,
+            attempts,
+            ..
+        } => {
+            assert_eq!(start, flaky_start);
+            assert_eq!(end, flaky_end);
+            // One attempt is not itself a retry, plus SEGMENT_MAX_RETRIES
+            // requeue-and-retry rounds before giving up -- the same total
+            // attempt budget every other segment failure mode gets.
+            assert_eq!(attempts, SEGMENT_MAX_RETRIES + 1);
+        }
+        other => panic!("expected PullError::SegmentLowSpeed, got {other:?}"),
+    }
+    // This is a retryable, source-fallback-eligible error, exactly like the
+    // other segment failure modes -- `download_with_retries`'s outer loop
+    // (untouched by this change) is what actually retries the whole attempt
+    // or falls back to the next mirror.
+    assert!(is_retryable_download_error(&error));
+    assert!(is_source_fallback_error(&error));
+    assert_eq!(
+        probe_client.attempts_on_flaky_segment(),
+        SEGMENT_MAX_RETRIES + 1
+    );
 }
 
 /// Regression guard: `reqwest::blocking::ClientBuilder::timeout` defaults to

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -1548,54 +1548,184 @@ fn pull_retries_low_speed_body_and_restarts_safely() {
     assert_eq!(client.ranges(), vec![None, None]);
 }
 
-#[test]
-fn segment_low_speed_window_trips_when_a_window_clears_without_the_byte_floor() {
-    // `Duration::ZERO` makes every `observe` call judge its window
-    // immediately (matches the same zero-timeout trick the whole-file
-    // `pull_retries_low_speed_body_and_restarts_safely` test above uses),
-    // so this is deterministic without any real sleep.
-    let options = PullOptions {
+/// Default `PullOptions` low-speed knobs, but with a zero window timeout so
+/// `SegmentLowSpeedWindow::observe` judges its window on the very first call
+/// regardless of real elapsed time (matches the same trick the whole-file
+/// `pull_retries_low_speed_body_and_restarts_safely` test above uses). Safe
+/// here specifically because `observe` compares raw per-window *byte counts*,
+/// never a computed bytes/sec rate, so there is no division-by-elapsed-time
+/// to make unstable.
+fn zero_window_options() -> PullOptions {
+    PullOptions {
         segment_low_speed_timeout: Duration::ZERO,
-        segment_low_speed_min_bytes: 10,
         ..PullOptions::default()
-    };
-    let mut window = SegmentLowSpeedWindow::new(&options);
-    assert!(
-        window.observe(1),
-        "1 byte is below the 10-byte floor and the window already elapsed"
+    }
+}
+
+/// Feeds `samples` into a reference (each one both consulted as history and
+/// then recorded), so a test can cheaply establish "this session has already
+/// seen these per-window byte counts" before evaluating the sample under
+/// test in isolation.
+fn reference_with_history(samples: &[u64]) -> SegmentThroughputReference {
+    let reference = SegmentThroughputReference::new();
+    for sample in samples {
+        reference.record(*sample);
+    }
+    reference
+}
+
+#[test]
+fn segment_throughput_reference_is_cold_below_the_minimum_sample_count() {
+    let reference = SegmentThroughputReference::new();
+    assert_eq!(reference.median(), None, "no samples yet: cold start");
+    reference.record(1_000_000);
+    reference.record(1_000_000);
+    assert_eq!(
+        reference.median(),
+        None,
+        "still below SEGMENT_LOW_SPEED_MIN_REFERENCE_SAMPLES"
+    );
+    reference.record(1_000_000);
+    assert_eq!(
+        reference.median(),
+        Some(1_000_000),
+        "the Nth sample must cross the cold-start threshold"
     );
 }
 
 #[test]
-fn segment_low_speed_window_disabled_when_min_bytes_is_zero() {
-    let options = PullOptions {
-        segment_low_speed_timeout: Duration::ZERO,
-        segment_low_speed_min_bytes: 0,
-        ..PullOptions::default()
-    };
-    let mut window = SegmentLowSpeedWindow::new(&options);
-    assert!(!window.observe(0));
-    assert!(!window.observe(1));
+fn segment_low_speed_window_never_trips_during_cold_start() {
+    // Fewer than `SEGMENT_LOW_SPEED_MIN_REFERENCE_SAMPLES` samples exist, so
+    // there is no reference yet to be an outlier against -- even a session's
+    // very first, objectively tiny window must never be judged low-speed.
+    let reference = reference_with_history(&[1_000_000, 1_000_000]);
+    let cooldown_slot = Mutex::new(None);
+    let options = zero_window_options();
+    let mut window = SegmentLowSpeedWindow::new(&options, &reference, &cooldown_slot, false);
+    assert!(
+        !window.observe(1),
+        "cold start (fewer than the minimum reference samples) must never trip"
+    );
 }
 
 #[test]
-fn segment_low_speed_window_resets_after_a_window_clears_the_floor() {
-    // A segment that starts out fast and later degrades must still be
-    // caught: clearing the floor once must reset the window rather than
-    // permanently disabling the guard for the rest of the segment.
-    let options = PullOptions {
-        segment_low_speed_timeout: Duration::ZERO,
-        segment_low_speed_min_bytes: 5,
-        ..PullOptions::default()
-    };
-    let mut window = SegmentLowSpeedWindow::new(&options);
+fn segment_low_speed_window_trips_on_a_relative_outlier_matching_the_reported_case() {
+    // Models the reported real-world failure: the bulk of the download ran
+    // fast (here, a 10 MB/window reference -- comparable to a healthy several
+    // MB/s connection), then a lone tail segment lands on a degraded
+    // connection running at a small fraction of that.
+    let reference = reference_with_history(&[10_000_000, 10_000_000, 10_000_000, 10_000_000]);
+    let cooldown_slot = Mutex::new(None);
+    let options = zero_window_options();
+    let mut window = SegmentLowSpeedWindow::new(&options, &reference, &cooldown_slot, false);
+    // Well under 15% of the 10 MB reference AND under the absolute floor.
     assert!(
-        !window.observe(5),
-        "5 bytes clears the 5-byte floor; must reset, not trip"
+        window.observe(1_000_000),
+        "1 MB against a 10 MB reference is both a relative outlier and below \
+         the absolute floor -- must trip"
     );
+}
+
+#[test]
+fn segment_low_speed_window_never_trips_in_a_uniformly_slow_session() {
+    // Every window in this session reads about the same (a real, working,
+    // if modest ~200 KB/s-class connection): no segment is an outlier
+    // relative to its own siblings, so the ratio test alone must never fire,
+    // regardless of how small the absolute numbers are. This is the "慢但能成"
+    // contract: a uniformly slow network must never be turned into a
+    // deterministic failure by this guard.
+    let uniform_window_bytes = 200_000_u64;
+    let reference = reference_with_history(&[
+        uniform_window_bytes,
+        uniform_window_bytes,
+        uniform_window_bytes,
+        uniform_window_bytes,
+    ]);
+    let cooldown_slot = Mutex::new(None);
+    let options = zero_window_options();
+    let mut window = SegmentLowSpeedWindow::new(&options, &reference, &cooldown_slot, false);
     assert!(
-        window.observe(1),
-        "the next window starts fresh at 0 bytes, so 1 byte must trip again"
+        !window.observe(uniform_window_bytes),
+        "a segment performing exactly like its siblings must never be an outlier"
+    );
+}
+
+#[test]
+fn segment_low_speed_window_absolute_floor_protects_a_merely_modest_speed_in_a_fast_session() {
+    // A segment reading ~400 KB/s-equivalent worth of bytes in one window is
+    // a real, working connection -- just not this unusually fast session's
+    // best. The ratio alone would flag it (well under 15% of a very high
+    // reference), but the absolute floor must still protect it from being
+    // needlessly abandoned.
+    let fast_reference_window_bytes = 150_000_000_u64; // ~10 MB/s-class
+    let reference = reference_with_history(&[
+        fast_reference_window_bytes,
+        fast_reference_window_bytes,
+        fast_reference_window_bytes,
+    ]);
+    let modest_but_real_window_bytes = 6_000_000_u64; // ~400 KB/s over the 15s window
+    assert!(
+        modest_but_real_window_bytes > SEGMENT_LOW_SPEED_ABSOLUTE_FLOOR_BYTES,
+        "fixture must sit above the absolute floor to exercise its protection"
+    );
+    let cooldown_slot = Mutex::new(None);
+    let options = zero_window_options();
+    let mut window = SegmentLowSpeedWindow::new(&options, &reference, &cooldown_slot, false);
+    assert!(
+        !window.observe(modest_but_real_window_bytes),
+        "above the absolute floor must never trip, no matter how fast the reference is"
+    );
+}
+
+#[test]
+fn segment_low_speed_window_reflects_the_sessions_historical_median_for_a_lone_tail_segment() {
+    // Once every other segment has completed, the reference is entirely this
+    // session's *history* (nothing else is in flight to compare against) --
+    // exactly the "one straggler segment left" case from the report. This
+    // test only asserts that history alone (no live siblings) is sufficient
+    // for the guard to keep working, by feeding a fast history and then
+    // evaluating a slow lone window against it.
+    let reference = reference_with_history(&[8_000_000, 8_000_000, 8_000_000, 8_000_000]);
+    let cooldown_slot = Mutex::new(None);
+    let options = zero_window_options();
+    let mut window = SegmentLowSpeedWindow::new(&options, &reference, &cooldown_slot, false);
+    assert!(
+        window.observe(90_000),
+        "a lone straggler window judged purely against session history must still trip"
+    );
+}
+
+#[test]
+fn segment_low_speed_window_cooldown_suppresses_a_thrashing_retrip() {
+    // Hysteresis: once tripped, the same segment index must not immediately
+    // re-trip on its very next window even if that window is also still an
+    // outlier -- this damps requeue churn for a segment sitting right at the
+    // boundary instead of burning through reconnects one window apart.
+    let reference = reference_with_history(&[10_000_000, 10_000_000, 10_000_000, 10_000_000]);
+    let cooldown_slot = Mutex::new(None);
+    let options = zero_window_options();
+    let mut first = SegmentLowSpeedWindow::new(&options, &reference, &cooldown_slot, false);
+    assert!(first.observe(1_000_000), "first window: a genuine outlier");
+    let mut second = SegmentLowSpeedWindow::new(&options, &reference, &cooldown_slot, false);
+    assert!(
+        !second.observe(1_000_000),
+        "still within the cooldown since the first trip: must be suppressed"
+    );
+}
+
+#[test]
+fn segment_low_speed_window_disabled_flag_never_trips_regardless_of_speed() {
+    // Once a segment has exhausted its reconnect budget, evaluation is
+    // disabled for its final attempt: the worst case must degrade to
+    // "let it finish", never a hard failure, no matter how extreme the
+    // outlier looks.
+    let reference = reference_with_history(&[10_000_000, 10_000_000, 10_000_000, 10_000_000]);
+    let cooldown_slot = Mutex::new(None);
+    let options = zero_window_options();
+    let mut window = SegmentLowSpeedWindow::new(&options, &reference, &cooldown_slot, true);
+    assert!(
+        !window.observe(1),
+        "disabled must never trip, even for a single byte against a 10 MB reference"
     );
 }
 
@@ -3329,18 +3459,22 @@ impl Read for OneByteAtATimeReader {
     }
 }
 
-/// A `RangeServerClient`-alike whose responses for one specific segment
-/// (`flaky_start`) trickle one byte at a time -- tripping a zero-timeout
-/// `SegmentLowSpeedWindow` on the very first chunk -- while every other
-/// segment (and, if `always_flaky` is `false`, every attempt after the
-/// first on the flaky segment too) is served normally in one read. Models
-/// "one connection to this source is bad; a fresh one for the same range is
-/// fine" without needing a real slow socket.
+/// A `RangeServerClient`-alike whose responses trickle one byte at a time
+/// for whichever segment(s) `flaky_start` selects -- tripping a zero-timeout
+/// `SegmentLowSpeedWindow` window on the very first chunk of that segment --
+/// while every other segment (and, if `always_flaky` is `false`, every
+/// attempt after the first on the flaky segment too) is served normally in
+/// one read. Models "one connection to this source is bad; a fresh one for
+/// the same range is fine" without needing a real slow socket.
+///
+/// `flaky_start: None` makes *every* segment trickle uniformly instead of
+/// singling one out -- used to model a session where the whole network is
+/// slow, not just one connection.
 #[derive(Clone)]
 struct FlakySegmentRangeClient {
     bytes: Arc<Vec<u8>>,
     attempts_by_start: Arc<Mutex<HashMap<u64, usize>>>,
-    flaky_start: u64,
+    flaky_start: Option<u64>,
     always_flaky: bool,
 }
 
@@ -3349,18 +3483,44 @@ impl FlakySegmentRangeClient {
         Self {
             bytes: Arc::new(bytes),
             attempts_by_start: Arc::new(Mutex::new(HashMap::new())),
-            flaky_start,
+            flaky_start: Some(flaky_start),
             always_flaky,
         }
     }
 
-    fn attempts_on_flaky_segment(&self) -> usize {
+    /// Every segment trickles on every attempt: models a uniformly slow
+    /// session (see the type's doc comment).
+    fn new_uniformly_slow(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes: Arc::new(bytes),
+            attempts_by_start: Arc::new(Mutex::new(HashMap::new())),
+            flaky_start: None,
+            always_flaky: true,
+        }
+    }
+
+    fn attempts_for(&self, start: u64) -> usize {
         self.attempts_by_start
             .lock()
             .unwrap()
-            .get(&self.flaky_start)
+            .get(&start)
             .copied()
             .unwrap_or(0)
+    }
+
+    fn attempts_on_flaky_segment(&self) -> usize {
+        let flaky_start = self
+            .flaky_start
+            .expect("attempts_on_flaky_segment requires a single flaky_start");
+        self.attempts_for(flaky_start)
+    }
+
+    fn every_recorded_segment_attempted_exactly_once(&self) -> bool {
+        self.attempts_by_start
+            .lock()
+            .unwrap()
+            .values()
+            .all(|count| *count == 1)
     }
 }
 
@@ -3381,7 +3541,10 @@ impl DownloadClient for FlakySegmentRangeClient {
             *counter += 1;
             *counter
         };
-        let is_flaky_now = start == self.flaky_start && (self.always_flaky || attempt == 1);
+        let is_flaky_now = match self.flaky_start {
+            None => true,
+            Some(flaky_start) => start == flaky_start && (self.always_flaky || attempt == 1),
+        };
         let reader: Box<dyn Read> = if is_flaky_now {
             Box::new(OneByteAtATimeReader::new(slice))
         } else {
@@ -3410,38 +3573,54 @@ fn parallel_attempt_paths(home: &Path, resolved: &ResolvedCatalogPull) -> (PullT
     (target, paths)
 }
 
+/// `connections: 1` makes the single worker drain the shared queue strictly
+/// in ascending index order (FIFO, one segment at a time) -- these tests
+/// need that determinism to control exactly how many reference samples
+/// exist by the time a particular segment is evaluated, which a real
+/// multi-connection race wouldn't guarantee.
+fn single_worker_parallel_config(
+    factory: &dyn Fn() -> Result<BoxedDownloadClient, PullError>,
+) -> ParallelDownloadConfig<'_> {
+    ParallelDownloadConfig {
+        connections: 1,
+        factory,
+    }
+}
+
+fn low_speed_test_options(segment_bytes: u64) -> PullOptions {
+    // Duration::ZERO: see `zero_window_options` above -- makes every
+    // `observe` call judge its window (here, one buffer read) immediately.
+    PullOptions {
+        segment_low_speed_timeout: Duration::ZERO,
+        ..parallel_test_options(segment_bytes)
+    }
+}
+
 #[test]
 fn parallel_download_low_speed_segment_requeues_onto_fresh_connection_and_recovers() {
     let bytes = tiny_pack_bytes();
     let resolved = resolved_for(&bytes);
     let temp = tempfile::tempdir().unwrap();
-    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let segment_bytes = small_segment_bytes(bytes.len(), 5);
     let total_segments = segment_count(bytes.len() as u64, segment_bytes);
     assert!(
-        total_segments >= 3,
-        "fixture too small to give the flaky segment (index 1, not the probe) \
-         siblings to run alongside"
+        total_segments >= 5,
+        "fixture too small: need the probe plus 3 normal siblings to warm the \
+         reference before the flaky (last) segment is evaluated"
     );
-    // Index 1, not 0: segment 0 is always the synchronous probe segment, and
-    // this test targets the worker-queue requeue path in `run_segment_worker`
-    // specifically (the probe has its own low-speed retry loop, covered by
-    // the probe-path test below).
-    let (flaky_start, _) = segment_range(1, bytes.len() as u64, segment_bytes);
+    // The *last* index, fetched last by a single sequential worker: by the
+    // time it's evaluated, the probe (index 0) plus every other worker
+    // segment before it have already recorded their (normal-speed) windows,
+    // satisfying SEGMENT_LOW_SPEED_MIN_REFERENCE_SAMPLES -- exactly the
+    // reported "lone tail straggler after a fast bulk" scenario.
+    let (flaky_start, _) = segment_range(total_segments - 1, bytes.len() as u64, segment_bytes);
 
     let mut probe_client = FlakySegmentRangeClient::new(bytes.clone(), flaky_start, false);
     let factory_client = probe_client.clone();
     let factory: Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>> =
         Box::new(move || Ok(Box::new(factory_client.clone()) as BoxedDownloadClient));
-    let parallel = ParallelDownloadConfig {
-        connections: 4,
-        factory: &*factory,
-    };
-
-    let options = PullOptions {
-        segment_low_speed_timeout: Duration::ZERO,
-        segment_low_speed_min_bytes: 2,
-        ..parallel_test_options(segment_bytes)
-    };
+    let parallel = single_worker_parallel_config(&*factory);
+    let options = low_speed_test_options(segment_bytes);
 
     let progress_events = Arc::new(Mutex::new(Vec::<(u64, u64)>::new()));
     let progress_sink = progress_events.clone();
@@ -3500,31 +3679,94 @@ fn parallel_download_low_speed_segment_requeues_onto_fresh_connection_and_recove
 }
 
 #[test]
-fn parallel_download_probe_segment_low_speed_retries_in_place_and_recovers() {
-    // Same recovery contract as the worker-side test above, but for the
-    // probe segment (always index 0), which runs synchronously before any
-    // worker thread exists and so has its own retry loop in
-    // `download_parallel_attempt` instead of the shared work queue.
+fn parallel_download_low_speed_segment_gives_up_after_max_abandons_and_still_completes() {
+    // The worst case after exhausting the reconnect budget must be identical
+    // to not having this guard at all: the download still succeeds, just
+    // slower for this one segment, never a hard failure.
     let bytes = tiny_pack_bytes();
     let resolved = resolved_for(&bytes);
     let temp = tempfile::tempdir().unwrap();
-    let segment_bytes = small_segment_bytes(bytes.len(), 4);
-    let (flaky_start, _) = segment_range(0, bytes.len() as u64, segment_bytes);
+    let segment_bytes = small_segment_bytes(bytes.len(), 5);
+    let total_segments = segment_count(bytes.len() as u64, segment_bytes);
+    assert!(
+        total_segments >= 5,
+        "fixture too small to warm the reference"
+    );
+    let (flaky_start, _) = segment_range(total_segments - 1, bytes.len() as u64, segment_bytes);
 
-    let mut probe_client = FlakySegmentRangeClient::new(bytes.clone(), flaky_start, false);
+    // `always_flaky: true` -- this segment never recovers, no matter how
+    // many fresh connections it gets, exercising the bounded degrade-and-
+    // finish path.
+    let mut probe_client = FlakySegmentRangeClient::new(bytes.clone(), flaky_start, true);
     let factory_client = probe_client.clone();
     let factory: Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>> =
         Box::new(move || Ok(Box::new(factory_client.clone()) as BoxedDownloadClient));
-    let parallel = ParallelDownloadConfig {
-        connections: 4,
-        factory: &*factory,
-    };
-
+    let parallel = single_worker_parallel_config(&*factory);
+    // Cooldown disabled: this test isolates the abandon-count cap from the
+    // separate hysteresis behavior (covered by
+    // `segment_low_speed_window_cooldown_suppresses_a_thrashing_retrip`).
+    // With the default cooldown active, this mock's near-instant retry would
+    // itself fall inside the cooldown window and never re-trip -- which
+    // would still finish successfully, but wouldn't be exercising the cap.
     let options = PullOptions {
-        segment_low_speed_timeout: Duration::ZERO,
-        segment_low_speed_min_bytes: 2,
-        ..parallel_test_options(segment_bytes)
+        segment_low_speed_cooldown: Duration::ZERO,
+        ..low_speed_test_options(segment_bytes)
     };
+    let (target, paths) = parallel_attempt_paths(temp.path(), &resolved);
+
+    let outcome = download_parallel_attempt(
+        &target,
+        &paths,
+        &mut probe_client,
+        &parallel,
+        segment_bytes,
+        &options,
+        &mut |_| {},
+        &|| false,
+        &|| false,
+    )
+    .unwrap();
+
+    let downloaded = match outcome {
+        ParallelAttemptOutcome::Completed(downloaded) => downloaded,
+        ParallelAttemptOutcome::RangeNotSupported => {
+            panic!("this mock always honors Range with 206")
+        }
+    };
+    assert_eq!(downloaded.sha256, sha256_hex(&bytes));
+    assert_eq!(fs::read(&paths.partial_path).unwrap(), bytes);
+
+    // SEGMENT_MAX_RETRIES abandon-and-requeue rounds, then one final attempt
+    // with the guard disabled that's simply allowed to trickle to
+    // completion -- never a `PullError` (that variant no longer exists).
+    assert_eq!(
+        probe_client.attempts_on_flaky_segment(),
+        SEGMENT_MAX_RETRIES + 1
+    );
+}
+
+#[test]
+fn parallel_download_cold_start_never_flags_an_early_trickling_segment() {
+    // The segment fetched immediately after the probe has, at most, one
+    // prior sample (the probe's own) -- below
+    // SEGMENT_LOW_SPEED_MIN_REFERENCE_SAMPLES, so it must never be judged
+    // low-speed no matter how slowly it trickles. This is the same
+    // cold-start contract as the pure unit test above, exercised end to end
+    // through the real mock transport.
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 5);
+    let total_segments = segment_count(bytes.len() as u64, segment_bytes);
+    assert!(total_segments >= 5, "fixture too small");
+    let (flaky_start, _) = segment_range(1, bytes.len() as u64, segment_bytes);
+
+    let mut probe_client = FlakySegmentRangeClient::new(bytes.clone(), flaky_start, true);
+    let factory_client = probe_client.clone();
+    let factory: Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>> =
+        Box::new(move || Ok(Box::new(factory_client.clone()) as BoxedDownloadClient));
+    let parallel = single_worker_parallel_config(&*factory);
+    let options = low_speed_test_options(segment_bytes);
     let (target, paths) = parallel_attempt_paths(temp.path(), &resolved);
 
     let outcome = download_parallel_attempt(
@@ -3548,25 +3790,25 @@ fn parallel_download_probe_segment_low_speed_retries_in_place_and_recovers() {
             panic!("this mock always honors Range with 206")
         }
     }
-    assert_eq!(probe_client.attempts_on_flaky_segment(), 2);
+    // Never requeued: cold start suppressed every evaluation of this segment.
+    assert_eq!(probe_client.attempts_on_flaky_segment(), 1);
 }
 
 #[test]
-fn parallel_download_low_speed_segment_gives_up_after_max_abandons() {
+fn parallel_download_uniformly_slow_session_completes_without_any_requeue() {
+    // The "慢但能成" contract end to end: every segment (including the
+    // probe) trickles uniformly, so no segment is ever an outlier relative
+    // to its own siblings -- the ratio test alone must never fire, and the
+    // whole download must still succeed without a single requeue, exactly
+    // like it would have before this guard existed.
     let bytes = tiny_pack_bytes();
     let resolved = resolved_for(&bytes);
     let temp = tempfile::tempdir().unwrap();
-    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let segment_bytes = small_segment_bytes(bytes.len(), 5);
     let total_segments = segment_count(bytes.len() as u64, segment_bytes);
-    assert!(
-        total_segments >= 3,
-        "fixture too small to give the flaky segment (index 1) siblings"
-    );
-    let (flaky_start, flaky_end) = segment_range(1, bytes.len() as u64, segment_bytes);
+    assert!(total_segments >= 5, "fixture too small");
 
-    // `always_flaky: true` -- this segment never recovers, no matter how
-    // many fresh connections it gets, exercising the bounded give-up path.
-    let mut probe_client = FlakySegmentRangeClient::new(bytes.clone(), flaky_start, true);
+    let mut probe_client = FlakySegmentRangeClient::new_uniformly_slow(bytes.clone());
     let factory_client = probe_client.clone();
     let factory: Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>> =
         Box::new(move || Ok(Box::new(factory_client.clone()) as BoxedDownloadClient));
@@ -3574,15 +3816,10 @@ fn parallel_download_low_speed_segment_gives_up_after_max_abandons() {
         connections: 4,
         factory: &*factory,
     };
-
-    let options = PullOptions {
-        segment_low_speed_timeout: Duration::ZERO,
-        segment_low_speed_min_bytes: 2,
-        ..parallel_test_options(segment_bytes)
-    };
+    let options = low_speed_test_options(segment_bytes);
     let (target, paths) = parallel_attempt_paths(temp.path(), &resolved);
 
-    let error = download_parallel_attempt(
+    let outcome = download_parallel_attempt(
         &target,
         &paths,
         &mut probe_client,
@@ -3593,33 +3830,19 @@ fn parallel_download_low_speed_segment_gives_up_after_max_abandons() {
         &|| false,
         &|| false,
     )
-    .unwrap_err();
+    .unwrap();
 
-    match error {
-        PullError::SegmentLowSpeed {
-            start,
-            end,
-            attempts,
-            ..
-        } => {
-            assert_eq!(start, flaky_start);
-            assert_eq!(end, flaky_end);
-            // One attempt is not itself a retry, plus SEGMENT_MAX_RETRIES
-            // requeue-and-retry rounds before giving up -- the same total
-            // attempt budget every other segment failure mode gets.
-            assert_eq!(attempts, SEGMENT_MAX_RETRIES + 1);
+    match outcome {
+        ParallelAttemptOutcome::Completed(downloaded) => {
+            assert_eq!(downloaded.sha256, sha256_hex(&bytes));
         }
-        other => panic!("expected PullError::SegmentLowSpeed, got {other:?}"),
+        ParallelAttemptOutcome::RangeNotSupported => {
+            panic!("this mock always honors Range with 206")
+        }
     }
-    // This is a retryable, source-fallback-eligible error, exactly like the
-    // other segment failure modes -- `download_with_retries`'s outer loop
-    // (untouched by this change) is what actually retries the whole attempt
-    // or falls back to the next mirror.
-    assert!(is_retryable_download_error(&error));
-    assert!(is_source_fallback_error(&error));
-    assert_eq!(
-        probe_client.attempts_on_flaky_segment(),
-        SEGMENT_MAX_RETRIES + 1
+    assert!(
+        probe_client.every_recorded_segment_attempted_exactly_once(),
+        "a uniformly slow session must never trigger a single requeue"
     );
 }
 


### PR DESCRIPTION
## Summary

Rescues the "download stuck at 99% behind one slow connection" case in the parallel segment downloader. A segment is abandoned onto a fresh connection only when it is an outlier RELATIVE to the session's own observed throughput (window bytes < 15% of the rolling per-window median AND < a 4MiB/15s absolute floor); a uniformly slow session never triggers. After SEGMENT_MAX_RETRIES abandonments the guard disables itself for that segment and lets it finish on the current connection, so the worst case is exactly today's behavior - the guard can only help, never fail a pull (the SegmentLowSpeed error variant is gone). A 30s per-segment cooldown suppresses boundary flapping; progress rollback keeps bytes_done exact across requeues.

## Why

A user-reported 4.4GB pull sat at 99% at 90KB/s for ~12 minutes: work-stealing naturally narrows to the last segment, and a single bad route had no low-speed detection on the segment path (the single-stream path has one). The first review round rejected an absolute-threshold design that would have turned honest slow networks into deterministic failures; this version is relative and strictly never-worse.

## Tests run

- fmt/clippy -D warnings/deny/doc all clean; nextest workspace 2845 passed
- new unit+mock matrix: outlier triggers, uniformly-slow never triggers (zero-requeue assertion), fast-session modest-speed floor protection, tail-segment historical reference, cold-start suppression, cooldown, retry-cap degrade-to-complete, progress no-double-count
- real network: single-stream small pack and chunked whisper-base:fp16 both install with byte-exact sha256, no false warnings

AI usage disclosure: YES