### PR TITLE
chore(hygiene): remove workstation paths and tighten public claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         run: scripts/gpu-weight-placement-gate.sh
       - name: Install python test dependencies
         run: python3 -m pip install --user numpy
+      - name: Public source hygiene gate
+        run: python3 tooling/check_public_source_hygiene.py
       - name: Python helper gates
         run: |
           python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -79,10 +79,10 @@ jobs:
       # below for why (#132: STATUS_DLL_NOT_FOUND on machines with no GPU
       # driver). This is a *runtime redistributable* pin, independent of
       # VULKAN_VERSION above (that one pins the *build-time* SDK used to
-      # compile/link openasr.exe). Kept in lockstep with openasr-app's
-      # apps/desktop/scripts/stage-vulkan-loader.mjs, which pins the identical
+      # compile/link openasr.exe). Kept in lockstep with the desktop product's
+      # Vulkan loader staging script, which pins the identical
       # version + both hashes for the desktop sidecar bundle -- bump all three
-      # together in both repos, cross-checked against LunarG's own published
+      # together in both places, cross-checked against LunarG's own published
       # hash at https://vulkan.lunarg.com/sdk/sha/<version>/windows/VulkanRT-X64-<version>-Components.zip.json.
       VULKAN_LOADER_VERSION: 1.4.350.0
       # sha256 of the downloaded vulkan-runtime-components.zip archive.
@@ -826,7 +826,7 @@ jobs:
         # fine, enumerates zero devices, and HardwareFallbackPolicy falls
         # back to CPU in Rust -- never a DLL-load failure.
         #
-        # Mirrors openasr-app's apps/desktop/scripts/stage-vulkan-loader.mjs
+        # Mirrors the desktop product's Vulkan loader staging script
         # (identical version pin + identical two-layer hash verification) for
         # the desktop sidecar bundle. Fail-closed throughout: a download
         # failure, a hash mismatch at either layer, or a missing extracted
@@ -860,7 +860,7 @@ jobs:
           if ($actualArchiveSha -ne $env:VULKAN_LOADER_ARCHIVE_SHA256) {
             Write-Error ("sha256 mismatch for Vulkan runtime archive: expected $env:VULKAN_LOADER_ARCHIVE_SHA256, got $actualArchiveSha. " +
               "Refusing to stage an unverified Vulkan runtime archive -- if LunarG genuinely rotated this release's bytes, re-pin " +
-              "VULKAN_LOADER_ARCHIVE_SHA256 (and VULKAN_LOADER_DLL_SHA256) here AND in openasr-app's stage-vulkan-loader.mjs, " +
+              "VULKAN_LOADER_ARCHIVE_SHA256 (and VULKAN_LOADER_DLL_SHA256) here AND in the desktop product's Vulkan loader staging script, " +
               "cross-checked against https://vulkan.lunarg.com/sdk/sha/$env:VULKAN_LOADER_VERSION/windows/VulkanRT-X64-$env:VULKAN_LOADER_VERSION-Components.zip.json.")
             exit 1
           }
@@ -958,17 +958,17 @@ jobs:
         if: runner.os == 'Windows' && env.LEG_SELECTED == 'true' && steps.signing-check.outputs.have_secrets != 'true' && github.event.inputs.dry_run != 'true'
         shell: bash
         run: |
-          echo "::error::AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET are not set -- refusing to package an unsigned Windows release binary. Configure the Azure Trusted Signing service principal secrets (see openasr-app's apps/desktop/SIGNING-WINDOWS.md for the account/profile this reuses), or re-run this workflow_dispatch with dry_run=true to build without signing for local debugging only." >&2
+          echo "::error::AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET are not set -- refusing to package an unsigned Windows release binary. Configure the Azure Trusted Signing service principal secrets (see the desktop product's Windows signing docs for the account/profile this reuses), or re-run this workflow_dispatch with dry_run=true to build without signing for local debugging only." >&2
           exit 1
 
       # Azure Trusted Signing (Artifact Signing): same account/certificate
       # profile as the OpenASR Desktop Windows installer (openasr-sign /
-      # openasr-codesign, publisher "Caelum Inc.") -- see openasr-app's
-      # apps/desktop/SIGNING-WINDOWS.md for the account itself. The service
+      # openasr-codesign, publisher "Caelum Inc.") -- see the desktop product's
+      # Windows signing docs for the account itself. The service
       # principal behind these secrets needs the "Artifact Signing
       # Certificate Profile Signer" role on that account (see this repo's
       # docs/RELEASING.md); it may be a different App Registration than the
-      # desktop repo's, but must be granted the same role on the same
+      # desktop product's, but must be granted the same role on the same
       # account/profile.
       # GitHub's windows runner image stopped shipping a pre-registered PSGallery
       # PowerShell repository (surfaced alongside the Node 20 -> 24 default bump),

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ No terminal needed. Install the app, drop in an audio file, and get your transcr
 
 ## Why OpenASR
 
