### PR TITLE
feat(core): add request-level exact GPU route foundation

### DIFF
--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -862,6 +862,12 @@ pub enum BackendError {
         "Native ASR Core transcription stayed fail-closed after local runtime source validation/dispatch: {reason}\nNo partial transcript was emitted."
     )]
     NativeFailClosed { reason: String },
+    #[error("Native ASR execution device was not found: {detail}")]
+    ExecutionDeviceNotFound { detail: String },
+    #[error("Native ASR execution device is not exactly addressable: {detail}")]
+    ExecutionDeviceNotAddressable { detail: String },
+    #[error("Native ASR execution device failed to initialize: {detail}")]
+    ExecutionDeviceInitFailed { detail: String },
     #[error(
         "Native ASR Core serve-batch decode is temporarily unavailable: {reason}\nThis is a transient condition; retry the request."
     )]

--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -890,6 +890,33 @@ pub enum BackendError {
     WordTimestampAlignmentFailed { reason: String },
 }
 
+impl BackendError {
+    /// Map a typed execution-route failure onto the public backend error surface.
+    ///
+    /// Used by request-time route resolve and by dispatch recovery when a family
+    /// executor stringified a graph-init `ExecutionRoute` error.
+    pub fn from_execution_route_error(
+        error: crate::device::execution_route::ExecutionRouteError,
+    ) -> Self {
+        use crate::device::execution_route::ExecutionRouteError;
+        match error {
+            ExecutionRouteError::DeviceNotFound { detail } => {
+                Self::ExecutionDeviceNotFound { detail }
+            }
+            ExecutionRouteError::NotAddressable { detail } => {
+                Self::ExecutionDeviceNotAddressable { detail }
+            }
+            ExecutionRouteError::InitFailed { detail } => {
+                Self::ExecutionDeviceInitFailed { detail }
+            }
+            ExecutionRouteError::AcceleratedUnavailable => Self::NativeFailClosed {
+                reason: "execution_target=accelerated was requested, but no ggml GPU device is available."
+                    .to_string(),
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -909,6 +936,29 @@ mod tests {
         let error = "not-a-backend".parse::<BackendKind>().unwrap_err();
         assert!(error.contains("Unsupported backend 'not-a-backend'"));
         assert!(error.contains("mock, native"));
+    }
+
+    #[test]
+    fn from_execution_route_error_preserves_typed_variants() {
+        use crate::device::execution_route::ExecutionRouteError;
+
+        assert!(matches!(
+            BackendError::from_execution_route_error(ExecutionRouteError::device_not_found("cuda0")),
+            BackendError::ExecutionDeviceNotFound { detail } if detail == "cuda0"
+        ));
+        assert!(matches!(
+            BackendError::from_execution_route_error(ExecutionRouteError::not_addressable("metal")),
+            BackendError::ExecutionDeviceNotAddressable { detail } if detail == "metal"
+        ));
+        assert!(matches!(
+            BackendError::from_execution_route_error(ExecutionRouteError::init_failed("hip0")),
+            BackendError::ExecutionDeviceInitFailed { detail } if detail == "hip0"
+        ));
+        assert!(matches!(
+            BackendError::from_execution_route_error(ExecutionRouteError::AcceleratedUnavailable),
+            BackendError::NativeFailClosed { reason }
+                if reason.contains("execution_target=accelerated")
+        ));
     }
 
     #[test]

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -441,11 +441,9 @@ fn native_ggml_backend_preference_from_hardware_target(
             if has_accelerated_device {
                 Ok(GgmlAsrBackendPreference::Accelerated)
             } else {
-                Err(NativeAsrError::SessionFailed {
-                    message: format!(
-                        "hardware target '{target}' was requested, but no ggml GPU device is available"
-                    ),
-                })
+                Err(NativeAsrError::from_execution_route_error(
+                    crate::device::execution_route::ExecutionRouteError::AcceleratedUnavailable,
+                ))
             }
         }
         NativeAsrHardwareTarget::IntelNpu => {
@@ -515,9 +513,21 @@ fn native_ggml_streaming_error_to_asr(
                 backend: adapter_id.to_string(),
             }
         }
-        other => NativeAsrError::SessionFailed {
-            message: format!("native ggml streaming session failed: {other}"),
-        },
+        GgmlAsrExecutionError::ExecutionRoute(error) => {
+            NativeAsrError::from_execution_route_error(error)
+        }
+        other => {
+            if let Some(route_error) =
+                crate::device::execution_route::ExecutionRouteError::from_embedded_message(
+                    &other.to_string(),
+                )
+            {
+                return NativeAsrError::from_execution_route_error(route_error);
+            }
+            NativeAsrError::SessionFailed {
+                message: format!("native ggml streaming session failed: {other}"),
+            }
+        }
     }
 }
 

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -787,9 +787,10 @@ fn classify_backend_error_for_failure_log(error: &BackendError) -> FailureCatego
         | BackendError::PhraseBiasUnsupportedByModel { .. }
         | BackendError::RequestOptionUnsupportedByModel { .. }
         | BackendError::WordTimestampAlignmentRequiresWordTimestamps
-        | BackendError::WordTimestampAlignmentPackMissing { .. } => {
-            FailureCategory::UnsupportedCapability
-        }
+        | BackendError::WordTimestampAlignmentPackMissing { .. }
+        | BackendError::ExecutionDeviceNotFound { .. }
+        | BackendError::ExecutionDeviceNotAddressable { .. }
+        | BackendError::ExecutionDeviceInitFailed { .. } => FailureCategory::UnsupportedCapability,
         BackendError::TranscriptionCanceled => FailureCategory::Canceled,
         BackendError::ServeBatchUnavailable { .. } => FailureCategory::Transient,
         BackendError::NativeFailClosed { .. }

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -2198,9 +2198,25 @@ fn dispatch_error_to_backend(error: GgmlAsrExecutionError) -> BackendError {
         GgmlAsrExecutionError::ServeBatchUnavailable { reason, retryable } => {
             BackendError::ServeBatchUnavailable { reason, retryable }
         }
-        other => BackendError::NativeFailClosed {
-            reason: other.to_string(),
-        },
+        GgmlAsrExecutionError::ExecutionRoute(error) => {
+            BackendError::from_execution_route_error(error)
+        }
+        other => {
+            // Family executors historically stringify `GgmlCpuGraphError` into
+            // `ExecutorFailed.reason`. Recover the typed route failure when the
+            // Display text still embeds it so Exact/init failures stay
+            // `ExecutionDevice*` end-to-end.
+            if let Some(route_error) =
+                crate::device::execution_route::ExecutionRouteError::from_embedded_message(
+                    &other.to_string(),
+                )
+            {
+                return BackendError::from_execution_route_error(route_error);
+            }
+            BackendError::NativeFailClosed {
+                reason: other.to_string(),
+            }
+        }
     }
 }
 

--- a/crates/openasr-core/src/api/native/errors.rs
+++ b/crates/openasr-core/src/api/native/errors.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 use super::{NativeAsrHardwareTarget, NativeAsrRuntimeReadiness};
+use crate::device::execution_route::ExecutionRouteError;
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum NativeAsrError {
@@ -21,6 +22,12 @@ pub enum NativeAsrError {
         adapter: String,
         model_family: String,
     },
+    #[error("Native ASR execution device was not found: {detail}.")]
+    ExecutionDeviceNotFound { detail: String },
+    #[error("Native ASR execution device is not exactly addressable: {detail}.")]
+    ExecutionDeviceNotAddressable { detail: String },
+    #[error("Native ASR execution device failed to initialize: {detail}.")]
+    ExecutionDeviceInitFailed { detail: String },
     #[error("Native ASR session is closed.")]
     SessionClosed,
     #[error("Native ASR session failed: {message}.")]
@@ -44,6 +51,23 @@ impl NativeAsrError {
                 "Native ASR session backpressure exceeded: {}",
                 message.into()
             ),
+        }
+    }
+
+    pub fn from_execution_route_error(error: ExecutionRouteError) -> Self {
+        match error {
+            ExecutionRouteError::DeviceNotFound { detail } => {
+                Self::ExecutionDeviceNotFound { detail }
+            }
+            ExecutionRouteError::NotAddressable { detail } => {
+                Self::ExecutionDeviceNotAddressable { detail }
+            }
+            ExecutionRouteError::InitFailed { detail } => {
+                Self::ExecutionDeviceInitFailed { detail }
+            }
+            ExecutionRouteError::AcceleratedUnavailable => Self::ProviderUnavailable {
+                provider: "accelerated".to_string(),
+            },
         }
     }
 }

--- a/crates/openasr-core/src/api/native/errors.rs
+++ b/crates/openasr-core/src/api/native/errors.rs
@@ -54,6 +54,10 @@ impl NativeAsrError {
         }
     }
 
