### PR TITLE
fix(moss): chunk resident prefill to stop Metal OOM

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -3863,6 +3863,23 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         Ok(())
     }
 
+    /// Rebind this prepared persistent graph after another graph temporarily
+    /// used the shared scheduler. Scheduler allocations are graph-specific, so
+    /// a persistent graph must become the active allocation again before its
+    /// next compute.
+    pub(crate) fn restore_prepared_graph_allocation(&mut self) -> Result<(), GgmlCpuGraphError> {
+        let (Some(scheduler), Some(graph)) = (self.scheduler, self.prepared_graph) else {
+            return Ok(());
+        };
+        unsafe { ffi::ggml_backend_sched_reset(scheduler.as_ptr()) };
+        let allocated =
+            unsafe { ffi::ggml_backend_sched_alloc_graph(scheduler.as_ptr(), graph.as_ptr()) };
+        if !allocated {
+            return Err(GgmlCpuGraphError::BackendSchedulerGraphAllocationFailed);
+        }
+        Ok(())
+    }
+
     pub(crate) fn set_f16_bits_slice(
         &mut self,
         tensor: GgmlCpuTensor<'a>,

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -489,7 +489,15 @@ fn run_moss_td_decoder_with_cached_runtime(
                 token_major_values: spliced.token_major_values,
             };
 
-            let layer_kv_caches = decoder.new_kv_caches();
+            // Request-sized, not the checkpoint's native 131072-token RoPE
+            // context: see `MossTdDecoderRuntime::new_kv_caches`'s doc comment
+            // for why the fixed reuse-graph span this sizes must stay tight
+            // to what this utterance actually needs.
+            let layer_kv_caches = decoder.new_kv_caches(
+                spliced
+                    .token_count
+                    .saturating_add(MOSS_TD_MAX_GENERATED_TOKENS),
+            );
             let mut step_executor = MossTdGreedyStepExecutor {
                 decoder,
                 layer_kv_caches,

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -58,7 +58,8 @@ use super::llm_decoder::MossTdDecoderRuntime;
 use super::prompt_embedding::build_moss_td_prompt_embeddings_with_audio_splice;
 use super::runtime_contract::{
     MOSS_TD_ADAPTOR_NORM_EPSILON, MossTdDecoderMetadata, moss_td_kv_cache_positions,
-    parse_adaptor_metadata, parse_decoder_metadata, parse_encoder_metadata,
+    moss_td_request_kv_cache_positions, parse_adaptor_metadata, parse_decoder_metadata,
+    parse_encoder_metadata,
 };
 use super::tokenizer::MossTdTokenizer;
 
@@ -72,12 +73,18 @@ const SAMPLE_RATE_HZ: usize = 16_000;
 /// `_compute_audio_token_length`'s `stride` (`processing_moss_transcribe_diarize.py`).
 const WHISPER_ENCODER_CONV_STRIDE: usize = 2;
 const HOP_LENGTH: usize = 160;
-/// Generous upper bound on generated tokens; greedy decode stops at
-/// `<|im_end|>` well before this in practice (the real checkpoint's own
-/// reference generation config used this exact cap -- verified against
-/// `tmp/moss-td/golden/*.json`'s `max_new_tokens`). Only the fail-closed
-/// backstop against a runaway (non-terminating) decode.
+/// Absolute fail-closed backstop for a non-terminating decode. The checkpoint's
+/// reference configuration uses this ceiling, but each request receives a much
+/// smaller audio-proportional budget below so its persistent Metal KV graph does
+/// not reserve the runaway allowance for ordinary speech.
 const MOSS_TD_MAX_GENERATED_TOKENS: usize = 4096;
+/// A conservative output allowance for timestamped MOSS transcripts. The
+/// three-minute AISHELL-4 golden emits 920 tokens (about 5.1 tokens/s); six
+/// tokens/s plus the fixed margin leaves headroom without reserving all 4096
+/// runaway tokens in every request's Metal reuse graph.
+const MOSS_TD_GENERATED_TOKENS_PER_AUDIO_SECOND: usize = 6;
+const MOSS_TD_MIN_GENERATED_TOKENS: usize = 128;
+const MOSS_TD_GENERATED_TOKEN_BUDGET_MARGIN: usize = 128;
 /// Audio tokens per second the adaptor emits (`audio_tokens_per_second` in
 /// `processing_moss_transcribe_diarize.py`, same value `decode_prompt`'s marker
 /// cadence uses). Only used to render the `AudioExceedsContext` limit as an
@@ -99,13 +106,18 @@ enum MossTdExecutorError {
     TokenizerBuildFailed { reason: String },
     #[error("moss-transcribe-diarize requires non-empty audio")]
     EmptyAudio,
+    #[error("moss-transcribe-diarize decode budget is unavailable: {reason}")]
+    DecodeBudgetUnavailable { reason: String },
     #[error(
-        "moss-transcribe-diarize audio is too long: its {prompt_tokens}-token audio prompt \
-         needs at least one free position within the {kv_capacity}-position decoder context \
-         (about {max_minutes:.0} min of audio); split the input into shorter files"
+        "moss-transcribe-diarize audio is too long: its {prompt_tokens}-token audio prompt plus \
+         the {generation_budget}-token decode budget needs {required_positions} positions within \
+         the {kv_capacity}-position decoder context (about {max_minutes:.0} min of audio); split \
+         the input into shorter files"
     )]
     AudioExceedsContext {
         prompt_tokens: usize,
+        generation_budget: usize,
+        required_positions: usize,
         kv_capacity: usize,
         max_minutes: f32,
     },
@@ -146,15 +158,15 @@ impl Seq2SeqGreedyDecodeStepExecutor for MossTdGreedyStepExecutor<'_> {
     ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyDecodeError> {
         if let Some(prompt_embeddings) = self.prompt_embeddings.take() {
             self.cache_prompt_tokens = prompt_embeddings.token_count;
-            let logits = self
+            let prefill = self
                 .decoder
                 .prefill(&prompt_embeddings, &mut self.layer_kv_caches)
                 .map_err(|error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
                     reason: error.to_string(),
                 })?;
             return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
-                logits,
-                greedy_token_hint: None,
+                logits: prefill.logits,
+                greedy_token_hint: prefill.greedy_token_hint,
             });
         }
         let last_token = input.generated_tokens.last().copied().ok_or_else(|| {
@@ -170,6 +182,18 @@ impl Seq2SeqGreedyDecodeStepExecutor for MossTdGreedyStepExecutor<'_> {
             .ok_or_else(|| Seq2SeqGreedyDecodeError::DecoderStepFailed {
                 reason: "moss-transcribe-diarize decode cache position underflowed".to_string(),
             })?;
+        if let Some(token_id) = self
+            .decoder
+            .decode_step_reused_top1(last_token, cache_position, &self.layer_kv_caches)
+            .map_err(|error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                reason: error.to_string(),
+            })?
+        {
+            return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: Some(token_id),
+            });
+        }
         let logits = self
             .decoder
             .decode_step(last_token, cache_position, &mut self.layer_kv_caches)
@@ -270,6 +294,28 @@ fn moss_td_aligned_frame_count(total_frames: usize, merge_size: usize) -> usize 
     (total_frames / merge_size) * merge_size
 }
 
+/// Derive the per-request decode budget from audio duration, preserving the
+/// checkpoint's 4096-token ceiling solely as a fail-closed runaway backstop.
+/// This is part of the request capacity: the Metal reuse graph must have room
+/// for the complete configured decode, but must not reserve the global ceiling
+/// for short and ordinary long utterances.
+fn moss_td_generated_token_budget(sample_count: usize) -> Result<usize, MossTdExecutorError> {
+    let audio_tokens = sample_count
+        .checked_mul(MOSS_TD_GENERATED_TOKENS_PER_AUDIO_SECOND)
+        .and_then(|value| value.checked_add(SAMPLE_RATE_HZ - 1))
+        .and_then(|value| value.checked_div(SAMPLE_RATE_HZ))
+        .ok_or_else(|| MossTdExecutorError::DecodeBudgetUnavailable {
+            reason: "audio-duration token budget overflowed".to_string(),
+        })?;
+    let desired = audio_tokens
+        .checked_add(MOSS_TD_GENERATED_TOKEN_BUDGET_MARGIN)
+        .ok_or_else(|| MossTdExecutorError::DecodeBudgetUnavailable {
+            reason: "audio-duration token budget margin overflowed".to_string(),
+        })?
+        .max(MOSS_TD_MIN_GENERATED_TOKENS);
+    Ok(desired.min(MOSS_TD_MAX_GENERATED_TOKENS))
+}
+
 /// Weight-free, always-on coverage for the executor's chunk/slice-planning
 /// arithmetic: pure integer math with no model pack involved, so (unlike the
 /// family's `golden_diff_*` end-to-end tests below, which need the private