-**Private.** Your audio never leaves your machine. No uploads, no cloud processing, no telemetry. The engine either produces a real transcript or tells you why it can't — it never silently reaches for the internet.
+**Private.** In the default local mode, audio stays on your machine. Remote compute is available only when you explicitly pair and enable it; see [SECURITY.md](SECURITY.md#local-first-security-notes). No telemetry, no silent uploads, and no silent network fallback. The engine either produces a real transcript or tells you why it can't.
 
 **Broad.** 28 models across 13 families — Whisper, Qwen3-ASR, Parakeet, SenseVoice, FireRed, Dolphin, Moonshine, and more. Pick the one that fits your language and workload. All run through one binary on CPU and Apple Metal.
 
-**Open.** The engine is Apache-2.0. Models ship under their own permissive licenses. Every model download is verified against a signed catalog before it runs.
+**Open.** The engine is Apache-2.0. Each model pack ships under its own upstream license as recorded in the registry and pack metadata. Every model download is verified against a signed catalog before it runs.
 
 ---
 
@@ -128,4 +128,4 @@ Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for build setup, b
 
 [Apache License 2.0](LICENSE). See [NOTICE](NOTICE) for attribution.
 
-The ggml inference backend is MIT-licensed. Model packs carry their own upstream licenses (MIT / Apache-2.0). See [ACKNOWLEDGMENTS.md](ACKNOWLEDGMENTS.md) for the projects and model authors OpenASR builds on.
+The ggml inference backend is MIT-licensed. Each model pack's license is defined by its registry entry and pack metadata; packs may use Apache-2.0, MIT, CC-BY, FunASR, or other upstream terms. This is not an exhaustive license guarantee. See [ACKNOWLEDGMENTS.md](ACKNOWLEDGMENTS.md) for the projects and model authors OpenASR builds on.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,7 +26,7 @@
 <p><strong>macOS</strong> (Apple Silicon) · <strong>Windows</strong> (x64, Windows 10+) · Linux 桌面版开发中</p>
 </div>
 
-不需要命令行,不需要配环境。安装应用,拖入音频文件,转写结果直接出来——全程离线,音频不出你的电脑。
+不需要命令行,不需要配环境。安装应用,拖入音频文件,转写结果直接出来——默认全程本地运行。
 
 > 本仓库是桌面应用背后的 Apache-2.0 开源核心:Rust 命令行工具 + 本地 OpenAI 兼容 HTTP API + ggml 推理引擎。桌面应用在同一个引擎之上套了原生图形界面,没有任何隐藏的网络通道。
 
@@ -43,11 +43,11 @@
 
 ## 为什么选 OpenASR
 
-**隐私。** 音频不出你的电脑。没有上传,没有云端处理,没有遥测——一个字节都不会偷偷发出去。引擎要么给你一份真实的转写结果,要么明确告诉你哪里出了问题。
+**隐私。** 默认本地模式下,音频留在你的设备上。远程算力仅在你显式配对并启用后可用,详见 [SECURITY.md](SECURITY.md#local-first-security-notes)。没有遥测、没有静默上传、没有静默联网回退。引擎要么给你一份真实的转写结果,要么明确告诉你哪里出了问题。
 
 **广度。** 11 个模型家族、26 个公开模型——Whisper、Qwen3-ASR、Parakeet、SenseVoice、FireRed、Dolphin、Moonshine……选对模型比选对工具更重要,而 OpenASR 把它们统一到一个运行时里,CPU 和 Apple Metal 都能跑。
 
-**开源。** 引擎代码 Apache-2.0,模型各自持有宽松许可(MIT / Apache-2.0)。每次模型下载都经过签名目录的完整性校验,装到本地的就是发布者打包的原件。
+**开源。** 引擎代码 Apache-2.0。每个模型包的许可证以 registry 条目和 pack metadata 为准。每次模型下载都经过签名目录的完整性校验,装到本地的就是发布者打包的原件。
 
 ---
 
@@ -128,7 +128,7 @@ openasr pull whisper-small    # 安装一个试试
 
 [Apache License 2.0](LICENSE),详见 [NOTICE](NOTICE)。
 
-ggml 推理后端为 MIT 许可。模型包各自遵循上游许可证(MIT / Apache-2.0)。致谢完整列表见 [ACKNOWLEDGMENTS.md](ACKNOWLEDGMENTS.md)。
+ggml 推理后端为 MIT 许可。每个模型包的许可证以 registry 条目和 pack metadata 为准;可能包含 Apache-2.0、MIT、CC-BY、FunASR 或其他上游条款。这不是穷尽保证。致谢完整列表见 [ACKNOWLEDGMENTS.md](ACKNOWLEDGMENTS.md)。
 
 ## 找到我们
 

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -1753,9 +1753,9 @@ mod tests {
         assert_eq!(language_mode_label(None), "unspecified");
     }
 
-    /// Desktop-sidecar contract: `apps/desktop/src-tauri/src/sidecar.rs` spawns
-    /// this binary as `openasr serve --backend native --parent-pid <pid> ...`
-    /// (see `openasr-app` `sidecar.rs`'s `Command::new(..).args([...])`). Both
+    /// Desktop-sidecar contract: the desktop sidecar spawns
+    /// this binary as `openasr serve --backend native --parent-pid <pid> ...`.
+    /// Both
     /// flags are `hide = true` in `cli_args.rs` because they are launch-detail
     /// only, never meant for interactive use -- but "hidden from `--help`" must
     /// never come to mean "safe to rename or remove". This test locks the two

--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -1,8 +1,8 @@
 use assert_cmd::Command;
 use openasr_core::api::backend::transcribe_with_mock_backend;
 use openasr_core::testing::{
-    TinyGgufFixtureSpec, write_local_dev_signed_catalog, write_reserved_oasr_container,
-    write_tiny_gguf_runtime_source,
+    TinyGgufFixtureSpec, external_test_fixture_path, write_local_dev_signed_catalog,
+    write_reserved_oasr_container, write_tiny_gguf_runtime_source,
 };
 use openasr_core::{ResponseFormat, TranscriptionRequest, render_transcription};
 use predicates::prelude::*;
@@ -680,10 +680,6 @@ fn transcribe_mock_formats_match_core_renderers() {
 // slicer picked 3 chunks here, whose seams show as the two small stray-token
 // artifacts in the golden ("我 我" and an extra "中") -- both present in the
 // real committed pack's output, not smoothed over.
-fn firered_llm_dev_pack_path() -> PathBuf {
-    PathBuf::from("/Volumes/QuintinDocument/openasr-dev/tmp-weights/fr2/out/firered2-llm-q8_0.oasr")
-}
-
 const FIRERED_LLM_GOLDEN_LONGFORM_EN_ZH_TEXT: &str = "and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗中 周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country";
 
 #[test]
@@ -691,11 +687,14 @@ const FIRERED_LLM_GOLDEN_LONGFORM_EN_ZH_TEXT: &str = "and so my fellow americans
             longform-chunked CLI transcribe path on a ~69s fixture, OPENASR_GGML_BACKEND=cpu \
             (~30 minutes wall clock at this family's current CPU-decode RTF -- see the T5 report)"]
 fn firered_llm_golden_diff_longform_cli_transcribe_matches_reference_decode() {
-    let pack_path = firered_llm_dev_pack_path();
-    if !pack_path.exists() {
-        eprintln!("skipping: {} not present", pack_path.display());
-        return;
-    }
+    let pack_path =
+        match external_test_fixture_path("OPENASR_FIRERED_LLM_PACK", "FireRed2 LLM .oasr pack") {
+            Ok(path) => path,
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                return;
+            }
+        };
     let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../fixtures/longform_en_zh.wav")
         .canonicalize()
@@ -734,12 +733,6 @@ fn firered_llm_golden_diff_longform_cli_transcribe_matches_reference_decode() {
 // content). Pinned against `OPENASR_GGML_BACKEND=cpu` (Metal memory fit for
 // this family's ~8B combined weights on a 16GB unified-memory Mac is
 // unverified, see this module's e2e report).
-fn mimo_asr_dev_pack_path() -> PathBuf {
-    PathBuf::from(
-        "/Volumes/QuintinDocument/openasr-dev/tmp-weights/mimo/out/mimo-v2.5-asr-q8_0.oasr",
-    )
-}
-
 // The longform assembler joins retained, trimmed segment texts with one space.
 // The spaces inside this `concat!` are therefore golden bytes. The same
 // family's single-utterance EN->ZH golden
@@ -765,11 +758,14 @@ const GOLDEN_MIMO_LONGFORM_EN_ZH_TEXT: &str = concat!(
             (~38 minutes wall clock at this family's current CPU-decode RTF -- 3 chunk \
             decodes, see this test's doc comment)"]
 fn mimo_asr_golden_diff_longform_cli_transcribe_matches_reference_decode() {
-    let pack_path = mimo_asr_dev_pack_path();
-    if !pack_path.exists() {
-        eprintln!("skipping: {} not present", pack_path.display());
-        return;
-    }
+    let pack_path = match external_test_fixture_path("OPENASR_MIMO_ASR_PACK", "MiMo ASR .oasr pack")
+    {
+        Ok(path) => path,
+        Err(skip) => {
+            eprintln!("skipping: {skip}");
+            return;
+        }
+    };
     let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../fixtures/longform_en_zh.wav")
         .canonicalize()
@@ -882,12 +878,6 @@ fn firered_aed_golden_diff_longform_cli_transcribe_matches_reference_decode() {
 // those tags (see the family's module doc comment). Pinned against
 // `OPENASR_GGML_BACKEND=cpu` (this family's Metal path has a known encoder
 // numerics defect, see the arch descriptor's `auto_gpu_policy` doc).
-fn moss_transcribe_diarize_dev_pack_path() -> PathBuf {
-    PathBuf::from(
-        "/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/moss-transcribe-diarize-fp16.oasr",
-    )
-}
-
 const GOLDEN_MOSS_TRANSCRIBE_DIARIZE_LONGFORM_EN_ZH_TEXT: &str = concat!(
     "[0.27][S01]And so, my fellow Americans,[2.34][3.21][S01]ask not[4.44][5.31][S01]what your ",
     "country can do for you,[7.64][8.11][S01]ask what you can do for your country.",
@@ -907,11 +897,16 @@ const GOLDEN_MOSS_TRANSCRIBE_DIARIZE_LONGFORM_EN_ZH_TEXT: &str = concat!(
 #[ignore = "requires the private dev-only moss-transcribe-diarize-fp16.oasr pack; runs the real \
             longform-chunked CLI transcribe path on a ~69s fixture, OPENASR_GGML_BACKEND=cpu"]
 fn moss_transcribe_diarize_golden_diff_longform_cli_transcribe_matches_reference_decode() {
-    let pack_path = moss_transcribe_diarize_dev_pack_path();
-    if !pack_path.exists() {
-        eprintln!("skipping: {} not present", pack_path.display());
-        return;
-    }
+    let pack_path = match external_test_fixture_path(
+        "OPENASR_MOSS_TRANSCRIBE_DIARIZE_PACK",
+        "MOSS Transcribe Diarize .oasr pack",
+    ) {
+        Ok(path) => path,
+        Err(skip) => {
+            eprintln!("skipping: {skip}");
+            return;
+        }
+    };
     let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../fixtures/longform_en_zh.wav")
         .canonicalize()

--- a/crates/openasr-core/src/diarize/embed/redimnet/backbone.rs
+++ b/crates/openasr-core/src/diarize/embed/redimnet/backbone.rs
@@ -1039,12 +1039,17 @@ mod tests {
         }
     }
 
-    /// Spike scratch assets (golden `.npy` dumps + the f32 pack fixture), not
-    /// committed; every parity test here is `#[ignore]` and skips if absent.
-    const SPIKE_ROOT: &str = "/Volumes/QuintinDocument/openasr-dev/tmp/redimnet2-spike";
-
     fn spike_root() -> PathBuf {
-        PathBuf::from(SPIKE_ROOT)
+        match crate::testing::external_test_fixture_path(
+            "OPENASR_REDIMNET_SPIKE_ROOT",
+            "ReDimNet parity fixture directory",
+        ) {
+            Ok(path) => path,
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                PathBuf::new()
+            }
+        }
     }
 
     fn f32_pack_path() -> PathBuf {

--- a/crates/openasr-core/src/diarize/embed/redimnet/frontend.rs
+++ b/crates/openasr-core/src/diarize/embed/redimnet/frontend.rs
@@ -259,10 +259,18 @@ mod tests {
     use super::*;
     use std::path::{Path, PathBuf};
 
-    /// Spike scratch dir holding the reference `frontend_dump/*.npy`. Not
-    /// committed; the parity test is `#[ignore]` and skips if absent.
-    const FRONTEND_DUMP: &str =
-        "/Volumes/QuintinDocument/openasr-dev/tmp/redimnet2-spike/frontend_dump";
+    fn dump() -> PathBuf {
+        match crate::testing::external_test_fixture_path(
+            "OPENASR_REDIMNET_FRONTEND_DUMP",
+            "ReDimNet frontend parity fixture directory",
+        ) {
+            Ok(path) => path,
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                PathBuf::new()
+            }
+        }
+    }
 
     fn load_npy_f32(path: &Path) -> (Vec<usize>, Vec<f32>) {
         let bytes = std::fs::read(path).expect("read npy");
@@ -324,10 +332,6 @@ mod tests {
             sum += d as f64;
         }
         (max, (sum / actual.len() as f64) as f32)
-    }
-
-    fn dump() -> PathBuf {
-        PathBuf::from(FRONTEND_DUMP)
     }
 
     #[test]

--- a/crates/openasr-core/src/diarize/embed/tests.rs
+++ b/crates/openasr-core/src/diarize/embed/tests.rs
@@ -230,14 +230,18 @@ fn wespeaker_oasr_roundtrip_matches_safetensors() {
     let _ = std::fs::remove_file(&out);
 }
 
-/// Spike scratch assets (golden `.npy` embeddings + the f32 pack fixture), not
-/// committed; the parity test below is `#[ignore]` and skips if absent. See
-/// `redimnet::backbone::tests` for the staged per-op parity harness this
-/// reuses transitively -- this test instead exercises the *trait* entry point
-/// end to end (raw audio -> front end -> backbone -> L2-normalize), which
-/// none of the backbone-only tests cover (they feed a pre-dumped front-end
-/// tensor directly).
-const REDIMNET_SPIKE_ROOT: &str = "/Volumes/QuintinDocument/openasr-dev/tmp/redimnet2-spike";
+fn redimnet_spike_root() -> Option<std::path::PathBuf> {
+    match crate::testing::external_test_fixture_path(
+        "OPENASR_REDIMNET_SPIKE_ROOT",
+        "ReDimNet parity fixture directory",
+    ) {
+        Ok(path) => Some(path),
+        Err(skip) => {
+            eprintln!("skipping: {skip}");
+            None
+        }
+    }
+}
 
 /// Plain C-order f32 `.npy` loader (no fortran-order handling needed for the
 /// golden embedding dumps), matching the loader in `redimnet::backbone::tests`.
@@ -261,7 +265,10 @@ fn read_redimnet_golden_embedding(path: &std::path::Path) -> Vec<f32> {
 #[test]
 #[ignore = "requires local redimnet2-spike assets under tmp/ (not committed)"]
 fn redimnet_embedder_matches_python_reference_e2e_jfk() {
-    let pack = std::path::Path::new(REDIMNET_SPIKE_ROOT).join("redimnet2-b6-f32.oasr");
+    let Some(root) = redimnet_spike_root() else {
+        return;
+    };
+    let pack = root.join("redimnet2-b6-f32.oasr");
     if !pack.exists() {
         eprintln!("skip: {pack:?} not present");
         return;
@@ -281,11 +288,7 @@ fn redimnet_embedder_matches_python_reference_e2e_jfk() {
     let mine = embedder.embed(&samples, 16_000).expect("redimnet embed");
     assert_eq!(mine.dim(), 192);
 
-    let golden = read_redimnet_golden_embedding(
-        &std::path::Path::new(REDIMNET_SPIKE_ROOT)
-            .join("embeddings_b6")
-            .join("jfk.npy"),
-    );
+    let golden = read_redimnet_golden_embedding(&root.join("embeddings_b6").join("jfk.npy"));
     assert_eq!(mine.0.len(), golden.len());
     // Golden is the raw (pre-L2-normalize) reference embedding; cosine is
     // scale-invariant so comparing it against `mine`'s normalized vector is

--- a/crates/openasr-core/src/diarize/vad/firered_stream/tests.rs
+++ b/crates/openasr-core/src/diarize/vad/firered_stream/tests.rs
@@ -156,9 +156,16 @@ fn provider_rejects_wrong_sample_rate() {
 #[test]
 #[ignore = "host-local: requires tmp/audio/clips/black_cat_poe_ty_5min.wav"]
 fn benchmark_forward_pass_rtf_on_real_5min_recording() {
-    let path = std::path::PathBuf::from(
-        "/Volumes/QuintinDocument/openasr-dev/openasr-legacy/tmp/audio/clips/black_cat_poe_ty_5min.wav",
-    );
+    let path = match crate::testing::external_test_fixture_path(
+        "OPENASR_FIRERED_STREAM_VAD_BENCH_AUDIO",
+        "Stream-VAD benchmark audio fixture",
+    ) {
+        Ok(path) => path,
+        Err(skip) => {
+            eprintln!("skipping: {skip}");
+            return;
+        }
+    };
     let samples = crate::api::audio_io::load_wav_16khz_mono_f32_v0(
         &path,
         "Stream-VAD RTF benchmark",

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -694,15 +694,19 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::{Mutex, OnceLock};
 
-    const FIXTURE_ROOT: &str =
-        "/Volumes/QuintinDocument/openasr-dev/openasr/tmp/publish/dolphin-cn-dialect-small";
+    fn root() -> Option<PathBuf> {
+        match crate::testing::external_test_fixture_path(
+            "OPENASR_DOLPHIN_PARITY_ROOT",
+            "Dolphin parity fixture directory",
+        ) {
+            Ok(path) => Some(path),
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                None
+            }
+        }
+    }
 
-    /// Pin the importer's `DolphinLanguageScheme::label()` writer against this
-    /// module's `parse_dolphin_language_scheme_value` reader: every scheme must
-    /// round-trip label -> parse -> the same scheme, so the two literal sets
-    /// (write side here, read side in `package_import.rs`) cannot silently drift
-    /// apart. Also pins the backward-compat default (missing key -> CnDialect)
-    /// and the fail-closed rejection of an unrecognized value.
     #[test]
     fn language_scheme_label_round_trips_through_the_executor_parser() {
         for scheme in [
@@ -728,7 +732,6 @@ mod tests {
             "an unrecognized scheme value must fail closed rather than silently default"
         );
     }
-
     /// Golden `attention_rescoring` transcript (manifest `text_nospecial`): the
     /// model's own joint-decode output for the Sichuan clip. This is the parity
     /// target -- the human ground-truth WSC transcript differs by one homophone
@@ -738,10 +741,6 @@ mod tests {
     const REFERENCE_WSC_TEXT: &str = "学校河底下好多那种野生枸杞";
     /// Reference CTC greedy transcript (manifest `ctc_greedy_search.text`).
     const REFERENCE_CTC_GREEDY_TEXT: &str = "学校火底下好多那种野生枸杞";
-
-    fn root() -> PathBuf {
-        PathBuf::from(FIXTURE_ROOT)
-    }
 
     // --- minimal little-endian f32 .npy reader (mirrors parity.rs) -------------
     fn load_npy_f32(path: &Path) -> (Vec<usize>, Vec<f32>) {
@@ -947,7 +946,9 @@ mod tests {
     #[test]
     #[ignore = "requires local Dolphin checkpoint + golden under tmp/publish (not committed)"]
     fn dolphin_encoder_from_pack_parity() {
-        let root = root();
+        let Some(root) = root() else {
+            return;
+        };
         if ensure_dolphin_pack(&root, DolphinQuantizationMode::Fp16).is_none() {
             eprintln!("skip: dolphin checkpoint/units not present under {root:?}");
             return;
@@ -1037,7 +1038,9 @@ mod tests {
     #[ignore = "perf AB harness: requires local Dolphin checkpoint + golden clip under tmp/publish"]
     fn dolphin_perf_ab() {
         use std::time::{Duration, Instant};
-        let root = root();
+        let Some(root) = root() else {
+            return;
+        };
         let clip = root.join("golden/clip_sichuan.wav");
         // Quant rung under test (fp16 golden by default); the driver script sweeps
         // fp16/q8_0/q4_k so each is measured in its own process (isolated peak RSS).
@@ -1137,7 +1140,9 @@ mod tests {
     #[test]
     #[ignore = "requires local Dolphin checkpoint + golden clip under tmp/publish (not committed)"]
     fn dolphin_joint_decode_end_to_end() {
-        let root = root();
+        let Some(root) = root() else {
+            return;
+        };
         let clip = root.join("golden/clip_sichuan.wav");
         let Some(pack) = ensure_dolphin_pack(&root, DolphinQuantizationMode::Fp16) else {
             eprintln!("skip: dolphin checkpoint/units not present under {root:?}");
@@ -1307,7 +1312,9 @@ mod tests {
     #[test]
     #[ignore = "requires local Dolphin checkpoint + golden clip under tmp/publish (not committed)"]
     fn dolphin_hotword_flips_recognition_error() {
-        let root = root();
+        let Some(root) = root() else {
+            return;
+        };
         let clip = root.join("golden/clip_sichuan.wav");
         let Some(pack) = ensure_dolphin_pack(&root, DolphinQuantizationMode::Fp16) else {
             eprintln!("skip: dolphin checkpoint/units not present under {root:?}");

--- a/crates/openasr-core/src/models/dolphin/parity.rs
+++ b/crates/openasr-core/src/models/dolphin/parity.rs
@@ -18,11 +18,17 @@ use crate::ggml_runtime::GgmlCpuGraphBackend;
 use super::decoder_graph::{DolphinDecoderConfig, decode_prompt_logits};
 use super::encoder_graph::{DolphinEncoderConfig, encode};
 
-const FIXTURE_ROOT: &str =
-    "/Volumes/QuintinDocument/openasr-dev/openasr/tmp/publish/dolphin-cn-dialect-small";
-
-fn root() -> PathBuf {
-    PathBuf::from(FIXTURE_ROOT)
+fn root() -> Option<PathBuf> {
+    match crate::testing::external_test_fixture_path(
+        "OPENASR_DOLPHIN_PARITY_ROOT",
+        "Dolphin parity fixture directory",
+    ) {
+        Ok(path) => Some(path),
+        Err(skip) => {
+            eprintln!("skipping: {skip}");
+            None
+        }
+    }
 }
 
 // --- minimal safetensors reader (all tensors f32) --------------------------
@@ -167,7 +173,9 @@ fn relative_max_diff(actual: &[f32], expected: &[f32]) -> f32 {
 #[test]
 #[ignore = "requires local 866MB Dolphin weights under tmp/publish (not committed)"]
 fn dolphin_encoder_parity() {
-    let root = root();
+    let Some(root) = root() else {
+        return;
+    };
     let weights_path = root.join("weights/encoder.safetensors");
     if !weights_path.exists() {
         eprintln!("skip: {weights_path:?} not present");
@@ -276,7 +284,9 @@ const DECODER_PROMPT: [u32; 5] = [2, 5, 10, 4, 109];
 #[test]
 #[ignore = "requires local Dolphin full.safetensors + golden under tmp/publish (not committed)"]
 fn dolphin_decoder_parity() {
-    let root = root();
+    let Some(root) = root() else {
+        return;
+    };
     let weights_path = root.join("weights/full.safetensors");
     let encoder_out_path = root.join("golden/encoder_out.npy");
     let step0_path = root.join("golden/decoder_step0_logits.npy");
@@ -366,7 +376,9 @@ fn dolphin_decoder_parity() {
 fn dolphin_hotword_context_parity() {
     use super::hotword_context::{apply_hotword_deep_biasing, encode_hotword_context_embeddings};
 
-    let root = root();
+    let Some(root) = root() else {
+        return;
+    };
     let weights_path = root.join("weights/full.safetensors");
     let context_emb_path = root.join("golden/hotword_context_emb.npy");
     if !weights_path.exists() || !context_emb_path.exists() {

--- a/crates/openasr-core/src/models/firered_llm/adapter_graph.rs
+++ b/crates/openasr-core/src/models/firered_llm/adapter_graph.rs
@@ -265,10 +265,17 @@ mod tests {
         parse_firered_llm_adapter_metadata, parse_firered_llm_encoder_metadata,
     };
 
-    fn dev_pack_path() -> std::path::PathBuf {
-        std::path::PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp-weights/fr2/out/firered2-llm-q4_k.oasr",
-        )
+    fn dev_pack_path() -> Option<std::path::PathBuf> {
+        match crate::testing::external_test_fixture_path(
+            "OPENASR_FIRERED_LLM_Q4_PACK",
+            "FireRed2 LLM q4 .oasr pack",
+        ) {
+            Ok(path) => Some(path),
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                None
+            }
+        }
     }
 
     fn jfk_wav_path() -> std::path::PathBuf {
@@ -334,7 +341,9 @@ mod tests {
     #[ignore = "requires the private ~4.7GB dev-only firered2-llm-q4_k.oasr pack; numeric parity \
                 against the removed scalar host implementation on the real jfk.wav utterance"]
     fn ggml_graph_adapter_matches_reference_scalar_implementation_on_jfk_wav() {
-        let pack_path = dev_pack_path();
+        let Some(pack_path) = dev_pack_path() else {
+            return;
+        };
         if !pack_path.exists() {
             eprintln!("skipping: {} not present", pack_path.display());
             return;

--- a/crates/openasr-core/src/models/firered_llm/executor.rs
+++ b/crates/openasr-core/src/models/firered_llm/executor.rs
@@ -662,10 +662,17 @@ mod tests {
     /// fetch, so this stays `#[ignore]`d and skips silently when absent
     /// (matches firered-aed's own dev-pack test convention) rather than
     /// gating CI on a multi-GB private artifact.
-    fn dev_pack_path() -> PathBuf {
-        PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp-weights/fr2/out/firered2-llm-q8_0.oasr",
-        )
+    fn dev_pack_path() -> Option<PathBuf> {
+        match crate::testing::external_test_fixture_path(
+            "OPENASR_FIRERED_LLM_PACK",
+            "FireRed2 LLM .oasr pack",
+        ) {
+            Ok(path) => Some(path),
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                None
+            }
+        }
     }
 
     // Pinned to the real dev-pack decode. CPU is the deterministic reference
@@ -702,7 +709,8 @@ mod tests {
     }
 
     fn transcribe_with_dev_pack(wav_path: PathBuf) -> Option<(String, std::time::Duration, f32)> {
-        transcribe_with_pack(dev_pack_path(), wav_path, GgmlAsrBackendPreference::CpuOnly)
+        let pack_path = dev_pack_path()?;
+        transcribe_with_pack(pack_path, wav_path, GgmlAsrBackendPreference::CpuOnly)
     }
 
     fn transcribe_with_pack(
@@ -755,9 +763,16 @@ mod tests {
                 under tmp-weights/fr2/out; env-selected backend/quant, prints FR2_LLM_AB + peak RSS"]
     fn firered_llm_perf_ab() {
         let quant = std::env::var("OPENASR_FR2_AB_QUANT").unwrap_or_else(|_| "q4_k".to_string());
-        let pack_path = PathBuf::from(format!(
-            "/Volumes/QuintinDocument/openasr-dev/tmp-weights/fr2/out/firered2-llm-{quant}.oasr"
-        ));
+        let pack_path = match crate::testing::external_test_fixture_path(
+            "OPENASR_FR2_AB_PACK",
+            "FireRed2 LLM benchmark .oasr pack",
+        ) {
+            Ok(path) => path,
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                return;
+            }
+        };
         let backend = match std::env::var("OPENASR_FR2_AB_BACKEND").as_deref() {
             Ok("cpu") => GgmlAsrBackendPreference::CpuOnly,
             Ok("metal") | Ok("gpu") => GgmlAsrBackendPreference::Accelerated,

--- a/crates/openasr-core/src/models/firered_llm/llm_transformer.rs
+++ b/crates/openasr-core/src/models/firered_llm/llm_transformer.rs
@@ -424,16 +424,22 @@ mod parity_tests {
     use super::*;
     use crate::models::runtime_contract::ScalarMetadataView;
 
-    fn dev_pack_path() -> PathBuf {
-        PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp-weights/fr2/out/firered2-llm-q8_0.oasr",
+    fn dev_pack_path() -> Option<PathBuf> {
+        crate::testing::external_test_fixture_path(
+            "OPENASR_FIRERED_LLM_PACK",
+            "FireRed2 LLM .oasr pack",
         )
+        .inspect_err(|skip| eprintln!("skipping: {skip}"))
+        .ok()
     }
 
-    fn dump_dir() -> PathBuf {
-        PathBuf::from(
-            "/private/tmp/claude-501/-Volumes-QuintinDocument-openasr-dev/08bbaa3c-ccc3-4b2d-af9e-1e3a449e3d8d/scratchpad/fr2-t5-parity",
+    fn dump_dir() -> Option<PathBuf> {
+        crate::testing::external_test_fixture_path(
+            "OPENASR_FIRERED_LLM_PARITY_DUMP_DIR",
+            "FireRed2 LLM parity output directory",
         )
+        .inspect_err(|skip| eprintln!("skipping: {skip}"))
+        .ok()
     }
 
     /// Deterministic pseudo-random f32 generator (xorshift64*, no external
@@ -563,12 +569,16 @@ mod parity_tests {
                 per-segment outputs to scratchpad/fr2-t5-parity for compare_parity.py to diff \
                 against an independent PyTorch reference -- see this module's parity_tests doc"]
     fn dump_parity_segments_for_python_reference_comparison() {
-        let pack_path = dev_pack_path();
+        let Some(pack_path) = dev_pack_path() else {
+            return;
+        };
         if !pack_path.exists() {
             eprintln!("skipping: {} not present", pack_path.display());
             return;
         }
-        let dir = dump_dir();
+        let Some(dir) = dump_dir() else {
+            return;
+        };
 
         let gguf_metadata =
             crate::ggml_runtime::read_gguf_metadata(&pack_path).expect("read gguf metadata");
@@ -649,7 +659,9 @@ mod parity_tests {
     #[ignore = "requires the private ~8.9GB dev-only firered2-llm-q8_0.oasr pack; construction-only \
                 smoke check for the zero-copy tensor-name wiring this module's history fixed"]
     fn probe_decoder_runtime_construction_against_real_pack() {
-        let pack_path = dev_pack_path();
+        let Some(pack_path) = dev_pack_path() else {
+            return;
+        };
         if !pack_path.exists() {
             eprintln!("skipping: {} not present", pack_path.display());
             return;

--- a/crates/openasr-core/src/models/mimo_asr/executor.rs
+++ b/crates/openasr-core/src/models/mimo_asr/executor.rs
@@ -533,10 +533,17 @@ mod tests {
     /// Real converted dev pack from P2.1+P2.2 (`tooling/mimo-asr/convert_mimo_asr.py`),
     /// NOT committed to the repo (dev-only artifact, same convention as
     /// firered2-llm's own `tmp-weights/fr2/out/firered2-llm-q8_0.oasr`).
-    fn dev_pack_path() -> PathBuf {
-        PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp-weights/mimo/out/mimo-v2.5-asr-q8_0.oasr",
-        )
+    fn dev_pack_path() -> Option<PathBuf> {
+        match crate::testing::external_test_fixture_path(
+            "OPENASR_MIMO_ASR_PACK",
+            "MiMo ASR .oasr pack",
+        ) {
+            Ok(path) => Some(path),
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                None
+            }
+        }
     }
 
     // Pinned to the real dev-pack decode (q8_0, `OPENASR_GGML_BACKEND=cpu` --
@@ -592,7 +599,7 @@ mod tests {
     }
 
     fn transcribe_with_dev_pack(wav_path: PathBuf) -> Option<(String, std::time::Duration, f32)> {
-        let pack_path = dev_pack_path();
+        let pack_path = dev_pack_path()?;
         if !pack_path.exists() {
             eprintln!("skipping: {} not present", pack_path.display());
             return None;

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/decode_prompt.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/decode_prompt.rs
@@ -298,10 +298,17 @@ mod tests {
     /// for the tensor-parity half of this pack's provenance), NOT committed
     /// to the repo -- same dev-only-artifact convention as
     /// `mimo_asr::executor::tests::dev_pack_path`.
-    fn dev_pack_path() -> std::path::PathBuf {
-        std::path::PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/moss-transcribe-diarize-fp16.oasr",
-        )
+    fn dev_pack_path() -> Option<std::path::PathBuf> {
+        match crate::testing::external_test_fixture_path(
+            "OPENASR_MOSS_TRANSCRIBE_DIARIZE_PACK",
+            "MOSS Transcribe Diarize .oasr pack",
+        ) {
+            Ok(path) => Some(path),
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                None
+            }
+        }
     }
 
     /// Regression test for the `models::gpt2_bpe` pretokenizer fix: builds
@@ -315,7 +322,9 @@ mod tests {
     /// `"[S"` token instead of separate `"["`/`"S"` tokens).
     #[test]
     fn builds_the_real_golden_jfk_prompt_token_for_token() {
-        let pack_path = dev_pack_path();
+        let Some(pack_path) = dev_pack_path() else {
+            return;
+        };
         if !pack_path.exists() {
             eprintln!("skipping: {} not present", pack_path.display());
             return;

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -1436,9 +1436,18 @@ mod tests {
             !text.trim().is_empty(),
             "accelerated AISHELL-4 decode must emit a non-empty transcript"
         );
-        let golden_path = PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/golden/aishell4_multispeaker_3min.json",
-        );
+        let Ok(golden_root) = crate::testing::external_test_fixture_path(
+            "OPENASR_MOSS_TRANSCRIBE_DIARIZE_GOLDEN",
+            "MOSS Transcribe Diarize development golden directory",
+        )
+        .inspect_err(|skip| eprintln!("skipping: {skip}")) else {
+            return;
+        };
+        let golden_path = golden_root.join("aishell4_multispeaker_3min.json");
+        if !golden_path.exists() {
+            eprintln!("skipping: {} not present", golden_path.display());
+            return;
+        }
         let golden: serde_json::Value = serde_json::from_slice(
             &std::fs::read(&golden_path).expect("read AISHELL-4 development golden"),
         )

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -851,14 +851,26 @@ mod tests {
     /// Real converted dev pack (fp16), NOT committed -- same dev-only-artifact
     /// convention as `decode_prompt`'s own `dev_pack_path` and mimo-asr's
     /// `mimo-v2.5-asr-q8_0.oasr`.
-    fn dev_pack_path() -> PathBuf {
-        PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/moss-transcribe-diarize-fp16.oasr",
+    fn dev_pack_path() -> Option<PathBuf> {
+        crate::testing::external_test_fixture_path(
+            "OPENASR_MOSS_TRANSCRIBE_DIARIZE_PACK",
+            "MOSS Transcribe Diarize .oasr pack",
         )
+        .inspect_err(|skip| eprintln!("skipping: {skip}"))
+        .ok()
     }
 
     fn dev_sample_path(name: &str) -> PathBuf {
-        PathBuf::from("/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/samples").join(name)
+        match crate::testing::external_test_fixture_path(
+            "OPENASR_MOSS_TRANSCRIBE_DIARIZE_SAMPLES",
+            "MOSS Transcribe Diarize sample directory",
+        ) {
+            Ok(path) => path.join(name),
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                PathBuf::new()
+            }
+        }
     }
 
     // Pinned to the real dev-pack CPU decode (backend forced to CPU below).
@@ -910,7 +922,7 @@ mod tests {
         wav_path: PathBuf,
         backend_preference: GgmlAsrBackendPreference,
     ) -> Option<(String, Vec<Segment>, std::time::Duration, f32)> {
-        let pack_path = dev_pack_path();
+        let pack_path = dev_pack_path()?;
         if !pack_path.exists() {
             eprintln!("skipping: {} not present", pack_path.display());
             return None;
@@ -963,7 +975,7 @@ mod tests {
     /// `speaker_segments::parse_moss_td_speaker_segments` (as wired into the
     /// executor) into the same structure the golden `[Sxx]`/`[t]` tags encode.
     fn transcribe_with_dev_pack_segments(wav_path: PathBuf) -> Option<Vec<Segment>> {
-        let pack_path = dev_pack_path();
+        let pack_path = dev_pack_path()?;
         if !pack_path.exists() {
             eprintln!("skipping: {} not present", pack_path.display());
             return None;

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
@@ -1227,13 +1227,20 @@ mod tests {
     // real-dev-pack test in this crate, e.g. `firered_llm::executor`'s
     // `dev_pack_path()`). Skips silently when absent so this stays runnable
     // without the multi-GB download.
-    fn dev_checkpoint_root() -> PathBuf {
-        PathBuf::from("/Volumes/QuintinDocument/openasr-dev/tmp/moss-td/model")
+    fn dev_checkpoint_root() -> Option<PathBuf> {
+        crate::testing::external_test_fixture_path(
+            "OPENASR_MOSS_TRANSCRIBE_DIARIZE_SOURCE",
+            "MOSS Transcribe Diarize source checkpoint directory",
+        )
+        .inspect_err(|skip| eprintln!("skipping: {skip}"))
+        .ok()
     }
 
     #[test]
     fn golden_diff_converted_pack_tensors_match_source_checkpoint_bit_for_bit() {
-        let source_root = dev_checkpoint_root();
+        let Some(source_root) = dev_checkpoint_root() else {
+            return;
+        };
         if !source_root.exists() {
             eprintln!("skipping: {} not present", source_root.display());
             return;

--- a/crates/openasr-core/src/models/qwen/audio_encoder.rs
+++ b/crates/openasr-core/src/models/qwen/audio_encoder.rs
@@ -1380,8 +1380,16 @@ mod tests {
         use crate::ggml_runtime::GgufTensorDataReader;
         use crate::models::qwen::runtime_contract::Qwen3AsrExecutionMetadata;
 
-        let source_root =
-            PathBuf::from("/Volumes/QuintinDocument/hf-cache/qwen3-forced-aligner-0.6b");
+        let source_root = match crate::testing::external_test_fixture_path(
+            "OPENASR_QWEN_FORCED_ALIGNER_SOURCE",
+            "Qwen forced-aligner source checkpoint directory",
+        ) {
+            Ok(path) => path,
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                return;
+            }
+        };
         let ref_dir =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp/forced-aligner-ref/fixtures");
         let mel_path = ref_dir.join("audio_mel_input.f32le");

--- a/crates/openasr-core/src/models/qwen/forced_aligner_import.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_import.rs
@@ -515,8 +515,16 @@ mod tests {
     /// safetensors tensor 1:1, plus the two synthesized frontend tensors.
     #[test]
     fn forced_aligner_conversion_produces_tensor_parity_with_source_checkpoint() {
-        let source_root =
-            PathBuf::from("/Volumes/QuintinDocument/hf-cache/qwen3-forced-aligner-0.6b");
+        let source_root = match crate::testing::external_test_fixture_path(
+            "OPENASR_QWEN_FORCED_ALIGNER_SOURCE",
+            "Qwen forced-aligner source checkpoint directory",
+        ) {
+            Ok(path) => path,
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                return;
+            }
+        };
         if !source_root.exists() {
             eprintln!(
                 "skipping: {} not present (Stage 0 reference download is dev-machine only)",

--- a/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
@@ -516,8 +516,16 @@ mod tests {
         use super::super::package_import::Qwen3AsrRuntimeQuantizationMode as ForcedAlignerQuantMode;
         use crate::api::audio_io::load_wav_16khz_mono_f32_v0;
 
-        let source_root =
-            PathBuf::from("/Volumes/QuintinDocument/hf-cache/qwen3-forced-aligner-0.6b");
+        let source_root = match crate::testing::external_test_fixture_path(
+            "OPENASR_QWEN_FORCED_ALIGNER_SOURCE",
+            "Qwen forced-aligner source checkpoint directory",
+        ) {
+            Ok(path) => path,
+            Err(skip) => {
+                eprintln!("skipping: {skip}");
+                return;
+            }
+        };
         let ref_dir =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp/forced-aligner-ref");
         let reference_output_path = ref_dir.join("reference_output.json");

--- a/crates/openasr-core/src/stage_timing.rs
+++ b/crates/openasr-core/src/stage_timing.rs
@@ -2,8 +2,7 @@
 //! daemon/server/CLI logs.
 //!
 //! `daemon.log` (stdout+stderr of `openasr serve`, captured by the desktop
-//! sidecar -- see `openasr-app/apps/desktop/src-tauri/src/sidecar.rs`) had no
-//! timestamps at all: server boot, model-pack loading, and realtime warm-up
+//! sidecar) had no timestamps at all: server boot, model-pack loading, and realtime warm-up
 //! were each a plain `println!`/`eprintln!` with no timing, so diagnosing how
 //! long any of it took meant guessing from wall-clock reads of unrelated
 //! surrounding events. This module is the single place that formats a dual

--- a/crates/openasr-core/src/testing.rs
+++ b/crates/openasr-core/src/testing.rs
@@ -3,7 +3,7 @@ use std::sync::{Mutex, OnceLock};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs, io,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use crate::models::ggml_asr_executor::GgmlAsrPreparedAudio;
@@ -60,6 +60,53 @@ const WHISPER_REQUIRED_TENSOR_ANCHORS_FOR_SKELETON: &[&str] = &[
     "model.decoder.layers.0.self_attn.q_proj.weight",
     "model.decoder.layers.0.encoder_attn.q_proj.weight",
 ];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExternalTestFixtureError {
+    Unset { env_var: String, purpose: String },
+    Missing { env_var: String, path: PathBuf },
+}
+
+impl std::fmt::Display for ExternalTestFixtureError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unset { env_var, purpose } => write!(
+                formatter,
+                "set {env_var} to the local {purpose} path to run this opt-in test"
+            ),
+            Self::Missing { env_var, path } => write!(
+                formatter,
+                "{env_var} points to missing external test fixture {}",
+                path.display()
+            ),
+        }
+    }
+}
+
+/// Resolves an opt-in fixture that is deliberately not tracked in this repository.
+///
+/// Tests that use this helper must report the returned error and skip rather than
+/// guessing a workstation-specific location or reading a user's home directory.
+pub fn external_test_fixture_path(
+    env_var: &str,
+    purpose: &str,
+) -> Result<PathBuf, ExternalTestFixtureError> {
+    let Some(value) = std::env::var_os(env_var) else {
+        return Err(ExternalTestFixtureError::Unset {
+            env_var: env_var.to_string(),
+            purpose: purpose.to_string(),
+        });
+    };
+    let path = PathBuf::from(value);
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(ExternalTestFixtureError::Missing {
+            env_var: env_var.to_string(),
+            path,
+        })
+    }
+}
 
 #[cfg(test)]
 pub(crate) fn with_forced_cpu_backend_for_test<T>(run: impl FnOnce() -> T) -> T {
@@ -1882,6 +1929,19 @@ mod tests {
     use crate::{read_gguf_metadata, read_gguf_tensor_index};
     use std::fs;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn external_fixture_path_reports_missing_fixture() {
+        let path = PathBuf::from("definitely-not-an-openasr-fixture");
+        assert_eq!(
+            external_test_fixture_path("OPENASR_TEST_MISSING_FIXTURE", "fixture"),
+            Err(ExternalTestFixtureError::Unset {
+                env_var: "OPENASR_TEST_MISSING_FIXTURE".to_string(),
+                purpose: "fixture".to_string(),
+            })
+        );
+        assert!(!path.exists(), "test fixture name must remain absent");
+    }
 
     #[test]
     fn whisper_graph_ready_fixture_includes_anchor_and_binding_tensors() {

--- a/crates/openasr-core/src/testing.rs
+++ b/crates/openasr-core/src/testing.rs
@@ -1931,16 +1931,53 @@ mod tests {
     use tempfile::NamedTempFile;
 
     #[test]
-    fn external_fixture_path_reports_missing_fixture() {
-        let path = PathBuf::from("definitely-not-an-openasr-fixture");
+    fn external_fixture_path_reports_unset_env() {
         assert_eq!(
-            external_test_fixture_path("OPENASR_TEST_MISSING_FIXTURE", "fixture"),
+            external_test_fixture_path("OPENASR_TEST_UNSET_FIXTURE", "fixture"),
             Err(ExternalTestFixtureError::Unset {
-                env_var: "OPENASR_TEST_MISSING_FIXTURE".to_string(),
+                env_var: "OPENASR_TEST_UNSET_FIXTURE".to_string(),
                 purpose: "fixture".to_string(),
             })
         );
-        assert!(!path.exists(), "test fixture name must remain absent");
+    }
+
+    #[test]
+    fn external_fixture_path_reports_missing_path() {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("external fixture env lock");
+        let env_var = "OPENASR_TEST_MISSING_FIXTURE_PATH";
+        let missing = PathBuf::from("definitely-not-an-openasr-fixture");
+        assert!(!missing.exists(), "test fixture path must remain absent");
+        let previous = std::env::var_os(env_var);
+        #[expect(unsafe_code, reason = "test-only process env override")]
+        unsafe {
+            std::env::set_var(env_var, &missing);
+        }
+        let result = external_test_fixture_path(env_var, "fixture");
+        match previous {
+            Some(value) => {
+                #[expect(unsafe_code, reason = "test-only process env restore")]
+                unsafe {
+                    std::env::set_var(env_var, value);
+                }
+            }
+            None => {
+                #[expect(unsafe_code, reason = "test-only process env restore")]
+                unsafe {
+                    std::env::remove_var(env_var);
+                }
+            }
+        }
+        assert_eq!(
+            result,
+            Err(ExternalTestFixtureError::Missing {
+                env_var: env_var.to_string(),
+                path: missing,
+            })
+        );
     }
 
     #[test]

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -10,9 +10,10 @@ run a shell / call a local HTTP API) at OpenASR. Two independent paths:
    HTTP (or want a long-lived local daemon instead of spawning a process per
    request).
 
-Both paths run entirely on-device: no telemetry, no cloud fallback, no
-implicit model download (see [SECURITY](../SECURITY.md) and the repo-root
-"Product principles").
+Both paths are local-first by default: no telemetry, no silent cloud fallback,
+no implicit model download (see [SECURITY](../SECURITY.md) and the repo-root
+"Product principles"). Remote compute is available only when explicitly paired
+and enabled.
 
 ## 1. Skill (CLI) path
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,8 +1,10 @@
 # Quickstart
 
 Get a real transcript on your own machine in three commands. OpenASR is
-local-first: native is the default backend, audio never leaves your machine, and
-there is no telemetry.
+local-first by default: native is the default backend, audio stays on your
+machine unless you explicitly pair and enable remote compute (see
+[SECURITY.md](../SECURITY.md#local-first-security-notes)), and there is no
+telemetry.
 
 > Building from source compiles the ggml backend, so clone recursively and have a
 > C/C++ toolchain available (`cmake`, a compiler, and on Linux `libasound2-dev`).

--- a/tooling/check_public_source_hygiene.py
+++ b/tooling/check_public_source_hygiene.py
@@ -18,8 +18,10 @@ SCAN_PREFIXES = (
     "crates/",
     "tooling/",
     "docs/",
+    "scripts/",
     ".github/",
     "README.md",
+    "README.zh-CN.md",
     "SECURITY.md",
     "AGENTS.md",
     "CONTRIBUTING.md",
@@ -70,6 +72,7 @@ def tracked_source_files() -> list[Path]:
             continue
         if path.suffix and path.suffix not in TEXT_SUFFIXES and path.name not in {
             "README.md",
+            "README.zh-CN.md",
             "SECURITY.md",
             "AGENTS.md",
             "CONTRIBUTING.md",

--- a/tooling/check_public_source_hygiene.py
+++ b/tooling/check_public_source_hygiene.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Reject workstation paths and private sibling repository names in public source.
+
+The gate scans tracked public-facing text sources. The only intentional
+occurrences of forbidden markers are the escaped pattern fragments in this
+file itself (so the script does not self-fail).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Broad public tree coverage. Exclude vendored/third-party trees and the gate
+# script itself (which keeps forbidden markers only as escaped fixtures).
+SCAN_PREFIXES = (
+    "crates/",
+    "tooling/",
+    "docs/",
+    ".github/",
+    "README.md",
+    "SECURITY.md",
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+)
+SKIP_PREFIXES = (
+    "crates/openasr-core/third_party/",
+)
+TEXT_SUFFIXES = {
+    ".rs",
+    ".py",
+    ".sh",
+    ".md",
+    ".yml",
+    ".yaml",
+    ".toml",
+    ".json",
+    ".txt",
+}
+SELF_PATH = Path("tooling/check_public_source_hygiene.py")
+
+# Escaped so this file is not itself a false positive.
+FORBIDDEN_PATTERNS = (
+    "/" + "Volumes" + "/",
+    "/" + "Users" + "/",
+    "openasr-" + "legacy",
+    "openasr-" + "app",
+)
+
+
+def tracked_source_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"], check=True, capture_output=True, text=False
+    )
+    files: list[Path] = []
+    for raw in result.stdout.split(b"\0"):
+        if not raw:
+            continue
+        rel = raw.decode()
+        path = Path(rel)
+        if path == SELF_PATH:
+            continue
+        if any(rel.startswith(prefix) for prefix in SKIP_PREFIXES):
+            continue
+        if not (
+            any(rel.startswith(prefix) for prefix in SCAN_PREFIXES)
+            or rel in SCAN_PREFIXES
+        ):
+            continue
+        if path.suffix and path.suffix not in TEXT_SUFFIXES and path.name not in {
+            "README.md",
+            "SECURITY.md",
+            "AGENTS.md",
+            "CONTRIBUTING.md",
+        }:
+            # Allow extensionless files only when explicitly listed above.
+            if path.suffix:
+                continue
+        files.append(path)
+    return files
+
+
+def main() -> int:
+    violations: list[str] = []
+    for path in tracked_source_files():
+        if not path.is_file():
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for line_number, line in enumerate(lines, start=1):
+            for pattern in FORBIDDEN_PATTERNS:
+                if pattern in line:
+                    violations.append(
+                        f"{path}:{line_number}: forbidden public-source marker ({pattern})"
+                    )
+                    break
+    if violations:
+        print("Public-source hygiene check failed:", file=sys.stderr)
+        print("\n".join(violations), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/release-manifest/README.md
+++ b/tooling/release-manifest/README.md
@@ -98,12 +98,12 @@ payload only ever names the canonical host).
 ## dl.openasr.org sync
 
 `b2_sync.py` -- uploads files to `core/v<version>/<filename>` in the SAME
-Backblaze B2 bucket / Cloudflare Worker `openasr-app`'s desktop installers
+Backblaze B2 bucket / Cloudflare Worker the desktop installers
 already publish to (`https://dl.openasr.org/desktop/...` there,
-`https://dl.openasr.org/core/...` here). It is a Python port of that repo's
-`apps/desktop/scripts/b2-s3-client.mjs` SigV4 signer (same env var names,
+`https://dl.openasr.org/core/...` here). It is a Python port of that desktop
+product's SigV4 signer (same env var names,
 same virtual-hosted-style request shape, same ETag-based immutability gate)
-plus `release-publish.mjs`'s upload-with-immutability-check logic --
+plus its upload-with-immutability-check logic --
 cross-validated against AWS's published SigV4 worked example in
 `b2_sync_test.py`, no network required to test.
 
@@ -154,9 +154,9 @@ is always a local, human-run step:
   maintainer's machine, with the B2 vars provided by `source
   ~/.openasr/b2-release.env` in that shell (the same credential file desktop
   releases use), not a repo secret and not a long-lived shell-profile export.
-- `openasr-app`'s own `release-desktop.yml` only runs this kind of publish
+- The desktop product's own release workflow only runs this kind of publish
   from a `workflow_dispatch` with an explicit `publish: true` input, gated by
-  repo secrets on the app repo -- i.e. even there, publishing to
+  repo secrets on that product repo -- i.e. even there, publishing to
   dl.openasr.org is a deliberate, per-run opt-in, not a side effect of every
   green build. Core follows the same posture, taken one step further: not
   even a gated dispatch, just a local script run after the maintainer has

--- a/tooling/release-manifest/b2_sync.py
+++ b/tooling/release-manifest/b2_sync.py
@@ -13,7 +13,7 @@
       dist/openasr-vendor-rocm-runtime-<sha12>.zip
 
 `sync` uploads each given file to `core/v<version>/<basename>` in the SAME B2
-bucket/Cloudflare-Worker setup `openasr-app`'s desktop installers already use
+bucket/Cloudflare-Worker setup used by the desktop installers already use
 (see that repo's `apps/desktop/scripts/release-publish.mjs` and
 `b2-s3-client.mjs`, which this script's SigV4 signer is a Python port of --
 `desktop/releases/v<version>/...` there, `core/v<version>/...` here).
@@ -232,7 +232,7 @@ class B2Client:
         endpoint_url = urlparse(credentials.endpoint)
         # Virtual-hosted-style (`https://<bucket>.<endpoint-host>/<key>`), NOT
         # path-style (`https://<endpoint-host>/<bucket>/<key>`) -- matches
-        # openasr-app's b2-s3-client.mjs `s3ObjectRequest`/`virtualHostedUrl`,
+        # desktop release client's `s3ObjectRequest`/`virtualHostedUrl`,
         # which this is a Python port of. The bucket is part of the signed
         # `host`, so getting this wrong produces a signature B2 rejects, not
         # just a wrong-looking URL.

--- a/tooling/release-manifest/b2_sync_test.py
+++ b/tooling/release-manifest/b2_sync_test.py
@@ -21,7 +21,7 @@ from b2_sync import (
 
 # AWS's own published worked example for SigV4 header-based auth (GET Object,
 # examplebucket/test.txt) -- the same canonical cross-implementation vector
-# openasr-app's b2-s3-client.test.mjs pins for its JS SigV4 signer (this
+# desktop release client's SigV4 signer pins for its JS implementation (this
 # module is a Python port of that signer). Matching the identical published
 # Authorization header is real evidence the signing math is correct,
 # independent of both implementations and of B2 itself.


### PR DESCRIPTION
## Summary

Remove hardcoded personal and private sibling paths from the public tree, route real-pack tests through an explicit opt-in fixture helper, and tighten README privacy/license wording so the public docs match the live product boundary.

## Why

A release-hygiene scan found twenty absolute `/Volumes/QuintinDocument/...` paths in tracked sources, including a private `openasr-legacy` audio fixture path. Those strings leak local topology into the public tree and break clean-room/CI assumptions. The English and Chinese README wording also over-claimed local-only privacy and MIT/Apache-only model licenses.

## Changes

- Replace hardcoded personal/private fixture paths with `external_test_fixture_path`, which is env opt-in and skips cleanly when unset.
- Add `tooling/check_public_source_hygiene.py` and run it from the default CI lint job.
- Block `/Volumes/`, `/Users/`, `openasr-legacy`, and `openasr-app` path leaks in public source text.
- Update English and Chinese README privacy text: default local operation, explicit remote-compute exception, link to SECURITY.
- Update license wording to follow registry/pack metadata rather than claiming MIT/Apache only.
- Cover `README.zh-CN.md` and `scripts/` in the hygiene scan prefixes.
- Add missing-path coverage for the external fixture helper.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Additional checks:

- `python3 tooling/check_public_source_hygiene.py`
- `cargo test -p openasr-core external_fixture_path -- --nocapture`

## Manual smoke checks

- Confirmed public-tree searches no longer hit personal absolute paths or private sibling checkout names outside the intentional hygiene fixtures.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR only closes public-tree path leakage and the matching README/privacy/license wording. It does not change runtime download policy, remote-compute protocol behavior, or model packaging.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
