### PR TITLE
fix(diarize): point missing-embedder copy at redimnet2-b6-cn

### DIFF
--- a/crates/openasr-cli/src/live.rs
+++ b/crates/openasr-cli/src/live.rs
@@ -1441,7 +1441,7 @@ impl LivePipeline {
         let streaming_diarizer = if config.diarize {
             Some(
                 openasr_core::diarize::streaming::StreamingDiarizer::shared(16_000).context(
-                    "Live diarization was requested but the active speaker-embedder pack could not be loaded.",
+                    openasr_core::diarize::embed::DIARIZATION_EMBEDDER_LOAD_FAILED_REASON,
                 )?,
             )
         } else {

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -835,7 +835,7 @@ fn enroll_speaker(input: &Path, name: &str, match_similarity: Option<f32>) -> Re
     }
     if match_similarity.is_some() {
         eprintln!(
-            "note: --match-similarity is ignored for Voice ID v2; matching uses the active embedder calibration."
+            "note: --match-similarity is ignored for Voice ID v2; matching uses the ReDimNet2-B6 embedder calibration."
         );
     }
     let home = openasr_core::openasr_home()
@@ -844,14 +844,17 @@ fn enroll_speaker(input: &Path, name: &str, match_similarity: Option<f32>) -> Re
         .map_err(|reason| anyhow::anyhow!("Could not open Voice ID store: {reason}."))?;
     let embedder = openasr_core::diarize::embed::shared_embedder().ok_or_else(|| {
         anyhow::anyhow!(
-            "Could not create speaker voice match: the active speaker-embedder pack is missing.\nInstall redimnet2-b6-cn first."
+            "Could not create speaker voice match: {}\nInstall {} first.",
+            openasr_core::diarize::embed::SPEAKER_EMBEDDER_PACK_LABEL,
+            openasr_core::diarize::embed::SPEAKER_EMBEDDER_PACK_ID,
         )
     })?;
     let identity = openasr_core::diarize::embed::shared_embedder_identity()
         .cloned()
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "Could not create speaker voice match: the active speaker-embedder pack is missing."
+                "Could not create speaker voice match: {} is missing.",
+                openasr_core::diarize::embed::SPEAKER_EMBEDDER_PACK_LABEL,
             )
         })?;
     let pcm = openasr_core::load_native_wav_16khz_mono_f32_v0(

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -897,7 +897,7 @@ fn diarization_supported(backend: BackendKind, model_pack_path: Option<&Path>) -
                 .diarization
                 .supported
         }
