### PR TITLE
feat(qwen): add shared phase-1 q8_0 KV cache path

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -1844,6 +1844,24 @@ impl GgmlStaticTensorArena {
         )
     }
 
+    pub(crate) fn set_bytes_slice_with_offset(
+        &mut self,
+        tensor: GgmlStaticTensor,
+        offset_bytes: usize,
+        values: &[u8],
+        tensor_name: &'static str,
+    ) -> Result<(), GgmlCpuGraphError> {
+        self.ensure_backend_buffer()?;
+        self.write_tensor_bytes_checked(
+            tensor,
+            values.as_ptr().cast::<c_void>(),
+            offset_bytes,
+            values.len(),
+            tensor_name,
+            true,
+        )
+    }
+
     #[cfg(test)]
     pub(crate) fn read_f16_bits_slice(
         &self,
@@ -2814,12 +2832,12 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         self.ensure_tensor_type(q, ffi::GGML_TYPE_F32, "ggml_flash_attn_ext q")?;
         self.ensure_tensor_type_in(
             k,
-            &[ffi::GGML_TYPE_F16, ffi::GGML_TYPE_F32],
+            &[ffi::GGML_TYPE_F16, ffi::GGML_TYPE_F32, ffi::GGML_TYPE_Q8_0],
             "ggml_flash_attn_ext k",
         )?;
         self.ensure_tensor_type_in(
             v,
-            &[ffi::GGML_TYPE_F16, ffi::GGML_TYPE_F32],
+            &[ffi::GGML_TYPE_F16, ffi::GGML_TYPE_F32, ffi::GGML_TYPE_Q8_0],
             "ggml_flash_attn_ext v",
         )?;
         if self.tensor_type(k) != self.tensor_type(v) {
@@ -2827,6 +2845,10 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 reason: "ggml_flash_attn_ext requires matching k/v tensor types",
             });
         }
+        self.ensure_kv_element_type_supported_on_backend(
+            self.tensor_type(k),
+            "ggml_flash_attn_ext",
+        )?;
         self.ensure_tensor_contiguous_rows(q, "ggml_flash_attn_ext q")?;
         self.ensure_tensor_contiguous_rows(k, "ggml_flash_attn_ext k")?;
         self.ensure_tensor_contiguous_rows(v, "ggml_flash_attn_ext v")?;
@@ -3415,9 +3437,10 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         self.ensure_can_extend_graph("ggml_set_rows")?;
         self.ensure_tensor_type_in(
             dst,
-            &[ffi::GGML_TYPE_F16, ffi::GGML_TYPE_F32],
+            &[ffi::GGML_TYPE_F16, ffi::GGML_TYPE_F32, ffi::GGML_TYPE_Q8_0],
             "ggml_set_rows dst",
         )?;
+        self.ensure_kv_element_type_supported_on_backend(self.tensor_type(dst), "ggml_set_rows")?;
         self.ensure_tensor_type(src, ffi::GGML_TYPE_F32, "ggml_set_rows src")?;
         self.ensure_tensor_type(row_indices, ffi::GGML_TYPE_I32, "ggml_set_rows indices")?;
         self.ensure_tensor_rowwise_contiguous(src, "ggml_set_rows src")?;
@@ -3912,6 +3935,23 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             tensor,
             values.as_ptr().cast::<c_void>(),
             0,
+            values.len(),
+            tensor_name,
+        )
+    }
+
+    pub(crate) fn set_bytes_slice_with_offset(
+        &mut self,
+        tensor: GgmlCpuTensor<'a>,
+        offset_bytes: usize,
+        values: &[u8],
+        tensor_name: &'static str,
+    ) -> Result<(), GgmlCpuGraphError> {
+        self.ensure_backend_buffer()?;
+        self.write_tensor_bytes_checked(
+            tensor,
+            values.as_ptr().cast::<c_void>(),
+            offset_bytes,
             values.len(),
             tensor_name,
         )
@@ -4532,8 +4572,8 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 "ggml_mul_mat lhs" => "ggml_mul_mat lhs must be f16/f32/q4_0/q8_0/q4_k",
                 "ggml_mul_mat rhs" => "ggml_mul_mat rhs must be f16 or f32",
                 "ggml_soft_max_ext mask" => "ggml_soft_max_ext mask must be f16 or f32",
-                "ggml_flash_attn_ext k" => "ggml_flash_attn_ext k must be f16 or f32",
-                "ggml_flash_attn_ext v" => "ggml_flash_attn_ext v must be f16 or f32",
+                "ggml_flash_attn_ext k" => "ggml_flash_attn_ext k must be f16, f32, or q8_0",
+                "ggml_flash_attn_ext v" => "ggml_flash_attn_ext v must be f16, f32, or q8_0",
                 "ggml_get_rows embeddings" => "ggml_get_rows embeddings must be f16 or f32",
                 "ggml_view_1d input" => "ggml_view_1d input type is unsupported",
                 "ggml_view_2d input" => "ggml_view_2d input type is unsupported",
@@ -4541,8 +4581,38 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 "ggml_view_4d input" => "ggml_view_4d input type is unsupported",
                 "ggml_permute input" => "ggml_permute input type is unsupported",
                 "ggml_cast input" => "ggml_cast input type is unsupported",
-                "ggml_set_rows dst" => "ggml_set_rows dst must be f16 or f32",
+                "ggml_set_rows dst" => "ggml_set_rows dst must be f16, f32, or q8_0",
                 _ => "operation input type is unsupported",
+            },
+        })
+    }
+
+    /// Phase-1 Q8 KV is fail-closed outside CPU/Metal. F16/F32 keep the existing
+    /// multi-backend surface; unknown types are rejected by the caller's type list.
+    fn ensure_kv_element_type_supported_on_backend(
+        &self,
+        type_: i32,
+        op: &'static str,
+    ) -> Result<(), GgmlCpuGraphError> {
+        if type_ != ffi::GGML_TYPE_Q8_0 {
+            return Ok(());
+        }
+        let backend = self.backend_kind();
+        if matches!(
+            backend,
+            GgmlCpuGraphBackend::Cpu | GgmlCpuGraphBackend::Metal
+        ) {
+            return Ok(());
+        }
+        Err(GgmlCpuGraphError::UnsupportedInputs {
+            reason: match op {
+                "ggml_flash_attn_ext" => {
+                    "ggml_flash_attn_ext q8_0 KV is only supported on CPU/Metal in phase 1"
+                }
+                "ggml_set_rows" => {
+                    "ggml_set_rows q8_0 KV is only supported on CPU/Metal in phase 1"
+                }
+                _ => "q8_0 KV is only supported on CPU/Metal in phase 1",
             },
         })
     }
