### PR TITLE
perf(qwen): apply the CPU threading-workload tiers to qwen's graph runners

### DIFF
--- a/crates/openasr-core/src/models/qwen/audio_encoder.rs
+++ b/crates/openasr-core/src/models/qwen/audio_encoder.rs
@@ -18,7 +18,7 @@ use crate::nn::ffn::FeedForwardActivation;
 use crate::{GgufTensorDataReadError, GgufTensorDataReader, GgufTensorMetadata};
 
 use super::frontend::Qwen3AsrMelFeatures;
-use super::graph_config::qwen_runtime_graph_config;
+use super::graph_config::qwen_encoder_graph_config;
 use super::runtime_contract::Qwen3AsrExecutionMetadata;
 
 /// Env flag to emit a per-chunk audio-encoder timing split. `setup_us` covers
@@ -166,7 +166,9 @@ pub(crate) struct Qwen3AsrAudioEncoderRuntime {
 
 impl Qwen3AsrAudioEncoderRuntime {
     pub(crate) fn new(runtime_path: Option<&Path>) -> Result<Self, Qwen3AsrAudioEncoderError> {
-        let mut config = qwen_runtime_graph_config();
+        // See `qwen_encoder_graph_config` for the `EncoderPrelude` threading
+        // tier rationale.
+        let mut config = qwen_encoder_graph_config();
         config.context_bytes = QWEN3_AUDIO_GRAPH_CONTEXT_BYTES;
         let runner = GgmlCpuGraphRunner::new(config).map_err(|source| {
             Qwen3AsrAudioEncoderError::GraphBuildFailed {

--- a/crates/openasr-core/src/models/qwen/graph_config.rs
+++ b/crates/openasr-core/src/models/qwen/graph_config.rs
@@ -1,8 +1,9 @@
-use crate::ggml_runtime::GgmlCpuGraphConfig;
+use crate::ggml_runtime::{GgmlCpuGraphConfig, GgmlCpuGraphThreadingWorkload};
 #[cfg(test)]
 use crate::models::graph_runtime_config::configure_model_runtime_graph_config;
 use crate::models::graph_runtime_config::{
     ModelMetalRuntimeOverrides, configure_model_runtime_graph_config_from_env,
+    has_explicit_thread_override,
 };
 
 /// qwen is NOT gated (`AutoGpuPolicy::AllBackends`, see `arch::mod`) as of
@@ -26,6 +27,51 @@ pub(crate) fn qwen_runtime_graph_config() -> GgmlCpuGraphConfig {
             default_n_threads_when_unset: Some(1),
         },
     )
+}
+
+/// Graph config for the audio-encoder runner. The encoder runs the whole
+/// utterance's conformer stack as one graph call with wide per-layer
+/// parallelism (many independent frames / attention heads) -- the same shape
+/// as firered-aed's encoder, which is why it takes the same `EncoderPrelude`
+/// tier (see `firered_aed::graph_config::firered_encoder_graph_config` for
+/// the precedent this mirrors). Unlike the decode path below, there is no
+/// per-token reuse here: one call per chunk, so maximizing threads for that
+/// one call is a clear win, not a per-step overhead trade-off.
+pub(crate) fn qwen_encoder_graph_config() -> GgmlCpuGraphConfig {
+    let mut config = qwen_runtime_graph_config();
+    if !has_explicit_thread_override() {
+        config.n_threads = GgmlCpuGraphConfig::resolve_runtime_thread_count_for(
+            config.backend,
+            GgmlCpuGraphThreadingWorkload::EncoderPrelude,
+        );
+    }
+    config
+}
+
+/// Graph config for the LLM decode-path runners (the whole-decoder executor
+/// and the logits head that feeds off it). Both are resident graphs reused
+/// across the whole pack lifetime, dominated by thousands of single-token
+/// autoregressive decode-step calls versus a handful of larger prefill
+/// chunks; per-token graphs have little row-level parallelism to hand out
+/// regardless of thread count. This takes the `Decoder` tier, mirroring
+/// firered-aed's decoder graph
+/// (`firered_aed::graph_config::firered_decoder_graph_config`) and
+/// deliberately requesting fewer threads than `Default` to cut thread-pool
+/// wake/join overhead on the dominant small-graph call instead of
+/// over-provisioning threads the per-token op mix cannot use. mimo-asr,
+/// firered2-llm, moss-transcribe-diarize, and hymt2 all construct their
+/// whole-decoder executor through
+/// `Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_rms_norm_epsilon_and_fused_logits_head`,
+/// so they inherit this tier automatically.
+pub(crate) fn qwen_decoder_graph_config() -> GgmlCpuGraphConfig {
+    let mut config = qwen_runtime_graph_config();
+    if !has_explicit_thread_override() {
+        config.n_threads = GgmlCpuGraphConfig::resolve_runtime_thread_count_for(
+            config.backend,
+            GgmlCpuGraphThreadingWorkload::Decoder,
+        );
+    }
+    config
 }
 
 #[cfg(test)]

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -13,7 +13,7 @@ use crate::ggml_runtime::{
     env_toggle_with_raw,
 };
 
-use super::graph_config::qwen_runtime_graph_config;
+use super::graph_config::qwen_decoder_graph_config;
 use super::kv_cache::Qwen3AsrLayerKvCacheState;
 use super::logits_head::{
     Qwen3AsrLlmFusedLogitsHeadSpec, first_max_argmax_reverse_indices,
@@ -1544,7 +1544,16 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 reason: "whole-decoder rms norm epsilon must be finite and positive",
             });
         }
-        let mut config = qwen_runtime_graph_config();
+        // This single resident graph is reused across the whole pack lifetime
+        // for both prompt-prefill chunks and single-token autoregressive
+        // decode steps (`ggml_executor`'s `QWEN_WHOLE_DECODER_BY_KEY` cache);
+        // `n_threads` is fixed once here at construction, so one tier has to
+        // be picked for the whole executor rather than per call. mimo-asr,
+        // firered2-llm, moss-transcribe-diarize, and hymt2 all construct this
+        // executor through `new_with_rms_norm_epsilon_and_fused_logits_head`
+        // too, so they inherit the `Decoder` tier below automatically. See
+        // `qwen_decoder_graph_config` for the tier rationale.
+        let mut config = qwen_decoder_graph_config();
         config.context_bytes = QWEN3_LLM_WHOLE_DECODE_GRAPH_CONTEXT_BYTES;
         let use_native_gqa = qwen_llm_resolve_use_native_gqa(config.backend);
         let runner = GgmlCpuGraphRunner::new(config)?;

--- a/crates/openasr-core/src/models/qwen/logits_head.rs
+++ b/crates/openasr-core/src/models/qwen/logits_head.rs
@@ -11,7 +11,7 @@ use crate::models::thread_local_runtime_cache::{
     with_thread_local_cached_mut_by_key,
 };
 
-use super::graph_config::qwen_runtime_graph_config;
+use super::graph_config::{qwen_decoder_graph_config, qwen_runtime_graph_config};
 use super::runtime_contract::Qwen3AsrExecutionMetadata;
 use super::tensor_names::{
     OUTPUT_NORM_WEIGHT as OUTPUT_NORM_WEIGHT_TENSOR_NAME,
@@ -451,7 +451,16 @@ impl Qwen3AsrLlmLogitsHeadGraphExecutor {
             });
         }
 
-        let mut config = qwen_runtime_graph_config();
+        // Norm + a single [1, d_model] x [d_model, vocab_size] projection per
+        // call -- a thin, memory-bandwidth-bound matrix-vector product with
+        // one output row, run once per decode step at the same cadence as
+        // the whole-decoder executor this feeds (thousands of decode-step
+        // calls dominating over a handful of prefill chunks). Little
+        // row-level parallelism to hand out per call regardless of thread
+        // count, so this takes the `Decoder` tier from
+        // `qwen_decoder_graph_config` on its own merits (there is no
+        // separate firered-aed logits-head module to mirror here).
+        let mut config = qwen_decoder_graph_config();
         config.context_bytes = QWEN3_LLM_LOGITS_GRAPH_CONTEXT_BYTES;
         let runner = GgmlCpuGraphRunner::new(config)?;
         let mut arena = runner.start_static_tensor_arena(config.context_bytes)?;


### PR DESCRIPTION
## Summary

Wire qwen's ggml graph runners (audio encoder, whole-decoder executor, logits
head) through the same `GgmlCpuGraphThreadingWorkload` tiering that
firered-aed already uses, so CPU inference actually spreads across available
cores instead of being pinned to whatever `qwen_runtime_graph_config`'s
generic default happened to resolve.

