### PR TITLE
perf(qwen): wire phase-1 q8_0 KV on CPU/Metal production paths

### DIFF
--- a/crates/openasr-core/src/models/hymt2/runtime.rs
+++ b/crates/openasr-core/src/models/hymt2/runtime.rs
@@ -252,14 +252,24 @@ impl Hymt2RuntimeSession {
         metadata: Hymt2ExecutionMetadata,
         max_positions: usize,
     ) -> Result<(), Hymt2RuntimeError> {
-        if self.layer_kv_caches.len() != metadata.layers {
+        let host = self.whole_decoder.kv_cache_spec().host;
+        if self.layer_kv_caches.len() != metadata.layers
+            || self
+                .layer_kv_caches
+                .iter()
+                .any(|cache| cache.element_type() != host)
+        {
             self.layer_kv_caches = (0..metadata.layers)
                 .map(|_| {
-                    Qwen3AsrLayerKvCacheState::new(
+                    Qwen3AsrLayerKvCacheState::new_with_element_type(
                         max_positions,
                         metadata.kv_heads,
                         metadata.head_dim,
+                        host,
                     )
+                    .unwrap_or_else(|reason| {
+                        panic!("shared LLM KV cache geometry rejected host type: {reason}")
+                    })
                 })
                 .collect();
             return Ok(());
@@ -754,13 +764,26 @@ impl Hymt2Runtime {
     }
 
     fn empty_layer_kv_caches(&self, max_positions: usize) -> Vec<Qwen3AsrLayerKvCacheState> {
+        // Match the production policy applied when the whole-decoder was built
+        // so host storage and graph history tensors stay element-type aligned.
+        let host = self
+            .session
+            .lock()
+            .expect("Hy-MT2 runtime session lock poisoned")
+            .whole_decoder
+            .kv_cache_spec()
+            .host;
         (0..self.metadata.layers)
             .map(|_| {
-                Qwen3AsrLayerKvCacheState::new(
+                Qwen3AsrLayerKvCacheState::new_with_element_type(
                     max_positions,
                     self.metadata.kv_heads,
                     self.metadata.head_dim,
+                    host,
                 )
+                .unwrap_or_else(|reason| {
+                    panic!("shared LLM KV cache geometry rejected host type: {reason}")
+                })
             })
             .collect()
     }

--- a/crates/openasr-core/src/models/qwen/batched_decode.rs
+++ b/crates/openasr-core/src/models/qwen/batched_decode.rs
@@ -13,12 +13,13 @@ use super::kv_cache::Qwen3AsrLayerKvCacheState;
 use super::llm_prefill::Qwen3AsrLlmPrefillInput;
 use super::llm_transformer::{
     Qwen3AsrLlmLayerAttentionProjection, Qwen3AsrLlmWholeDecoderGraphExecutor,
+    resolve_qwen_family_production_kv_cache_policy,
 };
 use super::logits_head::Qwen3AsrLlmLogitsHead;
 use super::runtime_contract::Qwen3AsrExecutionMetadata;
 use super::token_embedding::Qwen3AsrTokenEmbeddingTable;
 use super::tokenizer::Qwen3AsrTokenizer;
-use crate::ggml_runtime::GgmlCpuGraphBackend;
+use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig};
 use crate::models::decode_policy_component_registry::{
     BuiltinDecodePolicySeq2SeqTextPostprocessKind, apply_seq2seq_text_postprocess,
 };
@@ -1428,13 +1429,23 @@ impl Qwen3AsrBatchSlot {
                     .to_string(),
             });
         }
+        let host = resolve_qwen_family_production_kv_cache_policy(
+            GgmlCpuGraphConfig::resolve_runtime_backend(),
+            job.metadata.llm_head_dim,
+        )
+        .to_spec()
+        .host;
         let layer_kv_caches = (0..job.metadata.llm_layers)
             .map(|_| {
-                Qwen3AsrLayerKvCacheState::new(
+                Qwen3AsrLayerKvCacheState::new_with_element_type(
                     max_positions,
                     job.metadata.llm_kv_heads,
                     job.metadata.llm_head_dim,
+                    host,
                 )
+                .unwrap_or_else(|reason| {
+                    panic!("shared LLM KV cache geometry rejected host type: {reason}")
+                })
             })
             .collect();
         let stop_token_ids = build_seq2seq_greedy_stop_token_ids(&job.decode_config);
@@ -1466,13 +1477,21 @@ impl Qwen3AsrBatchSlot {
                 reason: "qwen serve batch dummy seed row width overflowed".to_string(),
             })?;
         let zero_row = vec![0.0_f32; row_width];
+        let host = resolve_qwen_family_production_kv_cache_policy(
+            GgmlCpuGraphConfig::resolve_runtime_backend(),
+            metadata.llm_head_dim,
+        )
+        .to_spec()
+        .host;
         let mut layers = Vec::with_capacity(metadata.llm_layers);
         for _ in 0..metadata.llm_layers {
-            let mut cache = Qwen3AsrLayerKvCacheState::new(
+            let mut cache = Qwen3AsrLayerKvCacheState::new_with_element_type(
                 max_positions,
                 metadata.llm_kv_heads,
                 metadata.llm_head_dim,
-            );
+                host,
+            )
+            .map_err(|reason| Qwen3AsrServeBatchError::DecodeFailed { reason })?;
             cache
                 .write(0, &zero_row, &zero_row)
                 .map_err(|reason| Qwen3AsrServeBatchError::DecodeFailed { reason })?;

--- a/crates/openasr-core/src/models/qwen/kv_cache.rs
+++ b/crates/openasr-core/src/models/qwen/kv_cache.rs
@@ -81,6 +81,10 @@ pub(crate) struct Qwen3AsrLayerKvCacheHistory<'a> {
 }
 
 impl Qwen3AsrLayerKvCacheState {
+    /// Host-F32 convenience constructor for tests and F32-pinned harnesses.
+    /// Production whole-decoder paths use [`Self::new_with_element_type`] with
+    /// the resolved `kv_cache_spec().host` so Q8 and F32 stay aligned.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(max_positions: usize, kv_heads: usize, head_dim: usize) -> Self {
         Self::new_with_element_type(max_positions, kv_heads, head_dim, GgmlKvElementType::F32)
             .expect("f32 host KV geometry is always valid")

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -28,7 +28,7 @@ use crate::nn::decoder::{
     allocate_zeroed_llm_resident_kv_arena, build_fixed_kv_attention_mask_bits,
     build_fixed_kv_attention_mask_bits_for_query_rows,
     build_fixed_kv_attention_mask_bits_for_sequences, compose_llm_decoder_layer_stack,
-    reusable_decode_graph_supported_for_runner,
+    resolve_production_llm_kv_cache_policy_from_env, reusable_decode_graph_supported_for_runner,
 };
 use crate::nn::half::f32_slice_to_f16_bits;
 
@@ -782,6 +782,23 @@ fn qwen_llm_resolve_use_native_gqa(backend: GgmlCpuGraphBackend) -> bool {
         std::env::var(QWEN3_LLM_NATIVE_GQA_ENV).ok().as_deref(),
         qwen_llm_native_gqa_default_for_backend(backend),
     )
+}
+
+/// Production KV-cache policy for every Qwen-shaped whole-decoder constructor
+/// (qwen / mimo / firered2 / moss / hymt2 / serve-batch).
+///
+/// Applies the shared phase-1 Q8 rules: CPU/Metal + native-GQA + flash geometry
+/// selects `Q8_0`; discrete GPU and incomplete geometry stay on Default.
+/// `OPENASR_QWEN_KV_CACHE_F32` opts back to host-F32 / resident-F16 for golden
+/// pins. Decode always uses flash; CPU/Metal prefill also always uses flash, so
+/// the construction-time flash flag is `true` for policy selection (discrete
+/// GPU is already rejected by backend support).
+pub(crate) fn resolve_qwen_family_production_kv_cache_policy(
+    backend: GgmlCpuGraphBackend,
+    head_dim: usize,
+) -> LlmKvCachePolicy {
+    let use_native_gqa = qwen_llm_resolve_use_native_gqa(backend);
+    resolve_production_llm_kv_cache_policy_from_env(backend, head_dim, use_native_gqa, true)
 }
 
 /// A decode-layer 2D projection weight: either an arena tensor (f32-uploaded) or
@@ -1681,7 +1698,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         for (tensor, values, name) in pending_lora_uploads {
             arena.set_f32_slice(tensor, &values, name)?;
         }
-        Ok(Self {
+        let mut executor = Self {
             reuse: None,
             loaded,
             runner,
@@ -1692,7 +1709,16 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             use_native_gqa,
             rms_norm_epsilon,
             kv_cache_spec: LlmKvCacheSpec::DEFAULT,
-        })
+        };
+        // Shared production policy for every family that builds this executor
+        // (qwen/mimo/firered2/moss/hymt2/serve-batch). Discrete GPU and the
+        // OPENASR_QWEN_KV_CACHE_F32 opt-out stay on Default.
+        let policy = resolve_qwen_family_production_kv_cache_policy(
+            executor.runner.backend_kind(),
+            executor.dims.head_dim,
+        );
+        executor.set_kv_cache_policy(policy)?;
+        Ok(executor)
     }
 
     pub(crate) fn layer_count(&self) -> usize {
@@ -1703,10 +1729,13 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         self.kv_cache_spec
     }
 
-    /// Internal execution option for phase-1 Q8 KV. Not a public env gate.
-    /// Validates geometry against the decoder head_dim; backend/GQA/flash checks
-    /// still happen when the graph is composed for a concrete backend path.
-    #[allow(dead_code)]
+    /// Set the host/resident KV element-type policy for this decoder.
+    ///
+    /// Production constructors already call this once via
+    /// [`resolve_qwen_family_production_kv_cache_policy`]. Remaining call sites
+    /// are explicit overrides (golden/parity harnesses that pin F32, or tests).
+    /// Validates geometry against the decoder `head_dim`; backend/GQA/flash
+    /// checks still happen when the graph is composed for a concrete path.
     pub(crate) fn set_kv_cache_policy(
         &mut self,
         policy: LlmKvCachePolicy,
@@ -5696,6 +5725,9 @@ mod tests {
             Qwen3AsrLlmWholeDecoderGraphExecutor::new(&projections, Some(&runtime_path))
                 .expect("qwen decoder");
         decoder
+            .set_kv_cache_policy(LlmKvCachePolicy::Default)
+            .expect("pin f32 KV for seed-only reset harness");
+        decoder
             .reset_reused_batched_seeded(&seeds_two, 1_000_000.0, token_count)
             .expect("seed-only reset n_seq=2");
         let reuse = decoder.reuse.as_ref().expect("reuse graph after n_seq=2");
@@ -5925,6 +5957,11 @@ mod tests {
         let mut decoder =
             Qwen3AsrLlmWholeDecoderGraphExecutor::new(projections, Some(runtime_path))
                 .expect("serial qwen decoder");
+        // Prefill parity compares against f32 host history rows. Pin Default so
+        // production Q8 does not silently break the manual harness.
+        decoder
+            .set_kv_cache_policy(LlmKvCachePolicy::Default)
+            .expect("pin f32 KV for prefill parity");
         let mut layer_kv_caches = (0..metadata.llm_layers)
             .map(|_| {
                 Qwen3AsrLayerKvCacheState::new(
@@ -5979,6 +6016,9 @@ mod tests {
             Qwen3AsrLlmWholeDecoderGraphExecutor::new(projections, Some(runtime_path))
                 .expect("prefill qwen decoder");
         decoder
+            .set_kv_cache_policy(LlmKvCachePolicy::Default)
+            .expect("pin f32 KV for prefill parity");
+        decoder
             .run_prefill(hidden, token_count, 1_000_000.0)
             .expect("qwen whole-prompt prefill")
     }
@@ -5995,6 +6035,9 @@ mod tests {
         let mut decoder =
             Qwen3AsrLlmWholeDecoderGraphExecutor::new(projections, Some(runtime_path))
                 .expect("chunked prefill qwen decoder");
+        decoder
+            .set_kv_cache_policy(LlmKvCachePolicy::Default)
+            .expect("pin f32 KV for prefill parity");
         let mut layer_kv_caches = (0..metadata.llm_layers)
             .map(|_| {
                 Qwen3AsrLayerKvCacheState::new(

--- a/crates/openasr-core/src/nn/decoder.rs
+++ b/crates/openasr-core/src/nn/decoder.rs
@@ -50,21 +50,30 @@ pub(crate) fn reusable_decode_graph_supported_for_runner(runner: &GgmlCpuGraphRu
     reusable_decode_graph_supported(runner.backend_kind(), runner.uses_scheduler())
 }
 
+/// Opt-out for production Q8 KV on Qwen-shaped whole-decoder stacks.
+///
+/// When truthy (`1`/`true`/`yes`/`on`), keep host-F32 / resident-F16 even on
+/// CPU/Metal with native-GQA + flash. Intended for golden/parity pins and
+/// short-audio quality A/B before the default is left unconditional. Not a
+/// pack/catalog quant tag.
+pub(crate) const OPENASR_QWEN_KV_CACHE_F32_ENV: &str = "OPENASR_QWEN_KV_CACHE_F32";
+
 /// Internal execution policy for Qwen-family LLM KV caches.
 ///
-/// Not a public env gate and not a pack/catalog quant tag. Default preserves the
-/// existing host-F32 / resident-F16 byte path. `Q8_0` opts into the phase-1
-/// shared quantized path (CPU/Metal, native-GQA, flash-only).
+/// Not a pack/catalog quant tag. `Default` is host-F32 / resident-F16.
+/// `Q8_0` is the phase-1 shared quantized path (CPU/Metal, native-GQA,
+/// flash-only). Production selection lives in
+/// [`resolve_production_llm_kv_cache_policy`]; whole-decoder construction
+/// applies it via `Qwen3AsrLlmWholeDecoderGraphExecutor::set_kv_cache_policy`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-#[allow(dead_code)]
 pub(crate) enum LlmKvCachePolicy {
     #[default]
     Default,
     Q8_0,
 }
 
-#[allow(dead_code)]
 impl LlmKvCachePolicy {
+    #[allow(dead_code)] // unit-test + diagnostics label; production uses to_spec()
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Default => "default",
@@ -78,6 +87,60 @@ impl LlmKvCachePolicy {
             Self::Q8_0 => LlmKvCacheSpec::Q8_0,
         }
     }
+}
+
+/// Pure production policy selector for shared Qwen-shaped whole-decoder stacks.
+///
+/// Returns [`LlmKvCachePolicy::Q8_0`] only when phase-1 execution validation
+/// accepts the geometry (CPU/Metal + native-GQA + flash + head_dim) and the
+/// F32 opt-out raw value is not truthy. Discrete GPU and incomplete geometry
+/// stay on [`LlmKvCachePolicy::Default`] (fail closed, no silent broken Q8).
+///
+/// `force_f32_kv_raw` is the raw value of [`OPENASR_QWEN_KV_CACHE_F32_ENV`]
+/// (or an injected test string). Pass `None` when the env is unset.
+pub(crate) fn resolve_production_llm_kv_cache_policy(
+    backend: GgmlCpuGraphBackend,
+    head_dim: usize,
+    use_native_gqa: bool,
+    use_flash_attention: bool,
+    force_f32_kv_raw: Option<&str>,
+) -> LlmKvCachePolicy {
+    if matches!(
+        force_f32_kv_raw
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    ) {
+        return LlmKvCachePolicy::Default;
+    }
+    let candidate = LlmKvCachePolicy::Q8_0;
+    match candidate.to_spec().validate_execution(
+        backend,
+        head_dim,
+        use_native_gqa,
+        use_flash_attention,
+    ) {
+        Ok(()) => candidate,
+        Err(_) => LlmKvCachePolicy::Default,
+    }
+}
+
+/// Process-env wrapper around [`resolve_production_llm_kv_cache_policy`].
+pub(crate) fn resolve_production_llm_kv_cache_policy_from_env(
+    backend: GgmlCpuGraphBackend,
+    head_dim: usize,
+    use_native_gqa: bool,
+    use_flash_attention: bool,
+) -> LlmKvCachePolicy {
+    let force_f32 = std::env::var(OPENASR_QWEN_KV_CACHE_F32_ENV).ok();
+    resolve_production_llm_kv_cache_policy(
+        backend,
+        head_dim,
+        use_native_gqa,
+        use_flash_attention,
+        force_f32.as_deref(),
+    )
 }
 
 /// Shared host + resident KV element-type pair for all Qwen-shaped decoders.
@@ -3365,6 +3428,88 @@ mod tests {
             spec.validate_execution(GgmlCpuGraphBackend::Cpu, 40, true, true)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn resolve_production_llm_kv_cache_policy_matrix() {
+        // CPU/Metal + native-GQA + flash + valid head_dim => Q8.
+        assert_eq!(
+            resolve_production_llm_kv_cache_policy(GgmlCpuGraphBackend::Cpu, 128, true, true, None,),
+            LlmKvCachePolicy::Q8_0
+        );
+        assert_eq!(
+            resolve_production_llm_kv_cache_policy(
+                GgmlCpuGraphBackend::Metal,
+                64,
+                true,
+                true,
+                None,
+            ),
+            LlmKvCachePolicy::Q8_0
+        );
+
+        // Discrete GPU stays Default even with native-GQA + flash.
+        assert_eq!(
+            resolve_production_llm_kv_cache_policy(GgmlCpuGraphBackend::Gpu, 128, true, true, None,),
+            LlmKvCachePolicy::Default
+        );
+
+        // Missing native-GQA or flash => Default.
+        assert_eq!(
+            resolve_production_llm_kv_cache_policy(
+                GgmlCpuGraphBackend::Cpu,
+                128,
+                false,
+                true,
+                None,
+            ),
+            LlmKvCachePolicy::Default
+        );
+        assert_eq!(
+            resolve_production_llm_kv_cache_policy(
+                GgmlCpuGraphBackend::Metal,
+                128,
+                true,
+                false,
+                None,
+            ),
+            LlmKvCachePolicy::Default
+        );
+
+        // head_dim not divisible by q8_0 block size => Default.
+        assert_eq!(
+            resolve_production_llm_kv_cache_policy(GgmlCpuGraphBackend::Cpu, 40, true, true, None,),
+            LlmKvCachePolicy::Default
+        );
+
+        // F32 opt-out env (truthy forms) wins over an otherwise-eligible path.
+        for raw in ["1", "true", "TRUE", "yes", "on", " On "] {
+            assert_eq!(
+                resolve_production_llm_kv_cache_policy(
+                    GgmlCpuGraphBackend::Cpu,
+                    128,
+                    true,
+                    true,
+                    Some(raw),
+                ),
+                LlmKvCachePolicy::Default,
+                "force_f32 raw={raw:?}"
+            );
+        }
+        // Non-truthy / empty raw does not force F32.
+        for raw in [None, Some("0"), Some("false"), Some("off"), Some("maybe")] {
+            assert_eq!(
+                resolve_production_llm_kv_cache_policy(
+                    GgmlCpuGraphBackend::Cpu,
+                    128,
+                    true,
+                    true,
+                    raw,
+                ),
+                LlmKvCachePolicy::Q8_0,
+                "force_f32 raw={raw:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wire the existing phase-1 `q8_0` LLM KV-cache path into production whole-decoder construction for shared Qwen-shaped stacks on CPU and Metal.

## Why

Phase-1 Q8 KV support already existed (`LlmKvCacheSpec::Q8_0`, host/resident packing, graph compose validation), but `set_kv_cache_policy` had no production caller, so every family kept host-F32 / resident-F16. Wiring it cuts long-prompt / longform KV RAM on the backends that already validate Q8 (CPU/Metal + native-GQA + flash). Discrete GPU stays on the existing Default path and continues to fail closed if Q8 is requested.

## Changes

- Add shared production policy selector `resolve_production_llm_kv_cache_policy` (+ env wrapper) in `nn/decoder.rs`.
- Apply it once in `Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_adapter` via `set_kv_cache_policy`, so qwen / mimo / firered2-llm / moss / hymt2 / serve-batch all inherit the same choice.
- Default: `Q8_0` when backend is CPU or Metal, native GQA is on, flash geometry is allowed, and `head_dim` is Q8-valid.
- Opt-out: `OPENASR_QWEN_KV_CACHE_F32=1` (truthy forms) forces host-F32 / resident-F16 for golden/parity pins.
- Discrete GPU (`GgmlCpuGraphBackend::Gpu`: CUDA/HIP/Vulkan) remains Default; existing `validate_execution` still rejects Q8 there.
- Align host KV allocation in hymt2 and qwen serve-batch with `kv_cache_spec().host` / the shared selector.
- Manual prefill-parity harnesses pin Default so F32 history helpers stay valid.
- Matrix unit test covering backend x env x gqa/flash/head_dim (no weights).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`
- [x] `cargo test -p openasr-core --lib llm_kv_cache`
- [x] `cargo test -p openasr-core --lib kv_element`
- [x] `cargo test -p openasr-core --lib models::qwen::kv_cache`
- [x] `cargo test -p openasr-core --lib models::qwen::llm_transformer`
- [x] `cargo test -p openasr-core --lib models::qwen::batched_decode`
- [x] `cargo test -p openasr-core --lib models::hymt2`
- [x] `cargo test -p openasr-core --lib resident_kv_arena`

## Manual smoke checks

None in this PR (no RTF/WER). Use `OPENASR_QWEN_KV_CACHE_F32=1` to pin F32 for any local golden/parity comparison.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No catalog RTF/RAM number changes.
- No short-audio quality gate / WER freeze (follow-up before treating Q8 as unconditional product default in audit forms).
- No discrete-GPU Q8 enablement.
- No audit-form edits.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implementation assistance; human owns review and maintenance.