@@ -7652,6 +7722,89 @@ mod tests {
             .compute_output_f32(output, 8)
             .expect("kv cache graph should compute");
         assert_eq!(output, vec![1.0, 2.0, 5.0, 6.0, 7.0, 8.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn set_rows_and_flash_attn_accept_q8_0_kv_on_cpu() {
+        // Tiny native-GQA-shaped flash path: q heads=2, kv heads=1, head_dim=32.
+        const HEAD_DIM: usize = 32;
+        const KV_SPAN: usize = 2;
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("cpu graph runner should initialize");
+        let mut arena = runner
+            .start_static_tensor_arena(GgmlCpuGraphConfig::default().context_bytes)
+            .expect("static arena should initialize");
+        let key = arena
+            .new_tensor_4d_typed(HEAD_DIM, KV_SPAN, 1, 1, ffi::GGML_TYPE_Q8_0, "q8_k")
+            .expect("q8 key");
+        let value = arena
+            .new_tensor_4d_typed(HEAD_DIM, KV_SPAN, 1, 1, ffi::GGML_TYPE_Q8_0, "q8_v")
+            .expect("q8 value");
+        let zero =
+            vec![
+                0_u8;
+                unsafe { ffi::ggml_row_size(ffi::GGML_TYPE_Q8_0, HEAD_DIM as i64) * KV_SPAN }
+            ];
+        arena.set_bytes_slice(key, &zero, "q8_k").expect("zero key");
+        arena
+            .set_bytes_slice(value, &zero, "q8_v")
+            .expect("zero value");
+
+        let mut graph = runner.start_graph();
+        let q = graph.new_tensor_4d_f32(HEAD_DIM, 1, 2, 1, "q").expect("q");
+        let src_k = graph
+            .new_tensor_4d_f32(HEAD_DIM, 1, 1, 1, "src_k")
+            .expect("src_k");
+        let src_v = graph
+            .new_tensor_4d_f32(HEAD_DIM, 1, 1, 1, "src_v")
+            .expect("src_v");
+        let rows = graph.new_tensor_1d_i32(1, "rows").expect("rows");
+        graph.set_input(q).expect("q input");
+        graph.set_input(src_k).expect("src_k input");
+        graph.set_input(src_v).expect("src_v input");
+        graph.set_input(rows).expect("rows input");
+
+        let key_t = arena.graph_tensor(key);
+        let value_t = arena.graph_tensor(value);
+        let write_k = graph.set_rows(key_t, src_k, rows).expect("set_rows q8 k");
+        let write_v = graph.set_rows(value_t, src_v, rows).expect("set_rows q8 v");
+        graph.add_side_effect_root(write_k).expect("k side effect");
+        graph.add_side_effect_root(write_v).expect("v side effect");
+        let attended = graph
+            .flash_attn_ext(
+                q,
+                key_t,
+                value_t,
+                None,
+                1.0 / (HEAD_DIM as f32).sqrt(),
+                0.0,
+                0.0,
+            )
+            .expect("flash_attn q8");
+        graph.set_output(attended).expect("output");
+
+        let mut q_vals = vec![0.0_f32; HEAD_DIM * 2];
+        let mut kv_vals = vec![0.0_f32; HEAD_DIM];
+        for i in 0..HEAD_DIM {
+            q_vals[i] = 0.01 * (i as f32);
+            q_vals[HEAD_DIM + i] = -0.01 * (i as f32);
+            kv_vals[i] = 0.02 * (i as f32) - 0.3;
+        }
+        graph.set_f32_slice(q, &q_vals, "q").expect("q upload");
+        graph
+            .set_f32_slice(src_k, &kv_vals, "src_k")
+            .expect("src_k upload");
+        graph
+            .set_f32_slice(src_v, &kv_vals, "src_v")
+            .expect("src_v upload");
+        graph
+            .set_i32_slice(rows, &[0], "rows")
+            .expect("rows upload");
+        let output = graph
+            .compute_output_f32(attended, HEAD_DIM * 2)
+            .expect("q8 flash path should compute");
+        assert!(output.iter().all(|v| v.is_finite()));
+        assert!(output.iter().any(|v| *v != 0.0));
     }
 
     #[test]

--- a/crates/openasr-core/src/ggml_runtime/kv_element.rs
+++ b/crates/openasr-core/src/ggml_runtime/kv_element.rs
@@ -1,0 +1,297 @@
+//! Shared KV-cache element types for decoder-only LLM paths.
+//!
+//! Runtime temporary state only: never part of `.oasr` packs, catalog tags, or
+//! model signatures. Host and resident storage share this vocabulary so every
+//! Qwen-shaped family (qwen3-asr / mimo / firered2-llm / moss) can opt into the
+//! same typed path without copying quant logic.
+
+use std::ffi::c_void;
+
+use super::cpu_graph::GgmlCpuGraphBackend;
+use super::ffi;
+
+/// Element type used by host-side and/or device-resident LLM KV caches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum GgmlKvElementType {
+    F32,
+    F16,
+    Q8_0,
+}
+
+impl GgmlKvElementType {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::F32 => "f32",
+            Self::F16 => "f16",
+            Self::Q8_0 => "q8_0",
+        }
+    }
+
+    pub(crate) const fn ggml_type(self) -> i32 {
+        match self {
+            Self::F32 => ffi::GGML_TYPE_F32,
+            Self::F16 => ffi::GGML_TYPE_F16,
+            Self::Q8_0 => ffi::GGML_TYPE_Q8_0,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) const fn is_quantized(self) -> bool {
+        matches!(self, Self::Q8_0)
+    }
+
+    pub(crate) fn block_size(self) -> usize {
+        let blck = unsafe { ffi::ggml_blck_size(self.ggml_type()) };
+        usize::try_from(blck).unwrap_or(0)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn type_size(self) -> usize {
+        unsafe { ffi::ggml_type_size(self.ggml_type()) }
+    }
+
+    /// Bytes for one logical row of `head_dim` values (one KV head at one position).
+    pub(crate) fn row_nbytes(self, head_dim: usize) -> Result<usize, String> {
+        self.validate_head_dim(head_dim)?;
+        let ne0 = i64::try_from(head_dim).map_err(|_| {
+            format!(
+                "kv element type {}: head_dim={head_dim} does not fit i64",
+                self.as_str()
+            )
+        })?;
+        let nbytes = unsafe { ffi::ggml_row_size(self.ggml_type(), ne0) };
+        if nbytes == 0 {
+            return Err(format!(
+                "kv element type {}: ggml_row_size(head_dim={head_dim}) returned 0",
+                self.as_str()
+            ));
+        }
+        Ok(nbytes)
+    }
+
+    pub(crate) fn plane_nbytes(
+        self,
+        head_dim: usize,
+        max_positions: usize,
+        kv_heads: usize,
+    ) -> Result<usize, String> {
+        let row = self.row_nbytes(head_dim)?;
+        row.checked_mul(max_positions)
+            .and_then(|n| n.checked_mul(kv_heads))
+            .ok_or_else(|| {
+                format!(
+                    "kv element type {}: plane byte count overflow (head_dim={head_dim}, max_positions={max_positions}, kv_heads={kv_heads})",
+                    self.as_str()
+                )
+            })
+    }
+
+    pub(crate) fn validate_head_dim(self, head_dim: usize) -> Result<(), String> {
+        if head_dim == 0 {
+            return Err(format!(
+                "kv element type {}: head_dim must be positive",
+                self.as_str()
+            ));
+        }
+        let block = self.block_size();
+        if block == 0 {
+            return Err(format!(
+                "kv element type {}: ggml block size is unavailable",
+                self.as_str()
+            ));
+        }
+        if !head_dim.is_multiple_of(block) {
+            return Err(format!(
+                "kv element type {}: head_dim={head_dim} is not divisible by block_size={block}",
+                self.as_str()
+            ));
+        }
+        Ok(())
+    }
+
+    /// Phase-1 Q8 is CPU/Metal only. F16/F32 keep the existing backend surface.
+    pub(crate) fn supports_backend(self, backend: GgmlCpuGraphBackend) -> bool {
+        match self {
+            Self::F32 | Self::F16 => true,
+            Self::Q8_0 => matches!(
+                backend,
+                GgmlCpuGraphBackend::Cpu | GgmlCpuGraphBackend::Metal
+            ),
+        }
+    }
+
+    /// Quantize `row_count` contiguous rows of `head_dim` f32 values into the
+    /// native ggml layout for this type. F32/F16 are not quantized here.
+    pub(crate) fn quantize_rows_from_f32(
+        self,
+        values: &[f32],
+        head_dim: usize,
+        row_count: usize,
+    ) -> Result<Vec<u8>, String> {
+        match self {
+            Self::F32 | Self::F16 => Err(format!(
+                "kv element type {}: quantize_rows_from_f32 is only valid for quantized types",
+                self.as_str()
+            )),
+            Self::Q8_0 => quantize_q8_0_rows(values, head_dim, row_count),
+        }
+    }
+}
+
+fn quantize_q8_0_rows(
+    values: &[f32],
+    head_dim: usize,
+    row_count: usize,
+) -> Result<Vec<u8>, String> {
+    GgmlKvElementType::Q8_0.validate_head_dim(head_dim)?;
+    if row_count == 0 {
+        return Ok(Vec::new());
+    }
+    let expected_elems = head_dim.checked_mul(row_count).ok_or_else(|| {
+        format!("q8_0 quantize element count overflow (head_dim={head_dim}, rows={row_count})")
+    })?;
+    if values.len() != expected_elems {
+        return Err(format!(
+            "q8_0 quantize input length mismatch: got {} values, expected {expected_elems} (head_dim={head_dim}, rows={row_count})",
+            values.len()
+        ));
+    }
+    if values.iter().any(|v| !v.is_finite()) {
+        return Err("q8_0 quantize rejected non-finite values".to_string());
+    }
+    let row_nbytes = GgmlKvElementType::Q8_0.row_nbytes(head_dim)?;
+    let expected_bytes = row_nbytes.checked_mul(row_count).ok_or_else(|| {
+        format!("q8_0 quantize byte count overflow (row_nbytes={row_nbytes}, rows={row_count})")
+    })?;
+    let mut bytes = vec![0_u8; expected_bytes];
+    let head_dim_i64 = i64::try_from(head_dim)
+        .map_err(|_| format!("q8_0 quantize head_dim={head_dim} does not fit i64"))?;
+    let row_count_i64 = i64::try_from(row_count)
+        .map_err(|_| format!("q8_0 quantize row_count={row_count} does not fit i64"))?;
+    let produced = unsafe {
+        ffi::ggml_quantize_chunk(
+            ffi::GGML_TYPE_Q8_0,
+            values.as_ptr(),
+            bytes.as_mut_ptr().cast::<c_void>(),
+            0,
+            row_count_i64,
+            head_dim_i64,
+            std::ptr::null(),
+        )
+    };
+    if produced != expected_bytes {
+        return Err(format!(
+            "q8_0 quantize size mismatch: expected {expected_bytes} bytes, got {produced}"
+        ));
+    }
+    Ok(bytes)
+}
+
+/// Dequantize packed q8_0 rows back to f32 for tests and diagnostics.
+#[cfg(test)]
+pub(crate) fn dequantize_q8_0_rows(
+    bytes: &[u8],
+    head_dim: usize,
+    row_count: usize,
+) -> Result<Vec<f32>, String> {
+    GgmlKvElementType::Q8_0.validate_head_dim(head_dim)?;
+    if row_count == 0 {
+        return Ok(Vec::new());
+    }
+    let row_nbytes = GgmlKvElementType::Q8_0.row_nbytes(head_dim)?;
+    let expected_bytes = row_nbytes.checked_mul(row_count).ok_or_else(|| {
+        format!("q8_0 dequantize byte count overflow (row_nbytes={row_nbytes}, rows={row_count})")
+    })?;
+    if bytes.len() != expected_bytes {
+        return Err(format!(
+            "q8_0 dequantize input length mismatch: got {} bytes, expected {expected_bytes}",
+            bytes.len()
+        ));
+    }
+    let traits_ptr = unsafe { ffi::ggml_get_type_traits(ffi::GGML_TYPE_Q8_0) };
+    if traits_ptr.is_null() {
+        return Err("q8_0 type traits unavailable".to_string());
+    }
+    let to_float = unsafe { (*traits_ptr).to_float }
+        .ok_or_else(|| "q8_0 type traits missing to_float".to_string())?;
+    let mut out = vec![0.0_f32; head_dim.saturating_mul(row_count)];
+    let head_dim_i64 = i64::try_from(head_dim)
+        .map_err(|_| format!("q8_0 dequantize head_dim={head_dim} does not fit i64"))?;
+    for row in 0..row_count {
+        let src_off = row
+            .checked_mul(row_nbytes)
+            .ok_or_else(|| "q8_0 dequantize source offset overflow".to_string())?;
+        let dst_off = row
+            .checked_mul(head_dim)
+            .ok_or_else(|| "q8_0 dequantize destination offset overflow".to_string())?;
+        unsafe {
+            to_float(
+                bytes.as_ptr().add(src_off).cast::<c_void>(),
+                out.as_mut_ptr().add(dst_off),
+                head_dim_i64,
+            );
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn q8_0_row_layout_matches_ggml_block_geometry() {
+        let head_dim = 128;
+        assert_eq!(GgmlKvElementType::Q8_0.block_size(), 32);
+        assert_eq!(GgmlKvElementType::Q8_0.type_size(), 34);
+        assert_eq!(
+            GgmlKvElementType::Q8_0.row_nbytes(head_dim).expect("row"),
+            136
+        );
+        assert_eq!(
+            GgmlKvElementType::Q8_0
+                .plane_nbytes(head_dim, 8, 2)
+                .expect("plane"),
+            136 * 8 * 2
+        );
+        assert!(GgmlKvElementType::Q8_0.validate_head_dim(40).is_err());
+        assert!(GgmlKvElementType::Q8_0.validate_head_dim(0).is_err());
+    }
+
+    #[test]
+    fn q8_0_quantize_roundtrips_within_block_scale_tolerance() {
+        let head_dim = 64;
+        let row_count = 3;
+        let mut values = Vec::with_capacity(head_dim * row_count);
+        for row in 0..row_count {
+            for dim in 0..head_dim {
+                values.push((row as f32) * 0.25 + (dim as f32) * 0.01 - 0.5);
+            }
+        }
+        let bytes = GgmlKvElementType::Q8_0
+            .quantize_rows_from_f32(&values, head_dim, row_count)
+            .expect("quantize");
+        let restored = dequantize_q8_0_rows(&bytes, head_dim, row_count).expect("dequant");
+        assert_eq!(restored.len(), values.len());
+        let mut max_abs = 0.0_f32;
+        for (a, b) in values.iter().zip(restored.iter()) {
+            max_abs = max_abs.max((a - b).abs());
+        }
+        // q8_0 is 8-bit with per-32-block scale; unit-scale rows stay well under 0.05.
+        assert!(
+            max_abs < 0.05,
+            "q8_0 roundtrip max abs err {max_abs} exceeded tolerance"
+        );
+    }
+
+    #[test]
+    fn q8_0_backend_surface_is_cpu_and_metal_only() {
+        assert!(GgmlKvElementType::Q8_0.supports_backend(GgmlCpuGraphBackend::Cpu));
+        assert!(GgmlKvElementType::Q8_0.supports_backend(GgmlCpuGraphBackend::Metal));
+        assert!(!GgmlKvElementType::Q8_0.supports_backend(GgmlCpuGraphBackend::Gpu));
+        assert!(GgmlKvElementType::F16.supports_backend(GgmlCpuGraphBackend::Gpu));
+        assert!(GgmlKvElementType::Q8_0.is_quantized());
+        assert!(!GgmlKvElementType::F32.is_quantized());
+        assert_eq!(GgmlKvElementType::Q8_0.type_size(), 34);
+    }
+}

--- a/crates/openasr-core/src/ggml_runtime/mod.rs
+++ b/crates/openasr-core/src/ggml_runtime/mod.rs
@@ -8,6 +8,7 @@ mod gguf_metadata;
 mod gguf_tensor_data;
 mod gguf_tensor_index;
 mod gguf_write;
+mod kv_element;
 mod package_probe;
 mod runtime_source;
 
@@ -55,6 +56,9 @@ pub(crate) use gguf_write::{
     GgufWriteTensor, GgufWriteTensorType, GgufWriteValue, quantize_f32_to_ggml_tensor_data,
     write_gguf_file_v0,
 };
+pub(crate) use kv_element::GgmlKvElementType;
+#[cfg(test)]
+pub(crate) use kv_element::dequantize_q8_0_rows;
 pub use package_probe::{
     GgmlPackageExtensionHint, GgmlPackageFormat, GgmlPackageModelIdentityProbe, GgmlPackageProbe,
     GgmlPackageProbeError, OPENASR_RUNTIME_PACK_EXTENSION, has_openasr_runtime_pack_extension,

--- a/crates/openasr-core/src/models/firered_llm/llm_transformer.rs
+++ b/crates/openasr-core/src/models/firered_llm/llm_transformer.rs
@@ -196,13 +196,18 @@ impl FireRedLlmDecoderRuntime {
     /// `qwen::ggml_executor`'s own `decode_prompt.token_ids.len()
     /// .saturating_add(decode_config.max_generated_tokens)` sizing.
     pub(crate) fn new_kv_caches(&self, capacity: usize) -> Vec<Qwen3AsrLayerKvCacheState> {
+        let host = self.whole_decoder.kv_cache_spec().host;
         (0..self.metadata.n_layers)
             .map(|_| {
-                Qwen3AsrLayerKvCacheState::new(
+                Qwen3AsrLayerKvCacheState::new_with_element_type(
                     capacity,
                     self.metadata.n_kv_heads,
                     self.metadata.head_dim,
+                    host,
                 )
+                .unwrap_or_else(|reason| {
+                    panic!("shared LLM KV cache geometry rejected host type: {reason}")
+                })
             })
             .collect()
     }

--- a/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
+++ b/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
@@ -148,13 +148,18 @@ impl MimoLlmDecoderRuntime {
     /// persistent reuse graph's fixed attention span on Metal/GPU, which is a
     /// per-token compute cost there, not just a host allocation ceiling.
     pub(crate) fn new_kv_caches(&self, capacity: usize) -> Vec<Qwen3AsrLayerKvCacheState> {
+        let host = self.whole_decoder.kv_cache_spec().host;
         (0..self.metadata.n_layers)
             .map(|_| {
-                Qwen3AsrLayerKvCacheState::new(
+                Qwen3AsrLayerKvCacheState::new_with_element_type(
                     capacity,
                     self.metadata.n_kv_heads,
                     self.metadata.head_dim,
+                    host,
                 )
+                .unwrap_or_else(|reason| {
+                    panic!("shared LLM KV cache geometry rejected host type: {reason}")
+                })
             })
             .collect()
     }

--- a/crates/openasr-core/src/models/moonshine/decoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/decoder_graph.rs
@@ -476,6 +476,7 @@ impl MoonshineDecoderGraphRuntime {
                 self.metadata.n_heads,
                 self.n_seq,
                 "moonshine_decoder_resident_kv",
+                crate::nn::decoder::LlmKvCacheSpec::DEFAULT,
             )
             .map_err(build_err("moonshine_resident_self_kv"))?,
         );

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -197,13 +197,18 @@ impl MossTdDecoderRuntime {
     /// `decode_prompt.token_ids.len().saturating_add(decode_config.max_generated_tokens)`.
     pub(crate) fn new_kv_caches(&self, capacity: usize) -> Vec<Qwen3AsrLayerKvCacheState> {
         let cache_positions = capacity.min(moss_td_kv_cache_positions(self.metadata.max_positions));
+        let host = self.whole_decoder.kv_cache_spec().host;
         (0..self.metadata.n_layers)
             .map(|_| {
-                Qwen3AsrLayerKvCacheState::new(
+                Qwen3AsrLayerKvCacheState::new_with_element_type(
                     cache_positions,
                     self.metadata.n_kv_heads,
                     self.metadata.head_dim,
+                    host,
                 )
+                .unwrap_or_else(|reason| {
+                    panic!("shared LLM KV cache geometry rejected host type: {reason}")
+                })
             })
             .collect()
     }

--- a/crates/openasr-core/src/models/qwen/batched_decode.rs
+++ b/crates/openasr-core/src/models/qwen/batched_decode.rs
@@ -2609,8 +2609,10 @@ mod tests {
             assert_eq!(snapshot.value_width, 4);
             let history = layer.full_history_storage().expect("history");
             assert_eq!(history.written_positions, 1);
-            assert!(history.keys.iter().all(|&value| value == 0.0));
-            assert!(history.values.iter().all(|&value| value == 0.0));
+            let keys = history.keys_f32.expect("f32 keys");
+            let values = history.values_f32.expect("f32 values");
+            assert!(keys.iter().all(|&value| value == 0.0));
+            assert!(values.iter().all(|&value| value == 0.0));
         }
     }
 

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -553,14 +553,18 @@ impl Qwen3AsrGgmlExecutor {
         let kv_cache_started_at = qwen_decode_profile_start();
         let layer_kv_caches = (0..metadata.llm_layers)
             .map(|_| {
-                Qwen3AsrLayerKvCacheState::new(
+                Qwen3AsrLayerKvCacheState::new_with_element_type(
                     decode_prompt
                         .token_ids
                         .len()
                         .saturating_add(decode_config.max_generated_tokens),
                     metadata.llm_kv_heads,
                     metadata.llm_head_dim,
+                    whole_decoder.kv_cache_spec().host,
                 )
+                .unwrap_or_else(|reason| {
+                    panic!("shared LLM KV cache geometry rejected host type: {reason}")
+                })
             })
             .collect();
         qwen_decode_profile_log_opt("layer_kv_cache_alloc", kv_cache_started_at);

--- a/crates/openasr-core/src/models/qwen/kv_cache.rs
+++ b/crates/openasr-core/src/models/qwen/kv_cache.rs
@@ -1,13 +1,61 @@
-use crate::ggml_runtime::{GgmlCpuGraphBuilder, GgmlCpuGraphError, GgmlCpuTensor};
+use crate::ggml_runtime::{
+    GgmlCpuGraphBuilder, GgmlCpuGraphError, GgmlCpuTensor, GgmlKvElementType,
+};
 
+/// Per-layer host KV cache shared by every Qwen-shaped decoder family.
+///
+/// Default storage is f32 (byte-identical to the historical path). Opt-in
+/// `q8_0` stores native ggml q8_0 rows so host and resident paths share the
+/// same packed layout without a full f32 staging buffer.
 #[derive(Debug, Clone)]
 pub(crate) struct Qwen3AsrLayerKvCacheState {
     max_positions: usize,
     kv_heads: usize,
     head_dim: usize,
-    keys: Vec<f32>,
-    values: Vec<f32>,
+    element_type: GgmlKvElementType,
+    keys: HostKvStorage,
+    values: HostKvStorage,
     written_positions: usize,
+}
+
+#[derive(Debug, Clone)]
+enum HostKvStorage {
+    F32(Vec<f32>),
+    Q8(Vec<u8>),
+}
+
+impl HostKvStorage {
+    fn empty(element_type: GgmlKvElementType) -> Self {
+        match element_type {
+            GgmlKvElementType::F32 => Self::F32(Vec::new()),
+            GgmlKvElementType::Q8_0 => Self::Q8(Vec::new()),
+            GgmlKvElementType::F16 => {
+                // Host path never uses f16; resident path owns f16.
+                Self::F32(Vec::new())
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::F32(v) => v.is_empty(),
+            Self::Q8(v) => v.is_empty(),
+        }
+    }
+
+    fn f32_slice(&self) -> Result<&[f32], String> {
+        match self {
+            Self::F32(v) => Ok(v.as_slice()),
+            Self::Q8(_) => Err("host kv storage is q8_0, not f32".to_string()),
+        }
+    }
+
+    fn q8_slice(&self) -> Result<&[u8], String> {
+        match self {
+            Self::Q8(v) => Ok(v.as_slice()),
+            Self::F32(_) => Err("host kv storage is f32, not q8_0".to_string()),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -16,6 +64,7 @@ pub(crate) struct Qwen3AsrLayerKvCacheSnapshot {
     pub written_positions: usize,
     pub key_width: usize,
     pub value_width: usize,
+    pub element_type: GgmlKvElementType,
 }
 
 pub(crate) struct Qwen3AsrLayerKvCacheHistory<'a> {
@@ -23,20 +72,46 @@ pub(crate) struct Qwen3AsrLayerKvCacheHistory<'a> {
     pub kv_heads: usize,
     pub head_dim: usize,
     pub written_positions: usize,
-    pub keys: &'a [f32],
-    pub values: &'a [f32],
+    #[allow(dead_code)]
+    pub element_type: GgmlKvElementType,
+    pub keys_f32: Option<&'a [f32]>,
+    pub values_f32: Option<&'a [f32]>,
+    pub keys_q8: Option<&'a [u8]>,
+    pub values_q8: Option<&'a [u8]>,
 }
 
 impl Qwen3AsrLayerKvCacheState {
     pub(crate) fn new(max_positions: usize, kv_heads: usize, head_dim: usize) -> Self {
-        Self {
+        Self::new_with_element_type(max_positions, kv_heads, head_dim, GgmlKvElementType::F32)
+            .expect("f32 host KV geometry is always valid")
+    }
+
+    pub(crate) fn new_with_element_type(
+        max_positions: usize,
+        kv_heads: usize,
+        head_dim: usize,
+        element_type: GgmlKvElementType,
+    ) -> Result<Self, String> {
+        match element_type {
+            GgmlKvElementType::F32 | GgmlKvElementType::Q8_0 => {}
+            GgmlKvElementType::F16 => {
+                return Err("host KV cache does not use f16 storage; use resident f16".to_string());
+            }
+        }
+        element_type.validate_head_dim(head_dim)?;
+        Ok(Self {
             max_positions,
             kv_heads,
             head_dim,
-            keys: Vec::new(),
-            values: Vec::new(),
+            element_type,
+            keys: HostKvStorage::empty(element_type),
+            values: HostKvStorage::empty(element_type),
             written_positions: 0,
-        }
+        })
+    }
+
+    pub(crate) fn element_type(&self) -> GgmlKvElementType {
+        self.element_type
     }
 
     pub(crate) fn write(
@@ -71,22 +146,64 @@ impl Qwen3AsrLayerKvCacheState {
             ));
         }
 
-        Self::write_history_row(
-            &mut self.keys,
-            self.max_positions,
-            self.kv_heads,
-            self.head_dim,
-            position,
-            key,
-        )?;
-        Self::write_history_row(
-            &mut self.values,
-            self.max_positions,
-            self.kv_heads,
-            self.head_dim,
-            position,
-            value,
-        )?;
+        match self.element_type {
+            GgmlKvElementType::F32 => {
+                let keys = match &mut self.keys {
+                    HostKvStorage::F32(v) => v,
+                    HostKvStorage::Q8(_) => unreachable!("f32 element type with q8 storage"),
+                };
+                let values = match &mut self.values {
+                    HostKvStorage::F32(v) => v,
+                    HostKvStorage::Q8(_) => unreachable!("f32 element type with q8 storage"),
+                };
+                Self::write_history_row_f32(
+                    keys,
+                    self.max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    position,
+                    key,
+                )?;
+                Self::write_history_row_f32(
+                    values,
+                    self.max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    position,
+                    value,
+                )?;
+            }
+            GgmlKvElementType::Q8_0 => {
+                let row_nbytes = self.element_type.row_nbytes(self.head_dim)?;
+                let keys = match &mut self.keys {
+                    HostKvStorage::Q8(v) => v,
+                    HostKvStorage::F32(_) => unreachable!("q8 element type with f32 storage"),
+                };
+                let values = match &mut self.values {
+                    HostKvStorage::Q8(v) => v,
+                    HostKvStorage::F32(_) => unreachable!("q8 element type with f32 storage"),
+                };
+                Self::write_history_row_q8(
+                    keys,
+                    self.max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    row_nbytes,
+                    position,
+                    key,
+                )?;
+                Self::write_history_row_q8(
+                    values,
+                    self.max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    row_nbytes,
+                    position,
+                    value,
+                )?;
+            }
+            GgmlKvElementType::F16 => unreachable!("host KV rejects f16"),
+        }
         self.written_positions = self.written_positions.max(position.saturating_add(1));
         Ok(())
     }
@@ -140,41 +257,108 @@ impl Qwen3AsrLayerKvCacheState {
             });
         }
 
-        let per_head_len =
-            token_count
-                .checked_mul(self.head_dim)
-                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "qwen kv-cache upload prefix overflow",
+        match self.element_type {
+            GgmlKvElementType::F32 => {
+                let per_head_len = token_count.checked_mul(self.head_dim).ok_or(
+                    GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "qwen kv-cache upload prefix overflow",
+                    },
+                )?;
+                let per_head_stride = kv_span.checked_mul(self.head_dim).ok_or(
+                    GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "qwen kv-cache upload stride overflow",
+                    },
+                )?;
+                let keys =
+                    self.keys
+                        .f32_slice()
+                        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "qwen kv-cache upload f32 storage missing",
+                        })?;
+                let values =
+                    self.values
+                        .f32_slice()
+                        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "qwen kv-cache upload f32 storage missing",
+                        })?;
+                Self::upload_storage_prefix_f32(
+                    keys,
+                    graph,
+                    key_history,
+                    self.max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    per_head_len,
+                    per_head_stride,
+                    key_tensor_name,
+                )?;
+                Self::upload_storage_prefix_f32(
+                    values,
+                    graph,
+                    value_history,
+                    self.max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    per_head_len,
+                    per_head_stride,
+                    value_tensor_name,
+                )
+            }
+            GgmlKvElementType::Q8_0 => {
+                let row_nbytes = self.element_type.row_nbytes(self.head_dim).map_err(|_| {
+                    GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "qwen kv-cache upload q8 row size invalid",
+                    }
                 })?;
-        let per_head_stride =
-            kv_span
-                .checked_mul(self.head_dim)
-                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "qwen kv-cache upload stride overflow",
-                })?;
-
-        Self::upload_storage_prefix(
-            &self.keys,
-            graph,
-            key_history,
-            self.max_positions,
-            self.kv_heads,
-            self.head_dim,
-            per_head_len,
-            per_head_stride,
-            key_tensor_name,
-        )?;
-        Self::upload_storage_prefix(
-            &self.values,
-            graph,
-            value_history,
-            self.max_positions,
-            self.kv_heads,
-            self.head_dim,
-            per_head_len,
-            per_head_stride,
-            value_tensor_name,
-        )
+                let per_head_len = token_count.checked_mul(row_nbytes).ok_or(
+                    GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "qwen kv-cache upload q8 prefix overflow",
+                    },
+                )?;
+                let per_head_stride = kv_span.checked_mul(row_nbytes).ok_or(
+                    GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "qwen kv-cache upload q8 stride overflow",
+                    },
+                )?;
+                let keys =
+                    self.keys
+                        .q8_slice()
+                        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "qwen kv-cache upload q8 storage missing",
+                        })?;
+                let values =
+                    self.values
+                        .q8_slice()
+                        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "qwen kv-cache upload q8 storage missing",
+                        })?;
+                Self::upload_storage_prefix_bytes(
+                    keys,
+                    graph,
+                    key_history,
+                    self.max_positions,
+                    self.kv_heads,
+                    row_nbytes,
+                    per_head_len,
+                    per_head_stride,
+                    key_tensor_name,
+                )?;
+                Self::upload_storage_prefix_bytes(
+                    values,
+                    graph,
+                    value_history,
+                    self.max_positions,
+                    self.kv_heads,
+                    row_nbytes,
+                    per_head_len,
+                    per_head_stride,
+                    value_tensor_name,
+                )
+            }
+            GgmlKvElementType::F16 => Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "host kv-cache upload does not support f16 storage",
+            }),
+        }
     }
 
     pub(crate) fn max_positions(&self) -> usize {
@@ -221,45 +405,106 @@ impl Qwen3AsrLayerKvCacheState {
             ));
         }
 
