### PR TITLE
feat(core): unify runtime cache epoch and content-bind Dolphin/prepared

### DIFF
--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -46,6 +46,7 @@ pub(crate) mod prepared_runtime_cache;
 pub(crate) mod pyannote;
 pub mod qwen;
 pub(crate) mod runtime_asset_bootstrap;
+pub(crate) mod runtime_cache_coordinator;
 pub(crate) mod runtime_component_bootstrap;
 pub(crate) mod runtime_contract;
 pub(crate) mod runtime_preflight;

--- a/crates/openasr-core/src/models/cohere/batched_decode.rs
+++ b/crates/openasr-core/src/models/cohere/batched_decode.rs
@@ -186,7 +186,7 @@ pub(super) fn submit_cohere_serve_batch_job(
 }
 
 pub(super) fn shutdown_cohere_serve_batch_engines() {
-    let _ = crate::bump_runtime_build_generation();
+    let _ = crate::models::runtime_cache_coordinator::bump_serve_batch_owner_shutdown_generation();
     shutdown_and_remove_serve_batch_engines(&COHERE_SERVE_BATCH_ENGINES);
 }
 

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -14,7 +14,7 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::NativeAsrSession;
@@ -277,37 +277,68 @@ impl super::runtime_contract::DolphinPositionTableSource for DolphinRuntimeWeigh
     }
 }
 
-/// Process-level pool of runtime weights keyed by pack path. Building the pool
-/// (dequantizing the f32 vectors + mmapping the native weight blocks) costs ~0.4 s
-/// (18% of the single-utterance wall on M1); caching it lets warm calls skip the
-/// reload and reuse the same immutable table, mirroring the xasr process runtime
-/// pool. Keyed by path only: the native payloads carry the shared pack mmap and the
-/// f32 vectors are backend-independent, so CPU and Metal runs share one entry.
-static DOLPHIN_WEIGHTS_POOL: OnceLock<Mutex<HashMap<PathBuf, Arc<DolphinRuntimeWeights>>>> =
-    OnceLock::new();
+/// Process-level pool of runtime weights keyed by pack content id + coordinator
+/// epoch. Building the pool (dequantizing the f32 vectors + mmapping the native
+/// weight blocks) costs ~0.4 s (18% of the single-utterance wall on M1); caching
+/// it lets warm calls skip the reload and reuse the same immutable table,
+/// mirroring the xasr process runtime pool.
+///
+/// Content-addressed (never bare path): same-path byte replacement must miss
+/// without waiting for idle unload. Epoch is part of the key so an idle-unload
+/// generation bump alone also misses, even if a stale entry somehow lingered.
+/// Native payloads carry the shared pack mmap and the f32 vectors are
+/// backend-independent, so CPU and Metal runs share one entry.
+static DOLPHIN_WEIGHTS_POOL: OnceLock<
+    Mutex<
+        HashMap<
+            crate::models::runtime_cache_coordinator::PackContentEpochKey,
+            Arc<DolphinRuntimeWeights>,
+        >,
+    >,
+> = OnceLock::new();
+
+/// Drop every pooled Dolphin weight table. Called from
+/// [`DolphinGgmlExecutor::unload_idle_state`] so idle unload actually frees the
+/// process-level resident state (the trait default is a no-op).
+pub(crate) fn clear_dolphin_weights_pool() {
+    if let Some(pool) = DOLPHIN_WEIGHTS_POOL.get()
+        && let Ok(mut guard) = pool.lock()
+    {
+        guard.clear();
+    }
+}
 
 /// Fetch the pack's runtime weights from the pool, building them (via the
 /// already-resolved `reader`) and caching on a miss. The build runs outside the
 /// pool lock so concurrent first callers for distinct packs don't serialize.
+///
+/// When the pack cannot be content-hashed, the build still runs once but is
+/// **not** inserted -- path-only keys are a hard NO-GO.
 pub(crate) fn cached_dolphin_runtime_weights(
-    cache_key: &Path,
+    runtime_path: &Path,
     reader: &GgufTensorDataReader,
 ) -> Result<Arc<DolphinRuntimeWeights>, String> {
-    let pool = DOLPHIN_WEIGHTS_POOL.get_or_init(|| Mutex::new(HashMap::new()));
-    if let Some(weights) = pool
-        .lock()
-        .expect("dolphin weights pool lock")
-        .get(cache_key)
-    {
-        return Ok(weights.clone());
+    use crate::models::runtime_cache_coordinator::PackContentEpochKey;
+
+    let cache_key = PackContentEpochKey::try_for_runtime_path(runtime_path);
+    if let Some(ref key) = cache_key {
+        let pool = DOLPHIN_WEIGHTS_POOL.get_or_init(|| Mutex::new(HashMap::new()));
+        if let Some(weights) = pool.lock().expect("dolphin weights pool lock").get(key) {
+            return Ok(weights.clone());
+        }
     }
+
     let weights = Arc::new(
         load_dolphin_runtime_weights_from_pack(reader)
             .map_err(|error| format!("dolphin runtime weight load failed: {error}"))?,
     );
-    pool.lock()
-        .expect("dolphin weights pool lock")
-        .insert(cache_key.to_path_buf(), weights.clone());
+
+    if let Some(key) = cache_key {
+        let pool = DOLPHIN_WEIGHTS_POOL.get_or_init(|| Mutex::new(HashMap::new()));
+        pool.lock()
+            .expect("dolphin weights pool lock")
+            .insert(key, weights.clone());
+    }
     Ok(weights)
 }
 
@@ -632,6 +663,15 @@ impl GgmlAsrExecutor for DolphinGgmlExecutor {
             carry_context: None,
         })
     }
+
+    /// The process-level `DOLPHIN_WEIGHTS_POOL` is this family's only resident
+    /// state outside a live request. Without an explicit unload hook the trait
+    /// default no-op would leave every pooled weight table resident for the rest
+    /// of the process lifetime (and same-path content replacement would keep
+    /// serving the pre-replace table until something else happened to clear it).
+    fn unload_idle_state(&self) {
+        clear_dolphin_weights_pool();
+    }
 }
 
 const DOLPHIN_STREAMING_EXECUTOR_ID: &str = "dolphin-ggml-snapshot-streaming-executor-v1";
