### PR TITLE
fix(pull): allow local .oasr import without public catalog digest

### DIFF
--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -735,16 +735,14 @@ fn pull_target_from_local_oasr_pack(
         },
     };
 
-    if let Some(stem) = stem {
-        // Filename `family-q8_0.oasr` when metadata only carries the family.
-        if quant_hint.is_none()
-            && let Some((family, quant_token)) = split_family_and_trailing_quant_token(stem)
-        {
-            if model_id == family || model_id == stem {
-                model_id = family;
-                quant_hint = Some(quant_token);
-            }
-        }
+    // Filename `family-q8_0.oasr` when metadata only carries the family.
+    if quant_hint.is_none()
+        && let Some(stem) = stem
+        && let Some((family, quant_token)) = split_family_and_trailing_quant_token(stem)
+        && (model_id == family || model_id == stem)
+    {
+        model_id = family;
+        quant_hint = Some(quant_token);
     }
 
     let quant_from_metadata = crate::read_gguf_metadata(source_path)

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -574,6 +574,20 @@ pub fn install_model_pack_from_path(
     install_model_pack_from_path_with_target(&target, source_path, home, progress)
 }
 
+/// Install a local `.oasr` pack into `OPENASR_HOME`.
+///
+/// Resolution order (fail-closed on ambiguity / invalid packs, not on "missing
+/// from public catalog"):
+/// 1. If the file's sha256+size matches exactly one **public** catalog quant,
+///    reuse that catalog identity (same as a network pull of that quant).
+/// 2. Otherwise treat the file as an operator-supplied pack: identity comes
+///    from pack metadata / filename, integrity is the file's own digest, and
+///    [`preflight_model_pack_for_install`] still gates structural + runtime
+///    contract validity before commit.
+///
+/// This keeps marketplace pulls catalog-bound while allowing local import of
+/// packs that are published on HF but not yet in the signed public catalog
+/// (or private/dev builds).
 pub fn install_catalog_model_pack_from_path(
     catalog: &ModelCatalog,
     source_path: impl AsRef<Path>,
@@ -588,8 +602,14 @@ pub fn install_catalog_model_pack_from_path(
         });
     }
     let (size_bytes, sha256) = file_size_and_sha256(source_path)?;
