### PR TITLE
perf(moss-td): resident runtime cache, CI-safe test coverage, reference dumper

### DIFF
--- a/crates/openasr-core/src/models/moss_transcribe_diarize/encoder_graph.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/encoder_graph.rs
@@ -242,28 +242,36 @@ pub(crate) fn load_moss_encoder_weights_from_reader(
     })
 }
 
-/// Owns the encoder's graph runner plus the optional zero-copy weight
-/// context; both are expensive to rebuild per chunk (the loaded-weight
-/// context mmaps the whole pack), so callers build one runtime and call
-/// [`Self::encode`] once per 30s chunk. Mirrors
-/// `qwen::audio_encoder::Qwen3AsrAudioEncoderRuntime`.
+/// Owns the encoder's graph runner, the optional zero-copy weight context,
+/// and the fully-loaded [`MossEncoderWeights`]; all three are expensive to
+/// rebuild per chunk (the loaded-weight context mmaps the whole pack, and
+/// loading the weights reads every small tensor off disk), so callers build
+/// one runtime (typically via the thread-local resident cache in
+/// `executor.rs`, mirroring `firered_aed::executor`'s
+/// `FireRedEncoderGraphRuntime`) and call [`Self::encode`] once per 30s
+/// chunk. Mirrors `qwen::audio_encoder::Qwen3AsrAudioEncoderRuntime`.
 pub(crate) struct MossEncoderRuntime {
     runner: GgmlCpuGraphRunner,
     loaded: Option<GgmlLoadedWeightContext>,
+    weights: MossEncoderWeights,
 }
 
 impl MossEncoderRuntime {
     pub(crate) fn new(
-        graph_config: GgmlCpuGraphConfig,
-        runtime_path: Option<&Path>,
+        runtime_path: &Path,
+        config: MossEncoderConfig,
     ) -> Result<Self, MossEncoderError> {
+        let graph_config = super::graph_config::moss_td_encoder_graph_config();
         let runner = GgmlCpuGraphRunner::new(graph_config)
             .map_err(|source| map_graph_error("runner_init", source))?;
-        // `None` (no path) only happens off the production executor path; the
-        // only real caller (`executor.rs`) always resolves a concrete pack
-        // path through preflight first.
-        let loaded = runtime_path.and_then(|path| runner.load_gguf_weight_context(path).ok());
-        Ok(Self { runner, loaded })
+        let loaded = runner.load_gguf_weight_context(runtime_path).ok();
+        let reader = GgufTensorDataReader::from_path(runtime_path)?;
+        let weights = load_moss_encoder_weights_from_reader(&reader, config)?;
+        Ok(Self {
+            runner,
+            loaded,
+            weights,
+        })
     }
 
     /// Run one 30s-chunk forward pass: `mel` is `[n_mels, mel_frames]`
@@ -277,11 +285,11 @@ impl MossEncoderRuntime {
     /// d_model` values.
     pub(crate) fn encode(
         &mut self,
-        weights: &MossEncoderWeights,
         config: MossEncoderConfig,
         mel: &[f32],
         mel_frames: usize,
     ) -> Result<Vec<f32>, MossEncoderError> {
+        let weights = &self.weights;
         let expected_mel_len = config.n_mels * mel_frames;
         if mel.len() != expected_mel_len {
             return Err(MossEncoderError::InvalidMelInputLength {

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -19,10 +19,14 @@
 
 #![allow(dead_code)]
 
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+
 use thiserror::Error;
 
 use crate::NativeAsrError;
 use crate::api::backend::Transcription;
+use crate::ggml_runtime::GgmlCpuGraphBackend;
 use crate::models::decode_policy_component_registry::{
     BuiltinDecodePolicyComponentRegistryError, BuiltinSeq2SeqDecodePolicyConfigInput,
     run_builtin_seq2seq_decode_policy,
@@ -40,19 +44,21 @@ use crate::models::seq2seq_greedy_decode::{
     Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeStepExecutor, Seq2SeqGreedyDecodeStepInput,
     Seq2SeqGreedyDecodeStepLogitsOutput,
 };
+use crate::models::thread_local_runtime_cache::{
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
+    with_thread_local_cached_mut_by_key,
+};
 use crate::models::whisper::whisper_log_mel_spectrogram_16khz_mono_v0;
 
 use super::adaptor_graph::{load_moss_adaptor_weights_from_reader, run_moss_adaptor};
 use super::decode_prompt::build_moss_td_decode_prompt;
-use super::encoder_graph::{
-    MossEncoderConfig, MossEncoderRuntime, load_moss_encoder_weights_from_reader,
-};
-use super::graph_config::moss_td_encoder_graph_config;
+use super::encoder_graph::{MossEncoderConfig, MossEncoderRuntime};
+use super::graph_config::{moss_td_encoder_graph_config, moss_td_runtime_graph_config};
 use super::llm_decoder::MossTdDecoderRuntime;
 use super::prompt_embedding::build_moss_td_prompt_embeddings_with_audio_splice;
 use super::runtime_contract::{
-    MOSS_TD_ADAPTOR_NORM_EPSILON, moss_td_kv_cache_positions, parse_adaptor_metadata,
-    parse_decoder_metadata, parse_encoder_metadata,
+    MOSS_TD_ADAPTOR_NORM_EPSILON, MossTdDecoderMetadata, moss_td_kv_cache_positions,
+    parse_adaptor_metadata, parse_decoder_metadata, parse_encoder_metadata,
 };
 use super::tokenizer::MossTdTokenizer;
 
@@ -177,6 +183,358 @@ impl Seq2SeqGreedyDecodeStepExecutor for MossTdGreedyStepExecutor<'_> {
     }
 }
 
+/// Thread-local resident cache for the family's two heavy per-pack runtimes
+/// (the Whisper-Medium-style [`MossEncoderRuntime`] and the Qwen3
+/// [`MossTdDecoderRuntime`]), keyed by `(canonical pack path, resolved
+/// backend)`. Mirrors `firered_aed::executor`'s
+/// `FIRERED_AED_ENCODER_RUNTIME_BY_KEY`/`FIRERED_AED_DECODER_RUNTIME_BY_KEY`
+/// exactly -- same shared `BoundedRuntimeCache` + `with_thread_local_cached_mut_by_key`
+/// machinery, same key shape, same lazy idle-unload-generation eviction. Before
+/// this, every `execute()` rebuilt both runtimes from scratch: re-mmapped the
+/// pack, re-read every encoder tensor off disk, and re-uploaded every decoder
+/// layer's weights, on every single call (including every chunk of the same
+/// longform request).
+type MossTdEncoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+type MossTdDecoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+
+thread_local! {
+    static MOSS_TD_ENCODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<MossTdEncoderRuntimeCacheKey, MossEncoderRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
+    static MOSS_TD_DECODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<MossTdDecoderRuntimeCacheKey, MossTdDecoderRuntime>> =
+        RefCell::new(BoundedRuntimeCache::new());
+}
+
+// Test-only build counters, incremented from inside the two caches' `build`
+// closures below -- lets a same-thread test pin "a second call reuses the
+// cached runtime" as a structural fact (build count stays 1 across two
+// calls) rather than inferring cache-hit behavior from wall-clock timing.
+#[cfg(test)]
+thread_local! {
+    static MOSS_TD_ENCODER_RUNTIME_BUILD_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static MOSS_TD_DECODER_RUNTIME_BUILD_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn reset_moss_td_runtime_build_counts_for_test() {
+    MOSS_TD_ENCODER_RUNTIME_BUILD_COUNT.with(|count| count.set(0));
+    MOSS_TD_DECODER_RUNTIME_BUILD_COUNT.with(|count| count.set(0));
+}
+
+/// `(encoder builds, decoder builds)` recorded on the calling thread since
+/// the last [`reset_moss_td_runtime_build_counts_for_test`].
+#[cfg(test)]
+fn moss_td_runtime_build_counts_for_test() -> (usize, usize) {
+    (
+        MOSS_TD_ENCODER_RUNTIME_BUILD_COUNT.with(std::cell::Cell::get),
+        MOSS_TD_DECODER_RUNTIME_BUILD_COUNT.with(std::cell::Cell::get),
+    )
+}
+
+/// Upstream `_compute_audio_token_length`'s per-chunk audio-token count: how
+/// many post-merge adaptor tokens one Whisper-encoder chunk of `chunk_samples`
+/// raw 16kHz samples produces, given `token_stride` (`hop_length` * the
+/// Whisper conv stem's 2x stride * the adaptor's merge size). Pure integer
+/// arithmetic with no model-pack dependency -- factored out of the encode
+/// loop below so the slice-planning math can be pinned by a weight-free unit
+/// test (`moss_td_chunk_frame_math_tests`) that runs in every default
+/// `cargo nextest run`, unlike the family's real end-to-end `golden_diff_*`
+/// tests, which need the private dev-only fp16 pack and stay `#[ignore]`d
+/// (same artifact-policy constraint every other builtin family's CI golden
+/// coverage works around -- see e.g. firered-aed's weight-free frontend
+/// golden).
+fn moss_td_chunk_token_length(chunk_samples: usize, token_stride: usize) -> usize {
+    (chunk_samples - 1) / token_stride.max(1) + 1
+}
+
+/// This chunk's post-merge encoder frames actually kept: `token_length` audio
+/// tokens each span `merge_size` pre-merge encoder frames, capped at the
+/// encoder's `max_source_positions` (a full un-trimmed 30s chunk can never
+/// legitimately need more than that many frames kept).
+fn moss_td_chunk_keep_frames(
+    token_length: usize,
+    merge_size: usize,
+    max_source_positions: usize,
+) -> usize {
+    (token_length * merge_size).min(max_source_positions)
+}
+
+/// Upstream's `time_merge` truncation: the total kept frames across every
+/// chunk, rounded down to the nearest full `merge_size` group. In practice
+/// every chunk's `moss_td_chunk_keep_frames` result is already a multiple of
+/// `merge_size` (either `token_length * merge_size` directly, or the
+/// `max_source_positions` cap, which is itself merge-size-aligned for every
+/// real checkpoint), so summing them keeps the running total aligned too --
+/// this is a no-op guard against that invariant, not a silent frame drop.
+fn moss_td_aligned_frame_count(total_frames: usize, merge_size: usize) -> usize {
+    let merge_size = merge_size.max(1);
+    (total_frames / merge_size) * merge_size
+}
+
+/// Weight-free, always-on coverage for the executor's chunk/slice-planning
+/// arithmetic: pure integer math with no model pack involved, so (unlike the
+/// family's `golden_diff_*` end-to-end tests below, which need the private
+/// dev-only fp16 pack and stay `#[ignore]`d) these run in every default
+/// `cargo nextest run --workspace`. Constants are pinned against the real
+/// checkpoint's shape (`runtime_contract::tests::parses_adaptor_metadata_matching_real_checkpoint`'s
+/// `merge_size == 4`, `package_import`'s `audio_merge_size: 4`, and
+/// `parses_encoder_metadata_matching_real_checkpoint`'s
+/// `max_source_positions == 1500` -- the standard Whisper-Medium 30s ->
+/// 1500-frame shape).
+#[cfg(test)]
+mod moss_td_chunk_frame_math_tests {
+    use super::*;
+
+    const MERGE_SIZE: usize = 4;
+    const MAX_SOURCE_POSITIONS: usize = 1500;
+    const TOKEN_STRIDE: usize = HOP_LENGTH * WHISPER_ENCODER_CONV_STRIDE * MERGE_SIZE;
+
+    #[test]
+    fn token_stride_matches_the_real_checkpoints_merge_size() {
+        assert_eq!(TOKEN_STRIDE, 1_280);
+    }
+
+    #[test]
+    fn short_clip_single_partial_chunk_keeps_the_expected_frame_count() {
+        // A ~10s clip (jfk.wav-shaped): one partial 30s chunk, well under
+        // `CHUNK_SAMPLES`, never hits the `max_source_positions` cap.
+        let chunk_samples = 160_000; // 10s @ 16kHz
+        let token_length = moss_td_chunk_token_length(chunk_samples, TOKEN_STRIDE);
+        assert_eq!(token_length, 125);
+        let keep_frames = moss_td_chunk_keep_frames(token_length, MERGE_SIZE, MAX_SOURCE_POSITIONS);
+        assert_eq!(keep_frames, 500);
+    }
+
+    #[test]
+    fn full_chunk_saturates_max_source_positions_without_truncating() {
+        // A full un-trimmed 30s chunk (`CHUNK_SAMPLES`) always keeps exactly
+        // `max_source_positions` frames -- the encoder always outputs that
+        // many for a full chunk, so the `.min()` cap lands exactly on it
+        // rather than truncating away real content.
+        let token_length = moss_td_chunk_token_length(CHUNK_SAMPLES, TOKEN_STRIDE);
+        assert_eq!(token_length, 375);
+        let keep_frames = moss_td_chunk_keep_frames(token_length, MERGE_SIZE, MAX_SOURCE_POSITIONS);
+        assert_eq!(keep_frames, MAX_SOURCE_POSITIONS);
+    }
+
+    #[test]
+    fn multi_chunk_long_file_sums_every_chunks_kept_frames() {
+        // A ~76s file (longform-shaped, like the other builtin families'
+        // committed `fixtures/longform_en_zh.wav` golden): splits into three
+        // `CHUNK_SAMPLES`-bounded chunks -- two full 30s chunks plus a ~16s
+        // tail -- exercising the same multi-chunk accumulation the
+        // executor's real encode loop runs across every chunk of a longform
+        // request, all the way through the final merge-size-alignment
+        // truncation, without needing a real pack/weights.
+        let chunk_lens = [CHUNK_SAMPLES, CHUNK_SAMPLES, 256_000];
+        let mut total_frames = 0usize;
+        for &chunk_samples in &chunk_lens {
+            let token_length = moss_td_chunk_token_length(chunk_samples, TOKEN_STRIDE);
+            total_frames +=
+                moss_td_chunk_keep_frames(token_length, MERGE_SIZE, MAX_SOURCE_POSITIONS);
+        }
+        assert_eq!(total_frames, 1_500 + 1_500 + 800);
+        // Every chunk's kept-frame count is already a multiple of
+        // `MERGE_SIZE`, so the running total across all three chunks stays
+        // aligned and the final truncation is a no-op (see
+        // `moss_td_aligned_frame_count`'s doc comment).
+        assert_eq!(
+            moss_td_aligned_frame_count(total_frames, MERGE_SIZE),
+            total_frames
+        );
+    }
+
+    #[test]
+    fn aligned_frame_count_truncates_a_synthetic_misaligned_total() {
+        // Real per-chunk totals are always already merge-size-aligned (see
+        // the test above), so this never fires in production -- but the
+        // truncation function itself must still behave correctly as
+        // defense-in-depth if that invariant is ever violated by a future
+        // change.
+        assert_eq!(moss_td_aligned_frame_count(3_803, MERGE_SIZE), 3_800);
+        assert_eq!(moss_td_aligned_frame_count(3_800, MERGE_SIZE), 3_800);
+    }
+}
+
+/// Encodes every 30s chunk of `samples` against the cached, resident encoder
+/// runtime for this pack+backend, returning the concatenated (already
+/// merge-size-aligned) encoder rows and the number of kept frames -- the same
+/// computation the executor's per-chunk loop always did, just routed through
+/// the shared resident-runtime cache instead of building a fresh
+/// [`MossEncoderRuntime`] (and re-reading every encoder tensor from disk) on
+/// every call.
+fn encode_moss_td_chunks_with_cached_runtime(
+    runtime_path: &Path,
+    encoder_config: MossEncoderConfig,
+    merge_size: usize,
+    samples: &[f32],
+) -> Result<(Vec<f32>, usize), MossTdExecutorError> {
+    let key = (
+        canonical_runtime_cache_path(runtime_path),
+        moss_td_encoder_graph_config().backend,
+    );
+    // Upstream `_compute_audio_token_length`'s stride: hop_length * the
+    // Whisper conv stem's 2x stride * audio_merge_size.
+    let token_stride = HOP_LENGTH * WHISPER_ENCODER_CONV_STRIDE * merge_size;
+    with_thread_local_cached_mut_by_key(
+        &MOSS_TD_ENCODER_RUNTIME_BY_KEY,
+        key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
+        || {
+            #[cfg(test)]
+            MOSS_TD_ENCODER_RUNTIME_BUILD_COUNT.with(|count| count.set(count.get() + 1));
+            MossEncoderRuntime::new(runtime_path, encoder_config).map_err(|error| {
+                MossTdExecutorError::EncoderFailed {
+                    reason: format!("could not initialize encoder runtime: {error}"),
+                }
+            })
+        },
+        |runtime| {
+            let mut concatenated_rows: Vec<f32> = Vec::new();
+            let mut total_frames = 0usize;
+            for chunk in samples.chunks(CHUNK_SAMPLES) {
+                let mel = whisper_log_mel_spectrogram_16khz_mono_v0(
+                    chunk,
+                    encoder_config.n_mels,
+                    MEL_TARGET_FRAMES,
+                )
+                .map_err(|error| MossTdExecutorError::FrontendFailed {
+                    reason: error.to_string(),
+                })?;
+                let encoder_out = runtime
+                    .encode(encoder_config, mel.data(), MEL_TARGET_FRAMES)
+                    .map_err(|error| MossTdExecutorError::EncoderFailed {
+                        reason: error.to_string(),
+                    })?;
+                let token_length = moss_td_chunk_token_length(chunk.len(), token_stride);
+                let keep_frames = moss_td_chunk_keep_frames(
+                    token_length,
+                    merge_size,
+                    encoder_config.max_source_positions,
+                );
+                let keep_values = keep_frames * encoder_config.d_model;
+                concatenated_rows.extend_from_slice(&encoder_out[..keep_values]);
+                total_frames += keep_frames;
+            }
+            Ok((concatenated_rows, total_frames))
+        },
+    )
+}
+
+/// Runs the ChatML+audio-splice prompt embedding through the cached, resident
+/// decoder runtime for this pack+backend: prefill, then the shared greedy
+/// decode driver through to `<|im_end|>` (or the fail-closed token budget),
+/// returning the trimmed decode text. Mirrors `firered_aed::executor`'s
+/// `decode_with_cached_runtime`: the runtime (loaded weights + the Qwen
+/// decode graph's reuse machinery) stays resident across calls, while every
+/// per-utterance KV cache is still allocated fresh right here
+/// (`MossTdDecoderRuntime::new_kv_caches`) -- unlike firered-aed's decoder,
+/// this family's `MossTdDecoderRuntime` carries no cross-request KV state of
+/// its own between calls, so no cache-reset step is needed before reuse.
+fn run_moss_td_decoder_with_cached_runtime(
+    runtime_path: &Path,
+    decoder_metadata: MossTdDecoderMetadata,
+    decode_prompt_token_ids: &[u32],
+    audio_pad_positions: &[usize],
+    audio_rows: &[f32],
+    tokenizer: &MossTdTokenizer,
+) -> Result<String, MossTdExecutorError> {
+    let key = (
+        canonical_runtime_cache_path(runtime_path),
+        moss_td_runtime_graph_config().backend,
+    );
+    with_thread_local_cached_mut_by_key(
+        &MOSS_TD_DECODER_RUNTIME_BY_KEY,
+        key,
+        DEFAULT_RUNTIME_CACHE_CAPACITY,
+        || {
+            #[cfg(test)]
+            MOSS_TD_DECODER_RUNTIME_BUILD_COUNT.with(|count| count.set(count.get() + 1));
+            MossTdDecoderRuntime::new(runtime_path, decoder_metadata).map_err(|error| {
+                MossTdExecutorError::DecoderFailed {
+                    reason: error.to_string(),
+                }
+            })
+        },
+        |decoder| {
+            if std::env::var_os("OPENASR_MOSS_TD_PROFILE").is_some() {
+                eprintln!(
+                    "OPENASR_MOSS_TD_PROFILE decoder_backend={}",
+                    decoder.backend_label()
+                );
+            }
+
+            let token_rows_len = decode_prompt_token_ids.len() * decoder_metadata.d_model;
+            let mut token_rows = Vec::with_capacity(token_rows_len);
+            for &token_id in decode_prompt_token_ids {
+                let row = decoder.gather_token_embedding(token_id).map_err(|error| {
+                    MossTdExecutorError::DecoderFailed {
+                        reason: error.to_string(),
+                    }
+                })?;
+                token_rows.extend_from_slice(&row);
+            }
+            let spliced = build_moss_td_prompt_embeddings_with_audio_splice(
+                decode_prompt_token_ids.len(),
+                audio_pad_positions,
+                decoder_metadata.d_model,
+                &token_rows,
+                audio_rows,
+            )
+            .map_err(|error| MossTdExecutorError::PromptEmbeddingFailed {
+                reason: error.to_string(),
+            })?;
+            let prompt_embeddings = Qwen3AsrPromptEmbeddings {
+                hidden_size: spliced.hidden_size,
+                token_count: spliced.token_count,
+                token_major_values: spliced.token_major_values,
+            };
+
+            let layer_kv_caches = decoder.new_kv_caches();
+            let mut step_executor = MossTdGreedyStepExecutor {
+                decoder,
+                layer_kv_caches,
+                prompt_embeddings: Some(prompt_embeddings),
+                cache_prompt_tokens: 0,
+            };
+            let config = BuiltinSeq2SeqDecodePolicyConfigInput {
+                initial_prompt_tokens: decode_prompt_token_ids.to_vec(),
+                eot_token_id: tokenizer.im_end_token_id,
+                vocab_size: decoder_metadata.vocab_size,
+                max_generated_tokens: MOSS_TD_MAX_GENERATED_TOKENS,
+            };
+            let result = run_builtin_seq2seq_decode_policy(
+                crate::arch::MOSS_TD_DECODE_POLICY_ID,
+                &config,
+                tokenizer,
+                None,
+                &mut step_executor,
+                &|token_ids: &[u32]| {
+                    tokenizer.decode_text_token_ids(token_ids).map_err(|error| {
+                        Seq2SeqGreedyDecodeError::TokenizerDecodeFailed {
+                            reason: error.to_string(),
+                        }
+                    })
+                },
+                |error: Seq2SeqGreedyDecodeError| error,
+                |error: Seq2SeqGreedyDecodeError| error,
+                map_registry_error,
+            );
+            // Release this request's per-token grow-to-fit host buffer before
+            // the runtime goes back into the cache (mirrors qwen3-asr's
+            // `ggml_executor`'s `release_session_scoped_buffers` call around
+            // its own resident whole-decoder cache) -- unconditionally, on
+            // both the success and failure paths, so a failed decode never
+            // leaves a session-scoped allocation riding along on the cached
+            // runtime.
+            step_executor.decoder.release_session_scoped_buffers();
+            let result = result.map_err(|error| MossTdExecutorError::GreedyDecodeFailed {
+                reason: error.to_string(),
+            })?;
+            Ok(result.text.trim().to_string())
+        },
+    )
+}
+
 impl MossTdGgmlExecutor {
     fn execute_inner(
         &self,
@@ -234,10 +592,6 @@ impl MossTdGgmlExecutor {
             n_mels: encoder_metadata.n_mels,
             max_source_positions: encoder_metadata.max_source_positions,
         };
-        let encoder_weights = load_moss_encoder_weights_from_reader(&reader, encoder_config)
-            .map_err(|error| MossTdExecutorError::EncoderFailed {
-                reason: error.to_string(),
-            })?;
         let adaptor_weights = load_moss_adaptor_weights_from_reader(
             &reader,
             encoder_metadata.d_model,
@@ -249,55 +603,18 @@ impl MossTdGgmlExecutor {
             reason: error.to_string(),
         })?;
 
-        // Upstream `_compute_audio_token_length`'s stride: hop_length * the
-        // Whisper conv stem's 2x stride * audio_merge_size.
-        let token_stride = HOP_LENGTH * WHISPER_ENCODER_CONV_STRIDE * adaptor_metadata.merge_size;
-        // Built once and reused across every chunk in the loop below: the
-        // loaded-weight context mmaps the whole pack once, and the six 2D
-        // projection weights per layer bind zero-copy from it on every
-        // `encode()` call (see `encoder_graph`'s module doc).
-        let mut encoder_runtime = MossEncoderRuntime::new(
-            moss_td_encoder_graph_config(),
-            Some(preflight.runtime_source.path()),
-        )
-        .map_err(|error| MossTdExecutorError::EncoderFailed {
-            reason: format!("could not initialize encoder runtime: {error}"),
-        })?;
-
-        let mut concatenated_rows: Vec<f32> = Vec::new();
-        let mut total_frames = 0usize;
-        for chunk in samples.chunks(CHUNK_SAMPLES) {
-            let mel = whisper_log_mel_spectrogram_16khz_mono_v0(
-                chunk,
-                encoder_metadata.n_mels,
-                MEL_TARGET_FRAMES,
-            )
-            .map_err(|error| MossTdExecutorError::FrontendFailed {
-                reason: error.to_string(),
-            })?;
-            let encoder_out = encoder_runtime
-                .encode(
-                    &encoder_weights,
-                    encoder_config,
-                    mel.data(),
-                    MEL_TARGET_FRAMES,
-                )
-                .map_err(|error| MossTdExecutorError::EncoderFailed {
-                    reason: error.to_string(),
-                })?;
-            let token_length = (chunk.len() - 1) / token_stride.max(1) + 1;
-            let keep_frames = (token_length * adaptor_metadata.merge_size)
-                .min(encoder_metadata.max_source_positions);
-            let keep_values = keep_frames * encoder_metadata.d_model;
-            concatenated_rows.extend_from_slice(&encoder_out[..keep_values]);
-            total_frames += keep_frames;
-        }
-        // Upstream's `time_merge` truncates any remainder below a full
-        // merge-size group; concatenating already-merge-size-aligned
-        // per-chunk lengths (see above) means the total is already aligned,
-        // so this is a no-op guard, not a silent frame drop.
-        let aligned_frames =
-            (total_frames / adaptor_metadata.merge_size) * adaptor_metadata.merge_size;
+        // Routed through the resident, thread-local encoder-runtime cache
+        // (mirrors `firered_aed::executor`'s cached encoder): the loaded
+        // weights + mmap'd zero-copy context stay resident across calls to
+        // this pack+backend instead of being rebuilt from scratch on every
+        // `execute()`.
+        let (mut concatenated_rows, total_frames) = encode_moss_td_chunks_with_cached_runtime(
+            preflight.runtime_source.path(),
+            encoder_config,
+            adaptor_metadata.merge_size,
+            samples,
+        )?;
+        let aligned_frames = moss_td_aligned_frame_count(total_frames, adaptor_metadata.merge_size);
         concatenated_rows.truncate(aligned_frames * encoder_metadata.d_model);
 
         let (audio_rows, audio_token_count) = run_moss_adaptor(
@@ -338,81 +655,20 @@ impl MossTdGgmlExecutor {
             });
         }
 
+        // Routed through the resident, thread-local decoder-runtime cache
+        // (mirrors `firered_aed::executor`'s cached decoder): the loaded
+        // decoder weights + reuse-graph machinery stay resident across calls
+        // to this pack+backend, while the KV cache for this one utterance is
+        // still allocated fresh inside the helper.
         let runtime_path = preflight.runtime_source.path();
-        let mut decoder =
-            MossTdDecoderRuntime::new(runtime_path, decoder_metadata).map_err(|error| {
-                MossTdExecutorError::DecoderFailed {
-                    reason: error.to_string(),
-                }
-            })?;
-        if std::env::var_os("OPENASR_MOSS_TD_PROFILE").is_some() {
-            eprintln!(
-                "OPENASR_MOSS_TD_PROFILE decoder_backend={}",
-                decoder.backend_label()
-            );
-        }
-
-        let token_rows_len = decode_prompt.token_ids.len() * decoder_metadata.d_model;
-        let mut token_rows = Vec::with_capacity(token_rows_len);
-        for &token_id in &decode_prompt.token_ids {
-            let row = decoder.gather_token_embedding(token_id).map_err(|error| {
-                MossTdExecutorError::DecoderFailed {
-                    reason: error.to_string(),
-                }
-            })?;
-            token_rows.extend_from_slice(&row);
-        }
-        let spliced = build_moss_td_prompt_embeddings_with_audio_splice(
-            decode_prompt.token_ids.len(),
+        let text = run_moss_td_decoder_with_cached_runtime(
+            runtime_path,
+            decoder_metadata,
+            &decode_prompt.token_ids,
             &decode_prompt.audio_pad_positions,
-            decoder_metadata.d_model,
-            &token_rows,
             &audio_rows,
-        )
-        .map_err(|error| MossTdExecutorError::PromptEmbeddingFailed {
-            reason: error.to_string(),
-        })?;
-        let prompt_embeddings = Qwen3AsrPromptEmbeddings {
-            hidden_size: spliced.hidden_size,
-            token_count: spliced.token_count,
-            token_major_values: spliced.token_major_values,
-        };
-
-        let layer_kv_caches = decoder.new_kv_caches();
-        let mut step_executor = MossTdGreedyStepExecutor {
-            decoder: &mut decoder,
-            layer_kv_caches,
-            prompt_embeddings: Some(prompt_embeddings),
-            cache_prompt_tokens: 0,
-        };
-        let config = BuiltinSeq2SeqDecodePolicyConfigInput {
-            initial_prompt_tokens: decode_prompt.token_ids.clone(),
-            eot_token_id: tokenizer.im_end_token_id,
-            vocab_size: decoder_metadata.vocab_size,
-            max_generated_tokens: MOSS_TD_MAX_GENERATED_TOKENS,
-        };
-        let result = run_builtin_seq2seq_decode_policy(
-            crate::arch::MOSS_TD_DECODE_POLICY_ID,
-            &config,
             &tokenizer,
-            None,
-            &mut step_executor,
-            &|token_ids: &[u32]| {
-                tokenizer.decode_text_token_ids(token_ids).map_err(|error| {
-                    Seq2SeqGreedyDecodeError::TokenizerDecodeFailed {
-                        reason: error.to_string(),
-                    }
-                })
-            },
-            |error: Seq2SeqGreedyDecodeError| error,
-            |error: Seq2SeqGreedyDecodeError| error,
-            map_registry_error,
-        )
-        .map_err(|error| MossTdExecutorError::GreedyDecodeFailed {
-            reason: error.to_string(),
-        })?;
-
-        let text = result.text.trim().to_string();
+        )?;
         // Parse the model's own inline `[start][end][SNN]` markup into real
         // speaker segments, degrading fail-closed to the single speaker-less
         // segment carrying the untouched raw text when the tag stream is
@@ -748,6 +1004,50 @@ mod tests {
         assert_eq!(text, GOLDEN_JFK_TEXT);
     }
 
+    /// Pins the resident-runtime cache's two contracts introduced by this
+    /// PR: (1) a second `execute()` on the same thread against the same pack
+    /// reuses both the cached encoder and decoder runtimes rather than
+    /// rebuilding them (asserted structurally via the build counters, not by
+    /// timing -- see `moss_td_runtime_build_counts_for_test`'s doc comment),
+    /// and (2) reuse changes nothing observable: the second call's transcript
+    /// is byte-for-byte identical to the first (and to `GOLDEN_JFK_TEXT`).
+    #[test]
+    #[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack \
+                and tmp/moss-td/samples/*.wav; CPU-only (Metal path has known defects)"]
+    fn resident_runtime_cache_hits_on_a_second_transcribe_call_for_the_same_pack() {
+        reset_moss_td_runtime_build_counts_for_test();
+        let Some((first_text, _, _)) = transcribe_with_dev_pack(dev_sample_path("jfk.wav")) else {
+            return;
+        };
+        assert_eq!(first_text, GOLDEN_JFK_TEXT);
+        let (encoder_builds, decoder_builds) = moss_td_runtime_build_counts_for_test();
+        assert_eq!(
+            encoder_builds, 1,
+            "first call must build the encoder runtime exactly once"
+        );
+        assert_eq!(
+            decoder_builds, 1,
+            "first call must build the decoder runtime exactly once"
+        );
+
+        let Some((second_text, _, _)) = transcribe_with_dev_pack(dev_sample_path("jfk.wav")) else {
+            return;
+        };
+        assert_eq!(
+            second_text, first_text,
+            "reusing the cached runtimes must not change the decode"
+        );
+        let (encoder_builds, decoder_builds) = moss_td_runtime_build_counts_for_test();
+        assert_eq!(
+            encoder_builds, 1,
+            "second call must hit the cached encoder runtime, not rebuild it"
+        );
+        assert_eq!(
+            decoder_builds, 1,
+            "second call must hit the cached decoder runtime, not rebuild it"
+        );
+    }
+
     #[test]
     #[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack \
                 and tmp/moss-td/samples/*.wav; CPU-only (Metal path has known defects)"]
@@ -856,6 +1156,70 @@ mod tests {
                     4.96,
                     12.88,
                     "今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去伊加新"
+                ),
+            ]
+        );
+    }
+
+    /// Synthetic (not a real decode) multi-chunk-duration transcript: every
+    /// anchor above sits well inside `executor.rs`'s first 30s encoder chunk
+    /// (`CHUNK_SAMPLES`), so `snapshot_jfk_and_en_zh_mixed_golden_speaker_segments`
+    /// never exercises `speaker_segments` against text spanning more than one
+    /// chunk's worth of audio duration. This transcript's anchors straddle
+    /// two `CHUNK_SAMPLES` boundaries (30s and 60s) across three speaker
+    /// turns and a language switch, covering the shape a real multi-chunk
+    /// longform decode would produce -- text parsing itself is chunk-count-
+    /// agnostic (it runs once over the final concatenated decode, same as
+    /// for a single-chunk clip), so this is a scale/structure regression
+    /// check on the parser, not a claim that this exact text was ever
+    /// decoded from real audio.
+    const SYNTHETIC_MULTI_CHUNK_TEXT: &str = concat!(
+        "[0.50][S01] Good morning everyone, let's get started.[29.80][31.20][S01] ",
+        "First, a quick recap of last week's numbers.[58.90][61.40][S02] 谢谢，我来补充一下财务方面的情况。",
+        "[92.15][93.00][S01] Great, let's move to questions then.[110.75]",
+    );
+
+    #[test]
+    fn synthetic_multi_chunk_duration_transcript_parses_into_structured_segments() {
+        let segments = parse_moss_td_speaker_segments(SYNTHETIC_MULTI_CHUNK_TEXT, 110.75)
+            .expect("synthetic multi-chunk transcript parses");
+        let snapshot: Vec<(&str, f32, f32, &str)> = segments
+            .iter()
+            .map(|segment| {
+                (
+                    segment.speaker.as_deref().unwrap_or(""),
+                    segment.start,
+                    segment.end,
+                    segment.text.as_str(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            snapshot,
+            vec![
+                (
+                    "SPEAKER_01",
+                    0.50,
+                    29.80,
+                    "Good morning everyone, let's get started."
+                ),
+                (
+                    "SPEAKER_01",
+                    31.20,
+                    58.90,
+                    "First, a quick recap of last week's numbers."
+                ),
+                (
+                    "SPEAKER_02",
+                    61.40,
+                    92.15,
+                    "谢谢，我来补充一下财务方面的情况。"
+                ),
+                (
+                    "SPEAKER_01",
+                    93.00,
+                    110.75,
+                    "Great, let's move to questions then."
                 ),
             ]
         );

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -160,6 +160,17 @@ impl MossTdDecoderRuntime {
         self.whole_decoder.backend_label()
     }
 
+    /// Frees this decoder's per-token grow-to-fit host step buffer. Call
+    /// after every decode, right before this runtime goes back into
+    /// `executor.rs`'s thread-local resident cache -- without it, a session-
+    /// scoped allocation sized for one utterance would otherwise ride along
+    /// on the cached runtime into the next, unrelated request. Mirrors
+    /// `qwen::ggml_executor`'s identical call around its own resident
+    /// whole-decoder cache.
+    pub(crate) fn release_session_scoped_buffers(&mut self) {
+        self.whole_decoder.release_session_scoped_buffers();
+    }
+
     pub(crate) fn new_kv_caches(&self) -> Vec<Qwen3AsrLayerKvCacheState> {
         // Clamp the RoPE context limit (`max_positions`, up to 131072) down to
         // the KV-cache preallocation cap: `Qwen3AsrLayerKvCacheState::new`

--- a/tooling/moss-reference-dumper/README.md
+++ b/tooling/moss-reference-dumper/README.md
@@ -1,0 +1,159 @@
+# moss-transcribe-diarize reference dumper
+
+Runs the **official** OpenMOSS/MOSS-Transcribe-Diarize python reference
+implementation on real fixture wavs and dumps its output, so the ggml side
+(`crates/openasr-core/src/models/moss_transcribe_diarize/`) can be diffed
+against ground truth. Two scripts:
+
+- `dump_golden.py`: full greedy `model.generate()` -> golden transcript JSON
+  (token ids, decoded text, parsed speaker/timestamp segments). This is the
+  process that produced `tmp/moss-td/golden/*.json` and, transcribed from
+  those, the `GOLDEN_JFK_TEXT` / `GOLDEN_EN_ZH_MIXED_TEXT` constants pinned
+  in `executor.rs`'s `#[ignore]`d `golden_diff_end_to_end_transcribe_*` tests
+  -- this script makes that generation reproducible in-tree instead of
+  leaving it as an untracked one-off.
+- `dump_intermediate.py`: single-clip stage-by-stage activation dump
+  (Whisper-Medium encoder output, post-time-merge features, VQAdaptor
+  output, first prefill-step logits) as `.npy` files, for diffing individual
+  ggml execution stages against the reference forward pass.
+
+Both are this family's "reference dumper" required by
+[`docs/model-audits/TEMPLATE.md`](../../docs/model-audits/TEMPLATE.md)
+section 10 ("Reference dumper exists for this family").
+
+Nothing here is vendored into the repo: no third-party code, no weights, no
+dump output. All of that lives outside the tracked tree (see below).
+
+## Official reference source (do not vendor -- clone locally)
+
+- Code: <https://github.com/OpenMOSS/MOSS-Transcribe-Diarize>, pinned commit
+  `40cf8549c6b5634ba36b7e817cf523b5ad400c2e` (2026-07-20). Clone it yourself:
+
+  ```bash
+  git clone https://github.com/OpenMOSS/MOSS-Transcribe-Diarize.git /path/to/moss-td-refcode
+  cd /path/to/moss-td-refcode && git checkout 40cf8549c6b5634ba36b7e817cf523b5ad400c2e
+  ```
+
+  Both scripts only import from this clone for `parse_transcript` /
+  `inference_utils` (`build_transcription_messages`, `prepare_inputs`) --
+  the model/processor code itself loads straight off the checkpoint via
+  `trust_remote_code=True` (the checkpoint ships its own
+  `modeling_moss_transcribe_diarize.py` / `processing_moss_transcribe_diarize.py`,
+  same convention `AutoModelForCausalLM.from_pretrained(...,
+  trust_remote_code=True)` uses for any custom-code HF repo), so no code
+  clone is strictly required just to run the model -- only to reach
+  `parse_transcript`, which lives in the repo's installable package rather
+  than the checkpoint's `trust_remote_code` module set.
+
+- Weights: <https://huggingface.co/OpenMOSS/MOSS-Transcribe-Diarize> (gated;
+  request access on the HF page). Point `--weights-dir` at a local copy laid
+  out exactly like the upstream HF repo:
+
+  ```text
+  <weights-dir>/
+    config.json
+    configuration_moss_transcribe_diarize.py
+    modeling_moss_transcribe_diarize.py
+    processing_moss_transcribe_diarize.py
+    processor_config.json
+    preprocessor_config.json
+    generation_config.json
+    tokenizer_config.json
+    special_tokens_map.json
+    added_tokens.json
+    vocab.json
+    merges.txt
+    tokenizer.json
+    model-00000-of-00001.safetensors   # single shard, ~1.8GB fp32
+    model.safetensors.index.json
+  ```
+
+## Setup
+
+Host python (this repo has no dedicated venv for tooling scripts; these are
+all small pure/wheel packages, matching `firered2-reference-dumper`'s
+convention):
+
+```bash
+python3 -m pip install --user "transformers>=5.0,<6.0" "torch>=2.8" numpy
+```
+
+Verified against `transformers==5.13.0` / `torch==2.12.0`.
+
+## Memory
+
+The whole checkpoint (Whisper-Medium encoder + `VQAdaptor` + Qwen3-0.6B
+decoder, ~1.6B params combined) fits comfortably in fp32 on a 16GB dev
+machine -- well under 4GB resident. Unlike `firered2-reference-dumper`'s
+7B-parameter Qwen2 decoder, this family needs none of that dumper's
+meta-device layer-streaming trick or `vm_stat`-gated wait loop:
+`AutoModelForCausalLM.from_pretrained(..., dtype=torch.float32)` loads the
+whole model directly, so both scripts here have no `--stage` flag or memory
+gate to make that trade-off with.
+
+## `dump_golden.py` usage
+
+```bash
+cd tooling/moss-reference-dumper
+python3 dump_golden.py \
+  --moss-repo /path/to/moss-td-refcode \
+  --weights-dir /path/to/moss-transcribe-diarize-weights \
+  --samples-dir ../../fixtures \
+  --sample jfk=jfk.wav \
+  --out-dir /path/to/scratch/moss-td-golden
+```
+
+`--sample NAME=RELATIVE_WAV_PATH` is repeatable; each path resolves against
+`--samples-dir`. Writes `<out-dir>/<name>.json`, one record per sample, in
+the exact shape the committed golden fixtures were transcribed from: prompt
+token ids, full/generated token ids, decoded text (with and without special
+tokens), elapsed time, environment versions, and `parse_transcript`'s parsed
+`[start, end, speaker, text]` segments.
+
+Greedy (`do_sample=False`), CPU, fp32, seeded (`--seed`, default `0`) for
+determinism -- matches the golden-diff convention every other builtin
+family's dev-only reference dump uses (see e.g.
+`firered2-reference-dumper/dump_reference.py`'s `llm` stage).
+
+## `dump_intermediate.py` usage
+
+```bash
+cd tooling/moss-reference-dumper
+python3 dump_intermediate.py \
+  --moss-repo /path/to/moss-td-refcode \
+  --weights-dir /path/to/moss-transcribe-diarize-weights \
+  --wav ../../fixtures/jfk.wav \
+  --out-dir /path/to/scratch/moss-td-dump
+```
+
+Dumps `input_features.npy`, `whisper_encoder.npy`, `merged.npy`,
+`adaptor.npy`, and `prefill_last_logits.npy` -- see the script's module doc
+for exact shapes and semantics. Only single-chunk (<=30s) wavs are supported
+by this dumper's trim math (it mirrors the executor's single-chunk trim, not
+its multi-chunk concatenation loop); `dump_golden.py`'s full `generate()`
+call already exercises the multi-chunk path correctly via the checkpoint's
+own `get_audio_features`, it just does not expose these intermediate
+per-stage tensors.
+
+## Verified results (2026-07-21, Apple M1 16GB)
+
+- `jfk.wav`, `en_zh_mixed.wav`, and a 3-minute multi-speaker `aishell4`
+  clip all ran end to end through `dump_golden.py`'s predecessor; their
+  outputs are what `GOLDEN_JFK_TEXT` / `GOLDEN_EN_ZH_MIXED_TEXT` in
+  `executor.rs` were transcribed from (see those constants' own doc comments
+  for the exact fp16+flash-vs-fp32 numeric nuance: byte-identical text on
+  `jfk`/`aishell4`, two 0.02s time-anchor shifts on `en_zh_mixed`).
+- Peak RSS during the full pipeline (model load + encoder + adaptor +
+  greedy generate to `<|im_end|>`): well under 4GB, consistent with the
+  "Memory" section above.
+
+## Scope
+
+Neither script here has a self-test: both are thin, mostly-I/O wrappers
+around the official reference stack's own `generate()` / module forward
+calls (unlike `firered2-reference-dumper/dump_reference.py`, which has
+enough standalone arithmetic -- the memory-check parser, the adapter's
+frame-stacking math -- to make a weight-free unit test worthwhile). The
+actual correctness check for this dumper is a real run against the real
+checkpoint, cross-referenced against the ggml runtime's own committed
+`golden_diff_*` tests in `executor.rs`.

--- a/tooling/moss-reference-dumper/dump_golden.py
+++ b/tooling/moss-reference-dumper/dump_golden.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Reference-implementation golden-transcript dumper for moss-transcribe-diarize
+(OpenMOSS/MOSS-Transcribe-Diarize, 0.9B).
+
+Runs the *official* python reference stack (not a reimplementation) --
+`AutoModelForCausalLM.generate()` plus the checkpoint's own `AutoProcessor`
+and `parse_transcript` helper -- on real fixture wavs, greedy/deterministic,
+CPU, fp32, and dumps one JSON record per sample: full generated token ids,
+decoded text, prompt token ids, and parsed speaker/timestamp segments. This
+is the process that produced the committed
+`crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs`
+`GOLDEN_JFK_TEXT` / `GOLDEN_EN_ZH_MIXED_TEXT` fixtures (and the
+`tmp/moss-td/golden/*.json` records those constants were transcribed from) --
+this script makes that generation process reproducible in-tree rather than
+leaving it as an untracked one-off. Satisfies the "Reference dumper exists
+for this family" row in `docs/model-audits/TEMPLATE.md` section 10.
+
+Official reference source (do not vendor -- clone locally)
+------------------------------------------------------------
+Code:    https://github.com/OpenMOSS/MOSS-Transcribe-Diarize
+         pinned commit 40cf8549c6b5634ba36b7e817cf523b5ad400c2e (2026-07-20)
+Weights: https://huggingface.co/OpenMOSS/MOSS-Transcribe-Diarize (gated;
+         request access, then download the standard HF layout: `config.json`,
+         `configuration_moss_transcribe_diarize.py`,
+         `modeling_moss_transcribe_diarize.py`,
+         `processing_moss_transcribe_diarize.py`, `model-*.safetensors`,
+         `model.safetensors.index.json`, `vocab.json`, `merges.txt`,
+         `tokenizer.json`, `added_tokens.json`, `special_tokens_map.json`,
+         `tokenizer_config.json`, `preprocessor_config.json`,
+         `processor_config.json`, `generation_config.json`).
+
+This script does NOT vendor the official repo or any weights into the repo
+(both are third-party; the repo ships its own `modeling_*.py`/
+`processing_*.py` alongside the checkpoint via `trust_remote_code=True`, so
+no separate code clone is even required at *load* time -- `--moss-repo` only
+needs to point at a checkout for its `parse_transcript` helper, which is not
+part of the HF `trust_remote_code` module set).
+
+Setup (host python, matches `tooling/publish-model` / `firered2-reference-
+dumper` convention -- no dedicated venv in this repo):
+
+    python3 -m pip install --user "transformers>=5.0,<6.0" "torch>=2.8" numpy
+
+Usage
+-----
+    cd tooling/moss-reference-dumper
+    python3 dump_golden.py \\
+      --moss-repo /path/to/MOSS-Transcribe-Diarize \\
+      --weights-dir /path/to/moss-transcribe-diarize-weights \\
+      --samples-dir ../../fixtures \\
+      --sample jfk=jfk.wav \\
+      --out-dir /path/to/scratch/moss-td-golden
+
+`--sample NAME=RELATIVE_WAV_PATH` may be repeated; each is resolved against
+`--samples-dir`. Every sample writes `<out-dir>/<name>.json` in the exact
+shape `executor.rs`'s golden tests were transcribed from (see
+`GOLDEN_JFK_TEXT`'s doc comment there for the byte-level nuance: the
+committed fp16+flash ggml decode matches this fp32 reference's text
+byte-for-byte on `jfk`/`aishell4_multispeaker_3min` and up to a 0.02s time-
+anchor shift on `en_zh_mixed`, consistent with an fp16-vs-fp32 numeric
+delta rather than a bug).
+
+Memory
+------
+The whole checkpoint (Whisper-Medium encoder + VQAdaptor + Qwen3-0.6B
+decoder, ~1.6B params combined) fits comfortably in fp32 on a 16GB dev
+machine (well under 4GB resident) -- unlike firered2-llm's 7B-parameter Qwen2
+decoder, this family needs none of that dumper's meta-device layer-streaming
+trick. `AutoModelForCausalLM.from_pretrained(..., dtype=torch.float32)` loads
+the whole model directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import torch
+import transformers
+
+
+def parse_sample_arg(raw: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise argparse.ArgumentTypeError(f"--sample expects NAME=RELATIVE_WAV_PATH, got '{raw}'")
+    name, _, relative_wav = raw.partition("=")
+    name = name.strip()
+    relative_wav = relative_wav.strip()
+    if not name or not relative_wav:
+        raise argparse.ArgumentTypeError(f"--sample expects NAME=RELATIVE_WAV_PATH, got '{raw}'")
+    return name, relative_wav
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--moss-repo",
+        type=Path,
+        required=True,
+        help="local clone of OpenMOSS/MOSS-Transcribe-Diarize (for parse_transcript)",
+    )
+    parser.add_argument(
+        "--weights-dir",
+        type=Path,
+        required=True,
+        help="local HF checkpoint directory (config.json, model-*.safetensors, ...)",
+    )
+    parser.add_argument("--samples-dir", type=Path, required=True, help="base dir for --sample wav paths")
+    parser.add_argument(
+        "--sample",
+        dest="samples",
+        action="append",
+        type=parse_sample_arg,
+        required=True,
+        help="NAME=RELATIVE_WAV_PATH, repeatable",
+    )
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--max-new-tokens", type=int, default=4096)
+    return parser
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
+    sys.path.insert(0, str(args.moss_repo))
+    from moss_transcribe_diarize import parse_transcript
+    from moss_transcribe_diarize.inference_utils import (
+        build_transcription_messages,
+        prepare_inputs,
+    )
+    from transformers import AutoModelForCausalLM, AutoProcessor
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cpu")
+    dtype = torch.float32
+
+    print(f"transformers={transformers.__version__} torch={torch.__version__}")
+    print(f"loading {args.weights_dir} on CPU (fp32, deterministic)...")
+    t0 = time.time()
+    torch.manual_seed(args.seed)
+    model = (
+        AutoModelForCausalLM.from_pretrained(args.weights_dir, trust_remote_code=True, dtype=dtype)
+        .to(device=device)
+        .eval()
+    )
+    processor = AutoProcessor.from_pretrained(args.weights_dir, trust_remote_code=True)
+    print(f"model loaded in {time.time() - t0:.1f}s")
+
+    for name, relative_wav in args.samples:
+        audio_path = args.samples_dir / relative_wav
+        if not audio_path.exists():
+            print(f"SKIP {name}: {audio_path} not found")
+            continue
+        print(f"\n=== {name} ({audio_path}) ===")
+        torch.manual_seed(args.seed)
+        messages = build_transcription_messages(str(audio_path))
+        inputs = prepare_inputs(processor, messages, device=device)
+        prompt_len = int(inputs["attention_mask"][0].sum().item())
+        prompt_ids = inputs["input_ids"][0][:prompt_len].tolist()
+
+        generation_config = model.generation_config
+        generation_config.do_sample = False
+        generation_config.max_new_tokens = args.max_new_tokens
+
+        t0 = time.time()
+        with torch.inference_mode():
+            outputs = model.generate(
+                input_ids=inputs["input_ids"],
+                attention_mask=inputs["attention_mask"],
+                input_features=inputs["input_features"],
+                audio_feature_lengths=inputs["audio_feature_lengths"],
+                audio_chunk_mapping=inputs["audio_chunk_mapping"],
+                generation_config=generation_config,
+            )
+        elapsed = time.time() - t0
+
+        full_ids = outputs[0].tolist()
+        generated_ids = full_ids[prompt_len:]
+        text = processor.tokenizer.decode(generated_ids, skip_special_tokens=True).strip()
+        text_with_special = processor.tokenizer.decode(generated_ids, skip_special_tokens=False)
+
+        print(f"text:\n{text}")
+        print(f"prompt_len={prompt_len} generated_tokens={len(generated_ids)} elapsed={elapsed:.1f}s")
+
+        segments = parse_transcript(text)
+        for seg in segments:
+            print(f"  [{seg.start}][{seg.speaker}] {seg.text} [{seg.end}]")
+
+        record = {
+            "sample_name": name,
+            "audio_path": str(audio_path),
+            "device": "cpu",
+            "dtype": "float32",
+            "seed": args.seed,
+            "transformers_version": transformers.__version__,
+            "torch_version": torch.__version__,
+            "do_sample": False,
+            "max_new_tokens": args.max_new_tokens,
+            "prompt_len": prompt_len,
+            "generated_tokens": len(generated_ids),
+            "elapsed_seconds": elapsed,
+            "prompt_input_ids": prompt_ids,
+            "generated_token_ids": generated_ids,
+            "full_token_ids": full_ids,
+            "text": text,
+            "text_with_special_tokens": text_with_special,
+            "segments": [
+                {"start": s.start, "end": s.end, "speaker": s.speaker, "text": s.text}
+                for s in segments
+            ],
+        }
+        out_path = args.out_dir / f"{name}.json"
+        out_path.write_text(json.dumps(record, ensure_ascii=False, indent=2))
+        print(f"saved -> {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/moss-reference-dumper/dump_intermediate.py
+++ b/tooling/moss-reference-dumper/dump_intermediate.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Reference-implementation intermediate-activation dumper for
+moss-transcribe-diarize (OpenMOSS/MOSS-Transcribe-Diarize, 0.9B).
+
+Runs the *official* python reference stack on one fixture wav and dumps the
+Whisper-Medium encoder output, the post-time-merge/pre-adaptor features, the
+VQAdaptor output, and the first prefill step's logits as `.npy` files -- so
+the ggml side (`crates/openasr-core/src/models/moss_transcribe_diarize/
+encoder_graph.rs`, `adaptor_graph.rs`, `llm_decoder.rs`) can be diffed against
+ground truth stage by stage, the same role `dump_reference.py`'s `fbank`/
+`encoder`/`adapter`/`llm` stages play for firered2-llm (see
+`../firered2-reference-dumper/README.md`). Unlike that dumper this is a
+single fixed pipeline run rather than a `--stage`-selectable one: this
+family's whole checkpoint (~1.6B params) is small enough that dumping every
+stage costs nothing extra, so there is no `--stage`-driven memory trade-off
+to make in the first place (see `dump_golden.py`'s module doc's "Memory"
+section for why the checkpoint size makes firered2-llm's meta-device
+layer-streaming machinery unnecessary here).
+
+Official reference source (do not vendor -- clone locally)
+------------------------------------------------------------
+Code:    https://github.com/OpenMOSS/MOSS-Transcribe-Diarize
+         pinned commit 40cf8549c6b5634ba36b7e817cf523b5ad400c2e (2026-07-20)
+Weights: https://huggingface.co/OpenMOSS/MOSS-Transcribe-Diarize (gated; see
+         `dump_golden.py`'s module doc for the expected local layout)
+
+Setup: same as `dump_golden.py`:
+
+    python3 -m pip install --user "transformers>=5.0,<6.0" "torch>=2.8" numpy
+
+Usage
+-----
+    cd tooling/moss-reference-dumper
+    python3 dump_intermediate.py \\
+      --moss-repo /path/to/MOSS-Transcribe-Diarize \\
+      --weights-dir /path/to/moss-transcribe-diarize-weights \\
+      --wav ../../fixtures/jfk.wav \\
+      --out-dir /path/to/scratch/moss-td-dump
+
+Dumps, into `--out-dir`:
+
+| file | contents | shape |
+| --- | --- | --- |
+| `input_features.npy` | mel frontend output fed to the Whisper encoder | `[1, n_mels, mel_frames]` |
+| `whisper_encoder.npy` | Whisper-Medium encoder's `last_hidden_state` | `[1, max_source_positions, d_model]` |
+| `merged.npy` | post-`time_merge` (4x reshape, no learned weights), trimmed to this clip's valid token length before merging (mirrors `get_audio_features`'s `whisper_features[chunk_idx:chunk_idx+1, :token_len*4]` truncation -- see `executor.rs`'s module doc) | `[1, token_len, 4*d_model]` |
+| `adaptor.npy` | `VQAdaptor` output spliced into the LLM prompt at the audio-pad token's positions | `[1, token_len, llm_d_model]` |
+| `prefill_last_logits.npy` | full-prompt forward's last-position logits (pre-generation, one token's worth) | `[vocab_size]` |
+
+Only single-chunk (<=30s) wavs are supported by this dumper's trimming logic
+-- it mirrors the executor's own single-chunk trim math, not its multi-chunk
+concatenation loop; a wav longer than 30s needs the multi-chunk path
+`dump_golden.py`'s full `model.generate()` call already exercises correctly
+via the checkpoint's own `get_audio_features`, just without exposing these
+intermediate stage-by-stage tensors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--moss-repo", type=Path, required=True)
+    parser.add_argument("--weights-dir", type=Path, required=True)
+    parser.add_argument("--wav", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
+    sys.path.insert(0, str(args.moss_repo))
+    from moss_transcribe_diarize.inference_utils import build_transcription_messages, prepare_inputs
+    from transformers import AutoModelForCausalLM, AutoProcessor
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cpu")
+
+    torch.manual_seed(0)
+    model = (
+        AutoModelForCausalLM.from_pretrained(args.weights_dir, trust_remote_code=True, dtype=torch.float32)
+        .to(device=device)
+        .eval()
+    )
+    processor = AutoProcessor.from_pretrained(args.weights_dir, trust_remote_code=True)
+
+    messages = build_transcription_messages(str(args.wav))
+    inputs = prepare_inputs(processor, messages, device=device)
+    print("input_features", inputs["input_features"].shape, inputs["input_features"].dtype)
+    print("audio_feature_lengths", inputs["audio_feature_lengths"])
+    print("audio_chunk_mapping", inputs["audio_chunk_mapping"])
+
+    mm = model.model
+    input_features = inputs["input_features"].to(torch.float32)
+    np.save(args.out_dir / "input_features.npy", input_features.numpy())
+
+    with torch.inference_mode():
+        whisper_out = mm.whisper_encoder(input_features, return_dict=True).last_hidden_state
+        print("whisper last_hidden_state", whisper_out.shape)
+        np.save(args.out_dir / "whisper_encoder.npy", whisper_out.to(torch.float32).numpy())
+
+        # Mirrors `get_audio_features`'s single-chunk trim (see
+        # `executor.rs`'s module doc): only valid for a <=30s clip, where the
+        # whole input is one chunk.
+        token_len = int(inputs["audio_feature_lengths"][0].item())
+        feat = whisper_out[0:1, : token_len * 4]
+        print("trimmed encoder feat", feat.shape, "token_len", token_len)
+        merged = mm.time_merge(feat)
+        print("merged", merged.shape)
+        np.save(args.out_dir / "merged.npy", merged.to(torch.float32).numpy())
+        adapted = mm.vq_adaptor(merged)
+        print("adaptor out (audio_features)", adapted.shape)
+        np.save(args.out_dir / "adaptor.npy", adapted.to(torch.float32).numpy())
+
+        out = model(
+            input_ids=inputs["input_ids"],
+            attention_mask=inputs["attention_mask"],
+            input_features=inputs["input_features"],
+            audio_feature_lengths=inputs["audio_feature_lengths"],
+            audio_chunk_mapping=inputs["audio_chunk_mapping"],
+        )
+        logits = out.logits[0, -1].to(torch.float32).numpy()
+        np.save(args.out_dir / "prefill_last_logits.npy", logits)
+        topk = np.argsort(logits)[::-1][:10]
+        print("prefill top10 tokens:", [(int(t), float(logits[t])) for t in topk])
+
+    for name in ["whisper_encoder", "merged", "adaptor"]:
+        a = np.load(args.out_dir / f"{name}.npy")
+        print(f"{name}: shape={a.shape} mean={a.mean():.5f} std={a.std():.5f} min={a.min():.4f} max={a.max():.4f}")
+    print("DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Four finishing items for the moss-transcribe-diarize family:

1. A resident, thread-local cache for the encoder and decoder runtimes, mirroring
   firered-aed's `BoundedRuntimeCache` design.
2. CI-safe, weight-free structural test coverage for the chunk/slice-planning
   arithmetic and the speaker-segment parsing path (short clip + a synthetic
   multi-chunk-duration long clip), plus a dev-only cache-hit regression test.
3. An in-tree HF reference dumper so the committed golden fixtures can be
   regenerated.

The module doc this batch was originally asked to refresh
(`mod.rs`'s "only the importer exists ... not yet runnable" line) turned out
to already be accurate on current `main` -- it was fixed in #194, before this
branch was cut. No change needed there; noting it here rather than silently
dropping the item.

## Why

moss-transcribe-diarize's executor rebuilt both the Whisper-Medium encoder
runtime and the Qwen3 decoder runtime from scratch on every `execute()` call:
re-mmapping the pack, re-reading every encoder tensor off disk, and
re-uploading every decoder layer's weights, on every single transcription
(including every 30s chunk of the same longform request). Every other
seq2seq family already avoids this via a resident, thread-local cache; this
family was the one left out.

Separately, every one of this family's `golden_diff_*` tests requires the
private, non-committed fp16 dev pack and stays `#[ignore]`d, so
`cargo nextest run --workspace` (default CI) had no moss-td-specific
correctness coverage at all, and this family had no reference dumper in the
repo (its golden fixtures were generated by an untracked one-off script).

## Changes

- `crates/openasr-core/src/models/moss_transcribe_diarize/encoder_graph.rs`:
  `MossEncoderRuntime` now owns its fully-loaded `MossEncoderWeights` (loaded
  once in `::new()`), matching firered-aed's encoder runtime shape, instead of
  taking them as a per-call `encode()` argument.
- `crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs`:
  `MossTdDecoderRuntime` gains a `release_session_scoped_buffers()` proxy so a
  resident decoder frees its per-request grow-to-fit host buffer before going
  back into the cache, mirroring qwen3-asr's own resident whole-decoder cache.
- `crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs`:
  - Adds the thread-local `BoundedRuntimeCache` + `with_thread_local_cached_
    mut_by_key` wiring for both runtimes, keyed by `(canonical pack path,
    resolved backend)` -- the same shared machinery and key shape firered-aed
    uses, not a second caching mechanism.
  - Factors the per-chunk frame-keeping arithmetic (token length, kept frames,
    merge-size alignment) into small pure functions, used by both the cache
    wiring and a new weight-free test module (`moss_td_chunk_frame_math_tests`)
    covering a short single-chunk clip, a full 30s chunk, and a multi-chunk
    (>60s) longform file.
  - Adds a synthetic long, multi-speaker-turn transcript test exercising
    `speaker_segments` parsing at a duration spanning multiple encoder chunks,
    extending the family's existing short-clip-only structural golden coverage
    (clearly labeled synthetic, not a real decode).
  - Adds a dev-only (`#[ignore]`d) test against the real pack,
    `resident_runtime_cache_hits_on_a_second_transcribe_call_for_the_same_pack`,
    pinning the cache's two contracts directly: a second `execute()` call for
    the same pack reuses both cached runtimes rather than rebuilding them
    (checked via test-only build counters, not timing), and reuse does not
    change the decode -- the second call's transcript stays byte-for-byte
    identical to the first and to the committed golden.
- `tooling/moss-reference-dumper/`: new `dump_golden.py` (greedy
  `model.generate()` -> golden JSON, the process that produced
  `tmp/moss-td/golden/*.json` and the `GOLDEN_JFK_TEXT` /
  `GOLDEN_EN_ZH_MIXED_TEXT` constants pinned in `executor.rs`) and
  `dump_intermediate.py` (single-clip stage-by-stage activation dump: Whisper
  encoder output, post-time-merge features, VQAdaptor output, first
  prefill-step logits), mirroring `tooling/firered2-reference-dumper/`'s shape.
  Neither vendors the official repo or any weights.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2859 passed, 150 skipped/ignored)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (all non-ignored
      golden_diff tests pass; moss-td's private-pack goldens correctly stay
      ignored with the expected reason strings)
- [x] Locally, against the real private dev-only fp16 pack (not committed):
      the three previously-ignored `golden_diff_end_to_end_transcribe_jfk_wav*`
      tests (plain, accelerated, speaker-segments) all still pass byte-for-byte
      against the pre-existing golden -- confirms the resident-cache refactor
      does not change a single request's output.
- [x] Locally, against the same real pack: the new
      `resident_runtime_cache_hits_on_a_second_transcribe_call_for_the_same_pack`
      test passes -- a second `execute()` call reuses both cached runtimes
      (build count stays 1, not 2) and produces an identical transcript.

## Manual smoke checks

None beyond the real-pack test runs above (no CLI/API surface changed).

## Docs updated

- [x] No docs overclaim current capabilities. `mod.rs`'s stage-status doc was
      already accurate on `main` (fixed by #194); left untouched.
- [ ] README or docs updated, if behavior or limitations changed. (N/A --
      internal executor/runtime-cache change, no public behavior change.)

## Scope / non-goals

- Does not attempt to make any moss-td `golden_diff_*` end-to-end test run in
  CI -- that would require committing model weights, which the artifact
  policy forbids. This mirrors the existing house pattern for
  firered-aed/firered-llm/mimo-asr/whisper: the CI-safe fallback here is the
  weight-free chunk-math + speaker-segments structural coverage described
  above, not a bit-exact end-to-end golden.
- Does not touch `mod.rs`'s module doc -- already accurate, see "Why" above.
- Does not change any public API, CLI surface, or catalog/release wiring for
  this family.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts,
      secrets, or private audio.
- [x] I did not add vendored runtime sources outside
      `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage
      policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI
      assistance, and I own its maintenance.
- AI usage disclosure: YES -- implementation drafted with AI assistance,
  reviewed and verified locally (including real-pack runs) before submission.
