### PR TITLE
perf(core): fuse CPU relative-position attention online-softmax

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -893,6 +893,10 @@ pub enum GgmlCpuGraphError {
         head_dim: usize,
         supported: &'static [usize],
     },
+    #[error(
+        "ggml_flash_attn_rel_pos is CPU-only; backend={backend:?} must keep the naive mul_mat + rel_shift fallback"
+    )]
+    FlashAttnRelPosCpuOnly { backend: GgmlCpuGraphBackend },
 }
 
 pub struct GgmlCpuGraphRunner {
@@ -2866,6 +2870,72 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             )
         };
         self.new_tensor_checked(raw, "ggml_flash_attn_ext")
+    }
+
+    /// CPU-only fused Transformer-XL relative-position attention
+    /// (`ggml_flash_attn_rel_pos`). Fails closed on non-CPU backends so callers
+    /// must keep the naive mul_mat + rel_shift path rather than claiming the
+    /// fused op is supported on Metal/GPU.
+    pub(crate) fn flash_attn_rel_pos(
+        &self,
+        q_u: GgmlCpuTensor<'a>,
+        q_v: GgmlCpuTensor<'a>,
+        k: GgmlCpuTensor<'a>,
+        r: GgmlCpuTensor<'a>,
+        v: GgmlCpuTensor<'a>,
+        mask: Option<GgmlCpuTensor<'a>>,
+        scale: f32,
+    ) -> Result<GgmlCpuTensor<'a>, GgmlCpuGraphError> {
+        self.ensure_can_extend_graph("ggml_flash_attn_rel_pos")?;
+        if self.backend_kind != GgmlCpuGraphBackend::Cpu {
+            return Err(GgmlCpuGraphError::FlashAttnRelPosCpuOnly {
+                backend: self.backend_kind,
+            });
+        }
+        self.ensure_tensor_type(q_u, ffi::GGML_TYPE_F32, "ggml_flash_attn_rel_pos q_u")?;
+        self.ensure_tensor_type(q_v, ffi::GGML_TYPE_F32, "ggml_flash_attn_rel_pos q_v")?;
+        self.ensure_tensor_type(k, ffi::GGML_TYPE_F32, "ggml_flash_attn_rel_pos k")?;
+        self.ensure_tensor_type(r, ffi::GGML_TYPE_F32, "ggml_flash_attn_rel_pos r")?;
+        self.ensure_tensor_type(v, ffi::GGML_TYPE_F32, "ggml_flash_attn_rel_pos v")?;
+        self.ensure_tensor_contiguous_rows(q_u, "ggml_flash_attn_rel_pos q_u")?;
+        self.ensure_tensor_contiguous_rows(q_v, "ggml_flash_attn_rel_pos q_v")?;
+        self.ensure_tensor_contiguous_rows(k, "ggml_flash_attn_rel_pos k")?;
+        self.ensure_tensor_contiguous_rows(r, "ggml_flash_attn_rel_pos r")?;
+        self.ensure_tensor_contiguous_rows(v, "ggml_flash_attn_rel_pos v")?;
+        if !scale.is_finite() {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos scale must be finite",
+            });
+        }
+        self.ensure_flash_attn_rel_pos_compatible(q_u, q_v, k, r, v)?;
+
+        let mask_raw = if let Some(mask) = mask {
+            self.ensure_tensor_type(mask, ffi::GGML_TYPE_F32, "ggml_flash_attn_rel_pos mask")?;
+            self.ensure_flash_attn_rel_pos_mask_compatible(q_u, k, mask)?;
+            mask.raw.as_ptr()
+        } else {
+            ptr::null_mut()
+        };
+
+        let raw = unsafe {
+            ffi::ggml_flash_attn_rel_pos(
+                self.context.as_ptr(),
+                q_u.raw.as_ptr(),
+                q_v.raw.as_ptr(),
+                k.raw.as_ptr(),
+                r.raw.as_ptr(),
+                v.raw.as_ptr(),
+                mask_raw,
+                scale,
+            )
+        };
+        self.new_tensor_checked(raw, "ggml_flash_attn_rel_pos")
+    }
+
+    /// Predicate used by shared relative-position attention wrappers: the fused
+    /// op is only emitted on the plain CPU backend.
+    pub(crate) fn supports_flash_attn_rel_pos(&self) -> bool {
+        self.backend_kind == GgmlCpuGraphBackend::Cpu
     }
 
     pub(crate) fn gelu(
@@ -4848,6 +4918,91 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         if q_shape[2] % mask_shape[2] != 0 || q_shape[3] % mask_shape[3] != 0 {
             return Err(GgmlCpuGraphError::UnsupportedInputs {
                 reason: "ggml_flash_attn_ext mask batch dims are not broadcast-compatible",
+            });
+        }
+        Ok(())
+    }
+
+    fn ensure_flash_attn_rel_pos_compatible(
+        &self,
+        q_u: GgmlCpuTensor<'a>,
+        q_v: GgmlCpuTensor<'a>,
+        k: GgmlCpuTensor<'a>,
+        r: GgmlCpuTensor<'a>,
+        v: GgmlCpuTensor<'a>,
+    ) -> Result<(), GgmlCpuGraphError> {
+        self.ensure_can_mul_mat(k, q_u)?;
+        self.ensure_can_mul_mat(r, q_v)?;
+
+        let q_u_shape = self.tensor_shape_4d(q_u)?;
+        let q_v_shape = self.tensor_shape_4d(q_v)?;
+        let k_shape = self.tensor_shape_4d(k)?;
+        let r_shape = self.tensor_shape_4d(r)?;
+        let v_shape = self.tensor_shape_4d(v)?;
+
+        if q_u_shape != q_v_shape {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos q_u/q_v shapes must match",
+            });
+        }
+        if q_u_shape[0] != k_shape[0] || q_u_shape[0] != r_shape[0] {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos head dims must match across q/k/r",
+            });
+        }
+        if k_shape[1] != v_shape[1] {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos k/v sequence lengths must match",
+            });
+        }
+        if k_shape[2] != v_shape[2] || k_shape[2] != r_shape[2] {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos k/v/r head counts must match",
+            });
+        }
+        if q_u_shape[3] != k_shape[3] || q_u_shape[3] != v_shape[3] || q_u_shape[3] != r_shape[3] {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos batch dims must match",
+            });
+        }
+        if q_u_shape[2] % k_shape[2] != 0 {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos query heads must be a multiple of kv heads",
+            });
+        }
+        let nq = q_u_shape[1];
+        let nk = k_shape[1];
+        let expected_nr = nq
+            .checked_add(nk)
+            .and_then(|value| value.checked_sub(1))
+            .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos relative length overflow",
+            })?;
+        if r_shape[1] != expected_nr {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos r length must equal Nq + Nk - 1",
+            });
+        }
+        Ok(())
+    }
+
+    fn ensure_flash_attn_rel_pos_mask_compatible(
+        &self,
+        q_u: GgmlCpuTensor<'a>,
+        k: GgmlCpuTensor<'a>,
+        mask: GgmlCpuTensor<'a>,
+    ) -> Result<(), GgmlCpuGraphError> {
+        let q_shape = self.tensor_shape_4d(q_u)?;
+        let k_shape = self.tensor_shape_4d(k)?;
+        let mask_shape = self.tensor_shape_4d(mask)?;
+        if mask_shape[0] < k_shape[1] {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos mask.ne0 must cover key sequence",
+            });
+        }
+        if q_shape[2] % mask_shape[2] != 0 || q_shape[3] % mask_shape[3] != 0 {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "ggml_flash_attn_rel_pos mask batch dims are not broadcast-compatible",
             });
         }
         Ok(())
