### PR TITLE
docs(brand): trademark, branding, and xcframework distribution policy

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -1,0 +1,85 @@
+# OpenASR Branding Guidelines
+
+How to refer to OpenASR in products, documentation, and store listings without
+creating the impression of an official or endorsed app. Trademark rules are
+normative in [TRADEMARKS.md](TRADEMARKS.md); this file is the practical checklist.
+
+## Primary product identity
+
+Third-party products that use OpenASR open-core, the CLI, the local API, or the
+iOS/macOS xcframework **must** ship under an independent product identity:
+
+| Element | Third-party requirement |
+| --- | --- |
+| Product / app name | Not "OpenASR" and not confusingly similar |
+| Logo and app icon | Your own artwork; do not copy official icons |
+| UI chrome | Your own design system and screens |
+| Store listing | Your developer account, screenshots, and description |
+| Support | Your own support email, site, or channel |
+| Signing | Your certificates, bundle IDs, and package names |
+
+Official OpenASR Desktop and mobile apps are published only by the project
+operators. See [TRADEMARKS.md](TRADEMARKS.md#official-applications).
+
+## Attribution that is welcome
+
+Preferred secondary attribution (footer, About screen, documentation):
+
+```text
+Powered by OpenASR
+https://openasr.org
+```
+
+Also fine:
+
+- "Speech recognition uses OpenASR open-core (Apache-2.0)."
+- "Compatible with OpenASR `.oasr` model packs."
+- "Local API compatible with the OpenASR HTTP subset."
+
+Keep attribution **secondary**: smaller than the product name, not the store
+title, not the home-screen label.
+
+## Phrasing to avoid
+
+Do not use copy that suggests official status, for example:
+
+- "Official OpenASR client" / "Official OpenASR for iOS"
+- "OpenASR Certified" / "Authorized OpenASR partner" (unless you have a written
+  agreement)
+- "The OpenASR app" when referring to a third-party build
+- App names like "OpenASR Pro", "OpenASR+", "OpenASR Mobile", "OpenASR Cloud"
+- Reusing official marketing screenshots or store preview GIFs as if they were
+  your product
+
+## Visual marks
+
+- Prefer text attribution ("Powered by OpenASR") over pasting the logo.
+- If you need a logo for a dependency wall or conference slide, use only assets
+  the project explicitly publishes for that purpose on
+  [https://openasr.org](https://openasr.org), and do not alter them in a way that
+  suggests a different product.
+- Do not place the OpenASR logo more prominently than your own product mark on
+  an app icon, splash screen, or store icon.
+
+## Relationship to the open-core license
+
+Branding rules do **not** shrink Apache-2.0 rights in the code. You may still
+fork, modify, embed, and redistribute the software under [LICENSE](LICENSE).
+You may not use the OpenASR brand as if the fork or embed were the official
+product. When you redistribute, keep license notices (`LICENSE`, `NOTICE`) as
+Apache-2.0 requires.
+
+## Desktop and web wrappers
+
+Electron, Tauri, SwiftUI, or other shells around the open-core binary or
+xcframework are welcome. Each wrapper is a **separate product** for branding
+purposes: independent name, UI, and support. Shipping a thin re-skin of the
+official OpenASR Desktop UI under another name is fine; shipping it under the
+OpenASR name or icon is not.
+
+## Questions
+
+For partnership, co-marketing, or permission to use logos beyond "Powered by
+OpenASR", contact the maintainers via [https://openasr.org](https://openasr.org)
+or the publishing GitHub organization. Until you have written permission, stay
+within the allowed uses in [TRADEMARKS.md](TRADEMARKS.md).

--- a/README.md
+++ b/README.md
@@ -129,3 +129,11 @@ Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for build setup, b
 [Apache License 2.0](LICENSE). See [NOTICE](NOTICE) for attribution.
 
 The ggml inference backend is MIT-licensed. Each model pack's license is defined by its registry entry and pack metadata; packs may use Apache-2.0, MIT, CC-BY, FunASR, or other upstream terms. This is not an exhaustive license guarantee. See [ACKNOWLEDGMENTS.md](ACKNOWLEDGMENTS.md) for the projects and model authors OpenASR builds on.
+
+## Trademarks and branding
+
+The OpenASR name, logo, and official app icons are reserved. Apache-2.0 covers the code, not the brand. Third-party products may say **“Powered by OpenASR”** and must not use OpenASR as their primary product name or imply official endorsement. Official apps are published only by the project operators.
+
+- [TRADEMARKS.md](TRADEMARKS.md) — name, logo, and official-app reservation
+- [BRANDING.md](BRANDING.md) — practical product-identity checklist
+- [XCFRAMEWORK-DISTRIBUTION.md](XCFRAMEWORK-DISTRIBUTION.md) — shipping iOS/macOS apps that embed the SDK

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -130,6 +130,14 @@ openasr pull whisper-small    # 安装一个试试
 
 ggml 推理后端为 MIT 许可。每个模型包的许可证以 registry 条目和 pack metadata 为准;可能包含 Apache-2.0、MIT、CC-BY、FunASR 或其他上游条款。这不是穷尽保证。致谢完整列表见 [ACKNOWLEDGMENTS.md](ACKNOWLEDGMENTS.md)。
 
+## 商标与品牌
+
+OpenASR 名称、Logo 与官方 App 图标由项目方保留。Apache-2.0 覆盖代码，不授予商标权。第三方产品可以使用 **“Powered by OpenASR”** 作为次要署名，但不得以 OpenASR 作为主产品名，也不得暗示官方授权、认证或合作。官方应用仅由项目运营方的开发者账号发布。
+
+- [TRADEMARKS.md](TRADEMARKS.md) — 名称、标识与官方应用保留
+- [BRANDING.md](BRANDING.md) — 产品标识实务清单
+- [XCFRAMEWORK-DISTRIBUTION.md](XCFRAMEWORK-DISTRIBUTION.md) — 嵌入 SDK 的 iOS/macOS 应用分发说明
+
 ## 找到我们
 
 OpenASR 还在早期，「早鸟营」微信群是离我们最近的地方——聊用法、反馈问题、第一时间拿到新版本。

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,102 @@
+# OpenASR Trademarks
+
+This policy covers the **OpenASR** name, word marks, logos, official app icons,
+and other brand assets of the OpenASR project. It is separate from the
+Apache-2.0 license that covers the open-core source code.
+
+Apache-2.0 **does not** grant trademark rights. Section 6 of the
+[LICENSE](LICENSE) already states that the license does not grant permission to
+use the trade names, trademarks, service marks, or product names of the
+licensor, except as required for reasonable and customary use in describing the
+origin of the work. This document states how the project applies that rule in
+practice.
+
+## What is reserved
+
+The project operators retain all rights in:
+
+- the name **OpenASR** and confusingly similar variants (including spacing,
+  capitalization, and transliterations used as a product name);
+- the official OpenASR logos and wordmarks;
+- the official OpenASR Desktop / mobile **app icons** and store listing artwork
+  published by the project;
+- domain names and URLs operated by the project (including `openasr.org` and
+  `dl.openasr.org`), when used to imply official status.
+
+## Software license vs trademarks
+
+| Asset | Covered by Apache-2.0? | Trademark / brand rules |
+| --- | --- | --- |
+| Source code, docs text, build scripts | Yes | You may use, modify, and redistribute under Apache-2.0 |
+| Compiled binaries / libraries you build from source | Yes (as Object form) | You may ship them, but **not** under the OpenASR product name as your primary app identity (see below) |
+| Name "OpenASR", logos, official icons | **No** | This policy |
+
+Using the open-core code does **not** make a third-party product an official
+OpenASR product.
+
+## Allowed uses (no extra permission required)
+
+You may:
+
+1. **Factual reference.** State that your product uses, embeds, or is compatible
+   with OpenASR open-core software (for example in documentation, academic
+   papers, or a dependency list).
+2. **"Powered by OpenASR".** Use that exact phrase (or a clear equivalent such as
+   "Uses OpenASR open-core") in a secondary attribution line, provided it does
+   not look like the primary product name or store title.
+3. **Describe origin.** As Apache-2.0 allows, note that portions of the work are
+   derived from the OpenASR project and point to the upstream repository.
+4. **Compatibility claims that are true.** For example "imports OpenASR `.oasr`
+   packs" or "speaks the OpenASR local HTTP API", when accurate.
+
+## Not allowed without written permission
+
+You may **not**:
+
+1. Use **OpenASR** (or a confusingly similar name) as the **primary product
+   name**, app name, store listing title, or home-screen label of a third-party
+   product.
+2. Use the official OpenASR **logo** or **app icon** as your product's logo,
+   icon, or store artwork.
+3. Imply **official status**: endorsement, certification, partnership,
+   "authorized", "official client", "official build", or joint offering with the
+   OpenASR project or its operators, unless you have a written agreement that
+   says so.
+4. Present modified or re-skinned builds as **the** OpenASR Desktop / mobile app
+   or as updates to the official app.
+5. Register company names, trademarks, app IDs, or domains that are likely to
+   confuse users into thinking they are dealing with the official project
+   (for example `openasr-pro.example`, `get-openasr`, or look-alike icons).
+
+## Official applications
+
+Official OpenASR end-user applications (desktop and mobile store builds) are
+published **only** by the project operators through their own developer
+accounts (including the official Apple Developer and other store accounts they
+control). Store listings, signing identities, and bundle identifiers for those
+official apps are not licensed for third-party reuse as a way to appear
+official.
+
+Third parties who ship apps that embed OpenASR open-core or the xcframework
+must use **their own** product name, UI, branding, signing identity, store
+listing, and user-support channels. See [BRANDING.md](BRANDING.md) and
+[XCFRAMEWORK-DISTRIBUTION.md](XCFRAMEWORK-DISTRIBUTION.md).
+
+## Fair use and nominative use
+
+Nothing in this policy is intended to limit non-confusing nominative fair use
+under applicable law (for example, "we converted weights for use with OpenASR"
+in a technical write-up). When in doubt, prefer a factual sentence plus a link
+to [https://openasr.org](https://openasr.org) over logo use.
+
+## Reporting confusion
+
+If you believe a product is misusing the OpenASR name or marks in a way that
+confuses users about official status, contact the maintainers through the
+channels listed on [https://openasr.org](https://openasr.org) or the GitHub
+organization that publishes this repository.
+
+## Changes
+
+This policy may be updated as the project and its official products evolve.
+The copy in the default branch of this repository is the current version.

--- a/XCFRAMEWORK-DISTRIBUTION.md
+++ b/XCFRAMEWORK-DISTRIBUTION.md
@@ -1,0 +1,109 @@
+# Distributing apps that embed OpenASR.xcframework
+
+This note is for developers who link `OpenASR.xcframework` (from
+`crates/openasr-ffi`) into iOS, iPadOS, or macOS applications. Build and API
+details live in [docs/SDK_IOS_MACOS.md](docs/SDK_IOS_MACOS.md). Brand and
+trademark rules live in [TRADEMARKS.md](TRADEMARKS.md) and
+[BRANDING.md](BRANDING.md).
+
+## What you may ship
+
+Under Apache-2.0 you may:
+
+- build the xcframework from this repository (or use a binary build you
+  obtained lawfully);
+- statically or dynamically link it into your app;
+- redistribute the linked binary as part of your app, with the required
+  license notices (`LICENSE`, `NOTICE`, and third-party notices as applicable);
+- call the C ABI for local transcription, streaming, and consent-based model
+  install as documented in the SDK guide.
+
+The xcframework artifact does **not** carry a separate proprietary SDK license.
+Trademark rules still apply to the **name and branding** of the shipping app.
+
+## What you must not do
+
+1. **Primary app name.** Do not name the App Store / TestFlight / Mac App Store
+   product "OpenASR" or a confusingly similar title.
+2. **Official icons.** Do not use the official OpenASR app icon or logo as your
+   app icon or store artwork.
+3. **Imply Apple or OpenASR endorsement.** Do not claim that Apple, the OpenASR
+   project, or the project operators certified, authorized, or co-publish your
+   app unless that is true under a written agreement.
+4. **Pass off as the official app.** Do not reuse official bundle identifiers,
+   App Store product pages, screenshots, or update funnels in a way that makes
+   users think they are installing or updating the official OpenASR app.
+5. **Support deflection.** Do not point end users at official OpenASR support
+   channels for issues in your app's UI, accounts, billing, or packaging. You
+   own support for your product.
+
+## Required independent product surface
+
+Any App Store (or sideloaded) app that embeds the xcframework must provide:
+
+| Surface | Requirement |
+| --- | --- |
+| App display name | Independent of "OpenASR" |
+| Bundle ID | Under **your** team / reverse-DNS |
+| Signing & notarization | **Your** Apple Developer team |
+| UI | Your screens and interaction design |
+| Privacy nutrition / policies | Your privacy policy and data practices |
+| User support | Your support URL or email in the store listing |
+
+Attribution such as **“Powered by OpenASR”** on an About screen is encouraged.
+It must remain secondary to your product name.
+
+## Official apps vs ecosystem apps
+
+| | Official OpenASR apps | Third-party apps embedding the xcframework |
+| --- | --- | --- |
+| Publisher | Project operators only | Any third party under this policy |
+| Apple Developer account | Project-controlled accounts only | Your account |
+| Product name | OpenASR (and official localized names) | Your brand |
+| Engine | Same open-core / FFI | Same open-core / FFI allowed |
+| Model packs | Signed catalog + user consent | Same trust rules in-engine; your UX for consent |
+
+This split exists so users can tell who ships and supports the app they
+installed, and so the project can show a clear chain of custody for official
+store listings when needed (including evidence for platform review).
+
+## Store review and “who publishes OpenASR?”
+
+If a platform reviewer asks whether your binary is the official OpenASR app:
+
+- **Official app:** published by the project operators’ developer accounts,
+  under the OpenASR name and icon, listed from [https://openasr.org](https://openasr.org).
+- **Your app:** a separate product that embeds Apache-2.0 OpenASR engine code;
+  you are the sole publisher and support contact; engine attribution is
+  “Powered by OpenASR” (or equivalent), not a claim of official status.
+
+Keep a short statement to that effect in your review notes if you embed the
+framework. This repository’s trademark and branding docs are the public
+reference you can link.
+
+## Technical obligations (unchanged)
+
+Embedding the framework does not relax engine invariants:
+
+- **No silent downloads.** Catalog fetch and model pull remain explicit,
+  consent-driven calls; transcription must not trigger network install.
+- **Fail closed.** Invalid packs, failed verification, and missing models must
+  surface errors, not fabricated transcripts.
+- **Trust boundary in-core.** Signature and path validation stay in
+  `openasr-core`; do not bypass them from app code.
+
+See [AGENTS.md](AGENTS.md) and [docs/SDK_IOS_MACOS.md](docs/SDK_IOS_MACOS.md).
+
+## License notices in shipping apps
+
+Ship Apache-2.0 attribution for OpenASR and the third-party components listed in
+[NOTICE](NOTICE) (for example in Settings → Acknowledgments or a `Licenses`
+screen). That is a license condition; it is not permission to brand the app as
+OpenASR.
+
+## Related docs
+
+- [TRADEMARKS.md](TRADEMARKS.md) — name, logo, official-app reservation
+- [BRANDING.md](BRANDING.md) — practical do / don’t for product identity
+- [docs/SDK_IOS_MACOS.md](docs/SDK_IOS_MACOS.md) — build, C API, CPU-only v1 posture
+- [LICENSE](LICENSE) / [NOTICE](NOTICE) — Apache-2.0 and third-party notices

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -54,6 +54,14 @@ no persistent voiceprint, identity-stays-on-client) live in
 | [Android Build](ANDROID_BUILD.md) | Android (aarch64) cross-compilation. |
 | [iOS / macOS SDK](SDK_IOS_MACOS.md) | `crates/openasr-ffi`'s C ABI and `OpenASR.xcframework`: build, C API, Swift bridging sketch, CPU-only v1 posture. |
 
+## Brand & distribution (repo root)
+
+| Doc | What it covers |
+| --- | --- |
+| [Trademarks](../TRADEMARKS.md) | OpenASR name, logo, and official app icon reservation; allowed "Powered by OpenASR"; no implied endorsement. |
+| [Branding](../BRANDING.md) | Practical checklist: independent product name, UI, store listing, and support for third-party apps. |
+| [xcframework distribution](../XCFRAMEWORK-DISTRIBUTION.md) | Shipping App Store / Mac apps that embed `OpenASR.xcframework` without passing as the official app. |
+
 ## Notes
 
 - The user-facing quantization path is import-time tier selection (`fp16` /

--- a/docs/SDK_IOS_MACOS.md
+++ b/docs/SDK_IOS_MACOS.md
@@ -56,8 +56,13 @@ until a real-device benchmark says otherwise; wiring up an iOS Metal build is
 unstarted, follow-up work.
 
 **License**: Apache-2.0, same as the rest of this open-core repository (see
-`LICENSE`, `NOTICE`). No additional restriction applies to the xcframework
-artifact or the generated header.
+`LICENSE`, `NOTICE`). No additional *copyright* restriction applies to the
+xcframework artifact or the generated header. The OpenASR **name, logo, and
+official app icons** are not licensed under Apache-2.0: third-party apps that
+embed this framework must ship under their own product identity and must not
+imply they are the official OpenASR app. See
+[XCFRAMEWORK-DISTRIBUTION.md](../XCFRAMEWORK-DISTRIBUTION.md),
+[TRADEMARKS.md](../TRADEMARKS.md), and [BRANDING.md](../BRANDING.md).
 
 ## Building
 


### PR DESCRIPTION
## Summary

Add formal brand policy for the open-core repository so ecosystem apps and store review have a clear public reference.

## Why

Apache-2.0 covers code, not trademarks. Third parties embedding the engine or `OpenASR.xcframework` need explicit rules: reserved name/logo/official icons, allowed "Powered by OpenASR", no implied endorsement, official apps only from project operator developer accounts, and independent UI/brand/support for third-party apps.

## Changes

- `TRADEMARKS.md` - reserved marks, allowed/forbidden uses, official-app reservation
- `BRANDING.md` - practical product-identity checklist
- `XCFRAMEWORK-DISTRIBUTION.md` - App Store / Mac distribution when embedding the SDK
- Links from `README.md`, `README.zh-CN.md`, `docs/DOCS_INDEX.md`, `docs/SDK_IOS_MACOS.md`

## Tests run

- [x] Docs-only review (no code/runtime change)
- [ ] `cargo fmt --check` (N/A docs-only)
- [ ] `cargo clippy --all-targets -- -D warnings` (N/A)
- [ ] `cargo nextest run --workspace` (N/A)
- [ ] `cargo test --workspace --doc` (N/A)
- [ ] `cargo deny check` (N/A)

## Manual smoke checks

- [x] Cross-links between the three new docs and SDK/README resolve in-tree

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not register trademarks with any office
- Does not change Apache-2.0 grant on code
- Does not ship logo asset packs (text policy only)
- Legal entity display name left as "project operators" pending any preferred legal name wording

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - drafting assistance; human owns wording and maintenance.