-        let mut forked = Self::new(max_positions, self.kv_heads, self.head_dim);
+        let mut forked = Self::new_with_element_type(
+            max_positions,
+            self.kv_heads,
+            self.head_dim,
+            self.element_type,
+        )?;
         if written_positions == 0 {
             return Ok(forked);
         }
-        let width = self.key_width();
-        let old_expected_len = self
-            .max_positions
-            .checked_mul(width)
-            .ok_or_else(|| "qwen3-asr kv-cache fork old length overflowed".to_string())?;
-        if self.keys.len() != old_expected_len || self.values.len() != old_expected_len {
-            return Err(format!(
-                "qwen3-asr kv-cache fork storage length mismatch: keys={} values={} expected={old_expected_len}",
-                self.keys.len(),
-                self.values.len()
-            ));
+        match self.element_type {
+            GgmlKvElementType::F32 => {
+                let width = self.key_width();
+                let old_expected_len = self
+                    .max_positions
+                    .checked_mul(width)
+                    .ok_or_else(|| "qwen3-asr kv-cache fork old length overflowed".to_string())?;
+                let keys = self.keys.f32_slice()?;
+                let values = self.values.f32_slice()?;
+                if keys.len() != old_expected_len || values.len() != old_expected_len {
+                    return Err(format!(
+                        "qwen3-asr kv-cache fork storage length mismatch: keys={} values={} expected={old_expected_len}",
+                        keys.len(),
+                        values.len()
+                    ));
+                }
+                let new_len = max_positions
+                    .checked_mul(width)
+                    .ok_or_else(|| "qwen3-asr kv-cache fork new length overflowed".to_string())?;
+                let mut new_keys = vec![0.0; new_len];
+                let mut new_values = vec![0.0; new_len];
+                Self::copy_history_prefix_to_span_f32(
+                    keys,
+                    &mut new_keys,
+                    self.max_positions,
+                    max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    written_positions,
+                )?;
+                Self::copy_history_prefix_to_span_f32(
+                    values,
+                    &mut new_values,
+                    self.max_positions,
+                    max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    written_positions,
+                )?;
+                forked.keys = HostKvStorage::F32(new_keys);
+                forked.values = HostKvStorage::F32(new_values);
+            }
+            GgmlKvElementType::Q8_0 => {
+                let row_nbytes = self.element_type.row_nbytes(self.head_dim)?;
+                let old_expected_len = self
+                    .max_positions
+                    .checked_mul(self.kv_heads)
+                    .and_then(|n| n.checked_mul(row_nbytes))
+                    .ok_or_else(|| {
+                        "qwen3-asr kv-cache fork old q8 length overflowed".to_string()
+                    })?;
+                let keys = self.keys.q8_slice()?;
+                let values = self.values.q8_slice()?;
+                if keys.len() != old_expected_len || values.len() != old_expected_len {
+                    return Err(format!(
+                        "qwen3-asr kv-cache fork q8 storage length mismatch: keys={} values={} expected={old_expected_len}",
+                        keys.len(),
+                        values.len()
+                    ));
+                }
+                let new_len = max_positions
+                    .checked_mul(self.kv_heads)
+                    .and_then(|n| n.checked_mul(row_nbytes))
+                    .ok_or_else(|| {
+                        "qwen3-asr kv-cache fork new q8 length overflowed".to_string()
+                    })?;
+                let mut new_keys = vec![0_u8; new_len];
+                let mut new_values = vec![0_u8; new_len];
+                Self::copy_history_prefix_to_span_bytes(
+                    keys,
+                    &mut new_keys,
+                    self.max_positions,
+                    max_positions,
+                    self.kv_heads,
+                    row_nbytes,
+                    written_positions,
+                )?;
+                Self::copy_history_prefix_to_span_bytes(
+                    values,
+                    &mut new_values,
+                    self.max_positions,
+                    max_positions,
+                    self.kv_heads,
+                    row_nbytes,
+                    written_positions,
+                )?;
+                forked.keys = HostKvStorage::Q8(new_keys);
+                forked.values = HostKvStorage::Q8(new_values);
+            }
+            GgmlKvElementType::F16 => unreachable!("host KV rejects f16"),
         }
-        let new_len = max_positions
-            .checked_mul(width)
-            .ok_or_else(|| "qwen3-asr kv-cache fork new length overflowed".to_string())?;
-        forked.keys = vec![0.0; new_len];
-        forked.values = vec![0.0; new_len];
-        Self::copy_history_prefix_to_span(
-            &self.keys,
-            &mut forked.keys,
-            self.max_positions,
-            max_positions,
-            self.kv_heads,
-            self.head_dim,
-            written_positions,
-        )?;
-        Self::copy_history_prefix_to_span(
-            &self.values,
-            &mut forked.values,
-            self.max_positions,
-            max_positions,
-            self.kv_heads,
-            self.head_dim,
-            written_positions,
-        )?;
         forked.written_positions = written_positions;
         Ok(forked)
     }