## Why

qwen3-asr's CPU long-form transcription was measured only using 1-3 of 8
logical cores. firered-aed already resolves its encoder/decoder graphs
through `EncoderPrelude`/`Decoder` threading tiers
(`firered_aed::graph_config`); qwen never adopted the same policy.

## Changes

- `models/qwen/graph_config.rs`: add `qwen_encoder_graph_config` and
  `qwen_decoder_graph_config`, mirroring
  `firered_encoder_graph_config`/`firered_decoder_graph_config` -- each wraps
  `qwen_runtime_graph_config` and applies the matching
  `GgmlCpuGraphThreadingWorkload` tier via
  `GgmlCpuGraphConfig::resolve_runtime_thread_count_for`, honoring an
  explicit `n_threads` override when present.
- `models/qwen/audio_encoder.rs`: the audio encoder runner now uses
  `qwen_encoder_graph_config` (`EncoderPrelude` tier) -- one wide graph call
  per chunk with plenty of per-layer parallelism to hand out.
- `models/qwen/llm_transformer.rs`: the whole-decoder executor now uses
  `qwen_decoder_graph_config` (`Decoder` tier) -- this resident graph is
  reused across the whole pack lifetime and its calls are overwhelmingly
  narrow single-token decode steps rather than large prefill chunks.