@@ -8035,6 +8190,27 @@ mod tests {
                 assert_eq!(supported, METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS);
             }
             Err(err) => panic!("unexpected flash_attn_ext error: {err}"),
+        }
+    }
+
+    #[test]
+    fn flash_attn_rel_pos_rejects_non_cpu_backend_kind() {
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default())
+            .expect("cpu graph runner should initialize");
+        let graph = runner.start_graph();
+        let mut metal_graph = graph;
+        metal_graph.backend_kind = GgmlCpuGraphBackend::Metal;
+        assert!(!metal_graph.supports_flash_attn_rel_pos());
+
+        let q = metal_graph
+            .new_tensor_3d_f32(4, 2, 1, "q")
+            .expect("q should allocate");
+        match metal_graph.flash_attn_rel_pos(q, q, q, q, q, None, 1.0) {
+            Ok(_) => panic!("flash_attn_rel_pos must reject non-CPU backends"),
+            Err(GgmlCpuGraphError::FlashAttnRelPosCpuOnly {
+                backend: GgmlCpuGraphBackend::Metal,
+            }) => {}
+            Err(err) => panic!("unexpected flash_attn_rel_pos error: {err}"),
         }
     }
 

--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -415,6 +415,18 @@ unsafe extern "C" {
         max_bias: f32,
         logit_softcap: f32,
     ) -> GgmlTensorRaw;