@@ -279,68 +524,162 @@ impl Qwen3AsrLayerKvCacheState {
             return Ok(());
         }
 
-        let width = self.key_width();
-        let old_expected_len = self
-            .max_positions
-            .checked_mul(width)
-            .ok_or_else(|| "qwen3-asr kv-cache resize old length overflowed".to_string())?;
-        if self.keys.len() != old_expected_len || self.values.len() != old_expected_len {
-            return Err(format!(
-                "qwen3-asr kv-cache resize storage length mismatch: keys={} values={} expected={old_expected_len}",
-                self.keys.len(),
-                self.values.len()
-            ));
+        match self.element_type {
+            GgmlKvElementType::F32 => {
+                let width = self.key_width();
+                let old_expected_len = self
+                    .max_positions
+                    .checked_mul(width)
+                    .ok_or_else(|| "qwen3-asr kv-cache resize old length overflowed".to_string())?;
+                let keys = self.keys.f32_slice()?.to_vec();
+                let values = self.values.f32_slice()?.to_vec();
+                if keys.len() != old_expected_len || values.len() != old_expected_len {
+                    return Err(format!(
+                        "qwen3-asr kv-cache resize storage length mismatch: keys={} values={} expected={old_expected_len}",
+                        keys.len(),
+                        values.len()
+                    ));
+                }
+                let new_len = new_max_positions
+                    .checked_mul(width)
+                    .ok_or_else(|| "qwen3-asr kv-cache resize new length overflowed".to_string())?;
+                let mut new_keys = vec![0.0; new_len];
+                let mut new_values = vec![0.0; new_len];
+                Self::copy_history_prefix_to_span_f32(
+                    &keys,
+                    &mut new_keys,
+                    self.max_positions,
+                    new_max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    self.written_positions,
+                )?;
+                Self::copy_history_prefix_to_span_f32(
+                    &values,
+                    &mut new_values,
+                    self.max_positions,
+                    new_max_positions,
+                    self.kv_heads,
+                    self.head_dim,
+                    self.written_positions,
+                )?;
+                self.max_positions = new_max_positions;
+                self.keys = HostKvStorage::F32(new_keys);
+                self.values = HostKvStorage::F32(new_values);
+            }
+            GgmlKvElementType::Q8_0 => {
+                let row_nbytes = self.element_type.row_nbytes(self.head_dim)?;
+                let old_expected_len = self
+                    .max_positions
+                    .checked_mul(self.kv_heads)
+                    .and_then(|n| n.checked_mul(row_nbytes))
+                    .ok_or_else(|| {
+                        "qwen3-asr kv-cache resize old q8 length overflowed".to_string()
+                    })?;
+                let keys = self.keys.q8_slice()?.to_vec();
+                let values = self.values.q8_slice()?.to_vec();
+                if keys.len() != old_expected_len || values.len() != old_expected_len {
+                    return Err(format!(
+                        "qwen3-asr kv-cache resize q8 storage length mismatch: keys={} values={} expected={old_expected_len}",
+                        keys.len(),
+                        values.len()
+                    ));
+                }
+                let new_len = new_max_positions
+                    .checked_mul(self.kv_heads)
+                    .and_then(|n| n.checked_mul(row_nbytes))
+                    .ok_or_else(|| {
+                        "qwen3-asr kv-cache resize new q8 length overflowed".to_string()
+                    })?;
+                let mut new_keys = vec![0_u8; new_len];
+                let mut new_values = vec![0_u8; new_len];
+                Self::copy_history_prefix_to_span_bytes(
+                    &keys,
+                    &mut new_keys,
+                    self.max_positions,
+                    new_max_positions,
+                    self.kv_heads,
+                    row_nbytes,
+                    self.written_positions,
+                )?;
+                Self::copy_history_prefix_to_span_bytes(
+                    &values,
+                    &mut new_values,
+                    self.max_positions,
+                    new_max_positions,
+                    self.kv_heads,
+                    row_nbytes,
+                    self.written_positions,
+                )?;
+                self.max_positions = new_max_positions;
+                self.keys = HostKvStorage::Q8(new_keys);
+                self.values = HostKvStorage::Q8(new_values);
+            }
+            GgmlKvElementType::F16 => unreachable!("host KV rejects f16"),
         }
-        let new_len = new_max_positions
-            .checked_mul(width)
-            .ok_or_else(|| "qwen3-asr kv-cache resize new length overflowed".to_string())?;
-        let mut keys = vec![0.0; new_len];
-        let mut values = vec![0.0; new_len];
-        Self::copy_history_prefix_to_span(
-            &self.keys,
-            &mut keys,
-            self.max_positions,
-            new_max_positions,
-            self.kv_heads,
-            self.head_dim,
-            self.written_positions,
-        )?;
-        Self::copy_history_prefix_to_span(
-            &self.values,
-            &mut values,
-            self.max_positions,
-            new_max_positions,
-            self.kv_heads,
-            self.head_dim,
-            self.written_positions,
-        )?;
-        self.max_positions = new_max_positions;
-        self.keys = keys;
-        self.values = values;
         Ok(())
     }
 
     pub(crate) fn full_history_storage(&self) -> Result<Qwen3AsrLayerKvCacheHistory<'_>, String> {
-        let expected_len = self
-            .max_positions
-            .checked_mul(self.key_width())
-            .ok_or_else(|| "qwen3-asr kv-cache storage length overflowed".to_string())?;
-        if self.keys.len() != expected_len || self.values.len() != expected_len {
-            return Err(format!(
-                "qwen3-asr kv-cache storage length mismatch: keys={} values={} expected={}",
-                self.keys.len(),
-                self.values.len(),
-                expected_len
-            ));
+        match self.element_type {
+            GgmlKvElementType::F32 => {
+                let expected_len = self
+                    .max_positions
+                    .checked_mul(self.key_width())
+                    .ok_or_else(|| "qwen3-asr kv-cache storage length overflowed".to_string())?;
+                let keys = self.keys.f32_slice()?;
+                let values = self.values.f32_slice()?;
+                if keys.len() != expected_len || values.len() != expected_len {
+                    return Err(format!(
+                        "qwen3-asr kv-cache storage length mismatch: keys={} values={} expected={}",
+                        keys.len(),
+                        values.len(),
+                        expected_len
+                    ));
+                }
+                Ok(Qwen3AsrLayerKvCacheHistory {
+                    max_positions: self.max_positions,
+                    kv_heads: self.kv_heads,
+                    head_dim: self.head_dim,
+                    written_positions: self.written_positions,
+                    element_type: self.element_type,
+                    keys_f32: Some(keys),
+                    values_f32: Some(values),
+                    keys_q8: None,
+                    values_q8: None,
+                })
+            }
+            GgmlKvElementType::Q8_0 => {
+                let row_nbytes = self.element_type.row_nbytes(self.head_dim)?;
+                let expected_len = self
+                    .max_positions
+                    .checked_mul(self.kv_heads)
+                    .and_then(|n| n.checked_mul(row_nbytes))
+                    .ok_or_else(|| "qwen3-asr kv-cache q8 storage length overflowed".to_string())?;
+                let keys = self.keys.q8_slice()?;
+                let values = self.values.q8_slice()?;
+                if keys.len() != expected_len || values.len() != expected_len {
+                    return Err(format!(
+                        "qwen3-asr kv-cache q8 storage length mismatch: keys={} values={} expected={}",
+                        keys.len(),
+                        values.len(),
+                        expected_len
+                    ));
+                }
+                Ok(Qwen3AsrLayerKvCacheHistory {
+                    max_positions: self.max_positions,
+                    kv_heads: self.kv_heads,
+                    head_dim: self.head_dim,
+                    written_positions: self.written_positions,
+                    element_type: self.element_type,
+                    keys_f32: None,
+                    values_f32: None,
+                    keys_q8: Some(keys),
+                    values_q8: Some(values),
+                })
+            }
+            GgmlKvElementType::F16 => Err("host kv-cache history does not support f16".to_string()),
         }
-        Ok(Qwen3AsrLayerKvCacheHistory {
-            max_positions: self.max_positions,
-            kv_heads: self.kv_heads,
-            head_dim: self.head_dim,
-            written_positions: self.written_positions,
-            keys: &self.keys,
-            values: &self.values,
-        })
     }
 
     #[cfg(test)]
@@ -349,6 +688,7 @@ impl Qwen3AsrLayerKvCacheState {
             written_positions: self.written_positions,
             key_width: self.key_width(),
             value_width: self.value_width(),
+            element_type: self.element_type,
         })
     }
 
@@ -367,20 +707,34 @@ impl Qwen3AsrLayerKvCacheState {
             ));
         }
         if self.keys.is_empty() {
-            let key_len = self
-                .max_positions
-                .checked_mul(key_width)
-                .ok_or_else(|| "qwen3-asr kv-cache key allocation overflowed".to_string())?;
-            self.keys = vec![0.0; key_len];
+            self.keys = self.allocate_storage()?;
         }
         if self.values.is_empty() {
-            let value_len = self
-                .max_positions
-                .checked_mul(value_width)
-                .ok_or_else(|| "qwen3-asr kv-cache value allocation overflowed".to_string())?;
-            self.values = vec![0.0; value_len];
+            self.values = self.allocate_storage()?;
         }
         Ok(())
