### PR TITLE
fix(core): cooperative cancel at seq2seq greedy token boundary

### DIFF
--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -10,6 +10,7 @@ mod native;
 mod request_context;
 
 pub use mock::transcribe_with_mock_backend;
+pub(crate) use native::current_transcription_control;
 pub use native::{
     ActiveTranscriptionControlGuard, NativeBackend, NativeBackendExecutor,
     NativeRuntimeModelAdapter, NativeRuntimeModelIdSource, NativeRuntimeModelIdentity,
@@ -877,7 +878,7 @@ pub enum BackendError {
     )]
     ServeBatchUnavailable { reason: String, retryable: bool },
     #[error(
-        "Native ASR Core transcription was canceled at a slice boundary before completion.\nThe already-decoded portion was discarded; no partial transcript is returned."
+        "Native ASR Core transcription was canceled before completion.\nThe already-decoded portion was discarded; no partial transcript is returned."
     )]
     TranscriptionCanceled,
     #[error(

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -58,6 +58,10 @@ pub use transcription_control::{
     ActiveTranscriptionControlGuard, SliceBoundaryControl, TranscriptionControl,
     install_active_transcription_control,
 };
+// Used by the shared seq2seq greedy driver (L1 cooperative cancel) and any other
+// crate-internal decode loop that must observe in-flight cancel without a
+// threaded handle. Not part of the public API surface.
+pub(crate) use transcription_control::current_transcription_control;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NativeBackend;

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1330,10 +1330,12 @@ fn run_native_transcription_impl(
             // In-session pause/cancel control for this in-flight transcription,
             // bound to this decode thread by the caller (see
             // `install_active_transcription_control`). Checked at each slice
-            // boundary: a cancel unwinds cleanly with `TranscriptionCanceled`
+            // boundary (L0): a cancel unwinds cleanly with `TranscriptionCanceled`
             // (dropping the assembler and progress guard), and a pause blocks the
-            // worker here until resume or cancel. Absent (CLI / no control
-            // registered) leaves the decode byte-identical to before.
+            // worker here until resume or cancel. The shared seq2seq greedy driver
+            // also polls cancel at each token step (L1) so cancel does not wait
+            // for the end of a long slice. Absent (CLI / no control registered)
+            // leaves the decode byte-identical to before.
             let transcription_control =
                 super::transcription_control::current_transcription_control();
             let mut slice_index = 0usize;
@@ -2191,6 +2193,18 @@ fn map_family_selection_error(error: GgmlFamilyRegistrySelectionError) -> Backen
 }
 
 fn dispatch_error_to_backend(error: GgmlAsrExecutionError) -> BackendError {
+    // L1 cooperative cancel (token-loop) and L0 slice cancel both leave the
+    // active control flagged. Prefer the typed cancel surface over a generic
+    // fail-closed reason so CLI/native and server agree on
+    // `BackendError::TranscriptionCanceled` (HTTP 409). Also recognize the
+    // stable cancel marker embedded in family executor reason strings in case
+    // the thread-local control was already cleared by an outer guard.
+    if super::transcription_control::current_transcription_control()
+        .is_some_and(|control| control.is_canceled())
+        || is_cooperative_cancel_reason(&error.to_string())
+    {
+        return BackendError::TranscriptionCanceled;
+    }
     match error {
         GgmlAsrExecutionError::ExecutorUnavailable { .. } => BackendError::NativeFailClosed {
             reason: format!(
@@ -2220,6 +2234,14 @@ fn dispatch_error_to_backend(error: GgmlAsrExecutionError) -> BackendError {
             }
         }
     }
+}
+
+/// Stable substring shared by `Seq2SeqGreedyDecodeError::Canceled` and the
+/// family greedy bridges (`"... canceled by transcription control"`). Used as
+/// a belt-and-suspenders signal when the active control handle is no longer
+/// bound on this thread.
+fn is_cooperative_cancel_reason(reason: &str) -> bool {
+    reason.contains("canceled by transcription control")
 }
 
 fn run_dispatch_once(

--- a/crates/openasr-core/src/models/cohere/greedy_decode.rs
+++ b/crates/openasr-core/src/models/cohere/greedy_decode.rs
@@ -58,6 +58,8 @@ pub(crate) enum CohereTranscribeGreedyDecodeError {
     DecoderStepFailed { reason: String },
     #[error("cohere-transcribe greedy decode tokenizer decode failed: {reason}")]
     TokenizerDecodeFailed { reason: String },
+    #[error("cohere-transcribe greedy decode canceled by transcription control")]
+    Canceled,
 }
 
 pub(crate) fn run_cohere_transcribe_greedy_decode_loop(
@@ -135,6 +137,7 @@ fn map_cohere_error_to_shared(
         CohereTranscribeGreedyDecodeError::TokenizerDecodeFailed { reason } => {
             Seq2SeqGreedyDecodeError::TokenizerDecodeFailed { reason }
         }
+        CohereTranscribeGreedyDecodeError::Canceled => Seq2SeqGreedyDecodeError::Canceled,
     }
 }
 
@@ -186,6 +189,7 @@ fn map_shared_error(error: Seq2SeqGreedyDecodeError) -> CohereTranscribeGreedyDe
         Seq2SeqGreedyDecodeError::TokenizerDecodeFailed { reason } => {
             CohereTranscribeGreedyDecodeError::TokenizerDecodeFailed { reason }
         }
+        Seq2SeqGreedyDecodeError::Canceled => CohereTranscribeGreedyDecodeError::Canceled,
     }
 }
 