+    /// OpenASR-local CPU fused Transformer-XL relative-position attention.
+    /// Non-CPU backends do not implement this op.
+    pub(crate) fn ggml_flash_attn_rel_pos(
+        ctx: GgmlContextRaw,
+        q_u: GgmlTensorRaw,
+        q_v: GgmlTensorRaw,
+        k: GgmlTensorRaw,
+        r: GgmlTensorRaw,
+        v: GgmlTensorRaw,
+        mask: GgmlTensorRaw,
+        scale: f32,
+    ) -> GgmlTensorRaw;
     pub(crate) fn ggml_can_repeat(a: GgmlTensorRaw, b: GgmlTensorRaw) -> bool;
     pub(crate) fn ggml_gelu(ctx: GgmlContextRaw, a: GgmlTensorRaw) -> GgmlTensorRaw;
     pub(crate) fn ggml_gelu_erf(ctx: GgmlContextRaw, a: GgmlTensorRaw) -> GgmlTensorRaw;

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -30,8 +30,8 @@ use thiserror::Error;
 use crate::ggml_runtime::{GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlLoadedWeightContext};
 use crate::nn::attn::{
     AttentionHeadLayout, AttentionReshapeSteps, AttentionValueMergeSteps,
-    STANDARD_HEAD_PERMUTE_AXES, attention_context_from_probs,
-    reshape_projection_to_attention_heads,
+    RelativePositionAttentionInputs, RelativePositionAttentionSteps, STANDARD_HEAD_PERMUTE_AXES,
+    relative_position_attention_context, reshape_projection_to_attention_heads,
 };
 use crate::nn::conv::{
     Conv2dParams, ConvActivation, ConvBlockSteps, apply_conv_2d_bias_activation, reshape_bias_4d,
@@ -522,11 +522,10 @@ fn firered_conformer_block<'a>(
         },
         map_err,
     )?;
-    // No `ggml_cont` on `k_heads`/`r_heads`: both feed `mul_mat` as src0 (the
-    // `attn_ac`/`attn_bd_raw` score matmuls below), which only requires its src0
-    // contiguous on the first (head) dim -- already satisfied by the permuted
-    // reshape view, the same strided-src0 form `q_u`/`q_v` above already use. The
-    // extra materialization was pure copy work (~11.5 MB/layer transient).
+    // No `ggml_cont` on `k_heads`/`r_heads` for the naive path: both feed
+    // `mul_mat` as src0, which only requires its src0 contiguous on the first
+    // (head) dim -- already satisfied by the permuted reshape view. The fused
+    // CPU path cont's internally before `ggml_flash_attn_rel_pos`.
     let k_heads = reshape_projection_to_attention_heads(
         graph,
         k,
@@ -556,45 +555,8 @@ fn firered_conformer_block<'a>(
         },
         map_err,
     )?;
-    let ac = graph
-        .mul_mat(k_heads, q_u)
-        .map_err(|source| map_err("ggml_mul_mat(attn_ac)", source))?;
-    let bd_raw = graph
-        .mul_mat(r_heads, q_v)
-        .map_err(|source| map_err("ggml_mul_mat(attn_bd_raw)", source))?;
-    let element = std::mem::size_of::<f32>();
-    let rel_shift_nb1 = (2 * n_frames - 2) * element;
-    let rel_shift_nb2 = (2 * n_frames - 1) * n_frames * element;
-    let rel_shift_offset = (n_frames - 1) * element;
-    let bd = graph
-        .view_3d(
-            bd_raw,
-            n_frames,
-            n_frames,
-            heads,
-            rel_shift_nb1,
-            rel_shift_nb2,
-            rel_shift_offset,
-        )
-        .map_err(|source| map_err("ggml_view_3d(relative_shift)", source))?;
-    let mut scores = graph
-        .add(ac, bd)
-        .map_err(|source| map_err("ggml_add(attn_scores)", source))?;
-    scores = graph
-        .scale(scores, 1.0 / (head_dim as f32).sqrt())
-        .map_err(|source| map_err("ggml_scale(attn_scores)", source))?;
-    // Mask out context-pad key frames (upstream `src_mask`, applied identically
-    // to every layer): `[n_frames,1,1]` broadcasts over the query and head dims.
-    scores = graph
-        .add(scores, key_mask)
-        .map_err(|source| map_err("ggml_add(attn_key_mask)", source))?;
-    let scores = graph
-        .soft_max(scores)
-        .map_err(|source| map_err("ggml_soft_max(attn_scores)", source))?;
-    // No `ggml_cont` here: `attention_context_from_probs` immediately re-permutes
-    // this tensor (its own `value_permute` step) before the value_cont that
-    // materializes it, so the two permutes compose into one and only the final
-    // `ggml_cont` needs to run.
+    // No `ggml_cont` here for naive: `attention_context_from_probs` immediately
+    // re-permutes this tensor. Fused path cont's internally.
     let v_heads = reshape_projection_to_attention_heads(
         graph,
         v,
@@ -608,11 +570,26 @@ fn firered_conformer_block<'a>(
         },
         map_err,
     )?;