+    }
+
+    fn allocate_storage(&self) -> Result<HostKvStorage, String> {
+        match self.element_type {
+            GgmlKvElementType::F32 => {
+                let len = self
+                    .max_positions
+                    .checked_mul(self.key_width())
+                    .ok_or_else(|| "qwen3-asr kv-cache f32 allocation overflowed".to_string())?;
+                Ok(HostKvStorage::F32(vec![0.0; len]))
+            }
+            GgmlKvElementType::Q8_0 => {
+                let row_nbytes = self.element_type.row_nbytes(self.head_dim)?;
+                let len = self
+                    .max_positions
+                    .checked_mul(self.kv_heads)
+                    .and_then(|n| n.checked_mul(row_nbytes))
+                    .ok_or_else(|| "qwen3-asr kv-cache q8 allocation overflowed".to_string())?;
+                Ok(HostKvStorage::Q8(vec![0_u8; len]))
+            }
+            GgmlKvElementType::F16 => Err("host KV rejects f16 storage".to_string()),
+        }
     }
 
     fn key_width(&self) -> usize {
@@ -391,7 +745,7 @@ impl Qwen3AsrLayerKvCacheState {
         self.key_width()
     }
 
-    fn write_history_row(
+    fn write_history_row_f32(
         storage: &mut [f32],
         max_positions: usize,
         kv_heads: usize,
@@ -419,7 +773,47 @@ impl Qwen3AsrLayerKvCacheState {
         Ok(())
     }
 
-    fn copy_history_prefix_to_span(
+    fn write_history_row_q8(
+        storage: &mut [u8],
+        max_positions: usize,
+        kv_heads: usize,
+        head_dim: usize,
+        row_nbytes: usize,
+        position: usize,
+        row: &[f32],
+    ) -> Result<(), String> {
+        for kv_head in 0..kv_heads {
+            let row_start = kv_head
+                .checked_mul(head_dim)
+                .ok_or_else(|| "qwen3-asr kv-cache q8 row indexing overflowed".to_string())?;
+            let row_end = row_start
+                .checked_add(head_dim)
+                .ok_or_else(|| "qwen3-asr kv-cache q8 row indexing overflowed".to_string())?;
+            let packed = GgmlKvElementType::Q8_0.quantize_rows_from_f32(
+                &row[row_start..row_end],
+                head_dim,
+                1,
+            )?;
+            if packed.len() != row_nbytes {
+                return Err(format!(
+                    "qwen3-asr kv-cache q8 row size mismatch: got {} expected {row_nbytes}",
+                    packed.len()
+                ));
+            }
+            let storage_start = kv_head
+                .checked_mul(max_positions)
+                .and_then(|base| base.checked_add(position))
+                .and_then(|slot| slot.checked_mul(row_nbytes))
+                .ok_or_else(|| "qwen3-asr kv-cache q8 storage indexing overflowed".to_string())?;
+            let storage_end = storage_start
+                .checked_add(row_nbytes)
+                .ok_or_else(|| "qwen3-asr kv-cache q8 storage indexing overflowed".to_string())?;
+            storage[storage_start..storage_end].copy_from_slice(&packed);
+        }
+        Ok(())
+    }
+
+    fn copy_history_prefix_to_span_f32(
         source: &[f32],
         target: &mut [f32],
         old_max_positions: usize,
@@ -455,7 +849,43 @@ impl Qwen3AsrLayerKvCacheState {
         Ok(())
     }
 
-    fn upload_storage_prefix<'a>(
+    fn copy_history_prefix_to_span_bytes(
+        source: &[u8],
+        target: &mut [u8],
+        old_max_positions: usize,
+        new_max_positions: usize,
+        kv_heads: usize,
+        row_nbytes: usize,
+        written_positions: usize,
+    ) -> Result<(), String> {
+        let prefix_len = written_positions
+            .checked_mul(row_nbytes)
+            .ok_or_else(|| "qwen3-asr kv-cache q8 resize prefix length overflowed".to_string())?;
+        for kv_head in 0..kv_heads {
+            let source_start = kv_head
+                .checked_mul(old_max_positions)
+                .and_then(|base| base.checked_mul(row_nbytes))
+                .ok_or_else(|| {
+                    "qwen3-asr kv-cache q8 resize source indexing overflowed".to_string()
+                })?;
+            let source_end = source_start.checked_add(prefix_len).ok_or_else(|| {
+                "qwen3-asr kv-cache q8 resize source indexing overflowed".to_string()
+            })?;
+            let target_start = kv_head
+                .checked_mul(new_max_positions)
+                .and_then(|base| base.checked_mul(row_nbytes))
+                .ok_or_else(|| {
+                    "qwen3-asr kv-cache q8 resize target indexing overflowed".to_string()
+                })?;
+            let target_end = target_start.checked_add(prefix_len).ok_or_else(|| {
+                "qwen3-asr kv-cache q8 resize target indexing overflowed".to_string()
+            })?;
+            target[target_start..target_end].copy_from_slice(&source[source_start..source_end]);
+        }
+        Ok(())
+    }
+
+    fn upload_storage_prefix_f32<'a>(
         storage: &[f32],
         graph: &mut GgmlCpuGraphBuilder<'a>,
         tensor: GgmlCpuTensor<'a>,
@@ -492,11 +922,50 @@ impl Qwen3AsrLayerKvCacheState {
         }
         Ok(())
     }
+
+    fn upload_storage_prefix_bytes<'a>(
+        storage: &[u8],
+        graph: &mut GgmlCpuGraphBuilder<'a>,
+        tensor: GgmlCpuTensor<'a>,
+        max_positions: usize,
+        kv_heads: usize,
+        row_nbytes: usize,
+        per_head_len: usize,
+        per_head_stride: usize,
+        tensor_name: &'static str,
+    ) -> Result<(), GgmlCpuGraphError> {
+        for kv_head in 0..kv_heads {
+            let storage_start = kv_head
+                .checked_mul(max_positions)
+                .and_then(|base| base.checked_mul(row_nbytes))
+                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "qwen kv-cache upload q8 storage indexing overflow",
+                })?;
+            let storage_end = storage_start.checked_add(per_head_len).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "qwen kv-cache upload q8 storage indexing overflow",
+                },
+            )?;
+            let output_offset = kv_head.checked_mul(per_head_stride).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "qwen kv-cache upload q8 output indexing overflow",
+                },
+            )?;
+            graph.set_bytes_slice_with_offset(
+                tensor,
+                output_offset,
+                &storage[storage_start..storage_end],
+                tensor_name,
+            )?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ggml_runtime::dequantize_q8_0_rows;
 
     #[test]
     fn host_kv_cache_tracks_written_prefix() {
@@ -515,6 +984,7 @@ mod tests {
                 written_positions: 2,
                 key_width: 2,
                 value_width: 2,
+                element_type: GgmlKvElementType::F32,
             }
         );
     }
@@ -535,14 +1005,14 @@ mod tests {
         assert_eq!(history.max_positions, 5);
         assert_eq!(history.written_positions, 2);
         assert_eq!(
-            history.keys,
+            history.keys_f32.expect("f32 keys"),
             &[
                 1.0, 2.0, 5.0, 6.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, //
                 3.0, 4.0, 7.0, 8.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
             ]
         );
         assert_eq!(
-            history.values,
+            history.values_f32.expect("f32 values"),
             &[
                 10.0, 20.0, 50.0, 60.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, //
                 30.0, 40.0, 70.0, 80.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
@@ -568,7 +1038,7 @@ mod tests {
         assert_eq!(history.max_positions, 5);
         assert_eq!(history.written_positions, 2);
         assert_eq!(
-            history.keys,
+            history.keys_f32.expect("f32 keys"),
             &[
                 1.0, 2.0, 5.0, 6.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, //
                 3.0, 4.0, 7.0, 8.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
@@ -578,5 +1048,52 @@ mod tests {
         cache.truncate_written_positions(1).expect("truncate");
         assert_eq!(cache.written_positions(), 1);
         assert!(cache.truncate_written_positions(2).is_err());
+    }
+
+    #[test]
+    fn host_q8_kv_cache_write_resize_fork_preserve_logical_prefix() {
+        let head_dim = 32;
+        let mut cache = Qwen3AsrLayerKvCacheState::new_with_element_type(
+            3,
+            2,
+            head_dim,
+            GgmlKvElementType::Q8_0,
+        )
+        .expect("q8 cache");
+        let mut row0 = vec![0.0_f32; head_dim * 2];
+        let mut row1 = vec![0.0_f32; head_dim * 2];
+        for i in 0..head_dim {
+            row0[i] = (i as f32) * 0.01;
+            row0[head_dim + i] = (i as f32) * -0.01;
+            row1[i] = 0.5 + (i as f32) * 0.01;
+            row1[head_dim + i] = -0.5 - (i as f32) * 0.01;
+        }
+        cache.write(0, &row0, &row0).expect("row0");
+        cache.write(1, &row1, &row1).expect("row1");
+        cache.resize_max_positions(5).expect("resize");
+        let fork = cache.fork_prefix(2, 6).expect("fork");
+        assert_eq!(fork.written_positions(), 2);
+        assert_eq!(fork.max_positions(), 6);
+        assert_eq!(fork.element_type(), GgmlKvElementType::Q8_0);
+
+        let history = fork.full_history_storage().expect("history");
+        let keys = history.keys_q8.expect("q8 keys");
+        let row_nbytes = GgmlKvElementType::Q8_0.row_nbytes(head_dim).expect("row");
+        // Dequantize head0 position0 and compare to source within q8 tolerance.
+        let packed0 = &keys[0..row_nbytes];
+        let restored = dequantize_q8_0_rows(packed0, head_dim, 1).expect("dequant");
+        let mut max_abs = 0.0_f32;
+        for (a, b) in row0[..head_dim].iter().zip(restored.iter()) {
+            max_abs = max_abs.max((a - b).abs());
+        }
+        assert!(max_abs < 0.05, "q8 host roundtrip max abs {max_abs}");
+    }
+
+    #[test]
+    fn host_q8_kv_cache_rejects_misaligned_head_dim() {
+        let err =
+            Qwen3AsrLayerKvCacheState::new_with_element_type(4, 1, 30, GgmlKvElementType::Q8_0)
+                .expect_err("head_dim 30 must fail");
+        assert!(err.contains("block_size"), "{err}");
     }
 }

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -8,9 +8,9 @@ use std::fmt;
 use thiserror::Error;
 
 use crate::ggml_runtime::{
-    GgmlCpuGraphBackend, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlRopeExtParams,
-    GgmlStaticTensor, GgmlStaticTensorArena, GgufTensorDataReadError, GgufTensorDataReader,
-    env_toggle_with_raw,
+    GgmlCpuGraphBackend, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlKvElementType,
+    GgmlRopeExtParams, GgmlStaticTensor, GgmlStaticTensorArena, GgufTensorDataReadError,
+    GgufTensorDataReader, env_toggle_with_raw,
 };
 
 use super::graph_config::qwen_decoder_graph_config;
@@ -23,9 +23,10 @@ use super::lora::{QwenLayerLoraSlots, QwenLoraAdapter, new_qwen_lora_slot};
 use super::runtime_contract::Qwen3AsrExecutionMetadata;
 use super::tensor_names::llm_layer_tensor_names;
 use crate::nn::decoder::{
-    LlmDecoderStackConfig, LlmDecoderStackInputs, LlmLayerWeights, LlmResidentKvArena,
-    LlmReusableDecodeGraph, allocate_zeroed_llm_resident_kv_arena,
-    build_fixed_kv_attention_mask_bits, build_fixed_kv_attention_mask_bits_for_query_rows,
+    LlmDecoderStackConfig, LlmDecoderStackInputs, LlmKvCachePolicy, LlmKvCacheSpec,
+    LlmLayerWeights, LlmResidentKvArena, LlmReusableDecodeGraph,
+    allocate_zeroed_llm_resident_kv_arena, build_fixed_kv_attention_mask_bits,
+    build_fixed_kv_attention_mask_bits_for_query_rows,
     build_fixed_kv_attention_mask_bits_for_sequences, compose_llm_decoder_layer_stack,
     reusable_decode_graph_supported_for_runner,
 };
@@ -853,6 +854,7 @@ fn qwen_llm_stack_config(
     token_count: usize,
     n_seq: usize,
     use_flash_attention: bool,
+    kv_cache_spec: LlmKvCacheSpec,
 ) -> LlmDecoderStackConfig {
     LlmDecoderStackConfig {
         d_model: dims.d_model,
@@ -874,6 +876,7 @@ fn qwen_llm_stack_config(
         // serve needs n_seq > 1 support in the unfused head-expansion path.
         use_native_gqa: use_native_gqa || n_seq > 1,
         use_flash_attention,
+        kv_cache_spec,
     }
 }
 
@@ -1467,6 +1470,7 @@ pub(crate) struct Qwen3AsrLlmWholeDecoderGraphExecutor {
     dims: Qwen3AsrLlmDecodeDims,
     use_native_gqa: bool,
     rms_norm_epsilon: f32,
+    kv_cache_spec: LlmKvCacheSpec,
 }
 
 impl fmt::Debug for Qwen3AsrLlmWholeDecoderGraphExecutor {
@@ -1679,11 +1683,36 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             dims,
             use_native_gqa,
             rms_norm_epsilon,
+            kv_cache_spec: LlmKvCacheSpec::DEFAULT,
         })
     }
 
     pub(crate) fn layer_count(&self) -> usize {
         self.layers.len()
+    }
+
+    pub(crate) fn kv_cache_spec(&self) -> LlmKvCacheSpec {
+        self.kv_cache_spec
+    }
+
+    /// Internal execution option for phase-1 Q8 KV. Not a public env gate.
+    /// Validates geometry against the decoder head_dim; backend/GQA/flash checks
+    /// still happen when the graph is composed for a concrete backend path.
+    #[allow(dead_code)]
+    pub(crate) fn set_kv_cache_policy(
+        &mut self,
+        policy: LlmKvCachePolicy,
+    ) -> Result<(), GgmlCpuGraphError> {
+        let spec = policy.to_spec();
+        if let Err(_reason) = spec.validate_geometry(self.dims.head_dim) {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "llm KV cache policy is incompatible with decoder head_dim",
+            });
+        }
+        // Drop any resident reuse graph built under the previous element type.
+        self.reuse = None;
+        self.kv_cache_spec = spec;
+        Ok(())
     }
 
     /// Releases the CPU per-token grow-to-fit step buffer this decoder's
@@ -1876,6 +1905,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 1,
                 1,
                 true,
+                self.kv_cache_spec,
             ),
             LlmDecoderStackInputs {
                 state: hidden_tensor,
@@ -2081,6 +2111,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 1,
                 1,
                 true,
+                self.kv_cache_spec,
             ),
             LlmDecoderStackInputs {
                 state: hidden_tensor,
@@ -2491,6 +2522,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                     token_count,
                     n_seq,
                     use_flash_attention,
+                    self.kv_cache_spec,
                 ),
                 LlmDecoderStackInputs {
                     state: hidden_tensor,
@@ -2714,6 +2746,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 token_count,
                 n_seq,
                 use_flash_attention,
+                self.kv_cache_spec,
             ),
             LlmDecoderStackInputs {
                 state: hidden_tensor,
@@ -2752,20 +2785,56 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         )?;
         graph.set_f16_bits_slice(attention_mask, &mask_bits, "qwen_llm_prefill_self_mask")?;
         for (layer_index, (key_history, value_history)) in kv_inputs.into_iter().enumerate() {
-            let (key_values, value_values) = qwen_prefill_history_inputs_for_layer(
-                dims,
-                total_token_count,
-                n_seq,
-                layer_index,
-                position_offset,
-                layer_caches_by_sequence,
-            )?;
-            graph.set_f32_slice(key_history, &key_values, "qwen_llm_prefill_key_history")?;
-            graph.set_f32_slice(
-                value_history,
-                &value_values,
-                "qwen_llm_prefill_value_history",
-            )?;
+            match self.kv_cache_spec.host {
+                GgmlKvElementType::F32 => {
+                    let (key_values, value_values) = qwen_prefill_history_inputs_for_layer(
+                        dims,
+                        total_token_count,
+                        n_seq,
+                        layer_index,
+                        position_offset,
+                        layer_caches_by_sequence,
+                    )?;
+                    graph.set_f32_slice(
+                        key_history,
+                        &key_values,
+                        "qwen_llm_prefill_key_history",
+                    )?;
+                    graph.set_f32_slice(
+                        value_history,
+                        &value_values,
+                        "qwen_llm_prefill_value_history",
+                    )?;
+                }
+                GgmlKvElementType::Q8_0 => {
+                    // Host q8_0 stores packed rows; upload them directly into the
+                    // matching q8_0 history tensors without a full f32 staging buffer.
+                    if n_seq != 1 || layer_caches_by_sequence.len() != 1 {
+                        return Err(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "q8_0 host prefill history upload currently supports n_seq=1",
+                        });
+                    }
+                    let cache = layer_caches_by_sequence[0].get(layer_index).ok_or(
+                        GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "q8_0 host prefill history layer/cache count mismatch",
+                        },
+                    )?;
+                    cache.upload_history_prefix_to_fixed_span_graph(
+                        &mut graph,
+                        key_history,
+                        value_history,
+                        position_offset,
+                        total_token_count,
+                        "qwen_llm_prefill_key_history",
+                        "qwen_llm_prefill_value_history",
+                    )?;
+                }
+                GgmlKvElementType::F16 => {
+                    return Err(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "host prefill history upload rejects f16 storage",
+                    });
+                }
+            }
         }
 
         let mut requested: Vec<(GgmlCpuTensor, usize)> =