-    let resolved = resolve_catalog_pull_by_file_digest(catalog, size_bytes, &sha256)?;
-    install_model_pack_from_path(&resolved, source_path, home, progress)
+    match resolve_catalog_pull_by_file_digest(catalog, size_bytes, &sha256)? {
+        Some(resolved) => install_model_pack_from_path(&resolved, source_path, home, progress),
+        None => {
+            let target = pull_target_from_local_oasr_pack(source_path, size_bytes, &sha256)?
+                .with_source("local");
+            install_model_pack_from_path_with_target(&target, source_path, home, progress)
+        }
+    }
 }
 
 fn install_model_pack_from_path_with_target(
@@ -616,11 +636,15 @@ fn install_model_pack_from_path_with_target(
     verify_partial_and_install(target, &paths, None, &|| false, progress)
 }
 
+/// Look up a public catalog quant by content digest.
+///
+/// Returns `Ok(None)` when no public entry matches (caller may fall back to
+/// pack-intrinsic identity). Returns `Err` only on ambiguous multi-match.
 fn resolve_catalog_pull_by_file_digest(
     catalog: &ModelCatalog,
     size_bytes: u64,
     sha256: &str,
-) -> Result<ResolvedCatalogPull, PullError> {
+) -> Result<Option<ResolvedCatalogPull>, PullError> {
     let matches = catalog
         .models
         .iter()
@@ -635,17 +659,158 @@ fn resolve_catalog_pull_by_file_digest(
         .collect::<Vec<_>>();
 
     match matches.as_slice() {
-        [resolved] => Ok(resolved.clone()),
-        [] => Err(PullError::InvalidTarget {
-            field: "sha256",
-            reason: "local OASR pack sha256/size is not present in the signed model catalog"
-                .to_string(),
-        }),
+        [resolved] => Ok(Some(resolved.clone())),
+        [] => Ok(None),
         _ => Err(PullError::InvalidTarget {
             field: "sha256",
             reason: "local OASR pack sha256/size matches multiple catalog entries".to_string(),
         }),
     }
+}
+
+/// Build a store identity for a local `.oasr` that is not (yet) in the signed
+/// public catalog. Prefers GGUF `openasr.model.id` / `openasr.quantization`,
+/// then filename stem tokens; always binds sha256/size to the file on disk.
+fn pull_target_from_local_oasr_pack(
+    source_path: &Path,
+    size_bytes: u64,
+    sha256: &str,
+) -> Result<PullTarget, PullError> {
+    if size_bytes == 0 {
+        return Err(PullError::InvalidTarget {
+            field: "size_bytes",
+            reason: "local OASR pack is empty".to_string(),
+        });
+    }
+    validate_sha256("sha256", sha256).map_err(|reason| PullError::InvalidTarget {
+        field: "sha256",
+        reason,
+    })?;
+
+    let filename = source_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty() && !name.contains('/') && !name.contains('\\'))
+        .ok_or_else(|| PullError::InvalidTarget {
+            field: "path",
+            reason: "local OASR pack path must end with a plain .oasr basename".to_string(),
+        })?
+        .to_string();
+
+    let identity = crate::probe_ggml_package_model_identity(source_path);
+    if let Some(error) = identity.metadata_read_error.as_deref() {
+        return Err(PullError::GgufPreflight {
+            path: source_path.to_path_buf(),
+            reason: error.to_string(),
+        });
+    }
+
+    let metadata_model_id = identity
+        .model_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let stem = source_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    let (mut model_id, mut quant_hint) = match metadata_model_id {
+        Some(raw) => match parse_model_ref(raw) {
+            Ok(parsed) => (parsed.family, parsed.tag),
+            Err(_) => (raw.to_string(), None),
+        },
+        None => match stem {
+            Some(raw) => match parse_model_ref(raw) {
+                Ok(parsed) => (parsed.family, parsed.tag),
+                Err(_) => (raw.to_string(), None),
+            },
+            None => {
+                return Err(PullError::InvalidTarget {
+                    field: "path",
+                    reason: "could not derive model id from pack metadata or filename".to_string(),
+                });
+            }
+        },
+    };
+
+    if let Some(stem) = stem {
+        // Filename `family-q8_0.oasr` when metadata only carries the family.
+        if quant_hint.is_none()
+            && let Some((family, quant_token)) = split_family_and_trailing_quant_token(stem)
+        {
+            if model_id == family || model_id == stem {
+                model_id = family;
+                quant_hint = Some(quant_token);
+            }
+        }
+    }
+
+    let quant_from_metadata = crate::read_gguf_metadata(source_path)
+        .ok()
+        .and_then(|metadata| {
+            metadata
+                .get_string("openasr.quantization")
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        });
+
+    let quant_raw = quant_from_metadata
+        .or(quant_hint)
+        .unwrap_or_else(|| "unknown".to_string());
+    let quant = canonical_quant_tag(&quant_raw).to_string();
+    let suffix = catalog_style_pull_suffix_for_quant(&quant).to_string();
+    let pull = format!("{model_id}:{suffix}");
+    let display_name = model_id.clone();
+
+    // Local-only identity: no network URL / revision. Download paths never use
+    // this target; install only copies + verifies digest + runtime preflight.
+    Ok(PullTarget {
+        model_id,
+        display_name,
+        quant,
+        suffix,
+        pull,
+        filename,
+        url: String::new(),
+        hf_revision: "local".to_string(),
+        sha256: sha256.to_string(),
+        size_bytes,
+        source: None,
+    })
+}
+
+/// Pull-grammar suffix for a canonical quant (matches publish-model QUANT_METADATA).
+fn catalog_style_pull_suffix_for_quant(quant: &str) -> &str {
+    match canonical_quant_tag(quant) {
+        "q8_0" => "q8",
+        "q4_k" => "q4",
+        "q4_k_m" => "q4km",
+        "q3_k" => "q3",
+        other => other,
+    }
+}
+
+/// Split `family-q8_0` / `family-fp16` stems into (family, quant_token).
+fn split_family_and_trailing_quant_token(stem: &str) -> Option<(String, String)> {
+    let (family, token) = stem.rsplit_once('-')?;
+    if family.is_empty() || token.is_empty() {
+        return None;
+    }
+    let canonical = canonical_quant_tag(token);
+    // Accept only recognized quant spellings (alias table + known canons).
+    let recognized = matches!(
+        canonical,
+        "fp16" | "f32" | "q8_0" | "q4_k" | "q4_k_m" | "q3_k"
+    ) || matches!(
+        token,
+        "q8" | "q4" | "q4km" | "q3" | "q4_k_m" | "q8_0" | "q4_k" | "q3_k"
+    );
+    if !recognized {
+        return None;
+    }
+    Some((family.to_string(), token.to_string()))
 }
 
 fn resolved_catalog_pull_from_quant(

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -672,6 +672,8 @@ fn install_catalog_model_pack_from_path_accepts_uncatalogued_pack_via_filename_i
     assert_eq!(canonical_quant_tag(&installed.quant), "q8_0");
     assert_eq!(installed.pull, "moonshine-tiny:q8");
     assert_eq!(installed.source.as_deref(), Some("local"));
+    assert_eq!(installed.url, "");
+    assert_eq!(installed.hf_revision, "local");
     assert_eq!(installed.sha256, sha256_hex(&bytes));
     assert_eq!(installed.size_bytes, bytes.len() as u64);
     assert_eq!(list_installed_packs(temp.path()).unwrap().len(), 1);

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -652,26 +652,29 @@ fn pull_installs_valid_pack_and_writes_record() {
 }
 
 #[test]
-fn install_catalog_model_pack_from_path_requires_signed_catalog_digest_match() {
+fn install_catalog_model_pack_from_path_accepts_uncatalogued_pack_via_filename_identity() {
+    // Pack bytes that do not match any public catalog digest must still install
+    // when the .oasr passes runtime preflight. Identity comes from the pack /
+    // filename (here `moonshine-tiny-q8_0.oasr` -> model moonshine-tiny, quant q8_0).
     let bytes = tiny_pack_bytes();
     let mut resolved = resolved_for(&bytes);
     resolved.sha256 = "b".repeat(64);
+    resolved.size_bytes = bytes.len() as u64 + 1;
     let catalog = catalog_for_resolved(&resolved);
     let temp = tempfile::tempdir().unwrap();
     let source_path = temp.path().join("moonshine-tiny-q8_0.oasr");
-    fs::write(&source_path, bytes).unwrap();
+    fs::write(&source_path, &bytes).unwrap();
 
-    let error = install_catalog_model_pack_from_path(&catalog, &source_path, temp.path(), |_| {})
-        .unwrap_err();
+    let installed =
+        install_catalog_model_pack_from_path(&catalog, &source_path, temp.path(), |_| {}).unwrap();
 
-    assert!(matches!(
-        error,
-        PullError::InvalidTarget {
-            field: "sha256",
-            ..
-        }
-    ));
-    assert!(list_installed_packs(temp.path()).unwrap().is_empty());
+    assert_eq!(installed.model_id, "moonshine-tiny");
+    assert_eq!(canonical_quant_tag(&installed.quant), "q8_0");
+    assert_eq!(installed.pull, "moonshine-tiny:q8");
+    assert_eq!(installed.source.as_deref(), Some("local"));
+    assert_eq!(installed.sha256, sha256_hex(&bytes));
+    assert_eq!(installed.size_bytes, bytes.len() as u64);
+    assert_eq!(list_installed_packs(temp.path()).unwrap().len(), 1);
 }
 
 #[test]

--- a/crates/openasr-ffi/include/openasr.h
+++ b/crates/openasr-ffi/include/openasr.h
@@ -657,11 +657,16 @@ enum OpenAsrStatus openasr_pull_model(const struct OpenAsrCatalog *catalog,
                                       char **out_installed_json);
 
 /**
- * Verifies and installs a `.oasr` pack the app already has on disk (e.g. one
- * side-loaded or copied into the app) without downloading it. The pack's
- * sha256/size must match an entry in the verified `catalog`, or the call fails
- * closed with [`OpenAsrStatus::PullFailed`] -- so a hand-supplied file cannot be
- * installed as a model the catalog never vouched for.
+ * Installs a `.oasr` pack the app already has on disk (side-loaded or copied)
+ * without downloading it.
+ *
+ * Resolution: if the file's sha256+size matches exactly one **public** catalog
+ * quant, that catalog identity is used; otherwise the pack is installed from
+ * pack/filename identity. In both cases the shared runtime preflight
+ * (GGUF structure + native pack contract) must pass, or the call fails closed
+ * with [`OpenAsrStatus::PullFailed`]. Uncatalogued packs are allowed for
+ * operator sideload (e.g. HF-published models not yet in the signed public
+ * catalog); integrity is the file digest + preflight, not catalog vouching.
  *
  * `oasr_path` is the local pack path; `home_dir` is the app's OpenASR home.
  * `progress_cb` (optional) reports the verify/install phases. `out_installed_json`,

--- a/crates/openasr-ffi/src/market.rs
+++ b/crates/openasr-ffi/src/market.rs
@@ -25,7 +25,7 @@
 //!   [`openasr_core::PullModelPackRequest`], which enforces https-only URLs,
 //!   streams a sha256 checked against the catalog-pinned digest, runs the GGUF /
 //!   runtime preflight, and installs atomically. [`openasr_install_local_pack`]
-//!   verifies a user-provided `.oasr`'s sha256/size against the signed catalog
+//!   installs a user-provided `.oasr` (catalog digest match when present; otherwise pack-intrinsic identity + runtime preflight)
 //!   before installing. The app never gets to hand over a URL or a hash -- only a
 //!   catalog reference (`model:quant`), so it cannot redirect the download or
 //!   bypass the digest check.
@@ -344,7 +344,7 @@ pub unsafe extern "C" fn openasr_pull_model(
 
 /// Verifies and installs a `.oasr` pack the app already has on disk (e.g. one
 /// side-loaded or copied into the app) without downloading it. The pack's
-/// sha256/size must match an entry in the verified `catalog`, or the call fails
+/// Prefer a unique public-catalog digest match; otherwise install from pack identity + preflight
 /// closed with [`OpenAsrStatus::PullFailed`] -- so a hand-supplied file cannot be
 /// installed as a model the catalog never vouched for.
 ///

--- a/crates/openasr-ffi/src/market.rs
+++ b/crates/openasr-ffi/src/market.rs
@@ -25,10 +25,11 @@
 //!   [`openasr_core::PullModelPackRequest`], which enforces https-only URLs,
 //!   streams a sha256 checked against the catalog-pinned digest, runs the GGUF /
 //!   runtime preflight, and installs atomically. [`openasr_install_local_pack`]
-//!   installs a user-provided `.oasr` (catalog digest match when present; otherwise pack-intrinsic identity + runtime preflight)
-//!   before installing. The app never gets to hand over a URL or a hash -- only a
-//!   catalog reference (`model:quant`), so it cannot redirect the download or
-//!   bypass the digest check.
+//!   installs a user-provided `.oasr`: prefers a unique public-catalog
+//!   sha256/size match when present, otherwise pack-intrinsic identity, always
+//!   gated by runtime preflight. Network pulls still take only a catalog
+//!   reference (`model:quant`) so the app cannot redirect the download or
+//!   bypass the catalog-pinned digest.
 //!
 //! The app supplies its own sandbox directory as the OpenASR home (the iOS
 //! equivalent of `OPENASR_HOME`); packs install under `<home>/models/...`, and
@@ -342,11 +343,16 @@ pub unsafe extern "C" fn openasr_pull_model(
     })
 }
 
-/// Verifies and installs a `.oasr` pack the app already has on disk (e.g. one
-/// side-loaded or copied into the app) without downloading it. The pack's
-/// Prefer a unique public-catalog digest match; otherwise install from pack identity + preflight
-/// closed with [`OpenAsrStatus::PullFailed`] -- so a hand-supplied file cannot be
-/// installed as a model the catalog never vouched for.
+/// Installs a `.oasr` pack the app already has on disk (side-loaded or copied)
+/// without downloading it.
+///
+/// Resolution: if the file's sha256+size matches exactly one **public** catalog
+/// quant, that catalog identity is used; otherwise the pack is installed from
+/// pack/filename identity. In both cases the shared runtime preflight
+/// (GGUF structure + native pack contract) must pass, or the call fails closed
+/// with [`OpenAsrStatus::PullFailed`]. Uncatalogued packs are allowed for
+/// operator sideload (e.g. HF-published models not yet in the signed public
+/// catalog); integrity is the file digest + preflight, not catalog vouching.
 ///
 /// `oasr_path` is the local pack path; `home_dir` is the app's OpenASR home.
 /// `progress_cb` (optional) reports the verify/install phases. `out_installed_json`,

--- a/docs/SDK_IOS_MACOS.md
+++ b/docs/SDK_IOS_MACOS.md
@@ -239,7 +239,7 @@ OpenAsrStatus openasr_pull_model(const OpenAsrCatalog *catalog,
                                  OpenAsrPullCancelCallback cancel_cb, void *cancel_user_data,
                                  char **out_installed_json);   // free with openasr_string_free
 
-// Verify + install a .oasr the app already has on disk (sha256/size must match catalog).
+// Install a .oasr already on disk (catalog digest match when present; else pack identity + preflight).
 OpenAsrStatus openasr_install_local_pack(const OpenAsrCatalog *catalog, const char *oasr_path,
                                          const char *home_dir,
                                          OpenAsrPullProgressCallback progress_cb, void *progress_user_data,


### PR DESCRIPTION
## Summary
- Local `.oasr` install still uses a unique public-catalog sha256/size match when one exists.
- If the pack is not in the signed public catalog, install from pack/filename identity and keep the existing runtime preflight gate.
- Unblocks sideloading HF-published packs (e.g. MOSS) before catalog public listing.

## Test plan
- [x] `cargo test -p openasr-core --lib install_catalog_model_pack_from_path`
- [x] `cargo test -p openasr-core --lib pull::tests` (95 passed)
- [ ] CI green

## AI disclosure
YES