-    let mut attn_out = attention_context_from_probs(
+    let element = std::mem::size_of::<f32>();
+    let rel_shift_nb1 = (2 * n_frames - 2) * element;
+    let rel_shift_nb2 = (2 * n_frames - 1) * n_frames * element;
+    let rel_shift_offset = (n_frames - 1) * element;
+    let mut attn_out = relative_position_attention_context(
         graph,
-        v_heads,
-        scores,
-        attention_layout,
+        RelativePositionAttentionInputs {
+            q_u,
+            q_v,
+            k: k_heads,
+            r: r_heads,
+            v: v_heads,
+            mask: Some(key_mask),
+            layout: attention_layout,
+            scale: 1.0 / (head_dim as f32).sqrt(),
+            rel_shift_nb1,
+            rel_shift_nb2,
+            rel_shift_offset,
+        },
+        RelativePositionAttentionSteps::DEFAULT,
         AttentionValueMergeSteps {
             value_permute: "ggml_permute(attn_v_t)",
             value_cont: "ggml_cont(attn_v_t)",
@@ -1027,39 +1004,6 @@ fn firered_conformer_block_with_taps<'a>(
         },
         map_err,
     )?;
-    let ac = graph
-        .mul_mat(k_heads, q_u)
-        .map_err(|source| map_err("ggml_mul_mat(attn_ac)", source))?;
-    let bd_raw = graph
-        .mul_mat(r_heads, q_v)
-        .map_err(|source| map_err("ggml_mul_mat(attn_bd_raw)", source))?;
-    let element = std::mem::size_of::<f32>();
-    let rel_shift_nb1 = (2 * n_frames - 2) * element;
-    let rel_shift_nb2 = (2 * n_frames - 1) * n_frames * element;
-    let rel_shift_offset = (n_frames - 1) * element;
-    let bd = graph
-        .view_3d(
-            bd_raw,
-            n_frames,
-            n_frames,
-            heads,
-            rel_shift_nb1,
-            rel_shift_nb2,
-            rel_shift_offset,
-        )
-        .map_err(|source| map_err("ggml_view_3d(relative_shift)", source))?;
-    let mut scores = graph
-        .add(ac, bd)
-        .map_err(|source| map_err("ggml_add(attn_scores)", source))?;
-    scores = graph
-        .scale(scores, 1.0 / (head_dim as f32).sqrt())
-        .map_err(|source| map_err("ggml_scale(attn_scores)", source))?;
-    scores = graph
-        .add(scores, key_mask)
-        .map_err(|source| map_err("ggml_add(attn_key_mask)", source))?;
-    let scores = graph
-        .soft_max(scores)
-        .map_err(|source| map_err("ggml_soft_max(attn_scores)", source))?;
     let v_heads = reshape_projection_to_attention_heads(
         graph,
         v,
@@ -1073,11 +1017,26 @@ fn firered_conformer_block_with_taps<'a>(
         },
         map_err,
     )?;
