### PR TITLE
chore(ggml): sync vendored ggml to 9be3133

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -600,8 +600,7 @@ unsafe extern "C" {
     pub(crate) fn gguf_get_n_tensors(ctx: *const c_void) -> i64;
     pub(crate) fn gguf_get_tensor_offset(ctx: *const c_void, tensor_id: i64) -> usize;
     pub(crate) fn gguf_get_tensor_name(ctx: *const c_void, tensor_id: i64) -> *const c_char;
-    pub(crate) fn gguf_get_tensor_n_dims(ctx: *const c_void, tensor_id: i64) -> u32;
-    pub(crate) fn gguf_get_tensor_dim(ctx: *const c_void, tensor_id: i64, dim: c_int) -> i64;
+    pub(crate) fn gguf_get_tensor_ne(ctx: *const c_void, tensor_id: i64) -> *const i64;
     pub(crate) fn gguf_get_tensor_type(ctx: *const c_void, tensor_id: i64) -> c_int;
     pub(crate) fn gguf_get_tensor_size(ctx: *const c_void, tensor_id: i64) -> usize;
     pub(crate) fn ggml_type_name(type_: c_int) -> *const c_char;

--- a/crates/openasr-core/src/ggml_runtime/gguf_tensor_index.rs
+++ b/crates/openasr-core/src/ggml_runtime/gguf_tensor_index.rs
@@ -152,22 +152,12 @@ pub enum GgufTensorIndexReadError {
         source: std::str::Utf8Error,
     },
     #[error(
-        "gguf tensor '{tensor_name}' in '{path}' has invalid rank: rank={rank}, tensor_index={tensor_index}"
+        "gguf tensor '{tensor_name}' in '{path}' has a null dimension pointer: tensor_index={tensor_index}"
     )]
-    InvalidTensorRank {
+    NullTensorDimensions {
         path: PathBuf,
         tensor_name: String,
         tensor_index: i64,
-        rank: u32,
-    },
-    #[error(
-        "gguf tensor '{tensor_name}' in '{path}' rank does not fit usize: rank={rank}, tensor_index={tensor_index}"
-    )]
-    TensorRankOverflow {
-        path: PathBuf,
-        tensor_name: String,
-        tensor_index: i64,
-        rank: u32,
     },
     #[error(
         "gguf tensor '{tensor_name}' in '{path}' has negative dim: dim_index={dim_index}, value={value}"
@@ -305,39 +295,29 @@ pub fn read_gguf_tensor_index_from_runtime_source(
             })?;
         let name = name.to_string();
 