-        // The VAD + active speaker-embedder diarization path is model-agnostic,
+        // The VAD + ReDimNet2-B6 diarization path is model-agnostic,
         // so without a resolved pack path the native answer is exactly "is it installed".
         (BackendKind::Native, None) => openasr_core::diarize::vad_diarization_available(),
         _ => {
@@ -1644,17 +1644,16 @@ mod tests {
     fn diarization_cli_uses_backend_capabilities() {
         let _guard = env_lock();
         let temp = tempfile::tempdir().unwrap();
-        // Isolate the model-agnostic VAD + speaker-embedder probe from the host
+        // Isolate the model-agnostic VAD + ReDimNet2-B6 probe from the host
         // machine's installed packs so the fail-closed expectations are hermetic.
-        let _campplus_pack = EnvVarRestore::remove("OPENASR_CAMPPLUS_PACK");
         let _redimnet_pack = EnvVarRestore::remove("OPENASR_REDIMNET_PACK");
-        let _speaker_embedder = EnvVarRestore::remove("OPENASR_SPEAKER_EMBEDDER");
         let _home = EnvVarRestore::set_os("OPENASR_HOME", temp.path());
 
         let error = ensure_diarization_supported(BackendKind::Mock, None, true)
             .expect_err("mock diarization should fail closed")
             .to_string();
         assert!(error.contains("speaker-embedder pack"));
+        assert!(error.contains("redimnet2-b6-cn"));
         assert!(error.contains(backend_name(BackendKind::Mock)));
 
         let base_runtime_path = temp.path().join("cohere-base.oasr");
@@ -1668,6 +1667,7 @@ mod tests {
                 .expect_err("base native pack must keep diarization fail-closed")
                 .to_string();
         assert!(error.contains("speaker-embedder pack"));
+        assert!(error.contains("redimnet2-b6-cn"));
         assert!(error.contains(backend_name(BackendKind::Native)));
 
         // Installing the ReDimNet2-B6 embedder pack enables the model-agnostic

--- a/crates/openasr-core/src/api/backend/mock.rs
+++ b/crates/openasr-core/src/api/backend/mock.rs
@@ -83,6 +83,7 @@ mod tests {
         let error = backend.transcribe(request).unwrap_err().to_string();
 
         assert!(error.contains("speaker-embedder pack"));
+        assert!(error.contains("redimnet2-b6-cn"));
         assert!(error.contains("mock backend"));
         assert!(error.contains("omit --diarize / diarize=true"));
     }

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -667,12 +667,12 @@ fn native_phrase_bias_capability_for_adapter(
 }
 
 /// Reason reported when neither a self-diarizing pack nor the model-agnostic
-/// VAD + active speaker-embedder path is installed.
+/// VAD + ReDimNet2-B6 (`redimnet2-b6-cn`) path is installed.
 pub(crate) const NATIVE_DIARIZATION_UNAVAILABLE_REASON: &str = "Diarization needs the ReDimNet2-B6 speaker-embedder pack (redimnet2-b6-cn) or a self-diarizing model pack; install one or omit diarize=true.";
 
 /// Diarization capability for a runtime pack: supported when the model
 /// self-diarizes (e.g. the cohere token-stream) or the model-agnostic
-/// VAD + active speaker-embedder path is installed for this process.
+/// VAD + ReDimNet2-B6 path is installed for this process.
 fn native_diarization_capability_for_adapter(
     adapter: Option<&NativeRuntimeModelAdapter>,
 ) -> BackendFeatureCapability {
@@ -2402,6 +2402,7 @@ mod tests {
             let error = backend.transcribe(request).unwrap_err().to_string();
 
             assert!(error.contains("speaker-embedder pack"));
+            assert!(error.contains("redimnet2-b6-cn"));
             assert!(error.contains("native backend"));
         });
     }
@@ -2626,7 +2627,8 @@ mod tests {
             capabilities
                 .diarization
                 .reason
-                .is_some_and(|reason| reason.contains("speaker-embedder pack"))
+                .is_some_and(|reason| reason.contains("speaker-embedder pack")
+                    && reason.contains("redimnet2-b6-cn"))
         );
     }
 

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1097,7 +1097,7 @@ fn run_native_transcription_impl(
         request.phrase_bias.as_ref(),
     )?;
     // Diarization is supported when the model self-diarizes (e.g. cohere) or the
-    // model-agnostic neural VAD + active speaker-embedder pack is available.
+    // model-agnostic neural VAD + ReDimNet2-B6 pack is available.
     let model_self_diarizes = super::native_runtime_metadata_supports_diarization(
         &runtime_preflight.metadata,
         selected_family.self_diarizes,

--- a/crates/openasr-core/src/diarize/embed/mod.rs
+++ b/crates/openasr-core/src/diarize/embed/mod.rs
@@ -14,7 +14,10 @@ pub(crate) mod weights;
 mod tests;
 
 pub use pack::{
-    SpeakerEmbedderIdentity, embedder_pack_installed, shared_embedder, shared_embedder_identity,
+    DIARIZATION_EMBEDDER_LOAD_FAILED_REASON, REALTIME_DIARIZATION_EMBEDDER_MISSING_REASON,
+    SPEAKER_EMBEDDER_PACK_ID, SPEAKER_EMBEDDER_PACK_LABEL, SpeakerEmbedderIdentity,
+    VOICE_ID_EMBEDDER_PACK_MISSING_REASON, VOICE_MATCH_EMBEDDER_PACK_MISSING_REASON,
+    embedder_pack_installed, shared_embedder, shared_embedder_identity,
 };
 
 use thiserror::Error;

--- a/crates/openasr-core/src/diarize/embed/pack.rs
+++ b/crates/openasr-core/src/diarize/embed/pack.rs
@@ -16,6 +16,26 @@ static SHARED_EMBEDDER: OnceLock<SharedEmbedderState> = OnceLock::new();
 const REDIMNET_PACK_ENV: &str = "OPENASR_REDIMNET_PACK";
 const REDIMNET_INSTALLED_DIR_HINT: &str = "redimnet";
 
+/// Catalog / pull id of the only supported speaker-embedder pack.
+pub const SPEAKER_EMBEDDER_PACK_ID: &str = "redimnet2-b6-cn";
+
+/// User-facing label for the only supported speaker-embedder pack.
+pub const SPEAKER_EMBEDDER_PACK_LABEL: &str =
+    "ReDimNet2-B6 speaker-embedder pack (redimnet2-b6-cn)";
+
+/// Fail-closed reason when Voice ID enrollment cannot resolve the pack.
+pub const VOICE_ID_EMBEDDER_PACK_MISSING_REASON: &str = "creating a voice id requires the ReDimNet2-B6 speaker-embedder pack (redimnet2-b6-cn); install the pack first";
+
+/// Fail-closed reason when legacy voice-match enrollment cannot resolve the pack.
+pub const VOICE_MATCH_EMBEDDER_PACK_MISSING_REASON: &str = "creating a voice match profile requires the ReDimNet2-B6 speaker-embedder pack (redimnet2-b6-cn); install the pack first";
+
+/// Fail-closed reason when diarize was accepted by capability probe but the pack
+/// then failed to load (path present, weights unusable).
+pub const DIARIZATION_EMBEDDER_LOAD_FAILED_REASON: &str = "Diarization was requested but the ReDimNet2-B6 speaker-embedder pack (redimnet2-b6-cn) could not be loaded.";
+
+/// Fail-closed reason when realtime diarize is requested without the pack.
+pub const REALTIME_DIARIZATION_EMBEDDER_MISSING_REASON: &str = "Realtime diarization needs the ReDimNet2-B6 speaker-embedder pack (redimnet2-b6-cn); install it or omit diarize=true.";
+
 /// Human-readable label for ReDimNet2-B6's embedding space (documentation /
 /// audit metadata only). The actual runtime compatibility gate is the pack's
 /// content fingerprint (`SpeakerEmbedderIdentity::pack_fingerprint`, a sha256
@@ -114,5 +134,34 @@ mod tests {
     fn redimnet_pack_env_name_is_stable() {
         assert_eq!(REDIMNET_PACK_ENV, "OPENASR_REDIMNET_PACK");
         assert_eq!(REDIMNET_INSTALLED_DIR_HINT, "redimnet");
+    }
+
+    #[test]
+    fn missing_embedder_reasons_name_redimnet2_b6_cn() {
+        assert_eq!(SPEAKER_EMBEDDER_PACK_ID, "redimnet2-b6-cn");
+        for reason in [
+            VOICE_ID_EMBEDDER_PACK_MISSING_REASON,
+            VOICE_MATCH_EMBEDDER_PACK_MISSING_REASON,
+            DIARIZATION_EMBEDDER_LOAD_FAILED_REASON,
+            REALTIME_DIARIZATION_EMBEDDER_MISSING_REASON,
+            SPEAKER_EMBEDDER_PACK_LABEL,
+        ] {
+            assert!(
+                reason.contains(SPEAKER_EMBEDDER_PACK_ID),
+                "reason must name the install id: {reason}"
+            );
+            assert!(
+                reason.contains("ReDimNet2-B6"),
+                "reason must name the pack family: {reason}"
+            );
+            assert!(
+                !reason.to_ascii_lowercase().contains("wespeaker"),
+                "reason must not mention WeSpeaker: {reason}"
+            );
+            assert!(
+                !reason.contains("active speaker-embedder"),
+                "reason must not use the retired dual-path wording: {reason}"
+            );
+        }
     }
 }

--- a/crates/openasr-core/src/diarize/enrollment.rs
+++ b/crates/openasr-core/src/diarize/enrollment.rs
@@ -128,9 +128,7 @@ pub enum SpeakerEnrollmentError {
         "enrollment audio is too short: need at least {required:.1} seconds of speech, got {actual:.2}"
     )]
     TooShortSpeech { required: f32, actual: f32 },
-    #[error(
-        "creating a voice match profile requires the ReDimNet2-B6 speaker-embedder pack (redimnet2-b6-cn); install the pack first"
-    )]
+    #[error("{}", crate::diarize::embed::VOICE_MATCH_EMBEDDER_PACK_MISSING_REASON)]
     EmbedderPackMissing,
     #[error("could not embed enrollment audio: {0}")]
     Embed(EmbedError),