-    let mut attn_out_proj = attention_context_from_probs(
+    let element = std::mem::size_of::<f32>();
+    let rel_shift_nb1 = (2 * n_frames - 2) * element;
+    let rel_shift_nb2 = (2 * n_frames - 1) * n_frames * element;
+    let rel_shift_offset = (n_frames - 1) * element;
+    let mut attn_out_proj = relative_position_attention_context(
         graph,
-        v_heads,
-        scores,
-        attention_layout,
+        RelativePositionAttentionInputs {
+            q_u,
+            q_v,
+            k: k_heads,
+            r: r_heads,
+            v: v_heads,
+            mask: Some(key_mask),
+            layout: attention_layout,
+            scale: 1.0 / (head_dim as f32).sqrt(),
+            rel_shift_nb1,
+            rel_shift_nb2,
+            rel_shift_offset,
+        },
+        RelativePositionAttentionSteps::DEFAULT,
         AttentionValueMergeSteps {
             value_permute: "ggml_permute(attn_v_t)",
             value_cont: "ggml_cont(attn_v_t)",

--- a/crates/openasr-core/src/nn/attn.rs
+++ b/crates/openasr-core/src/nn/attn.rs
@@ -26,6 +26,66 @@ pub(crate) struct AttentionValueMergeSteps {
     pub context_merge_reshape: &'static str,
 }
 
+/// Shared labels for the Transformer-XL AC+BD relative-position score path so
+/// family graphs (Cohere / FastConformer / FireRed-AED) do not fork step names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RelativePositionAttentionSteps {
+    pub cont_k: &'static str,
+    pub cont_r: &'static str,
+    pub cont_q_u: &'static str,
+    pub cont_q_v: &'static str,
+    pub cont_v: &'static str,
+    pub mul_ac: &'static str,
+    pub mul_bd_raw: &'static str,
+    pub relative_shift: &'static str,
+    pub add_scores: &'static str,
+    pub scale_scores: &'static str,
+    pub add_mask: &'static str,
+    pub soft_max: &'static str,
+    pub fused: &'static str,
+    pub fused_merge: &'static str,
+}
+
+impl RelativePositionAttentionSteps {
+    pub(crate) const DEFAULT: Self = Self {
+        cont_k: "ggml_cont(attn_k)",
+        cont_r: "ggml_cont(attn_r)",
+        cont_q_u: "ggml_cont(attn_q_u)",
+        cont_q_v: "ggml_cont(attn_q_v)",
+        cont_v: "ggml_cont(attn_v)",
+        mul_ac: "ggml_mul_mat(attn_ac)",
+        mul_bd_raw: "ggml_mul_mat(attn_bd_raw)",
+        relative_shift: "ggml_view_3d(relative_shift)",
+        add_scores: "ggml_add(attn_scores)",
+        scale_scores: "ggml_scale(attn_scores)",
+        add_mask: "ggml_add(attn_key_mask)",
+        soft_max: "ggml_soft_max(attn_scores)",
+        fused: "ggml_flash_attn_rel_pos(attn)",
+        fused_merge: "ggml_reshape_2d(attn_rel_pos_merge)",
+    };
+}
+
+/// Inputs to Transformer-XL relative-position self-attention after Q/K/V/R have
+/// already been projected and reshaped into attention-head layout
+/// (`[head_dim, seq, heads]` after the standard permute).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RelativePositionAttentionInputs<'a> {
+    pub q_u: GgmlCpuTensor<'a>,
+    pub q_v: GgmlCpuTensor<'a>,
+    pub k: GgmlCpuTensor<'a>,
+    pub r: GgmlCpuTensor<'a>,
+    pub v: GgmlCpuTensor<'a>,
+    /// Optional additive F32 mask broadcast over scores (FireRed pad mask).
+    pub mask: Option<GgmlCpuTensor<'a>>,
+    pub layout: AttentionHeadLayout,
+    pub scale: f32,
+    /// Byte strides for the naive `rel_shift` view of `bd_raw`. Only used on
+    /// the non-CPU fallback path.
+    pub rel_shift_nb1: usize,
+    pub rel_shift_nb2: usize,
+    pub rel_shift_offset: usize,
+}
+
 pub(crate) fn reshape_projection_to_attention_heads<'a, E, F>(
     graph: &GgmlCpuGraphBuilder<'a>,
     projection: GgmlCpuTensor<'a>,
@@ -110,4 +170,267 @@ where
             layout.sequence_len,
         )
         .map_err(|source| map_err(steps.context_merge_reshape, source))