-        let rank = unsafe { ffi::gguf_get_tensor_n_dims(context.as_ptr(), tensor_index) };
-        if rank == 0 {
-            return Err(GgufTensorIndexReadError::InvalidTensorRank {
+        let dims_ptr = unsafe { ffi::gguf_get_tensor_ne(context.as_ptr(), tensor_index) };
+        if dims_ptr.is_null() {
+            return Err(GgufTensorIndexReadError::NullTensorDimensions {
                 path: path.to_path_buf(),
                 tensor_name: name.clone(),
                 tensor_index,
-                rank,
             });
         }
-        let rank_usize =
-            usize::try_from(rank).map_err(|_| GgufTensorIndexReadError::TensorRankOverflow {
-                path: path.to_path_buf(),
-                tensor_name: name.clone(),
-                tensor_index,
-                rank,
-            })?;
-        let mut dims = Vec::with_capacity(rank_usize);
-        for dim_index in 0..rank_usize {
-            let dim_index_c = i32::try_from(dim_index).map_err(|_| {
-                GgufTensorIndexReadError::TensorRankOverflow {
-                    path: path.to_path_buf(),
-                    tensor_name: name.clone(),
-                    tensor_index,
-                    rank,
-                }
-            })?;
-            let dim_value =
-                unsafe { ffi::gguf_get_tensor_dim(context.as_ptr(), tensor_index, dim_index_c) };
+        // Upstream returns a GGML_MAX_DIMS shape array and pads dimensions above
+        // the stored rank with one. Trim that padding so OpenASR keeps the
+        // canonical shape representation used by package validation.
+        let raw_dims = unsafe { std::slice::from_raw_parts(dims_ptr, ffi::GGML_MAX_DIMS) };
+        let rank = raw_dims
+            .iter()
+            .rposition(|&value| value != 1)
+            .map_or(1, |last_non_unit| last_non_unit + 1);
+        let mut dims = Vec::with_capacity(rank);
+        for (dim_index, &dim_value) in raw_dims[..rank].iter().enumerate() {
             if dim_value < 0 {
                 return Err(GgufTensorIndexReadError::NegativeTensorDimension {
                     path: path.to_path_buf(),
                     tensor_name: name.clone(),
-                    dim_index: dim_index_c,
+                    dim_index: dim_index as i32,
                     value: dim_value,
                 });
             }

--- a/tooling/ggml-sync/README.md
+++ b/tooling/ggml-sync/README.md
@@ -14,15 +14,16 @@ instead of a history untangle.
 
 The current local patch stack (oldest first):
 
-1. Expose GGUF tensor dimension accessors (`gguf_get_tensor_n_dims`) -- used by
-   the Rust GGUF tensor index.
-2. backend-dl: open plugins with `LOAD_WITH_ALTERED_SEARCH_PATH` on Windows.
-3. Filter `GGML_LOG_LEVEL_DEBUG` spam unless `GGML_DEBUG` / `OPENASR_GGML_DEBUG`.
-4. Persist the Metal pipeline cache (MTLBinaryArchive serialised to disk for
+1. backend-dl: open plugins with `LOAD_WITH_ALTERED_SEARCH_PATH` on Windows.
+2. Filter `GGML_LOG_LEVEL_DEBUG` spam unless `GGML_DEBUG` / `OPENASR_GGML_DEBUG`.
+3. Persist the Metal pipeline cache (MTLBinaryArchive serialised to disk for
    faster cold start).
-5. Isolate that Metal pipeline cache under an `openasr/` cache subdir.
-6. Default Metal residency sets off unless the device exposes the tensor API
+4. Isolate that Metal pipeline cache under an `openasr/` cache subdir.
+5. Default Metal residency sets off unless the device exposes the tensor API
    (`GGML_METAL_RESIDENCY_ENABLE` / `GGML_METAL_NO_RESIDENCY` override).
+
+GGUF tensor shapes use upstream `gguf_get_tensor_ne`; do not restore local
+per-dimension accessors.
 
 Deliberately **not** carried on the pin:
 

--- a/tooling/ggml-sync/sync.sh
+++ b/tooling/ggml-sync/sync.sh
@@ -92,7 +92,10 @@ base="$(git_sub merge-base "${target_sha}" "${pin}")"
 # The OpenASR-local stack = non-merge commits reachable from the current pin but
 # not from its clean upstream base. On a clean pin this is exactly the reviewed
 # patch stack, oldest first.
-mapfile -t patches < <(git_sub log --reverse --no-merges --format='%H' "${base}..${pin}")
+patches=()
+while IFS= read -r sha; do
+  patches+=("${sha}")
+done < <(git_sub log --reverse --no-merges --format='%H' "${base}..${pin}")
 
 echo
 echo "current pin:   ${pin}"


### PR DESCRIPTION
## Summary

Sync the vendored `openasr-ggml` pin to the real upstream `ggml-org/ggml@9be3133` (ggml 0.17.0), replay the retained OpenASR local patch stack, and migrate the Rust GGUF tensor-shape accessor onto the upstream API.

## Why

The previous pin lagged real upstream by dozens of commits. Staying on the fork master line would keep missing upstream fixes such as CPU/Vulkan F16-to-quantized `SET_ROWS`, while also accumulating drift that makes later syncs harder. Periodic sync should target the real upstream base and keep OpenASR-specific patches as a small replayable stack.

## Changes

- Move the vendored gitlink to `oasr/sync-ggml-9be3133` based on `ggml-org/ggml@9be3133`.
- Retire the old local GGUF dimension-accessor patch and switch Rust FFI/index code to `gguf_get_tensor_ne`.
- Preserve the remaining local patches for Windows loader behavior, debug filtering, Metal pipeline-cache persistence/isolation, and residency defaults.
- Update the sync tooling for macOS Bash 3.2 and document the fixed upstream target.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Additional checks:

- `tooling/ggml-sync/sync.sh --target 9be3133... --dry-run`
- `cargo test -p openasr-core golden_diff -- --nocapture`
- catalog signature verification
- `cargo check -p openasr-core -p openasr-ffi --target aarch64-apple-ios`
- Apple M1 Metal smoke with an isolated Whisper Tiny pack and `fixtures/jfk.wav`

## Manual smoke checks

- Real-device Metal backend initialization on Apple M1.
- Metal pipeline-cache path isolation under `openasr/ggml-metal/...`.
- Residency-set default remains off without tensor residency support.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
  - `tooling/ggml-sync/README.md` updated for the fixed upstream target and Bash 3.2 sync flow.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR only performs the periodic upstream sync and the Rust accessor migration required by that sync. It does not add Transformer-XL fused relative attention, Metal multi-device exact init, Q8 KV productization, or Vulkan/CUDA/HIP feature work beyond keeping existing compile paths intact.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