+    /// Production mapping used when a native session/stream hits a typed
+    /// execution-route failure (Exact miss / not-addressable / init failed /
+    /// accelerated unavailable). Keep in lockstep with
+    /// [`crate::BackendError::from_execution_route_error`].
     pub fn from_execution_route_error(error: ExecutionRouteError) -> Self {
         match error {
             ExecutionRouteError::DeviceNotFound { detail } => {

--- a/crates/openasr-core/src/device/execution_route.rs
+++ b/crates/openasr-core/src/device/execution_route.rs
@@ -1,8 +1,9 @@
 //! Request-level execution route foundation.
 //!
 //! Public request surfaces stay coarse (`ExecutionTarget::{Auto,Cpu,Accelerated}`).
-//! This module adds the internal exact-route vocabulary that cache, worker, and
-//! admission isolation must share before any product UI exposes GPU0/GPU1 picks.
+//! This module adds the internal exact-route vocabulary that backend-handle cache
+//! and streaming-worker isolation share before any product UI exposes GPU0/GPU1
+//! picks.
 //!
 //! Correct abstraction:
 //! - [`ResolvedExecutionRoute`] = logical `(provider, stable_id)` plus optional
@@ -10,6 +11,11 @@
 //! - Exact resolution is typed fail-closed: no silent card swap, no CPU fallback
 //! - Metal devices are enumerable but [`DeviceAddressability::NotExactlyAddressable`]
 //!   because ggml Metal still initializes via `MTLCreateSystemDefaultDevice` only
+//! - Admission capacity stays **per model identity** (route does not split slots).
+//!   Route identity isolates thread-local ggml backend handles and streaming
+//!   workers only. Family prepared-runtime caches and serve-batch engine keys are
+//!   still coarse `(path, backend)` -- not route-isolated -- until a follow-up
+//!   runtime-cache coordinator lands (hard gate before public Exact).
 
 use std::fmt;
 
@@ -87,6 +93,11 @@ impl fmt::Display for ExecutionProvider {
 /// `domain:bus:device.function` (e.g. `0000:c1:00.0`). CUDA/HIP always aim to
 /// provide this; Vulkan does when the instance exposes the PCI bus id; Metal
 /// never does.
+///
+/// Normalization is intentionally weak today: trim + ASCII lower-case only.
+/// A full PCI BDF grammar validator is a known follow-up (see
+/// `docs/KNOWN_LIMITATIONS.md`); callers must not treat this type as proof of
+/// a well-formed BDF string.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PhysicalResourceKey(String);
 
@@ -148,12 +159,15 @@ impl RouteDeviceKind {
     }
 }
 
-/// Logical route identity used for cache / worker / admission isolation.
+/// Logical route identity used for backend-handle cache and streaming-worker
+/// isolation (not admission capacity -- see [`admission_identity_for_route`]).
 ///
 /// `(provider, stable_id)` is always present. [`PhysicalResourceKey`] is layered
-/// on when ggml supplies a PCI-style `device_id`. Registry ordinal is retained
-/// only as a fail-closed disambiguator when two same-provider devices would
-/// otherwise collapse to one isolation key.
+/// on when ggml supplies a PCI-style `device_id`. `registry_ordinal` is retained
+/// so init-time device matching can disambiguate inventory rows when PCI ids are
+/// absent; it is intentionally **not** part of [`Self::isolation_key`] /
+/// [`Self::cache_key`] so a stable device keeps its key across harmless
+/// re-enumeration order shifts when `stable_id` (and PCI when present) identify it.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ResolvedExecutionRoute {
     pub provider: ExecutionProvider,
@@ -165,9 +179,10 @@ pub struct ResolvedExecutionRoute {
 }
 
 impl ResolvedExecutionRoute {
-    /// Isolation key shared by backend cache, streaming worker keys, and model
-    /// admission slots. Exact and preferred-accelerated routes that resolve to
-    /// the same device must produce the same key.
+    /// Isolation key shared by the thread-local ggml backend-handle cache and
+    /// streaming worker keys. Exact and preferred-accelerated routes that resolve
+    /// to the same device must produce the same key. Admission capacity does
+    /// **not** use this key (see [`admission_identity_for_route`]).
     pub fn isolation_key(&self) -> String {
         match self.addressability.physical_key() {
             Some(physical) => format!(
@@ -180,9 +195,8 @@ impl ResolvedExecutionRoute {
         }
     }
 
-    /// Backend-cache key: provider + stable_id, plus physical key when present.
-    /// Ordinal is intentionally excluded so a stable device keeps its cache
-    /// entry across harmless re-enumeration order shifts when identity is known.
+    /// Backend-handle cache key: provider + stable_id, plus physical key when
+    /// present. Ordinal is intentionally excluded (see struct docs).
     pub fn cache_key(&self) -> ExecutionRouteCacheKey {
         ExecutionRouteCacheKey {
             provider: self.provider,
@@ -293,6 +307,42 @@ impl ExecutionRouteError {
         Self::InitFailed {
             detail: detail.into(),
         }
+    }
+
+    /// Recover a typed route error from a coarse string that embedded this
+    /// error's Display text (family executors historically stringify
+    /// `GgmlCpuGraphError` before it reaches `dispatch_error_to_backend`).
+    ///
+    /// Matches the stable thiserror messages below; keep those strings in sync
+    /// if the `#[error(...)]` text on this enum changes.
+    pub fn from_embedded_message(message: &str) -> Option<Self> {
+        const NOT_FOUND: &str = "requested execution device was not found: ";
+        const NOT_ADDRESSABLE: &str = "requested execution device is not exactly addressable: ";
+        const INIT_FAILED: &str = "requested execution device failed to initialize: ";
+        const ACCEL_UNAVAILABLE: &str = "no accelerated execution device is available";
+
+        if let Some(detail) = message
+            .rfind(NOT_FOUND)
+            .map(|idx| &message[idx + NOT_FOUND.len()..])
+        {
+            return Some(Self::device_not_found(detail.trim()));
+        }
+        if let Some(detail) = message
+            .rfind(NOT_ADDRESSABLE)
+            .map(|idx| &message[idx + NOT_ADDRESSABLE.len()..])
+        {
+            return Some(Self::not_addressable(detail.trim()));
+        }
+        if let Some(detail) = message
+            .rfind(INIT_FAILED)
+            .map(|idx| &message[idx + INIT_FAILED.len()..])
+        {
+            return Some(Self::init_failed(detail.trim()));
+        }
+        if message.contains(ACCEL_UNAVAILABLE) {
+            return Some(Self::AcceleratedUnavailable);
+        }
+        None
     }
 }
 
@@ -423,17 +473,33 @@ fn resolve_auto_route(
 fn resolve_preferred_accelerated_route(
     inventory: &[EnumeratedComputeDevice],
 ) -> Result<ResolvedExecutionRoute, ExecutionRouteError> {
-    inventory
-        .iter()
-        .filter(|device| device.kind == RouteDeviceKind::Accelerated)
-        .min_by_key(|device| {
-            (
-                crate::ggml_runtime::accelerated_device_rank(device.ggml_kind),
-                device.registry_ordinal,
-            )
-        })
+    ranked_preferred_accelerated_devices(inventory)
+        .into_iter()
+        .next()
         .map(EnumeratedComputeDevice::to_resolved_route)
         .ok_or(ExecutionRouteError::AcceleratedUnavailable)
+}
+
+/// Preferred accelerated candidates in Optimus-aware rank order
+/// (discrete GPU before iGPU / accelerator), then registry ordinal.
+///
+/// Used by route resolve and by preferred/Auto GPU backend init so discrete
+/// init failure can fall through to the next ranked device **under that
+/// device's own cache key**.
+pub fn ranked_preferred_accelerated_devices(
+    inventory: &[EnumeratedComputeDevice],
+) -> Vec<&EnumeratedComputeDevice> {
+    let mut devices: Vec<&EnumeratedComputeDevice> = inventory
+        .iter()
+        .filter(|device| device.kind == RouteDeviceKind::Accelerated)
+        .collect();
+    devices.sort_by_key(|device| {
+        (
+            crate::ggml_runtime::accelerated_device_rank(device.ggml_kind),
+            device.registry_ordinal,
+        )
+    });
+    devices
 }
 
 fn resolve_exact_route(
@@ -472,6 +538,19 @@ fn resolve_exact_route(
                 .join(", ")
         ))),
         [device] => {
+            // CPU is selected only by the coarse `cpu` target, never Exact pin.
+            if device.provider == ExecutionProvider::Cpu {
+                return Err(ExecutionRouteError::not_addressable(format!(
+                    "provider=cpu stable_id={} reason={}",
+                    device.stable_id,
+                    match &device.addressability {
+                        DeviceAddressability::NotExactlyAddressable { reason } => *reason,
+                        DeviceAddressability::ExactlyAddressable { .. } => {
+                            "CPU is selected by the coarse cpu target, not by Exact device pin"
+                        }
+                    }
+                )));
+            }
             // Metal (and other not-exactly-addressable providers) may match by
             // stable_id in inventory, but Exact must still fail closed.
             if device.provider == ExecutionProvider::Metal
@@ -492,10 +571,10 @@ fn resolve_exact_route(
             }
             // Stable-id Exact on CUDA/HIP/Vulkan is allowed even when PCI id is
             // missing: the stable ggml name is still a concrete device pin and
-            // must not silently retarget another card.
+            // must not silently retarget another card. Non-exact providers
+            // (Accelerator/Unknown/...) stay fail-closed here.
             if matches!(selector, ExactDeviceSelector::StableId { .. })
                 && !device.provider.supports_exact_selection()
-                && device.provider != ExecutionProvider::Cpu
             {
                 return Err(ExecutionRouteError::not_addressable(format!(
                     "provider={} does not support Exact selection (stable_id={})",
@@ -516,15 +595,20 @@ fn resolve_exact_route(
     }
 }
 
-/// Admission / capacity slot identity: model pack identity plus resolved route.
+/// Admission / capacity slot identity for native model sessions.
+///
+/// Foundation invariant: capacity is **per model identity only**. The optional
+/// `route` argument is accepted so call sites can pass the resolved route they
+/// already have for worker/backend-handle isolation, but it must not split the
+/// global per-model slot (CPU and accelerated/Exact requests for the same model
+/// share one capacity unit). Route isolation belongs to backend-handle cache and
+/// streaming workers via [`worker_route_isolation_key`] / [`ResolvedExecutionRoute::cache_key`].
 pub fn admission_identity_for_route(
     model_identity: &str,
     route: Option<&ResolvedExecutionRoute>,
 ) -> String {
-    match route {
-        Some(route) => format!("{model_identity}|route={}", route.isolation_key()),
-        None => model_identity.to_string(),
-    }
+    let _ = route;
+    model_identity.to_string()
 }
 
 /// Worker-key route component. Coarse targets keep their public spelling when no
@@ -674,19 +758,85 @@ mod tests {
     }
 
     #[test]
-    fn admission_and_worker_keys_include_resolved_route() {
-        let route =
+    fn admission_stays_per_model_while_worker_keys_include_route() {
+        let accelerated =
             resolve_execution_route(&ExecutionRouteRequest::Accelerated, &hybrid_inventory())
                 .unwrap();
+        let cpu =
+            resolve_execution_route(&ExecutionRouteRequest::Cpu, &hybrid_inventory()).unwrap();
+        // Capacity is global per model: CPU and accelerated must share one slot.
         assert_eq!(
-            admission_identity_for_route("native:whisper@pack", Some(&route)),
-            "native:whisper@pack|route=vulkan/Vulkan1/pci:0000:01:00.0"
+            admission_identity_for_route("native:whisper@pack", Some(&accelerated)),
+            "native:whisper@pack"
         );
         assert_eq!(
-            worker_route_isolation_key("accelerated", Some(&route)),
+            admission_identity_for_route("native:whisper@pack", Some(&cpu)),
+            admission_identity_for_route("native:whisper@pack", Some(&accelerated))
+        );
+        assert_eq!(
+            admission_identity_for_route("native:whisper@pack", None),
+            "native:whisper@pack"
+        );
+        // Workers still isolate by concrete device.
+        assert_eq!(
+            worker_route_isolation_key("accelerated", Some(&accelerated)),
             "vulkan/Vulkan1/pci:0000:01:00.0"
         );
+        assert_ne!(
+            worker_route_isolation_key("accelerated", Some(&accelerated)),
+            worker_route_isolation_key("cpu", Some(&cpu))
+        );
         assert_eq!(worker_route_isolation_key("cpu", None), "cpu");
+    }
+
+    #[test]
+    fn cpu_stable_id_exact_is_not_addressable() {
+        let inventory = hybrid_inventory();
+        let error = resolve_execution_route(
+            &ExecutionRouteRequest::Exact(ExactDeviceSelector::StableId {
+                provider: Some(ExecutionProvider::Cpu),
+                stable_id: "CPU".to_string(),
+            }),
+            &inventory,
+        )
+        .expect_err("cpu exact");
+        assert!(matches!(error, ExecutionRouteError::NotAddressable { .. }));
+    }
+
+    #[test]
+    fn preferred_accelerated_rank_orders_discrete_before_integrated() {
+        let inventory = hybrid_inventory();
+        let ranked = ranked_preferred_accelerated_devices(&inventory);
+        assert_eq!(
+            ranked
+                .iter()
+                .map(|device| device.stable_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Vulkan1", "Vulkan0"]
+        );
+        // Fallthrough cache keys must be the actual candidate's key, never the
+        // preferred route's key reused for a lower-ranked device.
+        assert_ne!(
+            ranked[0].to_resolved_route().cache_key(),
+            ranked[1].to_resolved_route().cache_key()
+        );
+    }
+
+    #[test]
+    fn embedded_route_error_message_recovers_typed_variant() {
+        let source =
+            ExecutionRouteError::init_failed("provider=cuda stable_id=CUDA0 backend=CUDA0");
+        let wrapped = format!("could not initialize ggml cpu graph runner: {source}");
+        assert_eq!(
+            ExecutionRouteError::from_embedded_message(&wrapped),
+            Some(source)
+        );
+        assert_eq!(
+            ExecutionRouteError::from_embedded_message(
+                "ggml executor failed: no accelerated execution device is available"
+            ),
+            Some(ExecutionRouteError::AcceleratedUnavailable)
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/device/execution_route.rs
+++ b/crates/openasr-core/src/device/execution_route.rs
@@ -1,0 +1,717 @@
+//! Request-level execution route foundation.
+//!
+//! Public request surfaces stay coarse (`ExecutionTarget::{Auto,Cpu,Accelerated}`).
+//! This module adds the internal exact-route vocabulary that cache, worker, and
+//! admission isolation must share before any product UI exposes GPU0/GPU1 picks.
+//!
+//! Correct abstraction:
+//! - [`ResolvedExecutionRoute`] = logical `(provider, stable_id)` plus optional
+//!   [`PhysicalResourceKey`] (PCI BDF when ggml supplies `device_id`)
+//! - Exact resolution is typed fail-closed: no silent card swap, no CPU fallback
+//! - Metal devices are enumerable but [`DeviceAddressability::NotExactlyAddressable`]
+//!   because ggml Metal still initializes via `MTLCreateSystemDefaultDevice` only
+
+use std::fmt;
+
+use thiserror::Error;
+
+use crate::ggml_runtime::{GgmlBackendDevice, GgmlBackendKind};
+
+/// Backend provider family for route identity. Distinct from the public coarse
+/// [`crate::ExecutionTarget`] surface (`auto` / `cpu` / `accelerated`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExecutionProvider {
+    Cpu,
+    Metal,
+    Cuda,
+    Hip,
+    Vulkan,
+    Accelerator,
+    Unknown,
+}
+
+impl ExecutionProvider {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::Metal => "metal",
+            Self::Cuda => "cuda",
+            Self::Hip => "hip",
+            Self::Vulkan => "vulkan",
+            Self::Accelerator => "accelerator",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Infer provider from a ggml backend/device name.
+    pub fn from_backend_name(name: &str) -> Self {
+        let lower = name.trim().to_ascii_lowercase();
+        if lower.is_empty() {
+            return Self::Unknown;
+        }
+        if lower == "cpu" || lower.starts_with("cpu") {
+            return Self::Cpu;
+        }
+        if lower.contains("metal") || lower.starts_with("mtl") {
+            return Self::Metal;
+        }
+        if lower.starts_with("cuda") {
+            return Self::Cuda;
+        }
+        if lower.starts_with("hip") || lower.starts_with("rocm") {
+            return Self::Hip;
+        }
+        if lower.starts_with("vulkan") || lower.starts_with("vk") {
+            return Self::Vulkan;
+        }
+        if lower.contains("blas") || lower.contains("accel") {
+            return Self::Accelerator;
+        }
+        Self::Unknown
+    }
+
+    pub const fn supports_exact_selection(self) -> bool {
+        matches!(self, Self::Cuda | Self::Hip | Self::Vulkan)
+    }
+}
+
+impl fmt::Display for ExecutionProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Stable physical identity when the backend exposes one.
+///
+/// For PCI devices ggml documents `device_id` as lower-case
+/// `domain:bus:device.function` (e.g. `0000:c1:00.0`). CUDA/HIP always aim to
+/// provide this; Vulkan does when the instance exposes the PCI bus id; Metal
+/// never does.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PhysicalResourceKey(String);
+
+impl PhysicalResourceKey {
+    pub fn new(raw: impl Into<String>) -> Option<Self> {
+        let value = normalize_physical_key(&raw.into())?;
+        Some(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for PhysicalResourceKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Whether a visible device can be the target of an Exact request.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DeviceAddressability {
+    ExactlyAddressable {
+        physical_key: PhysicalResourceKey,
+    },
+    /// Device is usable via Auto/Accelerated, but Exact pin is refused.
+    NotExactlyAddressable {
+        reason: &'static str,
+    },
+}
+
+impl DeviceAddressability {
+    pub const fn is_exactly_addressable(&self) -> bool {
+        matches!(self, Self::ExactlyAddressable { .. })
+    }
+
+    pub fn physical_key(&self) -> Option<&PhysicalResourceKey> {
+        match self {
+            Self::ExactlyAddressable { physical_key } => Some(physical_key),
+            Self::NotExactlyAddressable { .. } => None,
+        }
+    }
+}
+
+/// Coarse class used by route ranking (CPU vs any accelerated device).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RouteDeviceKind {
+    Cpu,
+    Accelerated,
+}
+
+impl RouteDeviceKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::Accelerated => "accelerated",
+        }
+    }
+}
+
+/// Logical route identity used for cache / worker / admission isolation.
+///
+/// `(provider, stable_id)` is always present. [`PhysicalResourceKey`] is layered
+/// on when ggml supplies a PCI-style `device_id`. Registry ordinal is retained
+/// only as a fail-closed disambiguator when two same-provider devices would
+/// otherwise collapse to one isolation key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResolvedExecutionRoute {
+    pub provider: ExecutionProvider,
+    /// Provider-local ggml device name (`CUDA0`, `Vulkan1`, `Metal`, `CPU`, ...).
+    pub stable_id: String,
+    pub registry_ordinal: usize,
+    pub kind: RouteDeviceKind,
+    pub addressability: DeviceAddressability,
+}
+
+impl ResolvedExecutionRoute {
+    /// Isolation key shared by backend cache, streaming worker keys, and model
+    /// admission slots. Exact and preferred-accelerated routes that resolve to
+    /// the same device must produce the same key.
+    pub fn isolation_key(&self) -> String {
+        match self.addressability.physical_key() {
+            Some(physical) => format!(
+                "{}/{}/pci:{}",
+                self.provider.as_str(),
+                self.stable_id,
+                physical.as_str()
+            ),
+            None => format!("{}/{}", self.provider.as_str(), self.stable_id),
+        }
+    }
+
+    /// Backend-cache key: provider + stable_id, plus physical key when present.
+    /// Ordinal is intentionally excluded so a stable device keeps its cache
+    /// entry across harmless re-enumeration order shifts when identity is known.
+    pub fn cache_key(&self) -> ExecutionRouteCacheKey {
+        ExecutionRouteCacheKey {
+            provider: self.provider,
+            stable_id: self.stable_id.clone(),
+            physical_key: self
+                .addressability
+                .physical_key()
+                .map(|key| key.as_str().to_string()),
+        }
+    }
+
+    pub fn cpu() -> Self {
+        Self {
+            provider: ExecutionProvider::Cpu,
+            stable_id: "CPU".to_string(),
+            registry_ordinal: 0,
+            kind: RouteDeviceKind::Cpu,
+            addressability: DeviceAddressability::NotExactlyAddressable {
+                reason: "CPU is selected by the coarse cpu target, not by Exact device pin",
+            },
+        }
+    }
+}
+
+/// Hash key for the thread-local ggml backend cache.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExecutionRouteCacheKey {
+    pub provider: ExecutionProvider,
+    pub stable_id: String,
+    pub physical_key: Option<String>,
+}
+
+impl fmt::Display for ExecutionRouteCacheKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.physical_key {
+            Some(physical) => write!(
+                f,
+                "{}/{}/pci:{}",
+                self.provider.as_str(),
+                self.stable_id,
+                physical
+            ),
+            None => write!(f, "{}/{}", self.provider.as_str(), self.stable_id),
+        }
+    }
+}
+
+/// Internal request intent. The public HTTP/CLI surface still only accepts
+/// `auto` / `cpu` / `accelerated`; Exact exists so the runtime can grow a pin
+/// path without inventing a second abstraction later.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutionRouteRequest {
+    Auto,
+    Cpu,
+    /// Preferred accelerated device (discrete-over-integrated). Not Exact.
+    Accelerated,
+    /// Pin one device. Fail-closed on miss / not-addressable / init failure.
+    Exact(ExactDeviceSelector),
+}
+
+impl ExecutionRouteRequest {
+    pub fn from_execution_target(target: crate::ExecutionTarget) -> Self {
+        match target {
+            crate::ExecutionTarget::Auto => Self::Auto,
+            crate::ExecutionTarget::Cpu => Self::Cpu,
+            crate::ExecutionTarget::Accelerated => Self::Accelerated,
+        }
+    }
+}
+
+/// Exact device selector. Prefer physical PCI identity when the caller has it;
+/// fall back to provider-scoped stable ggml name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExactDeviceSelector {
+    PhysicalKey(PhysicalResourceKey),
+    StableId {
+        provider: Option<ExecutionProvider>,
+        stable_id: String,
+    },
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ExecutionRouteError {
+    #[error("requested execution device was not found: {detail}")]
+    DeviceNotFound { detail: String },
+    #[error("requested execution device is not exactly addressable: {detail}")]
+    NotAddressable { detail: String },
+    #[error("requested execution device failed to initialize: {detail}")]
+    InitFailed { detail: String },
+    #[error("no accelerated execution device is available")]
+    AcceleratedUnavailable,
+}
+
+impl ExecutionRouteError {
+    pub fn device_not_found(detail: impl Into<String>) -> Self {
+        Self::DeviceNotFound {
+            detail: detail.into(),
+        }
+    }
+
+    pub fn not_addressable(detail: impl Into<String>) -> Self {
+        Self::NotAddressable {
+            detail: detail.into(),
+        }
+    }
+
+    pub fn init_failed(detail: impl Into<String>) -> Self {
+        Self::InitFailed {
+            detail: detail.into(),
+        }
+    }
+}
+
+/// One inventory row produced from ggml enumeration (or a fake test registry).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumeratedComputeDevice {
+    pub provider: ExecutionProvider,
+    pub stable_id: String,
+    pub description: String,
+    pub registry_ordinal: usize,
+    pub kind: RouteDeviceKind,
+    pub ggml_kind: GgmlBackendKind,
+    pub addressability: DeviceAddressability,
+    /// Raw ggml `device_id` string when present (pre-normalization).
+    pub device_id: Option<String>,
+}
+
+impl EnumeratedComputeDevice {
+    pub fn to_resolved_route(&self) -> ResolvedExecutionRoute {
+        ResolvedExecutionRoute {
+            provider: self.provider,
+            stable_id: self.stable_id.clone(),
+            registry_ordinal: self.registry_ordinal,
+            kind: self.kind,
+            addressability: self.addressability.clone(),
+        }
+    }
+}
+
+/// Build route inventory from live (or test) ggml device rows.
+pub fn enumerate_compute_devices_from_ggml(
+    devices: &[GgmlBackendDevice],
+) -> Vec<EnumeratedComputeDevice> {
+    devices
+        .iter()
+        .enumerate()
+        .map(|(registry_ordinal, device)| enumerated_from_ggml_device(registry_ordinal, device))
+        .collect()
+}
+
+fn enumerated_from_ggml_device(
+    registry_ordinal: usize,
+    device: &GgmlBackendDevice,
+) -> EnumeratedComputeDevice {
+    let provider = ExecutionProvider::from_backend_name(&device.name);
+    let kind = if device.kind == GgmlBackendKind::Cpu || provider == ExecutionProvider::Cpu {
+        RouteDeviceKind::Cpu
+    } else {
+        RouteDeviceKind::Accelerated
+    };
+    let addressability = addressability_for_device(provider, device.device_id.as_deref());
+    EnumeratedComputeDevice {
+        provider,
+        stable_id: device.name.clone(),
+        description: device.description.clone(),
+        registry_ordinal,
+        kind,
+        ggml_kind: device.kind,
+        addressability,
+        device_id: device.device_id.clone(),
+    }
+}
+
+fn addressability_for_device(
+    provider: ExecutionProvider,
+    raw_device_id: Option<&str>,
+) -> DeviceAddressability {
+    match provider {
+        ExecutionProvider::Metal => DeviceAddressability::NotExactlyAddressable {
+            reason: "Metal initializes via MTLCreateSystemDefaultDevice only; \
+                     exact multi-device selection is not available",
+        },
+        ExecutionProvider::Cpu => DeviceAddressability::NotExactlyAddressable {
+            reason: "CPU is selected by the coarse cpu target, not by Exact device pin",
+        },
+        ExecutionProvider::Accelerator | ExecutionProvider::Unknown => {
+            DeviceAddressability::NotExactlyAddressable {
+                reason: "provider does not expose a stable Exact device identity",
+            }
+        }
+        ExecutionProvider::Cuda | ExecutionProvider::Hip | ExecutionProvider::Vulkan => {
+            match raw_device_id.and_then(PhysicalResourceKey::new) {
+                Some(physical_key) => DeviceAddressability::ExactlyAddressable { physical_key },
+                // Vulkan (and rare CUDA/HIP builds) may omit PCI ids. Stable ggml
+                // names still isolate cache/worker slots; Exact by stable_id is
+                // allowed, Exact by physical key is not.
+                None => DeviceAddressability::NotExactlyAddressable {
+                    reason: "backend did not report a PCI device_id; Exact by \
+                             physical key is unavailable (stable_id Exact may still work)",
+                },
+            }
+        }
+    }
+}
+
+/// Resolve a request against an inventory. Exact never falls back to another
+/// card or to CPU.
+pub fn resolve_execution_route(
+    request: &ExecutionRouteRequest,
+    inventory: &[EnumeratedComputeDevice],
+) -> Result<ResolvedExecutionRoute, ExecutionRouteError> {
+    match request {
+        ExecutionRouteRequest::Cpu => Ok(resolve_cpu_route(inventory)),
+        ExecutionRouteRequest::Auto => resolve_auto_route(inventory),
+        ExecutionRouteRequest::Accelerated => resolve_preferred_accelerated_route(inventory),
+        ExecutionRouteRequest::Exact(selector) => resolve_exact_route(selector, inventory),
+    }
+}
+
+fn resolve_cpu_route(inventory: &[EnumeratedComputeDevice]) -> ResolvedExecutionRoute {
+    inventory
+        .iter()
+        .find(|device| device.kind == RouteDeviceKind::Cpu)
+        .map(EnumeratedComputeDevice::to_resolved_route)
+        .unwrap_or_else(ResolvedExecutionRoute::cpu)
+}
+
+fn resolve_auto_route(
+    inventory: &[EnumeratedComputeDevice],
+) -> Result<ResolvedExecutionRoute, ExecutionRouteError> {
+    match resolve_preferred_accelerated_route(inventory) {
+        Ok(route) => Ok(route),
+        Err(ExecutionRouteError::AcceleratedUnavailable) => Ok(resolve_cpu_route(inventory)),
+        Err(other) => Err(other),
+    }
+}
+
+fn resolve_preferred_accelerated_route(
+    inventory: &[EnumeratedComputeDevice],
+) -> Result<ResolvedExecutionRoute, ExecutionRouteError> {
+    inventory
+        .iter()
+        .filter(|device| device.kind == RouteDeviceKind::Accelerated)
+        .min_by_key(|device| {
+            (
+                crate::ggml_runtime::accelerated_device_rank(device.ggml_kind),
+                device.registry_ordinal,
+            )
+        })
+        .map(EnumeratedComputeDevice::to_resolved_route)
+        .ok_or(ExecutionRouteError::AcceleratedUnavailable)
+}
+
+fn resolve_exact_route(
+    selector: &ExactDeviceSelector,
+    inventory: &[EnumeratedComputeDevice],
+) -> Result<ResolvedExecutionRoute, ExecutionRouteError> {
+    let matches: Vec<&EnumeratedComputeDevice> = match selector {
+        ExactDeviceSelector::PhysicalKey(wanted) => inventory
+            .iter()
+            .filter(|device| {
+                device
+                    .addressability
+                    .physical_key()
+                    .is_some_and(|key| key == wanted)
+            })
+            .collect(),
+        ExactDeviceSelector::StableId {
+            provider,
+            stable_id,
+        } => inventory
+            .iter()
+            .filter(|device| {
+                provider.is_none_or(|wanted| device.provider == wanted)
+                    && device.stable_id == *stable_id
+            })
+            .collect(),
+    };
+
+    match matches.as_slice() {
+        [] => Err(ExecutionRouteError::device_not_found(format!(
+            "selector={selector:?}; inventory_stable_ids=[{}]",
+            inventory
+                .iter()
+                .map(|device| device.stable_id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))),
+        [device] => {
+            // Metal (and other not-exactly-addressable providers) may match by
+            // stable_id in inventory, but Exact must still fail closed.
+            if device.provider == ExecutionProvider::Metal
+                || (matches!(selector, ExactDeviceSelector::PhysicalKey(_))
+                    && !device.addressability.is_exactly_addressable())
+            {
+                return Err(ExecutionRouteError::not_addressable(format!(
+                    "provider={} stable_id={} reason={}",
+                    device.provider.as_str(),
+                    device.stable_id,
+                    match &device.addressability {
+                        DeviceAddressability::NotExactlyAddressable { reason } => *reason,
+                        DeviceAddressability::ExactlyAddressable { .. } => {
+                            "device is not exactly addressable"
+                        }
+                    }
+                )));
+            }
+            // Stable-id Exact on CUDA/HIP/Vulkan is allowed even when PCI id is
+            // missing: the stable ggml name is still a concrete device pin and
+            // must not silently retarget another card.
+            if matches!(selector, ExactDeviceSelector::StableId { .. })
+                && !device.provider.supports_exact_selection()
+                && device.provider != ExecutionProvider::Cpu
+            {
+                return Err(ExecutionRouteError::not_addressable(format!(
+                    "provider={} does not support Exact selection (stable_id={})",
+                    device.provider.as_str(),
+                    device.stable_id
+                )));
+            }
+            Ok(device.to_resolved_route())
+        }
+        many => Err(ExecutionRouteError::device_not_found(format!(
+            "selector={selector:?} matched {} devices (ordinals {}); Exact requires a unique target",
+            many.len(),
+            many.iter()
+                .map(|device| device.registry_ordinal.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        ))),
+    }
+}
+
+/// Admission / capacity slot identity: model pack identity plus resolved route.
+pub fn admission_identity_for_route(
+    model_identity: &str,
+    route: Option<&ResolvedExecutionRoute>,
+) -> String {
+    match route {
+        Some(route) => format!("{model_identity}|route={}", route.isolation_key()),
+        None => model_identity.to_string(),
+    }
+}
+
+/// Worker-key route component. Coarse targets keep their public spelling when no
+/// resolved route is available; once a route is resolved (preferred accelerated
+/// or Exact), isolation uses the route key so two GPUs never share a worker.
+pub fn worker_route_isolation_key(
+    coarse_target: &str,
+    route: Option<&ResolvedExecutionRoute>,
+) -> String {
+    match route {
+        Some(route) => route.isolation_key(),
+        None => coarse_target.to_string(),
+    }
+}
+
+fn normalize_physical_key(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ggml_runtime::GgmlDeviceMemory;
+
+    fn fake_device(
+        ordinal: usize,
+        name: &str,
+        kind: GgmlBackendKind,
+        device_id: Option<&str>,
+    ) -> EnumeratedComputeDevice {
+        let provider = ExecutionProvider::from_backend_name(name);
+        let route_kind = if kind == GgmlBackendKind::Cpu {
+            RouteDeviceKind::Cpu
+        } else {
+            RouteDeviceKind::Accelerated
+        };
+        EnumeratedComputeDevice {
+            provider,
+            stable_id: name.to_string(),
+            description: name.to_string(),
+            registry_ordinal: ordinal,
+            kind: route_kind,
+            ggml_kind: kind,
+            addressability: addressability_for_device(provider, device_id),
+            device_id: device_id.map(str::to_string),
+        }
+    }
+
+    fn hybrid_inventory() -> Vec<EnumeratedComputeDevice> {
+        vec![
+            fake_device(0, "CPU", GgmlBackendKind::Cpu, None),
+            fake_device(
+                1,
+                "Vulkan0",
+                GgmlBackendKind::IntegratedGpu,
+                Some("0000:00:02.0"),
+            ),
+            fake_device(2, "Vulkan1", GgmlBackendKind::Gpu, Some("0000:01:00.0")),
+        ]
+    }
+
+    #[test]
+    fn auto_prefers_discrete_gpu_over_integrated() {
+        let route = resolve_execution_route(&ExecutionRouteRequest::Auto, &hybrid_inventory())
+            .expect("auto resolves");
+        assert_eq!(route.stable_id, "Vulkan1");
+        assert_eq!(route.provider, ExecutionProvider::Vulkan);
+        assert!(route.addressability.is_exactly_addressable());
+        assert_eq!(route.isolation_key(), "vulkan/Vulkan1/pci:0000:01:00.0");
+    }
+
+    #[test]
+    fn accelerated_fail_closed_without_gpu() {
+        let inventory = vec![fake_device(0, "CPU", GgmlBackendKind::Cpu, None)];
+        let error = resolve_execution_route(&ExecutionRouteRequest::Accelerated, &inventory)
+            .expect_err("no gpu");
+        assert_eq!(error, ExecutionRouteError::AcceleratedUnavailable);
+    }
+
+    #[test]
+    fn exact_by_physical_key_pins_one_card() {
+        let inventory = hybrid_inventory();
+        let key = PhysicalResourceKey::new("0000:00:02.0").unwrap();
+        let route = resolve_execution_route(
+            &ExecutionRouteRequest::Exact(ExactDeviceSelector::PhysicalKey(key)),
+            &inventory,
+        )
+        .expect("exact physical");
+        assert_eq!(route.stable_id, "Vulkan0");
+        assert_ne!(
+            route.isolation_key(),
+            hybrid_inventory()[2].to_resolved_route().isolation_key()
+        );
+    }
+
+    #[test]
+    fn exact_missing_device_is_device_not_found() {
+        let key = PhysicalResourceKey::new("0000:ff:00.0").unwrap();
+        let error = resolve_execution_route(
+            &ExecutionRouteRequest::Exact(ExactDeviceSelector::PhysicalKey(key)),
+            &hybrid_inventory(),
+        )
+        .expect_err("missing");
+        assert!(matches!(error, ExecutionRouteError::DeviceNotFound { .. }));
+    }
+
+    #[test]
+    fn metal_exact_is_not_addressable() {
+        let inventory = vec![
+            fake_device(0, "CPU", GgmlBackendKind::Cpu, None),
+            fake_device(1, "Metal", GgmlBackendKind::Gpu, None),
+        ];
+        let error = resolve_execution_route(
+            &ExecutionRouteRequest::Exact(ExactDeviceSelector::StableId {
+                provider: Some(ExecutionProvider::Metal),
+                stable_id: "Metal".to_string(),
+            }),
+            &inventory,
+        )
+        .expect_err("metal exact");
+        assert!(matches!(error, ExecutionRouteError::NotAddressable { .. }));
+        assert!(!inventory[1].addressability.is_exactly_addressable());
+    }
+
+    #[test]
+    fn cuda_without_pci_still_allows_stable_id_exact() {
+        let inventory = vec![
+            fake_device(0, "CPU", GgmlBackendKind::Cpu, None),
+            fake_device(1, "CUDA0", GgmlBackendKind::Gpu, None),
+            fake_device(2, "CUDA1", GgmlBackendKind::Gpu, None),
+        ];
+        let route = resolve_execution_route(
+            &ExecutionRouteRequest::Exact(ExactDeviceSelector::StableId {
+                provider: Some(ExecutionProvider::Cuda),
+                stable_id: "CUDA1".to_string(),
+            }),
+            &inventory,
+        )
+        .expect("stable id exact");
+        assert_eq!(route.stable_id, "CUDA1");
+        assert_eq!(route.isolation_key(), "cuda/CUDA1");
+        assert_eq!(route.cache_key().stable_id, "CUDA1");
+    }
+
+    #[test]
+    fn admission_and_worker_keys_include_resolved_route() {
+        let route =
+            resolve_execution_route(&ExecutionRouteRequest::Accelerated, &hybrid_inventory())
+                .unwrap();
+        assert_eq!(
+            admission_identity_for_route("native:whisper@pack", Some(&route)),
+            "native:whisper@pack|route=vulkan/Vulkan1/pci:0000:01:00.0"
+        );
+        assert_eq!(
+            worker_route_isolation_key("accelerated", Some(&route)),
+            "vulkan/Vulkan1/pci:0000:01:00.0"
+        );
+        assert_eq!(worker_route_isolation_key("cpu", None), "cpu");
+    }
+
+    #[test]
+    fn ggml_device_inventory_reads_device_id() {
+        let devices = vec![
+            GgmlBackendDevice::for_test("CPU", "CPU", GgmlBackendKind::Cpu, None),
+            GgmlBackendDevice::for_test_with_device_id(
+                "CUDA0",
+                "NVIDIA A100",
+                GgmlBackendKind::Gpu,
+                Some(GgmlDeviceMemory {
+                    free_bytes: 1,
+                    total_bytes: 2,
+                }),
+                Some("0000:C1:00.0"),
+            ),
+        ];
+        let inventory = enumerate_compute_devices_from_ggml(&devices);
+        assert_eq!(inventory[1].provider, ExecutionProvider::Cuda);
+        assert_eq!(
+            inventory[1]
+                .addressability
+                .physical_key()
+                .map(PhysicalResourceKey::as_str),
+            Some("0000:c1:00.0")
+        );
+    }
+}

--- a/crates/openasr-core/src/device/mod.rs
+++ b/crates/openasr-core/src/device/mod.rs
@@ -1,3 +1,4 @@
 pub mod capabilities;
 pub mod compute_devices;
+pub mod execution_route;
 pub mod types;

--- a/crates/openasr-core/src/ggml_runtime/backend.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend.rs
@@ -33,6 +33,13 @@ pub struct GgmlBackendDevice {
     /// diagnosed from the boot log alone instead of asking the reporter to
     /// re-run with a debug build.
     pub buffer_alignment: Option<usize>,
+    /// Optional stable physical identity from `ggml_backend_dev_props.device_id`.
+    /// For PCI devices ggml documents this as lower-case
+    /// `domain:bus:device.function` (e.g. `0000:c1:00.0`). CUDA/HIP populate it;
+    /// Vulkan does when the instance exposes a PCI bus id; Metal leaves it
+    /// null (system-default device only). Consumed by execution-route Exact
+    /// resolution and cache/worker isolation keys.
+    pub device_id: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -141,6 +148,19 @@ impl GgmlBackendDevice {
         kind: GgmlBackendKind,
         memory: Option<GgmlDeviceMemory>,
     ) -> Self {
+        Self::for_test_with_device_id(name, description, kind, memory, None)
+    }
+
+    /// Test helper that also sets ggml `device_id` (PCI BDF when simulating
+    /// CUDA/HIP/Vulkan identity).
+    #[cfg(test)]
+    pub(crate) fn for_test_with_device_id(
+        name: &str,
+        description: &str,
+        kind: GgmlBackendKind,
+        memory: Option<GgmlDeviceMemory>,
+        device_id: Option<&str>,
+    ) -> Self {
         Self {
             raw: NonNull::dangling(),
             name: name.to_string(),
@@ -148,6 +168,7 @@ impl GgmlBackendDevice {
             kind,
             memory,
             buffer_alignment: None,
+            device_id: device_id.map(str::to_string),
         }
     }
 }
@@ -507,6 +528,22 @@ pub fn ggml_available_devices() -> Vec<GgmlBackendDevice> {
             (!buft.is_null()).then(|| ffi::ggml_backend_buft_get_alignment(buft))
         };
 
+        let device_id = {
+            let mut props = ffi::GgmlBackendDevProps {
+                name: ptr::null(),
+                description: ptr::null(),
+                memory_free: 0,
+                memory_total: 0,
+                type_: 0,
+                device_id: ptr::null(),
+                caps: ffi::GgmlBackendDevCaps::default(),
+            };
+            unsafe { ffi::ggml_backend_dev_get_props(raw.as_ptr(), &mut props) };
+            let raw_id = unsafe { cstr_lossy(props.device_id) };
+            let trimmed = raw_id.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        };
+
         devices.push(GgmlBackendDevice {
             raw,
             name: unsafe { cstr_lossy(ffi::ggml_backend_dev_name(raw.as_ptr())) },
@@ -514,6 +551,7 @@ pub fn ggml_available_devices() -> Vec<GgmlBackendDevice> {
             kind,
             memory,
             buffer_alignment,
+            device_id,
         });
     }
 
@@ -650,6 +688,7 @@ mod tests {
                     total_bytes: 12 * 1024 * 1024 * 1024,
                 }),
                 buffer_alignment: Some(16),
+                device_id: Some("0000:01:00.0".to_string()),
             }],
             cpu_features: GgmlCpuFeatures::default(),
         };

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -22,6 +22,10 @@ use super::{
     GgmlBackendKind, GgmlRuntimeError, GgufTensorDataReader, GgufWeightTensorPayload,
     accelerated_device_rank, ensure_backends_loaded, ggml_available_devices,
 };
+use crate::device::execution_route::{
+    ExecutionProvider, ExecutionRouteCacheKey, ExecutionRouteError, ExecutionRouteRequest,
+    ResolvedExecutionRoute, enumerate_compute_devices_from_ggml, resolve_execution_route,
+};
 
 const F32_WIDTH_BYTES: usize = std::mem::size_of::<f32>();
 const F16_WIDTH_BYTES: usize = std::mem::size_of::<u16>();
@@ -131,20 +135,24 @@ impl Default for GgmlCpuGraphConfig {
 /// Per-request execution-backend preference, installed thread-locally for the
 /// duration of a decode (same idiom as the inference-threads override).
 /// `GgmlCpuGraphConfig::resolve_runtime_backend` consults it BEFORE the env,
-/// so every downstream backend decision — graph configs, runtime cache keys,
-/// serve-batch job snapshots, telemetry labels — follows the request instead
+/// so every downstream backend decision - graph configs, runtime cache keys,
+/// serve-batch job snapshots, telemetry labels - follows the request instead
 /// of the process-global default. Values that cross threads (e.g. qwen
 /// serve-batch jobs) materialize the backend on the submitting thread, so the
 /// override propagates with the job.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+///
+/// `Exact` carries a fully resolved route and is fail-closed: init must use
+/// that device only (no card swap, no CPU fallback).
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RequestBackendPreference {
     CpuOnly,
     Accelerated,
+    Exact(ResolvedExecutionRoute),
 }
 
 thread_local! {
-    static REQUEST_BACKEND_PREFERENCE: std::cell::Cell<Option<RequestBackendPreference>> =
-        const { std::cell::Cell::new(None) };
+    static REQUEST_BACKEND_PREFERENCE: RefCell<Option<RequestBackendPreference>> =
+        const { RefCell::new(None) };
 }
 
 pub struct RequestBackendOverrideGuard {
@@ -153,7 +161,9 @@ pub struct RequestBackendOverrideGuard {
 
 impl Drop for RequestBackendOverrideGuard {
     fn drop(&mut self) {
-        REQUEST_BACKEND_PREFERENCE.with(|preference| preference.set(self.previous));
+        REQUEST_BACKEND_PREFERENCE.with(|preference| {
+            *preference.borrow_mut() = self.previous.take();
+        });
     }
 }
 
@@ -162,15 +172,32 @@ pub fn install_request_backend_override(
     preference: Option<RequestBackendPreference>,
 ) -> RequestBackendOverrideGuard {
     let previous = REQUEST_BACKEND_PREFERENCE.with(|cell| {
-        let previous = cell.get();
-        cell.set(preference);
+        let previous = cell.borrow().clone();
+        *cell.borrow_mut() = preference;
         previous
     });
     RequestBackendOverrideGuard { previous }
 }
 
 pub fn request_backend_override() -> Option<RequestBackendPreference> {
-    REQUEST_BACKEND_PREFERENCE.with(std::cell::Cell::get)
+    REQUEST_BACKEND_PREFERENCE.with(|cell| cell.borrow().clone())
+}
+
+/// Resolve the request-level route for the current preference against live ggml
+/// devices. Used by admission/worker key construction and by GPU backend init.
+pub fn resolve_request_execution_route(
+    preference: Option<&RequestBackendPreference>,
+) -> Result<Option<ResolvedExecutionRoute>, ExecutionRouteError> {
+    let request = match preference {
+        None => return Ok(None),
+        Some(RequestBackendPreference::CpuOnly) => ExecutionRouteRequest::Cpu,
+        Some(RequestBackendPreference::Accelerated) => ExecutionRouteRequest::Accelerated,
+        Some(RequestBackendPreference::Exact(route)) => {
+            return Ok(Some(route.clone()));
+        }
+    };
+    let inventory = enumerate_compute_devices_from_ggml(&ggml_available_devices());
+    resolve_execution_route(&request, &inventory).map(Some)
 }
 
 impl GgmlCpuGraphConfig {
@@ -307,6 +334,15 @@ impl GgmlCpuGraphConfig {
         match request_backend_override() {
             Some(RequestBackendPreference::CpuOnly) => GgmlCpuGraphBackend::Cpu,
             Some(RequestBackendPreference::Accelerated) => Self::default_gpu_backend(),
+            Some(RequestBackendPreference::Exact(route)) => match route.provider {
+                ExecutionProvider::Cpu => GgmlCpuGraphBackend::Cpu,
+                ExecutionProvider::Metal => GgmlCpuGraphBackend::Metal,
+                ExecutionProvider::Cuda
+                | ExecutionProvider::Hip
+                | ExecutionProvider::Vulkan
+                | ExecutionProvider::Accelerator
+                | ExecutionProvider::Unknown => GgmlCpuGraphBackend::Gpu,
+            },
             None => Self::parse_backend_env(std::env::var(Self::BACKEND_ENV).ok().as_deref()),
         }
     }
@@ -687,6 +723,29 @@ fn backend_kind_is_accelerated(kind: GgmlBackendKind) -> bool {
     )
 }
 
+fn find_ggml_device_for_route<'a>(
+    devices: &'a [super::GgmlBackendDevice],
+    route: &ResolvedExecutionRoute,
+) -> Option<&'a super::GgmlBackendDevice> {
+    let inventory = enumerate_compute_devices_from_ggml(devices);
+    let matched = inventory.iter().find(|device| {
+        device.provider == route.provider
+            && device.stable_id == route.stable_id
+            && match (
+                device.addressability.physical_key(),
+                route.addressability.physical_key(),
+            ) {
+                (Some(left), Some(right)) => left == right,
+                (None, None) => {
+                    device.registry_ordinal == route.registry_ordinal
+                        || device.stable_id == route.stable_id
+                }
+                _ => false,
+            }
+    })?;
+    devices.get(matched.registry_ordinal)
+}
+
 fn backend_name_is_accelerated(name: &str) -> bool {
     let name = name.to_ascii_lowercase();
     name.contains("metal")
@@ -789,6 +848,8 @@ pub enum GgmlCpuGraphError {
     MetalBackendUnavailable { actual_backend: String },
     #[error("ggml gpu backend is unavailable (actual backend: {actual_backend})")]
     GpuBackendUnavailable { actual_backend: String },
+    #[error(transparent)]
+    ExecutionRoute(#[from] ExecutionRouteError),
     #[error("ggml cpu graph only supports add in this version, got {operation:?}")]
     UnsupportedOperation { operation: GgmlCpuBinaryOp },
     #[error("ggml cpu graph input tensors are unsupported: {reason}")]
@@ -5203,19 +5264,22 @@ struct GgmlBackendSchedulerGuard {
 
 /// GPU-class backends are expensive to initialize (device enumeration + driver
 /// context creation) and are safe to keep resident for the thread's lifetime,
-/// so they are cached per-thread per-kind and handed out with
+/// so they are cached per-thread per resolved route and handed out with
 /// `free_on_drop=false` (the cached entry owns the single instance). Metal had
 /// this since inception; the discrete-GPU lane (HIP/CUDA/Vulkan) now shares the
-/// exact same path so it stops paying `ggml_backend_dev_init`/free on every
-/// `execute()`. The CPU backend is cheap and is intentionally not cached.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-enum CachedBackendKind {
+/// same path keyed by [`ExecutionRouteCacheKey`] (provider + stable_id [+ PCI])
+/// so two Exact pins never share one backend handle. The CPU backend is cheap
+/// and is intentionally not cached.
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum CachedBackendKey {
+    /// System-default Metal device (not exactly addressable).
     Metal,
-    Gpu,
+    /// Discrete / Vulkan / CUDA / HIP device keyed by resolved route identity.
+    Route(ExecutionRouteCacheKey),
 }
 
 thread_local! {
-    static THREAD_BACKEND_CACHE_BY_KIND: RefCell<HashMap<CachedBackendKind, GgmlCachedBackendGuard>> =
+    static THREAD_BACKEND_CACHE_BY_KIND: RefCell<HashMap<CachedBackendKey, GgmlCachedBackendGuard>> =
         RefCell::new(HashMap::new());
 }
 
@@ -5237,22 +5301,25 @@ impl GgmlBackendGuard {
     }
 
     fn metal() -> Result<Self, GgmlCpuGraphError> {
-        Self::cached_backend(CachedBackendKind::Metal, Self::init_metal_backend)
+        Self::cached_backend(CachedBackendKey::Metal, Self::init_metal_backend)
     }
 
     fn gpu() -> Result<Self, GgmlCpuGraphError> {
-        Self::cached_backend(CachedBackendKind::Gpu, Self::init_gpu_backend)
+        let (cache_key, init_route) = Self::resolve_gpu_cache_target()?;
+        Self::cached_backend(cache_key, move || {
+            Self::init_gpu_backend_for_route(init_route)
+        })
     }
 
-    /// Return a thread-local cached backend of `kind`, initializing it once via
+    /// Return a thread-local cached backend of `key`, initializing it once via
     /// `init` on first use. The cached entry owns the backend for the thread's
     /// lifetime; handed-out guards never free it (`free_on_drop=false`).
     fn cached_backend(
-        kind: CachedBackendKind,
+        key: CachedBackendKey,
         init: impl FnOnce() -> Result<NonNull<c_void>, GgmlCpuGraphError>,
     ) -> Result<Self, GgmlCpuGraphError> {
         if let Some(raw) =
-            THREAD_BACKEND_CACHE_BY_KIND.with(|cache| cache.borrow().get(&kind).map(|g| g.raw))
+            THREAD_BACKEND_CACHE_BY_KIND.with(|cache| cache.borrow().get(&key).map(|g| g.raw))
         {
             return Ok(Self {
                 raw,
@@ -5263,12 +5330,54 @@ impl GgmlBackendGuard {
         THREAD_BACKEND_CACHE_BY_KIND.with(|cache| {
             cache
                 .borrow_mut()
-                .insert(kind, GgmlCachedBackendGuard { raw })
+                .insert(key, GgmlCachedBackendGuard { raw })
         });
         Ok(Self {
             raw,
             free_on_drop: false,
         })
+    }
+
+    /// Decide which resolved GPU route this request must initialize, and the
+    /// cache key that isolates it from other devices on the same thread.
+    fn resolve_gpu_cache_target()
+    -> Result<(CachedBackendKey, Option<ResolvedExecutionRoute>), GgmlCpuGraphError> {
+        match request_backend_override() {
+            Some(RequestBackendPreference::Exact(route)) => {
+                if route.provider == ExecutionProvider::Metal {
+                    return Err(GgmlCpuGraphError::ExecutionRoute(
+                        ExecutionRouteError::not_addressable(format!(
+                            "provider=metal stable_id={} reason=Metal is not exactly addressable",
+                            route.stable_id
+                        )),
+                    ));
+                }
+                Ok((CachedBackendKey::Route(route.cache_key()), Some(route)))
+            }
+            Some(RequestBackendPreference::Accelerated) | None => {
+                let inventory = enumerate_compute_devices_from_ggml(&ggml_available_devices());
+                match resolve_execution_route(&ExecutionRouteRequest::Accelerated, &inventory) {
+                    Ok(route) => Ok((CachedBackendKey::Route(route.cache_key()), Some(route))),
+                    // Fall through to ranked init without a pinned route key when
+                    // inventory is empty; init_gpu_backend_for_route(None) keeps
+                    // the previous preferred-device scan + typed unavailable error.
+                    Err(ExecutionRouteError::AcceleratedUnavailable) => Ok((
+                        CachedBackendKey::Route(ExecutionRouteCacheKey {
+                            provider: ExecutionProvider::Unknown,
+                            stable_id: "accelerated".to_string(),
+                            physical_key: None,
+                        }),
+                        None,
+                    )),
+                    Err(error) => Err(GgmlCpuGraphError::ExecutionRoute(error)),
+                }
+            }
+            Some(RequestBackendPreference::CpuOnly) => Err(GgmlCpuGraphError::ExecutionRoute(
+                ExecutionRouteError::device_not_found(
+                    "internal: gpu backend requested under CpuOnly preference",
+                ),
+            )),
+        }
     }
 
     fn accelerators(
@@ -5318,17 +5427,51 @@ impl GgmlBackendGuard {
         Ok(raw)
     }
 
-    fn init_gpu_backend() -> Result<NonNull<c_void>, GgmlCpuGraphError> {
+    fn init_gpu_backend_for_route(
+        route: Option<ResolvedExecutionRoute>,
+    ) -> Result<NonNull<c_void>, GgmlCpuGraphError> {
+        let devices = ggml_available_devices();
+        if let Some(route) = route.as_ref() {
+            // Exact (and preferred-accelerated once resolved) pin one inventory
+            // row. Fail closed: never silently retarget another card or CPU.
+            if let Some(device) = find_ggml_device_for_route(&devices, route) {
+                return match device.initialize() {
+                    Ok(backend) => Ok(backend.into_raw()),
+                    Err(GgmlRuntimeError::BackendUnavailable(name)) => {
+                        Err(GgmlCpuGraphError::ExecutionRoute(
+                            ExecutionRouteError::init_failed(format!(
+                                "provider={} stable_id={} backend={name}",
+                                route.provider.as_str(),
+                                route.stable_id
+                            )),
+                        ))
+                    }
+                };
+            }
+            if matches!(
+                request_backend_override(),
+                Some(RequestBackendPreference::Exact(_))
+            ) {
+                return Err(GgmlCpuGraphError::ExecutionRoute(
+                    ExecutionRouteError::device_not_found(format!(
+                        "provider={} stable_id={} isolation_key={}",
+                        route.provider.as_str(),
+                        route.stable_id,
+                        route.isolation_key()
+                    )),
+                ));
+            }
+            // Preferred accelerated resolved to a route that disappeared between
+            // resolve and init: fall through to ranked scan below.
+        }
+
         // Rank candidates so a hybrid-graphics host (Optimus-style laptop
         // exposing both an Intel integrated GPU and an NVIDIA/AMD discrete GPU
         // through the same Vulkan backend) tries the discrete GPU first,
         // falling through to lower-ranked devices only if a higher-ranked one
-        // fails to initialize -- see `accelerated_device_rank`. A plain
-        // registry-order scan here (the previous behavior) picked whichever
-        // device the platform/driver happened to enumerate first, which on
-        // several reported Optimus setups was the integrated GPU, leaving the
-        // discrete GPU idle even though it is almost always the better choice.
-        let mut candidates: Vec<_> = ggml_available_devices()
+        // fails to initialize -- see `accelerated_device_rank`. Exact requests
+        // never reach this fallback.
+        let mut candidates: Vec<_> = devices
             .into_iter()
             .filter(|device| backend_kind_is_accelerated(device.kind))
             .collect();

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -20,11 +20,12 @@ use thiserror::Error;
 use super::ffi;
 use super::{
     GgmlBackendKind, GgmlRuntimeError, GgufTensorDataReader, GgufWeightTensorPayload,
-    accelerated_device_rank, ensure_backends_loaded, ggml_available_devices,
+    ensure_backends_loaded, ggml_available_devices,
 };
 use crate::device::execution_route::{
     ExecutionProvider, ExecutionRouteCacheKey, ExecutionRouteError, ExecutionRouteRequest,
-    ResolvedExecutionRoute, enumerate_compute_devices_from_ggml, resolve_execution_route,
+    ResolvedExecutionRoute, enumerate_compute_devices_from_ggml,
+    ranked_preferred_accelerated_devices, resolve_execution_route,
 };
 
 const F32_WIDTH_BYTES: usize = std::mem::size_of::<f32>();
@@ -5265,11 +5266,13 @@ struct GgmlBackendSchedulerGuard {
 /// GPU-class backends are expensive to initialize (device enumeration + driver
 /// context creation) and are safe to keep resident for the thread's lifetime,
 /// so they are cached per-thread per resolved route and handed out with
-/// `free_on_drop=false` (the cached entry owns the single instance). Metal had
-/// this since inception; the discrete-GPU lane (HIP/CUDA/Vulkan) now shares the
-/// same path keyed by [`ExecutionRouteCacheKey`] (provider + stable_id [+ PCI])
-/// so two Exact pins never share one backend handle. The CPU backend is cheap
-/// and is intentionally not cached.
+/// `free_on_drop=false` (the cached entry owns the single instance).
+///
+/// Invariant: a cache entry's [`CachedBackendKey`] is always the route of the
+/// device that was actually initialized. Preferred/Auto may Optimus-fall
+/// through discrete -> iGPU, but each successful init is inserted under that
+/// device's own key -- never under a preferred route key while holding a
+/// different card. Exact never falls through.
 #[derive(Clone, PartialEq, Eq, Hash)]
 enum CachedBackendKey {
     /// System-default Metal device (not exactly addressable).
@@ -5305,43 +5308,6 @@ impl GgmlBackendGuard {
     }
 
     fn gpu() -> Result<Self, GgmlCpuGraphError> {
-        let (cache_key, init_route) = Self::resolve_gpu_cache_target()?;
-        Self::cached_backend(cache_key, move || {
-            Self::init_gpu_backend_for_route(init_route)
-        })
-    }
-
-    /// Return a thread-local cached backend of `key`, initializing it once via
-    /// `init` on first use. The cached entry owns the backend for the thread's
-    /// lifetime; handed-out guards never free it (`free_on_drop=false`).
-    fn cached_backend(
-        key: CachedBackendKey,
-        init: impl FnOnce() -> Result<NonNull<c_void>, GgmlCpuGraphError>,
-    ) -> Result<Self, GgmlCpuGraphError> {
-        if let Some(raw) =
-            THREAD_BACKEND_CACHE_BY_KIND.with(|cache| cache.borrow().get(&key).map(|g| g.raw))
-        {
-            return Ok(Self {
-                raw,
-                free_on_drop: false,
-            });
-        }
-        let raw = init()?;
-        THREAD_BACKEND_CACHE_BY_KIND.with(|cache| {
-            cache
-                .borrow_mut()
-                .insert(key, GgmlCachedBackendGuard { raw })
-        });
-        Ok(Self {
-            raw,
-            free_on_drop: false,
-        })
-    }
-
-    /// Decide which resolved GPU route this request must initialize, and the
-    /// cache key that isolates it from other devices on the same thread.
-    fn resolve_gpu_cache_target()
-    -> Result<(CachedBackendKey, Option<ResolvedExecutionRoute>), GgmlCpuGraphError> {
         match request_backend_override() {
             Some(RequestBackendPreference::Exact(route)) => {
                 if route.provider == ExecutionProvider::Metal {
@@ -5352,25 +5318,16 @@ impl GgmlBackendGuard {
                         )),
                     ));
                 }
-                Ok((CachedBackendKey::Route(route.cache_key()), Some(route)))
+                // Exact: pin one device, fail closed on miss/init failure, key
+                // is exactly that route (no fallthrough, no key drift).
+                Self::cached_backend(CachedBackendKey::Route(route.cache_key()), move || {
+                    Self::init_exact_gpu_backend(&route)
+                })
             }
             Some(RequestBackendPreference::Accelerated) | None => {
-                let inventory = enumerate_compute_devices_from_ggml(&ggml_available_devices());
-                match resolve_execution_route(&ExecutionRouteRequest::Accelerated, &inventory) {
-                    Ok(route) => Ok((CachedBackendKey::Route(route.cache_key()), Some(route))),
-                    // Fall through to ranked init without a pinned route key when
-                    // inventory is empty; init_gpu_backend_for_route(None) keeps
-                    // the previous preferred-device scan + typed unavailable error.
-                    Err(ExecutionRouteError::AcceleratedUnavailable) => Ok((
-                        CachedBackendKey::Route(ExecutionRouteCacheKey {
-                            provider: ExecutionProvider::Unknown,
-                            stable_id: "accelerated".to_string(),
-                            physical_key: None,
-                        }),
-                        None,
-                    )),
-                    Err(error) => Err(GgmlCpuGraphError::ExecutionRoute(error)),
-                }
+                // Preferred/Auto GPU lane: ranked Optimus fallthrough with
+                // per-candidate cache keys (see preferred_gpu_backend).
+                Self::preferred_gpu_backend()
             }
             Some(RequestBackendPreference::CpuOnly) => Err(GgmlCpuGraphError::ExecutionRoute(
                 ExecutionRouteError::device_not_found(
@@ -5378,6 +5335,86 @@ impl GgmlBackendGuard {
                 ),
             )),
         }
+    }
+
+    /// Return a thread-local cached backend of `key`, initializing it once via
+    /// `init` on first use. The cached entry owns the backend for the thread's
+    /// lifetime; handed-out guards never free it (`free_on_drop=false`).
+    fn cached_backend(
+        key: CachedBackendKey,
+        init: impl FnOnce() -> Result<NonNull<c_void>, GgmlCpuGraphError>,
+    ) -> Result<Self, GgmlCpuGraphError> {
+        if let Some(raw) = Self::cached_backend_lookup(&key) {
+            return Ok(Self {
+                raw,
+                free_on_drop: false,
+            });
+        }
+        let raw = init()?;
+        Self::cached_backend_insert(key, raw);
+        Ok(Self {
+            raw,
+            free_on_drop: false,
+        })
+    }
+
+    fn cached_backend_lookup(key: &CachedBackendKey) -> Option<NonNull<c_void>> {
+        THREAD_BACKEND_CACHE_BY_KIND.with(|cache| cache.borrow().get(key).map(|g| g.raw))
+    }
+
+    fn cached_backend_insert(key: CachedBackendKey, raw: NonNull<c_void>) {
+        THREAD_BACKEND_CACHE_BY_KIND.with(|cache| {
+            cache
+                .borrow_mut()
+                .insert(key, GgmlCachedBackendGuard { raw })
+        });
+    }
+
+    /// Preferred/Auto GPU init with Optimus-aware ranked fallthrough.
+    ///
+    /// Invariant: the thread-local cache key is always the route of the device
+    /// that actually initialized. If discrete GPU init fails, the next ranked
+    /// candidate (e.g. iGPU) is tried and -- on success -- cached under *its*
+    /// key, never under the preferred discrete key. Empty inventory or total
+    /// init failure is typed fail-closed (no `init_best` retarget into a fake
+    /// `unknown/accelerated` key).
+    fn preferred_gpu_backend() -> Result<Self, GgmlCpuGraphError> {
+        let devices = ggml_available_devices();
+        let inventory = enumerate_compute_devices_from_ggml(&devices);
+        let ranked = ranked_preferred_accelerated_devices(&inventory);
+        if ranked.is_empty() {
+            return Err(GgmlCpuGraphError::ExecutionRoute(
+                ExecutionRouteError::AcceleratedUnavailable,
+            ));
+        }
+
+        let mut last_init_error: Option<GgmlCpuGraphError> = None;
+        for candidate in ranked {
+            let route = candidate.to_resolved_route();
+            let key = CachedBackendKey::Route(route.cache_key());
+            if let Some(raw) = Self::cached_backend_lookup(&key) {
+                return Ok(Self {
+                    raw,
+                    free_on_drop: false,
+                });
+            }
+            match Self::init_route_gpu_device(&devices, &route) {
+                Ok(raw) => {
+                    Self::cached_backend_insert(key, raw);
+                    return Ok(Self {
+                        raw,
+                        free_on_drop: false,
+                    });
+                }
+                Err(error) => {
+                    last_init_error = Some(error);
+                }
+            }
+        }
+
+        Err(last_init_error.unwrap_or(GgmlCpuGraphError::ExecutionRoute(
+            ExecutionRouteError::AcceleratedUnavailable,
+        )))
     }
 
     fn accelerators(
@@ -5427,76 +5464,39 @@ impl GgmlBackendGuard {
         Ok(raw)
     }
 
-    fn init_gpu_backend_for_route(
-        route: Option<ResolvedExecutionRoute>,
+    /// Exact pin: one inventory row only. Find miss -> DeviceNotFound.
+    /// Initialize failure -> InitFailed. Never tries another card.
+    fn init_exact_gpu_backend(
+        route: &ResolvedExecutionRoute,
     ) -> Result<NonNull<c_void>, GgmlCpuGraphError> {
         let devices = ggml_available_devices();
-        if let Some(route) = route.as_ref() {
-            // Exact (and preferred-accelerated once resolved) pin one inventory
-            // row. Fail closed: never silently retarget another card or CPU.
-            if let Some(device) = find_ggml_device_for_route(&devices, route) {
-                return match device.initialize() {
-                    Ok(backend) => Ok(backend.into_raw()),
-                    Err(GgmlRuntimeError::BackendUnavailable(name)) => {
-                        Err(GgmlCpuGraphError::ExecutionRoute(
-                            ExecutionRouteError::init_failed(format!(
-                                "provider={} stable_id={} backend={name}",
-                                route.provider.as_str(),
-                                route.stable_id
-                            )),
-                        ))
-                    }
-                };
-            }
-            if matches!(
-                request_backend_override(),
-                Some(RequestBackendPreference::Exact(_))
-            ) {
-                return Err(GgmlCpuGraphError::ExecutionRoute(
-                    ExecutionRouteError::device_not_found(format!(
-                        "provider={} stable_id={} isolation_key={}",
-                        route.provider.as_str(),
-                        route.stable_id,
-                        route.isolation_key()
-                    )),
-                ));
-            }
-            // Preferred accelerated resolved to a route that disappeared between
-            // resolve and init: fall through to ranked scan below.
-        }
+        Self::init_route_gpu_device(&devices, route)
+    }
 
-        // Rank candidates so a hybrid-graphics host (Optimus-style laptop
-        // exposing both an Intel integrated GPU and an NVIDIA/AMD discrete GPU
-        // through the same Vulkan backend) tries the discrete GPU first,
-        // falling through to lower-ranked devices only if a higher-ranked one
-        // fails to initialize -- see `accelerated_device_rank`. Exact requests
-        // never reach this fallback.
-        let mut candidates: Vec<_> = devices
-            .into_iter()
-            .filter(|device| backend_kind_is_accelerated(device.kind))
-            .collect();
-        candidates.sort_by_key(|device| accelerated_device_rank(device.kind));
-        for device in candidates {
-            match device.initialize() {
-                Ok(backend) => return Ok(backend.into_raw()),
-                Err(GgmlRuntimeError::BackendUnavailable(_)) => continue,
-            }
-        }
-
-        let raw = unsafe { ffi::ggml_backend_init_best() };
-        let Some(raw) = NonNull::new(raw) else {
-            return Err(GgmlCpuGraphError::GpuBackendUnavailable {
-                actual_backend: "<none>".to_string(),
-            });
+    fn init_route_gpu_device(
+        devices: &[super::GgmlBackendDevice],
+        route: &ResolvedExecutionRoute,
+    ) -> Result<NonNull<c_void>, GgmlCpuGraphError> {
+        let Some(device) = find_ggml_device_for_route(devices, route) else {
+            return Err(GgmlCpuGraphError::ExecutionRoute(
+                ExecutionRouteError::device_not_found(format!(
+                    "provider={} stable_id={} isolation_key={}",
+                    route.provider.as_str(),
+                    route.stable_id,
+                    route.isolation_key()
+                )),
+            ));
         };
-        let name = backend_name(raw);
-        if !backend_name_is_accelerated(&name) {
-            unsafe { ffi::ggml_backend_free(raw.as_ptr()) };
-            return Err(GgmlCpuGraphError::GpuBackendUnavailable {
-                actual_backend: name,
-            });
+        match device.initialize() {
+            Ok(backend) => Ok(backend.into_raw()),
+            Err(GgmlRuntimeError::BackendUnavailable(name)) => Err(
+                GgmlCpuGraphError::ExecutionRoute(ExecutionRouteError::init_failed(format!(
+                    "provider={} stable_id={} backend={name}",
+                    route.provider.as_str(),
+                    route.stable_id
+                ))),
+            ),
         }
-        Ok(raw)
     }
 
     fn set_n_threads(&mut self, n_threads: usize) -> Result<(), GgmlCpuGraphError> {

--- a/crates/openasr-core/src/ggml_runtime/mod.rs
+++ b/crates/openasr-core/src/ggml_runtime/mod.rs
@@ -28,6 +28,7 @@ pub use cpu_graph::{
     AutoGpuPolicy, GgmlCpuBinaryOp, GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphError,
     GgmlCpuGraphRunner, GgmlCpuGraphThreadingWorkload, RequestBackendOverrideGuard,
     RequestBackendPreference, install_request_backend_override, request_backend_override,
+    resolve_request_execution_route,
 };
 pub(crate) use cpu_graph::{
     GgmlCpuGraphBuilder, GgmlCpuTensor, GgmlLoadedTensor, GgmlLoadedWeightContext,

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -126,6 +126,12 @@ pub use device::capabilities::{
 pub use device::compute_devices::{
     ComputeDevice, compute_devices_from_runtime, default_execution_target,
 };
+pub use device::execution_route::{
+    DeviceAddressability, EnumeratedComputeDevice, ExactDeviceSelector, ExecutionProvider,
+    ExecutionRouteCacheKey, ExecutionRouteError, ExecutionRouteRequest, PhysicalResourceKey,
+    ResolvedExecutionRoute, RouteDeviceKind, admission_identity_for_route,
+    enumerate_compute_devices_from_ggml, resolve_execution_route, worker_route_isolation_key,
+};
 pub use device::types::{CapabilityClass, DeviceCapabilities};
 pub use download_source::{DownloadSource, DownloadSourcePref, resolve_chain};
 pub use format::{ResponseFormat, render_transcription};
@@ -142,7 +148,7 @@ pub use ggml_runtime::{
     probe_ggml_package_model_identity, probe_ggml_package_path, read_gguf_metadata,
     read_gguf_metadata_from_runtime_source, read_gguf_tensor_index,
     read_gguf_tensor_index_from_runtime_source, render_gguf_c_parser_sandbox_child_output,
-    validate_ggml_runtime_source_path,
+    resolve_request_execution_route, validate_ggml_runtime_source_path,
 };
 pub use home::{OpenAsrHomeError, openasr_home, resolve_openasr_home};
 pub use host::{

--- a/crates/openasr-core/src/models/ggml_asr_executor.rs
+++ b/crates/openasr-core/src/models/ggml_asr_executor.rs
@@ -553,6 +553,11 @@ pub enum GgmlAsrExecutionError {
         model_family: &'static str,
         adapter_path: String,
     },
+    /// Typed Exact/preferred device failure from graph backend init. Kept as a
+    /// first-class variant so `dispatch_error_to_backend` can surface
+    /// `BackendError::ExecutionDevice*` without string recovery.
+    #[error(transparent)]
+    ExecutionRoute(#[from] crate::device::execution_route::ExecutionRouteError),
     /// A transient serve-batch failure (queue saturation / owner gone / GPU step
     /// hung) carried out of the executor so the backend can map it to a retryable
     /// HTTP status instead of a generic 500. `retryable == true` => queue full
@@ -571,6 +576,24 @@ impl GgmlAsrExecutionError {
             executor_id,
             adapter_id,
             reason: reason.into(),
+        }
+    }
+
+    /// Preserve typed route failures from graph init; stringify everything else.
+    /// Prefer this at family `GgmlCpuGraphError` boundaries so dispatch does not
+    /// need Display recovery. Covered by unit tests; production call sites migrate
+    /// family-by-family.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn from_ggml_cpu_graph_error(
+        executor_id: &'static str,
+        adapter_id: &'static str,
+        error: crate::ggml_runtime::GgmlCpuGraphError,
+    ) -> Self {
+        match error {
+            crate::ggml_runtime::GgmlCpuGraphError::ExecutionRoute(error) => {
+                Self::ExecutionRoute(error)
+            }
+            other => Self::executor_failed(executor_id, adapter_id, other.to_string()),
         }
     }
 }
@@ -1533,5 +1556,33 @@ mod tests {
                 .to_string()
                 .contains(missing_path.display().to_string().as_str())
         );
+    }
+
+    #[test]
+    fn from_ggml_cpu_graph_error_preserves_execution_route() {
+        use crate::device::execution_route::ExecutionRouteError;
+        use crate::ggml_runtime::GgmlCpuGraphError;
+
+        let route_error = ExecutionRouteError::init_failed("provider=cuda stable_id=CUDA0");
+        let mapped = GgmlAsrExecutionError::from_ggml_cpu_graph_error(
+            "test-executor",
+            "test-adapter",
+            GgmlCpuGraphError::ExecutionRoute(route_error.clone()),
+        );
+        assert_eq!(mapped, GgmlAsrExecutionError::ExecutionRoute(route_error));
+
+        let other = GgmlAsrExecutionError::from_ggml_cpu_graph_error(
+            "test-executor",
+            "test-adapter",
+            GgmlCpuGraphError::CpuBackendUnavailable,
+        );
+        assert!(matches!(
+            other,
+            GgmlAsrExecutionError::ExecutorFailed {
+                executor_id: "test-executor",
+                adapter_id: "test-adapter",
+                ..
+            }
+        ));
     }
 }

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1192,10 +1192,19 @@ impl Default for ServerRuntime {
 impl ServerRuntime {
     /// Acquires the server-wide native execution permit for the validated
     /// runtime pack. Every ggml ASR execution path enters through this method.
-    pub(crate) fn acquire_native_execution(&self) -> Result<ModelSessionPermit, ApiError> {
+    ///
+    /// When `route` is `Some`, the admission slot is isolated by the resolved
+    /// execution route (provider + stable device identity) so two Exact/preferred
+    /// GPU pins never share one capacity slot. `None` keeps the historical
+    /// model-only key used by coarse paths that have not resolved a device yet.
+    pub(crate) fn acquire_native_execution(
+        &self,
+        route: Option<&openasr_core::ResolvedExecutionRoute>,
+    ) -> Result<ModelSessionPermit, ApiError> {
         let model_identity = native_model_session_key(self)?;
+        let identity = openasr_core::admission_identity_for_route(&model_identity, route);
         self.native_execution
-            .try_acquire(model_identity)
+            .try_acquire(identity)
             .map_err(ApiError::ModelSessionCapacity)
     }
 
@@ -2432,10 +2441,13 @@ impl IntoResponse for ApiError {
                     | openasr_core::BackendError::WordTimestampAlignmentRequiresWordTimestamps
                     | openasr_core::BackendError::WordTimestampAlignmentPackMissing { .. }
                     | openasr_core::BackendError::WordTimestampAlignmentFailed { .. }
+                    | openasr_core::BackendError::ExecutionDeviceNotFound { .. }
+                    | openasr_core::BackendError::ExecutionDeviceNotAddressable { .. }
+                    | openasr_core::BackendError::ExecutionDeviceInitFailed { .. }
                     | openasr_core::BackendError::NativeFailClosed { .. } => {
                         // Native backend "fail-closed" is a deliberate, client-facing
                         // refusal (unexecutable/unsupported request or unusable pack),
-                        // not a server fault — genuine internal panics surface via
+                        // not a server fault -- genuine internal panics surface via
                         // BackendJoin. Classify it as 400, matching the fail-closed
                         // contract the api.rs native tests assert.
                         StatusCode::BAD_REQUEST

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1193,10 +1193,11 @@ impl ServerRuntime {
     /// Acquires the server-wide native execution permit for the validated
     /// runtime pack. Every ggml ASR execution path enters through this method.
     ///
-    /// When `route` is `Some`, the admission slot is isolated by the resolved
-    /// execution route (provider + stable device identity) so two Exact/preferred
-    /// GPU pins never share one capacity slot. `None` keeps the historical
-    /// model-only key used by coarse paths that have not resolved a device yet.
+    /// Admission capacity is **per model identity only**. The optional `route`
+    /// is forwarded for API symmetry with worker/backend-handle isolation but
+    /// does not split the slot: CPU and accelerated/Exact requests for the same
+    /// model share one capacity unit. Route identity isolates streaming workers
+    /// and thread-local ggml backend handles instead.
     pub(crate) fn acquire_native_execution(
         &self,
         route: Option<&openasr_core::ResolvedExecutionRoute>,

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -53,22 +53,41 @@ pub(crate) enum BackendResult {
 pub(crate) struct NativeStreamingWorkerKey {
     pub(crate) model_pack_path: PathBuf,
     pub(crate) hardware_target: String,
+    /// Resolved execution-route isolation key (provider/stable_id[/pci:...]).
+    /// Coarse targets without a resolved device keep the public spelling
+    /// (`auto`/`cpu`/`accelerated`) so existing single-device hosts behave as
+    /// before; Exact / preferred-accelerated pins isolate per device.
+    pub(crate) execution_route_key: String,
     pub(crate) inference_threads: Option<u16>,
 }
 
 impl NativeStreamingWorkerKey {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(
         model_pack_path: impl Into<PathBuf>,
         hardware_target: openasr_core::NativeAsrHardwareTarget,
+        inference_threads: Option<u16>,
+    ) -> Self {
+        Self::with_route(model_pack_path, hardware_target, None, inference_threads)
+    }
+
+    pub(crate) fn with_route(
+        model_pack_path: impl Into<PathBuf>,
+        hardware_target: openasr_core::NativeAsrHardwareTarget,
+        resolved_route: Option<&openasr_core::ResolvedExecutionRoute>,
         inference_threads: Option<u16>,
     ) -> Self {
         let model_pack_path = model_pack_path.into();
         let model_pack_path = model_pack_path
             .canonicalize()
             .unwrap_or_else(|_| model_pack_path.clone());
+        let hardware_target = hardware_target.to_string();
+        let execution_route_key =
+            openasr_core::worker_route_isolation_key(&hardware_target, resolved_route);
         Self {
             model_pack_path,
-            hardware_target: hardware_target.to_string(),
+            hardware_target,
+            execution_route_key,
             inference_threads,
         }
     }
@@ -527,10 +546,11 @@ pub(crate) fn native_streaming_worker_for_key(
             openasr_core::stage_timing::log_event(
                 "native_streaming_watchdog",
                 format_args!(
-                    "model_pack_path={} hardware_target={} inference_threads={:?} \
+                    "model_pack_path={} hardware_target={} execution_route_key={} inference_threads={:?} \
                      reason=same_key_preemption_client_disconnected action=abandon_occupant",
                     key.model_pack_path.display(),
                     key.hardware_target,
+                    key.execution_route_key,
                     key.inference_threads,
                 ),
             );
@@ -736,10 +756,11 @@ pub(crate) fn abandon_stuck_native_streaming_worker(
     openasr_core::stage_timing::log_event(
         "native_streaming_watchdog",
         format_args!(
-            "model_pack_path={} hardware_target={} inference_threads={:?} reason={reason} \
+            "model_pack_path={} hardware_target={} execution_route_key={} inference_threads={:?} reason={reason} \
              action=abandon_worker abandoned_workers={abandoned_count}",
             key.model_pack_path.display(),
             key.hardware_target,
+            key.execution_route_key,
             key.inference_threads,
         ),
     );
@@ -997,7 +1018,19 @@ pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime
     };
     // Warmup is opportunistic. It must not queue behind an active request or
     // allocate a second runtime; a real request owns the capacity slot first.
-    let Ok(model_session_permit) = runtime.acquire_native_execution() else {
+    let preferences_home = openasr_core::openasr_home().ok();
+    let inference_threads = preferences_home
+        .as_deref()
+        .and_then(realtime_inference_threads_preference);
+    let execution_target_preference = preferences_home
+        .as_deref()
+        .and_then(realtime_execution_target_preference);
+    let resolved_route = crate::routes::transcription::resolve_execution_route_for_target(
+        execution_target_preference,
+    )
+    .ok()
+    .flatten();
+    let Ok(model_session_permit) = runtime.acquire_native_execution(resolved_route.as_ref()) else {
         return;
     };
     let Some(adapter) = openasr_core::native_runtime_model_adapter_for_path(&model_pack_path)
@@ -1016,13 +1049,6 @@ pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime
     // `openasr_home()` resolution failing here (unreadable env, race) just
     // means "no preference found" -- same graceful fallback to defaults the
     // request-time paths use.
-    let preferences_home = openasr_core::openasr_home().ok();
-    let inference_threads = preferences_home
-        .as_deref()
-        .and_then(realtime_inference_threads_preference);
-    let execution_target_preference = preferences_home
-        .as_deref()
-        .and_then(realtime_execution_target_preference);
     let options = NativeAsrRequestOptions::new().with_inference_threads(inference_threads);
     let session_config = NativeAsrStreamingSessionConfig::new()
         .with_audio_format(RealtimeAudioFormat::pcm16_mono_16khz());
@@ -1040,8 +1066,12 @@ pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime
         Ok(session) => session,
         Err(_) => return,
     };
-    let key =
-        NativeStreamingWorkerKey::new(model_pack.root.clone(), hardware_target, inference_threads);
+    let key = NativeStreamingWorkerKey::with_route(
+        model_pack.root.clone(),
+        hardware_target,
+        resolved_route.as_ref(),
+        inference_threads,
+    );
     attach_and_run_boot_warmup(key, session, Some(model_session_permit)).await;
 }
 

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -2020,7 +2020,7 @@ async fn boot_native_warmup_skips_when_the_runtime_slot_is_occupied() {
         model_pack_path: Some(pack_path),
     };
     let occupied_slot = runtime
-        .acquire_native_execution()
+        .acquire_native_execution(None)
         .expect("fixture runtime must admit the active native session");
 
     tokio::time::timeout(
@@ -2031,12 +2031,12 @@ async fn boot_native_warmup_skips_when_the_runtime_slot_is_occupied() {
     .expect("boot warm-up must skip instead of waiting for a busy model slot");
 
     assert!(
-        runtime.acquire_native_execution().is_err(),
+        runtime.acquire_native_execution(None).is_err(),
         "the only capacity slot must still belong to the active native session"
     );
     drop(occupied_slot);
     assert!(
-        runtime.acquire_native_execution().is_ok(),
+        runtime.acquire_native_execution(None).is_ok(),
         "skipped boot warm-up must not retain a capacity permit"
     );
 }
@@ -3297,8 +3297,15 @@ async fn fallback_capacity_rejection_is_backend_not_ready_and_recoverable() {
         ffmpeg_bin_explicit: false,
         model_pack_path: Some(pack_path),
     };
+    let occupied_route = crate::routes::transcription::resolve_execution_route_for_target(None)
+        .expect("fixture route resolve must succeed")
+        .or_else(|| {
+            // CPU-only hosts still need a concrete isolation key that matches
+            // the Auto resolve path used by the fallback backend job.
+            Some(openasr_core::ResolvedExecutionRoute::cpu())
+        });
     let occupied_slot = runtime
-        .acquire_native_execution()
+        .acquire_native_execution(occupied_route.as_ref())
         .expect("fixture runtime must admit the occupied native session");
     let (event_sender, mut event_receiver) = mpsc::channel(8);
     let mut session = WsSession::new(runtime, test_distribution(), event_sender);

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -1630,7 +1630,24 @@ impl WsSession {
             .await?;
             return Err(());
         };
-        let model_session_permit = match self.runtime.acquire_native_execution() {
+        let resolved_route = match crate::routes::transcription::resolve_execution_route_for_target(
+            self.execution_target,
+        ) {
+            Ok(route) => route,
+            Err(error) => {
+                self.emit_error(
+                    RealtimeErrorCode::StartupConfigError,
+                    &format!("Could not resolve native execution route: {error}"),
+                    false,
+                )
+                .await?;
+                return Err(());
+            }
+        };
+        let model_session_permit = match self
+            .runtime
+            .acquire_native_execution(resolved_route.as_ref())
+        {
             Ok(permit) => permit,
             Err(error) => {
                 let recoverable = matches!(error, ApiError::ModelSessionCapacity(_));
@@ -1700,9 +1717,10 @@ impl WsSession {
         // and drains outcomes separately so a slow partial decode never blocks
         // socket ingest for this session.
         self.attach_native_streaming_session_admitted(
-            NativeStreamingWorkerKey::new(
+            NativeStreamingWorkerKey::with_route(
                 model_pack.root.clone(),
                 hardware_target,
+                resolved_route.as_ref(),
                 self.inference_threads,
             ),
             session,

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1446,7 +1446,10 @@ pub(crate) async fn transcribe_with_runtime(
                         .with_native_non_wav_conversion(true),
                 )
                 .map_err(ApiError::AudioPreparation)?;
-                let model_session_permit = runtime.acquire_native_execution()?;
+                let resolved_route = resolve_execution_route_for_target(request.execution_target)
+                    .map_err(ApiError::Backend)?;
+                let model_session_permit =
+                    runtime.acquire_native_execution(resolved_route.as_ref())?;
                 run_admitted_native_transcription(model_session_permit, move || {
                     // Marks this offline (file-transcription / realtime-per-utterance
                     // backend-job) decode as active for the whole synchronous run, so
@@ -1561,6 +1564,51 @@ pub(crate) fn native_hardware_target_from_execution_target(
     }
 }
 
+/// Resolve the request-level execution route used for admission / worker
+/// isolation. Public surfaces still only accept auto/cpu/accelerated; this
+/// maps those coarse targets onto the internal route vocabulary without
+/// exposing Exact device pins yet.
+pub(crate) fn resolve_execution_route_for_target(
+    target: Option<ExecutionTarget>,
+) -> Result<Option<openasr_core::ResolvedExecutionRoute>, openasr_core::BackendError> {
+    let request =
+        openasr_core::ExecutionRouteRequest::from_execution_target(target.unwrap_or_default());
+    let inventory =
+        openasr_core::enumerate_compute_devices_from_ggml(&openasr_core::ggml_available_devices());
+    match openasr_core::resolve_execution_route(&request, &inventory) {
+        Ok(route) => Ok(Some(route)),
+        Err(openasr_core::ExecutionRouteError::AcceleratedUnavailable) => {
+            // Coarse accelerated requests still fail closed later at backend
+            // preference conversion; admission keeps the model-only key so a
+            // missing GPU does not invent a fake device slot.
+            Ok(None)
+        }
+        Err(error) => Err(backend_error_from_execution_route(error)),
+    }
+}
+
+pub(crate) fn backend_error_from_execution_route(
+    error: openasr_core::ExecutionRouteError,
+) -> openasr_core::BackendError {
+    match error {
+        openasr_core::ExecutionRouteError::DeviceNotFound { detail } => {
+            openasr_core::BackendError::ExecutionDeviceNotFound { detail }
+        }
+        openasr_core::ExecutionRouteError::NotAddressable { detail } => {
+            openasr_core::BackendError::ExecutionDeviceNotAddressable { detail }
+        }
+        openasr_core::ExecutionRouteError::InitFailed { detail } => {
+            openasr_core::BackendError::ExecutionDeviceInitFailed { detail }
+        }
+        openasr_core::ExecutionRouteError::AcceleratedUnavailable => {
+            openasr_core::BackendError::NativeFailClosed {
+                reason: "execution_target=accelerated was requested, but no ggml GPU device is available."
+                    .to_string(),
+            }
+        }
+    }
+}
+
 fn native_asr_error_to_backend(error: NativeAsrError) -> openasr_core::BackendError {
     match error {
         NativeAsrError::PhraseBiasUnsupportedByModel {
@@ -1570,6 +1618,15 @@ fn native_asr_error_to_backend(error: NativeAsrError) -> openasr_core::BackendEr
             adapter,
             model_family,
         },
+        NativeAsrError::ExecutionDeviceNotFound { detail } => {
+            openasr_core::BackendError::ExecutionDeviceNotFound { detail }
+        }
+        NativeAsrError::ExecutionDeviceNotAddressable { detail } => {
+            openasr_core::BackendError::ExecutionDeviceNotAddressable { detail }
+        }
+        NativeAsrError::ExecutionDeviceInitFailed { detail } => {
+            openasr_core::BackendError::ExecutionDeviceInitFailed { detail }
+        }
         error => openasr_core::BackendError::NativeFailClosed {
             reason: error.to_string(),
         },

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1590,23 +1590,7 @@ pub(crate) fn resolve_execution_route_for_target(
 pub(crate) fn backend_error_from_execution_route(
     error: openasr_core::ExecutionRouteError,
 ) -> openasr_core::BackendError {
-    match error {
-        openasr_core::ExecutionRouteError::DeviceNotFound { detail } => {
-            openasr_core::BackendError::ExecutionDeviceNotFound { detail }
-        }
-        openasr_core::ExecutionRouteError::NotAddressable { detail } => {
-            openasr_core::BackendError::ExecutionDeviceNotAddressable { detail }
-        }
-        openasr_core::ExecutionRouteError::InitFailed { detail } => {
-            openasr_core::BackendError::ExecutionDeviceInitFailed { detail }
-        }
-        openasr_core::ExecutionRouteError::AcceleratedUnavailable => {
-            openasr_core::BackendError::NativeFailClosed {
-                reason: "execution_target=accelerated was requested, but no ggml GPU device is available."
-                    .to_string(),
-            }
-        }
-    }
+    openasr_core::BackendError::from_execution_route_error(error)
 }
 
 fn native_asr_error_to_backend(error: NativeAsrError) -> openasr_core::BackendError {

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -2294,7 +2294,7 @@ async fn native_audio_preparation_does_not_consume_model_capacity() {
     }
 
     let permit = runtime
-        .acquire_native_execution()
+        .acquire_native_execution(None)
         .expect("audio-only preparation must not consume native model capacity");
     drop(permit);
     std::fs::write(&release_path, b"release").unwrap();

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -80,12 +80,22 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   device. There is no public per-provider/per-device pinning surface such as
   `gpu0`. Internally the runtime can resolve a concrete execution route
   (`provider` + ggml stable device name + optional PCI `device_id` from CUDA/HIP,
-  and from Vulkan when available) for cache/worker/admission isolation. Exact
-  device pins are fail-closed: missing devices, init failures, and Metal (which
-  still initializes only via `MTLCreateSystemDefaultDevice`) return typed
+  and from Vulkan when available). What is route-isolated today:
+  - thread-local ggml **backend-handle** cache (Exact pin never shares a handle;
+    preferred/Auto may Optimus-fall through discrete -> iGPU but always caches
+    under the device that actually initialized)
+  - streaming **worker** keys
+  What is intentionally **not** route-isolated yet (hard gate before public Exact):
+  - family prepared-runtime caches remain coarse `(path, backend)`
+  - serve-batch engine keys do not include route
+  - **admission capacity stays per model identity** (CPU and accelerated share one
+    slot for the same model; route does not multiply capacity)
+  Exact device pins are fail-closed: missing devices, init failures, Metal
+  (still `MTLCreateSystemDefaultDevice` only), and CPU StableId Exact return typed
   not-found / not-addressable / init-failed errors instead of silently swapping
   cards or falling back to CPU. Unavailable coarse `accelerated` targets still
-  fail closed.
+  fail closed. Physical PCI keys are normalized (trim + lower-case) only; full
+  BDF grammar validation is a follow-up.
 - No public reproducible real-backend benchmark or long-audio stability evidence
   is published. The performance harness, regression gates, and competitive
   comparisons are internal (see [Performance](../perf/PERFORMANCE.md)); no claim of

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -77,9 +77,15 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   by the aligner's output, never segment text or speaker attribution.
 - Hardware execution target selection is generic: Desktop/server requests support
   `auto`, `cpu`, and `accelerated` when the native runtime reports an accelerated
-  device. There is no per-provider/per-device pinning surface such as `gpu0`,
-  and unavailable accelerated targets still fail closed or collapse back to
-  supported choices as appropriate.
+  device. There is no public per-provider/per-device pinning surface such as
+  `gpu0`. Internally the runtime can resolve a concrete execution route
+  (`provider` + ggml stable device name + optional PCI `device_id` from CUDA/HIP,
+  and from Vulkan when available) for cache/worker/admission isolation. Exact
+  device pins are fail-closed: missing devices, init failures, and Metal (which
+  still initializes only via `MTLCreateSystemDefaultDevice`) return typed
+  not-found / not-addressable / init-failed errors instead of silently swapping
+  cards or falling back to CPU. Unavailable coarse `accelerated` targets still
+  fail closed.
 - No public reproducible real-backend benchmark or long-audio stability evidence
   is published. The performance harness, regression gates, and competitive
   comparisons are internal (see [Performance](../perf/PERFORMANCE.md)); no claim of

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,9 +36,11 @@ These were prior roadmap goals and are now shipped on the native runtime path:
   (`auto`/`cpu`/`accelerated`) through preferences, file transcription, remote
   file transcription, realtime, and dictation. Internal runtime foundations now
   resolve those coarse targets onto a typed execution route
-  (`provider` + `stable_id` + optional PCI `device_id`) so backend cache, worker,
-  and admission isolation can pin a concrete device. Public Exact GPU0/GPU1
-  selection is intentionally not a product surface yet: Metal remains
+  (`provider` + `stable_id` + optional PCI `device_id`) so the thread-local
+  ggml backend-handle cache and streaming workers can pin a concrete device.
+  Admission capacity remains per-model (not per-route). Family prepared-runtime
+  caches and serve-batch engine keys are still coarse `(path, backend)` and are
+  a hard gate before any public Exact GPU0/GPU1 surface. Metal remains
   not-exactly-addressable (`MTLCreateSystemDefaultDevice` only), and Exact
   requests fail closed rather than falling back to another card or CPU.
 - Desktop remote compute has secure HTTPS/WSS client/server plumbing with

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,8 +34,13 @@ These were prior roadmap goals and are now shipped on the native runtime path:
   real-runtime smoke; published release packs and product claims remain gated.
 - Desktop/server requests carry a generic native execution target
   (`auto`/`cpu`/`accelerated`) through preferences, file transcription, remote
-  file transcription, realtime, and dictation. Per-device GPU/provider pinning is
-  intentionally not part of the current surface.
+  file transcription, realtime, and dictation. Internal runtime foundations now
+  resolve those coarse targets onto a typed execution route
+  (`provider` + `stable_id` + optional PCI `device_id`) so backend cache, worker,
+  and admission isolation can pin a concrete device. Public Exact GPU0/GPU1
+  selection is intentionally not a product surface yet: Metal remains
+  not-exactly-addressable (`MTLCreateSystemDefaultDevice` only), and Exact
+  requests fail closed rather than falling back to another card or CPU.
 - Desktop remote compute has secure HTTPS/WSS client/server plumbing with
   approved pairing, TOFU fingerprint pinning, keychain device credentials, file
   transcription routing, realtime routing, revocation, and server-history


### PR DESCRIPTION
## Summary

Add a request-level exact GPU execution-route foundation: resolve provider/stable-id routes, isolate backend handles and workers by route, keep admission per-model, and fail closed with typed device errors.

## Why

Today accelerated execution is a coarse auto/cpu/accelerated choice. Multi-GPU and exact-device selection need a resolved route identity that cannot silently retarget another device while still caching under the wrong key. This PR lands the foundation only; public Exact pinning and family runtime/serve-batch route keys remain follow-ups.

## Changes

- Introduce `ResolvedExecutionRoute` (provider, stable id, ordinal, kind, addressability) separate from optional physical resource keys.
- Exact init never retargets: miss → device-not-found, init fail → init-failed.
- preferred/Auto walks Optimus rank (discrete → iGPU) and inserts cache entries only under the **successful candidate's** own cache key.
- Remove unknown/accelerated pseudo keys and silent `init_best` retargeting.
- Admission stays per-model (route ignored); route isolates backend-handle cache and workers only.
- Typed `ExecutionRoute` / `ExecutionDevice*` errors reach backend and streaming paths instead of being collapsed to opaque fail-closed strings.
- Metal remains NotExactlyAddressable; public `ExecutionTarget` stays auto/cpu/accelerated.
- Docs honestly state family prepared-runtime caches and serve-batch engine keys are **not** route-isolated yet; Exact product surface is gated on that follow-up.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core -p openasr-server --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core --lib execution_route`
- [x] warmup capacity / CPU||accelerated same-slot coverage
- [x] `cargo nextest run --workspace --lib` (one unrelated concurrent flaky mock-ffmpeg timing test; passes alone)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

- None claimed beyond unit/integration coverage in this PR.

## Docs updated

- [x] `docs/KNOWN_LIMITATIONS.md` and `docs/ROADMAP.md` narrowed to backend-handle + worker isolation; family/serve-batch route isolation called out as remaining hard gate.
- [x] No docs overclaim public Exact device pinning.

## Scope / non-goals

Foundation only. Does not expose Exact on CLI/HTTP, does not retarget Metal as exactly addressable, does not rewrite every family runtime cache or serve-batch engine key (tracked for the runtime-cache coordinator follow-up).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