+}
+
+/// Shared Transformer-XL relative-position self-attention.
+///
+/// On the plain CPU backend this emits the fused
+/// `ggml_flash_attn_rel_pos` op (tile-local content + relative scores with
+/// online softmax; never materializes T x T). Non-CPU backends keep the
+/// existing mul_mat + rel_shift + soft_max fallback and never claim the fused
+/// op is supported.
+pub(crate) fn relative_position_attention_context<'a, E, F>(
+    graph: &GgmlCpuGraphBuilder<'a>,
+    inputs: RelativePositionAttentionInputs<'a>,
+    rel_steps: RelativePositionAttentionSteps,
+    merge_steps: AttentionValueMergeSteps,
+    map_err: F,
+) -> Result<GgmlCpuTensor<'a>, E>
+where
+    F: Fn(&'static str, GgmlCpuGraphError) -> E + Copy,
+{
+    if graph.supports_flash_attn_rel_pos() {
+        relative_position_attention_fused(graph, inputs, rel_steps, map_err)
+    } else {
+        relative_position_attention_naive(graph, inputs, rel_steps, merge_steps, map_err)
+    }
+}
+
+fn relative_position_attention_fused<'a, E, F>(
+    graph: &GgmlCpuGraphBuilder<'a>,
+    inputs: RelativePositionAttentionInputs<'a>,
+    rel_steps: RelativePositionAttentionSteps,
+    map_err: F,
+) -> Result<GgmlCpuTensor<'a>, E>
+where
+    F: Fn(&'static str, GgmlCpuGraphError) -> E + Copy,
+{
+    let q_u = graph
+        .cont(inputs.q_u)
+        .map_err(|source| map_err(rel_steps.cont_q_u, source))?;
+    let q_v = graph
+        .cont(inputs.q_v)
+        .map_err(|source| map_err(rel_steps.cont_q_v, source))?;
+    let k = graph
+        .cont(inputs.k)
+        .map_err(|source| map_err(rel_steps.cont_k, source))?;
+    let r = graph
+        .cont(inputs.r)
+        .map_err(|source| map_err(rel_steps.cont_r, source))?;
+    let v = graph
+        .cont(inputs.v)
+        .map_err(|source| map_err(rel_steps.cont_v, source))?;
+    let flash = graph
+        .flash_attn_rel_pos(q_u, q_v, k, r, v, inputs.mask, inputs.scale)
+        .map_err(|source| map_err(rel_steps.fused, source))?;
+    graph
+        .reshape_2d(
+            flash,
+            inputs.layout.head_dim * inputs.layout.attention_heads,
+            inputs.layout.sequence_len,
+        )
+        .map_err(|source| map_err(rel_steps.fused_merge, source))
+}
+
+fn relative_position_attention_naive<'a, E, F>(
+    graph: &GgmlCpuGraphBuilder<'a>,
+    inputs: RelativePositionAttentionInputs<'a>,
+    rel_steps: RelativePositionAttentionSteps,
+    merge_steps: AttentionValueMergeSteps,
+    map_err: F,
+) -> Result<GgmlCpuTensor<'a>, E>
+where
+    F: Fn(&'static str, GgmlCpuGraphError) -> E + Copy,
+{
+    let frame_count = inputs.layout.sequence_len;
+    let heads = inputs.layout.attention_heads;
+    let ac = graph
+        .mul_mat(
+            graph
+                .cont(inputs.k)
+                .map_err(|source| map_err(rel_steps.cont_k, source))?,
+            inputs.q_u,
+        )
+        .map_err(|source| map_err(rel_steps.mul_ac, source))?;
+    let bd_raw = graph
+        .mul_mat(
+            graph
+                .cont(inputs.r)
+                .map_err(|source| map_err(rel_steps.cont_r, source))?,
+            inputs.q_v,
+        )
+        .map_err(|source| map_err(rel_steps.mul_bd_raw, source))?;
+    let bd = graph
+        .view_3d(
+            bd_raw,
+            frame_count,
+            frame_count,
+            heads,
+            inputs.rel_shift_nb1,
+            inputs.rel_shift_nb2,
+            inputs.rel_shift_offset,
+        )
+        .map_err(|source| map_err(rel_steps.relative_shift, source))?;
+    let mut scores = graph
+        .add(ac, bd)
+        .map_err(|source| map_err(rel_steps.add_scores, source))?;
+    scores = graph
+        .scale(scores, inputs.scale)
+        .map_err(|source| map_err(rel_steps.scale_scores, source))?;
+    if let Some(mask) = inputs.mask {
+        scores = graph
+            .add(scores, mask)
+            .map_err(|source| map_err(rel_steps.add_mask, source))?;
+    }
+    let scores = graph
+        .soft_max(scores)
+        .map_err(|source| map_err(rel_steps.soft_max, source))?;
+    // Match historical FireRed/cohere layout: value heads may already be
+    // contiguous or strided; `attention_context_from_probs` re-permutes them.
+    attention_context_from_probs(graph, inputs.v, scores, inputs.layout, merge_steps, map_err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphRunner};
+
+    fn identity_map_err(step: &'static str, source: GgmlCpuGraphError) -> GgmlCpuGraphError {
+        let _ = step;
+        source
+    }
+
+    fn run_rel_pos_once(
+        force_naive: bool,
+        head_dim: usize,
+        heads: usize,
+        frames: usize,
+        seed: u32,
+    ) -> Vec<f32> {
+        let d_model = head_dim * heads;
+        let nr = 2 * frames - 1;
+        let config = GgmlCpuGraphConfig {
+            backend: GgmlCpuGraphBackend::Cpu,
+            ..GgmlCpuGraphConfig::conservative_default()
+        };
+        let mut runner = GgmlCpuGraphRunner::new(config).expect("runner");
+        let mut graph = runner.start_graph();
+
+        let q_u = graph
+            .new_tensor_3d_f32(head_dim, frames, heads, "q_u")
+            .expect("q_u");
+        let q_v = graph
+            .new_tensor_3d_f32(head_dim, frames, heads, "q_v")
+            .expect("q_v");
+        let k = graph
+            .new_tensor_3d_f32(head_dim, frames, heads, "k")
+            .expect("k");
+        let r = graph
+            .new_tensor_3d_f32(head_dim, nr, heads, "r")
+            .expect("r");
+        let v = graph
+            .new_tensor_3d_f32(head_dim, frames, heads, "v")
+            .expect("v");
+        for tensor in [q_u, q_v, k, r, v] {
+            graph.set_input(tensor).expect("set_input");
+        }
+
+        let element = std::mem::size_of::<f32>();
+        let inputs = RelativePositionAttentionInputs {
+            q_u,
+            q_v,
+            k,
+            r,
+            v,
+            mask: None,
+            layout: AttentionHeadLayout {
+                head_dim,
+                attention_heads: heads,
+                sequence_len: frames,
+            },
+            scale: 1.0 / (head_dim as f32).sqrt(),
+            rel_shift_nb1: (2 * frames - 2) * element,
+            rel_shift_nb2: (2 * frames - 1) * frames * element,
+            rel_shift_offset: (frames - 1) * element,
+        };
+        let merge = AttentionValueMergeSteps {
+            value_permute: "value_permute",
+            value_cont: "value_cont",
+            context_mul: "context_mul",
+            context_merge_permute: "merge_permute",
+            context_merge_cont: "merge_cont",
+            context_merge_reshape: "merge_reshape",
+        };
+        let out = if force_naive {
+            relative_position_attention_naive(
+                &graph,
+                inputs,
+                RelativePositionAttentionSteps::DEFAULT,
+                merge,
+                identity_map_err,
+            )
+            .expect("naive")
+        } else {
+            relative_position_attention_context(
+                &graph,
+                inputs,
+                RelativePositionAttentionSteps::DEFAULT,
+                merge,
+                identity_map_err,
+            )
+            .expect("fused_or_naive")
+        };
+        graph.set_output(out).expect("output");
+
+        let fill = |base: f32| -> Vec<f32> {
+            let mut values = vec![0.0f32; head_dim * frames * heads];
+            for (idx, slot) in values.iter_mut().enumerate() {
+                let t = (seed as f32 + base + idx as f32) * 0.017;
+                *slot = t.sin();
+            }
+            values
+        };
+        let r_fill = {
+            let mut values = vec![0.0f32; head_dim * nr * heads];
+            for (idx, slot) in values.iter_mut().enumerate() {
+                let t = (seed as f32 + 9.0 + idx as f32) * 0.013;
+                *slot = t.cos();
+            }
+            values
+        };
+
+        graph.set_f32_slice(q_u, &fill(0.0), "q_u").expect("q_u");
+        graph.set_f32_slice(q_v, &fill(1.0), "q_v").expect("q_v");
+        graph.set_f32_slice(k, &fill(2.0), "k").expect("k");
+        graph.set_f32_slice(r, &r_fill, "r").expect("r");
+        graph.set_f32_slice(v, &fill(4.0), "v").expect("v");
+        graph
+            .compute_output_f32(out, d_model * frames)
+            .expect("compute")
+    }
+
+    #[test]
+    fn fused_relative_position_attention_matches_naive_on_cpu() {
+        assert!(
+            GgmlCpuGraphRunner::new(GgmlCpuGraphConfig {
+                backend: GgmlCpuGraphBackend::Cpu,
+                ..GgmlCpuGraphConfig::conservative_default()
+            })
+            .expect("runner")
+            .start_graph()
+            .supports_flash_attn_rel_pos(),
+            "CPU backend must advertise fused relative-position attention"
+        );
+        let fused = run_rel_pos_once(false, 8, 2, 5, 3);
+        let naive = run_rel_pos_once(true, 8, 2, 5, 3);
+        assert_eq!(fused.len(), naive.len());
+        let mut max_abs = 0.0f32;
+        for (a, b) in fused.iter().zip(naive.iter()) {
+            max_abs = max_abs.max((a - b).abs());
+        }
+        assert!(
+            max_abs < 2e-5,
+            "fused vs naive max_abs_diff={max_abs} exceeds tolerance"
+        );
+    }
 }

--- a/crates/openasr-core/src/nn/encoder.rs
+++ b/crates/openasr-core/src/nn/encoder.rs
@@ -16,7 +16,8 @@
 use crate::ggml_runtime::{GgmlCpuGraphBuilder, GgmlCpuGraphError, GgmlCpuTensor};
 use crate::nn::attn::{
     AttentionHeadLayout, AttentionReshapeSteps, AttentionValueMergeSteps,
-    STANDARD_HEAD_PERMUTE_AXES, attention_context_from_probs,
+    RelativePositionAttentionInputs, RelativePositionAttentionSteps, STANDARD_HEAD_PERMUTE_AXES,
+    attention_context_from_probs, relative_position_attention_context,
     reshape_projection_to_attention_heads,
 };
 use crate::nn::ffn::{
@@ -284,42 +285,6 @@ where
         },
         map_err,
     )?;