--- a/crates/openasr-core/src/diarize/mod.rs
+++ b/crates/openasr-core/src/diarize/mod.rs
@@ -9,11 +9,10 @@
 //! diarization pipeline (interval contract, speaker segmentation/embedding,
 //! clustering, and attribution) under this module.
 
-/// Whether the model-agnostic VAD + speaker-embedder diarization path can run:
-/// the active speaker-embedder pack is installed (the Stream-VAD VAD is
-/// vendored and always available). This is a presence-only probe for
-/// capability reporting; a pack that fails to load still fails closed at
-/// request time.
+/// Whether the model-agnostic VAD + ReDimNet2-B6 diarization path can run:
+/// the `redimnet2-b6-cn` pack is installed (the Stream-VAD VAD is vendored and
+/// always available). This is a presence-only probe for capability reporting;
+/// a pack that fails to load still fails closed at request time.
 pub fn vad_diarization_available() -> bool {
     embed::embedder_pack_installed()
 }

--- a/crates/openasr-core/src/diarize/voice_id/service.rs
+++ b/crates/openasr-core/src/diarize/voice_id/service.rs
@@ -27,9 +27,7 @@ pub enum VoiceIdServiceError {
     Quality(#[from] QualityError),
     #[error("speaker enrollment requires a 16 kHz mono PCM16 WAV: {0}")]
     InvalidAudio(String),
-    #[error(
-        "creating a voice id requires the active speaker-embedder pack; install the pack first"
-    )]
+    #[error("{}", crate::diarize::embed::VOICE_ID_EMBEDDER_PACK_MISSING_REASON)]
     EmbedderPackMissing,
     #[error("could not embed enrollment audio: {0}")]
     Embed(#[from] EmbedError),

--- a/crates/openasr-core/src/realtime/backend.rs
+++ b/crates/openasr-core/src/realtime/backend.rs
@@ -261,11 +261,11 @@ impl RealtimeBackendCapabilities {
 
 /// Realtime diarization capability for a session mode, derived fresh on every
 /// call: the streaming diarizer labels utterances inside the session loop, so
-/// it is model-agnostic and needs only the installed active speaker-embedder
-/// pack. The file-per-utterance path diarizes the buffered utterance audio;
-/// true-streaming sessions retain a bounded speech-gated copy of each
-/// utterance for the same purpose. Presence-only probe; pack load failures
-/// still fail closed at session configure time.
+/// it is model-agnostic and needs only the installed ReDimNet2-B6
+/// (`redimnet2-b6-cn`) pack. The file-per-utterance path diarizes the buffered
+/// utterance audio; true-streaming sessions retain a bounded speech-gated copy
+/// of each utterance for the same purpose. Presence-only probe; pack load
+/// failures still fail closed at session configure time.
 pub fn realtime_diarization_capability(mode: RealtimeBackendMode) -> BackendFeatureCapability {
     match mode {
         RealtimeBackendMode::Unsupported => realtime_diarization_unprobed(),
@@ -274,7 +274,7 @@ pub fn realtime_diarization_capability(mode: RealtimeBackendMode) -> BackendFeat
                 BackendFeatureCapability::supported()
             } else {
                 BackendFeatureCapability::reject_request(
-                    "Realtime diarization needs the ReDimNet2-B6 speaker-embedder pack (redimnet2-b6-cn); install it or omit diarize=true.",
+                    crate::diarize::embed::REALTIME_DIARIZATION_EMBEDDER_MISSING_REASON,
                 )
             }
         }
@@ -285,7 +285,7 @@ pub fn realtime_diarization_capability(mode: RealtimeBackendMode) -> BackendFeat
 /// constructors overwrite it via [`realtime_diarization_capability`].
 const fn realtime_diarization_unprobed() -> BackendFeatureCapability {
     BackendFeatureCapability::reject_request(
-        "Realtime diarization needs the ReDimNet2-B6 speaker-embedder pack (redimnet2-b6-cn); install it or omit diarize=true.",
+        crate::diarize::embed::REALTIME_DIARIZATION_EMBEDDER_MISSING_REASON,
     )
 }
 
@@ -345,14 +345,16 @@ mod tests {
         assert!(
             fallback
                 .reason
-                .is_some_and(|reason| reason.contains("speaker-embedder pack"))
+                .is_some_and(|reason| reason.contains("speaker-embedder pack")
+                    && reason.contains("redimnet2-b6-cn"))
         );
         let streaming = realtime_diarization_capability(RealtimeBackendMode::TrueStreaming);
         assert!(!streaming.supported);
         assert!(
             streaming
                 .reason
-                .is_some_and(|reason| reason.contains("speaker-embedder pack"))
+                .is_some_and(|reason| reason.contains("speaker-embedder pack")
+                    && reason.contains("redimnet2-b6-cn"))
         );
 
         let install_dir = temp.path().join("models/redimnet2-b6-cn/fp16");

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -3595,6 +3595,7 @@ async fn session_start_rejects_diarize_without_embedder_pack() {
         RealtimeEvent::Error(RealtimeErrorEvent { code, message, .. }) => {
             assert_eq!(*code, RealtimeErrorCode::StartupConfigError);
             assert!(message.contains("speaker-embedder pack"));
+            assert!(message.contains("redimnet2-b6-cn"));
         }
         other => panic!("expected startup config error, got {other:?}"),
     }
@@ -4584,6 +4585,7 @@ async fn session_start_rejects_diarize_when_embedder_pack_fails_to_load() {
         RealtimeEvent::Error(RealtimeErrorEvent { code, message, .. }) => {
             assert_eq!(*code, RealtimeErrorCode::StartupConfigError);
             assert!(message.contains("could not be loaded"));
+            assert!(message.contains("redimnet2-b6-cn"));
         }
         other => panic!("expected startup config error, got {other:?}"),
     }

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -1028,7 +1028,7 @@ impl WsSession {
             let Some(diarizer) = self.build_streaming_diarizer(16_000) else {
                 self.emit_error(
                     RealtimeErrorCode::StartupConfigError,
-                    "Realtime diarization was requested but the active speaker-embedder pack could not be loaded.",
+                    openasr_core::diarize::embed::DIARIZATION_EMBEDDER_LOAD_FAILED_REASON,
                     false,
                 )
                 .await?;

--- a/crates/openasr-server/src/routes/speakers.rs
+++ b/crates/openasr-server/src/routes/speakers.rs
@@ -226,16 +226,14 @@ fn active_embedder_and_identity() -> Result<
 > {
     let embedder = openasr_core::diarize::embed::shared_embedder().ok_or_else(|| {
         ApiError::BadRequest(
-            "creating a voice id requires the active speaker-embedder pack; install the pack first"
-                .into(),
+            openasr_core::diarize::embed::VOICE_ID_EMBEDDER_PACK_MISSING_REASON.into(),
         )
     })?;
     let identity = openasr_core::diarize::embed::shared_embedder_identity()
         .cloned()
         .ok_or_else(|| {
             ApiError::BadRequest(
-                "creating a voice id requires the active speaker-embedder pack; install the pack first"
-                    .into(),
+                openasr_core::diarize::embed::VOICE_ID_EMBEDDER_PACK_MISSING_REASON.into(),
             )
         })?;
     Ok((embedder, identity))

--- a/crates/openasr-server/src/routes/voice_id.rs
+++ b/crates/openasr-server/src/routes/voice_id.rs
@@ -437,16 +437,14 @@ fn active_embedder_and_identity() -> Result<
 > {
     let embedder = openasr_core::diarize::embed::shared_embedder().ok_or_else(|| {
         ApiError::BadRequest(
-            "creating a voice id requires the active speaker-embedder pack; install the pack first"
-                .into(),
+            openasr_core::diarize::embed::VOICE_ID_EMBEDDER_PACK_MISSING_REASON.into(),
         )
     })?;
     let identity = openasr_core::diarize::embed::shared_embedder_identity()
         .cloned()
         .ok_or_else(|| {
             ApiError::BadRequest(
-                "creating a voice id requires the active speaker-embedder pack; install the pack first"
-                    .into(),
+                openasr_core::diarize::embed::VOICE_ID_EMBEDDER_PACK_MISSING_REASON.into(),
             )
         })?;
     Ok((embedder, identity))

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -2236,6 +2236,12 @@ async fn speaker_enrollment_routes_reject_short_silent_and_missing_pack() {
                 .unwrap()
                 .contains("speaker-embedder pack")
         );
+        assert!(
+            json["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("redimnet2-b6-cn")
+        );
     })
     .await;
 }
@@ -4511,6 +4517,7 @@ async fn transcriptions_with_native_backend_and_diarize_returns_bad_request() {
     let bytes = to_bytes(response.into_body(), 1024 * 256).await.unwrap();
     let body = String::from_utf8_lossy(&bytes);
     assert!(body.contains("speaker-embedder pack"));
+    assert!(body.contains("redimnet2-b6-cn"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

After #228 removed the WeSpeaker runtime, residual user-facing and capability-probe messages still said "active speaker-embedder pack". This PR centralizes ReDimNet2-B6 / `redimnet2-b6-cn` fail-closed reasons and routes CLI, server, Voice ID, and realtime paths through them.

## Why

Missing-embedder errors and capability probes should name the only supported pack (`redimnet2-b6-cn`) instead of dual-path wording left over from the WeSpeaker era.

## Changes

- Add shared constants in `diarize/embed/pack.rs` for pack id, label, and missing/load-failed reasons
- Wire Voice ID, voice-match enrollment, CLI, server routes, and realtime session start through those constants
- Drop leftover `OPENASR_CAMPPLUS_PACK` / dual-path wording in comments and tests
- Strengthen tests to assert messages contain `redimnet2-b6-cn`

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core -p openasr-cli -p openasr-server --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`
- [x] Focused: openasr-core diarization/embedder tests, openasr-cli `diarization_cli_uses_backend_capabilities`, openasr-server realtime diarize reject tests + speaker/api diarize tests

## Manual smoke checks

- N/A (string/capability-probe cleanup; no runtime path change beyond error text)

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.
- Historical design/audit docs and signature-bound `catalog_incident` fixtures intentionally left unchanged.

## Scope / non-goals

- Does not reintroduce or delete historical WeSpeaker fixtures
- Does not change catalog packaging or release artifacts
- Desktop/app-repo WeSpeaker docs and tray fixtures are out of scope (separate PR if needed)

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - assisted drafting of the shared-constant cleanup and test updates; PR text written and reviewed by the submitter.