- `models/qwen/logits_head.rs`: the logits-head executor now uses the same
  `qwen_decoder_graph_config` (`Decoder` tier), argued on its own merits
  (thin bandwidth-bound matvec, same per-decode-step cadence as the
  whole-decoder executor it feeds) -- firered-aed has no separate
  logits-head module, so this is not claimed as a precedent there.

**Blast radius:** `Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_rms_norm_epsilon_and_fused_logits_head`
is the shared LLM decode-path constructor. `grep -rln
new_with_rms_norm_epsilon_and_fused_logits_head crates/openasr-core/src`
shows it is called by **five** families total: qwen3-asr, mimo-asr,
firered2-llm, moss-transcribe-diarize, and hymt2 (a shipped model family,
see `model-registry/models/hymt2-1.8b.toml`). All five inherit the `Decoder`
tier from this change, not just qwen3-asr.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2853 passed, 149 skipped -- private
      model-pack-gated tests, 0 failed)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (not run -- no dependency changes in this PR)

Also ran a targeted `cargo nextest run -p openasr-core -E 'test(qwen) or
test(mimo_asr) or test(firered_llm)'` (165 unit/import tests, all passed)
and `cargo test -p openasr-core golden_diff -- --nocapture` (4 passed, 14
ignored -- require private dev-only model packs, 0 failed) to specifically
exercise the shared decode executor's surrounding code.

**Real-pack decode evidence:** this environment has local dev-only q8_0
packs for two of the five families, so their `#[ignore]`d golden decode
tests (normally skipped without a pack) were run for real, one family at a
time (serial, `--test-threads=1`, `OPENASR_GGML_BACKEND=cpu`, to avoid
concurrent memory pressure from the ~9GB packs):

- `models::mimo_asr::executor::tests::golden_diff_end_to_end_transcribe_*`
  (jfk.wav, zh_sample.wav, en_zh_mixed.wav): **3 passed, 0 failed** --
  transcripts matched the pinned reference text with the new `Decoder` tier
  active.
- `models::firered_llm::executor::tests::golden_diff_end_to_end_transcribe_matches_reference_decode_on_*`
  (jfk.wav, zh_sample.wav, en_zh_mixed.wav): **3 passed, 0 failed** --
  same result.

moss-transcribe-diarize and hymt2 do not have a local dev pack in this
environment, so their golden decode tests were not exercised; their
unit/import tests are covered by the full workspace `nextest` run above.
No RTF/timing numbers from this run are performance claims -- these tests
ran on a shared machine with other work in progress and only assert
correctness.

## Manual smoke checks

None beyond the real-pack golden decode tests above.

## Docs updated

- [x] No behavior/capability documentation changes needed; this only changes
      an internal CPU thread-count heuristic, not user-facing behavior.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No performance/RTF numbers are claimed in this PR; the golden decode runs
  above are correctness checks only.
- No changes to `docs/model-audits/`.
- No changes to the shared threading-tier mechanism itself
  (`GgmlCpuGraphThreadingWorkload`, `resolve_runtime_thread_count_for`) --
  only qwen's graph runners are wired into the existing mechanism, matching
  firered-aed's precedent.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implementation and this PR description were drafted with AI assistance.