-    let ac = graph
-        .mul_mat(
-            graph
-                .cont(k)
-                .map_err(|source| map_err("ggml_cont(attn_k)", source))?,
-            q_u,
-        )
-        .map_err(|source| map_err("ggml_mul_mat(attn_ac)", source))?;
-    let bd_raw = graph
-        .mul_mat(
-            graph
-                .cont(r)
-                .map_err(|source| map_err("ggml_cont(attn_r)", source))?,
-            q_v,
-        )
-        .map_err(|source| map_err("ggml_mul_mat(attn_bd_raw)", source))?;
-    let bd = graph
-        .view_3d(
-            bd_raw,
-            frame_count,
-            frame_count,
-            heads,
-            config.rel_shift_nb1,
-            config.rel_shift_nb2,
-            config.rel_shift_offset,
-        )
-        .map_err(|source| map_err("ggml_view_3d(relative_shift)", source))?;
-    let mut scores = graph
-        .add(ac, bd)
-        .map_err(|source| map_err("ggml_add(attn_scores)", source))?;
-    scores = graph
-        .scale(scores, 1.0 / (head_dim as f32).sqrt())
-        .map_err(|source| map_err("ggml_scale(attn_scores)", source))?;
-    let scores = graph
-        .soft_max(scores)
-        .map_err(|source| map_err("ggml_soft_max(attn_scores)", source))?;
     let v_heads = reshape_projection_to_attention_heads(
         graph,
         v,
@@ -333,11 +298,22 @@ where
         },
         map_err,
     )?;