@@ -2870,6 +2939,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 dims.kv_heads,
                 n_seq,
                 "qwen_llm_resident_kv",
+                self.kv_cache_spec,
             )?;
 
             let mut session = self
@@ -2899,6 +2969,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                     1,
                     n_seq,
                     true,
+                    self.kv_cache_spec,
                 ),
                 LlmDecoderStackInputs {
                     state: hidden_tensor,
@@ -3106,6 +3177,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             slot_index,
             cache_position,
             layer_kv,
+            self.kv_cache_spec.resident,
         )
     }
 
@@ -3138,6 +3210,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             max_positions,
             dims.kv_heads,
             slot_index,
+            self.kv_cache_spec.resident,
         )
     }
 
@@ -3164,6 +3237,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             dims.kv_heads,
             n_seq,
             "qwen_llm_resident_kv",
+            self.kv_cache_spec,
         )?;
         if let Some((prefix_lengths, seed_layers)) = seed {
             seed_qwen_batched_resident_kv_arena(
@@ -3173,6 +3247,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 dims.kv_heads,
                 prefix_lengths,
                 seed_layers,
+                self.kv_cache_spec.resident,
             )?;
         }
 
@@ -3203,6 +3278,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 1,
                 n_seq,
                 true,
+                self.kv_cache_spec,
             ),
             LlmDecoderStackInputs {
                 state: hidden_tensor,
@@ -3529,6 +3605,11 @@ fn qwen_prefill_history_inputs_for_layer(
                 .ok_or(GgmlCpuGraphError::UnsupportedInputs {
                     reason: "whole-decoder prefill history layer/cache count mismatch",
                 })?;
+        if !matches!(cache.element_type(), GgmlKvElementType::F32) {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder f32 prefill history helper requires host f32 KV",
+            });
+        }
         let history =
             cache
                 .full_history_storage()
@@ -3545,6 +3626,16 @@ fn qwen_prefill_history_inputs_for_layer(
                 reason: "whole-decoder prefill history requested unwritten prefix",
             });
         }
+        let keys = history
+            .keys_f32
+            .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder prefill history missing f32 keys",
+            })?;
+        let values = history
+            .values_f32
+            .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder prefill history missing f32 values",
+            })?;
         let source_head_stride = history.max_positions.checked_mul(dims.head_dim).ok_or(
             GgmlCpuGraphError::UnsupportedInputs {
                 reason: "whole-decoder prefill history source stride overflow",
@@ -3580,10 +3671,9 @@ fn qwen_prefill_history_inputs_for_layer(
                     reason: "whole-decoder prefill history target end overflow",
                 },
             )?;
-            key_values[target_start..target_end]
-                .copy_from_slice(&history.keys[source_start..source_end]);
+            key_values[target_start..target_end].copy_from_slice(&keys[source_start..source_end]);
             value_values[target_start..target_end]
-                .copy_from_slice(&history.values[source_start..source_end]);
+                .copy_from_slice(&values[source_start..source_end]);
         }
     }
     Ok((key_values, value_values))
@@ -3596,6 +3686,7 @@ fn seed_qwen_batched_resident_kv_arena(
     kv_heads: usize,
     prefix_lengths: &[usize],
     layer_kv_by_sequence: &[&[Qwen3AsrLayerKvCacheState]],
+    resident_element_type: GgmlKvElementType,
 ) -> Result<(), GgmlCpuGraphError> {
     if prefix_lengths.is_empty() {
         return Err(GgmlCpuGraphError::UnsupportedInputs {
@@ -3616,66 +3707,180 @@ fn seed_qwen_batched_resident_kv_arena(
             reason: "batched resident KV seed layer count mismatch",
         });
     }
+    let host_type = layer_kv_by_sequence
+        .first()
+        .and_then(|layers| layers.first())
+        .map(|cache| cache.element_type())
+        .unwrap_or(GgmlKvElementType::F32);
+    if layer_kv_by_sequence
+        .iter()
+        .any(|layers| layers.iter().any(|cache| cache.element_type() != host_type))
+    {
+        return Err(GgmlCpuGraphError::UnsupportedInputs {
+            reason: "batched resident KV seed host element type mismatch",
+        });
+    }
+    match (host_type, resident_element_type) {
+        (GgmlKvElementType::F32, GgmlKvElementType::F16) => {}
+        (GgmlKvElementType::Q8_0, GgmlKvElementType::Q8_0) => {}
+        _ => {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "batched resident KV seed host/resident element type pair unsupported",
+            });
+        }
+    }
     let plane_elems = qwen_resident_kv_plane_elems(head_dim, max_positions, kv_heads)?;
+    let plane_nbytes = host_type
+        .plane_nbytes(head_dim, max_positions, kv_heads)
+        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+            reason: "batched resident KV seed plane byte size overflow",
+        })?;
     let tensor_elems = plane_elems.checked_mul(prefix_lengths.len()).ok_or(
         GgmlCpuGraphError::UnsupportedInputs {
             reason: "batched resident KV seed tensor size overflow",
         },
     )?;
+    let tensor_nbytes = plane_nbytes.checked_mul(prefix_lengths.len()).ok_or(
+        GgmlCpuGraphError::UnsupportedInputs {
+            reason: "batched resident KV seed tensor byte size overflow",
+        },
+    )?;
 
     for layer_index in 0..layer_count {
-        let mut key_planes = vec![0.0_f32; tensor_elems];
-        let mut value_planes = vec![0.0_f32; tensor_elems];
-        for (sequence_index, sequence_layers) in layer_kv_by_sequence.iter().enumerate() {
-            let history = sequence_layers[layer_index]
-                .full_history_storage()
-                .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "batched resident KV seed host cache storage invalid",
-                })?;
-            if history.head_dim != head_dim
-                || history.max_positions != max_positions
-                || history.kv_heads != kv_heads
-            {
+        match host_type {
+            GgmlKvElementType::F32 => {
+                let mut key_planes = vec![0.0_f32; tensor_elems];
+                let mut value_planes = vec![0.0_f32; tensor_elems];
+                for (sequence_index, sequence_layers) in layer_kv_by_sequence.iter().enumerate() {
+                    let history = sequence_layers[layer_index]
+                        .full_history_storage()
+                        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV seed host cache storage invalid",
+                        })?;
+                    if history.head_dim != head_dim
+                        || history.max_positions != max_positions
+                        || history.kv_heads != kv_heads
+                    {
+                        return Err(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV seed host cache shape mismatch",
+                        });
+                    }
+                    if history.written_positions != prefix_lengths[sequence_index] {
+                        return Err(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV seed written prefix mismatch",
+                        });
+                    }
+                    let keys = history
+                        .keys_f32
+                        .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV seed missing f32 keys",
+                        })?;
+                    let values =
+                        history
+                            .values_f32
+                            .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                                reason: "batched resident KV seed missing f32 values",
+                            })?;
+                    if keys.len() != plane_elems || values.len() != plane_elems {
+                        return Err(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV seed host cache plane length mismatch",
+                        });
+                    }
+                    let plane_start = sequence_index.checked_mul(plane_elems).ok_or(
+                        GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV seed plane offset overflow",
+                        },
+                    )?;
+                    let plane_end = plane_start.checked_add(plane_elems).ok_or(
+                        GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV seed plane offset overflow",
+                        },
+                    )?;
+                    key_planes[plane_start..plane_end].copy_from_slice(keys);
+                    value_planes[plane_start..plane_end].copy_from_slice(values);
+                }
+                let layer = resident_kv_arena.layers[layer_index];
+                // Default path: host f32 -> resident f16.
+                resident_kv_arena.arena.set_f16_bits_slice(
+                    layer.key,
+                    &f32_slice_to_f16_bits(&key_planes),
+                    "qwen_llm_resident_kv_seed_key",
+                )?;
+                resident_kv_arena.arena.set_f16_bits_slice(
+                    layer.value,
+                    &f32_slice_to_f16_bits(&value_planes),
+                    "qwen_llm_resident_kv_seed_value",
+                )?;
+            }
+            GgmlKvElementType::Q8_0 => {
+                let mut key_planes = vec![0_u8; tensor_nbytes];
+                let mut value_planes = vec![0_u8; tensor_nbytes];
+                for (sequence_index, sequence_layers) in layer_kv_by_sequence.iter().enumerate() {
+                    let history = sequence_layers[layer_index]
+                        .full_history_storage()
+                        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV q8 seed host cache storage invalid",
+                        })?;
+                    if history.head_dim != head_dim
+                        || history.max_positions != max_positions
+                        || history.kv_heads != kv_heads
+                    {
+                        return Err(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV q8 seed host cache shape mismatch",
+                        });
+                    }
+                    if history.written_positions != prefix_lengths[sequence_index] {
+                        return Err(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV q8 seed written prefix mismatch",
+                        });
+                    }
+                    let keys = history
+                        .keys_q8
+                        .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV q8 seed missing q8 keys",
+                        })?;
+                    let values = history
+                        .values_q8
+                        .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV q8 seed missing q8 values",
+                        })?;
+                    if keys.len() != plane_nbytes || values.len() != plane_nbytes {
+                        return Err(GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV q8 seed host cache plane length mismatch",
+                        });
+                    }
+                    let plane_start = sequence_index.checked_mul(plane_nbytes).ok_or(
+                        GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV q8 seed plane offset overflow",
+                        },
+                    )?;
+                    let plane_end = plane_start.checked_add(plane_nbytes).ok_or(
+                        GgmlCpuGraphError::UnsupportedInputs {
+                            reason: "batched resident KV q8 seed plane offset overflow",
+                        },
+                    )?;
+                    key_planes[plane_start..plane_end].copy_from_slice(keys);
+                    value_planes[plane_start..plane_end].copy_from_slice(values);
+                }
+                let layer = resident_kv_arena.layers[layer_index];
+                // Direct packed q8_0 upload: no full f32 staging.
+                resident_kv_arena.arena.set_bytes_slice(
+                    layer.key,
+                    &key_planes,
+                    "qwen_llm_resident_kv_seed_key",
+                )?;
+                resident_kv_arena.arena.set_bytes_slice(
+                    layer.value,
+                    &value_planes,
+                    "qwen_llm_resident_kv_seed_value",
+                )?;
+            }
+            GgmlKvElementType::F16 => {
                 return Err(GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "batched resident KV seed host cache shape mismatch",
+                    reason: "batched resident KV seed rejects host f16 storage",
                 });
             }
-            if history.written_positions != prefix_lengths[sequence_index] {
-                return Err(GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "batched resident KV seed written prefix mismatch",
-                });
-            }
-            if history.keys.len() != plane_elems || history.values.len() != plane_elems {
-                return Err(GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "batched resident KV seed host cache plane length mismatch",
-                });
-            }
-            let plane_start = sequence_index.checked_mul(plane_elems).ok_or(
-                GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "batched resident KV seed plane offset overflow",
-                },
-            )?;
-            let plane_end = plane_start.checked_add(plane_elems).ok_or(
-                GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "batched resident KV seed plane offset overflow",
-                },
-            )?;
-            key_planes[plane_start..plane_end].copy_from_slice(history.keys);
-            value_planes[plane_start..plane_end].copy_from_slice(history.values);
         }
-        let layer = resident_kv_arena.layers[layer_index];
-        // The resident arena is f16: convert the f32 host planes once at seed
-        // time (set_rows performs the same cast for rows written in-graph).
-        resident_kv_arena.arena.set_f16_bits_slice(
-            layer.key,
-            &f32_slice_to_f16_bits(&key_planes),
-            "qwen_llm_resident_kv_seed_key",
-        )?;
-        resident_kv_arena.arena.set_f16_bits_slice(
-            layer.value,
-            &f32_slice_to_f16_bits(&value_planes),
-            "qwen_llm_resident_kv_seed_value",
-        )?;
     }
     Ok(())
 }
@@ -3741,59 +3946,148 @@ fn seed_qwen_batched_resident_kv_slot(
     slot_index: usize,
     cache_position: usize,
     layer_kv: &[Qwen3AsrLayerKvCacheState],
+    resident_element_type: GgmlKvElementType,
 ) -> Result<(), GgmlCpuGraphError> {
     if layer_kv.len() != resident_kv_arena.layers.len() {
         return Err(GgmlCpuGraphError::UnsupportedInputs {
             reason: "batched resident KV slot seed layer count mismatch",
         });
     }
-    let plane_elems = qwen_resident_kv_plane_elems(head_dim, max_positions, kv_heads)?;
-    let plane_offset =
-        slot_index
-            .checked_mul(plane_elems)
-            .ok_or(GgmlCpuGraphError::UnsupportedInputs {
-                reason: "batched resident KV slot seed offset overflow",
-            })?;
-    for (layer_index, cache) in layer_kv.iter().enumerate() {
-        let history =
-            cache
-                .full_history_storage()
-                .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "batched resident KV slot seed host cache storage invalid",
-                })?;
-        if history.head_dim != head_dim
-            || history.max_positions != max_positions
-            || history.kv_heads != kv_heads
-        {
-            return Err(GgmlCpuGraphError::UnsupportedInputs {
-                reason: "batched resident KV slot seed host cache shape mismatch",
-            });
-        }
-        if history.written_positions != cache_position {
-            return Err(GgmlCpuGraphError::UnsupportedInputs {
-                reason: "batched resident KV slot seed written prefix mismatch",
-            });
-        }
-        if history.keys.len() != plane_elems || history.values.len() != plane_elems {
-            return Err(GgmlCpuGraphError::UnsupportedInputs {
-                reason: "batched resident KV slot seed host cache plane length mismatch",
-            });
-        }
-        let layer = resident_kv_arena.layers[layer_index];
-        resident_kv_arena.arena.set_f16_bits_slice_with_offset(
-            layer.key,
-            plane_offset,
-            &f32_slice_to_f16_bits(history.keys),
-            "qwen_llm_resident_kv_slot_seed_key",
-        )?;
-        resident_kv_arena.arena.set_f16_bits_slice_with_offset(
-            layer.value,
-            plane_offset,
-            &f32_slice_to_f16_bits(history.values),
-            "qwen_llm_resident_kv_slot_seed_value",
-        )?;
+    let host_type = layer_kv
+        .first()
+        .map(|cache| cache.element_type())
+        .unwrap_or(GgmlKvElementType::F32);
+    if layer_kv
+        .iter()
+        .any(|cache| cache.element_type() != host_type)
+    {
+        return Err(GgmlCpuGraphError::UnsupportedInputs {
+            reason: "batched resident KV slot seed host element type mismatch",
+        });
     }
