### PR TITLE
feat(server): limit concurrent native model sessions

### DIFF
--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -1,5 +1,6 @@
 use std::{
     net::SocketAddr,
+    num::NonZeroUsize,
     path::{Path, PathBuf},
 };
 
@@ -589,6 +590,14 @@ pub(crate) enum Command {
         /// Local `.oasr` runtime pack file for native backend transcription.
         #[arg(long)]
         model_pack: Option<PathBuf>,
+        /// Maximum concurrent native sessions for one resolved model. Keep the
+        /// default unless this host has enough memory for concurrent runtimes.
+        #[arg(
+            long,
+            env = "OPENASR_MAX_NATIVE_SESSIONS_PER_MODEL",
+            default_value_t = NonZeroUsize::new(1).expect("one is non-zero")
+        )]
+        max_native_sessions_per_model: NonZeroUsize,
         /// Pid of the process that launched this daemon (e.g. a desktop app's
         /// supervisor). While set, this process watches that pid and exits
         /// shortly after it disappears -- including an ungraceful death (a

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -340,6 +340,7 @@ async fn run() -> Result<()> {
             backend,
             ffmpeg_bin,
             model_pack,
+            max_native_sessions_per_model,
             parent_pid,
         } => {
             if let Some(parent_pid) = parent_pid {
@@ -351,6 +352,7 @@ async fn run() -> Result<()> {
                 backend,
                 RuntimePathOverrides { ffmpeg_bin },
                 model_pack.as_deref(),
+                max_native_sessions_per_model,
                 ServeSecurityOptions {
                     tls_self_signed,
                     tls_sans,
@@ -1776,6 +1778,7 @@ mod tests {
 
         let Command::Serve {
             backend,
+            max_native_sessions_per_model,
             parent_pid,
             ..
         } = cli.command
@@ -1784,7 +1787,16 @@ mod tests {
         };
 
         assert_eq!(backend, Some(BackendKind::Native));
+        assert_eq!(max_native_sessions_per_model.get(), 1);
         assert_eq!(parent_pid, Some(4321));
+    }
+
+    #[test]
+    fn serve_rejects_zero_native_sessions_per_model() {
+        assert!(
+            Cli::try_parse_from(["openasr", "serve", "--max-native-sessions-per-model", "0",])
+                .is_err()
+        );
     }
 
     #[test]
@@ -1798,6 +1810,7 @@ mod tests {
 
         let Command::Serve {
             backend,
+            max_native_sessions_per_model,
             parent_pid,
             ..
         } = cli.command
@@ -1806,6 +1819,7 @@ mod tests {
         };
 
         assert_eq!(backend, None);
+        assert_eq!(max_native_sessions_per_model.get(), 1);
         assert_eq!(parent_pid, None);
     }
 }

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -596,11 +596,13 @@ pub(super) async fn serve(
     // `idle_unload` lives on `Preferences`, on the same document already
     // loaded above as `config_document` -- no second read needed.
     launch_options.idle_unload_after = config_document.preferences.idle_unload.idle_threshold();
-    launch_options.max_concurrent_native_sessions_per_model = Some(max_native_sessions_per_model);
     openasr_server::serve_with_launch_options(
         addr,
         openasr_server::ServerRuntime {
             backend,
+            native_execution: openasr_server::NativeExecutionSupervisor::new(
+                max_native_sessions_per_model,
+            ),
             ffmpeg_bin,
             ffmpeg_bin_explicit,
             model_pack_path: model_source.model_pack_path,

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -526,6 +526,7 @@ pub(super) async fn serve(
     backend_kind: Option<BackendKind>,
     runtime_paths: RuntimePathOverrides,
     model_pack: Option<&Path>,
+    max_native_sessions_per_model: std::num::NonZeroUsize,
     security: ServeSecurityOptions,
 ) -> Result<()> {
     let home = openasr_home()?;
@@ -595,6 +596,7 @@ pub(super) async fn serve(
     // `idle_unload` lives on `Preferences`, on the same document already
     // loaded above as `config_document` -- no second read needed.
     launch_options.idle_unload_after = config_document.preferences.idle_unload.idle_threshold();
+    launch_options.max_concurrent_native_sessions_per_model = Some(max_native_sessions_per_model);
     openasr_server::serve_with_launch_options(
         addr,
         openasr_server::ServerRuntime {

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1,8 +1,12 @@
 mod idle_activity;
+mod model_admission;
 mod realtime;
 mod routes;
 
 pub(crate) use idle_activity::{NativeActivityGuard, spawn_idle_unload_reaper};
+pub(crate) use model_admission::{
+    ModelSessionAdmission, ModelSessionAdmissionError, ModelSessionPermit,
+};
 pub(crate) use routes::config::*;
 pub(crate) use routes::history::*;
 pub(crate) use routes::models_api::*;
@@ -20,6 +24,7 @@ use std::{
     fs,
     io::Write,
     net::SocketAddr,
+    num::NonZeroUsize,
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex, OnceLock,
@@ -126,6 +131,11 @@ pub fn app_with_runtime_and_distribution_and_launch_options(
     let distribution = DistributionContext::new(distribution_runtime);
     distribution.ensure_restart_resumes_started();
     let auth = launch_options.auth.clone();
+    let model_admission = ModelSessionAdmission::new(
+        launch_options
+            .max_concurrent_native_sessions_per_model
+            .unwrap_or_else(|| NonZeroUsize::new(1).expect("one is non-zero")),
+    );
     let health_identity = ServerHealthIdentity::from_launch_options(launch_options);
     Router::new()
         .route("/health", get(health))
@@ -204,6 +214,7 @@ pub fn app_with_runtime_and_distribution_and_launch_options(
         ))
         .layer(Extension(auth))
         .layer(Extension(health_identity))
+        .layer(Extension(model_admission))
         .layer(Extension(distribution))
         .layer(DefaultBodyLimit::max(MAX_TRANSCRIPTION_UPLOAD_BYTES))
         .with_state(runtime)
@@ -747,6 +758,9 @@ pub struct ServerLaunchOptions {
     /// (the default, and what `never` resolves to) never spawns the reaper,
     /// matching every existing caller/test that does not set this.
     pub idle_unload_after: Option<Duration>,
+    /// Maximum concurrent native executions for one resolved runtime model.
+    /// `None` keeps the conservative default of one session per model.
+    pub max_concurrent_native_sessions_per_model: Option<NonZeroUsize>,
     /// Where to persist (and load back) the self-signed TLS private key +
     /// certificate across restarts -- see
     /// `load_or_generate_self_signed_tls_identity`. `None` keeps the
@@ -2256,6 +2270,7 @@ pub(crate) enum ApiError {
     Multipart(axum::extract::multipart::MultipartError),
     AudioPreparation(AudioPreparationError),
     Backend(openasr_core::BackendError),
+    ModelSessionCapacity(ModelSessionAdmissionError),
     BackendJoin(tokio::task::JoinError),
     Pull(PullError),
     Registry(openasr_core::RegistryError),
@@ -2311,6 +2326,11 @@ impl std::fmt::Display for ApiError {
                 )
             }
             Self::Backend(error) => write!(f, "Could not transcribe audio: {error}"),
+            Self::ModelSessionCapacity(error) => write!(
+                f,
+                "Model '{}' is at its concurrent native session limit ({}). Retry when an existing request finishes, or increase --max-native-sessions-per-model if this host has enough memory.",
+                error.model_identity, error.limit,
+            ),
             Self::BackendJoin(error) => {
                 write!(
                     f,
@@ -2387,6 +2407,13 @@ impl IntoResponse for ApiError {
             Self::AudioPreparation(error) => (
                 StatusCode::BAD_REQUEST,
                 format!("Could not prepare uploaded audio for transcription: {error}"),
+            ),
+            Self::ModelSessionCapacity(error) => (
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Model '{}' is at its concurrent native session limit ({}). Retry when an existing request finishes, or increase --max-native-sessions-per-model if this host has enough memory.",
+                    error.model_identity, error.limit,
+                ),
             ),
             Self::Backend(error) => {
                 let status = match &error {
@@ -2543,6 +2570,26 @@ struct ErrorBody {
 #[cfg(test)]
 #[path = "http_wire_bindings_test.rs"]
 mod http_wire_bindings_test;
+
+#[cfg(test)]
+mod model_session_capacity_error_tests {
+    use std::num::NonZeroUsize;
+
+    use axum::response::IntoResponse;
+
+    use super::{ApiError, ModelSessionAdmissionError, StatusCode};
+
+    #[test]
+    fn model_session_capacity_is_a_retryable_http_overload() {
+        let response = ApiError::ModelSessionCapacity(ModelSessionAdmissionError {
+            model_identity: "native:whisper-small@pack-a".to_string(),
+            limit: NonZeroUsize::new(1).unwrap(),
+        })
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+}
 
 #[cfg(test)]
 #[path = "tests.rs"]

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -4,9 +4,8 @@ mod realtime;
 mod routes;
 
 pub(crate) use idle_activity::{NativeActivityGuard, spawn_idle_unload_reaper};
-pub(crate) use model_admission::{
-    ModelSessionAdmission, ModelSessionAdmissionError, ModelSessionPermit,
-};
+pub use model_admission::NativeExecutionSupervisor;
+pub(crate) use model_admission::{ModelSessionAdmissionError, ModelSessionPermit};
 pub(crate) use routes::config::*;
 pub(crate) use routes::history::*;
 pub(crate) use routes::models_api::*;
@@ -24,7 +23,6 @@ use std::{
     fs,
     io::Write,
     net::SocketAddr,
-    num::NonZeroUsize,
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex, OnceLock,
@@ -131,11 +129,6 @@ pub fn app_with_runtime_and_distribution_and_launch_options(
     let distribution = DistributionContext::new(distribution_runtime);
     distribution.ensure_restart_resumes_started();
     let auth = launch_options.auth.clone();
-    let model_admission = ModelSessionAdmission::new(
-        launch_options
-            .max_concurrent_native_sessions_per_model
-            .unwrap_or_else(|| NonZeroUsize::new(1).expect("one is non-zero")),
-    );
     let health_identity = ServerHealthIdentity::from_launch_options(launch_options);
     Router::new()
         .route("/health", get(health))
@@ -214,7 +207,6 @@ pub fn app_with_runtime_and_distribution_and_launch_options(
         ))
         .layer(Extension(auth))
         .layer(Extension(health_identity))
-        .layer(Extension(model_admission))
         .layer(Extension(distribution))
         .layer(DefaultBodyLimit::max(MAX_TRANSCRIPTION_UPLOAD_BYTES))
         .with_state(runtime)
@@ -758,9 +750,6 @@ pub struct ServerLaunchOptions {
     /// (the default, and what `never` resolves to) never spawns the reaper,
     /// matching every existing caller/test that does not set this.
     pub idle_unload_after: Option<Duration>,
-    /// Maximum concurrent native executions for one resolved runtime model.
-    /// `None` keeps the conservative default of one session per model.
-    pub max_concurrent_native_sessions_per_model: Option<NonZeroUsize>,
     /// Where to persist (and load back) the self-signed TLS private key +
     /// certificate across restarts -- see
     /// `load_or_generate_self_signed_tls_identity`. `None` keeps the
@@ -1176,6 +1165,9 @@ fn resolve_instance_token(launch_option: Option<String>) -> Option<String> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServerRuntime {
     pub backend: BackendKind,
+    /// Process-wide native execution supervisor shared by every server entry
+    /// point that can allocate or run a ggml model runtime.
+    pub native_execution: NativeExecutionSupervisor,
     pub ffmpeg_bin: Option<std::path::PathBuf>,
     /// Whether `ffmpeg_bin` came from an explicit operator choice (CLI flag,
     /// env var, or config) rather than PATH auto-discovery -- see
@@ -1189,6 +1181,7 @@ impl Default for ServerRuntime {
     fn default() -> Self {
         Self {
             backend: BackendKind::Mock,
+            native_execution: NativeExecutionSupervisor::default(),
             ffmpeg_bin: None,
             ffmpeg_bin_explicit: false,
             model_pack_path: None,
@@ -1197,6 +1190,15 @@ impl Default for ServerRuntime {
 }
 
 impl ServerRuntime {
+    /// Acquires the server-wide native execution permit for the validated
+    /// runtime pack. Every ggml ASR execution path enters through this method.
+    pub(crate) fn acquire_native_execution(&self) -> Result<ModelSessionPermit, ApiError> {
+        let model_identity = native_model_session_key(self)?;
+        self.native_execution
+            .try_acquire(model_identity)
+            .map_err(ApiError::ModelSessionCapacity)
+    }
+
     /// Validates the runtime is *safe to serve with*, not that a model is
     /// installed: no model bound at all (`model_pack_path: None`) is a normal
     /// state for a fresh install with zero pulled models, and the daemon must

--- a/crates/openasr-server/src/model_admission.rs
+++ b/crates/openasr-server/src/model_admission.rs
@@ -1,0 +1,226 @@
+use std::{
+    collections::HashMap,
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+};
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// Bounds concurrent native executions for one resolved runtime model identity.
+///
+/// Admission is deliberately non-blocking. Queuing a second heavyweight model
+/// session would retain its request state while providing no useful progress;
+/// callers receive a retryable overload error instead. Slots are removed after
+/// their final permit is released so model switches cannot grow this registry
+/// without bound.
+#[derive(Clone, Debug)]
+pub(crate) struct ModelSessionAdmission {
+    state: Arc<Mutex<ModelSessionAdmissionState>>,
+}
+
+#[derive(Debug)]
+struct ModelSessionAdmissionState {
+    limit: NonZeroUsize,
+    slots: HashMap<String, ModelSessionSlot>,
+}
+
+#[derive(Debug)]
+struct ModelSessionSlot {
+    semaphore: Arc<Semaphore>,
+    active: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelSessionAdmissionError {
+    pub(crate) model_identity: String,
+    pub(crate) limit: NonZeroUsize,
+}
+
+/// RAII permit for a native model execution. It remains owned by the blocking
+/// decode task or native streaming worker, so cancellation of the async caller
+/// cannot release capacity while the model still executes.
+#[derive(Debug)]
+pub(crate) struct ModelSessionPermit {
+    state: Arc<Mutex<ModelSessionAdmissionState>>,
+    model_identity: String,
+    permit: Option<OwnedSemaphorePermit>,
+}
+
+impl Default for ModelSessionAdmission {
+    fn default() -> Self {
+        Self::new(NonZeroUsize::new(1).expect("one is non-zero"))
+    }
+}
+
+impl ModelSessionAdmission {
+    pub(crate) fn new(limit: NonZeroUsize) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(ModelSessionAdmissionState {
+                limit,
+                slots: HashMap::new(),
+            })),
+        }
+    }
+
+    pub(crate) fn try_acquire(
+        &self,
+        model_identity: impl Into<String>,
+    ) -> Result<ModelSessionPermit, ModelSessionAdmissionError> {
+        let model_identity = model_identity.into();
+        let mut state = self.lock_state();
+        let limit = state.limit;
+        let slot = state
+            .slots
+            .entry(model_identity.clone())
+            .or_insert_with(|| ModelSessionSlot {
+                semaphore: Arc::new(Semaphore::new(limit.get())),
+                active: 0,
+            });
+        let permit = match Arc::clone(&slot.semaphore).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return Err(ModelSessionAdmissionError {
+                    model_identity,
+                    limit,
+                });
+            }
+        };
+        slot.active += 1;
+        drop(state);
+
+        Ok(ModelSessionPermit {
+            state: Arc::clone(&self.state),
+            model_identity,
+            permit: Some(permit),
+        })
+    }
+
+    #[cfg(test)]
+    fn active_slot_count(&self) -> usize {
+        self.lock_state().slots.len()
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, ModelSessionAdmissionState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl Drop for ModelSessionPermit {
+    fn drop(&mut self) {
+        let Some(permit) = self.permit.take() else {
+            return;
+        };
+        drop(permit);
+
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let should_remove = match state.slots.get_mut(&self.model_identity) {
+            Some(slot) => {
+                slot.active = slot.active.saturating_sub(1);
+                slot.active == 0
+            }
+            None => false,
+        };
+        if should_remove {
+            state.slots.remove(&self.model_identity);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use tokio::sync::oneshot;
+
+    use super::ModelSessionAdmission;
+
+    fn admission(limit: usize) -> ModelSessionAdmission {
+        ModelSessionAdmission::new(NonZeroUsize::new(limit).unwrap())
+    }
+
+    #[test]
+    fn rejects_without_waiting_when_model_is_at_capacity() {
+        let admission = admission(1);
+        let _first = admission
+            .try_acquire("native:whisper-small@pack-a")
+            .unwrap();
+
+        let error = admission
+            .try_acquire("native:whisper-small@pack-a")
+            .unwrap_err();
+
+        assert_eq!(error.model_identity, "native:whisper-small@pack-a");
+        assert_eq!(error.limit.get(), 1);
+    }
+
+    #[test]
+    fn releases_capacity_and_prunes_idle_model_slot() {
+        let admission = admission(1);
+        let first = admission
+            .try_acquire("native:whisper-small@pack-a")
+            .unwrap();
+        assert_eq!(admission.active_slot_count(), 1);
+
+        drop(first);
+
+        assert_eq!(admission.active_slot_count(), 0);
+        assert!(admission.try_acquire("native:whisper-small@pack-a").is_ok());
+    }
+
+    #[test]
+    fn different_models_do_not_serialize_each_other() {
+        let admission = admission(1);
+        let _first = admission
+            .try_acquire("native:whisper-small@pack-a")
+            .unwrap();
+
+        assert!(
+            admission
+                .try_acquire("native:qwen3-asr-0.6b@pack-b")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn configured_capacity_allows_that_many_sessions() {
+        let admission = admission(2);
+        let _first = admission
+            .try_acquire("native:whisper-small@pack-a")
+            .unwrap();
+        let _second = admission
+            .try_acquire("native:whisper-small@pack-a")
+            .unwrap();
+
+        assert!(
+            admission
+                .try_acquire("native:whisper-small@pack-a")
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn aborted_owner_releases_its_permit() {
+        let admission = admission(1);
+        let (acquired_tx, acquired_rx) = oneshot::channel();
+        let (_hold_tx, hold_rx) = oneshot::channel::<()>();
+        let task_admission = admission.clone();
+        let task = tokio::spawn(async move {
+            let _permit = task_admission
+                .try_acquire("native:whisper-small@pack-a")
+                .unwrap();
+            let _ = acquired_tx.send(());
+            let _ = hold_rx.await;
+        });
+
+        acquired_rx.await.unwrap();
+        task.abort();
+        let _ = task.await;
+
+        assert!(admission.try_acquire("native:whisper-small@pack-a").is_ok());
+    }
+}

--- a/crates/openasr-server/src/model_admission.rs
+++ b/crates/openasr-server/src/model_admission.rs
@@ -46,6 +46,44 @@ pub(crate) struct ModelSessionPermit {
     permit: Option<OwnedSemaphorePermit>,
 }
 
+#[derive(Clone, Debug)]
+pub struct NativeExecutionSupervisor {
+    admission: ModelSessionAdmission,
+}
+
+impl PartialEq for NativeExecutionSupervisor {
+    fn eq(&self, other: &Self) -> bool {
+        self.max_concurrent_sessions_per_model() == other.max_concurrent_sessions_per_model()
+    }
+}
+
+impl Eq for NativeExecutionSupervisor {}
+
+impl Default for NativeExecutionSupervisor {
+    fn default() -> Self {
+        Self::new(NonZeroUsize::new(1).expect("one is non-zero"))
+    }
+}
+
+impl NativeExecutionSupervisor {
+    pub fn new(max_concurrent_sessions_per_model: NonZeroUsize) -> Self {
+        Self {
+            admission: ModelSessionAdmission::new(max_concurrent_sessions_per_model),
+        }
+    }
+
+    pub(crate) fn try_acquire(
+        &self,
+        model_identity: impl Into<String>,
+    ) -> Result<ModelSessionPermit, ModelSessionAdmissionError> {
+        self.admission.try_acquire(model_identity)
+    }
+
+    pub fn max_concurrent_sessions_per_model(&self) -> NonZeroUsize {
+        self.admission.limit()
+    }
+}
+
 impl Default for ModelSessionAdmission {
     fn default() -> Self {
         Self::new(NonZeroUsize::new(1).expect("one is non-zero"))
@@ -98,6 +136,10 @@ impl ModelSessionAdmission {
     #[cfg(test)]
     fn active_slot_count(&self) -> usize {
         self.lock_state().slots.len()
+    }
+
+    fn limit(&self) -> NonZeroUsize {
+        self.lock_state().limit
     }
 
     fn lock_state(&self) -> std::sync::MutexGuard<'_, ModelSessionAdmissionState> {

--- a/crates/openasr-server/src/model_admission.rs
+++ b/crates/openasr-server/src/model_admission.rs
@@ -203,6 +203,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn panic_unwinds_and_releases_its_permit() {
+        let admission = admission(1);
+        let panic_admission = admission.clone();
+        let result = std::thread::spawn(move || {
+            let _permit = panic_admission
+                .try_acquire("native:whisper-small@pack-a")
+                .unwrap();
+            panic!("test panic after model admission");
+        })
+        .join();
+
+        assert!(result.is_err());
+        assert!(admission.try_acquire("native:whisper-small@pack-a").is_ok());
+    }
+
     #[tokio::test]
     async fn aborted_owner_releases_its_permit() {
         let admission = admission(1);

--- a/crates/openasr-server/src/realtime/mod.rs
+++ b/crates/openasr-server/src/realtime/mod.rs
@@ -54,12 +54,11 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 use super::{
-    ApiError, DistributionContext, HYMT2_TRANSLATION_MODEL_ID, ModelSessionAdmission, ServerAuth,
-    ServerRuntime, TranslationPackSelection, is_remote_compute_client_request,
-    native_hardware_target_from_execution_target, native_model_session_key,
-    parse_transcription_multipart, realtime_capabilities_for_runtime_and_distribution,
-    record_file_transcription_history, resolve_translation_pack_selection, transcribe_with_runtime,
-    translation_model_ref_supported,
+    ApiError, DistributionContext, HYMT2_TRANSLATION_MODEL_ID, ServerAuth, ServerRuntime,
+    TranslationPackSelection, is_remote_compute_client_request,
+    native_hardware_target_from_execution_target, parse_transcription_multipart,
+    realtime_capabilities_for_runtime_and_distribution, record_file_transcription_history,
+    resolve_translation_pack_selection, transcribe_with_runtime, translation_model_ref_supported,
 };
 
 mod native_worker;
@@ -140,7 +139,6 @@ static NATIVE_STREAMING_WORKER_REAPER_STARTED: OnceLock<()> = OnceLock::new();
 pub(crate) async fn websocket(
     State(runtime): State<ServerRuntime>,
     axum::Extension(distribution): axum::Extension<DistributionContext>,
-    axum::Extension(model_admission): axum::Extension<ModelSessionAdmission>,
     axum::Extension(auth): axum::Extension<ServerAuth>,
     headers: HeaderMap,
     ws: WebSocketUpgrade,
@@ -150,21 +148,12 @@ pub(crate) async fn websocket(
         .max_frame_size(MAX_WS_MESSAGE_BYTES)
         .write_buffer_size(MAX_WS_MESSAGE_BYTES)
         .max_write_buffer_size(MAX_WS_MESSAGE_BYTES * 2)
-        .on_upgrade(move |socket| {
-            handle_websocket(
-                socket,
-                runtime,
-                distribution,
-                model_admission,
-                record_history,
-            )
-        })
+        .on_upgrade(move |socket| handle_websocket(socket, runtime, distribution, record_history))
 }
 
 pub(crate) async fn stream_transcription(
     runtime: ServerRuntime,
     distribution: DistributionContext,
-    model_admission: ModelSessionAdmission,
     multipart: Result<Multipart, axum::extract::multipart::MultipartRejection>,
     record_history: bool,
 ) -> Result<Response, ApiError> {
@@ -205,7 +194,7 @@ pub(crate) async fn stream_transcription(
             send_sse(&sender, started).await;
         }
 
-        match transcribe_with_runtime(runtime, request, None, model_admission).await {
+        match transcribe_with_runtime(runtime, request, None).await {
             Ok(transcription) => {
                 let end_ms = transcription_end_ms(&transcription);
                 let history_transcription = transcription.clone();
@@ -307,7 +296,7 @@ pub(crate) async fn stream_transcription(
                     RealtimeErrorEvent {
                         code: realtime_error_code_for_api_error(&error),
                         message: error.to_string(),
-                        recoverable: false,
+                        recoverable: matches!(error, ApiError::ModelSessionCapacity(_)),
                     },
                     timestamp_now(),
                 ) {
@@ -369,7 +358,6 @@ async fn handle_websocket(
     socket: WebSocket,
     runtime: ServerRuntime,
     distribution: DistributionContext,
-    model_admission: ModelSessionAdmission,
     record_history: bool,
 ) {
     let (mut socket_sender, mut socket_receiver) = socket.split();
@@ -401,13 +389,8 @@ async fn handle_websocket(
         let _ = socket_sender.send(ws_close(close_code)).await;
     });
 
-    let mut session = WsSession::new_with_history(
-        runtime,
-        distribution,
-        model_admission,
-        event_sender,
-        record_history,
-    );
+    let mut session =
+        WsSession::new_with_history(runtime, distribution, event_sender, record_history);
     if session.emit_capabilities().await.is_err() {
         return;
     }
@@ -465,7 +448,9 @@ async fn handle_websocket(
                         result_timeout.as_secs()
                     );
                     let _ = session
-                        .apply_backend_result(BackendResult::Error(message))
+                        .apply_backend_result(BackendResult::Error(ApiError::Backend(
+                            openasr_core::BackendError::NativeFailClosed { reason: message },
+                        )))
                         .await;
                     break;
                 }

--- a/crates/openasr-server/src/realtime/mod.rs
+++ b/crates/openasr-server/src/realtime/mod.rs
@@ -54,11 +54,12 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 use super::{
-    ApiError, DistributionContext, HYMT2_TRANSLATION_MODEL_ID, ServerAuth, ServerRuntime,
-    TranslationPackSelection, is_remote_compute_client_request,
-    native_hardware_target_from_execution_target, parse_transcription_multipart,
-    realtime_capabilities_for_runtime_and_distribution, record_file_transcription_history,
-    resolve_translation_pack_selection, transcribe_with_runtime, translation_model_ref_supported,
+    ApiError, DistributionContext, HYMT2_TRANSLATION_MODEL_ID, ModelSessionAdmission, ServerAuth,
+    ServerRuntime, TranslationPackSelection, is_remote_compute_client_request,
+    native_hardware_target_from_execution_target, native_model_session_key,
+    parse_transcription_multipart, realtime_capabilities_for_runtime_and_distribution,
+    record_file_transcription_history, resolve_translation_pack_selection, transcribe_with_runtime,
+    translation_model_ref_supported,
 };
 
 mod native_worker;
@@ -139,6 +140,7 @@ static NATIVE_STREAMING_WORKER_REAPER_STARTED: OnceLock<()> = OnceLock::new();
 pub(crate) async fn websocket(
     State(runtime): State<ServerRuntime>,
     axum::Extension(distribution): axum::Extension<DistributionContext>,
+    axum::Extension(model_admission): axum::Extension<ModelSessionAdmission>,
     axum::Extension(auth): axum::Extension<ServerAuth>,
     headers: HeaderMap,
     ws: WebSocketUpgrade,
@@ -148,12 +150,21 @@ pub(crate) async fn websocket(
         .max_frame_size(MAX_WS_MESSAGE_BYTES)
         .write_buffer_size(MAX_WS_MESSAGE_BYTES)
         .max_write_buffer_size(MAX_WS_MESSAGE_BYTES * 2)
-        .on_upgrade(move |socket| handle_websocket(socket, runtime, distribution, record_history))
+        .on_upgrade(move |socket| {
+            handle_websocket(
+                socket,
+                runtime,
+                distribution,
+                model_admission,
+                record_history,
+            )
+        })
 }
 
 pub(crate) async fn stream_transcription(
     runtime: ServerRuntime,
     distribution: DistributionContext,
+    model_admission: ModelSessionAdmission,
     multipart: Result<Multipart, axum::extract::multipart::MultipartRejection>,
     record_history: bool,
 ) -> Result<Response, ApiError> {
@@ -194,7 +205,7 @@ pub(crate) async fn stream_transcription(
             send_sse(&sender, started).await;
         }
 
-        match transcribe_with_runtime(runtime, request, None).await {
+        match transcribe_with_runtime(runtime, request, None, model_admission).await {
             Ok(transcription) => {
                 let end_ms = transcription_end_ms(&transcription);
                 let history_transcription = transcription.clone();
@@ -358,6 +369,7 @@ async fn handle_websocket(
     socket: WebSocket,
     runtime: ServerRuntime,
     distribution: DistributionContext,
+    model_admission: ModelSessionAdmission,
     record_history: bool,
 ) {
     let (mut socket_sender, mut socket_receiver) = socket.split();
@@ -389,8 +401,13 @@ async fn handle_websocket(
         let _ = socket_sender.send(ws_close(close_code)).await;
     });
 
-    let mut session =
-        WsSession::new_with_history(runtime, distribution, event_sender, record_history);
+    let mut session = WsSession::new_with_history(
+        runtime,
+        distribution,
+        model_admission,
+        event_sender,
+        record_history,
+    );
     if session.emit_capabilities().await.is_err() {
         return;
     }
@@ -887,6 +904,7 @@ fn resolve_model(
 
 fn realtime_error_code_for_api_error(error: &ApiError) -> RealtimeErrorCode {
     match error {
+        ApiError::ModelSessionCapacity(_) => RealtimeErrorCode::BackendNotReady,
         ApiError::Backend(_) | ApiError::BackendJoin(_) => RealtimeErrorCode::BackendCrashed,
         ApiError::AudioPreparation(_) => RealtimeErrorCode::UnsupportedAudioFormat,
         _ => RealtimeErrorCode::StartupConfigError,

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -13,6 +13,8 @@ use std::{
 
 use tokio::sync::mpsc;
 
+use crate::ModelSessionPermit;
+
 use super::*;
 
 pub(crate) struct BackendJob {
@@ -352,6 +354,10 @@ pub(crate) enum NativeStreamingWorkerMessage {
         /// against it; the WS session and any external supervisor hold their
         /// own clones of the same `Arc<AttachToken>`.
         token: Arc<AttachToken>,
+        /// The model-capacity permit. The worker owns it until this attached
+        /// session has actually returned, including after the WS transport has
+        /// disconnected, so a detached blocking decode cannot be overlapped.
+        model_session_permit: Option<ModelSessionPermit>,
     },
 }
 
@@ -385,6 +391,14 @@ impl NativeStreamingDecodeWorker {
         key: NativeStreamingWorkerKey,
         session: Box<dyn NativeAsrSession>,
     ) -> Result<Self, String> {
+        Self::attach_admitted(key, session, None).await
+    }
+
+    pub(crate) async fn attach_admitted(
+        key: NativeStreamingWorkerKey,
+        session: Box<dyn NativeAsrSession>,
+        model_session_permit: Option<ModelSessionPermit>,
+    ) -> Result<Self, String> {
         let (command_tx, command_rx) = mpsc::channel::<NativeStreamingCommandEnvelope>(
             NATIVE_STREAMING_COMMAND_QUEUE_CAPACITY,
         );
@@ -414,6 +428,7 @@ impl NativeStreamingDecodeWorker {
                 outcomes: outcome_tx,
                 finalize_requested: Arc::clone(&finalize_requested),
                 token: Arc::clone(&token),
+                model_session_permit,
             })
             .await
         {
@@ -766,7 +781,12 @@ pub(crate) fn spawn_native_streaming_worker(
                         outcomes,
                         finalize_requested,
                         token,
+                        model_session_permit,
                     } => {
+                        // Keep the capacity permit owned by this worker thread
+                        // until `run_native_streaming_session_on_worker` returns.
+                        // A disconnected WS cannot release it early.
+                        let _model_session_permit = model_session_permit;
                         // Record this attach as the current occupant only now,
                         // as the thread actually begins driving it -- so
                         // external supervisors always act on the attach that
@@ -1083,6 +1103,7 @@ impl RealtimeBackendWorkerKey {
 pub(crate) struct RealtimeBackendWorkItem {
     pub(crate) session_key: String,
     pub(crate) job: BackendJob,
+    pub(crate) model_admission: ModelSessionAdmission,
     pub(crate) result_sender: mpsc::Sender<BackendResult>,
     pub(crate) cancelled: Arc<AtomicBool>,
 }
@@ -1238,7 +1259,7 @@ pub(crate) fn launch_realtime_backend_work_item(
     tokio::spawn(async move {
         let cancelled = Arc::clone(&item.cancelled);
         let result_sender = item.result_sender.clone();
-        let result = run_realtime_backend_job(runtime, item.job).await;
+        let result = run_realtime_backend_job(runtime, item.job, item.model_admission).await;
         if !cancelled.load(Ordering::Relaxed) {
             let _ = result_sender.send(result).await;
         }
@@ -1248,7 +1269,11 @@ pub(crate) fn launch_realtime_backend_work_item(
     });
 }
 
-async fn run_realtime_backend_job(runtime: ServerRuntime, job: BackendJob) -> BackendResult {
+async fn run_realtime_backend_job(
+    runtime: ServerRuntime,
+    job: BackendJob,
+    model_admission: ModelSessionAdmission,
+) -> BackendResult {
     // Echo the requested language into the final realtime result; the core
     // Transcription carries no detected language, so the request value is the
     // only source. Capture it before job.language is moved into the builder.
@@ -1270,7 +1295,7 @@ async fn run_realtime_backend_job(runtime: ServerRuntime, job: BackendJob) -> Ba
         .with_execution_target(job.execution_target)
         .with_word_timestamps(job.word_timestamps)
         .with_display_file_name(Some(job.display_name));
-    match transcribe_with_runtime(runtime, request, None).await {
+    match transcribe_with_runtime(runtime, request, None, model_admission).await {
         Ok(transcription) => {
             let words = realtime_words_from_transcription(&transcription);
             BackendResult::Final(BackendSuccess {

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -46,7 +46,7 @@ pub(crate) struct BackendSuccess {
 
 pub(crate) enum BackendResult {
     Final(BackendSuccess),
-    Error(String),
+    Error(ApiError),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -387,6 +387,7 @@ pub(crate) struct NativeStreamingDecodeWorker {
 }
 
 impl NativeStreamingDecodeWorker {
+    #[cfg(test)]
     pub(crate) async fn attach(
         key: NativeStreamingWorkerKey,
         session: Box<dyn NativeAsrSession>,
@@ -994,6 +995,11 @@ async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
         // still serves `/health`; a bound pack arrives on a future restart.
         return;
     };
+    // Warmup is opportunistic. It must not queue behind an active request or
+    // allocate a second runtime; a real request owns the capacity slot first.
+    let Ok(model_session_permit) = runtime.acquire_native_execution() else {
+        return;
+    };
     let Some(adapter) = openasr_core::native_runtime_model_adapter_for_path(&model_pack_path)
     else {
         return;
@@ -1036,7 +1042,7 @@ async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
     };
     let key =
         NativeStreamingWorkerKey::new(model_pack.root.clone(), hardware_target, inference_threads);
-    attach_and_run_boot_warmup(key, session).await;
+    attach_and_run_boot_warmup(key, session, Some(model_session_permit)).await;
 }
 
 /// The generic (session-agnostic) half of the boot warm-up: attach `session`
@@ -1050,8 +1056,11 @@ async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
 pub(crate) async fn attach_and_run_boot_warmup(
     key: NativeStreamingWorkerKey,
     session: Box<dyn NativeAsrSession>,
+    model_session_permit: Option<ModelSessionPermit>,
 ) {
-    let Ok(mut worker) = NativeStreamingDecodeWorker::attach(key, session).await else {
+    let Ok(mut worker) =
+        NativeStreamingDecodeWorker::attach_admitted(key, session, model_session_permit).await
+    else {
         return;
     };
     let envelope = NativeStreamingCommandEnvelope {
@@ -1103,7 +1112,6 @@ impl RealtimeBackendWorkerKey {
 pub(crate) struct RealtimeBackendWorkItem {
     pub(crate) session_key: String,
     pub(crate) job: BackendJob,
-    pub(crate) model_admission: ModelSessionAdmission,
     pub(crate) result_sender: mpsc::Sender<BackendResult>,
     pub(crate) cancelled: Arc<AtomicBool>,
 }
@@ -1259,7 +1267,7 @@ pub(crate) fn launch_realtime_backend_work_item(
     tokio::spawn(async move {
         let cancelled = Arc::clone(&item.cancelled);
         let result_sender = item.result_sender.clone();
-        let result = run_realtime_backend_job(runtime, item.job, item.model_admission).await;
+        let result = run_realtime_backend_job(runtime, item.job).await;
         if !cancelled.load(Ordering::Relaxed) {
             let _ = result_sender.send(result).await;
         }
@@ -1269,11 +1277,7 @@ pub(crate) fn launch_realtime_backend_work_item(
     });
 }
 
-async fn run_realtime_backend_job(
-    runtime: ServerRuntime,
-    job: BackendJob,
-    model_admission: ModelSessionAdmission,
-) -> BackendResult {
+async fn run_realtime_backend_job(runtime: ServerRuntime, job: BackendJob) -> BackendResult {
     // Echo the requested language into the final realtime result; the core
     // Transcription carries no detected language, so the request value is the
     // only source. Capture it before job.language is moved into the builder.
@@ -1295,7 +1299,7 @@ async fn run_realtime_backend_job(
         .with_execution_target(job.execution_target)
         .with_word_timestamps(job.word_timestamps)
         .with_display_file_name(Some(job.display_name));
-    match transcribe_with_runtime(runtime, request, None, model_admission).await {
+    match transcribe_with_runtime(runtime, request, None).await {
         Ok(transcription) => {
             let words = realtime_words_from_transcription(&transcription);
             BackendResult::Final(BackendSuccess {
@@ -1308,8 +1312,6 @@ async fn run_realtime_backend_job(
                 words,
             })
         }
-        Err(error) => BackendResult::Error(format!(
-            "Could not transcribe completed realtime utterance: {error}"
-        )),
+        Err(error) => BackendResult::Error(error),
     }
 }

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -986,7 +986,7 @@ pub(crate) fn spawn_boot_native_warmup(runtime: ServerRuntime) {
     });
 }
 
-async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
+pub(crate) async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
     if runtime.backend != openasr_core::BackendKind::Native {
         return;
     }

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -986,7 +986,7 @@ pub(crate) fn spawn_boot_native_warmup(runtime: ServerRuntime) {
     });
 }
 
-pub(crate) async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
+pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime: ServerRuntime) {
     if runtime.backend != openasr_core::BackendKind::Native {
         return;
     }

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -346,7 +346,6 @@ fn work_item_for_test(session_key: &str, id: &str) -> RealtimeBackendWorkItem {
     RealtimeBackendWorkItem {
         session_key: session_key.to_string(),
         job: backend_job_for_test(id),
-        model_admission: crate::ModelSessionAdmission::default(),
         result_sender,
         cancelled: Arc::new(AtomicBool::new(false)),
     }
@@ -1985,7 +1984,7 @@ async fn boot_native_warmup_runs_in_background_without_blocking_a_concurrent_tas
     let key = test_native_streaming_worker_key("boot-warmup-nonblocking");
 
     let spawn_started = Instant::now();
-    let warmup_handle = tokio::spawn(attach_and_run_boot_warmup(key, session));
+    let warmup_handle = tokio::spawn(attach_and_run_boot_warmup(key, session, None));
     assert!(
         spawn_started.elapsed() < Duration::from_millis(100),
         "spawning the boot warm-up must not itself block"
@@ -2024,7 +2023,7 @@ async fn health_answers_immediately_while_boot_warmup_is_artificially_slow() {
     });
     let key = test_native_streaming_worker_key("health-vs-slow-warmup");
     let warmup_started = Instant::now();
-    let warmup_handle = tokio::spawn(attach_and_run_boot_warmup(key, session));
+    let warmup_handle = tokio::spawn(attach_and_run_boot_warmup(key, session, None));
 
     let app = crate::app_with_runtime(ServerRuntime::default());
     let response = tokio::time::timeout(
@@ -2073,7 +2072,7 @@ async fn boot_native_warmup_leaves_the_worker_thread_warm_for_the_next_real_atta
         warm_sleep: Duration::from_millis(50),
         warm_calls: Arc::clone(&warm_calls),
     });
-    attach_and_run_boot_warmup(key.clone(), boot_session).await;
+    attach_and_run_boot_warmup(key.clone(), boot_session, None).await;
     assert_eq!(warm_calls.load(Ordering::Acquire), 1);
 
     let (event_sender, _event_receiver) = mpsc::channel(8);
@@ -2643,6 +2642,7 @@ async fn native_realtime_server_smoke_with_real_qwen_pack() {
     let (event_sender, mut event_receiver) = mpsc::channel(512);
     let runtime = ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_path),
@@ -3025,6 +3025,7 @@ async fn session_capabilities_event_reports_frame_sync_only_for_xasr_zipformer()
     write_xasr_streaming_fixture_pack(&xasr_path, "xasr-zipformer-capability-test");
     let xasr_runtime = ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(xasr_path),
@@ -3044,6 +3045,7 @@ async fn session_capabilities_event_reports_frame_sync_only_for_xasr_zipformer()
     write_qwen_streaming_fixture_pack(&qwen_path, "qwen-capability-test");
     let qwen_runtime = ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(qwen_path),
@@ -3152,7 +3154,11 @@ async fn finish_discards_later_backend_finals_after_backend_error() {
     let (result_sender, result_receiver) = mpsc::channel(2);
     session.backend_results = Some(result_receiver);
     result_sender
-        .send(BackendResult::Error("backend failed".to_string()))
+        .send(BackendResult::Error(ApiError::Backend(
+            openasr_core::BackendError::NativeFailClosed {
+                reason: "backend failed".to_string(),
+            },
+        )))
         .await
         .unwrap();
     result_sender
@@ -3204,7 +3210,11 @@ async fn finish_remembers_backend_error_seen_before_shutdown() {
 
     assert!(
         session
-            .apply_backend_result(BackendResult::Error("backend failed".to_string()))
+            .apply_backend_result(BackendResult::Error(ApiError::Backend(
+                openasr_core::BackendError::NativeFailClosed {
+                    reason: "backend failed".to_string(),
+                }
+            )))
             .await
             .is_err()
     );
@@ -3307,6 +3317,7 @@ async fn session_start_rejects_xasr_hotwords_from_active_native_capabilities() {
     write_xasr_streaming_fixture_pack(&pack_path, model_id);
     let runtime = ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_path),
@@ -3349,6 +3360,7 @@ async fn session_start_accepts_hotwords_for_supporting_native_model() {
     write_moonshine_streaming_fixture_pack(&pack_path, model_id);
     let runtime = ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_path),
@@ -3388,6 +3400,7 @@ async fn native_streaming_configured_event_preserves_diarize_request() {
     let _wespeaker = EnvVarGuard::set("OPENASR_WESPEAKER_PACK", &wespeaker);
     let runtime = ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_path),
@@ -4731,13 +4744,8 @@ async fn remote_compute_websocket_session_does_not_record_server_history() {
         catalog_local_override: None,
     });
     let (event_sender, _event_receiver) = mpsc::channel(8);
-    let mut session = WsSession::new_with_history(
-        ServerRuntime::default(),
-        distribution,
-        crate::ModelSessionAdmission::default(),
-        event_sender,
-        false,
-    );
+    let mut session =
+        WsSession::new_with_history(ServerRuntime::default(), distribution, event_sender, false);
     let mut controller = RealtimeSessionController::new(RealtimeSessionConfig::new(
         "test_session",
         "whisper-large-v3-turbo",

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -1,9 +1,9 @@
 //! Unit tests for the realtime module. Pure code-motion from `realtime.rs`.
 
-use std::{collections::BTreeMap, fs, sync::OnceLock};
+use std::{collections::BTreeMap, fs, num::NonZeroUsize, sync::OnceLock};
 
 use super::*;
-use crate::PairingCredentialState;
+use crate::{ModelSessionAdmissionError, NativeExecutionSupervisor, PairingCredentialState};
 
 fn test_distribution() -> DistributionContext {
     let temp = tempfile::tempdir().unwrap();
@@ -2008,6 +2008,40 @@ async fn boot_native_warmup_runs_in_background_without_blocking_a_concurrent_tas
 }
 
 #[tokio::test]
+async fn boot_native_warmup_skips_when_the_runtime_slot_is_occupied() {
+    let temp = tempfile::tempdir().unwrap();
+    let pack_path = temp.path().join("boot-warmup-capacity-skip.oasr");
+    write_xasr_streaming_fixture_pack(&pack_path, "boot-warmup-capacity-skip");
+    let runtime = ServerRuntime {
+        backend: openasr_core::BackendKind::Native,
+        native_execution: NativeExecutionSupervisor::new(NonZeroUsize::new(1).unwrap()),
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: Some(pack_path),
+    };
+    let occupied_slot = runtime
+        .acquire_native_execution()
+        .expect("fixture runtime must admit the active native session");
+
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        warm_up_default_native_streaming_worker(runtime.clone()),
+    )
+    .await
+    .expect("boot warm-up must skip instead of waiting for a busy model slot");
+
+    assert!(
+        runtime.acquire_native_execution().is_err(),
+        "the only capacity slot must still belong to the active native session"
+    );
+    drop(occupied_slot);
+    assert!(
+        runtime.acquire_native_execution().is_ok(),
+        "skipped boot warm-up must not retain a capacity permit"
+    );
+}
+
+#[tokio::test]
 async fn health_answers_immediately_while_boot_warmup_is_artificially_slow() {
     use tower::ServiceExt;
 
@@ -3251,6 +3285,54 @@ async fn finish_remembers_backend_error_seen_before_shutdown() {
 }
 
 #[tokio::test]
+async fn fallback_capacity_error_is_backend_not_ready_and_recoverable() {
+    let (event_sender, mut event_receiver) = mpsc::channel(8);
+    let mut session = WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
+    let mut controller = RealtimeSessionController::new(RealtimeSessionConfig::new(
+        "test_session",
+        "whisper-large-v3-turbo",
+        timestamp_now(),
+    ))
+    .unwrap();
+    controller
+        .lifecycle(RealtimeLifecycleAction::Configure, timestamp_now())
+        .unwrap();
+    controller
+        .lifecycle(RealtimeLifecycleAction::StartAudio, timestamp_now())
+        .unwrap();
+    session.controller = Some(controller);
+
+    assert!(
+        session
+            .apply_backend_result(BackendResult::Error(ApiError::ModelSessionCapacity(
+                ModelSessionAdmissionError {
+                    model_identity: "native:whisper-large-v3-turbo@pack-a".to_string(),
+                    limit: NonZeroUsize::new(1).unwrap(),
+                },
+            )))
+            .await
+            .is_ok(),
+        "capacity exhaustion must not fail the realtime fallback session"
+    );
+    assert!(!session.backend_failed);
+    assert!(!session.backend_cancelled.load(Ordering::Relaxed));
+
+    let event = event_receiver
+        .recv()
+        .await
+        .expect("capacity exhaustion must emit a realtime error event");
+    assert_eq!(event.event_type, "error");
+    assert!(matches!(
+        event.event,
+        RealtimeEvent::Error(RealtimeErrorEvent {
+            code: RealtimeErrorCode::BackendNotReady,
+            recoverable: true,
+            ..
+        })
+    ));
+}
+
+#[tokio::test]
 async fn finish_transport_closed_cancels_pending_backend_jobs_without_waiting() {
     let (event_sender, _event_receiver) = mpsc::channel(8);
     let mut session = WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
@@ -3479,6 +3561,55 @@ async fn session_start_rejects_diarize_without_embedder_pack() {
             assert!(message.contains("speaker-embedder pack"));
         }
         other => panic!("expected startup config error, got {other:?}"),
+    }
+}
+
+#[test]
+fn hymt2_translation_worker_permit_lives_until_worker_exits() {
+    let supervisor = NativeExecutionSupervisor::new(NonZeroUsize::new(1).unwrap());
+    let model_identity = format!("hymt2:{HYMT2_TRANSLATION_MODEL_ID}");
+    let permit = supervisor
+        .try_acquire(model_identity.clone())
+        .expect("translation worker must acquire its model slot");
+    let (initialized_sender, initialized_receiver) = std::sync::mpsc::channel();
+
+    let translation = TranslationSession::spawn_thread_local(move || {
+        // This mirrors `load_hymt2_translation_session`: the permit is captured
+        // by the thread-local worker closure, not by the caller that spawned it.
+        let _model_session_permit = permit;
+        initialized_sender
+            .send(())
+            .expect("test must observe translation worker initialization");
+        Ok(move |_request: TranslationRequest| {
+            let _permit = &_model_session_permit;
+            Ok(TranslationWorkerOutput {
+                text: "translated".to_string(),
+                timings: openasr_core::TranslationTimings::default(),
+            })
+        })
+    });
+
+    initialized_receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("translation worker must initialize");
+    assert!(
+        supervisor.try_acquire(model_identity.clone()).is_err(),
+        "the worker must retain its Hy-MT2 permit while it remains alive"
+    );
+
+    drop(translation);
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        if let Ok(permit) = supervisor.try_acquire(model_identity.clone()) {
+            drop(permit);
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "worker exit must release the Hy-MT2 permit"
+        );
+        std::thread::sleep(Duration::from_millis(5));
     }
 }
 

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -3,7 +3,7 @@
 use std::{collections::BTreeMap, fs, num::NonZeroUsize, sync::OnceLock};
 
 use super::*;
-use crate::{ModelSessionAdmissionError, NativeExecutionSupervisor, PairingCredentialState};
+use crate::{NativeExecutionSupervisor, PairingCredentialState};
 
 fn test_distribution() -> DistributionContext {
     let temp = tempfile::tempdir().unwrap();
@@ -3285,37 +3285,55 @@ async fn finish_remembers_backend_error_seen_before_shutdown() {
 }
 
 #[tokio::test]
-async fn fallback_capacity_error_is_backend_not_ready_and_recoverable() {
+async fn fallback_capacity_rejection_is_backend_not_ready_and_recoverable() {
+    let temp = tempfile::tempdir().unwrap();
+    let model_id = "xasr-fallback-capacity";
+    let pack_path = temp.path().join("xasr-fallback-capacity.oasr");
+    write_xasr_streaming_fixture_pack(&pack_path, model_id);
+    let runtime = ServerRuntime {
+        backend: openasr_core::BackendKind::Native,
+        native_execution: NativeExecutionSupervisor::new(NonZeroUsize::new(1).unwrap()),
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: Some(pack_path),
+    };
+    let occupied_slot = runtime
+        .acquire_native_execution()
+        .expect("fixture runtime must admit the occupied native session");
     let (event_sender, mut event_receiver) = mpsc::channel(8);
-    let mut session = WsSession::new(ServerRuntime::default(), test_distribution(), event_sender);
-    let mut controller = RealtimeSessionController::new(RealtimeSessionConfig::new(
-        "test_session",
-        "whisper-large-v3-turbo",
-        timestamp_now(),
-    ))
-    .unwrap();
-    controller
-        .lifecycle(RealtimeLifecycleAction::Configure, timestamp_now())
-        .unwrap();
-    controller
-        .lifecycle(RealtimeLifecycleAction::StartAudio, timestamp_now())
-        .unwrap();
-    session.controller = Some(controller);
+    let mut session = WsSession::new(runtime, test_distribution(), event_sender);
+    let session_id = session.session_id.0.clone();
+    session.controller = Some(started_controller(&session_id, model_id));
+    session.spawn_backend_worker();
 
+    session
+        .queue_utterance(BufferedUtterance {
+            utterance_id: TranscriptUtteranceId("utt_fallback_capacity".to_string()),
+            start_ms: 0,
+            end_ms: 20,
+            frames: vec![frame(1, 0, 1000)],
+            reason: RealtimeUtteranceEndReason::VadStop,
+        })
+        .await
+        .expect("fallback job submission must succeed before backend admission");
+    assert_eq!(session.pending_backend_jobs, 1);
+
+    let result = tokio::time::timeout(Duration::from_secs(1), session.recv_backend_result())
+        .await
+        .expect("realtime worker must report the capacity rejection")
+        .expect("realtime worker result channel must remain open");
+    assert!(matches!(
+        result,
+        BackendResult::Error(ApiError::ModelSessionCapacity(_))
+    ));
     assert!(
-        session
-            .apply_backend_result(BackendResult::Error(ApiError::ModelSessionCapacity(
-                ModelSessionAdmissionError {
-                    model_identity: "native:whisper-large-v3-turbo@pack-a".to_string(),
-                    limit: NonZeroUsize::new(1).unwrap(),
-                },
-            )))
-            .await
-            .is_ok(),
+        session.apply_backend_result(result).await.is_ok(),
         "capacity exhaustion must not fail the realtime fallback session"
     );
+    assert_eq!(session.pending_backend_jobs, 0);
     assert!(!session.backend_failed);
     assert!(!session.backend_cancelled.load(Ordering::Relaxed));
+    assert!(!session.closed);
 
     let event = event_receiver
         .recv()
@@ -3330,6 +3348,7 @@ async fn fallback_capacity_error_is_backend_not_ready_and_recoverable() {
             ..
         })
     ));
+    drop(occupied_slot);
 }
 
 #[tokio::test]
@@ -3573,15 +3592,11 @@ fn hymt2_translation_worker_permit_lives_until_worker_exits() {
         .expect("translation worker must acquire its model slot");
     let (initialized_sender, initialized_receiver) = std::sync::mpsc::channel();
 
-    let translation = TranslationSession::spawn_thread_local(move || {
-        // This mirrors `load_hymt2_translation_session`: the permit is captured
-        // by the thread-local worker closure, not by the caller that spawned it.
-        let _model_session_permit = permit;
+    let translation = WsSession::spawn_admitted_hymt2_translation_worker(permit, move || {
         initialized_sender
             .send(())
             .expect("test must observe translation worker initialization");
         Ok(move |_request: TranslationRequest| {
-            let _permit = &_model_session_permit;
             Ok(TranslationWorkerOutput {
                 text: "translated".to_string(),
                 timings: openasr_core::TranslationTimings::default(),

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -346,6 +346,7 @@ fn work_item_for_test(session_key: &str, id: &str) -> RealtimeBackendWorkItem {
     RealtimeBackendWorkItem {
         session_key: session_key.to_string(),
         job: backend_job_for_test(id),
+        model_admission: crate::ModelSessionAdmission::default(),
         result_sender,
         cancelled: Arc::new(AtomicBool::new(false)),
     }
@@ -2353,6 +2354,7 @@ async fn failed_native_streaming_attach_send_retires_the_activity_guard() {
             outcomes: outcome_tx,
             finalize_requested: Arc::new(AtomicBool::new(false)),
             token,
+            model_session_permit: None,
         })
         .await;
     assert!(
@@ -4729,8 +4731,13 @@ async fn remote_compute_websocket_session_does_not_record_server_history() {
         catalog_local_override: None,
     });
     let (event_sender, _event_receiver) = mpsc::channel(8);
-    let mut session =
-        WsSession::new_with_history(ServerRuntime::default(), distribution, event_sender, false);
+    let mut session = WsSession::new_with_history(
+        ServerRuntime::default(),
+        distribution,
+        crate::ModelSessionAdmission::default(),
+        event_sender,
+        false,
+    );
     let mut controller = RealtimeSessionController::new(RealtimeSessionConfig::new(
         "test_session",
         "whisper-large-v3-turbo",

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -2,10 +2,13 @@
 //!
 //! Pure code-motion from `realtime.rs`; no behavior changes.
 
+use crate::ModelSessionPermit;
+
 use super::*;
 
 pub(crate) struct WsSession {
     pub(crate) runtime: ServerRuntime,
+    pub(crate) model_admission: ModelSessionAdmission,
     pub(crate) distribution: DistributionContext,
     pub(crate) session_id: RealtimeSessionId,
     /// The single connection-lifetime sequencer. Every envelope leaving this
@@ -623,12 +626,19 @@ impl WsSession {
         distribution: DistributionContext,
         event_sender: mpsc::Sender<RealtimeEventEnvelope>,
     ) -> Self {
-        Self::new_with_history(runtime, distribution, event_sender, true)
+        Self::new_with_history(
+            runtime,
+            distribution,
+            ModelSessionAdmission::default(),
+            event_sender,
+            true,
+        )
     }
 
     pub(crate) fn new_with_history(
         runtime: ServerRuntime,
         distribution: DistributionContext,
+        model_admission: ModelSessionAdmission,
         event_sender: mpsc::Sender<RealtimeEventEnvelope>,
         record_history: bool,
     ) -> Self {
@@ -637,6 +647,7 @@ impl WsSession {
         let session_id = next_session_id("rt_ws");
         Self {
             runtime,
+            model_admission,
             distribution,
             sequencer: RealtimeEventSequencer::new(session_id.clone()),
             emitted_event_ids: std::collections::HashMap::new(),
@@ -1586,6 +1597,34 @@ impl WsSession {
             .await?;
             return Err(());
         };
+        let model_session_key = match native_model_session_key(&self.runtime) {
+            Ok(key) => key,
+            Err(error) => {
+                self.emit_error(
+                    RealtimeErrorCode::StartupConfigError,
+                    &error.to_string(),
+                    false,
+                )
+                .await?;
+                return Err(());
+            }
+        };
+        let model_session_permit = match self.model_admission.try_acquire(model_session_key) {
+            Ok(permit) => permit,
+            Err(error) => {
+                self.emit_error(
+                    RealtimeErrorCode::BackendNotReady,
+                    &format!(
+                        "Model '{}' is at its concurrent native session limit ({}). Retry when an existing session finishes, or increase --max-native-sessions-per-model if this host has enough memory.",
+                        error.model_identity,
+                        error.limit,
+                    ),
+                    true,
+                )
+                .await?;
+                return Err(());
+            }
+        };
         let model_pack =
             NativeAsrModelPackRef::new(model_id, adapter.model_family(), model_pack_path);
         let context = NativeAsrSessionContext::from_realtime_session_id(self.session_id.clone());
@@ -1645,13 +1684,14 @@ impl WsSession {
         // The session moves onto its own decode thread; the WS task queues audio
         // and drains outcomes separately so a slow partial decode never blocks
         // socket ingest for this session.
-        self.attach_native_streaming_session(
+        self.attach_native_streaming_session_admitted(
             NativeStreamingWorkerKey::new(
                 model_pack.root.clone(),
                 hardware_target,
                 self.inference_threads,
             ),
             session,
+            model_session_permit,
         )
         .await
         .map_err(|message| {
@@ -1663,12 +1703,26 @@ impl WsSession {
         Ok(())
     }
 
+    #[cfg(test)]
     pub(crate) async fn attach_native_streaming_session(
         &mut self,
         key: NativeStreamingWorkerKey,
         session: Box<dyn NativeAsrSession>,
     ) -> Result<(), String> {
         self.native_streaming = Some(NativeStreamingDecodeWorker::attach(key, session).await?);
+        Ok(())
+    }
+
+    async fn attach_native_streaming_session_admitted(
+        &mut self,
+        key: NativeStreamingWorkerKey,
+        session: Box<dyn NativeAsrSession>,
+        model_session_permit: ModelSessionPermit,
+    ) -> Result<(), String> {
+        self.native_streaming = Some(
+            NativeStreamingDecodeWorker::attach_admitted(key, session, Some(model_session_permit))
+                .await?,
+        );
         Ok(())
     }
 
@@ -2824,6 +2878,7 @@ impl WsSession {
         let work_item = RealtimeBackendWorkItem {
             session_key: self.session_id.0.clone(),
             job,
+            model_admission: self.model_admission.clone(),
             result_sender,
             cancelled: Arc::clone(&self.backend_cancelled),
         };

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -2,13 +2,12 @@
 //!
 //! Pure code-motion from `realtime.rs`; no behavior changes.
 
-use crate::ModelSessionPermit;
+use crate::{ModelSessionPermit, NativeExecutionSupervisor};
 
 use super::*;
 
 pub(crate) struct WsSession {
     pub(crate) runtime: ServerRuntime,
-    pub(crate) model_admission: ModelSessionAdmission,
     pub(crate) distribution: DistributionContext,
     pub(crate) session_id: RealtimeSessionId,
     /// The single connection-lifetime sequencer. Every envelope leaving this
@@ -626,19 +625,12 @@ impl WsSession {
         distribution: DistributionContext,
         event_sender: mpsc::Sender<RealtimeEventEnvelope>,
     ) -> Self {
-        Self::new_with_history(
-            runtime,
-            distribution,
-            ModelSessionAdmission::default(),
-            event_sender,
-            true,
-        )
+        Self::new_with_history(runtime, distribution, event_sender, true)
     }
 
     pub(crate) fn new_with_history(
         runtime: ServerRuntime,
         distribution: DistributionContext,
-        model_admission: ModelSessionAdmission,
         event_sender: mpsc::Sender<RealtimeEventEnvelope>,
         record_history: bool,
     ) -> Self {
@@ -647,7 +639,6 @@ impl WsSession {
         let session_id = next_session_id("rt_ws");
         Self {
             runtime,
-            model_admission,
             distribution,
             sequencer: RealtimeEventSequencer::new(session_id.clone()),
             emitted_event_ids: std::collections::HashMap::new(),
@@ -1009,14 +1000,20 @@ impl WsSession {
             &session,
             capabilities,
             self.distribution.clone(),
+            self.runtime.native_execution.clone(),
             test_translation_worker,
         )
         .await
         {
             Ok(result) => result,
-            Err(message) => {
-                self.emit_error(RealtimeErrorCode::StartupConfigError, &message, false)
-                    .await?;
+            Err(error) => {
+                let recoverable = matches!(error, ApiError::ModelSessionCapacity(_));
+                self.emit_error(
+                    realtime_error_code_for_api_error(&error),
+                    &error.to_string(),
+                    recoverable,
+                )
+                .await?;
                 return Err(());
             }
         };
@@ -1210,8 +1207,9 @@ impl WsSession {
         session: &StartSession,
         capabilities: RealtimeBackendCapabilities,
         distribution: DistributionContext,
+        native_execution: NativeExecutionSupervisor,
         test_worker: Option<(TranslationWorkerHook, Option<TranslationWorkerInitHook>)>,
-    ) -> Result<(Option<RealtimeTranslationLane>, SessionTranslationSummary), String> {
+    ) -> Result<(Option<RealtimeTranslationLane>, SessionTranslationSummary), ApiError> {
         let Some(options) = session.translation.as_ref() else {
             return Ok((None, SessionTranslationSummary::disabled()));
         };
@@ -1224,9 +1222,9 @@ impl WsSession {
                 .translation
                 .reason
                 .unwrap_or(openasr_core::RealtimeTranslationCapability::REASON_PACK_MISSING);
-            return Err(format!(
+            return Err(ApiError::BadRequest(format!(
                 "Realtime translation was requested but is unavailable: {reason}."
-            ));
+            )));
         }
         let target_lang = options
             .target_lang
@@ -1235,41 +1233,45 @@ impl WsSession {
             .trim()
             .to_string();
         let Some(target_lang) = TargetLang::parse_mvp(&target_lang) else {
-            return Err(
+            return Err(ApiError::BadRequest(
                 "Realtime translation MVP only supports translation.target_lang=\"en\"."
                     .to_string(),
-            );
+            ));
         };
         let mode = options
             .mode
             .as_deref()
             .unwrap_or(openasr_core::RealtimeTranslationCapability::MODE_CLAUSE_RETRANSLATION);
         if mode != openasr_core::RealtimeTranslationCapability::MODE_CLAUSE_RETRANSLATION {
-            return Err(
+            return Err(ApiError::BadRequest(
                 "Realtime translation MVP only supports translation.mode=\"clause_retranslation\"."
                     .to_string(),
-            );
+            ));
         }
         if !session_language_is_chinese(session.language.as_deref()) {
-            return Err(
+            return Err(ApiError::BadRequest(
                 "Realtime translation MVP requires session.language=\"zh\" so zh->en is explicit."
                     .to_string(),
-            );
+            ));
         }
         if let Some(model) = options.model.as_deref()
             && !translation_model_ref_supported(model)
         {
-            return Err(format!(
+            return Err(ApiError::BadRequest(format!(
                 "Realtime translation MVP only supports translation.model=\"{}\" or \"hymt2-1.8b\".",
                 HYMT2_TRANSLATION_MODEL_ID
-            ));
+            )));
         }
 
         let model_id = HYMT2_TRANSLATION_MODEL_ID.to_string();
         let requested_model = options.model.clone();
-        let translation_session =
-            Self::build_translation_session(distribution, requested_model.as_deref(), test_worker)
-                .await?;
+        let translation_session = Self::build_translation_session(
+            distribution,
+            requested_model.as_deref(),
+            native_execution,
+            test_worker,
+        )
+        .await?;
         let summary = SessionTranslationSummary {
             enabled: true,
             target_lang: Some(target_lang.as_str().to_string()),
@@ -1300,8 +1302,9 @@ impl WsSession {
     async fn build_translation_session(
         distribution: DistributionContext,
         requested_model: Option<&str>,
+        native_execution: NativeExecutionSupervisor,
         test_worker: Option<(TranslationWorkerHook, Option<TranslationWorkerInitHook>)>,
-    ) -> Result<TranslationSession, String> {
+    ) -> Result<TranslationSession, ApiError> {
         if let Some((worker, init)) = test_worker {
             if let Some(init) = init {
                 return Ok(TranslationSession::spawn_thread_local(move || {
@@ -1312,8 +1315,15 @@ impl WsSession {
             return Ok(TranslationSession::spawn(move |request| worker(request)));
         }
 
-        let selection = resolve_translation_pack_selection(&distribution, requested_model)?;
-        Ok(Self::load_hymt2_translation_session(selection))
+        let selection = resolve_translation_pack_selection(&distribution, requested_model)
+            .map_err(ApiError::BadRequest)?;
+        let model_session_permit = native_execution
+            .try_acquire(format!("hymt2:{HYMT2_TRANSLATION_MODEL_ID}"))
+            .map_err(ApiError::ModelSessionCapacity)?;
+        Ok(Self::load_hymt2_translation_session(
+            selection,
+            model_session_permit,
+        ))
     }
 
     /// Spawns the Hy-MT2 translation worker with the (multi-second) model
@@ -1321,9 +1331,13 @@ impl WsSession {
     /// path. `session.start` is accepted immediately; readiness is announced
     /// via a `translation.status` event from `drain_translation_outputs`, and
     /// a load failure surfaces there as a session-fatal `error` event.
-    fn load_hymt2_translation_session(selection: TranslationPackSelection) -> TranslationSession {
+    fn load_hymt2_translation_session(
+        selection: TranslationPackSelection,
+        model_session_permit: ModelSessionPermit,
+    ) -> TranslationSession {
         let path = selection.path;
         TranslationSession::spawn_thread_local(move || {
+            let _model_session_permit = model_session_permit;
             let runtime =
                 Hymt2Runtime::from_path(path).map_err(|error| TranslationQueueError::Worker {
                     reason: format!(
@@ -1332,6 +1346,7 @@ impl WsSession {
                 })?;
             let mut cache = Hymt2TranslationSessionCache::default();
             Ok(move |request| {
+                let _permit = &_model_session_permit;
                 runtime
                     .translate_request_with_cache(&mut cache, &request)
                     .map_err(|error| TranslationQueueError::Worker {
@@ -1597,31 +1612,13 @@ impl WsSession {
             .await?;
             return Err(());
         };
-        let model_session_key = match native_model_session_key(&self.runtime) {
-            Ok(key) => key,
-            Err(error) => {
-                self.emit_error(
-                    RealtimeErrorCode::StartupConfigError,
-                    &error.to_string(),
-                    false,
-                )
-                .await?;
-                return Err(());
-            }
-        };
-        let model_session_permit = match self.model_admission.try_acquire(model_session_key) {
+        let model_session_permit = match self.runtime.acquire_native_execution() {
             Ok(permit) => permit,
             Err(error) => {
-                self.emit_error(
-                    RealtimeErrorCode::BackendNotReady,
-                    &format!(
-                        "Model '{}' is at its concurrent native session limit ({}). Retry when an existing session finishes, or increase --max-native-sessions-per-model if this host has enough memory.",
-                        error.model_identity,
-                        error.limit,
-                    ),
-                    true,
-                )
-                .await?;
+                let recoverable = matches!(error, ApiError::ModelSessionCapacity(_));
+                let code = realtime_error_code_for_api_error(&error);
+                self.emit_error(code, &error.to_string(), recoverable)
+                    .await?;
                 return Err(());
             }
         };
@@ -2878,7 +2875,6 @@ impl WsSession {
         let work_item = RealtimeBackendWorkItem {
             session_key: self.session_id.0.clone(),
             job,
-            model_admission: self.model_admission.clone(),
             result_sender,
             cancelled: Arc::clone(&self.backend_cancelled),
         };
@@ -2998,11 +2994,16 @@ impl WsSession {
                 }
                 Ok(())
             }
-            BackendResult::Error(message) => {
+            BackendResult::Error(error) => {
+                let recoverable = matches!(error, ApiError::ModelSessionCapacity(_));
+                let code = realtime_error_code_for_api_error(&error);
+                self.emit_error(code, &error.to_string(), recoverable)
+                    .await?;
+                if recoverable {
+                    return Ok(());
+                }
                 self.backend_failed = true;
                 self.cancel_backend_jobs();
-                self.emit_error(RealtimeErrorCode::BackendCrashed, &message, false)
-                    .await?;
                 Err(())
             }
         }
@@ -3051,14 +3052,21 @@ impl WsSession {
                     final_result @ BackendResult::Final(_) => {
                         self.apply_backend_result(final_result).await?
                     }
-                    BackendResult::Error(message) => {
+                    BackendResult::Error(error) => {
                         self.pending_backend_jobs = self.pending_backend_jobs.saturating_sub(1);
+                        let recoverable = matches!(error, ApiError::ModelSessionCapacity(_));
                         if !self.backend_failed {
-                            self.emit_error(RealtimeErrorCode::BackendCrashed, &message, false)
-                                .await?;
+                            self.emit_error(
+                                realtime_error_code_for_api_error(&error),
+                                &error.to_string(),
+                                recoverable,
+                            )
+                            .await?;
                         }
-                        self.backend_failed = true;
-                        self.cancel_backend_jobs();
+                        if !recoverable {
+                            self.backend_failed = true;
+                            self.cancel_backend_jobs();
+                        }
                     }
                 }
             } else {

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -1336,8 +1336,7 @@ impl WsSession {
         model_session_permit: ModelSessionPermit,
     ) -> TranslationSession {
         let path = selection.path;
-        TranslationSession::spawn_thread_local(move || {
-            let _model_session_permit = model_session_permit;
+        Self::spawn_admitted_hymt2_translation_worker(model_session_permit, move || {
             let runtime =
                 Hymt2Runtime::from_path(path).map_err(|error| TranslationQueueError::Worker {
                     reason: format!(
@@ -1346,12 +1345,31 @@ impl WsSession {
                 })?;
             let mut cache = Hymt2TranslationSessionCache::default();
             Ok(move |request| {
-                let _permit = &_model_session_permit;
                 runtime
                     .translate_request_with_cache(&mut cache, &request)
                     .map_err(|error| TranslationQueueError::Worker {
                         reason: error.to_string(),
                     })
+            })
+        })
+    }
+
+    /// Owns a Hy-MT2 capacity permit on the dedicated translation worker until
+    /// that worker exits, including while its model initializer is running.
+    pub(in crate::realtime) fn spawn_admitted_hymt2_translation_worker<W>(
+        model_session_permit: ModelSessionPermit,
+        init_worker: impl FnOnce() -> Result<W, TranslationQueueError> + Send + 'static,
+    ) -> TranslationSession
+    where
+        W: FnMut(TranslationRequest) -> Result<TranslationWorkerOutput, TranslationQueueError>
+            + 'static,
+    {
+        TranslationSession::spawn_thread_local(move || {
+            let model_session_permit = model_session_permit;
+            let mut worker = init_worker()?;
+            Ok(move |request| {
+                let _permit = &model_session_permit;
+                worker(request)
             })
         })
     }

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -29,19 +29,30 @@ pub(crate) async fn transcriptions(
     headers: HeaderMap,
     Extension(auth): Extension<ServerAuth>,
     Extension(distribution): Extension<DistributionContext>,
+    Extension(model_admission): Extension<ModelSessionAdmission>,
     multipart: Result<Multipart, MultipartRejection>,
 ) -> Result<Response, ApiError> {
     if query.stream.unwrap_or(false) {
         return crate::realtime::stream_transcription(
             runtime,
             distribution,
+            model_admission,
             multipart,
             !is_remote_compute_client_request(&headers, &auth),
         )
         .await;
     }
 
-    run_offline_transcription(runtime, headers, auth, distribution, multipart, None).await
+    run_offline_transcription(
+        runtime,
+        headers,
+        auth,
+        distribution,
+        model_admission,
+        multipart,
+        None,
+    )
+    .await
 }
 
 /// OpenAI-compatible `/v1/audio/translations`: always X->English translation.
@@ -53,6 +64,7 @@ pub(crate) async fn translations(
     headers: HeaderMap,
     Extension(auth): Extension<ServerAuth>,
     Extension(distribution): Extension<DistributionContext>,
+    Extension(model_admission): Extension<ModelSessionAdmission>,
     multipart: Result<Multipart, MultipartRejection>,
 ) -> Result<Response, ApiError> {
     run_offline_transcription(
@@ -60,6 +72,7 @@ pub(crate) async fn translations(
         headers,
         auth,
         distribution,
+        model_admission,
         multipart,
         Some(TranscriptionTask::Translate),
     )
@@ -243,6 +256,7 @@ async fn run_offline_transcription(
     headers: HeaderMap,
     auth: ServerAuth,
     distribution: DistributionContext,
+    model_admission: ModelSessionAdmission,
     multipart: Result<Multipart, MultipartRejection>,
     task_override: Option<TranscriptionTask>,
 ) -> Result<Response, ApiError> {
@@ -315,30 +329,36 @@ async fn run_offline_transcription(
         ActiveTranscriptionCleanup::new(distribution.clone(), id.clone(), Arc::clone(control))
     });
     let control_handle = control.as_ref().map(|(_, control)| Arc::clone(control));
-    let transcription =
-        match transcribe_with_runtime(runtime, parsed.request, control_handle.clone()).await {
-            Ok(transcription) => {
-                if let Some(cleanup) = control_cleanup.as_mut() {
-                    cleanup.disarm();
-                }
-                transcription
+    let transcription = match transcribe_with_runtime(
+        runtime,
+        parsed.request,
+        control_handle.clone(),
+        model_admission,
+    )
+    .await
+    {
+        Ok(transcription) => {
+            if let Some(cleanup) = control_cleanup.as_mut() {
+                cleanup.disarm();
             }
-            Err(error) => {
-                if let Some(cleanup) = control_cleanup.as_mut() {
-                    cleanup.disarm();
-                }
-                // A cancel surfaces from core as a generic fail-closed error (the
-                // typed cancel is flattened through the NativeAsrError layer), so
-                // consult the control to report it honestly as a 409 canceled result
-                // rather than a 400 fail-closed refusal.
-                if control_handle.is_some_and(|control| control.is_canceled()) {
-                    return Err(ApiError::Backend(
-                        openasr_core::BackendError::TranscriptionCanceled,
-                    ));
-                }
-                return Err(error);
+            transcription
+        }
+        Err(error) => {
+            if let Some(cleanup) = control_cleanup.as_mut() {
+                cleanup.disarm();
             }
-        };
+            // A cancel surfaces from core as a generic fail-closed error (the
+            // typed cancel is flattened through the NativeAsrError layer), so
+            // consult the control to report it honestly as a 409 canceled result
+            // rather than a 400 fail-closed refusal.
+            if control_handle.is_some_and(|control| control.is_canceled()) {
+                return Err(ApiError::Backend(
+                    openasr_core::BackendError::TranscriptionCanceled,
+                ));
+            }
+            return Err(error);
+        }
+    };
     let rendered = render_transcription(&transcription, parsed.response_format)
         .map_err(ApiError::Serialize)?;
     // History is a best-effort audit side-write: a successful transcription must
@@ -933,6 +953,35 @@ fn native_model_refs_match(requested: &str, runtime_source_id: &str) -> bool {
     openasr_core::native_runtime_model_refs_match(requested, runtime_source_id)
 }
 
+/// Stable identity for the actual native runtime that will execute requests.
+///
+/// It intentionally ignores the client-supplied model spelling: aliases and a
+/// bare runtime metadata id must all share one capacity slot. The identity comes
+/// from the validated runtime pack, never from an unbounded request value.
+pub(crate) fn native_model_session_key(runtime: &ServerRuntime) -> Result<String, ApiError> {
+    let model_pack_path = runtime.model_pack_path.as_deref().ok_or_else(|| {
+        ApiError::Backend(openasr_core::BackendError::NativeModelPackPathRequired)
+    })?;
+    let pack_root = openasr_core::validate_local_native_model_pack_path(model_pack_path)
+        .map_err(ApiError::Backend)?;
+    let identity = validate_native_runtime_pack(&pack_root).map_err(ApiError::Backend)?;
+    let model_ref = parse_model_ref(&identity.model_id).map_err(|error| {
+        ApiError::Backend(openasr_core::BackendError::NativeFailClosed {
+            reason: format!(
+                "could not canonicalize native runtime model identity '{}': {error}",
+                identity.model_id
+            ),
+        })
+    })?;
+    let quant = model_ref
+        .tag
+        .as_deref()
+        .map(openasr_core::canonical_quant_tag)
+        .map(|tag| format!(":{tag}"))
+        .unwrap_or_default();
+    Ok(format!("native:{}{quant}", model_ref.family))
+}
+
 // Bare ids of models that are *live* in the current catalog must never be
 // listed here: a native pack legitimately carries its bare family id as
 // metadata (packs burn no quant tag into `openasr.model.id` -- the "bare id
@@ -1294,6 +1343,7 @@ pub(crate) async fn transcribe_with_runtime(
     runtime: ServerRuntime,
     request: TranscriptionRequest,
     control: Option<Arc<openasr_core::TranscriptionControl>>,
+    model_admission: ModelSessionAdmission,
 ) -> Result<openasr_core::Transcription, ApiError> {
     match runtime.backend {
         BackendKind::Mock => {
@@ -1317,26 +1367,38 @@ pub(crate) async fn transcribe_with_runtime(
             }
             Ok(transcription)
         }
-        BackendKind::Native => tokio::task::spawn_blocking(move || {
-            // Marks this offline (file-transcription / realtime-per-utterance
-            // backend-job) decode as active for the whole synchronous run, so
-            // the idle_unload reaper never evicts the model runtime cache out
-            // from under it; dropped (any exit path) once the decode returns.
-            let _activity_guard = NativeActivityGuard::enter();
-            // Bind the pause/cancel control to this decode thread for the whole
-            // synchronous run so the long-form slice loop can observe it; the
-            // guard clears the binding on any exit. `None` (no control requested)
-            // leaves the decode byte-identical to before.
-            let _control_guard = control.map(openasr_core::install_active_transcription_control);
-            let model_pack_path = runtime.model_pack_path.clone().ok_or_else(|| {
-                TranscriptionRuntimeError::Backend(
-                    openasr_core::BackendError::NativeModelPackPathRejected {
-                        reason: "native backend requires an explicit local .oasr runtime pack path"
-                            .to_string(),
-                    },
-                )
-            })?;
-            let adapter =
+        BackendKind::Native => {
+            let model_session_key = native_model_session_key(&runtime)?;
+            let model_session_permit = model_admission
+                .try_acquire(model_session_key)
+                .map_err(ApiError::ModelSessionCapacity)?;
+            tokio::task::spawn_blocking(move || {
+                // This permit is deliberately owned by the blocking task rather
+                // than its async caller. Dropping an HTTP/SSE future detaches a
+                // spawned blocking task, but must not admit a second heavy decode
+                // while the first one still owns model execution resources.
+                let _model_session_permit = model_session_permit;
+                // Marks this offline (file-transcription / realtime-per-utterance
+                // backend-job) decode as active for the whole synchronous run, so
+                // the idle_unload reaper never evicts the model runtime cache out
+                // from under it; dropped (any exit path) once the decode returns.
+                let _activity_guard = NativeActivityGuard::enter();
+                // Bind the pause/cancel control to this decode thread for the whole
+                // synchronous run so the long-form slice loop can observe it; the
+                // guard clears the binding on any exit. `None` (no control requested)
+                // leaves the decode byte-identical to before.
+                let _control_guard =
+                    control.map(openasr_core::install_active_transcription_control);
+                let model_pack_path = runtime.model_pack_path.clone().ok_or_else(|| {
+                    TranscriptionRuntimeError::Backend(
+                        openasr_core::BackendError::NativeModelPackPathRejected {
+                            reason:
+                                "native backend requires an explicit local .oasr runtime pack path"
+                                    .to_string(),
+                        },
+                    )
+                })?;
+                let adapter =
                 native_runtime_model_adapter_for_path(&model_pack_path).ok_or_else(|| {
                     TranscriptionRuntimeError::Backend(
                         openasr_core::BackendError::NativeFailClosed {
@@ -1347,81 +1409,82 @@ pub(crate) async fn transcribe_with_runtime(
                         },
                     )
                 })?;
-            let prepared = prepare_audio_input(
-                &request.input_path,
-                &AudioPreparationOptions::new(runtime.backend)
-                    .with_ffmpeg_bin(runtime.ffmpeg_bin.clone())
-                    .with_ffmpeg_bin_explicit(runtime.ffmpeg_bin_explicit)
-                    .with_native_non_wav_conversion(true),
-            )
-            .map_err(TranscriptionRuntimeError::AudioPreparation)?;
-            let mut request = request;
-            request.input_path = prepared.path().to_path_buf();
-            let word_timestamps = request.word_timestamps;
-            let model_pack = NativeAsrModelPackRef::new(
-                request.model_id.clone(),
-                adapter.model_family(),
-                model_pack_path,
-            );
-            let offline_request = NativeAsrOfflineRequest::new(request.input_path.clone())
-                .with_options(
-                    NativeAsrRequestOptions::new()
-                        .with_language(request.language.clone())
-                        .with_prompt(request.prompt.clone())
-                        .with_phrase_bias(request.phrase_bias.clone())
-                        .with_inference_threads(request.inference_threads)
-                        .with_diarization(request.diarize)
-                        .with_word_timestamps(request.word_timestamps)
-                        .with_word_timestamps_refine(request.word_timestamps_refine),
+                let prepared = prepare_audio_input(
+                    &request.input_path,
+                    &AudioPreparationOptions::new(runtime.backend)
+                        .with_ffmpeg_bin(runtime.ffmpeg_bin.clone())
+                        .with_ffmpeg_bin_explicit(runtime.ffmpeg_bin_explicit)
+                        .with_native_non_wav_conversion(true),
                 )
-                .with_longform(request.longform.clone())
-                .with_display_file_name(request.display_file_name.clone())
-                .with_source(request.source)
-                // The source audio's real format for the `stage=request_context`
-                // log line -- `prepared.original()` is the pre-normalization
-                // probe (WAV fmt chunk) or decode (other recognized formats)
-                // result; `None` when this pipeline could not determine it
-                // (unrecognized extension, or a format only the external
-                // ffmpeg/afconvert fallback handles).
-                .with_source_audio_format(
-                    prepared.original().sample_rate_hz,
-                    prepared.original().channels,
+                .map_err(TranscriptionRuntimeError::AudioPreparation)?;
+                let mut request = request;
+                request.input_path = prepared.path().to_path_buf();
+                let word_timestamps = request.word_timestamps;
+                let model_pack = NativeAsrModelPackRef::new(
+                    request.model_id.clone(),
+                    adapter.model_family(),
+                    model_pack_path,
+                );
+                let offline_request = NativeAsrOfflineRequest::new(request.input_path.clone())
+                    .with_options(
+                        NativeAsrRequestOptions::new()
+                            .with_language(request.language.clone())
+                            .with_prompt(request.prompt.clone())
+                            .with_phrase_bias(request.phrase_bias.clone())
+                            .with_inference_threads(request.inference_threads)
+                            .with_diarization(request.diarize)
+                            .with_word_timestamps(request.word_timestamps)
+                            .with_word_timestamps_refine(request.word_timestamps_refine),
+                    )
+                    .with_longform(request.longform.clone())
+                    .with_display_file_name(request.display_file_name.clone())
+                    .with_source(request.source)
+                    // The source audio's real format for the `stage=request_context`
+                    // log line -- `prepared.original()` is the pre-normalization
+                    // probe (WAV fmt chunk) or decode (other recognized formats)
+                    // result; `None` when this pipeline could not determine it
+                    // (unrecognized extension, or a format only the external
+                    // ffmpeg/afconvert fallback handles).
+                    .with_source_audio_format(
+                        prepared.original().sample_rate_hz,
+                        prepared.original().channels,
+                    )
+                    // Extension only, off the upload's own temp file (which
+                    // preserves the client's original extension via
+                    // `safe_extension_suffix` -- see `ingest_field` above); never
+                    // the client-supplied file name/stem itself.
+                    .with_source_container(prepared.original().extension.clone())
+                    // Lets the native backend decode straight from the in-process
+                    // symphonia decode's in-memory samples (uploads are almost
+                    // always a non-WAV/non-conformant container) instead of
+                    // re-reading `input_path` from disk -- see
+                    // `PreparedAudioInput::shared_samples`.
+                    .with_prepared_samples(prepared.shared_samples());
+                let executor = NativeBackendExecutor;
+                let mut transcription = NativeAsrExecutor::transcribe(
+                    &executor,
+                    &adapter,
+                    &model_pack,
+                    native_hardware_target_from_execution_target(request.execution_target),
+                    offline_request,
                 )
-                // Extension only, off the upload's own temp file (which
-                // preserves the client's original extension via
-                // `safe_extension_suffix` -- see `ingest_field` above); never
-                // the client-supplied file name/stem itself.
-                .with_source_container(prepared.original().extension.clone())
-                // Lets the native backend decode straight from the in-process
-                // symphonia decode's in-memory samples (uploads are almost
-                // always a non-WAV/non-conformant container) instead of
-                // re-reading `input_path` from disk -- see
-                // `PreparedAudioInput::shared_samples`.
-                .with_prepared_samples(prepared.shared_samples());
-            let executor = NativeBackendExecutor;
-            let mut transcription = NativeAsrExecutor::transcribe(
-                &executor,
-                &adapter,
-                &model_pack,
-                native_hardware_target_from_execution_target(request.execution_target),
-                offline_request,
-            )
-            .map_err(native_asr_error_to_backend)
-            .map_err(TranscriptionRuntimeError::Backend)?;
-            // The decode above only returns `Ok` after the model runtime is
-            // built (or reused) and actually ran, so this is the resident
-            // signal `/health`'s `model_resident` field reads -- see
-            // `idle_activity::native_model_is_resident`.
-            crate::idle_activity::mark_native_model_warm();
-            if word_timestamps {
-                add_segment_word_timestamps(&mut transcription);
-            }
-            drop(prepared);
-            Ok::<_, TranscriptionRuntimeError>(transcription)
-        })
-        .await
-        .map_err(ApiError::BackendJoin)?
-        .map_err(ApiError::from),
+                .map_err(native_asr_error_to_backend)
+                .map_err(TranscriptionRuntimeError::Backend)?;
+                // The decode above only returns `Ok` after the model runtime is
+                // built (or reused) and actually ran, so this is the resident
+                // signal `/health`'s `model_resident` field reads -- see
+                // `idle_activity::native_model_is_resident`.
+                crate::idle_activity::mark_native_model_warm();
+                if word_timestamps {
+                    add_segment_word_timestamps(&mut transcription);
+                }
+                drop(prepared);
+                Ok::<_, TranscriptionRuntimeError>(transcription)
+            })
+            .await
+            .map_err(ApiError::BackendJoin)?
+            .map_err(ApiError::from)
+        }
     }
 }
 

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1319,6 +1319,83 @@ fn validate_timestamp_granularities(values: &[String]) -> Result<(), ApiError> {
 
 // ── Backend execution ─────────────────────────────────────────────────────────
 
+/// Runs the native-runtime portion of a transcription after all audio-only
+/// preparation has completed. The caller owns the blocking task, while this
+/// helper keeps the permit scoped to the real native execution closure.
+fn run_admitted_native_transcription<R>(
+    model_session_permit: ModelSessionPermit,
+    decode: impl FnOnce() -> Result<R, TranscriptionRuntimeError>,
+) -> Result<R, TranscriptionRuntimeError> {
+    let _model_session_permit = model_session_permit;
+    decode()
+}
+
+#[cfg(test)]
+mod admission_tests {
+    use std::{
+        num::NonZeroUsize,
+        sync::mpsc,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn admitted_native_decode_retains_capacity_after_owner_is_dropped() {
+        let supervisor = NativeExecutionSupervisor::new(NonZeroUsize::new(1).unwrap());
+        let model_identity = "native:test-decode-lifecycle";
+        let permit = supervisor
+            .try_acquire(model_identity)
+            .expect("first native decode must acquire the model slot");
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let task = tokio::task::spawn_blocking(move || {
+            run_admitted_native_transcription(permit, move || {
+                started_sender
+                    .send(())
+                    .expect("test must observe the native execution boundary");
+                release_receiver
+                    .recv()
+                    .expect("test must release the native decode");
+                Ok(())
+            })
+        });
+
+        started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("native decode must reach the admitted execution boundary");
+        assert!(
+            supervisor.try_acquire(model_identity).is_err(),
+            "a second same-model request must be rejected while native execution runs"
+        );
+
+        // Dropping the async owner detaches `spawn_blocking`; it must not release
+        // the permit before the real native decode closure exits.
+        drop(task);
+        assert!(
+            supervisor.try_acquire(model_identity).is_err(),
+            "a detached native decode must retain its model slot"
+        );
+
+        release_sender
+            .send(())
+            .expect("release the detached native decode");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if let Ok(permit) = supervisor.try_acquire(model_identity) {
+                drop(permit);
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "native model capacity must return after the decode exits"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+}
+
 pub(crate) async fn transcribe_with_runtime(
     runtime: ServerRuntime,
     request: TranscriptionRequest,
@@ -1347,34 +1424,43 @@ pub(crate) async fn transcribe_with_runtime(
             Ok(transcription)
         }
         BackendKind::Native => {
-            let model_session_permit = runtime.acquire_native_execution()?;
             tokio::task::spawn_blocking(move || {
-                // This permit is deliberately owned by the blocking task rather
-                // than its async caller. Dropping an HTTP/SSE future detaches a
-                // spawned blocking task, but must not admit a second heavy decode
-                // while the first one still owns model execution resources.
-                let _model_session_permit = model_session_permit;
-                // Marks this offline (file-transcription / realtime-per-utterance
-                // backend-job) decode as active for the whole synchronous run, so
-                // the idle_unload reaper never evicts the model runtime cache out
-                // from under it; dropped (any exit path) once the decode returns.
-                let _activity_guard = NativeActivityGuard::enter();
-                // Bind the pause/cancel control to this decode thread for the whole
-                // synchronous run so the long-form slice loop can observe it; the
-                // guard clears the binding on any exit. `None` (no control requested)
-                // leaves the decode byte-identical to before.
-                let _control_guard =
-                    control.map(openasr_core::install_active_transcription_control);
-                let model_pack_path = runtime.model_pack_path.clone().ok_or_else(|| {
-                    TranscriptionRuntimeError::Backend(
+                // Audio normalization may run an external converter or decode a
+                // full upload in process, but it does not touch a native model
+                // runtime. Keep it outside the per-model admission window so
+                // upload preparation cannot serialize an unrelated native session
+                // for the same model.
+                let prepared = prepare_audio_input(
+                    &request.input_path,
+                    &AudioPreparationOptions::new(runtime.backend)
+                        .with_ffmpeg_bin(runtime.ffmpeg_bin.clone())
+                        .with_ffmpeg_bin_explicit(runtime.ffmpeg_bin_explicit)
+                        .with_native_non_wav_conversion(true),
+                )
+                .map_err(ApiError::AudioPreparation)?;
+                let model_session_permit = runtime.acquire_native_execution()?;
+                run_admitted_native_transcription(model_session_permit, move || {
+                    // Marks this offline (file-transcription / realtime-per-utterance
+                    // backend-job) decode as active for the whole synchronous run, so
+                    // the idle_unload reaper never evicts the model runtime cache out
+                    // from under it; dropped (any exit path) once the decode returns.
+                    let _activity_guard = NativeActivityGuard::enter();
+                    // Bind the pause/cancel control to this decode thread for the whole
+                    // synchronous run so the long-form slice loop can observe it; the
+                    // guard clears the binding on any exit. `None` (no control requested)
+                    // leaves the decode byte-identical to before.
+                    let _control_guard =
+                        control.map(openasr_core::install_active_transcription_control);
+                    let model_pack_path = runtime.model_pack_path.clone().ok_or_else(|| {
+                        TranscriptionRuntimeError::Backend(
                         openasr_core::BackendError::NativeModelPackPathRejected {
                             reason:
                                 "native backend requires an explicit local .oasr runtime pack path"
                                     .to_string(),
                         },
                     )
-                })?;
-                let adapter =
+                    })?;
+                    let adapter =
                 native_runtime_model_adapter_for_path(&model_pack_path).ok_or_else(|| {
                     TranscriptionRuntimeError::Backend(
                         openasr_core::BackendError::NativeFailClosed {
@@ -1385,81 +1471,74 @@ pub(crate) async fn transcribe_with_runtime(
                         },
                     )
                 })?;
-                let prepared = prepare_audio_input(
-                    &request.input_path,
-                    &AudioPreparationOptions::new(runtime.backend)
-                        .with_ffmpeg_bin(runtime.ffmpeg_bin.clone())
-                        .with_ffmpeg_bin_explicit(runtime.ffmpeg_bin_explicit)
-                        .with_native_non_wav_conversion(true),
-                )
-                .map_err(TranscriptionRuntimeError::AudioPreparation)?;
-                let mut request = request;
-                request.input_path = prepared.path().to_path_buf();
-                let word_timestamps = request.word_timestamps;
-                let model_pack = NativeAsrModelPackRef::new(
-                    request.model_id.clone(),
-                    adapter.model_family(),
-                    model_pack_path,
-                );
-                let offline_request = NativeAsrOfflineRequest::new(request.input_path.clone())
-                    .with_options(
-                        NativeAsrRequestOptions::new()
-                            .with_language(request.language.clone())
-                            .with_prompt(request.prompt.clone())
-                            .with_phrase_bias(request.phrase_bias.clone())
-                            .with_inference_threads(request.inference_threads)
-                            .with_diarization(request.diarize)
-                            .with_word_timestamps(request.word_timestamps)
-                            .with_word_timestamps_refine(request.word_timestamps_refine),
+                    let mut request = request;
+                    request.input_path = prepared.path().to_path_buf();
+                    let word_timestamps = request.word_timestamps;
+                    let model_pack = NativeAsrModelPackRef::new(
+                        request.model_id.clone(),
+                        adapter.model_family(),
+                        model_pack_path,
+                    );
+                    let offline_request = NativeAsrOfflineRequest::new(request.input_path.clone())
+                        .with_options(
+                            NativeAsrRequestOptions::new()
+                                .with_language(request.language.clone())
+                                .with_prompt(request.prompt.clone())
+                                .with_phrase_bias(request.phrase_bias.clone())
+                                .with_inference_threads(request.inference_threads)
+                                .with_diarization(request.diarize)
+                                .with_word_timestamps(request.word_timestamps)
+                                .with_word_timestamps_refine(request.word_timestamps_refine),
+                        )
+                        .with_longform(request.longform.clone())
+                        .with_display_file_name(request.display_file_name.clone())
+                        .with_source(request.source)
+                        // The source audio's real format for the `stage=request_context`
+                        // log line -- `prepared.original()` is the pre-normalization
+                        // probe (WAV fmt chunk) or decode (other recognized formats)
+                        // result; `None` when this pipeline could not determine it
+                        // (unrecognized extension, or a format only the external
+                        // ffmpeg/afconvert fallback handles).
+                        .with_source_audio_format(
+                            prepared.original().sample_rate_hz,
+                            prepared.original().channels,
+                        )
+                        // Extension only, off the upload's own temp file (which
+                        // preserves the client's original extension via
+                        // `safe_extension_suffix` -- see `ingest_field` above); never
+                        // the client-supplied file name/stem itself.
+                        .with_source_container(prepared.original().extension.clone())
+                        // Lets the native backend decode straight from the in-process
+                        // symphonia decode's in-memory samples (uploads are almost
+                        // always a non-WAV/non-conformant container) instead of
+                        // re-reading `input_path` from disk -- see
+                        // `PreparedAudioInput::shared_samples`.
+                        .with_prepared_samples(prepared.shared_samples());
+                    let executor = NativeBackendExecutor;
+                    let mut transcription = NativeAsrExecutor::transcribe(
+                        &executor,
+                        &adapter,
+                        &model_pack,
+                        native_hardware_target_from_execution_target(request.execution_target),
+                        offline_request,
                     )
-                    .with_longform(request.longform.clone())
-                    .with_display_file_name(request.display_file_name.clone())
-                    .with_source(request.source)
-                    // The source audio's real format for the `stage=request_context`
-                    // log line -- `prepared.original()` is the pre-normalization
-                    // probe (WAV fmt chunk) or decode (other recognized formats)
-                    // result; `None` when this pipeline could not determine it
-                    // (unrecognized extension, or a format only the external
-                    // ffmpeg/afconvert fallback handles).
-                    .with_source_audio_format(
-                        prepared.original().sample_rate_hz,
-                        prepared.original().channels,
-                    )
-                    // Extension only, off the upload's own temp file (which
-                    // preserves the client's original extension via
-                    // `safe_extension_suffix` -- see `ingest_field` above); never
-                    // the client-supplied file name/stem itself.
-                    .with_source_container(prepared.original().extension.clone())
-                    // Lets the native backend decode straight from the in-process
-                    // symphonia decode's in-memory samples (uploads are almost
-                    // always a non-WAV/non-conformant container) instead of
-                    // re-reading `input_path` from disk -- see
-                    // `PreparedAudioInput::shared_samples`.
-                    .with_prepared_samples(prepared.shared_samples());
-                let executor = NativeBackendExecutor;
-                let mut transcription = NativeAsrExecutor::transcribe(
-                    &executor,
-                    &adapter,
-                    &model_pack,
-                    native_hardware_target_from_execution_target(request.execution_target),
-                    offline_request,
-                )
-                .map_err(native_asr_error_to_backend)
-                .map_err(TranscriptionRuntimeError::Backend)?;
-                // The decode above only returns `Ok` after the model runtime is
-                // built (or reused) and actually ran, so this is the resident
-                // signal `/health`'s `model_resident` field reads -- see
-                // `idle_activity::native_model_is_resident`.
-                crate::idle_activity::mark_native_model_warm();
-                if word_timestamps {
-                    add_segment_word_timestamps(&mut transcription);
-                }
-                drop(prepared);
-                Ok::<_, TranscriptionRuntimeError>(transcription)
+                    .map_err(native_asr_error_to_backend)
+                    .map_err(TranscriptionRuntimeError::Backend)?;
+                    // The decode above only returns `Ok` after the model runtime is
+                    // built (or reused) and actually ran, so this is the resident
+                    // signal `/health`'s `model_resident` field reads -- see
+                    // `idle_activity::native_model_is_resident`.
+                    crate::idle_activity::mark_native_model_warm();
+                    if word_timestamps {
+                        add_segment_word_timestamps(&mut transcription);
+                    }
+                    drop(prepared);
+                    Ok::<_, TranscriptionRuntimeError>(transcription)
+                })
+                .map_err(ApiError::from)
             })
             .await
             .map_err(ApiError::BackendJoin)?
-            .map_err(ApiError::from)
         }
     }
 }
@@ -1733,14 +1812,12 @@ mod native_runtime_tests {
 
 #[derive(Debug)]
 pub(crate) enum TranscriptionRuntimeError {
-    AudioPreparation(openasr_core::AudioPreparationError),
     Backend(openasr_core::BackendError),
 }
 
 impl From<TranscriptionRuntimeError> for ApiError {
     fn from(error: TranscriptionRuntimeError) -> Self {
         match error {
-            TranscriptionRuntimeError::AudioPreparation(error) => Self::AudioPreparation(error),
             TranscriptionRuntimeError::Backend(error) => Self::Backend(error),
         }
     }

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -29,30 +29,19 @@ pub(crate) async fn transcriptions(
     headers: HeaderMap,
     Extension(auth): Extension<ServerAuth>,
     Extension(distribution): Extension<DistributionContext>,
-    Extension(model_admission): Extension<ModelSessionAdmission>,
     multipart: Result<Multipart, MultipartRejection>,
 ) -> Result<Response, ApiError> {
     if query.stream.unwrap_or(false) {
         return crate::realtime::stream_transcription(
             runtime,
             distribution,
-            model_admission,
             multipart,
             !is_remote_compute_client_request(&headers, &auth),
         )
         .await;
     }
 
-    run_offline_transcription(
-        runtime,
-        headers,
-        auth,
-        distribution,
-        model_admission,
-        multipart,
-        None,
-    )
-    .await
+    run_offline_transcription(runtime, headers, auth, distribution, multipart, None).await
 }
 
 /// OpenAI-compatible `/v1/audio/translations`: always X->English translation.
@@ -64,7 +53,6 @@ pub(crate) async fn translations(
     headers: HeaderMap,
     Extension(auth): Extension<ServerAuth>,
     Extension(distribution): Extension<DistributionContext>,
-    Extension(model_admission): Extension<ModelSessionAdmission>,
     multipart: Result<Multipart, MultipartRejection>,
 ) -> Result<Response, ApiError> {
     run_offline_transcription(
@@ -72,7 +60,6 @@ pub(crate) async fn translations(
         headers,
         auth,
         distribution,
-        model_admission,
         multipart,
         Some(TranscriptionTask::Translate),
     )
@@ -256,7 +243,6 @@ async fn run_offline_transcription(
     headers: HeaderMap,
     auth: ServerAuth,
     distribution: DistributionContext,
-    model_admission: ModelSessionAdmission,
     multipart: Result<Multipart, MultipartRejection>,
     task_override: Option<TranscriptionTask>,
 ) -> Result<Response, ApiError> {
@@ -329,36 +315,30 @@ async fn run_offline_transcription(
         ActiveTranscriptionCleanup::new(distribution.clone(), id.clone(), Arc::clone(control))
     });
     let control_handle = control.as_ref().map(|(_, control)| Arc::clone(control));
-    let transcription = match transcribe_with_runtime(
-        runtime,
-        parsed.request,
-        control_handle.clone(),
-        model_admission,
-    )
-    .await
-    {
-        Ok(transcription) => {
-            if let Some(cleanup) = control_cleanup.as_mut() {
-                cleanup.disarm();
+    let transcription =
+        match transcribe_with_runtime(runtime, parsed.request, control_handle.clone()).await {
+            Ok(transcription) => {
+                if let Some(cleanup) = control_cleanup.as_mut() {
+                    cleanup.disarm();
+                }
+                transcription
             }
-            transcription
-        }
-        Err(error) => {
-            if let Some(cleanup) = control_cleanup.as_mut() {
-                cleanup.disarm();
+            Err(error) => {
+                if let Some(cleanup) = control_cleanup.as_mut() {
+                    cleanup.disarm();
+                }
+                // A cancel surfaces from core as a generic fail-closed error (the
+                // typed cancel is flattened through the NativeAsrError layer), so
+                // consult the control to report it honestly as a 409 canceled result
+                // rather than a 400 fail-closed refusal.
+                if control_handle.is_some_and(|control| control.is_canceled()) {
+                    return Err(ApiError::Backend(
+                        openasr_core::BackendError::TranscriptionCanceled,
+                    ));
+                }
+                return Err(error);
             }
-            // A cancel surfaces from core as a generic fail-closed error (the
-            // typed cancel is flattened through the NativeAsrError layer), so
-            // consult the control to report it honestly as a 409 canceled result
-            // rather than a 400 fail-closed refusal.
-            if control_handle.is_some_and(|control| control.is_canceled()) {
-                return Err(ApiError::Backend(
-                    openasr_core::BackendError::TranscriptionCanceled,
-                ));
-            }
-            return Err(error);
-        }
-    };
+        };
     let rendered = render_transcription(&transcription, parsed.response_format)
         .map_err(ApiError::Serialize)?;
     // History is a best-effort audit side-write: a successful transcription must
@@ -1343,7 +1323,6 @@ pub(crate) async fn transcribe_with_runtime(
     runtime: ServerRuntime,
     request: TranscriptionRequest,
     control: Option<Arc<openasr_core::TranscriptionControl>>,
-    model_admission: ModelSessionAdmission,
 ) -> Result<openasr_core::Transcription, ApiError> {
     match runtime.backend {
         BackendKind::Mock => {
@@ -1368,10 +1347,7 @@ pub(crate) async fn transcribe_with_runtime(
             Ok(transcription)
         }
         BackendKind::Native => {
-            let model_session_key = native_model_session_key(&runtime)?;
-            let model_session_permit = model_admission
-                .try_acquire(model_session_key)
-                .map_err(ApiError::ModelSessionCapacity)?;
+            let model_session_permit = runtime.acquire_native_execution()?;
             tokio::task::spawn_blocking(move || {
                 // This permit is deliberately owned by the blocking task rather
                 // than its async caller. Dropping an HTTP/SSE future detaches a

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -2232,7 +2232,7 @@ async fn native_transcribe_stays_fail_closed_with_local_pack_only_validation() {
         model_pack_path: Some(pack_root),
     };
     let request = TranscriptionRequest::new(sample_wav, "whisper-large-v3-turbo");
-    let error = transcribe_with_runtime(runtime, request, None)
+    let error = transcribe_with_runtime(runtime, request, None, ModelSessionAdmission::default())
         .await
         .unwrap_err();
     let rendered = error.to_string();

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -2244,6 +2244,65 @@ async fn native_transcribe_stays_fail_closed_with_local_pack_only_validation() {
     assert!(rendered.contains("Could not transcribe audio"));
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn native_audio_preparation_does_not_consume_model_capacity() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let pack_path = temp.path().join("native-preparation-capacity.oasr");
+    write_mock_gguf_runtime_source(&pack_path, Some("whisper-large-v3-turbo"));
+    let input_path = temp.path().join("blocked-preparation.mp3");
+    std::fs::write(&input_path, b"not an mp3 stream").unwrap();
+    let started_path = temp.path().join("preparation-started");
+    let release_path = temp.path().join("release-preparation");
+    let converter = temp.path().join("blocking-ffmpeg");
+    std::fs::write(
+        &converter,
+        format!(
+            "#!/bin/sh\ntouch '{}'\nwhile [ ! -f '{}' ]; do sleep 0.01; done\nexit 1\n",
+            started_path.display(),
+            release_path.display(),
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&converter, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let runtime = ServerRuntime {
+        backend: BackendKind::Native,
+        native_execution: NativeExecutionSupervisor::new(std::num::NonZeroUsize::new(1).unwrap()),
+        ffmpeg_bin: Some(converter),
+        ffmpeg_bin_explicit: true,
+        model_pack_path: Some(pack_path),
+    };
+    let request_runtime = runtime.clone();
+    let request = TranscriptionRequest::new(input_path, "whisper-large-v3-turbo");
+    let runtime_handle = tokio::runtime::Handle::current();
+    let request_task = tokio::task::spawn_blocking(move || {
+        runtime_handle.block_on(transcribe_with_runtime(request_runtime, request, None))
+    });
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+    while !started_path.exists() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "native audio preparation never reached the blocking converter"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+
+    let permit = runtime
+        .acquire_native_execution()
+        .expect("audio-only preparation must not consume native model capacity");
+    drop(permit);
+    std::fs::write(&release_path, b"release").unwrap();
+    let error = request_task
+        .await
+        .expect("preparation task must not panic")
+        .expect_err("blocking converter exits unsuccessfully");
+    assert!(matches!(error, ApiError::AudioPreparation(_)));
+}
+
 #[test]
 fn parse_segment_mode_accepts_energy_and_rejects_unknown() {
     assert_eq!(parse_segment_mode("energy").unwrap(), LongFormMode::Energy);

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -1709,6 +1709,7 @@ fn realtime_capabilities_for_native_runtime_come_from_model_pack() {
     write_mock_gguf_runtime_source(&pack_root, Some("whisper-large-v3-turbo"));
     let runtime = ServerRuntime {
         backend: BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -1761,6 +1762,7 @@ fn native_server_runtime_rejects_directory_runtime_source() {
     std::fs::create_dir_all(&pack_root).unwrap();
     let runtime = ServerRuntime {
         backend: BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -2195,6 +2197,7 @@ fn native_server_runtime_rejects_non_gguf_runtime_source_file() {
     std::fs::write(&pack_path, b"not a directory").unwrap();
     let runtime = ServerRuntime {
         backend: BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_path),
@@ -2210,6 +2213,7 @@ fn native_server_runtime_rejects_directory_runtime_source_without_file_fallback(
     std::fs::create_dir_all(&pack_root).unwrap();
     let runtime = ServerRuntime {
         backend: BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -2227,12 +2231,13 @@ async fn native_transcribe_stays_fail_closed_with_local_pack_only_validation() {
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/jfk.wav");
     let runtime = ServerRuntime {
         backend: BackendKind::Native,
+        native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
     };
     let request = TranscriptionRequest::new(sample_wav, "whisper-large-v3-turbo");
-    let error = transcribe_with_runtime(runtime, request, None, ModelSessionAdmission::default())
+    let error = transcribe_with_runtime(runtime, request, None)
         .await
         .unwrap_err();
     let rendered = error.to_string();

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -934,6 +934,7 @@ async fn capabilities_endpoint_reflects_active_xasr_phrase_bias_capability() {
     write_xasr_gguf_runtime_source(&pack_root, "xasr-capability");
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -1036,6 +1037,7 @@ async fn native_transcription_without_installed_model_fails_closed_and_never_dow
     let app = openasr_server::app_with_runtime_and_distribution(
         openasr_server::ServerRuntime {
             backend: openasr_core::BackendKind::Native,
+            native_execution: openasr_server::NativeExecutionSupervisor::default(),
             ffmpeg_bin: None,
             ffmpeg_bin_explicit: false,
             model_pack_path: None,
@@ -1094,6 +1096,7 @@ async fn daemon_starts_and_reports_ready_with_zero_models_installed() {
     std::fs::create_dir_all(&home).unwrap();
     let runtime = openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: None,
@@ -1165,6 +1168,7 @@ async fn health_reports_model_bound_but_not_resident_before_any_load() {
     write_mock_gguf_runtime_source(&pack_root, None);
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -2278,6 +2282,7 @@ fn native_server_runtime_with_no_model_pack_is_accepted_at_startup_validation() 
     // transcription-request time, not a reason to refuse to serve at all.
     openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: None,
@@ -2293,6 +2298,7 @@ fn native_server_runtime_falls_back_to_path_stem_when_metadata_model_id_is_retir
     write_mock_gguf_runtime_source(&pack_root, Some("whisper-tiny:q4_0"));
     openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -2308,6 +2314,7 @@ fn native_server_runtime_falls_back_to_path_stem_when_metadata_model_id_is_inval
     write_mock_gguf_runtime_source(&pack_root, Some("bad::id"));
     openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -2323,6 +2330,7 @@ fn native_server_runtime_rejects_reserved_oasr_container_magic() {
     write_reserved_oasr_runtime_source(&pack_root);
     let error = openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -4250,6 +4258,7 @@ async fn transcriptions_with_native_backend_fail_closed() {
     write_whisper_oasr_v1_fixture(&pack_root, "whisper-runtime");
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root.clone()),
@@ -4272,6 +4281,7 @@ async fn transcriptions_with_native_xasr_hotword_returns_model_unsupported_error
     write_xasr_gguf_runtime_source(&pack_root, model_id);
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -4303,6 +4313,7 @@ async fn transcriptions_with_native_backend_model_mismatch_returns_bad_request()
     write_whisper_oasr_v1_fixture(&pack_root, "whisper-runtime");
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root.clone()),
@@ -4339,6 +4350,7 @@ async fn transcriptions_with_native_backend_accepts_quant_alias_against_legacy_h
     write_whisper_oasr_v1_fixture(&pack_root, "mimo-v2.5-asr-q4_k");
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root.clone()),
@@ -4368,6 +4380,7 @@ async fn transcriptions_with_native_backend_and_diarize_returns_bad_request() {
     write_whisper_oasr_v1_fixture(&pack_root, "whisper-runtime");
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root.clone()),
@@ -4386,6 +4399,7 @@ async fn transcriptions_with_native_backend_and_diarize_returns_bad_request() {
 async fn transcriptions_with_native_backend_reject_retired_legacy_model_alias() {
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: None,
@@ -4414,6 +4428,7 @@ async fn transcriptions_with_native_backend_accepts_live_catalog_family_bare_met
     write_whisper_oasr_v1_fixture(&pack_root, "whisper-large-v3-turbo");
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root.clone()),
@@ -4436,6 +4451,7 @@ async fn stream_transcriptions_with_native_backend_reject_empty_model_form_value
     write_mock_gguf_runtime_source(&pack_root, Some("native-pack"));
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -4461,6 +4477,7 @@ async fn stream_transcriptions_with_native_backend_reject_empty_model_form_value
 async fn stream_transcriptions_with_mock_backend_emits_protocol_events() {
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Mock,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: None,
@@ -4501,6 +4518,7 @@ async fn stream_transcription_succeeds_when_history_cannot_be_recorded() {
     let app = openasr_server::app_with_runtime_and_distribution(
         openasr_server::ServerRuntime {
             backend: openasr_core::BackendKind::Mock,
+            native_execution: openasr_server::NativeExecutionSupervisor::default(),
             ffmpeg_bin: None,
             ffmpeg_bin_explicit: false,
             model_pack_path: None,
@@ -4538,6 +4556,7 @@ async fn static_bearer_remote_compute_stream_transcription_records_server_histor
     let app = openasr_server::app_with_runtime_and_distribution_and_launch_options(
         openasr_server::ServerRuntime {
             backend: openasr_core::BackendKind::Mock,
+            native_execution: openasr_server::NativeExecutionSupervisor::default(),
             ffmpeg_bin: None,
             ffmpeg_bin_explicit: false,
             model_pack_path: None,
@@ -4601,6 +4620,7 @@ async fn stream_transcriptions_with_native_backend_reject_srt_response_format() 
     write_mock_gguf_runtime_source(&pack_root, Some("native-pack"));
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -4629,6 +4649,7 @@ async fn stream_transcriptions_with_native_backend_reject_model_mismatch() {
     write_mock_gguf_runtime_source(&pack_root, Some("native-pack"));
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -4659,6 +4680,7 @@ async fn stream_transcriptions_with_native_xasr_hotword_emits_model_unsupported_
     write_xasr_gguf_runtime_source(&pack_root, model_id);
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -4696,6 +4718,7 @@ async fn stream_transcriptions_with_native_xasr_hotword_emits_model_unsupported_
 async fn stream_transcriptions_with_native_backend_reject_missing_model_pack_path() {
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: None,
@@ -4731,6 +4754,7 @@ async fn transcriptions_with_native_backend_srt_stays_fail_closed_for_unexecutab
     write_mock_gguf_runtime_source(&pack_root, Some("native-pack"));
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root.clone()),
@@ -4759,6 +4783,7 @@ async fn models_with_native_backend_lists_loaded_local_pack_id() {
     write_mock_gguf_runtime_source(&pack_root, Some("native-pack"));
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_root),
@@ -4786,6 +4811,7 @@ async fn models_with_native_backend_and_no_pack_lists_empty_instead_of_erroring(
     // closed the way an actual transcription request does.
     let app = openasr_server::app_with_runtime(openasr_server::ServerRuntime {
         backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
         model_pack_path: None,


### PR DESCRIPTION
## Summary

Add per-model admission control for native server execution so concurrent requests cannot overcommit the same model runtime by default.

## Why

Native model sessions can hold substantial device memory. Concurrent HTTP, SSE, realtime, warm-up, and translation workers previously had no shared per-model limit, which could allow overlapping runtimes to exhaust available memory. The server needs one canonical, fail-closed admission boundary with stable overload semantics.

## Changes

- Add a shared `NativeExecutionSupervisor` keyed by canonical runtime identity.
- Default each native model identity to one concurrent session, with an explicit `--max-native-sessions-per-model` operator override.
- Hold admission permits for the full native runtime lifetime across HTTP transcription and translation, SSE, realtime fallback, true streaming, boot warm-up, and Hy-MT2 translation workers.
- Defer offline admission until audio preparation completes, then retain the permit until the actual background decode exits, including after request cancellation.
- Map capacity exhaustion to HTTP 429 and recoverable realtime `backend_not_ready` events instead of backend crashes.
- Add behavior-level regression coverage for panic-safe release, warm-up skipping, realtime fallback propagation, Hy-MT2 worker lifetime, audio preparation boundaries, and detached decode lifetime.

## Tests run

- [x] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
  - Passed: `cargo clippy -p openasr-server --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
  - Passed targeted admission and lifecycle tests.
  - `cargo test -p openasr-server`: 194 passed, 4 failed, 1 ignored. The remaining failures are pre-existing shared activity/watchdog order-sensitive tests also reproduced on `main`.
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

- Verified a blocked audio converter does not consume a native model permit.
- Verified a running detached native decode continues to hold its permit until the worker exits.
- Verified realtime fallback capacity exhaustion reaches the client as `backend_not_ready` with `recoverable: true` without failing or closing the session.
- Verified Hy-MT2 and boot warm-up permits follow their production worker lifetimes.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
  - The operator setting is documented in CLI help; no separate documentation page was required for this focused server change.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR limits concurrent native sessions per canonical model identity. It does not provide a daemon-wide memory budget, enable serve-batch by default, claim that values above one are universally safe, or change model packs, catalog metadata, and client request schemas.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