-    let mut attn_out = attention_context_from_probs(
+    let mut attn_out = relative_position_attention_context(
         graph,
-        v_heads,
-        scores,
-        attention_layout,
+        RelativePositionAttentionInputs {
+            q_u,
+            q_v,
+            k,
+            r,
+            v: v_heads,
+            mask: None,
+            layout: attention_layout,
+            scale: 1.0 / (head_dim as f32).sqrt(),
+            rel_shift_nb1: config.rel_shift_nb1,
+            rel_shift_nb2: config.rel_shift_nb2,
+            rel_shift_offset: config.rel_shift_offset,
+        },
+        RelativePositionAttentionSteps::DEFAULT,
         AttentionValueMergeSteps {
             value_permute: "ggml_permute(attn_v_t)",
             value_cont: "ggml_cont(attn_v_t)",

--- a/tooling/ggml-sync/README.md
+++ b/tooling/ggml-sync/README.md
@@ -21,6 +21,10 @@ The current local patch stack (oldest first):
 4. Isolate that Metal pipeline cache under an `openasr/` cache subdir.
 5. Default Metal residency sets off unless the device exposes the tensor API
    (`GGML_METAL_RESIDENCY_ENABLE` / `GGML_METAL_NO_RESIDENCY` override).
+6. CPU-only fused Transformer-XL relative-position attention
+   (`GGML_OP_FLASH_ATTN_REL_POS` / `ggml_flash_attn_rel_pos`): content +
+   relative scores with online softmax, no T x T materialization. Non-CPU
+   backends leave the op unsupported.
 
 GGUF tensor shapes use upstream `gguf_get_tensor_ne`; do not restore local
 per-dimension accessors.


### PR DESCRIPTION
## Summary

Fuse Transformer-XL style relative-position attention on CPU into a single online-softmax op so long encoder contexts no longer materialize a full T×T score matrix.

## Why

CPU long-audio memory is dominated by naive relative-position attention buffers. A fused online-softmax path keeps the TXL shift algebra while dropping the quadratic materialization on CPU. Other backends stay fail-closed on the new op.

## Changes

- Add CPU-only `GGML_OP_FLASH_ATTN_REL_POS` / `ggml_flash_attn_rel_pos` in vendored openasr-ggml (local patch, replay documented).
- Shared wrapper `relative_position_attention_context` in `nn/attn.rs`.
- Wire Cohere / FastConformer-style encoder paths and FireRed-AED (pad mask preserved).
- Leave MOSS/Qwen flash paths untouched.
- Metal/CUDA/other backends reject the op; RPC/backend-meta/op count wired for the new opcode.
- Short golden/unit coverage with documented numeric tolerance.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Targeted encoder/attention unit and short golden checks on the branch
- [ ] `cargo nextest run --workspace` (fill after final gate)
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

- None claimed beyond unit/golden correctness on this PR.

## Docs updated

- [x] `tooling/ggml-sync/README.md` notes the local rel-pos patch.
- [x] No docs overclaim GPU support for the fused op.

## Scope / non-goals

CPU fused path only. Does not claim RTF wins without a quiet-window measurement, does not implement Metal fused rel-pos, does not change Qwen/MOSS flash-attn.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] Vendored runtime sources only under `crates/openasr-core/third_party/openasr-ggml` as a documented local patch.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