-    Ok(())
+    match (host_type, resident_element_type) {
+        (GgmlKvElementType::F32, GgmlKvElementType::F16) => {
+            let plane_elems = qwen_resident_kv_plane_elems(head_dim, max_positions, kv_heads)?;
+            let plane_offset = slot_index.checked_mul(plane_elems).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "batched resident KV slot seed offset overflow",
+                },
+            )?;
+            for (layer_index, cache) in layer_kv.iter().enumerate() {
+                let history = cache.full_history_storage().map_err(|_| {
+                    GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV slot seed host cache storage invalid",
+                    }
+                })?;
+                if history.head_dim != head_dim
+                    || history.max_positions != max_positions
+                    || history.kv_heads != kv_heads
+                {
+                    return Err(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV slot seed host cache shape mismatch",
+                    });
+                }
+                if history.written_positions != cache_position {
+                    return Err(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV slot seed written prefix mismatch",
+                    });
+                }
+                let keys = history
+                    .keys_f32
+                    .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV slot seed missing f32 keys",
+                    })?;
+                let values = history
+                    .values_f32
+                    .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV slot seed missing f32 values",
+                    })?;
+                if keys.len() != plane_elems || values.len() != plane_elems {
+                    return Err(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV slot seed host cache plane length mismatch",
+                    });
+                }
+                let layer = resident_kv_arena.layers[layer_index];
+                resident_kv_arena.arena.set_f16_bits_slice_with_offset(
+                    layer.key,
+                    plane_offset,
+                    &f32_slice_to_f16_bits(keys),
+                    "qwen_llm_resident_kv_slot_seed_key",
+                )?;
+                resident_kv_arena.arena.set_f16_bits_slice_with_offset(
+                    layer.value,
+                    plane_offset,
+                    &f32_slice_to_f16_bits(values),
+                    "qwen_llm_resident_kv_slot_seed_value",
+                )?;
+            }
+            Ok(())
+        }
+        (GgmlKvElementType::Q8_0, GgmlKvElementType::Q8_0) => {
+            let plane_nbytes = GgmlKvElementType::Q8_0
+                .plane_nbytes(head_dim, max_positions, kv_heads)
+                .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "batched resident KV q8 slot plane size overflow",
+                })?;
+            let plane_offset = slot_index.checked_mul(plane_nbytes).ok_or(
+                GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "batched resident KV q8 slot seed offset overflow",
+                },
+            )?;
+            for (layer_index, cache) in layer_kv.iter().enumerate() {
+                let history = cache.full_history_storage().map_err(|_| {
+                    GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV q8 slot seed host cache storage invalid",
+                    }
+                })?;
+                if history.head_dim != head_dim
+                    || history.max_positions != max_positions
+                    || history.kv_heads != kv_heads
+                {
+                    return Err(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV q8 slot seed host cache shape mismatch",
+                    });
+                }
+                if history.written_positions != cache_position {
+                    return Err(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV q8 slot seed written prefix mismatch",
+                    });
+                }
+                let keys = history
+                    .keys_q8
+                    .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV q8 slot seed missing q8 keys",
+                    })?;
+                let values = history
+                    .values_q8
+                    .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV q8 slot seed missing q8 values",
+                    })?;
+                if keys.len() != plane_nbytes || values.len() != plane_nbytes {
+                    return Err(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "batched resident KV q8 slot seed host cache plane length mismatch",
+                    });
+                }
+                let layer = resident_kv_arena.layers[layer_index];
+                resident_kv_arena.arena.set_bytes_slice_with_offset(
+                    layer.key,
+                    plane_offset,
+                    keys,
+                    "qwen_llm_resident_kv_slot_seed_key",
+                )?;
+                resident_kv_arena.arena.set_bytes_slice_with_offset(
+                    layer.value,
+                    plane_offset,
+                    values,
+                    "qwen_llm_resident_kv_slot_seed_value",
+                )?;
+            }
+            Ok(())
+        }
+        _ => Err(GgmlCpuGraphError::UnsupportedInputs {
+            reason: "batched resident KV slot seed host/resident element type pair unsupported",
+        }),
+    }
 }
 
 #[allow(dead_code)]
@@ -3803,23 +4097,28 @@ fn zero_qwen_batched_resident_kv_slot(
     max_positions: usize,
     kv_heads: usize,
     slot_index: usize,
+    resident_element_type: GgmlKvElementType,
 ) -> Result<(), GgmlCpuGraphError> {
-    let plane_elems = qwen_resident_kv_plane_elems(head_dim, max_positions, kv_heads)?;
+    let plane_nbytes = resident_element_type
+        .plane_nbytes(head_dim, max_positions, kv_heads)
+        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+            reason: "batched resident KV slot zero plane size overflow",
+        })?;
     let plane_offset =
         slot_index
-            .checked_mul(plane_elems)
+            .checked_mul(plane_nbytes)
             .ok_or(GgmlCpuGraphError::UnsupportedInputs {
                 reason: "batched resident KV slot zero offset overflow",
             })?;