@@ -353,6 +399,26 @@ mod moss_td_chunk_frame_math_tests {
         assert_eq!(moss_td_aligned_frame_count(3_803, MERGE_SIZE), 3_800);
         assert_eq!(moss_td_aligned_frame_count(3_800, MERGE_SIZE), 3_800);
     }
+
+    #[test]
+    fn decode_budget_scales_to_the_real_moss_golden_lengths() {
+        // The private-reference goldens emit 71 tokens for JFK (11s), 76 for
+        // the mixed clip (13s), and 920 for the three-minute AISHELL-4 clip.
+        // Every budget must retain headroom while avoiding a fixed 4096-token
+        // Metal reuse-graph reservation.
+        assert_eq!(
+            moss_td_generated_token_budget(11 * SAMPLE_RATE_HZ).expect("jfk budget"),
+            194
+        );
+        assert_eq!(
+            moss_td_generated_token_budget(13 * SAMPLE_RATE_HZ).expect("mixed budget"),
+            206
+        );
+        assert_eq!(
+            moss_td_generated_token_budget(180 * SAMPLE_RATE_HZ).expect("AISHELL-4 budget"),
+            1_208
+        );
+    }
 }
 
 /// Encodes every 30s chunk of `samples` against the cached, resident encoder
@@ -433,6 +499,8 @@ fn encode_moss_td_chunks_with_cached_runtime(
 fn run_moss_td_decoder_with_cached_runtime(
     runtime_path: &Path,
     decoder_metadata: MossTdDecoderMetadata,
+    request_kv_cache_positions: usize,
+    max_generated_tokens: usize,
     decode_prompt_token_ids: &[u32],
     audio_pad_positions: &[usize],
     audio_rows: &[f32],
@@ -489,15 +557,11 @@ fn run_moss_td_decoder_with_cached_runtime(
                 token_major_values: spliced.token_major_values,
             };
 
-            // Request-sized, not the checkpoint's native 131072-token RoPE
-            // context: see `MossTdDecoderRuntime::new_kv_caches`'s doc comment
-            // for why the fixed reuse-graph span this sizes must stay tight
-            // to what this utterance actually needs.
-            let layer_kv_caches = decoder.new_kv_caches(
-                spliced
-                    .token_count
-                    .saturating_add(MOSS_TD_MAX_GENERATED_TOKENS),
-            );
+            // Use the validated request capacity, not the checkpoint's
+            // 131072-token RoPE context, so the fixed Metal reuse-graph span
+            // remains proportional to this utterance and can serve the entire
+            // configured decode budget without a mid-decode bounds failure.
+            let layer_kv_caches = decoder.new_kv_caches(request_kv_cache_positions);
             let mut step_executor = MossTdGreedyStepExecutor {
                 decoder,
                 layer_kv_caches,
@@ -508,7 +572,7 @@ fn run_moss_td_decoder_with_cached_runtime(
                 initial_prompt_tokens: decode_prompt_token_ids.to_vec(),
                 eot_token_id: tokenizer.im_end_token_id,
                 vocab_size: decoder_metadata.vocab_size,
-                max_generated_tokens: MOSS_TD_MAX_GENERATED_TOKENS,
+                max_generated_tokens,
             };
             let result = run_builtin_seq2seq_decode_policy(
                 crate::arch::MOSS_TD_DECODE_POLICY_ID,
@@ -586,6 +650,7 @@ impl MossTdGgmlExecutor {
         if samples.is_empty() {
             return Err(MossTdExecutorError::EmptyAudio);
         }
+        let max_generated_tokens = moss_td_generated_token_budget(samples.len())?;
         let audio_duration_seconds = samples.len() as f32 / SAMPLE_RATE_HZ as f32;
 
         let reader = build_runtime_tensor_reader_from_preflight(&preflight).map_err(|error| {
@@ -643,25 +708,33 @@ impl MossTdGgmlExecutor {
                 }
             })?;
 
-        // Fail closed up front when the whole-audio prompt cannot fit the
-        // decoder's KV context. This family ingests the full audio in one
-        // decode (native longform slicing is disabled for it, see the
-        // decode-policy `SelfChunkingExecutorV1`), so a very long file grows
-        // the prompt until it exceeds the KV-cache capacity. `kv_capacity`
-        // positions (~one every 12.5 audio tokens/sec plus the fixed template
-        // and generated tokens) works out to roughly 7-10 minutes of audio;
-        // beyond that, fail with a clear message instead of a cryptic mid-
-        // decode KV-bounds error (or worse, silent truncation).
+        // Fail closed up front when the whole-audio prompt plus the configured
+        // decode budget cannot fit the decoder's KV context. This family
+        // ingests the full audio in one decode (native longform slicing is
+        // disabled for it, see the decode-policy `SelfChunkingExecutorV1`), so
+        // a very long file grows the prompt until it exceeds the KV-cache
+        // capacity. The request-sized cache must reserve every possible decode
+        // position; clamping an over-limit request would defer the failure to a
+        // cryptic KV write mid-generation.
         let kv_capacity = moss_td_kv_cache_positions(decoder_metadata.max_positions);
-        if decode_prompt.token_ids.len() >= kv_capacity {
-            let max_minutes =
-                (kv_capacity as f32 / AUDIO_TOKENS_PER_SECOND_FOR_LIMIT / 60.0).max(0.0);
-            return Err(MossTdExecutorError::AudioExceedsContext {
-                prompt_tokens: decode_prompt.token_ids.len(),
-                kv_capacity,
-                max_minutes,
-            });
-        }
+        let request_kv_cache_positions = moss_td_request_kv_cache_positions(
+            decoder_metadata.max_positions,
+            decode_prompt.token_ids.len(),
+            max_generated_tokens,
+        )
+        .ok_or_else(|| MossTdExecutorError::AudioExceedsContext {
+            prompt_tokens: decode_prompt.token_ids.len(),
+            generation_budget: max_generated_tokens,
+            required_positions: decode_prompt
+                .token_ids
+                .len()
+                .saturating_add(max_generated_tokens),
+            kv_capacity,
+            max_minutes: (kv_capacity.saturating_sub(max_generated_tokens) as f32
+                / AUDIO_TOKENS_PER_SECOND_FOR_LIMIT
+                / 60.0)
+                .max(0.0),
+        })?;
 
         // Routed through the resident, thread-local decoder-runtime cache
         // (mirrors `firered_aed::executor`'s cached decoder): the loaded
@@ -672,6 +745,8 @@ impl MossTdGgmlExecutor {
         let text = run_moss_td_decoder_with_cached_runtime(
             runtime_path,
             decoder_metadata,
+            request_kv_cache_positions,
+            max_generated_tokens,
             &decode_prompt.token_ids,
             &decode_prompt.audio_pad_positions,
             &audio_rows,

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -1403,4 +1403,31 @@ mod tests {
             ACCELERATED_ANCHOR_TOLERANCE_SECS,
         );
     }
+
+    #[test]
+    #[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack and the 3-minute AISHELL-4 fixture; drives an explicit accelerated request"]
+    fn accelerated_aishell4_three_minute_smoke_completes_with_structured_transcript() {
+        let Some((text, _, _)) = transcribe_with_dev_pack_backend(
+            dev_sample_path("aishell4_multispeaker_3min.wav"),
+            GgmlAsrBackendPreference::Accelerated,
+        ) else {
+            return;
+        };
+        assert!(
+            !text.trim().is_empty(),
+            "accelerated AISHELL-4 decode must emit a non-empty transcript"
+        );
+        let golden_path = PathBuf::from(
+            "/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/golden/aishell4_multispeaker_3min.json",
+        );
+        let golden: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(&golden_path).expect("read AISHELL-4 development golden"),
+        )
+        .expect("parse AISHELL-4 development golden");
+        assert_eq!(
+            text,
+            golden["text"].as_str().expect("AISHELL-4 golden text"),
+            "accelerated AISHELL-4 transcript must match the pinned reference text"
+        );
+    }
 }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -893,7 +893,9 @@ mod tests {
         // numeric divergence -> empty-shell output, and a per-step wired-memory
         // blow-up -- see the `arch` descriptor's `auto_gpu_policy` note), so the
         // reference decode is CPU-only.
-        transcribe_with_dev_pack_backend(wav_path, GgmlAsrBackendPreference::CpuOnly)
+        transcribe_with_dev_pack_backend(wav_path, GgmlAsrBackendPreference::CpuOnly).map(
+            |(text, _, elapsed, audio_duration_seconds)| (text, elapsed, audio_duration_seconds),
+        )
     }
 
     /// Same dev-pack e2e path as [`transcribe_with_dev_pack`], but lets the
@@ -907,7 +909,7 @@ mod tests {
     fn transcribe_with_dev_pack_backend(
         wav_path: PathBuf,
         backend_preference: GgmlAsrBackendPreference,
-    ) -> Option<(String, std::time::Duration, f32)> {
+    ) -> Option<(String, Vec<Segment>, std::time::Duration, f32)> {
         let pack_path = dev_pack_path();
         if !pack_path.exists() {
             eprintln!("skipping: {} not present", pack_path.display());
@@ -947,7 +949,12 @@ mod tests {
         let started_at = Instant::now();
         let result = executor.execute(&request).expect("moss-td transcribe");
         let elapsed = started_at.elapsed();
-        Some((result.transcription.text, elapsed, audio_duration_seconds))
+        Some((
+            result.transcription.text,
+            result.transcription.segments,
+            elapsed,
+            audio_duration_seconds,
+        ))
     }
 
     /// Same dev-pack e2e path as [`transcribe_with_dev_pack`], but returns the
@@ -1340,7 +1347,7 @@ mod tests {
                 and tmp/moss-td/samples/*.wav; drives an explicit accelerated request \
                 (Metal encoder + Metal decode) and needs a Metal device"]
     fn golden_diff_end_to_end_transcribe_jfk_wav_accelerated() {
-        let Some((text, elapsed, audio_duration_seconds)) = transcribe_with_dev_pack_backend(
+        let Some((text, _, elapsed, audio_duration_seconds)) = transcribe_with_dev_pack_backend(
             dev_sample_path("jfk.wav"),
             GgmlAsrBackendPreference::Accelerated,
         ) else {
@@ -1387,7 +1394,7 @@ mod tests {
                 and tmp/moss-td/samples/*.wav; drives an explicit accelerated request \
                 (Metal encoder + Metal decode) and needs a Metal device"]
     fn golden_diff_end_to_end_transcribe_en_zh_mixed_wav_accelerated() {
-        let Some((text, elapsed, audio_duration_seconds)) = transcribe_with_dev_pack_backend(
+        let Some((text, _, elapsed, audio_duration_seconds)) = transcribe_with_dev_pack_backend(
             dev_sample_path("en_zh_mixed.wav"),
             GgmlAsrBackendPreference::Accelerated,
         ) else {
@@ -1407,7 +1414,7 @@ mod tests {
     #[test]
     #[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack and the 3-minute AISHELL-4 fixture; drives an explicit accelerated request"]
     fn accelerated_aishell4_three_minute_smoke_completes_with_structured_transcript() {
-        let Some((text, _, _)) = transcribe_with_dev_pack_backend(
+        let Some((text, segments, _, _)) = transcribe_with_dev_pack_backend(
             dev_sample_path("aishell4_multispeaker_3min.wav"),
             GgmlAsrBackendPreference::Accelerated,
         ) else {
@@ -1428,6 +1435,30 @@ mod tests {
             text,
             golden["text"].as_str().expect("AISHELL-4 golden text"),
             "accelerated AISHELL-4 transcript must match the pinned reference text"
+        );
+        assert!(
+            !segments.is_empty(),
+            "AISHELL-4 must emit structured segments"
+        );
+        assert!(
+            segments.iter().all(|segment| {
+                segment.speaker.is_some()
+                    && segment.start.is_finite()
+                    && segment.end.is_finite()
+                    && segment.start <= segment.end
+                    && !segment.text.trim().is_empty()
+            }),
+            "AISHELL-4 segments must retain speaker labels and valid time ranges"
+        );
+        assert!(
+            segments
+                .windows(2)
+                .all(|pair| pair[0].start <= pair[1].start),
+            "AISHELL-4 segment starts must be ordered"
+        );
+        assert!(
+            parse_moss_td_speaker_segments(&text, 180.0).is_ok(),
+            "AISHELL-4 tagged transcript must parse without text-only degradation"
         );
     }
 }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -107,6 +107,11 @@ pub(crate) struct MossTdDecoderRuntime {
     metadata: MossTdDecoderMetadata,
 }
 
+pub(crate) struct MossTdPrefillOutput {
+    pub(crate) logits: Vec<f32>,
+    pub(crate) greedy_token_hint: Option<u32>,
+}
+
 impl MossTdDecoderRuntime {
     pub(crate) fn new(
         runtime_path: &std::path::Path,
@@ -115,16 +120,6 @@ impl MossTdDecoderRuntime {
         let reader = crate::ggml_runtime::GgufTensorDataReader::from_path(runtime_path)
             .map_err(map_tensor_read_error)?;
         let projections = load_moss_layer_projections(&reader, &metadata)?;
-        let whole_decoder =
-            Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_rms_norm_epsilon_and_fused_logits_head(
-                &projections,
-                Some(runtime_path),
-                MOSS_TD_RMS_NORM_EPSILON,
-                None,
-            )
-            .map_err(|error| MossTdDecoderError::GraphFailed {
-                reason: error.to_string(),
-            })?;
         let logits_head = load_llm_logits_head_from_reader_with_tensor_names(
             &reader,
             metadata.d_model,
@@ -148,6 +143,20 @@ impl MossTdDecoderRuntime {
         .map_err(|error| MossTdDecoderError::TokenEmbeddingFailed {
             reason: error.to_string(),
         })?;
+        // Keep the output projection in the same static arena as the resident
+        // decoder graph. Metal can then return a device-side top-1 token for
+        // every post-prefill step instead of constructing a separate full-vocab
+        // logits graph per token.
+        let whole_decoder =
+            Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_rms_norm_epsilon_and_fused_logits_head(
+                &projections,
+                Some(runtime_path),
+                MOSS_TD_RMS_NORM_EPSILON,
+                logits_head.fused_top1_spec(),
+            )
+            .map_err(|error| MossTdDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?;
         Ok(Self {
             whole_decoder,
             logits_head,
@@ -171,30 +180,23 @@ impl MossTdDecoderRuntime {
         self.whole_decoder.release_session_scoped_buffers();
     }
 
-    /// `capacity` should be the request-sized bound (prompt tokens + the
-    /// generation budget), NOT the checkpoint's native `max_positions`
-    /// (131072, a RoPE context ceiling -- see `moss_td_kv_cache_positions`'s
-    /// doc comment): `capacity` becomes the persistent Metal/GPU reuse
-    /// graph's fixed KV/mask/RoPE span (`run_prefill_auto_last_hidden`/
-    /// `run_step_auto` size it from this cache's `max_positions()`), and that
-    /// span is a per-token COMPUTE + device-resident-allocation cost there,
-    /// not just a host bound. Sizing it to the family-wide cap unconditionally
-    /// made every utterance -- including a short one needing a few hundred
-    /// positions -- pay a fixed 8192-wide attention span on every prefill
-    /// mask/decode step and a fixed ~1.9 GB device allocation regardless of
-    /// real audio length: measured 3.2-3.85x slower than the CPU backend, and
-    /// a several-minute clip's 28-layer x 8192-wide single-shot device
-    /// allocation exhausted Metal's working-set budget outright (OOM). This
-    /// still clamps to `moss_td_kv_cache_positions`'s family-wide ceiling, so
-    /// a request that genuinely needs more than that fails closed at the
-    /// cache's own bounds check instead of over-allocating. Mirrors
+    /// `capacity` is the request-sized bound (prompt tokens + the generation
+    /// budget), NOT the checkpoint's native `max_positions` (131072, a RoPE
+    /// context ceiling -- see `moss_td_kv_cache_positions`'s doc comment).
+    /// It becomes the persistent Metal/GPU reuse graph's fixed KV/mask/RoPE
+    /// span (`run_prefill_auto_last_hidden`/`run_step_auto` size it from this
+    /// cache's `max_positions()`), so it is a per-token compute and
+    /// device-resident-allocation cost, not just a host bound. The executor
+    /// validates this complete request against the pack's capped metadata
+    /// ceiling before calling here. Keeping the metadata minimum here as
+    /// defense in depth preserves a pack whose declared context is smaller
+    /// than the family cap; it must never be silently expanded. Mirrors
     /// `firered_llm::llm_transformer`'s and `mimo_asr::llm_transformer`'s
-    /// identical `new_kv_caches(capacity)` sizing (which never had this
-    /// family-wide-cap step because their native `max_positions` was already
-    /// a sane KV-cache size), and `qwen::ggml_executor`'s own
+    /// request-sized `new_kv_caches(capacity)` sizing, and
+    /// `qwen::ggml_executor`'s own
     /// `decode_prompt.token_ids.len().saturating_add(decode_config.max_generated_tokens)`.
     pub(crate) fn new_kv_caches(&self, capacity: usize) -> Vec<Qwen3AsrLayerKvCacheState> {
-        let cache_positions = moss_td_kv_cache_positions(capacity);
+        let cache_positions = capacity.min(moss_td_kv_cache_positions(self.metadata.max_positions));
         (0..self.metadata.n_layers)
             .map(|_| {
                 Qwen3AsrLayerKvCacheState::new(
@@ -238,7 +240,7 @@ impl MossTdDecoderRuntime {
         &mut self,
         prompt_embeddings: &Qwen3AsrPromptEmbeddings,
         layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
-    ) -> Result<Vec<f32>, MossTdDecoderError> {
+    ) -> Result<MossTdPrefillOutput, MossTdDecoderError> {
         let token_count = prompt_embeddings.token_count;
         // On a backend with persistent decode-graph reuse (Metal/single-GPU),
         // seed the resident-KV arena in one batched compute instead of the bulk
@@ -260,12 +262,28 @@ impl MossTdDecoderRuntime {
                 reason: error.to_string(),
             })?
         {
-            return self
+            if let Some(token_id) = self
+                .whole_decoder
+                .fused_logits_top1_from_hidden(&final_hidden)
+                .map_err(|error| MossTdDecoderError::GraphFailed {
+                    reason: error.to_string(),
+                })?
+            {
+                return Ok(MossTdPrefillOutput {
+                    logits: Vec::new(),
+                    greedy_token_hint: Some(token_id),
+                });
+            }
+            let logits = self
                 .logits_head
                 .compute_logits_for_last_hidden(&final_hidden)
                 .map_err(|error| MossTdDecoderError::LogitsHeadFailed {
                     reason: error.to_string(),
-                });
+                })?;
+            return Ok(MossTdPrefillOutput {
+                logits,
+                greedy_token_hint: None,
+            });
         }
         let host_chunked = self
             .whole_decoder
@@ -286,11 +304,16 @@ impl MossTdDecoderRuntime {
                 })?;
             self.write_prefill_outputs(0, token_count, &step, layer_kv_caches)?
         };
-        self.logits_head
+        let logits = self
+            .logits_head
             .compute_logits_for_last_hidden(&final_hidden)
             .map_err(|error| MossTdDecoderError::LogitsHeadFailed {
                 reason: error.to_string(),
-            })
+            })?;
+        Ok(MossTdPrefillOutput {
+            logits,
+            greedy_token_hint: None,
+        })
     }
 
     /// Segmented prefill (see [`Self::prefill`]): feed the prompt to the decoder
@@ -384,6 +407,41 @@ impl MossTdDecoderRuntime {
             .map_err(|error| MossTdDecoderError::LogitsHeadFailed {
                 reason: error.to_string(),
             })
+    }
+
+    /// On the resident Metal/GPU reuse graph, return the decoder's device-side
+    /// argmax directly. MOSS's registered policy has no suppression or phrase
+    /// bias, so the shared greedy driver can safely consume this as a validated
+    /// `greedy_token_hint`; CPU and any non-reuse backend fall back to the full
+    /// host logits path above.
+    pub(crate) fn decode_step_reused_top1(
+        &mut self,
+        token_id: u32,
+        cache_position: usize,
+        layer_kv_caches: &[Qwen3AsrLayerKvCacheState],
+    ) -> Result<Option<u32>, MossTdDecoderError> {
+        if !self.whole_decoder.supports_graph_reuse() || !self.whole_decoder.supports_fused_top1() {
+            return Ok(None);
+        }
+        let max_positions = layer_kv_caches
+            .first()
+            .map(Qwen3AsrLayerKvCacheState::max_positions)
+            .ok_or_else(|| MossTdDecoderError::KvCacheFailed {
+                reason: "moss-transcribe-diarize decoder has no layer KV caches".to_string(),
+            })?;
+        let hidden = self.gather_token_embedding(token_id)?;
+        let step = self
+            .whole_decoder
+            .run_step_reused_batched_top1(
+                &hidden,
+                &[cache_position],
+                MOSS_TD_ROPE_THETA,
+                max_positions,
+            )
+            .map_err(|error| MossTdDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?;
+        Ok(Some(step.token_id))
     }
 
     fn write_prefill_outputs(

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -171,14 +171,30 @@ impl MossTdDecoderRuntime {
         self.whole_decoder.release_session_scoped_buffers();
     }
 
-    pub(crate) fn new_kv_caches(&self) -> Vec<Qwen3AsrLayerKvCacheState> {
-        // Clamp the RoPE context limit (`max_positions`, up to 131072) down to
-        // the KV-cache preallocation cap: `Qwen3AsrLayerKvCacheState::new`
-        // eagerly allocates the full `max_positions` span on first write, so an
-        // uncapped 131072 reserves ~30 GB across the 28 layers (see
-        // `moss_td_kv_cache_positions`). This makes packs built before the cap
-        // (131072 baked into the GGUF) allocate the same ~1.9 GB as fresh ones.
-        let cache_positions = moss_td_kv_cache_positions(self.metadata.max_positions);
+    /// `capacity` should be the request-sized bound (prompt tokens + the
+    /// generation budget), NOT the checkpoint's native `max_positions`
+    /// (131072, a RoPE context ceiling -- see `moss_td_kv_cache_positions`'s
+    /// doc comment): `capacity` becomes the persistent Metal/GPU reuse
+    /// graph's fixed KV/mask/RoPE span (`run_prefill_auto_last_hidden`/
+    /// `run_step_auto` size it from this cache's `max_positions()`), and that
+    /// span is a per-token COMPUTE + device-resident-allocation cost there,
+    /// not just a host bound. Sizing it to the family-wide cap unconditionally
+    /// made every utterance -- including a short one needing a few hundred
+    /// positions -- pay a fixed 8192-wide attention span on every prefill
+    /// mask/decode step and a fixed ~1.9 GB device allocation regardless of
+    /// real audio length: measured 3.2-3.85x slower than the CPU backend, and
+    /// a several-minute clip's 28-layer x 8192-wide single-shot device
+    /// allocation exhausted Metal's working-set budget outright (OOM). This
+    /// still clamps to `moss_td_kv_cache_positions`'s family-wide ceiling, so
+    /// a request that genuinely needs more than that fails closed at the
+    /// cache's own bounds check instead of over-allocating. Mirrors
+    /// `firered_llm::llm_transformer`'s and `mimo_asr::llm_transformer`'s
+    /// identical `new_kv_caches(capacity)` sizing (which never had this
+    /// family-wide-cap step because their native `max_positions` was already
+    /// a sane KV-cache size), and `qwen::ggml_executor`'s own
+    /// `decode_prompt.token_ids.len().saturating_add(decode_config.max_generated_tokens)`.
+    pub(crate) fn new_kv_caches(&self, capacity: usize) -> Vec<Qwen3AsrLayerKvCacheState> {
+        let cache_positions = moss_td_kv_cache_positions(capacity);
         (0..self.metadata.n_layers)
             .map(|_| {
                 Qwen3AsrLayerKvCacheState::new(

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
@@ -1031,12 +1031,13 @@ fn moss_td_runtime_gguf_metadata(
         .u32("moss_td.llm.n_kv_heads", text.num_key_value_heads as u32)
         .u32("moss_td.llm.head_dim", text.head_dim as u32)
         .u32("moss_td.llm.vocab_size", tokens.len() as u32)
-        // Write a pragmatic KV-cache capacity, NOT the raw RoPE context limit
-        // (`max_position_embeddings` = 131072). The runtime caps this again on
-        // load (`llm_decoder::new_kv_caches`), so this keeps freshly built packs
-        // self-describing with the same value the runtime will use, rather than
-        // baking in a 131072 that would (uncapped) reserve ~30 GB of KV cache.
-        // See `runtime_contract::moss_td_kv_cache_positions`.
+        // Write the capped decoder context ceiling, NOT the raw RoPE context
+        // limit (`max_position_embeddings` = 131072). At execution time the
+        // decoder further narrows this ceiling to each request's prompt plus
+        // generation budget, while preserving this imported value as the
+        // fail-closed upper bound. This avoids baking a 131072-position cache
+        // contract into fresh packs. See
+        // `runtime_contract::moss_td_request_kv_cache_positions`.
         .u32(
             "moss_td.llm.max_positions",
             moss_td_kv_cache_positions(text.max_position_embeddings) as u32,
@@ -1090,6 +1091,32 @@ mod tests {
             },
         };
         assert!(validate_moss_config(&config).is_ok());
+    }
+
+    #[test]
+    fn imported_metadata_keeps_the_capped_context_as_a_runtime_ceiling() {
+        let config = base_config_for_test();
+        let request = MossTdImportRequest {
+            source_root: PathBuf::from("/tmp/moss-source"),
+            output_root: PathBuf::from("/tmp/moss-pack.oasr"),
+            model_id: "moss-test".to_string(),
+            quantization: MossTdQuantizationMode::Fp16,
+        };
+        let metadata = moss_td_runtime_gguf_metadata(
+            &config,
+            &request,
+            &["token".to_string()],
+            &[],
+            MossTdAudioTokenIds {
+                start: 151_669,
+                end: 151_670,
+                pad: 151_671,
+            },
+        );
+        assert_eq!(
+            metadata.get("moss_td.llm.max_positions"),
+            Some(&GgufWriteValue::U32(8_192))
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/runtime_contract.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/runtime_contract.rs
@@ -47,22 +47,30 @@ pub(crate) const MOSS_TD_ADAPTOR_NORM_EPSILON: f32 = 1e-6;
 /// reserves ~30 GB of address space (28 layers x 2 x 131072 x 8 x 128 x 4 B).
 /// That reservation is lazy-zeroed and harmless on the CPU backend (only the
 /// touched prefix is resident), but the Metal backend physically wires the
-/// buffers and exhausts a 16 GB machine. Cap the preallocation at a pragmatic
-/// ASR context length -- 8192 mirrors qwen3-asr's own audio-encoder value -- so
-/// real utterances (audio tokens + prompt + generated tokens) stay comfortably
-/// under it while the reservation drops to ~1.9 GB. A sequence longer than the
-/// cap fails closed at the cache's own bounds check, never by over-allocating.
+/// buffers and exhausts a 16 GB machine. This is a ceiling on top of the
+/// request-sized capacity `llm_decoder::new_kv_caches` computes (prompt +
+/// generation-budget tokens for the utterance actually being decoded, mirroring
+/// `firered_llm`/`mimo_asr`'s identical sizing) -- NOT the value that capacity
+/// is unconditionally forced to. Sizing every request to this cap
+/// unconditionally previously made the fixed Metal/GPU reuse-graph KV/mask/
+/// RoPE span 8192-wide regardless of real utterance length (3.2-3.85x slower
+/// than the CPU backend on short audio) and made a several-minute clip's
+/// 28-layer x 8192-wide single-shot device allocation exhaust Metal's working
+/// set outright (OOM) even though the utterance's real demand was far below
+/// the cap. A request whose real demand exceeds this cap still fails closed at
+/// the cache's own bounds check, never by over-allocating.
 ///
 /// Lesson, recorded so it does not recur: `max_position_embeddings` is an
 /// attention/positional-encoding ceiling, not a working-set size; the two must
 /// not be conflated when sizing runtime buffers.
 pub(crate) const MOSS_TD_MAX_KV_CACHE_POSITIONS: usize = 8192;
 
-/// Clamp a decoder `max_positions` value (which may be the raw RoPE context
-/// limit) to the KV-cache preallocation cap. Both the runtime decoder
-/// (`llm_decoder::new_kv_caches`) and the pack importer
-/// (`package_import`) route through this so a pack built before the cap (with
-/// 131072 baked in) and a freshly built pack allocate identically.
+/// Clamp a KV-cache capacity (request-sized, or the raw RoPE context limit for
+/// the pack importer's own bookkeeping) to the family-wide preallocation cap.
+/// Both the runtime decoder (`llm_decoder::new_kv_caches`, called with the
+/// request-sized capacity) and the pack importer (`package_import`, called
+/// with the raw checkpoint `max_positions`) route through this so neither ever
+/// allocates past the cap.
 pub(crate) fn moss_td_kv_cache_positions(max_positions: usize) -> usize {
     max_positions.min(MOSS_TD_MAX_KV_CACHE_POSITIONS)
 }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/runtime_contract.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/runtime_contract.rs
@@ -53,12 +53,13 @@ pub(crate) const MOSS_TD_ADAPTOR_NORM_EPSILON: f32 = 1e-6;
 /// `firered_llm`/`mimo_asr`'s identical sizing) -- NOT the value that capacity
 /// is unconditionally forced to. Sizing every request to this cap
 /// unconditionally previously made the fixed Metal/GPU reuse-graph KV/mask/
-/// RoPE span 8192-wide regardless of real utterance length (3.2-3.85x slower
-/// than the CPU backend on short audio) and made a several-minute clip's
-/// 28-layer x 8192-wide single-shot device allocation exhaust Metal's working
-/// set outright (OOM) even though the utterance's real demand was far below
-/// the cap. A request whose real demand exceeds this cap still fails closed at
-/// the cache's own bounds check, never by over-allocating.
+/// RoPE span 8192-wide regardless of real utterance length and made a
+/// several-minute clip's 28-layer x 8192-wide single-shot device allocation
+/// exhaust Metal's working set outright (OOM) even though the utterance's real
+/// demand was far below the cap. The executor validates the complete
+/// prompt-plus-generation request against this ceiling before constructing a
+/// decoder cache, so an over-limit request fails closed instead of allocating a
+/// cache that cannot serve its configured decode budget.
 ///
 /// Lesson, recorded so it does not recur: `max_position_embeddings` is an
 /// attention/positional-encoding ceiling, not a working-set size; the two must
@@ -67,12 +68,25 @@ pub(crate) const MOSS_TD_MAX_KV_CACHE_POSITIONS: usize = 8192;
 
 /// Clamp a KV-cache capacity (request-sized, or the raw RoPE context limit for
 /// the pack importer's own bookkeeping) to the family-wide preallocation cap.
-/// Both the runtime decoder (`llm_decoder::new_kv_caches`, called with the
-/// request-sized capacity) and the pack importer (`package_import`, called
-/// with the raw checkpoint `max_positions`) route through this so neither ever
-/// allocates past the cap.
+/// Both the runtime decoder and the pack importer route their respective bounds
+/// through this, so neither ever allocates past the cap.
 pub(crate) fn moss_td_kv_cache_positions(max_positions: usize) -> usize {
     max_positions.min(MOSS_TD_MAX_KV_CACHE_POSITIONS)
+}
+
+/// Return the exact request-sized KV allocation when its complete decode budget
+/// fits both the imported pack's advertised ceiling and the family-wide cap.
+/// `None` is a fail-closed result: callers must reject the request before
+/// constructing a decoder cache, rather than clamp it and hit a KV bounds error
+/// partway through generation.
+pub(crate) fn moss_td_request_kv_cache_positions(
+    pack_max_positions: usize,
+    prompt_tokens: usize,
+    max_generated_tokens: usize,
+) -> Option<usize> {
+    let request_positions = prompt_tokens.checked_add(max_generated_tokens)?;
+    (request_positions <= moss_td_kv_cache_positions(pack_max_positions))
+        .then_some(request_positions)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -314,5 +328,28 @@ mod tests {
         assert_eq!(moss_td_kv_cache_positions(8_192), 8_192);
         // A short-enough value passes through untouched.
         assert_eq!(moss_td_kv_cache_positions(300), 300);
+    }
+
+    #[test]
+    fn request_kv_cache_capacity_respects_pack_ceiling_and_decode_budget() {
+        // A legacy pack retains its raw RoPE metadata, but a short request only
+        // allocates the prompt plus its configured generation budget.
+        assert_eq!(
+            moss_td_request_kv_cache_positions(131_072, 300, 4_096),
+            Some(4_396)
+        );
+        // A freshly imported pack advertises the same 8192-position ceiling.
+        assert_eq!(
+            moss_td_request_kv_cache_positions(8_192, 4_096, 4_096),
+            Some(8_192)
+        );
+        // Never let an imported lower ceiling be silently expanded.
+        assert_eq!(moss_td_request_kv_cache_positions(4_096, 1, 4_096), None);
+        // Arithmetic overflow is also fail-closed rather than saturating into
+        // an undersized cache.
+        assert_eq!(
+            moss_td_request_kv_cache_positions(8_192, usize::MAX, 1),
+            None
+        );
     }
 }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
@@ -290,6 +290,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn accepts_an_adjacent_pending_start_correction() {
+        let segments = parse_moss_td_speaker_segments("[1.0][0.9][S01]hello[2.0]", 2.0)
+            .expect("adjacent corrected start should parse");
+        assert_eq!(segments[0].start, 0.9);
+        assert_eq!(segments[0].end, 2.0);
+    }
+
+    #[test]
+    fn rejects_a_backwards_anchor_after_text() {
+        let error = parse_moss_td_speaker_segments("[1.0][S01]hello[0.9]", 2.0)
+            .expect_err("text-attached backwards anchor must fail closed");
+        assert!(matches!(
+            error,
+            MossTdSpeakerSegmentParseError::TimeWentBackwards { .. }
+        ));
+    }
+
+    #[test]
     fn empty_stream_yields_no_segments() {
         assert_eq!(parse_moss_td_speaker_segments("", 5.0), Ok(Vec::new()));
     }

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
@@ -209,6 +209,16 @@ pub(crate) fn parse_moss_td_speaker_segments(
                 if let Some(previous) = last_anchor
                     && timestamp < previous
                 {
+                    // MOSS occasionally emits a corrected turn-start anchor
+                    // immediately after an initial anchor and before any text
+                    // (for example `[125.31][124.34][S01]`). It denotes the
+                    // same pending start, not a temporal reversal. Preserve
+                    // strict monotonicity once text has been attached.
+                    if buffer.trim().is_empty() && pending_start == Some(previous) {
+                        pending_start = Some(timestamp);
+                        last_anchor = Some(timestamp);
+                        continue;
+                    }
                     return Err(MossTdSpeakerSegmentParseError::TimeWentBackwards {
                         previous,
                         next: timestamp,

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -831,7 +831,6 @@ struct Qwen3AsrLlmFusedLogitsHeadHandles {
     rms_norm_epsilon: f32,
     output_norm_weight: GgmlStaticTensor,
     output_weight: LlmWeightHandle,
-    output_weight_is_vocab_hidden: bool,
     argmax_reverse_indices: GgmlStaticTensor,
 }
 
@@ -1243,11 +1242,9 @@ fn allocate_fused_logits_head_tensors(
             reason: "fused logits head norm width mismatch",
         });
     }
-    let output_weight_is_vocab_hidden = spec.output_weight_dims == [spec.vocab_size, dims.d_model];
-    if spec.output_weight_dims != [dims.d_model, spec.vocab_size] && !output_weight_is_vocab_hidden
-    {
+    if spec.output_weight_dims != [dims.d_model, spec.vocab_size] {
         return Err(GgmlCpuGraphError::UnsupportedInputs {
-            reason: "fused logits head requires [hidden, vocab] or [vocab, hidden] output weight",
+            reason: "fused logits head requires direct [hidden, vocab] output weight",
         });
     }
     if !spec.rms_norm_epsilon.is_finite() || spec.rms_norm_epsilon <= 0.0 {
@@ -1276,7 +1273,6 @@ fn allocate_fused_logits_head_tensors(
         rms_norm_epsilon: spec.rms_norm_epsilon,
         output_norm_weight,
         output_weight,
-        output_weight_is_vocab_hidden,
         argmax_reverse_indices,
     })
 }
@@ -1320,13 +1316,7 @@ fn build_fused_logits_top1<'a>(
     }
     let normed = graph.rms_norm(state, logits_head.rms_norm_epsilon)?;
     let normed = graph.mul(normed, arena.graph_tensor(logits_head.output_norm_weight))?;
-    let output_weight = logits_head.output_weight.as_graph_tensor(arena);
-    let output_weight = if logits_head.output_weight_is_vocab_hidden {
-        graph.transpose(output_weight)?
-    } else {
-        output_weight
-    };
-    let logits = graph.mul_mat(output_weight, normed)?;
+    let logits = graph.mul_mat(logits_head.output_weight.as_graph_tensor(arena), normed)?;
     graph.top1_argmax_first_max_reversed(
         logits,
         arena.graph_tensor(logits_head.argmax_reverse_indices),
@@ -4832,6 +4822,62 @@ mod tests {
         let token_id = validate_fused_top1_token_id(reversed_top1[0], spec.vocab_size)
             .expect("top1 should map to a valid token");
         assert_eq!(token_id, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "vocab-hidden fused logits handles should allocate")]
+    fn fused_logits_top1_rejects_vocab_hidden_output_layout() {
+        let config = GgmlCpuGraphConfig::default();
+        let mut runner =
+            GgmlCpuGraphRunner::new(config).expect("cpu graph runner should initialize");
+        let mut arena = runner
+            .start_static_tensor_arena(config.context_bytes)
+            .expect("static arena should allocate");
+        let dims = Qwen3AsrLlmDecodeDims {
+            d_model: 2,
+            q_width: 2,
+            k_width: 2,
+            v_width: 2,
+            head_dim: 2,
+            q_heads: 1,
+            kv_heads: 1,
+        };
+        // Physical [vocab, hidden] storage for the logical [hidden, vocab]
+        // projection used by the ordinary logits path.
+        let output_weight_bytes = [0.1_f32, 0.3, 0.3, 0.0, 0.0, 0.0]
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect::<Vec<_>>();
+        let spec = Qwen3AsrLlmFusedLogitsHeadSpec {
+            d_model: 2,
+            vocab_size: 3,
+            rms_norm_epsilon: DEFAULT_RMS_NORM_EPSILON,
+            output_norm_weight: &[1.0, 1.0],
+            output_weight_tensor_name: "synthetic.output.weight",
+            output_weight_ggml_type: GGML_TYPE_F32,
+            output_weight_dims: &[3, 2],
+            output_weight_bytes: &output_weight_bytes,
+        };
+        let handles = allocate_fused_logits_head_tensors(&mut arena, None, dims, &spec)
+            .expect("vocab-hidden fused logits handles should allocate");
+        upload_fused_logits_head_weights(&mut arena, &handles, &spec)
+            .expect("vocab-hidden fused logits weights should upload");
+        let mut graph = runner.start_graph();
+        let state = graph
+            .new_tensor_2d_f32(2, 1, "synthetic_state")
+            .expect("state");
+        graph.set_input(state).expect("state input");
+        let top1 = build_fused_logits_top1(&arena, &handles, &mut graph, state, 1)
+            .expect("vocab-hidden fused top1 should build");
+        graph.set_output(top1).expect("top1 output");
+        graph
+            .set_f32_slice(state, &[1.0, 0.0], "synthetic_state")
+            .expect("state upload");
+        let reversed = graph.compute_output_i32(top1, 1).expect("top1 compute");
+        assert_eq!(
+            validate_fused_top1_token_id(reversed[0], spec.vocab_size).expect("top1 token"),
+            1
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -2149,6 +2149,43 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         })
     }
 
+    /// Compute a fused device-side top-1 token from an already-materialized
+    /// decoder hidden row. This avoids allocating a separate full-vocabulary
+    /// logits executor after a resident prefill graph has populated its KV.
+    pub(crate) fn fused_logits_top1_from_hidden(
+        &mut self,
+        hidden: &[f32],
+    ) -> Result<Option<u32>, GgmlCpuGraphError> {
+        let Some(fused_logits_head) = self.fused_logits_head.as_ref() else {
+            return Ok(None);
+        };
+        if hidden.len() != self.dims.d_model {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder fused top1 hidden width mismatch",
+            });
+        }
+        let mut graph = self.runner.start_graph();
+        let hidden_tensor =
+            graph.new_tensor_2d_f32(self.dims.d_model, 1, "qwen_llm_fused_logits_hidden")?;
+        graph.set_input(hidden_tensor)?;
+        let top1 =
+            build_fused_logits_top1(&self.arena, fused_logits_head, &mut graph, hidden_tensor, 1)?;
+        graph.set_output(top1)?;
+        graph.set_f32_slice(hidden_tensor, hidden, "qwen_llm_fused_logits_hidden")?;
+        let token_id = graph
+            .compute_output_i32(top1, 1)?
+            .first()
+            .copied()
+            .ok_or(GgmlCpuGraphError::OutputByteSizeMismatch {
+                expected: std::mem::size_of::<i32>(),
+                actual: 0,
+            })
+            .and_then(|token_id| {
+                validate_fused_top1_token_id(token_id, fused_logits_head.vocab_size)
+            })?;
+        Ok(Some(token_id))
+    }
+
     /// Run an entire prompt prefix as one causal multi-query LLM graph. This is
     /// the prefill counterpart to `run_step`: K/V for all prompt rows are written
     /// by one `set_rows` call per layer, guarded by a `[kv, query, 1, 1]` causal

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -831,6 +831,7 @@ struct Qwen3AsrLlmFusedLogitsHeadHandles {
     rms_norm_epsilon: f32,
     output_norm_weight: GgmlStaticTensor,
     output_weight: LlmWeightHandle,
+    output_weight_is_vocab_hidden: bool,
     argmax_reverse_indices: GgmlStaticTensor,
 }
 
@@ -1242,9 +1243,11 @@ fn allocate_fused_logits_head_tensors(
             reason: "fused logits head norm width mismatch",
         });
     }
-    if spec.output_weight_dims != [dims.d_model, spec.vocab_size] {
+    let output_weight_is_vocab_hidden = spec.output_weight_dims == [spec.vocab_size, dims.d_model];
+    if spec.output_weight_dims != [dims.d_model, spec.vocab_size] && !output_weight_is_vocab_hidden
+    {
         return Err(GgmlCpuGraphError::UnsupportedInputs {
-            reason: "fused logits head requires direct [hidden, vocab] output weight",
+            reason: "fused logits head requires [hidden, vocab] or [vocab, hidden] output weight",
         });
     }
     if !spec.rms_norm_epsilon.is_finite() || spec.rms_norm_epsilon <= 0.0 {
@@ -1260,9 +1263,9 @@ fn allocate_fused_logits_head_tensors(
     let output_weight =
         match loaded.and_then(|context| context.tensor(spec.output_weight_tensor_name)) {
             Some(tensor) => LlmWeightHandle::Loaded(tensor),
-            None => LlmWeightHandle::Arena(arena.new_matmul_weight_2d_typed(
-                dims.d_model,
-                spec.vocab_size,
+            None => LlmWeightHandle::Arena(arena.new_tensor_2d_typed(
+                spec.output_weight_dims[0],
+                spec.output_weight_dims[1],
                 spec.output_weight_ggml_type,
                 "qwen_llm_fused_output_weight",
             )?),
@@ -1273,6 +1276,7 @@ fn allocate_fused_logits_head_tensors(
         rms_norm_epsilon: spec.rms_norm_epsilon,
         output_norm_weight,
         output_weight,
+        output_weight_is_vocab_hidden,
         argmax_reverse_indices,
     })
 }
@@ -1316,7 +1320,13 @@ fn build_fused_logits_top1<'a>(
     }
     let normed = graph.rms_norm(state, logits_head.rms_norm_epsilon)?;
     let normed = graph.mul(normed, arena.graph_tensor(logits_head.output_norm_weight))?;
-    let logits = graph.mul_mat(logits_head.output_weight.as_graph_tensor(arena), normed)?;
+    let output_weight = logits_head.output_weight.as_graph_tensor(arena);
+    let output_weight = if logits_head.output_weight_is_vocab_hidden {
+        graph.transpose(output_weight)?
+    } else {
+        output_weight
+    };
+    let logits = graph.mul_mat(output_weight, normed)?;
     graph.top1_argmax_first_max_reversed(
         logits,
         arena.graph_tensor(logits_head.argmax_reverse_indices),
@@ -2255,6 +2265,66 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         max_positions: usize,
         rope_theta: f32,
     ) -> Result<Qwen3AsrLlmWholeStepOutput, GgmlCpuGraphError> {
+        const RESIDENT_PREFILL_MAX_QUERY_TOKENS: usize = 256;
+        if token_count == 0 {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder resident prefill token count must be positive",
+            });
+        }
+        let hidden_per_token =
+            self.dims
+                .d_model
+                .checked_mul(n_seq)
+                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill hidden width overflow",
+                })?;
+        let mut final_step = None;
+        for position_offset in (0..token_count).step_by(RESIDENT_PREFILL_MAX_QUERY_TOKENS) {
+            let chunk_tokens =
+                (token_count - position_offset).min(RESIDENT_PREFILL_MAX_QUERY_TOKENS);
+            let chunk_start = position_offset.checked_mul(hidden_per_token).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill chunk offset overflow",
+                },
+            )?;
+            let chunk_len = chunk_tokens.checked_mul(hidden_per_token).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill chunk width overflow",
+                },
+            )?;
+            let chunk_hidden = sequence_major_hidden
+                .get(chunk_start..chunk_start + chunk_len)
+                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill chunk slice is out of bounds",
+                })?;
+            let step = self.run_prefill_chunk_into_reused_batched(
+                chunk_hidden,
+                chunk_tokens,
+                n_seq,
+                position_offset,
+                max_positions,
+                rope_theta,
+                position_offset + chunk_tokens == token_count,
+            )?;
+            if position_offset + chunk_tokens == token_count {
+                final_step = Some(step);
+            }
+        }
+        final_step.ok_or(GgmlCpuGraphError::UnsupportedInputs {
+            reason: "whole-decoder resident prefill produced no final chunk",
+        })
+    }
+
+    fn run_prefill_chunk_into_reused_batched(
+        &mut self,
+        sequence_major_hidden: &[f32],
+        token_count: usize,
+        n_seq: usize,
+        position_offset: usize,
+        max_positions: usize,
+        rope_theta: f32,
+        materialize_last_hidden: bool,
+    ) -> Result<Qwen3AsrLlmWholeStepOutput, GgmlCpuGraphError> {
         let dims = self.dims;
         if token_count == 0 {
             return Err(GgmlCpuGraphError::UnsupportedInputs {
@@ -2266,7 +2336,12 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 reason: "whole-decoder resident prefill n_seq must be positive",
             });
         }
-        if max_positions < token_count {
+        let chunk_end = position_offset.checked_add(token_count).ok_or(
+            GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder resident prefill position span overflow",
+            },
+        )?;
+        if max_positions < chunk_end {
             return Err(GgmlCpuGraphError::UnsupportedInputs {
                 reason: "whole-decoder resident prefill max-position span is too small",
             });
@@ -2297,13 +2372,18 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         let mut positions = Vec::with_capacity(output_tokens);
         for _sequence_index in 0..n_seq {
             for token_position in 0..token_count {
-                row_indices_usize.push(token_position);
-                row_indices.push(i32::try_from(token_position).map_err(|_| {
+                let absolute_position = position_offset.checked_add(token_position).ok_or(
+                    GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "whole-decoder resident prefill position overflow",
+                    },
+                )?;
+                row_indices_usize.push(absolute_position);
+                row_indices.push(i32::try_from(absolute_position).map_err(|_| {
                     GgmlCpuGraphError::UnsupportedInputs {
                         reason: "whole-decoder resident prefill cache index exceeds ggml int boundary",
                     }
                 })?);
-                positions.push(i32::try_from(token_position).map_err(|_| {
+                positions.push(i32::try_from(absolute_position).map_err(|_| {
                     GgmlCpuGraphError::UnsupportedInputs {
                         reason: "whole-decoder resident prefill rope position exceeds ggml int boundary",
                     }
@@ -2372,7 +2452,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 |_step, source| source,
             )?;
             let state = stack.state;
-            let (output_state, output_len) = if n_seq == 1 {
+            let (output_state, output_len) = if materialize_last_hidden && n_seq == 1 {
                 let final_hidden_offset = token_count
                     .checked_sub(1)
                     .and_then(|position| position.checked_mul(dims.d_model))
@@ -2389,9 +2469,11 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 )?;
                 (final_hidden, dims.d_model)
             } else {
-                (state, expected_hidden)
+                let completion = graph.view_1d(state, 1, 0)?;
+                (completion, 1)
             };
             graph.set_output(output_state)?;
+            graph.prepare_outputs_for_upload(&[output_state])?;
             graph.set_f32_slice(
                 hidden_tensor,
                 sequence_major_hidden,
@@ -2429,8 +2511,12 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 compute_micros,
             })
         })();
+        let restore_result = reuse.builder().restore_prepared_graph_allocation();
         self.reuse = Some(reuse);
-        result
+        match result {
+            Ok(output) => restore_result.map(|()| output),
+            Err(error) => Err(error),
+        }
     }
 
     fn run_prefill_with_history(

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -2257,6 +2257,83 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         )
     }
 
+    fn sequence_major_prefill_chunk(
+        sequence_major_hidden: &[f32],
+        token_count: usize,
+        n_seq: usize,
+        d_model: usize,
+        position_offset: usize,
+        chunk_tokens: usize,
+    ) -> Result<Vec<f32>, GgmlCpuGraphError> {
+        let chunk_end = position_offset.checked_add(chunk_tokens).ok_or(
+            GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder resident prefill chunk position overflow",
+            },
+        )?;
+        if n_seq == 0 || chunk_tokens == 0 || chunk_end > token_count {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder resident prefill chunk span is invalid",
+            });
+        }
+        let per_sequence =
+            token_count
+                .checked_mul(d_model)
+                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill sequence width overflow",
+                })?;
+        let expected =
+            per_sequence
+                .checked_mul(n_seq)
+                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill hidden width overflow",
+                })?;
+        if sequence_major_hidden.len() != expected {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder resident prefill hidden width mismatch",
+            });
+        }
+        let chunk_width =
+            chunk_tokens
+                .checked_mul(d_model)
+                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill chunk width overflow",
+                })?;
+        let mut chunk = Vec::with_capacity(chunk_width.checked_mul(n_seq).ok_or(
+            GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder resident prefill chunk allocation overflow",
+            },
+        )?);
+        for sequence_index in 0..n_seq {
+            let sequence_start = sequence_index.checked_mul(per_sequence).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill sequence offset overflow",
+                },
+            )?;
+            let token_start = position_offset.checked_mul(d_model).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill token offset overflow",
+                },
+            )?;
+            let start = sequence_start.checked_add(token_start).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill chunk start overflow",
+                },
+            )?;
+            let end =
+                start
+                    .checked_add(chunk_width)
+                    .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "whole-decoder resident prefill chunk end overflow",
+                    })?;
+            chunk.extend_from_slice(sequence_major_hidden.get(start..end).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "whole-decoder resident prefill chunk slice is out of bounds",
+                },
+            )?);
+        }
+        Ok(chunk)
+    }
+
     pub(crate) fn run_prefill_into_reused_batched(
         &mut self,
         sequence_major_hidden: &[f32],
@@ -2271,42 +2348,29 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 reason: "whole-decoder resident prefill token count must be positive",
             });
         }
-        let hidden_per_token =
-            self.dims
-                .d_model
-                .checked_mul(n_seq)
-                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "whole-decoder resident prefill hidden width overflow",
-                })?;
         let mut final_step = None;
         for position_offset in (0..token_count).step_by(RESIDENT_PREFILL_MAX_QUERY_TOKENS) {
             let chunk_tokens =
                 (token_count - position_offset).min(RESIDENT_PREFILL_MAX_QUERY_TOKENS);
-            let chunk_start = position_offset.checked_mul(hidden_per_token).ok_or(
-                GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "whole-decoder resident prefill chunk offset overflow",
-                },
+            let chunk_hidden = Self::sequence_major_prefill_chunk(
+                sequence_major_hidden,
+                token_count,
+                n_seq,
+                self.dims.d_model,
+                position_offset,
+                chunk_tokens,
             )?;
-            let chunk_len = chunk_tokens.checked_mul(hidden_per_token).ok_or(
-                GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "whole-decoder resident prefill chunk width overflow",
-                },
-            )?;
-            let chunk_hidden = sequence_major_hidden
-                .get(chunk_start..chunk_start + chunk_len)
-                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "whole-decoder resident prefill chunk slice is out of bounds",
-                })?;
+            let is_final_chunk = position_offset.checked_add(chunk_tokens) == Some(token_count);
             let step = self.run_prefill_chunk_into_reused_batched(
-                chunk_hidden,
+                &chunk_hidden,
                 chunk_tokens,
                 n_seq,
                 position_offset,
                 max_positions,
                 rope_theta,
-                position_offset + chunk_tokens == token_count,
+                is_final_chunk,
             )?;
-            if position_offset + chunk_tokens == token_count {
+            if is_final_chunk {
                 final_step = Some(step);
             }
         }
@@ -4587,6 +4651,43 @@ mod tests {
     const QWEN_PREFILL_REAL_PACK_ENV: &str = "OPENASR_QWEN_PREFILL_REAL_PACK";
     const QWEN_PREFILL_TOKENS_ENV: &str = "OPENASR_QWEN_PREFILL_TOKENS";
     const QWEN_PREFILL_CHUNK_TOKENS_ENV: &str = "OPENASR_QWEN_PREFILL_CHUNK_TOKENS";
+
+    #[test]
+    fn resident_prefill_chunk_preserves_each_sequence_token_span() {
+        const D_MODEL: usize = 2;
+        for n_seq in [2, 3] {
+            for token_count in [1, 255, 256, 257, 513] {
+                let values = (0..n_seq * token_count * D_MODEL)
+                    .map(|value| value as f32)
+                    .collect::<Vec<_>>();
+                for position_offset in (0..token_count).step_by(256) {
+                    let chunk_tokens = (token_count - position_offset).min(256);
+                    let actual =
+                        Qwen3AsrLlmWholeDecoderGraphExecutor::sequence_major_prefill_chunk(
+                            &values,
+                            token_count,
+                            n_seq,
+                            D_MODEL,
+                            position_offset,
+                            chunk_tokens,
+                        )
+                        .expect("valid sequence-major chunk");
+                    let expected = (0..n_seq)
+                        .flat_map(|sequence_index| {
+                            let start = (sequence_index * token_count + position_offset) * D_MODEL;
+                            values[start..start + chunk_tokens * D_MODEL]
+                                .iter()
+                                .copied()
+                        })
+                        .collect::<Vec<_>>();
+                    assert_eq!(
+                        actual, expected,
+                        "n_seq={n_seq}, token_count={token_count}, offset={position_offset}"
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn qwen_llm_native_gqa_default_is_on_for_cpu_metal_off_for_gpu() {

--- a/crates/openasr-core/src/models/qwen/logits_head.rs
+++ b/crates/openasr-core/src/models/qwen/logits_head.rs
@@ -347,9 +347,7 @@ fn load_direct_output_weight_payload(
     d_model: usize,
     vocab_size: usize,
 ) -> Result<Option<OwnedGgmlLogitsWeight>, Qwen3AsrLlmLogitsHeadError> {
-    let direct_layout =
-        dims == [d_model as u64, vocab_size as u64] || dims == [vocab_size as u64, d_model as u64];
-    if !direct_layout {
+    if dims != [d_model as u64, vocab_size as u64] {
         return Ok(None);
     }
     let payload = reader

--- a/crates/openasr-core/src/models/qwen/logits_head.rs
+++ b/crates/openasr-core/src/models/qwen/logits_head.rs
@@ -347,7 +347,9 @@ fn load_direct_output_weight_payload(
     d_model: usize,
     vocab_size: usize,
 ) -> Result<Option<OwnedGgmlLogitsWeight>, Qwen3AsrLlmLogitsHeadError> {
-    if dims != [d_model as u64, vocab_size as u64] {
+    let direct_layout =
+        dims == [d_model as u64, vocab_size as u64] || dims == [vocab_size as u64, d_model as u64];
+    if !direct_layout {
         return Ok(None);
     }
     let payload = reader


### PR DESCRIPTION
## Summary

Fix MOSS three-minute Metal OOM by sizing the resident KV cache to the request and chunking shared Qwen resident prefill graphs, while tightening structured transcript and fused-logits contracts.

## Why

Long MOSS requests previously built one whole-prompt resident prefill graph. On a three-minute AISHELL-4 sample that produced a Metal working-set blowup of roughly 17 GiB against a 12 GiB recommended limit, with temporary prefill arenas around 9.1 GiB and 3.6 GiB. Request-level KV sizing alone was not enough; the shared Qwen prefill path also needed bounded query-width chunking with global position offsets.

## Changes

- Size MOSS Metal KV capacity from the current request instead of the family ceiling.
- Chunk shared Qwen resident prefill by query width, writing into the same resident KV with global RoPE/row/mask positions.
- Fix sequence-major multi-sequence chunk extraction so `n_seq > 1` long prompts do not cross sequence boundaries.
- Restore persistent decode-graph scheduler allocation after each temporary prefill chunk.
- Preserve MOSS corrected speaker-anchor parsing and require structured transcript segments in the accelerated three-minute smoke.
- Tighten fused logits to the directly usable `[hidden, vocab]` layout and fail closed on unsupported transpose layouts.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Additional checks:

- Explicit accelerated AISHELL-4 three-minute structured smoke.
- MOSS JFK and mixed EN/ZH accelerated goldens.
- Sequence-major chunk helper coverage for `n_seq = 2/3` and token counts `1/255/256/257/513`.
- Fused-logits supported-layout parity and unsupported-layout rejection tests.
- GGML debug allocation log bound to the reviewed commit, peaking around 3.54 GiB on Apple M1.

## Manual smoke checks

- Three-minute AISHELL-4 Metal path stays under the recommended working set and returns structured speaker segments plus golden text.
- No recurrence of the old 9 GiB / 3.6 GiB temporary prefill arenas.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
  - No user-facing docs required for this internal runtime fix.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR fixes the Metal OOM root cause and the shared prefill/layout contracts needed for that path. It does not flip catalog backend policy, publish MOSS packs, or claim a final quiet-window RTF verdict.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
