### PR TITLE
perf(core): remove redundant contiguity copies

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -3420,7 +3420,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         )?;
         self.ensure_tensor_type(src, ffi::GGML_TYPE_F32, "ggml_set_rows src")?;
         self.ensure_tensor_type(row_indices, ffi::GGML_TYPE_I32, "ggml_set_rows indices")?;
-        self.ensure_tensor_contiguous(src, "ggml_set_rows src")?;
+        self.ensure_tensor_rowwise_contiguous(src, "ggml_set_rows src")?;
         self.ensure_tensor_contiguous(row_indices, "ggml_set_rows indices")?;
         self.ensure_set_rows_compatible(dst, src, row_indices)?;
         let raw = unsafe {
@@ -4571,6 +4571,22 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             });
         }
         Ok(())
+    }
+
+    fn ensure_tensor_rowwise_contiguous(
+        &self,
+        tensor: GgmlCpuTensor<'a>,
+        step: &'static str,
+    ) -> Result<(), GgmlCpuGraphError> {
+        if unsafe { ffi::ggml_is_contiguous_rows(tensor.raw.as_ptr()) } {
+            return Ok(());
+        }
+        Err(GgmlCpuGraphError::UnsupportedInputs {
+            reason: match step {
+                "ggml_set_rows src" => "ggml_set_rows src requires contiguous tensor rows",
+                _ => "operation requires contiguous tensor rows",
+            },
+        })
     }
 
     fn ensure_tensor_contiguous_rows(

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -6889,6 +6889,92 @@ mod tests {
     }
 
     #[test]
+    fn set_rows_accepts_row_contiguous_permuted_source() {
+        const HEAD_DIM: usize = 2;
+        const HEADS: usize = 2;
+        const TOKENS: usize = 2;
+        const SEQUENCES: usize = 2;
+        const MAX_POSITIONS: usize = 4;
+
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default())
+            .expect("cpu graph runner should initialize");
+        let mut graph = runner.start_graph();
+        let dst = graph
+            .new_tensor_4d_f32(HEAD_DIM, MAX_POSITIONS, HEADS, SEQUENCES, "dst")
+            .expect("dst should allocate");
+        let src_input = graph
+            .new_tensor_4d_f32(HEAD_DIM, HEADS, TOKENS, SEQUENCES, "src")
+            .expect("src should allocate");
+        let row_indices = graph
+            .new_tensor_4d_typed(TOKENS, 1, SEQUENCES, 1, ffi::GGML_TYPE_I32, "row_indices")
+            .expect("row indices should allocate");
+        graph.set_input(dst).expect("dst should be input");
+        graph.set_input(src_input).expect("src should be input");
+        graph
+            .set_input(row_indices)
+            .expect("row indices should be input");
+
+        let src_permuted = graph
+            .permute(src_input, 0, 2, 1, 3)
+            .expect("source permutation should build");
+        assert!(
+            !unsafe { ffi::ggml_is_contiguous(src_permuted.raw.as_ptr()) },
+            "[D,H,T,S] -> [D,T,H,S] must not be fully contiguous"
+        );
+        assert!(
+            unsafe { ffi::ggml_is_contiguous_rows(src_permuted.raw.as_ptr()) },
+            "[D,H,T,S] -> [D,T,H,S] must preserve row contiguity"
+        );
+        let output = graph
+            .set_rows(dst, src_permuted, row_indices)
+            .expect("set_rows should accept a row-contiguous permuted source");
+        graph.set_output(output).expect("output should be settable");
+
+        let src_values: Vec<f32> = (0..HEAD_DIM * HEADS * TOKENS * SEQUENCES)
+            .map(|index| index as f32 + 1.0)
+            .collect();
+        let dst_values = vec![0.0; HEAD_DIM * MAX_POSITIONS * HEADS * SEQUENCES];
+        let rows = [1_i32, 3, 0, 2];
+        graph
+            .set_f32_slice(dst, &dst_values, "dst")
+            .expect("dst upload should succeed");
+        graph
+            .set_f32_slice(src_input, &src_values, "src")
+            .expect("src upload should succeed");
+        graph
+            .set_i32_slice(row_indices, &rows, "row_indices")
+            .expect("row indices upload should succeed");
+        let output = graph
+            .compute_output_f32(output, dst_values.len())
+            .expect("set_rows should compute");
+
+        for sequence in 0..SEQUENCES {
+            for head in 0..HEADS {
+                for token in 0..TOKENS {
+                    let row = rows[sequence * TOKENS + token] as usize;
+                    for dim in 0..HEAD_DIM {
+                        let source_index =
+                            dim + HEAD_DIM * (head + HEADS * (token + TOKENS * sequence));
+                        let output_index =
+                            dim + HEAD_DIM * (row + MAX_POSITIONS * (head + HEADS * sequence));
+                        assert_eq!(output[output_index], src_values[source_index]);
+                    }
+                }
+                for row in 0..MAX_POSITIONS {
+                    if rows[sequence * TOKENS..(sequence + 1) * TOKENS].contains(&(row as i32)) {
+                        continue;
+                    }
+                    for dim in 0..HEAD_DIM {
+                        let output_index =
+                            dim + HEAD_DIM * (row + MAX_POSITIONS * (head + HEADS * sequence));
+                        assert_eq!(output[output_index], 0.0);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn batched_set_rows_multiple_query_rows_match_serial_planes() {
         fn compute_set_rows(
             n_seq: usize,

--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -431,6 +431,7 @@ unsafe extern "C" {
     pub(crate) fn ggml_nelements(tensor: GgmlTensorRaw) -> i64;
     pub(crate) fn ggml_is_transposed(tensor: GgmlTensorRaw) -> bool;
     pub(crate) fn ggml_is_contiguous(tensor: GgmlTensorRaw) -> bool;
+    pub(crate) fn ggml_is_contiguous_rows(tensor: GgmlTensorRaw) -> bool;
     pub(crate) fn ggml_reshape_2d(
         ctx: GgmlContextRaw,
         a: GgmlTensorRaw,

--- a/crates/openasr-core/src/models/qwen/audio_encoder.rs
+++ b/crates/openasr-core/src/models/qwen/audio_encoder.rs
@@ -432,12 +432,6 @@ fn encode_qwen3_audio_embeddings_with_graph<'a>(
         }
     })?;
     state = graph
-        .cont(state)
-        .map_err(|source| Qwen3AsrAudioEncoderError::GraphBuildFailed {
-            step: "ggml_cont(audio_positional)",
-            source,
-        })?;
-    state = graph
         .reshape_2d(state, metadata.audio_d_model, chunked_mel.row_count)
         .map_err(|source| Qwen3AsrAudioEncoderError::GraphBuildFailed {
             step: "ggml_reshape_2d(audio_sequence)",

--- a/crates/openasr-core/src/nn/decoder.rs
+++ b/crates/openasr-core/src/nn/decoder.rs
@@ -1630,15 +1630,6 @@ where
         (q_flash, k_new, v_new)
     } else {
         let q = graph
-            .cont(q)
-            .map_err(|source| map_err("llm_q_query_seq_cont", source))?;
-        let k = graph
-            .cont(k)
-            .map_err(|source| map_err("llm_k_query_seq_cont", source))?;
-        let v = graph
-            .cont(v)
-            .map_err(|source| map_err("llm_v_query_seq_cont", source))?;
-        let q = graph
             .reshape_4d(q, head_dim, config.q_heads, token_count, n_seq)
             .map_err(|source| map_err("llm_q_query_seq_reshape4d", source))?;
         let k = graph
@@ -1661,17 +1652,6 @@ where
     let q_flash = graph
         .cont(q_flash)
         .map_err(|source| map_err("llm_q_cont", source))?;
-    let (k_new, v_new) = if token_count == 1 {
-        (k_new, v_new)
-    } else {
-        let k_new = graph
-            .cont(k_new)
-            .map_err(|source| map_err("llm_k_set_rows_cont", source))?;
-        let v_new = graph
-            .cont(v_new)
-            .map_err(|source| map_err("llm_v_set_rows_cont", source))?;
-        (k_new, v_new)
-    };
     let k_full = graph
         .set_rows(kv.key_history, k_new, kv.row_indices)
         .map_err(|source| map_err("llm_k_set_rows", source))?;

--- a/crates/openasr-core/src/nn/encoder.rs
+++ b/crates/openasr-core/src/nn/encoder.rs
@@ -772,9 +772,6 @@ where
             .add(scores, mask)
             .map_err(|source| map_err("ggml_add(attn_mask)", source))?;
         let scores = graph
-            .cont(scores)
-            .map_err(|source| map_err("ggml_cont(attn_scores)", source))?;
-        let scores = graph
             .soft_max_ext(scores, None, scale, 0.0)
             .map_err(|source| map_err("ggml_soft_max_ext(attn_probs)", source))?;
         attention_context_from_probs(


### PR DESCRIPTION
## Summary

Remove seven redundant contiguity copies from shared Qwen-family decoder and encoder graphs while preserving the two discrete-GPU GQA safety copies.

## Why

Several graph nodes copied tensors that were already contiguous by construction, or only needed row-contiguous layout for `set_rows`. These copies add allocation and memory traffic across Qwen3-ASR, MiMo-ASR, FireRed2-LLM, MOSS, and the Qwen audio encoder without changing tensor values.

## Changes

- Remove redundant Q/K/V copies after operations that produce contiguous tensors.
- Remove redundant K/V copies before `set_rows` where the permuted source remains row-contiguous.
- Remove redundant copies after encoder and positional additions.
- Align the Rust `set_rows` source guard with ggml's row-contiguous contract through the pinned `ggml_is_contiguous_rows` API.
- Add a regression test using a permuted source that is row-contiguous but not fully contiguous.
- Keep the discrete-GPU GQA expansion copies unchanged.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Additional checks:

- `cargo test -p openasr-core set_rows -- --nocapture` - 5 passed.
- Qwen real-pack CPU prefill parity - exact hidden/KV parity.
- Qwen Metal chunked prefill parity - exact hidden/KV parity.
- Qwen real-pack audio encoder with flash enabled and disabled - passed.
- MiMo real-pack JFK golden - passed.
- FireRed2-LLM real-pack JFK golden - passed.
- MOSS real-pack Metal accelerated JFK golden - passed.

## Manual smoke checks

Real-pack tests used an isolated `OPENASR_HOME`; no user model state was read or modified.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
  - No user-facing behavior or limitation changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR removes only the seven statically verified redundant copies. It does not remove the two discrete-GPU GQA workaround copies and does not claim CUDA, Vulkan, or HIP runtime validation.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