-    let zeros = vec![0_u16; plane_elems];
+    let zeros = vec![0_u8; plane_nbytes];
     for layer in &resident_kv_arena.layers {
-        resident_kv_arena.arena.set_f16_bits_slice_with_offset(
+        resident_kv_arena.arena.set_bytes_slice_with_offset(
             layer.key,
             plane_offset,
             &zeros,
             "qwen_llm_resident_kv_slot_zero_key",
         )?;
-        resident_kv_arena.arena.set_f16_bits_slice_with_offset(
+        resident_kv_arena.arena.set_bytes_slice_with_offset(
             layer.value,
             plane_offset,
             &zeros,
@@ -5011,6 +5310,7 @@ mod tests {
             1,
             2,
             "test_qwen_seed_kv",
+            LlmKvCacheSpec::DEFAULT,
         )
         .expect("resident kv arena should allocate");
         let mut seq0 = Qwen3AsrLayerKvCacheState::new(3, 1, 2);
@@ -5025,8 +5325,16 @@ mod tests {
         let seq1_layers = vec![seq1];
         let seeds: [&[Qwen3AsrLayerKvCacheState]; 2] = [&seq0_layers, &seq1_layers];
 
-        seed_qwen_batched_resident_kv_arena(&mut resident, 2, 3, 1, &[2, 1], &seeds)
-            .expect("seed should upload");
+        seed_qwen_batched_resident_kv_arena(
+            &mut resident,
+            2,
+            3,
+            1,
+            &[2, 1],
+            &seeds,
+            LlmKvCacheSpec::DEFAULT.resident,
+        )
+        .expect("seed should upload");
 
         let layer = resident.layers[0];
         let key_values = resident
@@ -5064,6 +5372,7 @@ mod tests {
             1,
             2,
             "test_qwen_slot_seed_kv",
+            LlmKvCacheSpec::DEFAULT,
         )
         .expect("resident kv arena should allocate");
         let mut seq1 = Qwen3AsrLayerKvCacheState::new(3, 1, 2);
@@ -5073,8 +5382,17 @@ mod tests {
             .expect("seq1 row1");
         let seq1_layers = vec![seq1];
 
-        seed_qwen_batched_resident_kv_slot(&mut resident, 2, 3, 1, 1, 2, &seq1_layers)
-            .expect("slot seed should upload");
+        seed_qwen_batched_resident_kv_slot(
+            &mut resident,
+            2,
+            3,
+            1,
+            1,
+            2,
+            &seq1_layers,
+            LlmKvCacheSpec::DEFAULT.resident,
+        )
+        .expect("slot seed should upload");
 
         let layer = resident.layers[0];
         let key_values = resident
@@ -5096,8 +5414,15 @@ mod tests {
             ])
         );
 
-        zero_qwen_batched_resident_kv_slot(&mut resident, 2, 3, 1, 1)
-            .expect("slot zero should upload");
+        zero_qwen_batched_resident_kv_slot(
+            &mut resident,
+            2,
+            3,
+            1,
+            1,
+            LlmKvCacheSpec::DEFAULT.resident,
+        )
+        .expect("slot zero should upload");
         let key_values = resident
             .arena
             .read_f16_bits_slice(layer.key, 12)
@@ -5123,6 +5448,7 @@ mod tests {
             1,
             1,
             "test_qwen_seed_kv",
+            LlmKvCacheSpec::DEFAULT,
         )
         .expect("resident kv arena should allocate");
         let mut seq0 = Qwen3AsrLayerKvCacheState::new(3, 1, 2);
@@ -5131,8 +5457,16 @@ mod tests {
         let seq0_layers = vec![seq0];
         let seeds: [&[Qwen3AsrLayerKvCacheState]; 1] = [&seq0_layers];
 
-        let error = seed_qwen_batched_resident_kv_arena(&mut resident, 2, 3, 1, &[2], &seeds)
-            .expect_err("prefix mismatch must fail closed");
+        let error = seed_qwen_batched_resident_kv_arena(
+            &mut resident,
+            2,
+            3,
+            1,
+            &[2],
+            &seeds,
+            LlmKvCacheSpec::DEFAULT.resident,
+        )
+        .expect_err("prefix mismatch must fail closed");
         assert!(matches!(
             error,
             GgmlCpuGraphError::UnsupportedInputs {
@@ -5670,9 +6004,13 @@ mod tests {
         let history = cache.full_history_storage().expect("serial history");
         assert!(position < history.written_positions, "unwritten serial row");
         assert_eq!(history.kv_heads * history.head_dim, kv_width);
+        assert!(
+            matches!(history.element_type, GgmlKvElementType::F32),
+            "serial_layer_kv_row helper is f32-only"
+        );
         let storage = match kind {
-            KvRowKind::Key => history.keys,
-            KvRowKind::Value => history.values,
+            KvRowKind::Key => history.keys_f32.expect("f32 keys"),
+            KvRowKind::Value => history.values_f32.expect("f32 values"),
         };
         let mut row = Vec::with_capacity(kv_width);
         for kv_head in 0..history.kv_heads {

--- a/crates/openasr-core/src/nn/decoder.rs
+++ b/crates/openasr-core/src/nn/decoder.rs
@@ -20,7 +20,8 @@ use std::sync::Arc;
 
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphBuilder, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor,
-    GgmlPersistentGraphSession, GgmlRopeExtParams, GgmlStaticTensor, GgmlStaticTensorArena,
+    GgmlKvElementType, GgmlPersistentGraphSession, GgmlRopeExtParams, GgmlStaticTensor,
+    GgmlStaticTensorArena,
 };
 use crate::nn::attn::{
     AttentionHeadLayout, AttentionReshapeSteps, STANDARD_HEAD_PERMUTE_AXES,
@@ -47,6 +48,103 @@ pub(crate) fn reusable_decode_graph_supported(
 
 pub(crate) fn reusable_decode_graph_supported_for_runner(runner: &GgmlCpuGraphRunner) -> bool {
     reusable_decode_graph_supported(runner.backend_kind(), runner.uses_scheduler())
+}
+
+/// Internal execution policy for Qwen-family LLM KV caches.
+///
+/// Not a public env gate and not a pack/catalog quant tag. Default preserves the
+/// existing host-F32 / resident-F16 byte path. `Q8_0` opts into the phase-1
+/// shared quantized path (CPU/Metal, native-GQA, flash-only).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[allow(dead_code)]
+pub(crate) enum LlmKvCachePolicy {
+    #[default]
+    Default,
+    Q8_0,
+}
+
+#[allow(dead_code)]
+impl LlmKvCachePolicy {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Q8_0 => "q8_0",
+        }
+    }
+
+    pub(crate) const fn to_spec(self) -> LlmKvCacheSpec {
+        match self {
+            Self::Default => LlmKvCacheSpec::DEFAULT,
+            Self::Q8_0 => LlmKvCacheSpec::Q8_0,
+        }
+    }
+}
+
+/// Shared host + resident KV element-type pair for all Qwen-shaped decoders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct LlmKvCacheSpec {
+    pub host: GgmlKvElementType,
+    pub resident: GgmlKvElementType,
+}
+
+impl LlmKvCacheSpec {
+    pub(crate) const DEFAULT: Self = Self {
+        host: GgmlKvElementType::F32,
+        resident: GgmlKvElementType::F16,
+    };
+
+    pub(crate) const Q8_0: Self = Self {
+        host: GgmlKvElementType::Q8_0,
+        resident: GgmlKvElementType::Q8_0,
+    };
+
+    pub(crate) fn validate_geometry(self, head_dim: usize) -> Result<(), String> {
+        self.host.validate_head_dim(head_dim)?;
+        self.resident.validate_head_dim(head_dim)?;
+        Ok(())
+    }
+
+    /// Phase-1 Q8 is CPU/Metal + native-GQA + flash-only. Default is always OK.
+    pub(crate) fn validate_execution(
+        self,
+        backend: GgmlCpuGraphBackend,
+        head_dim: usize,
+        use_native_gqa: bool,
+        use_flash_attention: bool,
+    ) -> Result<(), String> {
+        self.validate_geometry(head_dim)?;
+        let uses_q8 = matches!(self.host, GgmlKvElementType::Q8_0)
+            || matches!(self.resident, GgmlKvElementType::Q8_0);
+        if !uses_q8 {
+            return Ok(());
+        }
+        if !matches!(self.host, GgmlKvElementType::Q8_0)
+            || !matches!(self.resident, GgmlKvElementType::Q8_0)
+        {
+            return Err(
+                "phase-1 q8_0 KV requires host and resident element types to both be q8_0"
+                    .to_string(),
+            );
+        }
+        if !self.host.supports_backend(backend) || !self.resident.supports_backend(backend) {
+            return Err(format!(
+                "phase-1 q8_0 KV is only supported on CPU/Metal (backend={backend:?})"
+            ));
+        }
+        if !use_native_gqa {
+            return Err(
+                "phase-1 q8_0 KV requires native GQA flash attention (manual GQA expand is unsupported)"
+                    .to_string(),
+            );
+        }
+        if !use_flash_attention {
+            return Err(
+                "phase-1 q8_0 KV requires flash_attn_ext (naive attention path is unsupported)"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Scalar/shape knobs for one seq2seq (cross-attending) decoder block.
@@ -1103,6 +1201,8 @@ pub(crate) struct LlmDecoderStackConfig {
     pub use_native_gqa: bool,
     /// See `LlmLayerConfig::use_flash_attention`.
     pub use_flash_attention: bool,
+    /// Host/resident KV element types for this stack composition.
+    pub kv_cache_spec: LlmKvCacheSpec,
 }
 
 /// Per-step inputs for one composition of an LLM decoder layer stack.
@@ -1834,6 +1934,23 @@ where
             },
         ));
     }
+    if let Err(reason) = config.kv_cache_spec.validate_execution(
+        graph.backend_kind(),
+        config.head_dim,
+        config.use_native_gqa,
+        config.use_flash_attention,
+    ) {
+        // Map dynamic validation into the shared static contract bucket. The
+        // full reason is preserved via a fixed classifier so callers stay on
+        // the existing error type without silent fallback.
+        let _ = reason;
+        return Err(map_err(
+            "llm_decoder_stack_kv_cache_spec",
+            GgmlCpuGraphError::UnsupportedInputs {
+                reason: "llm decoder KV cache spec is unsupported for this backend/attention mode",
+            },
+        ));
+    }
 
     let mut state = inputs.state;
     let mut kv_inputs = Vec::with_capacity(layer_count);
@@ -1842,21 +1959,24 @@ where
         let (key_history, value_history) = match resident_kv {
             Some(resident) => resident[layer_index],
             None => {
+                let host_type = config.kv_cache_spec.host.ggml_type();
                 let key_history = graph
-                    .new_tensor_4d_f32(
+                    .new_tensor_4d_typed(
                         config.head_dim,
                         inputs.kv_span,
                         config.kv_heads,
                         config.n_seq,
+                        host_type,
                         inputs.key_history_name,
                     )
                     .map_err(|source| map_err("llm_decoder_stack_key_history", source))?;
                 let value_history = graph
-                    .new_tensor_4d_f32(
+                    .new_tensor_4d_typed(
                         config.head_dim,
                         inputs.kv_span,
                         config.kv_heads,
                         config.n_seq,
+                        host_type,
                         inputs.value_history_name,
                     )
                     .map_err(|source| map_err("llm_decoder_stack_value_history", source))?;
@@ -1915,11 +2035,12 @@ where
     })
 }
 
-/// Allocate a zero-filled resident KV cache arena. The cache element type is
-/// always f16: it halves the arena footprint and the attention K/V read
-/// bandwidth; `set_rows` casts the f32 projection rows on write and both
-/// `flash_attn_ext` and `mul_mat` consume f16 K/V natively, so the decode
-/// graph shape is unchanged.
+/// Allocate a zero-filled resident KV cache arena.
+///
+/// Default spec keeps the historical f16 resident path (set_rows casts f32
+/// projection rows on write; flash_attn_ext / mul_mat consume f16 natively).
+/// Opt-in q8_0 allocates native ggml q8_0 tensors and relies on set_rows +
+/// flash_attn_ext to quantize/consume them without a full f32 staging buffer.
 pub(crate) fn allocate_zeroed_llm_resident_kv_arena(
     runner: &GgmlCpuGraphRunner,
     context_bytes: usize,
@@ -1929,39 +2050,72 @@ pub(crate) fn allocate_zeroed_llm_resident_kv_arena(
     kv_heads: usize,
     n_seq: usize,
     tensor_name_prefix: &str,
+    kv_cache_spec: LlmKvCacheSpec,
 ) -> Result<LlmResidentKvArena, GgmlCpuGraphError> {
     if n_seq == 0 {
         return Err(GgmlCpuGraphError::UnsupportedInputs {
             reason: "resident KV n_seq must be positive",
         });
     }
+    if let Err(_reason) = kv_cache_spec.validate_geometry(head_dim) {
+        return Err(GgmlCpuGraphError::UnsupportedInputs {
+            reason: "resident KV element type is incompatible with head_dim",
+        });
+    }
+    if !kv_cache_spec
+        .resident
+        .supports_backend(runner.backend_kind())
+    {
+        return Err(GgmlCpuGraphError::UnsupportedInputs {
+            reason: "resident KV element type is unsupported on this backend",
+        });
+    }
     let mut arena = runner.start_static_tensor_arena(context_bytes)?;
     let mut layers = Vec::with_capacity(layer_count);
+    let resident_type = kv_cache_spec.resident.ggml_type();
     for layer_idx in 0..layer_count {
         let key_name = Box::leak(format!("{tensor_name_prefix}_key_{layer_idx}").into_boxed_str())
             as &'static str;
         let value_name =
             Box::leak(format!("{tensor_name_prefix}_value_{layer_idx}").into_boxed_str())
                 as &'static str;
-        let key = arena.new_tensor_4d_f16(head_dim, max_positions, kv_heads, n_seq, key_name)?;
-        let value =
-            arena.new_tensor_4d_f16(head_dim, max_positions, kv_heads, n_seq, value_name)?;
+        let key = arena.new_tensor_4d_typed(
+            head_dim,
+            max_positions,
+            kv_heads,
+            n_seq,
+            resident_type,
+            key_name,
+        )?;
+        let value = arena.new_tensor_4d_typed(
+            head_dim,
+            max_positions,
+            kv_heads,
+            n_seq,
+            resident_type,
+            value_name,
+        )?;
         layers.push(LlmResidentKvLayer { key, value });
     }
     arena.allocate_backend_buffer()?;
-    let kv_elems = head_dim
-        .checked_mul(max_positions)
-        .and_then(|n| n.checked_mul(kv_heads))
-        .and_then(|n| n.checked_mul(n_seq))
-        .ok_or(GgmlCpuGraphError::UnsupportedInputs {
-            reason: "resident KV element count overflow",
+    let plane_nbytes = kv_cache_spec
+        .resident
+        .plane_nbytes(head_dim, max_positions, kv_heads)
+        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+            reason: "resident KV plane byte count overflow",
         })?;
-    // Zero-fill so masked (unwritten) positions never feed NaN/inf into
-    // flash-attn; the f16 bit pattern for zero is zero.
-    let kv_zero = vec![0_u16; kv_elems];
+    let tensor_nbytes =
+        plane_nbytes
+            .checked_mul(n_seq)
+            .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "resident KV tensor byte count overflow",
+            })?;
+    // Zero-fill so masked (unwritten) positions never feed garbage into
+    // attention. For f16/q8_0 the all-zero bit pattern dequantizes to zero.
+    let kv_zero = vec![0_u8; tensor_nbytes];
     for layer in &layers {
-        arena.set_f16_bits_slice(layer.key, &kv_zero, "resident_kv_key")?;
-        arena.set_f16_bits_slice(layer.value, &kv_zero, "resident_kv_value")?;
+        arena.set_bytes_slice(layer.key, &kv_zero, "resident_kv_key")?;
+        arena.set_bytes_slice(layer.value, &kv_zero, "resident_kv_value")?;
     }
     Ok(LlmResidentKvArena { arena, layers })
 }
@@ -2605,6 +2759,7 @@ mod tests {
                 rope: GgmlRopeExtParams::qwen_neox(1, 1, 10_000.0).expect("rope params"),
                 use_native_gqa: true,
                 use_flash_attention: true,
+                kv_cache_spec: LlmKvCacheSpec::DEFAULT,
             },
             LlmDecoderStackInputs {
                 state,
@@ -2673,6 +2828,7 @@ mod tests {
                 rope: GgmlRopeExtParams::qwen_neox(2, 3, 10_000.0).expect("rope params"),
                 use_native_gqa: false,
                 use_flash_attention: true,
+                kv_cache_spec: LlmKvCacheSpec::DEFAULT,
             },
             LlmDecoderStackInputs {
                 state,
@@ -2844,6 +3000,7 @@ mod tests {
                     .expect("rope params"),
                 use_native_gqa: true,
                 use_flash_attention: true,
+                kv_cache_spec: LlmKvCacheSpec::DEFAULT,
             },
             LlmDecoderStackInputs {
                 state,
@@ -3133,6 +3290,7 @@ mod tests {
             1,
             1,
             "test_resident_kv",
+            LlmKvCacheSpec::DEFAULT,
         )
         .expect("resident KV arena should allocate");
 
@@ -3167,5 +3325,65 @@ mod tests {
                 reason: "fixed KV attention mask token count exceeds max positions"
             }
         ));
+    }
+
+    #[test]
+    fn llm_kv_cache_policy_default_and_q8_specs() {
+        assert_eq!(LlmKvCachePolicy::Default.as_str(), "default");
+        assert_eq!(LlmKvCachePolicy::Q8_0.as_str(), "q8_0");
+        assert_eq!(LlmKvCachePolicy::Default.to_spec(), LlmKvCacheSpec::DEFAULT);
+        assert_eq!(LlmKvCachePolicy::Q8_0.to_spec(), LlmKvCacheSpec::Q8_0);
+        assert_eq!(LlmKvCacheSpec::DEFAULT.host, GgmlKvElementType::F32);
+        assert_eq!(LlmKvCacheSpec::DEFAULT.resident, GgmlKvElementType::F16);
+        assert_eq!(LlmKvCacheSpec::Q8_0.host, GgmlKvElementType::Q8_0);
+        assert_eq!(LlmKvCacheSpec::Q8_0.resident, GgmlKvElementType::Q8_0);
+    }
+
+    #[test]
+    fn llm_kv_cache_spec_q8_requires_native_gqa_flash_on_cpu_metal() {
+        let spec = LlmKvCacheSpec::Q8_0;
+        spec.validate_execution(GgmlCpuGraphBackend::Cpu, 128, true, true)
+            .expect("cpu native gqa flash q8");
+        spec.validate_execution(GgmlCpuGraphBackend::Metal, 128, true, true)
+            .expect("metal native gqa flash q8");
+        assert!(
+            spec.validate_execution(GgmlCpuGraphBackend::Gpu, 128, true, true)
+                .unwrap_err()
+                .contains("CPU/Metal")
+        );
+        assert!(
+            spec.validate_execution(GgmlCpuGraphBackend::Cpu, 128, false, true)
+                .unwrap_err()
+                .contains("native GQA")
+        );
+        assert!(
+            spec.validate_execution(GgmlCpuGraphBackend::Cpu, 128, true, false)
+                .unwrap_err()
+                .contains("flash_attn_ext")
+        );
+        assert!(
+            spec.validate_execution(GgmlCpuGraphBackend::Cpu, 40, true, true)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn resident_kv_arena_allocates_q8_layers() {
+        let runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("cpu graph runner should initialize");
+        let resident = allocate_zeroed_llm_resident_kv_arena(
+            &runner,
+            GgmlCpuGraphConfig::default().context_bytes,
+            2,
+            64,
+            4,
+            1,
+            1,
+            "test_resident_kv_q8",
+            LlmKvCacheSpec::Q8_0,
+        )
+        .expect("q8 resident KV arena should allocate");
+        assert_eq!(resident.layers.len(), 2);
+        assert_eq!(resident.graph_tensors().len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Add a shared phase-1 `q8_0` KV-cache path for the Qwen-family decoder stack, with typed fail-closed behavior on backends that cannot run it safely.

## Why

Resident F16 KV is the default, but Q8 is already present in ggml for CPU/Metal flash + native GQA. Opening a real packed Q8 path (no F32 staging) cuts KV memory for long prompts without inventing a second backend or a public env gate.

## Changes

- Introduce shared `GgmlKvElementType` and `LlmKvCacheSpec` / `LlmKvCachePolicy`.
- Keep default host F32 / resident F16 byte paths unchanged.
- Phase-1 Q8: host and resident both `q8_0`; allow only CPU/Metal + native-GQA + flash.
- Typed reject on CUDA / Vulkan / HIP (HIP native GQA correctness issues stay closed).
- Host Q8 uses raw packed bytes for upload/seed/resize/fork/truncate; resident Q8 writes packed blocks directly (no full F32 staging).
- Wire qwen3-asr / mimo / firered2-llm / moss through the shared path; moonshine stays on DEFAULT.
- Internal policy entry only (`set_kv_cache_policy` / family decoder spec). No public env gate, no `.oasr` or catalog changes.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (openasr-core)
- [x] `cargo nextest run -p openasr-core --lib` (2346 passed)
- [x] `cargo test -p openasr-core --doc`
- [ ] `cargo deny check`

Additional checks:

- Quantize layout / cache resize-fork-truncate unit coverage
- Capability fail-closed tests for disallowed backends
- Short golden regression on default (non-Q8) paths: moss jfk CPU/Metal, mimo jfk, qwen3-asr pack AB

## Manual smoke checks

- Default KV path transcripts unchanged on short fixtures above.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Phase-1 only. Does not enable Q8 on CUDA/Vulkan/HIP, does not change pack format or catalog, does not claim measured RTF/WER wins in this PR.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