--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -865,6 +865,13 @@ pub(crate) fn run_firered_aed_decoder_greedy_with_runtime(
                 generated_probabilities: Vec::new(),
             }
         }
+        // Preserve the stable cancel marker so native/server boundaries can
+        // rewrite to `BackendError::TranscriptionCanceled`.
+        Err(Seq2SeqGreedyDecodeError::Canceled) => {
+            return Err(FireRedDecoderError::InvalidInput {
+                reason: Seq2SeqGreedyDecodeError::Canceled.to_string(),
+            });
+        }
         Err(error) => {
             return Err(FireRedDecoderError::InvalidInput {
                 reason: error.to_string(),

--- a/crates/openasr-core/src/models/hymt2/runtime.rs
+++ b/crates/openasr-core/src/models/hymt2/runtime.rs
@@ -1650,20 +1650,25 @@ impl Seq2SeqGreedyDecodeStepExecutor for Hymt2SharedGreedyStepExecutor<'_> {
 /// outcome when the decode reaches its output budget
 /// (`max_output_tokens_for_source_tokens`) before a stop token -- the caller
 /// degrades to the generated prefix instead of failing the clause.
+/// `Canceled` is the L1 cooperative cancel from the shared greedy driver.
 enum Hymt2SharedDecodeError {
     Truncated { generated_tokens: Vec<u32> },
+    Canceled,
     Runtime(Hymt2RuntimeError),
 }
 
 fn map_hymt2_family_error_to_shared(error: Hymt2SharedDecodeError) -> Seq2SeqGreedyDecodeError {
-    Seq2SeqGreedyDecodeError::TokenizerDecodeFailed {
-        reason: match error {
-            Hymt2SharedDecodeError::Runtime(error) => error.to_string(),
-            // Unreachable: the token-decoder closure only fails with Runtime.
-            Hymt2SharedDecodeError::Truncated { .. } => {
-                "Hy-MT2 token decoder reported truncation".to_string()
-            }
+    match error {
+        Hymt2SharedDecodeError::Canceled => Seq2SeqGreedyDecodeError::Canceled,
+        Hymt2SharedDecodeError::Runtime(error) => Seq2SeqGreedyDecodeError::TokenizerDecodeFailed {
+            reason: error.to_string(),
         },
+        // Unreachable: the token-decoder closure only fails with Runtime.
+        Hymt2SharedDecodeError::Truncated { .. } => {
+            Seq2SeqGreedyDecodeError::TokenizerDecodeFailed {
+                reason: "Hy-MT2 token decoder reported truncation".to_string(),
+            }
+        }
     }
 }
 
@@ -1672,6 +1677,7 @@ fn map_shared_error_to_hymt2(error: Seq2SeqGreedyDecodeError) -> Hymt2SharedDeco
         Seq2SeqGreedyDecodeError::EotNotReachedBeforeMaxTokens {
             generated_tokens, ..
         } => Hymt2SharedDecodeError::Truncated { generated_tokens },
+        Seq2SeqGreedyDecodeError::Canceled => Hymt2SharedDecodeError::Canceled,
         other => Hymt2SharedDecodeError::Runtime(Hymt2RuntimeError::Decode {
             reason: other.to_string(),
         }),
@@ -1737,6 +1743,11 @@ fn run_hymt2_shared_greedy_decode(
                 .to_string();
             Ok((generated_tokens, text))
         }
+        Err(Hymt2SharedDecodeError::Canceled) => Err(Hymt2RuntimeError::Decode {
+            // Stable marker consumed by `dispatch_error_to_backend` so cancel
+            // becomes `BackendError::TranscriptionCanceled` end-to-end.
+            reason: Seq2SeqGreedyDecodeError::Canceled.to_string(),
+        }),
         Err(Hymt2SharedDecodeError::Runtime(error)) => Err(error),
     }
 }

--- a/crates/openasr-core/src/models/moonshine/decoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/decoder_graph.rs
@@ -224,6 +224,13 @@ fn run_moonshine_decoder_short_form_with_runtime(
             generated_tokens,
             generated_probabilities,
         },
+        // Preserve the stable cancel marker so native/server boundaries can
+        // rewrite to `BackendError::TranscriptionCanceled`.
+        Err(Seq2SeqGreedyDecodeError::Canceled) => {
+            return Err(MoonshineDecoderGraphError::InvalidInput {
+                reason: Seq2SeqGreedyDecodeError::Canceled.to_string(),
+            });
+        }
         Err(error) => {
             return Err(MoonshineDecoderGraphError::InvalidInput {
                 reason: error.to_string(),

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -639,6 +639,13 @@ impl Qwen3AsrGgmlExecutor {
                     .to_string();
                 (text, generated_tokens, generated_probabilities)
             }
+            // Preserve typed cancel identity through the stringified executor
+            // boundary via the stable "canceled by transcription control" marker.
+            Err(Qwen3AsrGreedyDecodeError::Canceled) => {
+                return Err(Qwen3AsrGgmlExecutorError::GreedyDecodeFailed {
+                    reason: Qwen3AsrGreedyDecodeError::Canceled.to_string(),
+                });
+            }
             Err(error) => {
                 return Err(Qwen3AsrGgmlExecutorError::GreedyDecodeFailed {
                     reason: error.to_string(),

--- a/crates/openasr-core/src/models/qwen/greedy_decode.rs
+++ b/crates/openasr-core/src/models/qwen/greedy_decode.rs
@@ -58,6 +58,8 @@ pub(crate) enum Qwen3AsrGreedyDecodeError {
     DecoderStepFailed { reason: String },
     #[error("qwen3-asr greedy decode tokenizer decode failed: {reason}")]
     TokenizerDecodeFailed { reason: String },
+    #[error("qwen3-asr greedy decode canceled by transcription control")]
+    Canceled,
 }
 
 pub(crate) fn run_qwen3_greedy_decode_loop(
@@ -133,6 +135,7 @@ fn map_qwen_error_to_shared(error: Qwen3AsrGreedyDecodeError) -> Seq2SeqGreedyDe
         Qwen3AsrGreedyDecodeError::TokenizerDecodeFailed { reason } => {
             Seq2SeqGreedyDecodeError::TokenizerDecodeFailed { reason }
         }
+        Qwen3AsrGreedyDecodeError::Canceled => Seq2SeqGreedyDecodeError::Canceled,
     }
 }
 
@@ -184,6 +187,7 @@ fn map_shared_error(error: Seq2SeqGreedyDecodeError) -> Qwen3AsrGreedyDecodeErro
         Seq2SeqGreedyDecodeError::TokenizerDecodeFailed { reason } => {
             Qwen3AsrGreedyDecodeError::TokenizerDecodeFailed { reason }
         }
+        Seq2SeqGreedyDecodeError::Canceled => Qwen3AsrGreedyDecodeError::Canceled,
     }
 }
 

--- a/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
+++ b/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
@@ -159,6 +159,15 @@ pub(crate) enum Seq2SeqGreedyDecodeError {
     DecoderStepFailed { reason: String },
     #[error("seq2seq greedy decode tokenizer decode failed: {reason}")]
     TokenizerDecodeFailed { reason: String },
+    /// Cooperative cancel observed at a token-step boundary via the active
+    /// [`crate::api::backend::TranscriptionControl`]. Distinct from a
+    /// graph/compute failure so callers can map it to
+    /// [`crate::BackendError::TranscriptionCanceled`] rather than a generic
+    /// fail-closed refusal. Pause is intentionally NOT handled here -- pause
+    /// still only blocks at the long-form slice boundary (L0) so a live
+    /// decode does not hold GPU/CPU arenas mid-utterance.
+    #[error("seq2seq greedy decode canceled by transcription control")]
+    Canceled,
 }
 
 pub(crate) trait Seq2SeqGreedyDecodeStepExecutor {
@@ -249,6 +258,16 @@ pub(crate) fn run_seq2seq_greedy_decode_loop_v0(
     let mut reached_eot = false;
 
     for step_index in 0..config.max_generated_tokens {
+        // L1 cooperative cancel: poll the active transcription control before
+        // each decoder step so cancel lands at a token boundary instead of
+        // waiting for the long-form slice boundary (L0). Pause is not blocked
+        // here -- holding the decode mid-token with live arenas is unsafe /
+        // wasteful; pause stays L0-only.
+        if crate::api::backend::current_transcription_control()
+            .is_some_and(|control| control.is_canceled())
+        {
+            return Err(Seq2SeqGreedyDecodeError::Canceled);
+        }
         let step_input = Seq2SeqGreedyDecodeStepInput {
             initial_prompt_tokens: &config.initial_prompt_tokens,
             generated_tokens: &generated,
@@ -1339,5 +1358,169 @@ mod tests {
         assert_eq!(output.text, "gu");
         // Tripped at the 4th identical token (steps 0..=3), so no further steps.
         assert_eq!(step_executor.logits_calls, 4);
+    }
+
+    /// Step executor that emits a non-stop token every call and records how many
+    /// times the driver entered `decode_step_logits`. Used to prove L1 cancel
+    /// aborts at a token boundary well before `max_generated_tokens`.
+    struct CountingNonStopStepExecutor {
+        vocab_size: usize,
+        token_id: u32,
+        logits_calls: usize,
+    }
+
+    impl Seq2SeqGreedyDecodeStepExecutor for CountingNonStopStepExecutor {
+        fn decode_step_logits(
+            &mut self,
+            _input: Seq2SeqGreedyDecodeStepInput<'_>,
+        ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyDecodeError> {
+            self.logits_calls = self.logits_calls.saturating_add(1);
+            let token_idx = usize::try_from(self.token_id).expect("token fits usize");
+            let mut logits = vec![-1000.0_f32; self.vocab_size];
+            logits[token_idx] = 1000.0;
+            Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits,
+                greedy_token_hint: None,
+            })
+        }
+    }
+
+    #[test]
+    fn seq2seq_greedy_decode_cancels_at_token_boundary_when_control_requests_cancel() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::thread;
+        use std::time::Duration;
+
+        use crate::api::backend::{TranscriptionControl, install_active_transcription_control};
+
+        let max_generated_tokens = 64usize;
+        let cancel_after_steps = 3usize;
+        let steps_seen = Arc::new(AtomicUsize::new(0));
+        let control = Arc::new(TranscriptionControl::new());
+
+        let worker_control = Arc::clone(&control);
+        let worker_steps = Arc::clone(&steps_seen);
+        let worker = thread::spawn(move || {
+            let _guard = install_active_transcription_control(worker_control);
+            let mut step_executor = CountingNonStopStepExecutor {
+                vocab_size: 16,
+                token_id: 1,
+                logits_calls: 0,
+            };
+            // Wrap the counting executor so each successful step publishes the
+            // observed call count to the shared atomic (the cancel thread
+            // waits on that signal).
+            struct PublishingExecutor<'a> {
+                inner: &'a mut CountingNonStopStepExecutor,
+                steps_seen: &'a AtomicUsize,
+            }
+            impl Seq2SeqGreedyDecodeStepExecutor for PublishingExecutor<'_> {
+                fn decode_step_logits(
+                    &mut self,
+                    input: Seq2SeqGreedyDecodeStepInput<'_>,
+                ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyDecodeError>
+                {
+                    let out = self.inner.decode_step_logits(input)?;
+                    self.steps_seen
+                        .store(self.inner.logits_calls, Ordering::SeqCst);
+                    // Give the canceler a window to observe progress without
+                    // racing past the whole token budget on a fast host.
+                    thread::sleep(Duration::from_millis(5));
+                    Ok(out)
+                }
+            }
+            let mut publisher = PublishingExecutor {
+                inner: &mut step_executor,
+                steps_seen: worker_steps.as_ref(),
+            };
+            let token_decoder = SyntheticTokenDecoder {
+                table: BTreeMap::from([(1, "a")]),
+            };
+            let config = Seq2SeqGreedyDecodeConfig {
+                initial_prompt_tokens: vec![42],
+                eot_token_id: 7,
+                stop_token_ids: Vec::new(),
+                vocab_size: 16,
+                max_generated_tokens,
+                suppress_first_step_token_ids: Vec::new(),
+                suppress_token_ids: Vec::new(),
+                phrase_biases: Vec::new(),
+            };
+            let mut no_token_trace = |_: usize, _: u32, _: bool| {};
+            let mut no_topk_trace = |_: usize, _: &[f32]| {};
+            let result = run_seq2seq_greedy_decode_loop_v0(
+                &config,
+                &mut publisher,
+                &token_decoder,
+                &mut no_token_trace,
+                &mut no_topk_trace,
+            );
+            (result, step_executor.logits_calls)
+        });
+
+        // Wait until the decode has entered a few steps, then cancel.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while steps_seen.load(Ordering::SeqCst) < cancel_after_steps {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "decode never reached {cancel_after_steps} steps before cancel"
+            );
+            thread::sleep(Duration::from_millis(1));
+        }
+        control.request_cancel();
+
+        let (result, logits_calls) = worker.join().expect("decode worker");
+        assert_eq!(
+            result,
+            Err(Seq2SeqGreedyDecodeError::Canceled),
+            "active cancel must surface as typed Canceled"
+        );
+        assert!(
+            logits_calls < max_generated_tokens,
+            "cancel must abort well before the token budget: logits_calls={logits_calls} max={max_generated_tokens}"
+        );
+        // Poll is before each step, so after cancel the next loop iteration
+        // returns without another decode_step_logits. Bound is loose so a slow
+        // scheduler that lets a few extra steps slip through still passes.
+        assert!(
+            logits_calls < max_generated_tokens / 2,
+            "expected early abort, got logits_calls={logits_calls}"
+        );
+    }
+
+    #[test]
+    fn seq2seq_greedy_decode_without_control_is_unchanged() {
+        // Sanity: with no control installed the loop still runs to EOT as before.
+        let mut step_executor = SyntheticStepExecutor {
+            vocab_size: 16,
+            sequence: vec![1, 2, 7],
+            logits_calls: 0,
+        };
+        let token_decoder = SyntheticTokenDecoder {
+            table: BTreeMap::from([(1, "hel"), (2, "lo")]),
+        };
+        let config = Seq2SeqGreedyDecodeConfig {
+            initial_prompt_tokens: vec![42],
+            eot_token_id: 7,
+            stop_token_ids: Vec::new(),
+            vocab_size: 16,
+            max_generated_tokens: 8,
+            suppress_first_step_token_ids: Vec::new(),
+            suppress_token_ids: Vec::new(),
+            phrase_biases: Vec::new(),
+        };
+        let mut no_token_trace = |_: usize, _: u32, _: bool| {};
+        let mut no_topk_trace = |_: usize, _: &[f32]| {};
+        let output = run_seq2seq_greedy_decode_loop_v0(
+            &config,
+            &mut step_executor,
+            &token_decoder,
+            &mut no_token_trace,
+            &mut no_topk_trace,
+        )
+        .expect("no-control path stays successful");
+        assert_eq!(output.text, "hello");
+        assert_eq!(step_executor.logits_calls, 3);
     }
 }

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -5395,6 +5395,11 @@ fn map_greedy_decode_error(error: WhisperGreedyDecodeError) -> WhisperGgmlExecut
         } => WhisperGgmlExecutorError::DecoderNoEotBeforeMaxTokens {
             max_generated_tokens,
         },
+        // Keep the stable cancel marker in the reason string so
+        // `dispatch_error_to_backend` can rewrite to TranscriptionCanceled.
+        WhisperGreedyDecodeError::Canceled => WhisperGgmlExecutorError::DecoderInvalidTokenDecode {
+            reason: WhisperGreedyDecodeError::Canceled.to_string(),
+        },
         WhisperGreedyDecodeError::TokenizerDecodeFailed { .. }
         | WhisperGreedyDecodeError::SelectedTokenOutOfVocab { .. }
         | WhisperGreedyDecodeError::EmptyInitialPrompt

--- a/crates/openasr-core/src/models/whisper/greedy_decode.rs
+++ b/crates/openasr-core/src/models/whisper/greedy_decode.rs
@@ -60,6 +60,8 @@ pub(crate) enum WhisperGreedyDecodeError {
     DecoderStepFailed { reason: String },
     #[error("whisper greedy decode tokenizer decode failed: {reason}")]
     TokenizerDecodeFailed { reason: String },
+    #[error("whisper greedy decode canceled by transcription control")]
+    Canceled,
 }
 
 pub(crate) fn run_whisper_greedy_decode_loop(
@@ -135,6 +137,7 @@ fn map_whisper_error_to_shared(error: WhisperGreedyDecodeError) -> Seq2SeqGreedy
         WhisperGreedyDecodeError::TokenizerDecodeFailed { reason } => {
             Seq2SeqGreedyDecodeError::TokenizerDecodeFailed { reason }
         }
+        WhisperGreedyDecodeError::Canceled => Seq2SeqGreedyDecodeError::Canceled,
     }
 }
 
@@ -186,6 +189,7 @@ fn map_shared_error(error: Seq2SeqGreedyDecodeError) -> WhisperGreedyDecodeError
         Seq2SeqGreedyDecodeError::TokenizerDecodeFailed { reason } => {
             WhisperGreedyDecodeError::TokenizerDecodeFailed { reason }
         }
+        Seq2SeqGreedyDecodeError::Canceled => WhisperGreedyDecodeError::Canceled,
     }
 }
 