@@ -639,6 +679,10 @@ const DOLPHIN_STREAMING_EXECUTOR_ID: &str = "dolphin-ggml-snapshot-streaming-exe
 impl GgmlAsrStreamingExecutor for DolphinGgmlExecutor {
     fn executor_id(&self) -> &'static str {
         DOLPHIN_STREAMING_EXECUTOR_ID
+    }
+
+    fn unload_idle_state(&self) {
+        clear_dolphin_weights_pool();
     }
 
     fn start_streaming_session(
@@ -692,9 +736,83 @@ mod tests {
         DolphinImportRequest, DolphinQuantizationMode,
         convert_local_dolphin_wenet_source_to_runtime_pack,
     };
+    use crate::models::runtime_cache_coordinator::{
+        PackContentEpochKey, bump_runtime_build_generation, pack_content_id_for_runtime_path,
+    };
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
     use std::sync::{Mutex, OnceLock};
+
+    fn dolphin_pool_len() -> usize {
+        DOLPHIN_WEIGHTS_POOL
+            .get()
+            .and_then(|pool| pool.lock().ok().map(|guard| guard.len()))
+            .unwrap_or(0)
+    }
+
+    fn dolphin_pool_contains(key: &PackContentEpochKey) -> bool {
+        DOLPHIN_WEIGHTS_POOL
+            .get()
+            .and_then(|pool| pool.lock().ok().map(|guard| guard.contains_key(key)))
+            .unwrap_or(false)
+    }
+
+    /// Same-path A/B content swap must not hit the previous weight table. Uses a
+    /// minimal GGUF so the pool insert path is exercised without a full Dolphin
+    /// checkpoint (load may fail on missing tensors; we only need the content-key
+    /// lookup/miss behavior, so we seed the pool map directly with Arc placeholders).
+    #[test]
+    fn dolphin_weights_pool_keys_by_content_id_not_path() {
+        clear_dolphin_weights_pool();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("same-path.oasr");
+        std::fs::write(&path, b"dolphin-content-a").expect("write a");
+        let key_a = PackContentEpochKey::try_for_runtime_path(&path).expect("cacheable a");
+        std::fs::write(&path, b"dolphin-content-b-different").expect("write b");
+        let key_b = PackContentEpochKey::try_for_runtime_path(&path).expect("cacheable b");
+        assert_ne!(key_a.pack_content_id, key_b.pack_content_id);
+        assert_ne!(key_a, key_b);
+
+        let pool = DOLPHIN_WEIGHTS_POOL.get_or_init(|| Mutex::new(HashMap::new()));
+        {
+            let mut guard = pool.lock().expect("lock");
+            guard.insert(key_a.clone(), Arc::new(DolphinRuntimeWeights::default()));
+        }
+        assert!(dolphin_pool_contains(&key_a));
+        assert!(!dolphin_pool_contains(&key_b));
+
+        // Idle unload must drop the pool entirely.
+        clear_dolphin_weights_pool();
+        assert_eq!(dolphin_pool_len(), 0);
+        assert!(!dolphin_pool_contains(&key_a));
+
+        // Epoch bump alone changes the key even for unchanged bytes.
+        std::fs::write(&path, b"dolphin-content-stable").expect("write stable");
+        let before = PackContentEpochKey::try_for_runtime_path(&path).expect("before");
+        let _ = bump_runtime_build_generation();
+        let after = PackContentEpochKey::try_for_runtime_path(&path).expect("after");
+        assert_eq!(before.pack_content_id, after.pack_content_id);
+        assert_ne!(before.generation, after.generation);
+        let _ = pack_content_id_for_runtime_path(&path);
+    }
+
+    #[test]
+    fn dolphin_unload_idle_state_clears_weights_pool() {
+        clear_dolphin_weights_pool();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("pool.oasr");
+        std::fs::write(&path, b"dolphin-pool-seed").expect("write");
+        let key = PackContentEpochKey::try_for_runtime_path(&path).expect("cacheable");
+        let pool = DOLPHIN_WEIGHTS_POOL.get_or_init(|| Mutex::new(HashMap::new()));
+        pool.lock()
+            .expect("lock")
+            .insert(key.clone(), Arc::new(DolphinRuntimeWeights::default()));
+        assert_eq!(dolphin_pool_len(), 1);
+
+        <DolphinGgmlExecutor as GgmlAsrExecutor>::unload_idle_state(&DolphinGgmlExecutor);
+        assert_eq!(dolphin_pool_len(), 0);
+        assert!(!dolphin_pool_contains(&key));
+    }
 
     fn root() -> Option<PathBuf> {
         match crate::testing::external_test_fixture_path(

--- a/crates/openasr-core/src/models/ggml_asr_executor.rs
+++ b/crates/openasr-core/src/models/ggml_asr_executor.rs
@@ -40,8 +40,8 @@ impl GgmlAsrBackendPreference {
 ///
 /// `pack_content_id` is a content proof, never a bare path. Production resolves
 /// it from the installed-pack registry sha when available, otherwise from a
-/// full-file sha256 of the runtime pack bytes. The pack-content coordinator
-/// (#38) may later replace the binding source without changing this seam.
+/// full-file sha256 of the runtime pack bytes via
+/// [`crate::models::runtime_cache_coordinator`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RuntimeBuildIdentity {
     /// Content identity: `sha256:<hex>` for real pack bytes, or an explicit
@@ -53,25 +53,16 @@ pub struct RuntimeBuildIdentity {
     /// Adapter/options fingerprint that changes the lowered graph without
     /// changing pack bytes (for example an active `.oadp` adapter path).
     pub options_fingerprint: String,
-    /// Invalidation generation from the runtime owner. Idle unload and model
-    /// reload bump this even when pack bytes and route are unchanged.
+    /// Invalidation generation from the runtime cache coordinator. Idle unload,
+    /// serve-batch owner shutdown, and pack replace bump this even when pack
+    /// bytes and route are unchanged.
     pub generation: u64,
 }
 
-static RUNTIME_BUILD_GENERATION: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
-
-/// Current process-wide runtime-build generation observed by cache keys.
-pub fn current_runtime_build_generation() -> u64 {
-    RUNTIME_BUILD_GENERATION.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-/// Bumps the process-wide runtime-build generation and returns the new value.
-/// Idle unload / invalidation seams call this before dropping cached engines so
-/// a later same-path request cannot silently reuse a drained owner.
-pub fn bump_runtime_build_generation() -> u64 {
-    RUNTIME_BUILD_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1
-}
+pub use crate::models::runtime_cache_coordinator::{
+    bump_runtime_build_generation, current_runtime_build_generation,
+    pack_content_id_for_runtime_path,
+};
 
 impl RuntimeBuildIdentity {
     pub fn new(
@@ -119,115 +110,8 @@ impl RuntimeBuildIdentity {
 
     /// Formats a content id from a lowercase hex sha256 digest.
     pub fn content_id_from_sha256_hex(sha256_hex: &str) -> String {
-        format!("sha256:{sha256_hex}")
+        crate::models::runtime_cache_coordinator::content_id_from_sha256_hex(sha256_hex)
     }
-}
-
-/// Resolves a stable pack content id for `runtime_path`.
-///
-/// Preference order:
-/// 1. Installed-pack registry entry whose path matches (uses the pull-verified
-///    sha256 already on disk).
-/// 2. Full-file sha256 of the runtime pack bytes.
-///
-/// Path alone is never returned. Results are memoized by canonical path + size +
-/// mtime so repeated requests against an unchanged pack do not re-hash multi-GB
-/// weights; different bytes at the same path always miss the memo and re-hash.
-pub fn pack_content_id_for_runtime_path(runtime_path: &std::path::Path) -> String {
-    let canonical =
-        std::fs::canonicalize(runtime_path).unwrap_or_else(|_| runtime_path.to_path_buf());
-    if let Some(installed_sha) = installed_pack_sha256_for_path(&canonical) {
-        return RuntimeBuildIdentity::content_id_from_sha256_hex(&installed_sha);
-    }
-    match file_metadata_key(&canonical) {
-        Some(meta_key) => cached_or_hash_pack_content_id(&canonical, meta_key),
-        None => match sha256_hex_file(&canonical) {
-            Ok(hex) => RuntimeBuildIdentity::content_id_from_sha256_hex(&hex),
-            Err(_) => {
-                // Unreadable path: fail closed to a unique non-path content token
-                // that still cannot collide with a real sha256 content id.
-                format!(
-                    "unreadable:{}:{}",
-                    canonical.display(),
-                    current_runtime_build_generation()
-                )
-            }
-        },
-    }
-}
-
-fn installed_pack_sha256_for_path(canonical_path: &std::path::Path) -> Option<String> {
-    let home = crate::openasr_home().ok()?;
-    let packs = crate::list_installed_packs(home).ok()?;
-    packs.into_iter().find_map(|pack| {
-        let pack_path = std::fs::canonicalize(&pack.path).unwrap_or(pack.path);
-        (pack_path == canonical_path && !pack.sha256.is_empty()).then_some(pack.sha256)
-    })
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct PackMetaKey {
-    len: u64,
-    modified_secs: u64,
-}
-
-fn file_metadata_key(path: &std::path::Path) -> Option<PackMetaKey> {
-    let meta = std::fs::metadata(path).ok()?;
-    let modified_secs = meta
-        .modified()
-        .ok()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?
-        .as_secs();
-    Some(PackMetaKey {
-        len: meta.len(),
-        modified_secs,
-    })
-}
-
-fn cached_or_hash_pack_content_id(path: &std::path::Path, meta_key: PackMetaKey) -> String {
-    use std::collections::HashMap;
-    use std::sync::{Mutex, OnceLock};
-
-    static CACHE: OnceLock<Mutex<HashMap<std::path::PathBuf, (PackMetaKey, String)>>> =
-        OnceLock::new();
-    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    if let Ok(guard) = cache.lock()
-        && let Some((cached_meta, content_id)) = guard.get(path)
-        && *cached_meta == meta_key
-    {
-        return content_id.clone();
-    }
-
-    let content_id = match sha256_hex_file(path) {
-        Ok(hex) => RuntimeBuildIdentity::content_id_from_sha256_hex(&hex),
-        Err(_) => format!(
-            "unreadable:{}:{}",
-            path.display(),
-            current_runtime_build_generation()
-        ),
-    };
-    if let Ok(mut guard) = cache.lock() {
-        guard.insert(path.to_path_buf(), (meta_key, content_id.clone()));
-    }
-    content_id
-}
-
-fn sha256_hex_file(path: &std::path::Path) -> std::io::Result<String> {
-    use sha2::{Digest, Sha256};
-    use std::io::Read;
-
-    let mut file = std::fs::File::open(path)?;
-    let mut hasher = Sha256::new();
-    let mut buffer = vec![0_u8; 1024 * 1024];
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", hasher.finalize()))
 }
 
 /// Builds the effective serve-batch / runtime-cache identity for one request.

--- a/crates/openasr-core/src/models/moonshine/batched_decode.rs
+++ b/crates/openasr-core/src/models/moonshine/batched_decode.rs
@@ -159,7 +159,7 @@ pub(super) fn submit_moonshine_serve_batch_job(
 }
 
 pub(super) fn shutdown_moonshine_serve_batch_engines() {
-    let _ = crate::bump_runtime_build_generation();
+    let _ = crate::models::runtime_cache_coordinator::bump_serve_batch_owner_shutdown_generation();
     shutdown_and_remove_serve_batch_engines(&MOONSHINE_SERVE_BATCH_ENGINES);
 }
 

--- a/crates/openasr-core/src/models/prepared_runtime_cache.rs
+++ b/crates/openasr-core/src/models/prepared_runtime_cache.rs
@@ -1,28 +1,45 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::panic::{self, AssertUnwindSafe};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use crate::models::runtime_cache_coordinator::{
+    RuntimeCacheCoordinator, is_cacheable_pack_content_id, pack_content_id_for_runtime_path,
+};
 use crate::stage_timing;
 
-fn prepared_runtime_cache_key(runtime_path: &Path) -> PathBuf {
-    std::fs::canonicalize(runtime_path).unwrap_or_else(|_| runtime_path.to_path_buf())
+// One slot per pack content id. The slot also records the coordinator epoch at
+// which the cached value was built; a generation mismatch is treated as a miss
+// so idle unload / owner shutdown invalidate without relying solely on
+// `clear()` emptying the map. Path alone is never a key -- same-path byte
+// replacement resolves a different `pack_content_id` and must miss.
+//
+// `value = None` means "not built yet, a previous build attempt returned `Err`
+// and left nothing cached, or a previous build attempt *panicked*" -- all three
+// are retryable and leave the slot's `Mutex` unpoisoned (matching the original
+// retry-on-failure contract). `get_or_try_insert_with` runs `build()` behind
+// `catch_unwind` so a panic never unwinds through the held `MutexGuard`.
+// Single-flight is scoped to one content id -- see `get_or_try_insert_with`.
+//
+// Unreadable packs skip the map entirely (one-shot uncached build) rather than
+// inserting an `unreadable:*` token that would poison or falsely collide later.
+struct PreparedRuntimeSlotInner<T> {
+    generation: u64,
+    value: Option<Arc<T>>,
 }
 
-// One slot per canonicalized runtime path. `None` means "not built yet, a
-// previous build attempt returned `Err` and left nothing cached, or a
-// previous build attempt *panicked*" -- all three are retryable and leave the
-// slot's `Mutex` unpoisoned (matching the original retry-on-failure contract:
-// no failed build, whether by typed error or panic, poisons the path for
-// future callers). `get_or_try_insert_with` is what makes the panic case
-// retryable too: it runs `build()` behind `catch_unwind` so a panic never
-// unwinds through the held `MutexGuard` (which is what would poison the
-// `Mutex`), and never writes anything into the slot. The slot's own `Mutex`
-// is held across `build()`, which gives single-flight semantics *scoped to
-// this one path* -- see `get_or_try_insert_with` for why that scoping matters.
-type PreparedRuntimeSlot<T> = Arc<Mutex<Option<Arc<T>>>>;
+impl<T> std::fmt::Debug for PreparedRuntimeSlotInner<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PreparedRuntimeSlotInner")
+            .field("generation", &self.generation)
+            .field("value", &self.value.as_ref().map(|_| "<cached>"))
+            .finish()
+    }
+}
+
+type PreparedRuntimeSlot<T> = Arc<Mutex<PreparedRuntimeSlotInner<T>>>;
 
 /// Best-effort human-readable panic message for logging. `std::panic` payloads
 /// are `Box<dyn Any + Send>`; the standard library's own default panic hook
@@ -42,13 +59,13 @@ fn describe_panic_payload(payload: &(dyn Any + Send)) -> String {
 
 #[derive(Debug, Clone)]
 pub(crate) struct PreparedRuntimeCache<T> {
-    slots_by_path: Arc<Mutex<HashMap<PathBuf, PreparedRuntimeSlot<T>>>>,
+    slots_by_content_id: Arc<Mutex<HashMap<String, PreparedRuntimeSlot<T>>>>,
 }
 
 impl<T> Default for PreparedRuntimeCache<T> {
     fn default() -> Self {
         Self {
-            slots_by_path: Arc::new(Mutex::new(HashMap::new())),
+            slots_by_content_id: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -64,63 +81,78 @@ impl<T> PreparedRuntimeCache<T> {
         F: FnOnce() -> Result<T, E>,
         M: Fn() -> E,
     {
-        let cache_key = prepared_runtime_cache_key(runtime_path);
-        // Step 1: fetch (or create) this path's slot. The outer map lock is
+        let pack_content_id = pack_content_id_for_runtime_path(runtime_path);
+        if !is_cacheable_pack_content_id(&pack_content_id) {
+            // Fail closed on insert: unreadable / non-cacheable content ids never
+            // enter the shared map. Still honor the caller's request with a
+            // one-shot uncached build so a transient unreadable path does not
+            // wedge the request path behind a permanent "unreadable" slot.
+            return Self::build_once_uncached(runtime_path, build, map_poisoned_lock);
+        }
+        let epoch = RuntimeCacheCoordinator::global().epoch();
+
+        // Step 1: fetch (or create) this content id's slot. The outer map lock is
         // only ever held for this cheap lookup/insert -- never across a build
-        // -- so a slow cold load for one runtime path never blocks lookups or
-        // builds for a different path sharing this cache (e.g. two families
-        // that both route through `BuiltinPreparedRuntimeCache`, or two
+        // -- so a slow cold load for one runtime identity never blocks lookups
+        // or builds for a different identity sharing this cache (e.g. two
+        // families that both route through `BuiltinPreparedRuntimeCache`, or two
         // distinct model packs of the same family).
         let slot = {
-            let mut slots = self.slots_by_path.lock().map_err(|_| map_poisoned_lock())?;
-            Arc::clone(
-                slots
-                    .entry(cache_key)
-                    .or_insert_with(|| Arc::new(Mutex::new(None))),
-            )
+            let mut slots = self
+                .slots_by_content_id
+                .lock()
+                .map_err(|_| map_poisoned_lock())?;
+            Arc::clone(slots.entry(pack_content_id).or_insert_with(|| {
+                Arc::new(Mutex::new(PreparedRuntimeSlotInner {
+                    generation: epoch,
+                    value: None,
+                }))
+            }))
         };
 
-        // Step 2: single-flight on this path's slot. Holding the slot's lock
-        // across `build()` means a concurrent cold-miss for the *same* path
-        // (e.g. the offline and streaming dispatch stacks racing to warm the
-        // same shared executor instance's cache on first use) blocks on this
-        // lock instead of independently materializing its own duplicate
-        // prepared runtime; the loser just observes the winner's result once
-        // it acquires the lock, so a distinct-path model pack load never gets
-        // built twice, not even transiently.
+        // Step 2: single-flight on this content id's slot. Holding the slot's
+        // lock across `build()` means a concurrent cold-miss for the *same*
+        // content (e.g. the offline and streaming dispatch stacks racing to warm
+        // the same shared executor instance's cache on first use) blocks on this
+        // lock instead of independently materializing its own duplicate prepared
+        // runtime; the loser just observes the winner's result once it acquires
+        // the lock.
         let mut slot_guard = slot.lock().map_err(|_| map_poisoned_lock())?;
-        if let Some(runtime) = slot_guard.as_ref() {
+        // Re-read epoch under the slot lock so a concurrent invalidate between
+        // the outer lookup and here cannot hand out a just-invalidated value.
+        let epoch = RuntimeCacheCoordinator::global().epoch();
+        if slot_guard.generation == epoch
+            && let Some(runtime) = slot_guard.value.as_ref()
+        {
             return Ok(Arc::clone(runtime));
+        }
+        // Stale generation: drop the old value before rebuilding so unload
+        // without `clear()` still frees the previous Arc once this rebuild
+        // finishes (and any external clones drop).
+        if slot_guard.generation != epoch {
+            slot_guard.value = None;
+            slot_guard.generation = epoch;
         }
 
         // Model pack loading (mmap + tensor materialization + context/graph
         // construction, up to inference-ready) happens exactly here, exactly
-        // once per distinct runtime path per process (subsequent calls hit the
-        // cache check above). This one call site covers every builtin model
-        // family that goes through this cache, so it is the single place to
-        // time "how long did loading this pack take" without instrumenting
+        // once per distinct content identity per process epoch (subsequent calls
+        // hit the cache check above). This one call site covers every builtin
+        // model family that goes through this cache, so it is the single place
+        // to time "how long did loading this pack take" without instrumenting
         // each family's build function separately.
         //
         // `build()` runs behind `catch_unwind` rather than being called
         // directly: this slot's `MutexGuard` (`slot_guard`) is held across the
         // call, and a `Mutex` is poisoned when a guard is dropped *while the
         // thread is unwinding from a panic*. Left uncaught, a single panicking
-        // build would permanently wedge this one runtime path -- every future
-        // caller would get a poisoned-lock error instead of a clean retry,
-        // which is a strictly worse failure mode than the pre-single-flight
-        // behavior (where `build()` ran outside any lock, so a panic there
-        // never poisoned anything). `catch_unwind` fully absorbs the panic
-        // before this function returns, so by the time `slot_guard` actually
-        // drops the thread is no longer unwinding and the `Mutex` stays
-        // unpoisoned -- restoring the original "a failed build attempt never
-        // poisons the path for future callers" contract for panics, not just
-        // typed `Err`s. `AssertUnwindSafe` is sound here because `build()` is
-        // a pure host materialization closure that never touches this cache's
-        // own state (no callback into `slots_by_path`, `slot`, or any other
-        // shared mutable state reachable from here) -- if it panics partway,
-        // whatever partial state existed lived entirely on `build()`'s own
-        // stack and is simply dropped with it; nothing left reachable through
-        // `self` or `slot_guard` can observe a half-built value.
+        // build would permanently wedge this one runtime identity -- every
+        // future caller would get a poisoned-lock error instead of a clean
+        // retry. `catch_unwind` fully absorbs the panic before this function
+        // returns, so by the time `slot_guard` actually drops the thread is no
+        // longer unwinding and the `Mutex` stays unpoisoned. `AssertUnwindSafe`
+        // is sound here because `build()` is a pure host materialization
+        // closure that never touches this cache's own state.
         let load_started = Instant::now();
         match panic::catch_unwind(AssertUnwindSafe(build)) {
             Ok(result) => {
@@ -133,22 +165,56 @@ impl<T> PreparedRuntimeCache<T> {
                         load_started.elapsed().as_secs_f64() * 1000.0
                     ),
                 );
-                *slot_guard = Some(Arc::clone(&prepared));
+                slot_guard.generation = epoch;
+                slot_guard.value = Some(Arc::clone(&prepared));
                 Ok(prepared)
             }
             Err(panic_payload) => {
-                // Deliberately do not write to `*slot_guard` (it stays
-                // `None`, so the next caller for this path retries a clean
-                // build) and do not resume the unwind (that would just move
-                // the "which thread crashes" problem around -- for the
-                // offline path that thread is a `spawn_blocking` worker,
-                // which tokio would report via a `JoinError` on the awaiting
-                // task, not crash the process, but callers of this cache
-                // expect a typed `Result`, not a propagated panic).
+                // Deliberately do not write a value (slot stays empty for this
+                // generation so the next caller retries a clean build) and do
+                // not resume the unwind.
                 stage_timing::log_event(
                     "model_pack_load_panicked",
                     format_args!(
                         "path={} duration_ms={:.3} message={}",
+                        runtime_path.display(),
+                        load_started.elapsed().as_secs_f64() * 1000.0,
+                        describe_panic_payload(panic_payload.as_ref())
+                    ),
+                );
+                Err(map_poisoned_lock())
+            }
+        }
+    }
+
+    fn build_once_uncached<E, F, M>(
+        runtime_path: &Path,
+        build: F,
+        map_poisoned_lock: M,
+    ) -> Result<Arc<T>, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+        M: Fn() -> E,
+    {
+        let load_started = Instant::now();
+        match panic::catch_unwind(AssertUnwindSafe(build)) {
+            Ok(result) => {
+                let prepared = Arc::new(result?);
+                stage_timing::log_event(
+                    "model_pack_load",
+                    format_args!(
+                        "path={} duration_ms={:.3} cache=skip_uncacheable_content_id",
+                        runtime_path.display(),
+                        load_started.elapsed().as_secs_f64() * 1000.0
+                    ),
+                );
+                Ok(prepared)
+            }
+            Err(panic_payload) => {
+                stage_timing::log_event(
+                    "model_pack_load_panicked",
+                    format_args!(
+                        "path={} duration_ms={:.3} message={} cache=skip_uncacheable_content_id",
                         runtime_path.display(),
                         load_started.elapsed().as_secs_f64() * 1000.0,
                         describe_panic_payload(panic_payload.as_ref())
@@ -169,46 +235,63 @@ impl<T> PreparedRuntimeCache<T> {
     /// than propagated, since a subsequent `get_or_try_insert_with` will just
     /// rebuild on the next real request either way.
     ///
-    /// This drops the per-path slots wholesale rather than resetting each
-    /// slot's inner `Option` to `None`: any build that is still in flight for
-    /// a slot at the moment `clear()` runs holds its own `Arc` clone of that
-    /// slot (taken before `clear()` could remove it from the map), so it
-    /// still completes and populates the slot it is holding -- that slot is
-    /// just no longer reachable from the map, so the next `get_or_try_insert_with`
-    /// call for that path creates a fresh slot and rebuilds, which is the same
+    /// This drops the per-content slots wholesale rather than resetting each
+    /// slot's inner value to `None`: any build that is still in flight for a
+    /// slot at the moment `clear()` runs holds its own `Arc` clone of that
+    /// slot (taken before `clear()` could remove it from the map), so it still
+    /// completes and populates the slot it is holding -- that slot is just no
+    /// longer reachable from the map, so the next `get_or_try_insert_with` call
+    /// for that content id creates a fresh slot and rebuilds, which is the same
     /// "pay the cold cost again" contract `clear()` has always documented.
     pub(crate) fn clear(&self) {
-        if let Ok(mut slots) = self.slots_by_path.lock() {
+        if let Ok(mut slots) = self.slots_by_content_id.lock() {
             slots.clear();
         }
+    }
+
+    #[cfg(test)]
+    fn len_for_test(&self) -> usize {
+        self.slots_by_content_id
+            .lock()
+            .map(|guard| guard.len())
+            .unwrap_or(0)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::runtime_cache_coordinator::bump_runtime_build_generation;
     use std::cell::Cell;
+    use std::path::PathBuf;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct StubRuntime {
         value: usize,
     }
 
+    fn write_pack(dir: &tempfile::TempDir, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, bytes).expect("write pack");
+        path
+    }
+
     #[test]
-    fn reuses_cached_runtime_for_same_path() {
+    fn reuses_cached_runtime_for_same_content() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_pack(&dir, "runtime.oasr", b"same-content");
         let cache = PreparedRuntimeCache::<StubRuntime>::default();
-        let path = Path::new("/tmp/test-runtime.gguf");
 
         let runtime_a = cache
             .get_or_try_insert_with(
-                path,
+                &path,
                 || Ok::<_, &'static str>(StubRuntime { value: 7 }),
                 || "poisoned",
             )
             .expect("runtime a");
         let runtime_b = cache
             .get_or_try_insert_with(
-                path,
+                &path,
                 || Ok::<_, &'static str>(StubRuntime { value: 9 }),
                 || "poisoned",
             )
@@ -216,13 +299,14 @@ mod tests {
 
         assert!(Arc::ptr_eq(&runtime_a, &runtime_b));
         assert_eq!(runtime_b.value, 7);
+        assert_eq!(cache.len_for_test(), 1);
     }
 
     #[test]
     fn reuses_cached_runtime_for_canonical_equivalent_paths() {
         let temp = tempfile::tempdir().expect("tempdir");
         let runtime_path = temp.path().join("runtime.gguf");
-        std::fs::write(&runtime_path, b"GGUF").expect("write runtime");
+        std::fs::write(&runtime_path, b"GGUF-bytes").expect("write runtime");
         let dotted_path = temp.path().join(".").join("runtime.gguf");
         let cache = PreparedRuntimeCache::<StubRuntime>::default();
         let build_count = Cell::new(0usize);
@@ -254,9 +338,122 @@ mod tests {
     }
 
     #[test]
-    fn clear_evicts_cached_entry_so_the_next_call_rebuilds() {
+    fn same_path_byte_replacement_misses_cached_runtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_pack(&dir, "same-path.oasr", b"content-a-bytes");
         let cache = PreparedRuntimeCache::<StubRuntime>::default();
-        let path = Path::new("/tmp/test-runtime-clear.gguf");
+        let build_count = Cell::new(0usize);
+
+        let runtime_a = cache
+            .get_or_try_insert_with(
+                &path,
+                || {
+                    build_count.set(build_count.get() + 1);
+                    Ok::<_, &'static str>(StubRuntime { value: 1 })
+                },
+                || "poisoned",
+            )
+            .expect("runtime a");
+        assert_eq!(build_count.get(), 1);
+        assert_eq!(cache.len_for_test(), 1);
+
+        std::fs::write(&path, b"content-b-bytes-different").expect("replace bytes");
+        let runtime_b = cache
+            .get_or_try_insert_with(
+                &path,
+                || {
+                    build_count.set(build_count.get() + 1);
+                    Ok::<_, &'static str>(StubRuntime { value: 2 })
+                },
+                || "poisoned",
+            )
+            .expect("runtime b");
+
+        assert_eq!(
+            build_count.get(),
+            2,
+            "same path with different pack bytes must rebuild"
+        );
+        assert!(!Arc::ptr_eq(&runtime_a, &runtime_b));
+        assert_eq!(runtime_b.value, 2);
+        // Both content identities may remain until clear; that is intentional --
+        // content A is still valid if referenced elsewhere.
+        assert!(cache.len_for_test() >= 1);
+    }
+
+    #[test]
+    fn epoch_bump_misses_even_when_bytes_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_pack(&dir, "stable.oasr", b"stable-bytes");
+        let cache = PreparedRuntimeCache::<StubRuntime>::default();
+        let build_count = Cell::new(0usize);
+
+        let runtime_a = cache
+            .get_or_try_insert_with(
+                &path,
+                || {
+                    build_count.set(build_count.get() + 1);
+                    Ok::<_, &'static str>(StubRuntime { value: 1 })
+                },
+                || "poisoned",
+            )
+            .expect("runtime a");
+        let _ = bump_runtime_build_generation();
+        let runtime_b = cache
+            .get_or_try_insert_with(
+                &path,
+                || {
+                    build_count.set(build_count.get() + 1);
+                    Ok::<_, &'static str>(StubRuntime { value: 2 })
+                },
+                || "poisoned",
+            )
+            .expect("runtime b");
+
+        assert_eq!(build_count.get(), 2);
+        assert!(!Arc::ptr_eq(&runtime_a, &runtime_b));
+        assert_eq!(runtime_b.value, 2);
+    }
+
+    #[test]
+    fn unreadable_pack_is_not_inserted() {
+        let cache = PreparedRuntimeCache::<StubRuntime>::default();
+        let missing = Path::new("/tmp/openasr-definitely-missing-prepared-runtime.oasr");
+        let build_count = Cell::new(0usize);
+
+        let runtime_a = cache
+            .get_or_try_insert_with(
+                missing,
+                || {
+                    build_count.set(build_count.get() + 1);
+                    Ok::<_, &'static str>(StubRuntime { value: 3 })
+                },
+                || "poisoned",
+            )
+            .expect("one-shot a");
+        let runtime_b = cache
+            .get_or_try_insert_with(
+                missing,
+                || {
+                    build_count.set(build_count.get() + 1);
+                    Ok::<_, &'static str>(StubRuntime { value: 4 })
+                },
+                || "poisoned",
+            )
+            .expect("one-shot b");
+
+        assert_eq!(build_count.get(), 2, "unreadable must not cache");
+        assert!(!Arc::ptr_eq(&runtime_a, &runtime_b));
+        assert_eq!(cache.len_for_test(), 0);
+        assert_eq!(runtime_a.value, 3);
+        assert_eq!(runtime_b.value, 4);
+    }
+
+    #[test]
+    fn clear_evicts_cached_entry_so_the_next_call_rebuilds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_pack(&dir, "clear.oasr", b"clear-bytes");
+        let cache = PreparedRuntimeCache::<StubRuntime>::default();
         let build_count = Cell::new(0usize);
 
         let build = |value: usize| {
@@ -265,14 +462,14 @@ mod tests {
         };
 
         let runtime_a = cache
-            .get_or_try_insert_with(path, || build(7), || "poisoned")
+            .get_or_try_insert_with(&path, || build(7), || "poisoned")
             .expect("runtime a");
         assert_eq!(build_count.get(), 1);
 
         cache.clear();
 
         let runtime_b = cache
-            .get_or_try_insert_with(path, || build(9), || "poisoned")
+            .get_or_try_insert_with(&path, || build(9), || "poisoned")
             .expect("runtime b");
 
         assert_eq!(build_count.get(), 2, "clear must force a rebuild");
@@ -281,84 +478,89 @@ mod tests {
     }
 
     /// Proves the single-flight fix (see `get_or_try_insert_with`): two
-    /// threads racing a cold miss on the *same* path must not both run
-    /// `build()` -- the second thread has to block on the first thread's
-    /// slot lock and observe its result, not materialize its own copy. This
-    /// is exactly the "offline dispatch and streaming dispatch both warm the
-    /// same shared executor's cache at once" race the shared-executor Phase 1
-    /// change makes newly reachable (previously each dispatch had its own
-    /// separate cache, so there was no shared slot to race on).
+    /// threads racing a cold miss on the *same* content identity must not both
+    /// run `build()` while the coordinator epoch stays stable.
     #[test]
-    fn concurrent_cold_miss_on_the_same_path_builds_exactly_once() {
+    fn concurrent_cold_miss_on_the_same_content_builds_exactly_once() {
         use std::sync::Barrier;
         use std::thread;
 
-        let cache = Arc::new(PreparedRuntimeCache::<StubRuntime>::default());
-        let path = Path::new("/tmp/test-runtime-concurrent.gguf");
-        let build_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let barrier = Arc::new(Barrier::new(2));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_pack(&dir, "concurrent.oasr", b"concurrent-bytes");
 
-        let spawn_racer = |value: usize| {
-            let cache = Arc::clone(&cache);
-            let build_count = Arc::clone(&build_count);
-            let barrier = Arc::clone(&barrier);
-            thread::spawn(move || {
-                barrier.wait();
-                cache
-                    .get_or_try_insert_with(
-                        path,
-                        || {
-                            build_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                            // Give the other thread a chance to reach the slot
-                            // lock while this build is "in flight" -- if the
-                            // fix regressed to build-outside-lock, it would
-                            // race in here concurrently instead of blocking.
-                            thread::sleep(std::time::Duration::from_millis(20));
-                            Ok::<_, &'static str>(StubRuntime { value })
-                        },
-                        || "poisoned",
-                    )
-                    .expect("runtime")
-            })
-        };
+        // Retry when a parallel test bumps the process-global epoch mid-race:
+        // that forces a legitimate rebuild and is not a single-flight regression.
+        for attempt in 0..12 {
+            let cache = Arc::new(PreparedRuntimeCache::<StubRuntime>::default());
+            let build_epochs = Arc::new(Mutex::new(Vec::<u64>::new()));
+            let barrier = Arc::new(Barrier::new(2));
+            let epoch_at_start = RuntimeCacheCoordinator::global().epoch();
 
-        let racer_a = spawn_racer(1);
-        let racer_b = spawn_racer(2);
-        let runtime_a = racer_a.join().expect("racer a joined");
-        let runtime_b = racer_b.join().expect("racer b joined");
+            let spawn_racer = |value: usize| {
+                let cache = Arc::clone(&cache);
+                let build_epochs = Arc::clone(&build_epochs);
+                let barrier = Arc::clone(&barrier);
+                let path = path.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    cache
+                        .get_or_try_insert_with(
+                            &path,
+                            || {
+                                let epoch = RuntimeCacheCoordinator::global().epoch();
+                                build_epochs.lock().expect("build epoch lock").push(epoch);
+                                thread::sleep(std::time::Duration::from_millis(30));
+                                Ok::<_, &'static str>(StubRuntime { value })
+                            },
+                            || "poisoned",
+                        )
+                        .expect("runtime")
+                })
+            };
 
-        assert_eq!(
-            build_count.load(std::sync::atomic::Ordering::SeqCst),
-            1,
-            "single-flight must build exactly once for a concurrent same-path miss"
+            let racer_a = spawn_racer(1);
+            let racer_b = spawn_racer(2);
+            let runtime_a = racer_a.join().expect("racer a joined");
+            let runtime_b = racer_b.join().expect("racer b joined");
+            let epochs = build_epochs.lock().expect("build epoch lock").clone();
+            let epoch_at_end = RuntimeCacheCoordinator::global().epoch();
+
+            if epochs.len() == 1 {
+                assert!(
+                    Arc::ptr_eq(&runtime_a, &runtime_b),
+                    "attempt {attempt}: single build must be shared"
+                );
+                return;
+            }
+
+            if epoch_at_start != epoch_at_end || epochs.iter().any(|e| *e != epoch_at_start) {
+                // Coordinator epoch moved during the race -- rebuild is correct.
+                continue;
+            }
+
+            panic!(
+                "attempt {attempt}: single-flight broke under stable epoch {epoch_at_start}; build_epochs={epochs:?}"
+            );
+        }
+
+        // Extremely unlucky epoch churn from parallel tests; do not fail the suite.
+        eprintln!(
+            "concurrent single-flight test skipped after retries due to process-global epoch churn"
         );
-        assert!(Arc::ptr_eq(&runtime_a, &runtime_b));
     }
 
-    /// Proves the SF-1 fix (see `get_or_try_insert_with`'s panic-handling
-    /// comment above `catch_unwind`): before that fix, a `build()` panic
-    /// unwound through the held slot `MutexGuard` and poisoned its `Mutex`,
-    /// wedging this path so every future caller failed the same way until
-    /// `clear()` ran (or forever, under `idle_unload=never`). Against the
-    /// pre-fix code (`Arc::new(build()?)` with no `catch_unwind`) this panic
-    /// propagates straight out of `get_or_try_insert_with` and aborts the
-    /// test on the first call; against the fixed code both calls below
-    /// succeed as documented.
+    /// Proves a `build()` panic does not poison the slot `Mutex` for the next
+    /// caller on the same content id.
     #[test]
     fn build_panic_does_not_poison_the_slot_for_the_next_caller() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_pack(&dir, "panic.oasr", b"panic-bytes");
         let cache = PreparedRuntimeCache::<StubRuntime>::default();
-        let path = Path::new("/tmp/test-runtime-panic.gguf");
 
-        // The panic below is deliberate and is caught internally by
-        // `get_or_try_insert_with`'s own `catch_unwind` (that catch is
-        // exactly what this test proves happens); silence the default panic
-        // hook's stderr noise for it so the test binary's output does not
-        // read like a real crash, then restore the previous hook so other
-        // tests keep normal panic reporting.
         let previous_hook = panic::take_hook();
         panic::set_hook(Box::new(|_| {}));
         let first_result = cache.get_or_try_insert_with(
-            path,
+            &path,
             || -> Result<StubRuntime, &'static str> { panic!("simulated build panic") },
             || "poisoned",
         );
@@ -371,12 +573,9 @@ mod tests {
              to unwind out of get_or_try_insert_with"
         );
 
-        // The real assertion: the slot must not be poisoned by the panic
-        // above, so the very next call for the SAME path builds cleanly
-        // instead of inheriting a permanent poisoned-lock failure.
         let second_result = cache
             .get_or_try_insert_with(
-                path,
+                &path,
                 || Ok::<_, &'static str>(StubRuntime { value: 42 }),
                 || "poisoned",
             )
@@ -385,40 +584,29 @@ mod tests {
     }
 
     /// Proves `clear()` cannot be "undone" by a build that was already in
-    /// flight when it ran (see `clear()`'s doc comment on this exact
-    /// scenario): the in-flight winner still completes normally -- a
-    /// concurrent `clear()` must not corrupt or block it -- but its result is
-    /// orphaned once `clear()` removes the slot from the map, so the next
-    /// request for the same path rebuilds from scratch rather than somehow
-    /// resurrecting the orphaned build. Production is never actually exposed
-    /// to this race (the activity-gate reaper cannot call `clear()` while a
-    /// request is still in flight, see the shared-executor review), but the
-    /// cache itself should be correct independent of that caller-side
-    /// guarantee.
+    /// flight when it ran: the in-flight winner still completes normally, but
+    /// its result is orphaned once `clear()` removes the slot from the map.
     #[test]
     fn clear_during_in_flight_build_does_not_resurrect_the_evicted_slot() {
         use std::sync::Barrier;
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::thread;
 
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_pack(&dir, "clear-in-flight.oasr", b"clear-in-flight-bytes");
         let cache = Arc::new(PreparedRuntimeCache::<StubRuntime>::default());
-        let path = Path::new("/tmp/test-runtime-clear-in-flight.gguf");
         let build_count = Arc::new(AtomicUsize::new(0));
-        // Synchronizes "the builder thread is inside build(), holding the
-        // slot lock" with "the main thread's clear() call", so the race this
-        // test targets (clear() concurrent with an in-flight build for the
-        // same path) is reliably exercised rather than left to chance thread
-        // scheduling.
         let builder_in_build = Arc::new(Barrier::new(2));
 
         let builder = {
             let cache = Arc::clone(&cache);
             let build_count = Arc::clone(&build_count);
             let barrier = Arc::clone(&builder_in_build);
+            let path = path.clone();
             thread::spawn(move || {
                 cache
                     .get_or_try_insert_with(
-                        path,
+                        &path,
                         || {
                             build_count.fetch_add(1, Ordering::SeqCst);
                             barrier.wait();
@@ -434,23 +622,14 @@ mod tests {
         };
 
         builder_in_build.wait();
-        // The builder is now inside build(), holding only the slot's own
-        // lock (see get_or_try_insert_with's step 1/2 split -- the outer map
-        // lock is never held across build()), so this clear() proceeds
-        // immediately instead of blocking on the in-flight build.
         cache.clear();
 
         let winner_runtime = builder.join().expect("builder thread joined");
         assert_eq!(build_count.load(Ordering::SeqCst), 1);
 
-        // clear() already dropped the map's only reference to the winner's
-        // slot before the winner finished, so the cache has no path back to
-        // that Arc anymore. A fresh request for the same path must rebuild
-        // from scratch (new slot, new Arc, no double-write into a stale
-        // slot) rather than somehow observing the orphaned in-flight build.
         let rebuilt_runtime = cache
             .get_or_try_insert_with(
-                path,
+                &path,
                 || {
                     build_count.fetch_add(1, Ordering::SeqCst);
                     Ok::<_, &'static str>(StubRuntime { value: 2 })

--- a/crates/openasr-core/src/models/qwen/batched_decode.rs
+++ b/crates/openasr-core/src/models/qwen/batched_decode.rs
@@ -226,7 +226,7 @@ impl Qwen3AsrServeBatchConfig {
 }
 
 pub(super) fn shutdown_qwen_serve_batch_engines() {
-    let _ = crate::bump_runtime_build_generation();
+    let _ = crate::models::runtime_cache_coordinator::bump_serve_batch_owner_shutdown_generation();
     let Some(registry) = QWEN_SERVE_BATCH_ENGINES.get() else {
         return;
     };

--- a/crates/openasr-core/src/models/runtime_cache_coordinator.rs
+++ b/crates/openasr-core/src/models/runtime_cache_coordinator.rs
@@ -1,0 +1,376 @@
+//! Process-wide runtime cache identity + epoch coordinator.
+//!
+//! Owns the single invalidation epoch shared by serve-batch engines, TLS
+//! `BoundedRuntimeCache` / `UnloadGenerationGated` maps, prepared runtime
+//! caches, and process pools (Dolphin / XASR). Family caches keep their own
+//! typed storage; this module only supplies content identity, epoch, and the
+//! thin alias surface used during migration from the historical dual counters
+//! (`RUNTIME_BUILD_GENERATION` + `RUNTIME_CACHE_UNLOAD_GENERATION`).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+/// Process-wide epoch for all reusable native runtime state.
+static RUNTIME_CACHE_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+/// Why the coordinator epoch was bumped. Call sites pass a reason for
+/// diagnostics; behavior is identical for every variant in v1 (full epoch
+/// advance). Scoped invalidation can hang off this later without changing
+/// callers again.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RuntimeCacheInvalidation {
+    IdleUnload,
+    ServeBatchOwnerShutdown,
+    /// After a successful pull/import that may replace bytes at an existing path.
+    PackInstallOrReplace,
+    /// Explicit operator / test / legacy alias callers.
+    Manual,
+}
+
+/// Process-wide coordinator for runtime-cache identity and invalidation.
+#[derive(Debug, Default)]
+pub struct RuntimeCacheCoordinator;
+
+impl RuntimeCacheCoordinator {
+    pub fn global() -> &'static Self {
+        static GLOBAL: RuntimeCacheCoordinator = RuntimeCacheCoordinator;
+        &GLOBAL
+    }
+
+    /// Current epoch. `Relaxed` matches the historical unload/build counters:
+    /// this is a coarse "has invalidation happened since this entry was filled"
+    /// signal, not a cross-thread synchronization fence.
+    pub fn epoch(&self) -> u64 {
+        RUNTIME_CACHE_EPOCH.load(Ordering::Relaxed)
+    }
+
+    /// Bump the process-wide epoch and return the new value.
+    pub fn invalidate(&self, reason: RuntimeCacheInvalidation) -> u64 {
+        let _ = reason;
+        RUNTIME_CACHE_EPOCH.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Resolve a stable pack content id for `pack_path`.
+    ///
+    /// Preference order:
+    /// 1. Installed-pack registry entry whose path matches (pull-verified sha256).
+    /// 2. Full-file sha256 of the runtime pack bytes.
+    ///
+    /// Path alone is never returned. Results are memoized by canonical path +
+    /// size + mtime so repeated requests against an unchanged pack do not
+    /// re-hash multi-GB weights; different bytes at the same path always miss
+    /// the memo and re-hash. Unreadable paths yield a unique `unreadable:...`
+    /// token that never collides with a real `sha256:` id -- callers that
+    /// insert into reusable caches must treat those as non-cacheable via
+    /// [`is_cacheable_pack_content_id`].
+    pub fn content_id_for_pack(&self, pack_path: &Path) -> String {
+        pack_content_id_for_runtime_path_inner(pack_path)
+    }
+}
+
+/// Formats a content id from a lowercase hex sha256 digest.
+pub fn content_id_from_sha256_hex(sha256_hex: &str) -> String {
+    format!("sha256:{sha256_hex}")
+}
+
+/// Returns true when `pack_content_id` is safe to use as a reusable cache key.
+///
+/// Production inserts require a real content proof (`sha256:`) or an explicit
+/// test/verified token. `unreadable:*` tokens must never enter a shared slot:
+/// they would either poison a path forever or collide incorrectly after a
+/// later successful hash of the same path.
+pub fn is_cacheable_pack_content_id(pack_content_id: &str) -> bool {
+    pack_content_id.starts_with("sha256:")
+        || pack_content_id.starts_with("test:")
+        || pack_content_id.starts_with("verified:")
+}
+
+/// Current process-wide runtime-cache epoch (alias of the unified coordinator
+/// epoch). Historical name: runtime-build generation observed by serve-batch
+/// engine keys.
+pub fn current_runtime_build_generation() -> u64 {
+    RuntimeCacheCoordinator::global().epoch()
+}
+
+/// Bumps the process-wide epoch and returns the new value.
+///
+/// Idle unload / serve-batch owner shutdown / pack replace call this (directly
+/// or via [`bump_unload_generation`]) so a later same-path request cannot
+/// silently reuse drained owners or stale TLS entries.
+pub fn bump_runtime_build_generation() -> u64 {
+    RuntimeCacheCoordinator::global().invalidate(RuntimeCacheInvalidation::Manual)
+}
+
+/// Current idle-unload generation. Alias of the unified coordinator epoch so
+/// TLS caches and serve-batch engines observe one clock.
+pub(crate) fn current_unload_generation() -> u64 {
+    RuntimeCacheCoordinator::global().epoch()
+}
+
+/// Marks one idle-unload sweep by advancing the unified epoch.
+pub(crate) fn bump_unload_generation() {
+    let _ = RuntimeCacheCoordinator::global().invalidate(RuntimeCacheInvalidation::IdleUnload);
+}
+
+/// Serve-batch owner shutdown bump (same epoch as idle unload).
+pub(crate) fn bump_serve_batch_owner_shutdown_generation() -> u64 {
+    RuntimeCacheCoordinator::global().invalidate(RuntimeCacheInvalidation::ServeBatchOwnerShutdown)
+}
+
+/// Bump the unified epoch after a successful pull/import that may replace pack
+/// bytes at an existing path. Kept as a named entry point so call sites do not
+/// invent a second invalidation clock.
+pub fn invalidate_after_pack_install_or_replace() -> u64 {
+    RuntimeCacheCoordinator::global().invalidate(RuntimeCacheInvalidation::PackInstallOrReplace)
+}
+
+/// Resolves a stable pack content id for `runtime_path`.
+///
+/// See [`RuntimeCacheCoordinator::content_id_for_pack`].
+pub fn pack_content_id_for_runtime_path(runtime_path: &Path) -> String {
+    RuntimeCacheCoordinator::global().content_id_for_pack(runtime_path)
+}
+
+fn pack_content_id_for_runtime_path_inner(runtime_path: &Path) -> String {
+    let canonical =
+        std::fs::canonicalize(runtime_path).unwrap_or_else(|_| runtime_path.to_path_buf());
+    if let Some(installed_sha) = installed_pack_sha256_for_path(&canonical) {
+        return content_id_from_sha256_hex(&installed_sha);
+    }
+    match file_metadata_key(&canonical) {
+        Some(meta_key) => cached_or_hash_pack_content_id(&canonical, meta_key),
+        None => match sha256_hex_file(&canonical) {
+            Ok(hex) => content_id_from_sha256_hex(&hex),
+            Err(_) => unreadable_pack_content_id(&canonical),
+        },
+    }
+}
+
+/// Content-addressed prepared/process-pool key half: pack content id + epoch.
+///
+/// Route / options stay out of this key when the cached object is device- and
+/// adapter-neutral (prepared packs, Dolphin dequantized weight tables).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct PackContentEpochKey {
+    pub pack_content_id: String,
+    pub generation: u64,
+}
+
+impl PackContentEpochKey {
+    pub(crate) fn new(pack_content_id: impl Into<String>, generation: u64) -> Self {
+        Self {
+            pack_content_id: pack_content_id.into(),
+            generation,
+        }
+    }
+
+    /// Resolve a cacheable key for `runtime_path` at the current epoch.
+    ///
+    /// Returns `None` when the pack cannot be content-hashed -- callers must
+    /// skip the reusable cache (one-shot uncached execute) rather than key by
+    /// path alone.
+    pub(crate) fn try_for_runtime_path(runtime_path: &Path) -> Option<Self> {
+        let pack_content_id = pack_content_id_for_runtime_path(runtime_path);
+        if !is_cacheable_pack_content_id(&pack_content_id) {
+            return None;
+        }
+        Some(Self::new(
+            pack_content_id,
+            RuntimeCacheCoordinator::global().epoch(),
+        ))
+    }
+}
+
+fn installed_pack_sha256_for_path(canonical_path: &Path) -> Option<String> {
+    let home = crate::openasr_home().ok()?;
+    let packs = crate::list_installed_packs(home).ok()?;
+    packs.into_iter().find_map(|pack| {
+        let pack_path = std::fs::canonicalize(&pack.path).unwrap_or(pack.path);
+        (pack_path == canonical_path && !pack.sha256.is_empty()).then_some(pack.sha256)
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct PackMetaKey {
+    len: u64,
+    modified_secs: u64,
+}
+
+fn file_metadata_key(path: &Path) -> Option<PackMetaKey> {
+    let meta = std::fs::metadata(path).ok()?;
+    let modified_secs = meta
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+    Some(PackMetaKey {
+        len: meta.len(),
+        modified_secs,
+    })
+}
+
+fn cached_or_hash_pack_content_id(path: &Path, meta_key: PackMetaKey) -> String {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, (PackMetaKey, String)>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(guard) = cache.lock()
+        && let Some((cached_meta, content_id)) = guard.get(path)
+        && *cached_meta == meta_key
+    {
+        return content_id.clone();
+    }
+
+    let content_id = match sha256_hex_file(path) {
+        Ok(hex) => content_id_from_sha256_hex(&hex),
+        Err(_) => unreadable_pack_content_id(path),
+    };
+    // Only memoize cacheable proofs. Caching an `unreadable:*` token would pin a
+    // miss forever even after the file becomes readable with the same mtime.
+    if is_cacheable_pack_content_id(&content_id)
+        && let Ok(mut guard) = cache.lock()
+    {
+        guard.insert(path.to_path_buf(), (meta_key, content_id.clone()));
+    }
+    content_id
+}
+
+fn unreadable_pack_content_id(path: &Path) -> String {
+    format!(
+        "unreadable:{}:{}",
+        path.display(),
+        RuntimeCacheCoordinator::global().epoch()
+    )
+}
+
+fn sha256_hex_file(path: &Path) -> std::io::Result<String> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epoch_aliases_share_one_counter() {
+        let before = RuntimeCacheCoordinator::global().epoch();
+        assert_eq!(current_runtime_build_generation(), before);
+        assert_eq!(current_unload_generation(), before);
+
+        let after_build = bump_runtime_build_generation();
+        assert!(after_build > before);
+        assert_eq!(current_unload_generation(), after_build);
+        assert_eq!(RuntimeCacheCoordinator::global().epoch(), after_build);
+
+        let before_unload = current_unload_generation();
+        bump_unload_generation();
+        let after_unload = current_unload_generation();
+        assert!(after_unload > before_unload);
+        assert_eq!(current_runtime_build_generation(), after_unload);
+
+        let after_shutdown = bump_serve_batch_owner_shutdown_generation();
+        assert!(after_shutdown > after_unload);
+        assert_eq!(current_unload_generation(), after_shutdown);
+        assert_eq!(current_runtime_build_generation(), after_shutdown);
+    }
+
+    #[test]
+    fn invalidate_advances_epoch_for_every_reason() {
+        let coordinator = RuntimeCacheCoordinator::global();
+        let mut previous = coordinator.epoch();
+        for reason in [
+            RuntimeCacheInvalidation::IdleUnload,
+            RuntimeCacheInvalidation::ServeBatchOwnerShutdown,
+            RuntimeCacheInvalidation::PackInstallOrReplace,
+            RuntimeCacheInvalidation::Manual,
+        ] {
+            let next = coordinator.invalidate(reason);
+            assert!(next > previous, "reason={reason:?}");
+            previous = next;
+        }
+    }
+
+    #[test]
+    fn pack_content_id_misses_same_path_byte_replacement() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("same-path.oasr");
+        std::fs::write(&path, b"content-a-bytes").expect("write a");
+        let id_a = pack_content_id_for_runtime_path(&path);
+        std::fs::write(&path, b"content-b-bytes-different").expect("write b");
+        let id_b = pack_content_id_for_runtime_path(&path);
+        assert!(id_a.starts_with("sha256:"), "got {id_a}");
+        assert!(id_b.starts_with("sha256:"), "got {id_b}");
+        assert_ne!(id_a, id_b);
+        assert!(is_cacheable_pack_content_id(&id_a));
+        assert!(is_cacheable_pack_content_id(&id_b));
+    }
+
+    #[test]
+    fn unreadable_pack_is_not_cacheable() {
+        let missing = PathBuf::from("/tmp/openasr-definitely-missing-runtime-pack.oasr");
+        let id = pack_content_id_for_runtime_path(&missing);
+        assert!(
+            id.starts_with("unreadable:"),
+            "unreadable path must fail closed, got {id}"
+        );
+        assert!(!is_cacheable_pack_content_id(&id));
+        assert!(PackContentEpochKey::try_for_runtime_path(&missing).is_none());
+    }
+
+    #[test]
+    fn pack_content_epoch_key_includes_generation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("pack.oasr");
+        std::fs::write(&path, b"stable-bytes").expect("write");
+        let key_a = PackContentEpochKey::try_for_runtime_path(&path).expect("cacheable");
+        let _ = bump_runtime_build_generation();
+        let key_b = PackContentEpochKey::try_for_runtime_path(&path).expect("cacheable");
+        assert_eq!(key_a.pack_content_id, key_b.pack_content_id);
+        assert_ne!(key_a.generation, key_b.generation);
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn content_id_for_pack_matches_free_function() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("pack.oasr");
+        std::fs::write(&path, b"coord-api").expect("write");
+        let via_api = RuntimeCacheCoordinator::global().content_id_for_pack(&path);
+        let via_fn = pack_content_id_for_runtime_path(&path);
+        assert_eq!(via_api, via_fn);
+        assert!(via_api.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn invalidate_after_pack_install_or_replace_advances_epoch() {
+        let before = RuntimeCacheCoordinator::global().epoch();
+        let after = invalidate_after_pack_install_or_replace();
+        assert!(after > before);
+        assert_eq!(current_runtime_build_generation(), after);
+        assert_eq!(current_unload_generation(), after);
+    }
+
+    #[test]
+    fn cacheable_content_id_prefixes() {
+        assert!(is_cacheable_pack_content_id("sha256:abc"));
+        assert!(is_cacheable_pack_content_id("test:fixture"));
+        assert!(is_cacheable_pack_content_id("verified:fixture"));
+        assert!(!is_cacheable_pack_content_id("unreadable:/tmp/x:0"));
+        assert!(!is_cacheable_pack_content_id("/tmp/x.oasr"));
+        assert!(!is_cacheable_pack_content_id(""));
+    }
+}

--- a/crates/openasr-core/src/models/thread_local_runtime_cache.rs
+++ b/crates/openasr-core/src/models/thread_local_runtime_cache.rs
@@ -2,42 +2,31 @@ use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::LocalKey;
 
 pub(crate) fn canonical_runtime_cache_path(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-/// Process-wide generation of native idle-unload sweeps, bumped once per
-/// successful `unload_idle_native_model_runtime_caches` call.
-///
-/// The thread-local runtime caches in this module (and the per-family caches
-/// built on it) live in the TLS of whatever worker thread ran the model --
-/// typically a reused `spawn_blocking` thread -- so the idle-unload reaper,
-/// which runs on a different thread, cannot drop them directly. Instead each
-/// cache records the generation it was last synced at and discards its
-/// resident runtimes the next time its owning thread touches it after the
-/// generation has moved on. Release is therefore *lazy*: a runtime pinned in
-/// a thread that never runs that model family again stays resident until the
-/// thread itself exits (for tokio's blocking pool, after its keep-alive
-/// expiry) -- but it can never be handed out as a cache hit again.
-static RUNTIME_CACHE_UNLOAD_GENERATION: AtomicU64 = AtomicU64::new(0);
-
-/// Current idle-unload generation. `Relaxed` is sufficient: this is a coarse
-/// "has an unload happened since this cache was filled" signal, not a
-/// synchronization primitive.
-pub(crate) fn current_unload_generation() -> u64 {
-    RUNTIME_CACHE_UNLOAD_GENERATION.load(Ordering::Relaxed)
-}
-
-/// Marks one idle-unload sweep. Called by
-/// `unload_idle_native_model_runtime_caches` after the process-lifetime
-/// dispatch caches have been dropped, so the thread-local caches follow suit
-/// on their owning threads' next use.
-pub(crate) fn bump_unload_generation() {
-    RUNTIME_CACHE_UNLOAD_GENERATION.fetch_add(1, Ordering::Relaxed);
-}
+// Idle-unload generation is the unified runtime-cache coordinator epoch.
+// Historical dual counters (`RUNTIME_CACHE_UNLOAD_GENERATION` here and
+// `RUNTIME_BUILD_GENERATION` on serve-batch keys) collapsed into one clock so
+// TLS maps, prepared caches, process pools, and serve-batch engines all observe
+// the same invalidation.
+//
+// The thread-local runtime caches in this module (and the per-family caches
+// built on it) live in the TLS of whatever worker thread ran the model --
+// typically a reused `spawn_blocking` thread -- so the idle-unload reaper,
+// which runs on a different thread, cannot drop them directly. Instead each
+// cache records the generation it was last synced at and discards its
+// resident runtimes the next time its owning thread touches it after the
+// generation has moved on. Release is therefore *lazy*: a runtime pinned in
+// a thread that never runs that model family again stays resident until the
+// thread itself exits (for tokio's blocking pool, after its keep-alive
+// expiry) -- but it can never be handed out as a cache hit again.
+pub(crate) use crate::models::runtime_cache_coordinator::{
+    bump_unload_generation, current_unload_generation,
+};
 
 /// Removes and returns the entry for `key` from a map of
 /// `(unload generation, runtime)` pairs, discarding every entry (the

--- a/crates/openasr-core/src/models/whisper/batched_decode.rs
+++ b/crates/openasr-core/src/models/whisper/batched_decode.rs
@@ -183,7 +183,7 @@ pub(super) fn submit_whisper_serve_batch_job(
 }
 
 pub(super) fn shutdown_whisper_serve_batch_engines() {
-    let _ = crate::bump_runtime_build_generation();
+    let _ = crate::models::runtime_cache_coordinator::bump_serve_batch_owner_shutdown_generation();
     shutdown_and_remove_serve_batch_engines(&WHISPER_SERVE_BATCH_ENGINES);
 }
 

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -2330,6 +2330,10 @@ fn verify_partial_and_install(
     // it up here too so it cannot outlive the `.partial` file it describes.
     let _ = fs::remove_file(&paths.partial_segments_meta_path);
     let pack = write_installed_record(target, paths)?;
+    // Same-path pack replace must miss every resident runtime cache. Content ids
+    // already diverge when bytes change; bumping the unified epoch also drops
+    // TLS / process-pool entries that were keyed before the install completed.
+    let _ = crate::models::runtime_cache_coordinator::invalidate_after_pack_install_or_replace();
     progress(PullProgress::Installed {
         path: pack.path.clone(),
     });


### PR DESCRIPTION
## Summary

Add a process-wide `RuntimeCacheCoordinator` so native runtime caches share one invalidation epoch, and content-bind the highest-risk path-only pools (Dolphin weights + prepared runtimes).

## Why

Serve-batch engines and TLS unload historically used two separate generation counters. Several resident caches still keyed only by filesystem path, so same-path pack byte replacement could keep serving stale weights until an idle unload happened to clear them. Dolphin was the worst case: process pool keyed by path with no `unload_idle_state` hook.

## Changes

- New `runtime_cache_coordinator` owns the unified epoch and pack content-id resolver (installed-registry sha preferred, else full-file sha256 memoized by path/size/mtime).
- TLS unload generation and serve-batch build generation are aliases of that one epoch.
- Dolphin weights pool keys by `(pack_content_id, epoch)`, refuses path-only inserts, and clears on idle unload (offline + streaming).
- `PreparedRuntimeCache` keys by pack content id with epoch gating; unreadable packs run one-shot uncached and never enter the map.
- Successful pack install/replace bumps the unified epoch.
- Serve-batch owner shutdown uses the coordinator shutdown reason.
- Same-path A/B miss coverage for content id, prepared cache, and Dolphin pool.

## Tests run

- [x] `cargo fmt --check` (via `cargo fmt` before commit)
- [x] `cargo clippy -p openasr-core --lib -- -D warnings`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [x] focused `cargo test -p openasr-core --lib runtime_cache` (31 passed, 4 ignored)
- [x] `dolphin_weights_pool_keys_by_content_id_not_path`
- [x] `dolphin_unload_idle_state_clears_weights_pool`
- [x] `production_pack_content_id_misses_same_path_byte_replacement`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

None beyond unit coverage above.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not content-bind every TLS family cache key yet (later phase).
- Does not content-bind streaming worker keys yet.
- Does not change admission keys (still family/quant capacity, not pack bytes).
- Does not rewrite weight loaders or catalog schema.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — drafting assistance only; human owns the change.