### PR DESCRIPTION
## Summary

Stop-transcription cancel now takes effect at shared seq2seq greedy token boundaries, not only at long-form slice boundaries.

## Why

Long-form cancel was only polled between slices, so a stop request could wait through an entire decode slice (often tens of seconds of work). Every AED / seq2seq family already runs through one shared greedy driver, so a single cooperative checkpoint there collapses cancel latency to the current token step on CPU and Metal alike.

## Changes

- Add `Seq2SeqGreedyDecodeError::Canceled` and poll `TranscriptionControl` before each step in `run_seq2seq_greedy_decode_loop_v0` (cancel only; pause stays slice-boundary / L0).
- Exhaustive family bridges for qwen / whisper / cohere / hymt2; moonshine and firered-aed preserve the stable cancel marker instead of a generic invalid-input path.
- Native dispatch rewrites canceled runs to `BackendError::TranscriptionCanceled` (control flag and/or stable reason marker), matching the server belt-and-suspenders path.
- Unit test: install control, cancel mid-loop, assert typed `Canceled` with steps well under the token budget; no-control path unchanged.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core seq2seq_greedy`
- [x] `cargo test -p openasr-core greedy_decode`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

None (no-weight unit coverage for the shared driver).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- L1 only: shared greedy token-loop cancel.
- Not in this PR: ggml abort_callback FFI (L2), Metal mid-graph abort, prefill/encoder chunk cancel, streaming cancel predicate unification.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implementation assistance for the shared cancel checkpoint and family error bridges; human owns the design and review.