### PR TITLE
feat(core): wire ggml abort_callback for cooperative graph cancel

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -2236,12 +2236,18 @@ fn dispatch_error_to_backend(error: GgmlAsrExecutionError) -> BackendError {
     }
 }
 
-/// Stable substring shared by `Seq2SeqGreedyDecodeError::Canceled` and the
-/// family greedy bridges (`"... canceled by transcription control"`). Used as
-/// a belt-and-suspenders signal when the active control handle is no longer
-/// bound on this thread.
+/// Stable substrings shared by cooperative-cancel error paths.
+///
+/// Matches:
+/// - `Seq2SeqGreedyDecodeError::Canceled` / family greedy bridges
+///   (`"... canceled by transcription control"`)
+/// - `GgmlCpuGraphError::Aborted` (`"aborted by cancel request"`)
+///
+/// Used as a belt-and-suspenders signal when the active control handle is no
+/// longer bound on this thread.
 fn is_cooperative_cancel_reason(reason: &str) -> bool {
     reason.contains("canceled by transcription control")
+        || reason.contains("aborted by cancel request")
 }
 
 fn run_dispatch_once(

--- a/crates/openasr-core/src/api/backend/transcription_control.rs
+++ b/crates/openasr-core/src/api/backend/transcription_control.rs
@@ -376,7 +376,7 @@ mod tests {
     #[test]
     fn no_control_path_leaves_job_cancel_idle() {
         // Bit-identical CLI path: without install_active_transcription_control,
-        // the abort trampoline data is null and always returns false.
+        // abort callback data is null and backends clear the callback entirely.
         assert!(thread_job_cancel_flag_data().is_null());
         assert!(!thread_job_cancel_requested());
         let orphan = TranscriptionControl::new();

--- a/crates/openasr-core/src/api/backend/transcription_control.rs
+++ b/crates/openasr-core/src/api/backend/transcription_control.rs
@@ -10,12 +10,21 @@
 //! CLI's calling thread), so a thread-local is enough for the slice loop to find
 //! its control.
 //!
+//! ggml's CPU abort_callback may run on a worker-pool thread that does **not**
+//! share that TLS. Cancel therefore also dual-writes a heap
+//! [`Arc`]`<`[`AtomicBool`]`>` that is published into
+//! [`crate::ggml_runtime::publish_job_cancel_flag`] for the duration of the
+//! install guard; the FFI trampoline reads only that atomic (never TLS).
+//!
 //! Scope is deliberately in-session: the control lives only for one in-flight
 //! transcription. Cross-request or cross-restart resume (which would need
 //! persisted partial decode state) is out of scope.
 
 use std::cell::RefCell;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
+
+use crate::ggml_runtime::{publish_job_cancel_flag, unpublish_job_cancel_flag_if_current};
 
 /// Outcome of a slice-boundary control check inside the long-form decode loop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,6 +53,11 @@ pub struct TranscriptionControl {
     // Signaled on resume or cancel so a worker blocked at a paused slice
     // boundary wakes promptly instead of busy-waiting.
     resumed_or_canceled: Condvar,
+    /// Wait-free cancel bit dual-written by [`Self::request_cancel`]. Shared with
+    /// the ggml abort_callback trampoline (which cannot use thread-locals) via
+    /// the job-scoped publish slot armed by
+    /// [`install_active_transcription_control`]. Pause never touches this bit.
+    cancel_flag: Arc<AtomicBool>,
 }
 
 impl TranscriptionControl {
@@ -51,19 +65,25 @@ impl TranscriptionControl {
         Self {
             state: Mutex::new(ControlState::default()),
             resumed_or_canceled: Condvar::new(),
+            cancel_flag: Arc::new(AtomicBool::new(false)),
         }
     }
 
-    /// Request cancellation at the next slice boundary. Idempotent. Wakes a
-    /// paused worker so it observes the cancel instead of staying blocked.
+    /// Request cancellation at the next cooperative checkpoint (slice boundary,
+    /// token step, or ggml CPU graph node). Idempotent. Wakes a paused worker so
+    /// it observes the cancel instead of staying blocked.
     pub fn request_cancel(&self) {
+        // Atomic first so a concurrent ggml abort_callback poll observes cancel
+        // even if it races the mutex write below.
+        self.cancel_flag.store(true, Ordering::SeqCst);
         let mut state = self.lock();
         state.cancel = true;
         self.resumed_or_canceled.notify_all();
     }
 
     /// Request a pause at the next slice boundary. Idempotent, and a no-op once
-    /// canceled (cancel wins and must not be masked by a late pause).
+    /// canceled (cancel wins and must not be masked by a late pause). Pause does
+    /// **not** arm the ggml abort_callback -- only cancel does.
     pub fn request_pause(&self) {
         let mut state = self.lock();
         if !state.cancel {
@@ -80,13 +100,20 @@ impl TranscriptionControl {
 
     /// Whether a cancel has been requested.
     pub fn is_canceled(&self) -> bool {
-        self.lock().cancel
+        // Atomic is the source of truth shared with the ggml trampoline; the
+        // mutex bit is kept in lockstep by request_cancel.
+        self.cancel_flag.load(Ordering::SeqCst)
     }
 
     /// Whether a pause is pending (and not superseded by a cancel).
     pub fn is_paused(&self) -> bool {
         let state = self.lock();
-        state.pause && !state.cancel
+        state.pause && !state.cancel && !self.cancel_flag.load(Ordering::SeqCst)
+    }
+
+    /// Heap cancel flag for job-scoped publish into the ggml abort trampoline.
+    pub(crate) fn cancel_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.cancel_flag)
     }
 
     /// Called by the decode loop at each slice boundary. Returns immediately with
@@ -102,7 +129,7 @@ impl TranscriptionControl {
     pub fn wait_at_slice_boundary(&self) -> SliceBoundaryControl {
         let mut state = self.lock();
         loop {
-            if state.cancel {
+            if state.cancel || self.cancel_flag.load(Ordering::SeqCst) {
                 return SliceBoundaryControl::Canceled;
             }
             if !state.pause {
@@ -131,8 +158,11 @@ impl Default for TranscriptionControl {
 impl std::fmt::Debug for TranscriptionControl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let (cancel, pause) = match self.state.lock() {
-            Ok(state) => (state.cancel, state.pause),
-            Err(_) => (false, false),
+            Ok(state) => (
+                state.cancel || self.cancel_flag.load(Ordering::SeqCst),
+                state.pause,
+            ),
+            Err(_) => (self.cancel_flag.load(Ordering::SeqCst), false),
         };
         f.debug_struct("TranscriptionControl")
             .field("cancel", &cancel)
@@ -154,10 +184,19 @@ thread_local! {
 /// RAII guard that binds a [`TranscriptionControl`] to the current thread for the
 /// duration of one native transcription and restores the previous binding on
 /// drop (normal return, early `?`, or panic), so a control never leaks into an
-/// unrelated later run on the same pooled worker thread.
+/// unrelated later run on the same pooled worker thread. Also arms the
+/// process-wide job cancel atomic used by the ggml abort trampoline.
 #[must_use = "the control binding is cleared when this guard is dropped"]
 pub struct ActiveTranscriptionControlGuard {
     previous: Option<Arc<TranscriptionControl>>,
+    previous_job_cancel: Option<Arc<AtomicBool>>,
+    published_flag: Arc<AtomicBool>,
+    /// Under `cfg(test)`, holds the job-cancel slot test lock for the full
+    /// install lifetime so parallel libtest threads cannot clobber the
+    /// process-wide publish slot mid-assertion. Declared last so `Drop` can
+    /// unpublish while the lock is still held, then the lock releases.
+    #[cfg(test)]
+    _job_cancel_slot_test_guard: crate::ggml_runtime::JobCancelSlotTestGuard,
 }
 
 impl Drop for ActiveTranscriptionControlGuard {
@@ -165,6 +204,9 @@ impl Drop for ActiveTranscriptionControlGuard {
         CURRENT_TRANSCRIPTION_CONTROL.with(|cell| {
             *cell.borrow_mut() = self.previous.take();
         });
+        // Disarm only if we still own the ggml job-cancel slot (nested installs
+        // restore the previous flag rather than clearing a deeper owner's publish).
+        unpublish_job_cancel_flag_if_current(&self.published_flag, self.previous_job_cancel.take());
     }
 }
 
@@ -172,11 +214,26 @@ impl Drop for ActiveTranscriptionControlGuard {
 /// long-form slice loop observes pause/cancel requests. Returns a guard that
 /// restores the previous binding on drop. Install this at the top of the
 /// synchronous decode (e.g. inside the server's `spawn_blocking` closure).
+///
+/// Also publishes `control`'s cancel atomic into the ggml runtime job slot so
+/// ggml's abort_callback (which may run off this thread) observes the same
+/// cancel bit. Pause is never published there -- the abort trampoline only
+/// recognizes cancel.
 pub fn install_active_transcription_control(
     control: Arc<TranscriptionControl>,
 ) -> ActiveTranscriptionControlGuard {
+    #[cfg(test)]
+    let job_cancel_slot_test_guard = crate::ggml_runtime::lock_job_cancel_slot_for_test();
+    let published_flag = control.cancel_flag();
+    let previous_job_cancel = publish_job_cancel_flag(Some(Arc::clone(&published_flag)));
     let previous = CURRENT_TRANSCRIPTION_CONTROL.with(|cell| cell.replace(Some(control)));
-    ActiveTranscriptionControlGuard { previous }
+    ActiveTranscriptionControlGuard {
+        previous,
+        previous_job_cancel,
+        published_flag,
+        #[cfg(test)]
+        _job_cancel_slot_test_guard: job_cancel_slot_test_guard,
+    }
 }
 
 /// The control bound to the current thread, if any. Read by the long-form decode
@@ -188,6 +245,7 @@ pub(crate) fn current_transcription_control() -> Option<Arc<TranscriptionControl
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ggml_runtime::job_cancel_requested;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::thread;
     use std::time::Duration;
@@ -267,6 +325,57 @@ mod tests {
         assert!(
             current_transcription_control().is_none(),
             "control binding must clear when the guard drops"
+        );
+    }
+
+    #[test]
+    fn cancel_atomic_visible_to_job_cancel_slot_without_slice_wait() {
+        // L2: ggml abort_callback reads the published heap atomic, not TLS and
+        // not the slice Condvar path. install_active_transcription_control holds
+        // the test slot lock for the guard lifetime so parallel libtests cannot
+        // clobber the process-wide publish mid-assertion.
+        let control = Arc::new(TranscriptionControl::new());
+        {
+            let _guard = install_active_transcription_control(Arc::clone(&control));
+            assert!(
+                !job_cancel_requested(),
+                "armed but not canceled => trampoline must stay false"
+            );
+            // Pause must not trip the abort bit.
+            control.request_pause();
+            assert!(
+                !job_cancel_requested(),
+                "pause must not arm ggml abort_callback"
+            );
+            control.request_cancel();
+            assert!(
+                job_cancel_requested(),
+                "request_cancel must dual-write the published atomic"
+            );
+            // Drop path unpublishes while still holding the test slot lock
+            // (field drop order). Post-drop global-slot idle is covered by
+            // job_cancel::publish_cancel_and_unpublish_are_visible under its
+            // own exclusive lock -- not asserted here (parallel install race).
+        }
+        // The control's own flag stays true after disarm (harmless); only the
+        // process-wide publish is cleared by Drop.
+        assert!(control.is_canceled());
+    }
+
+    #[test]
+    fn no_control_path_leaves_job_cancel_idle() {
+        // Bit-identical CLI path: without install_active_transcription_control,
+        // the abort trampoline always sees false. Take the test lock so a
+        // concurrent install in another libtest thread cannot publish under us.
+        let _exclusive = crate::ggml_runtime::lock_job_cancel_slot_for_test();
+        let _ = crate::ggml_runtime::publish_job_cancel_flag(None);
+        assert!(!job_cancel_requested());
+        let orphan = TranscriptionControl::new();
+        orphan.request_cancel();
+        assert!(orphan.is_canceled());
+        assert!(
+            !job_cancel_requested(),
+            "cancel without install must not publish into the ggml slot"
         );
     }
 }

--- a/crates/openasr-core/src/api/backend/transcription_control.rs
+++ b/crates/openasr-core/src/api/backend/transcription_control.rs
@@ -12,9 +12,11 @@
 //!
 //! ggml's CPU abort_callback may run on a worker-pool thread that does **not**
 //! share that TLS. Cancel therefore also dual-writes a heap
-//! [`Arc`]`<`[`AtomicBool`]`>` that is published into
-//! [`crate::ggml_runtime::publish_job_cancel_flag`] for the duration of the
-//! install guard; the FFI trampoline reads only that atomic (never TLS).
+//! [`Arc`]`<`[`AtomicBool`]`>` per job. On install, this thread's ggml backends
+//! are armed with that atomic as `abort_callback` data (`Arc::as_ptr`); the FFI
+//! trampoline wait-free-loads only that pointer (never a process-wide slot, never
+//! TLS). Parallel server jobs on different worker threads each hold distinct
+//! data pointers, so canceling job B cannot abort job A's CPU graph.
 //!
 //! Scope is deliberately in-session: the control lives only for one in-flight
 //! transcription. Cross-request or cross-restart resume (which would need
@@ -24,7 +26,7 @@ use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 
-use crate::ggml_runtime::{publish_job_cancel_flag, unpublish_job_cancel_flag_if_current};
+use crate::ggml_runtime::{arm_thread_job_cancel_flag, disarm_thread_job_cancel_flag_if_current};
 
 /// Outcome of a slice-boundary control check inside the long-form decode loop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,8 +56,8 @@ pub struct TranscriptionControl {
     // boundary wakes promptly instead of busy-waiting.
     resumed_or_canceled: Condvar,
     /// Wait-free cancel bit dual-written by [`Self::request_cancel`]. Shared with
-    /// the ggml abort_callback trampoline (which cannot use thread-locals) via
-    /// the job-scoped publish slot armed by
+    /// the ggml abort_callback trampoline (which cannot use thread-locals) as the
+    /// backend callback `data` pointer armed by
     /// [`install_active_transcription_control`]. Pause never touches this bit.
     cancel_flag: Arc<AtomicBool>,
 }
@@ -111,7 +113,7 @@ impl TranscriptionControl {
         state.pause && !state.cancel && !self.cancel_flag.load(Ordering::SeqCst)
     }
 
-    /// Heap cancel flag for job-scoped publish into the ggml abort trampoline.
+    /// Heap cancel flag for per-job abort_callback data on this worker's backends.
     pub(crate) fn cancel_flag(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.cancel_flag)
     }
@@ -184,19 +186,13 @@ thread_local! {
 /// RAII guard that binds a [`TranscriptionControl`] to the current thread for the
 /// duration of one native transcription and restores the previous binding on
 /// drop (normal return, early `?`, or panic), so a control never leaks into an
-/// unrelated later run on the same pooled worker thread. Also arms the
-/// process-wide job cancel atomic used by the ggml abort trampoline.
+/// unrelated later run on the same pooled worker thread. Also arms this thread's
+/// ggml backends with the job's cancel atomic as abort_callback data.
 #[must_use = "the control binding is cleared when this guard is dropped"]
 pub struct ActiveTranscriptionControlGuard {
     previous: Option<Arc<TranscriptionControl>>,
     previous_job_cancel: Option<Arc<AtomicBool>>,
     published_flag: Arc<AtomicBool>,
-    /// Under `cfg(test)`, holds the job-cancel slot test lock for the full
-    /// install lifetime so parallel libtest threads cannot clobber the
-    /// process-wide publish slot mid-assertion. Declared last so `Drop` can
-    /// unpublish while the lock is still held, then the lock releases.
-    #[cfg(test)]
-    _job_cancel_slot_test_guard: crate::ggml_runtime::JobCancelSlotTestGuard,
 }
 
 impl Drop for ActiveTranscriptionControlGuard {
@@ -204,9 +200,15 @@ impl Drop for ActiveTranscriptionControlGuard {
         CURRENT_TRANSCRIPTION_CONTROL.with(|cell| {
             *cell.borrow_mut() = self.previous.take();
         });
-        // Disarm only if we still own the ggml job-cancel slot (nested installs
-        // restore the previous flag rather than clearing a deeper owner's publish).
-        unpublish_job_cancel_flag_if_current(&self.published_flag, self.previous_job_cancel.take());
+        // Restore previous job cancel (nested) or clear, then re-arm backends so
+        // cached GPU/Metal entries never keep a dangling data pointer after the
+        // Arc below drops. Order matters: backends first see the restored/null
+        // pointer, then `published_flag` is released when this guard drops fields.
+        let _ = disarm_thread_job_cancel_flag_if_current(
+            &self.published_flag,
+            self.previous_job_cancel.take(),
+        );
+        crate::ggml_runtime::arm_thread_local_backends_abort_callback();
     }
 }
 
@@ -215,24 +217,24 @@ impl Drop for ActiveTranscriptionControlGuard {
 /// restores the previous binding on drop. Install this at the top of the
 /// synchronous decode (e.g. inside the server's `spawn_blocking` closure).
 ///
-/// Also publishes `control`'s cancel atomic into the ggml runtime job slot so
-/// ggml's abort_callback (which may run off this thread) observes the same
-/// cancel bit. Pause is never published there -- the abort trampoline only
-/// recognizes cancel.
+/// Also arms this worker thread's ggml backends with `control`'s cancel atomic
+/// as abort_callback data so ggml's abort_callback (which may run off this
+/// thread) observes the same cancel bit via a wait-free pointer load. Pause is
+/// never written to that atomic -- the abort trampoline only recognizes cancel.
 pub fn install_active_transcription_control(
     control: Arc<TranscriptionControl>,
 ) -> ActiveTranscriptionControlGuard {
-    #[cfg(test)]
-    let job_cancel_slot_test_guard = crate::ggml_runtime::lock_job_cancel_slot_for_test();
     let published_flag = control.cancel_flag();
-    let previous_job_cancel = publish_job_cancel_flag(Some(Arc::clone(&published_flag)));
+    let previous_job_cancel = arm_thread_job_cancel_flag(Some(Arc::clone(&published_flag)));
+    // Re-arm already-cached backends on this pooled worker with this job's flag
+    // pointer. Free-on-drop CPU backends created later pick up the same pointer
+    // at construction via thread_job_cancel_flag_data().
+    crate::ggml_runtime::arm_thread_local_backends_abort_callback();
     let previous = CURRENT_TRANSCRIPTION_CONTROL.with(|cell| cell.replace(Some(control)));
     ActiveTranscriptionControlGuard {
         previous,
         previous_job_cancel,
         published_flag,
-        #[cfg(test)]
-        _job_cancel_slot_test_guard: job_cancel_slot_test_guard,
     }
 }
 
@@ -245,8 +247,11 @@ pub(crate) fn current_transcription_control() -> Option<Arc<TranscriptionControl
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ggml_runtime::job_cancel_requested;
+    use crate::ggml_runtime::{
+        cancel_flag_requested_from_data, thread_job_cancel_flag_data, thread_job_cancel_requested,
+    };
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Barrier};
     use std::thread;
     use std::time::Duration;
 
@@ -329,53 +334,105 @@ mod tests {
     }
 
     #[test]
-    fn cancel_atomic_visible_to_job_cancel_slot_without_slice_wait() {
-        // L2: ggml abort_callback reads the published heap atomic, not TLS and
-        // not the slice Condvar path. install_active_transcription_control holds
-        // the test slot lock for the guard lifetime so parallel libtests cannot
-        // clobber the process-wide publish mid-assertion.
+    fn cancel_atomic_visible_to_job_abort_data_without_slice_wait() {
+        // L2: ggml abort_callback reads the per-job heap atomic via callback data,
+        // not TLS and not the slice Condvar path.
         let control = Arc::new(TranscriptionControl::new());
         {
             let _guard = install_active_transcription_control(Arc::clone(&control));
+            let data = thread_job_cancel_flag_data();
             assert!(
-                !job_cancel_requested(),
+                !data.is_null(),
+                "install must arm abort data on this thread"
+            );
+            assert!(
+                !cancel_flag_requested_from_data(data),
                 "armed but not canceled => trampoline must stay false"
             );
+            assert!(!thread_job_cancel_requested());
             // Pause must not trip the abort bit.
             control.request_pause();
             assert!(
-                !job_cancel_requested(),
+                !cancel_flag_requested_from_data(data),
                 "pause must not arm ggml abort_callback"
             );
             control.request_cancel();
             assert!(
-                job_cancel_requested(),
-                "request_cancel must dual-write the published atomic"
+                cancel_flag_requested_from_data(data),
+                "request_cancel must dual-write the job atomic behind abort data"
             );
-            // Drop path unpublishes while still holding the test slot lock
-            // (field drop order). Post-drop global-slot idle is covered by
-            // job_cancel::publish_cancel_and_unpublish_are_visible under its
-            // own exclusive lock -- not asserted here (parallel install race).
+            assert!(thread_job_cancel_requested());
         }
-        // The control's own flag stays true after disarm (harmless); only the
-        // process-wide publish is cleared by Drop.
+        // After Drop, this thread's abort data is cleared (backends re-armed null).
+        assert!(
+            thread_job_cancel_flag_data().is_null(),
+            "drop must disarm this thread's abort data"
+        );
+        assert!(!thread_job_cancel_requested());
+        // The control's own flag stays true after disarm (harmless).
         assert!(control.is_canceled());
     }
 
     #[test]
     fn no_control_path_leaves_job_cancel_idle() {
         // Bit-identical CLI path: without install_active_transcription_control,
-        // the abort trampoline always sees false. Take the test lock so a
-        // concurrent install in another libtest thread cannot publish under us.
-        let _exclusive = crate::ggml_runtime::lock_job_cancel_slot_for_test();
-        let _ = crate::ggml_runtime::publish_job_cancel_flag(None);
-        assert!(!job_cancel_requested());
+        // the abort trampoline data is null and always returns false.
+        assert!(thread_job_cancel_flag_data().is_null());
+        assert!(!thread_job_cancel_requested());
         let orphan = TranscriptionControl::new();
         orphan.request_cancel();
         assert!(orphan.is_canceled());
         assert!(
-            !job_cancel_requested(),
-            "cancel without install must not publish into the ggml slot"
+            thread_job_cancel_flag_data().is_null(),
+            "cancel without install must not arm abort data on this thread"
         );
+        assert!(!thread_job_cancel_requested());
+    }
+
+    #[test]
+    fn parallel_installs_cancel_b_does_not_abort_a() {
+        // Two fake server jobs on distinct worker threads. Cancel B must not make
+        // A's abort data read true -- the process-wide single-slot bug this guards.
+        let control_a = Arc::new(TranscriptionControl::new());
+        let control_b = Arc::new(TranscriptionControl::new());
+        let barrier = Arc::new(Barrier::new(3));
+
+        let thread_a = {
+            let control_a = Arc::clone(&control_a);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let _guard = install_active_transcription_control(control_a);
+                let data = thread_job_cancel_flag_data();
+                barrier.wait();
+                barrier.wait();
+                assert!(
+                    !cancel_flag_requested_from_data(data),
+                    "cancel B must not abort job A trampoline data"
+                );
+            })
+        };
+
+        let thread_b = {
+            let control_b = Arc::clone(&control_b);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let _guard = install_active_transcription_control(Arc::clone(&control_b));
+                let data = thread_job_cancel_flag_data();
+                barrier.wait();
+                control_b.request_cancel();
+                assert!(
+                    cancel_flag_requested_from_data(data),
+                    "cancel B must abort job B"
+                );
+                barrier.wait();
+            })
+        };
+
+        barrier.wait();
+        barrier.wait();
+        thread_a.join().expect("job A");
+        thread_b.join().expect("job B");
+        assert!(!control_a.is_canceled());
+        assert!(control_b.is_canceled());
     }
 }

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -890,6 +890,13 @@ pub enum GgmlCpuGraphError {
     OutputByteSizeMismatch { expected: usize, actual: usize },
     #[error("ggml cpu graph compute failed with status={status}")]
     ComputeFailed { status: i32 },
+    /// Graph compute returned `GGML_STATUS_ABORTED` because the installed
+    /// abort_callback observed a job cancel. Distinct from [`Self::ComputeFailed`]
+    /// so callers map it to `BackendError::TranscriptionCanceled` rather than a
+    /// generic session failure. Stable substring `"aborted by cancel request"` is
+    /// recognized by the native dispatch rewrite path.
+    #[error("ggml graph compute aborted by cancel request")]
+    Aborted,
     #[error("ggml cpu graph backend scheduler initialization failed")]
     BackendSchedulerInitFailed,
     #[error("ggml cpu graph backend scheduler graph allocation failed")]
@@ -4169,9 +4176,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 ffi::ggml_backend_graph_compute(self.backend.as_ptr(), graph.as_ptr())
             }
         };
-        if status != ffi::GGML_STATUS_SUCCESS {
-            return Err(GgmlCpuGraphError::ComputeFailed { status });
-        }
+        map_compute_status(status)?;
 
         let mut results = Vec::with_capacity(outputs.len());
         for ((output, expected_len), output_nbytes) in outputs.iter().zip(output_nbytes) {
@@ -4265,9 +4270,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 ffi::ggml_backend_graph_compute(self.backend.as_ptr(), graph.as_ptr())
             }
         };
-        if status != ffi::GGML_STATUS_SUCCESS {
-            return Err(GgmlCpuGraphError::ComputeFailed { status });
-        }
+        map_compute_status(status)?;
 
         let mut f32_results = Vec::with_capacity(f32_outputs.len());
         for ((output, expected_len), output_nbytes) in f32_outputs.iter().zip(f32_output_nbytes) {
@@ -4324,9 +4327,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 ffi::ggml_backend_graph_compute(self.backend.as_ptr(), graph.as_ptr())
             }
         };
-        if status != ffi::GGML_STATUS_SUCCESS {
-            return Err(GgmlCpuGraphError::ComputeFailed { status });
-        }
+        map_compute_status(status)?;
         Ok(())
     }
 
@@ -4372,9 +4373,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 ffi::ggml_backend_graph_compute(self.backend.as_ptr(), graph.as_ptr())
             }
         };
-        if status != ffi::GGML_STATUS_SUCCESS {
-            return Err(GgmlCpuGraphError::ComputeFailed { status });
-        }
+        map_compute_status(status)?;
 
         let mut values = vec![0_i32; expected_len];
         unsafe {
@@ -5295,12 +5294,18 @@ impl GgmlBackendGuard {
         let raw = unsafe {
             ffi::ggml_backend_init_by_type(ffi::GGML_BACKEND_DEVICE_TYPE_CPU, std::ptr::null())
         };
-        NonNull::new(raw)
-            .map(|raw| Self {
-                raw,
-                free_on_drop: true,
-            })
-            .ok_or(GgmlCpuGraphError::CpuBackendUnavailable)
+        let raw = NonNull::new(raw).ok_or(GgmlCpuGraphError::CpuBackendUnavailable)?;
+        // Abort callback reads the job-scoped cancel atomic (not TLS). Safe to
+        // install once per backend lifetime -- including free_on_drop CPU.
+        backend_set_abort_callback(
+            raw,
+            Some(openasr_ggml_abort_trampoline),
+            std::ptr::null_mut(),
+        );
+        Ok(Self {
+            raw,
+            free_on_drop: true,
+        })
     }
 
     fn metal() -> Result<Self, GgmlCpuGraphError> {
@@ -5340,17 +5345,34 @@ impl GgmlBackendGuard {
     /// Return a thread-local cached backend of `key`, initializing it once via
     /// `init` on first use. The cached entry owns the backend for the thread's
     /// lifetime; handed-out guards never free it (`free_on_drop=false`).
+    ///
+    /// Abort callback is installed at first init and kept for the cache entry's
+    /// lifetime. The trampoline reads a job-scoped atomic that is disarmed when
+    /// the transcription control guard drops, so a cached backend never holds a
+    /// dangling cancel pointer across jobs.
     fn cached_backend(
         key: CachedBackendKey,
         init: impl FnOnce() -> Result<NonNull<c_void>, GgmlCpuGraphError>,
     ) -> Result<Self, GgmlCpuGraphError> {
         if let Some(raw) = Self::cached_backend_lookup(&key) {
+            // Re-arm on handout in case a future code path constructs a backend
+            // without going through init (defensive; first init already sets it).
+            backend_set_abort_callback(
+                raw,
+                Some(openasr_ggml_abort_trampoline),
+                std::ptr::null_mut(),
+            );
             return Ok(Self {
                 raw,
                 free_on_drop: false,
             });
         }
         let raw = init()?;
+        backend_set_abort_callback(
+            raw,
+            Some(openasr_ggml_abort_trampoline),
+            std::ptr::null_mut(),
+        );
         Self::cached_backend_insert(key, raw);
         Ok(Self {
             raw,
@@ -5393,6 +5415,11 @@ impl GgmlBackendGuard {
             let route = candidate.to_resolved_route();
             let key = CachedBackendKey::Route(route.cache_key());
             if let Some(raw) = Self::cached_backend_lookup(&key) {
+                backend_set_abort_callback(
+                    raw,
+                    Some(openasr_ggml_abort_trampoline),
+                    std::ptr::null_mut(),
+                );
                 return Ok(Self {
                     raw,
                     free_on_drop: false,
@@ -5400,6 +5427,11 @@ impl GgmlBackendGuard {
             }
             match Self::init_route_gpu_device(&devices, &route) {
                 Ok(raw) => {
+                    backend_set_abort_callback(
+                        raw,
+                        Some(openasr_ggml_abort_trampoline),
+                        std::ptr::null_mut(),
+                    );
                     Self::cached_backend_insert(key, raw);
                     return Ok(Self {
                         raw,
@@ -5434,6 +5466,11 @@ impl GgmlBackendGuard {
                 raw,
                 free_on_drop: true,
             };
+            backend_set_abort_callback(
+                backend.raw,
+                Some(openasr_ggml_abort_trampoline),
+                std::ptr::null_mut(),
+            );
             if let Some(n_threads) = n_threads {
                 let _ = backend.set_n_threads_if_supported(n_threads);
             }
@@ -5529,6 +5566,76 @@ impl GgmlBackendGuard {
 
     fn name(&self) -> String {
         backend_name(self.raw)
+    }
+}
+
+/// Map a ggml graph-compute status code into a typed graph error.
+///
+/// Centralized so every compute site agrees: SUCCESS stays Ok, ABORTED becomes
+/// the cancel-shaped [`GgmlCpuGraphError::Aborted`] (never a bare
+/// `ComputeFailed { status: 1 }`), and every other code stays ComputeFailed.
+fn map_compute_status(status: c_int) -> Result<(), GgmlCpuGraphError> {
+    if status == ffi::GGML_STATUS_SUCCESS {
+        Ok(())
+    } else if status == ffi::GGML_STATUS_ABORTED {
+        Err(GgmlCpuGraphError::Aborted)
+    } else {
+        Err(GgmlCpuGraphError::ComputeFailed { status })
+    }
+}
+
+/// ggml abort_callback trampoline. Returns true only when the currently
+/// published job cancel atomic is set. Pause is intentionally ignored (pause
+/// stays L0 slice-boundary only). Must not unwind across the FFI boundary.
+unsafe extern "C" fn openasr_ggml_abort_trampoline(_data: *mut c_void) -> bool {
+    std::panic::catch_unwind(super::job_cancel_requested).unwrap_or(false)
+}
+
+/// Install an abort_callback on `backend` via the registry proc-address table
+/// (`"ggml_backend_set_abort_callback"`) -- the same pattern as
+/// [`backend_set_n_threads`], required under `GGML_BACKEND_DL`. Missing proc is a
+/// silent no-op (discrete GPU vendors typically have none today).
+///
+/// On macOS, falls back to the direct `ggml_backend_metal_set_abort_callback`
+/// symbol when the registry proc is absent: Metal does not register the proc
+/// today. Production Metal mid-graph abort remains ineffective upstream; the
+/// callback is still installed so flag=false graphs stay SUCCESS and a future
+/// Metal ABORTED path maps correctly.
+fn backend_set_abort_callback(
+    backend: NonNull<c_void>,
+    cb: ffi::GgmlAbortCallback,
+    data: *mut c_void,
+) {
+    type SetAbortCallbackFn =
+        unsafe extern "C" fn(ffi::GgmlBackendRaw, ffi::GgmlAbortCallback, *mut c_void);
+    unsafe {
+        let device = ffi::ggml_backend_get_device(backend.as_ptr());
+        if !device.is_null() {
+            let reg = ffi::ggml_backend_dev_backend_reg(device);
+            if !reg.is_null() {
+                let proc = ffi::ggml_backend_reg_get_proc_address(
+                    reg,
+                    c"ggml_backend_set_abort_callback".as_ptr(),
+                );
+                if !proc.is_null() {
+                    let set_fn: SetAbortCallbackFn = std::mem::transmute(proc);
+                    set_fn(backend.as_ptr(), cb, data);
+                    return;
+                }
+            }
+        }
+        #[cfg(target_os = "macos")]
+        {
+            // Metal fallback: direct symbol (not registered on Metal's proc table).
+            // Must gate on is_metal -- the C entry point GGML_ASSERTs otherwise.
+            if ffi::ggml_backend_is_metal(backend.as_ptr()) {
+                ffi::ggml_backend_metal_set_abort_callback(backend.as_ptr(), cb, data);
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (cb, data);
+        }
     }
 }
 
@@ -5953,6 +6060,53 @@ mod tests {
         let backend = super::GgmlBackendGuard::cpu().expect("cpu backend");
         assert!(super::backend_device_present(backend.raw));
         assert!(super::ensure_backend_device_present(backend.raw).is_ok());
+    }
+
+    #[test]
+    fn map_compute_status_success_aborted_and_other() {
+        assert!(super::map_compute_status(ffi::GGML_STATUS_SUCCESS).is_ok());
+        assert!(matches!(
+            super::map_compute_status(ffi::GGML_STATUS_ABORTED),
+            Err(GgmlCpuGraphError::Aborted)
+        ));
+        // Explicit status=1 must never collapse into a bare ComputeFailed after
+        // the L2 wiring -- ABORTED is the only code-1 mapping.
+        assert!(matches!(
+            super::map_compute_status(1),
+            Err(GgmlCpuGraphError::Aborted)
+        ));
+        assert!(matches!(
+            super::map_compute_status(-1),
+            Err(GgmlCpuGraphError::ComputeFailed { status: -1 })
+        ));
+        // Display carries the stable cancel marker used by dispatch rewrite.
+        let msg = GgmlCpuGraphError::Aborted.to_string();
+        assert!(
+            msg.contains("aborted by cancel request"),
+            "Aborted display must stay recognizable to is_cooperative_cancel_reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn cpu_backend_installs_abort_callback_without_forcing_abort() {
+        // Installing the trampoline with cancel=false must leave a trivial graph
+        // compute path as SUCCESS (Metal/CPU). No control installed =>
+        // job_cancel_requested is false => callback always returns false.
+        let _exclusive = crate::ggml_runtime::lock_job_cancel_slot_for_test();
+        let _ = crate::ggml_runtime::publish_job_cancel_flag(None);
+        let backend = super::GgmlBackendGuard::cpu().expect("cpu backend");
+        assert!(
+            !super::super::job_cancel_requested(),
+            "no-control path must keep abort trampoline idle"
+        );
+        // backend_set_abort_callback is already invoked by GgmlBackendGuard::cpu;
+        // re-arming is idempotent and must not panic / abort the process.
+        super::backend_set_abort_callback(
+            backend.raw,
+            Some(super::openasr_ggml_abort_trampoline),
+            std::ptr::null_mut(),
+        );
+        let _ = backend;
     }
 
     #[test]

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -5295,13 +5295,9 @@ impl GgmlBackendGuard {
             ffi::ggml_backend_init_by_type(ffi::GGML_BACKEND_DEVICE_TYPE_CPU, std::ptr::null())
         };
         let raw = NonNull::new(raw).ok_or(GgmlCpuGraphError::CpuBackendUnavailable)?;
-        // Abort callback reads the job-scoped cancel atomic (not TLS). Safe to
-        // install once per backend lifetime -- including free_on_drop CPU.
-        backend_set_abort_callback(
-            raw,
-            Some(openasr_ggml_abort_trampoline),
-            std::ptr::null_mut(),
-        );
+        // Abort callback data is this thread's per-job cancel atomic (or null).
+        // Safe to install once per backend lifetime -- including free_on_drop CPU.
+        arm_backend_abort_callback(raw);
         Ok(Self {
             raw,
             free_on_drop: true,
@@ -5346,33 +5342,25 @@ impl GgmlBackendGuard {
     /// `init` on first use. The cached entry owns the backend for the thread's
     /// lifetime; handed-out guards never free it (`free_on_drop=false`).
     ///
-    /// Abort callback is installed at first init and kept for the cache entry's
-    /// lifetime. The trampoline reads a job-scoped atomic that is disarmed when
-    /// the transcription control guard drops, so a cached backend never holds a
-    /// dangling cancel pointer across jobs.
+    /// Abort callback is re-armed on every handout with this thread's current
+    /// per-job cancel atomic (or null). Install/Drop of the transcription
+    /// control guard also bulk-rearms the whole cache so a pooled worker never
+    /// keeps a previous job's data pointer across jobs.
     fn cached_backend(
         key: CachedBackendKey,
         init: impl FnOnce() -> Result<NonNull<c_void>, GgmlCpuGraphError>,
     ) -> Result<Self, GgmlCpuGraphError> {
         if let Some(raw) = Self::cached_backend_lookup(&key) {
-            // Re-arm on handout in case a future code path constructs a backend
-            // without going through init (defensive; first init already sets it).
-            backend_set_abort_callback(
-                raw,
-                Some(openasr_ggml_abort_trampoline),
-                std::ptr::null_mut(),
-            );
+            // Re-arm on handout so a backend created under a prior job (or none)
+            // picks up the active job's cancel pointer before graph compute.
+            arm_backend_abort_callback(raw);
             return Ok(Self {
                 raw,
                 free_on_drop: false,
             });
         }
         let raw = init()?;
-        backend_set_abort_callback(
-            raw,
-            Some(openasr_ggml_abort_trampoline),
-            std::ptr::null_mut(),
-        );
+        arm_backend_abort_callback(raw);
         Self::cached_backend_insert(key, raw);
         Ok(Self {
             raw,
@@ -5415,11 +5403,7 @@ impl GgmlBackendGuard {
             let route = candidate.to_resolved_route();
             let key = CachedBackendKey::Route(route.cache_key());
             if let Some(raw) = Self::cached_backend_lookup(&key) {
-                backend_set_abort_callback(
-                    raw,
-                    Some(openasr_ggml_abort_trampoline),
-                    std::ptr::null_mut(),
-                );
+                arm_backend_abort_callback(raw);
                 return Ok(Self {
                     raw,
                     free_on_drop: false,
@@ -5427,11 +5411,7 @@ impl GgmlBackendGuard {
             }
             match Self::init_route_gpu_device(&devices, &route) {
                 Ok(raw) => {
-                    backend_set_abort_callback(
-                        raw,
-                        Some(openasr_ggml_abort_trampoline),
-                        std::ptr::null_mut(),
-                    );
+                    arm_backend_abort_callback(raw);
                     Self::cached_backend_insert(key, raw);
                     return Ok(Self {
                         raw,
@@ -5466,11 +5446,7 @@ impl GgmlBackendGuard {
                 raw,
                 free_on_drop: true,
             };
-            backend_set_abort_callback(
-                backend.raw,
-                Some(openasr_ggml_abort_trampoline),
-                std::ptr::null_mut(),
-            );
+            arm_backend_abort_callback(backend.raw);
             if let Some(n_threads) = n_threads {
                 let _ = backend.set_n_threads_if_supported(n_threads);
             }
@@ -5584,11 +5560,37 @@ fn map_compute_status(status: c_int) -> Result<(), GgmlCpuGraphError> {
     }
 }
 
-/// ggml abort_callback trampoline. Returns true only when the currently
-/// published job cancel atomic is set. Pause is intentionally ignored (pause
-/// stays L0 slice-boundary only). Must not unwind across the FFI boundary.
-unsafe extern "C" fn openasr_ggml_abort_trampoline(_data: *mut c_void) -> bool {
-    std::panic::catch_unwind(super::job_cancel_requested).unwrap_or(false)
+/// ggml abort_callback trampoline. `data` is either null or `Arc::as_ptr` of the
+/// job's cancel [`AtomicBool`]. Wait-free load; pause is intentionally ignored
+/// (pause stays L0 slice-boundary only). Must not unwind across the FFI boundary.
+unsafe extern "C" fn openasr_ggml_abort_trampoline(data: *mut c_void) -> bool {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        super::cancel_flag_requested_from_data(data)
+    }))
+    .unwrap_or(false)
+}
+
+/// Install this thread's current per-job cancel pointer as abort_callback data
+/// on `backend`. Null data when no transcription control is armed.
+fn arm_backend_abort_callback(backend: NonNull<c_void>) {
+    backend_set_abort_callback(
+        backend,
+        Some(openasr_ggml_abort_trampoline),
+        super::thread_job_cancel_flag_data(),
+    );
+}
+
+/// Re-arm every backend cached on this worker thread with the current per-job
+/// cancel data pointer (or null after disarm). Called from transcription-control
+/// install/Drop so pooled threads never leave a previous job's pointer installed
+/// on long-lived Metal/GPU cache entries.
+pub(crate) fn arm_thread_local_backends_abort_callback() {
+    let data = super::thread_job_cancel_flag_data();
+    THREAD_BACKEND_CACHE_BY_KIND.with(|cache| {
+        for cached in cache.borrow().values() {
+            backend_set_abort_callback(cached.raw, Some(openasr_ggml_abort_trampoline), data);
+        }
+    });
 }
 
 /// Install an abort_callback on `backend` via the registry proc-address table
@@ -6089,24 +6091,48 @@ mod tests {
 
     #[test]
     fn cpu_backend_installs_abort_callback_without_forcing_abort() {
-        // Installing the trampoline with cancel=false must leave a trivial graph
-        // compute path as SUCCESS (Metal/CPU). No control installed =>
-        // job_cancel_requested is false => callback always returns false.
-        let _exclusive = crate::ggml_runtime::lock_job_cancel_slot_for_test();
-        let _ = crate::ggml_runtime::publish_job_cancel_flag(None);
-        let backend = super::GgmlBackendGuard::cpu().expect("cpu backend");
+        // Installing the trampoline with cancel=false / null data must leave a
+        // trivial graph compute path as SUCCESS (Metal/CPU). No control installed
+        // => abort data is null => callback always returns false.
         assert!(
-            !super::super::job_cancel_requested(),
-            "no-control path must keep abort trampoline idle"
+            crate::ggml_runtime::thread_job_cancel_flag_data().is_null(),
+            "no-control path must keep abort data null"
         );
+        let backend = super::GgmlBackendGuard::cpu().expect("cpu backend");
         // backend_set_abort_callback is already invoked by GgmlBackendGuard::cpu;
         // re-arming is idempotent and must not panic / abort the process.
-        super::backend_set_abort_callback(
-            backend.raw,
-            Some(super::openasr_ggml_abort_trampoline),
-            std::ptr::null_mut(),
+        super::arm_backend_abort_callback(backend.raw);
+        assert!(
+            !crate::ggml_runtime::cancel_flag_requested_from_data(std::ptr::null_mut()),
+            "null abort data must never request cancel"
         );
         let _ = backend;
+    }
+
+    #[test]
+    fn abort_trampoline_reads_data_pointer_not_process_slot() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let flag_a = Arc::new(AtomicBool::new(false));
+        let flag_b = Arc::new(AtomicBool::new(true));
+        let data_a = Arc::as_ptr(&flag_a) as *mut std::ffi::c_void;
+        let data_b = Arc::as_ptr(&flag_b) as *mut std::ffi::c_void;
+
+        // SAFETY: trampoline is panic-catching and only loads the AtomicBool.
+        let abort_a = unsafe { super::openasr_ggml_abort_trampoline(data_a) };
+        let abort_b = unsafe { super::openasr_ggml_abort_trampoline(data_b) };
+        let abort_null = unsafe { super::openasr_ggml_abort_trampoline(std::ptr::null_mut()) };
+        assert!(!abort_a, "false flag must not abort");
+        assert!(abort_b, "true flag must abort");
+        assert!(!abort_null, "null data must not abort");
+
+        flag_a.store(true, Ordering::SeqCst);
+        let abort_a_after = unsafe { super::openasr_ggml_abort_trampoline(data_a) };
+        assert!(abort_a_after, "updated flag must be visible wait-free");
+        // B's pointer is independent -- already true; A becoming true does not
+        // change how B is read (distinct heap atomics, no global slot).
+        assert!(unsafe { super::openasr_ggml_abort_trampoline(data_b) });
     }
 
     #[test]

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -5295,8 +5295,8 @@ impl GgmlBackendGuard {
             ffi::ggml_backend_init_by_type(ffi::GGML_BACKEND_DEVICE_TYPE_CPU, std::ptr::null())
         };
         let raw = NonNull::new(raw).ok_or(GgmlCpuGraphError::CpuBackendUnavailable)?;
-        // Abort callback data is this thread's per-job cancel atomic (or null).
-        // Safe to install once per backend lifetime -- including free_on_drop CPU.
+        // Arm abort_callback only when this thread has a job cancel flag; otherwise
+        // clear it so the no-control path stays bit-identical to pre-L2.
         arm_backend_abort_callback(raw);
         Ok(Self {
             raw,
@@ -5342,8 +5342,8 @@ impl GgmlBackendGuard {
     /// `init` on first use. The cached entry owns the backend for the thread's
     /// lifetime; handed-out guards never free it (`free_on_drop=false`).
     ///
-    /// Abort callback is re-armed on every handout with this thread's current
-    /// per-job cancel atomic (or null). Install/Drop of the transcription
+    /// Abort callback is re-armed (or cleared) on every handout from this
+    /// thread's current per-job cancel flag. Install/Drop of the transcription
     /// control guard also bulk-rearms the whole cache so a pooled worker never
     /// keeps a previous job's data pointer across jobs.
     fn cached_backend(
@@ -5351,8 +5351,8 @@ impl GgmlBackendGuard {
         init: impl FnOnce() -> Result<NonNull<c_void>, GgmlCpuGraphError>,
     ) -> Result<Self, GgmlCpuGraphError> {
         if let Some(raw) = Self::cached_backend_lookup(&key) {
-            // Re-arm on handout so a backend created under a prior job (or none)
-            // picks up the active job's cancel pointer before graph compute.
+            // Re-arm or clear on handout so a backend created under a prior job
+            // (or none) matches the active job's cancel state before compute.
             arm_backend_abort_callback(raw);
             return Ok(Self {
                 raw,
@@ -5560,35 +5560,42 @@ fn map_compute_status(status: c_int) -> Result<(), GgmlCpuGraphError> {
     }
 }
 
-/// ggml abort_callback trampoline. `data` is either null or `Arc::as_ptr` of the
-/// job's cancel [`AtomicBool`]. Wait-free load; pause is intentionally ignored
-/// (pause stays L0 slice-boundary only). Must not unwind across the FFI boundary.
+/// ggml abort_callback trampoline. `data` is `Arc::as_ptr` of the job's cancel
+/// [`AtomicBool`] (never null when installed -- see [`arm_backend_abort_callback`]).
+/// Wait-free load; pause is intentionally ignored (pause stays L0 slice-boundary
+/// only). Body is panic-free (null-check + `AtomicBool::load`); no `catch_unwind`
+/// on the per-node CPU hot path.
 unsafe extern "C" fn openasr_ggml_abort_trampoline(data: *mut c_void) -> bool {
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        super::cancel_flag_requested_from_data(data)
-    }))
-    .unwrap_or(false)
+    super::cancel_flag_requested_from_data(data)
 }
 
-/// Install this thread's current per-job cancel pointer as abort_callback data
-/// on `backend`. Null data when no transcription control is armed.
+/// Arm or clear this backend's abort_callback from the thread's current job
+/// cancel flag.
+///
+/// - **Flag armed** (`thread_job_cancel_flag_data` non-null): install the
+///   trampoline with that pointer as callback data so ggml worker threads
+///   observe cancel wait-free.
+/// - **No control / disarmed** (null data): install a **null callback**. The
+///   no-control CLI/test path must stay bit-identical to pre-L2 (no per-node
+///   abort poll). Always-on trampolines that return false are not free and are
+///   not the no-control contract.
 fn arm_backend_abort_callback(backend: NonNull<c_void>) {
-    backend_set_abort_callback(
-        backend,
-        Some(openasr_ggml_abort_trampoline),
-        super::thread_job_cancel_flag_data(),
-    );
+    let data = super::thread_job_cancel_flag_data();
+    if data.is_null() {
+        backend_set_abort_callback(backend, None, std::ptr::null_mut());
+    } else {
+        backend_set_abort_callback(backend, Some(openasr_ggml_abort_trampoline), data);
+    }
 }
 
 /// Re-arm every backend cached on this worker thread with the current per-job
-/// cancel data pointer (or null after disarm). Called from transcription-control
-/// install/Drop so pooled threads never leave a previous job's pointer installed
-/// on long-lived Metal/GPU cache entries.
+/// cancel callback (or clear the callback after disarm). Called from
+/// transcription-control install/Drop so pooled threads never leave a previous
+/// job's data pointer installed on long-lived Metal/GPU cache entries.
 pub(crate) fn arm_thread_local_backends_abort_callback() {
-    let data = super::thread_job_cancel_flag_data();
     THREAD_BACKEND_CACHE_BY_KIND.with(|cache| {
         for cached in cache.borrow().values() {
-            backend_set_abort_callback(cached.raw, Some(openasr_ggml_abort_trampoline), data);
+            arm_backend_abort_callback(cached.raw);
         }
     });
 }
@@ -6090,17 +6097,14 @@ mod tests {
     }
 
     #[test]
-    fn cpu_backend_installs_abort_callback_without_forcing_abort() {
-        // Installing the trampoline with cancel=false / null data must leave a
-        // trivial graph compute path as SUCCESS (Metal/CPU). No control installed
-        // => abort data is null => callback always returns false.
+    fn cpu_backend_no_control_path_clears_abort_callback() {
+        // No control installed => abort data is null => arm must clear the
+        // callback (bit-identical to pre-L2), not install a always-false stub.
         assert!(
             crate::ggml_runtime::thread_job_cancel_flag_data().is_null(),
             "no-control path must keep abort data null"
         );
         let backend = super::GgmlBackendGuard::cpu().expect("cpu backend");
-        // backend_set_abort_callback is already invoked by GgmlBackendGuard::cpu;
-        // re-arming is idempotent and must not panic / abort the process.
         super::arm_backend_abort_callback(backend.raw);
         assert!(
             !crate::ggml_runtime::cancel_flag_requested_from_data(std::ptr::null_mut()),
@@ -6119,7 +6123,7 @@ mod tests {
         let data_a = Arc::as_ptr(&flag_a) as *mut std::ffi::c_void;
         let data_b = Arc::as_ptr(&flag_b) as *mut std::ffi::c_void;
 
-        // SAFETY: trampoline is panic-catching and only loads the AtomicBool.
+        // SAFETY: trampoline only null-checks and loads the AtomicBool.
         let abort_a = unsafe { super::openasr_ggml_abort_trampoline(data_a) };
         let abort_b = unsafe { super::openasr_ggml_abort_trampoline(data_b) };
         let abort_null = unsafe { super::openasr_ggml_abort_trampoline(std::ptr::null_mut()) };
@@ -6133,6 +6137,56 @@ mod tests {
         // B's pointer is independent -- already true; A becoming true does not
         // change how B is read (distinct heap atomics, no global slot).
         assert!(unsafe { super::openasr_ggml_abort_trampoline(data_b) });
+    }
+
+    #[test]
+    fn graph_compute_with_cancel_flag_false_stays_finite() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        // Armed cancel=false must still produce correct finite graph outputs.
+        // This is the production server path under an installed control that has
+        // not been canceled; regressions here surface as non-finite logits.
+        let flag = Arc::new(AtomicBool::new(false));
+        let previous = crate::ggml_runtime::arm_thread_job_cancel_flag(Some(Arc::clone(&flag)));
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("cpu graph runner should initialize");
+        let output = runner
+            .compute_add_f32(&[1.0, 2.5, -3.0, 8.0], &[4.0, -0.5, 7.0, 1.25])
+            .expect("cancel=false graph must compute successfully");
+        assert_eq!(output, vec![5.0, 2.0, 4.0, 9.25]);
+        assert!(
+            output.iter().all(|v| v.is_finite()),
+            "cancel=false must keep outputs finite"
+        );
+        assert!(
+            !flag.load(Ordering::SeqCst),
+            "compute must not flip the cancel flag"
+        );
+        assert!(crate::ggml_runtime::disarm_thread_job_cancel_flag_if_current(&flag, previous));
+        crate::ggml_runtime::arm_thread_local_backends_abort_callback();
+    }
+
+    #[test]
+    fn graph_compute_with_cancel_flag_true_returns_aborted() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+
+        // Sticky cancel=true must surface as typed Aborted, not a silent
+        // SUCCESS with garbage tensors and not a bare ComputeFailed.
+        let flag = Arc::new(AtomicBool::new(true));
+        let previous = crate::ggml_runtime::arm_thread_job_cancel_flag(Some(Arc::clone(&flag)));
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("cpu graph runner should initialize");
+        let err = runner
+            .compute_add_f32(&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0])
+            .expect_err("cancel=true must fail closed");
+        assert!(
+            matches!(err, GgmlCpuGraphError::Aborted),
+            "cancel=true must map to Aborted, got {err:?}"
+        );
+        assert!(crate::ggml_runtime::disarm_thread_job_cancel_flag_if_current(&flag, previous));
+        crate::ggml_runtime::arm_thread_local_backends_abort_callback();
     }
 
     #[test]

--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -83,7 +83,17 @@ pub(crate) const GGML_BACKEND_DEVICE_TYPE_ACCEL: c_int = 3;
 pub(crate) const GGML_BACKEND_DEVICE_TYPE_META: c_int = 4;
 
 pub(crate) const GGML_STATUS_SUCCESS: c_int = 0;
+/// Mirrors `enum ggml_status` in ggml.h (`GGML_STATUS_ABORTED = 1`).
+/// Returned by CPU graph compute when the installed abort_callback returns true
+/// between nodes. Metal production graphs currently ignore abort mid-graph
+/// (see docs/KNOWN_LIMITATIONS.md); the status is still mapped so a future
+/// upstream Metal path surfaces as a typed cancel rather than ComputeFailed.
+pub(crate) const GGML_STATUS_ABORTED: c_int = 1;
 pub(crate) const GGML_BACKEND_BUFFER_USAGE_WEIGHTS: c_int = 1;
+
+/// ggml abort predicate: return true to abort the in-flight graph. Called from
+/// ggml worker threads -- must stay panic-free and lock-light.
+pub(crate) type GgmlAbortCallback = Option<unsafe extern "C" fn(data: *mut c_void) -> bool>;
 
 pub(crate) const GGML_TYPE_F32: c_int = 0;
 pub(crate) const GGML_TYPE_F16: c_int = 1;
@@ -276,6 +286,19 @@ unsafe extern "C" {
     pub(crate) fn ggml_backend_blas_init() -> GgmlBackendRaw;
     #[cfg(target_os = "macos")]
     pub(crate) fn ggml_backend_blas_set_n_threads(backend: GgmlBackendRaw, n_threads: c_int);
+    // Metal does not register `ggml_backend_set_abort_callback` on its
+    // get_proc_address table (only CPU does). Fall back to the direct symbol
+    // linked via static ggml-metal on Apple hosts. Mid-graph abort on the
+    // production Metal path is still a no-op upstream; wiring is intentional
+    // so flag=false graphs stay SUCCESS and a future Metal ABORTED path works.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn ggml_backend_is_metal(backend: GgmlBackendRaw) -> bool;
+    #[cfg(target_os = "macos")]
+    pub(crate) fn ggml_backend_metal_set_abort_callback(
+        backend: GgmlBackendRaw,
+        abort_callback: GgmlAbortCallback,
+        user_data: *mut c_void,
+    );
     pub(crate) fn ggml_init(params: GgmlInitParams) -> GgmlContextRaw;
     pub(crate) fn ggml_reset(ctx: GgmlContextRaw);
     pub(crate) fn ggml_free(ctx: GgmlContextRaw);

--- a/crates/openasr-core/src/ggml_runtime/job_cancel.rs
+++ b/crates/openasr-core/src/ggml_runtime/job_cancel.rs
@@ -1,0 +1,98 @@
+//! Job-scoped cancel atomic for the ggml abort_callback trampoline.
+//!
+//! ggml CPU may invoke abort_callback on a worker-pool thread that does not
+//! share the transcription owner thread's TLS. Cancel is therefore published as
+//! a heap [`Arc`]`<`[`AtomicBool`]`>` for the duration of one native transcription
+//! (armed by `install_active_transcription_control`, disarmed on guard Drop).
+//!
+//! Lives under `ggml_runtime` (not `api::backend`) so the graph runner can read
+//! it without a crate-internal module cycle.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+static CURRENT_JOB_CANCEL: Mutex<Option<Arc<AtomicBool>>> = Mutex::new(None);
+
+/// Replace the published job cancel flag. Returns the previous flag (if any)
+/// so nested install guards can restore it on drop.
+pub(crate) fn publish_job_cancel_flag(flag: Option<Arc<AtomicBool>>) -> Option<Arc<AtomicBool>> {
+    match CURRENT_JOB_CANCEL.lock() {
+        Ok(mut slot) => std::mem::replace(&mut *slot, flag),
+        Err(_) => None,
+    }
+}
+
+/// True when the currently published job cancel atomic is set. False when no
+/// control is installed (CLI / no-control path stays bit-identical: trampoline
+/// always false). Panic-free for use under `catch_unwind` in the C trampoline.
+pub(crate) fn job_cancel_requested() -> bool {
+    match CURRENT_JOB_CANCEL.lock() {
+        Ok(slot) => slot
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::SeqCst)),
+        Err(_) => false,
+    }
+}
+
+/// Disarm the slot only if it still points at `flag` (nested installs restore
+/// their previous publish rather than clearing a deeper owner's flag).
+pub(crate) fn unpublish_job_cancel_flag_if_current(
+    flag: &Arc<AtomicBool>,
+    previous: Option<Arc<AtomicBool>>,
+) {
+    if let Ok(mut slot) = CURRENT_JOB_CANCEL.lock() {
+        let still_ours = slot
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, flag));
+        if still_ours {
+            *slot = previous;
+        }
+    }
+}
+
+/// Serializes unit tests that publish into the process-wide job-cancel slot so
+/// parallel libtest threads do not clobber each other's assertions. Held for the
+/// lifetime of an installed transcription control under `cfg(test)`. Production
+/// install/drop paths never take this lock.
+#[cfg(test)]
+pub(crate) type JobCancelSlotTestGuard = std::sync::MutexGuard<'static, ()>;
+
+#[cfg(test)]
+static JOB_CANCEL_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the test-only job-cancel slot lock.
+#[cfg(test)]
+pub(crate) fn lock_job_cancel_slot_for_test() -> JobCancelSlotTestGuard {
+    JOB_CANCEL_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publish_cancel_and_unpublish_are_visible() {
+        let _exclusive = lock_job_cancel_slot_for_test();
+        let _ = publish_job_cancel_flag(None);
+        assert!(!job_cancel_requested());
+        let flag = Arc::new(AtomicBool::new(false));
+        let prev = publish_job_cancel_flag(Some(Arc::clone(&flag)));
+        assert!(prev.is_none());
+        assert!(!job_cancel_requested());
+        flag.store(true, Ordering::SeqCst);
+        assert!(job_cancel_requested());
+        unpublish_job_cancel_flag_if_current(&flag, None);
+        assert!(!job_cancel_requested());
+        let other = Arc::new(AtomicBool::new(true));
+        let _ = publish_job_cancel_flag(Some(Arc::clone(&other)));
+        unpublish_job_cancel_flag_if_current(&flag, None);
+        assert!(
+            job_cancel_requested(),
+            "newer publish must survive stale unpublish"
+        );
+        unpublish_job_cancel_flag_if_current(&other, None);
+        assert!(!job_cancel_requested());
+    }
+}

--- a/crates/openasr-core/src/ggml_runtime/job_cancel.rs
+++ b/crates/openasr-core/src/ggml_runtime/job_cancel.rs
@@ -1,98 +1,227 @@
-//! Job-scoped cancel atomic for the ggml abort_callback trampoline.
+//! Per-job cancel atomic for the ggml abort_callback trampoline.
 //!
 //! ggml CPU may invoke abort_callback on a worker-pool thread that does not
-//! share the transcription owner thread's TLS. Cancel is therefore published as
-//! a heap [`Arc`]`<`[`AtomicBool`]`>` for the duration of one native transcription
-//! (armed by `install_active_transcription_control`, disarmed on guard Drop).
+//! share the transcription owner thread's TLS. Cancel is therefore carried as
+//! a heap [`Arc`]`<`[`AtomicBool`]`>` **per job**, and the backend callback's
+//! `data` pointer is set to that atomic (`Arc::as_ptr`) for the duration of the
+//! job on the worker thread that owns the backends.
+//!
+//! There is intentionally **no** process-wide publish slot: server multi-model
+//! parallel jobs each arm their own thread-local backends with their own flag
+//! pointer, so canceling job B cannot make job A's trampoline return true.
 //!
 //! Lives under `ggml_runtime` (not `api::backend`) so the graph runner can read
 //! it without a crate-internal module cycle.
 
+use std::cell::RefCell;
+use std::os::raw::c_void;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 
-static CURRENT_JOB_CANCEL: Mutex<Option<Arc<AtomicBool>>> = Mutex::new(None);
-
-/// Replace the published job cancel flag. Returns the previous flag (if any)
-/// so nested install guards can restore it on drop.
-pub(crate) fn publish_job_cancel_flag(flag: Option<Arc<AtomicBool>>) -> Option<Arc<AtomicBool>> {
-    match CURRENT_JOB_CANCEL.lock() {
-        Ok(mut slot) => std::mem::replace(&mut *slot, flag),
-        Err(_) => None,
-    }
+thread_local! {
+    /// Cancel flag for the transcription currently running on this worker thread.
+    /// Used only to supply `abort_callback` data when backends are created or
+    /// re-armed on this thread. The trampoline itself never reads this TLS -- it
+    /// loads through the `data` pointer installed on the backend.
+    static ACTIVE_JOB_CANCEL: RefCell<Option<Arc<AtomicBool>>> = const { RefCell::new(None) };
 }
 
-/// True when the currently published job cancel atomic is set. False when no
-/// control is installed (CLI / no-control path stays bit-identical: trampoline
-/// always false). Panic-free for use under `catch_unwind` in the C trampoline.
-pub(crate) fn job_cancel_requested() -> bool {
-    match CURRENT_JOB_CANCEL.lock() {
-        Ok(slot) => slot
-            .as_ref()
-            .is_some_and(|flag| flag.load(Ordering::SeqCst)),
-        Err(_) => false,
-    }
+/// Install or replace this thread's job cancel flag. Returns the previous flag
+/// (if any) so nested install guards can restore it on drop.
+pub(crate) fn arm_thread_job_cancel_flag(flag: Option<Arc<AtomicBool>>) -> Option<Arc<AtomicBool>> {
+    ACTIVE_JOB_CANCEL.with(|cell| std::mem::replace(&mut *cell.borrow_mut(), flag))
 }
 
-/// Disarm the slot only if it still points at `flag` (nested installs restore
-/// their previous publish rather than clearing a deeper owner's flag).
-pub(crate) fn unpublish_job_cancel_flag_if_current(
+/// Disarm only if the thread slot still points at `flag` (nested installs restore
+/// their previous publish rather than clearing a deeper owner's flag). Returns
+/// whether the slot was ours and was updated.
+pub(crate) fn disarm_thread_job_cancel_flag_if_current(
     flag: &Arc<AtomicBool>,
     previous: Option<Arc<AtomicBool>>,
-) {
-    if let Ok(mut slot) = CURRENT_JOB_CANCEL.lock() {
+) -> bool {
+    ACTIVE_JOB_CANCEL.with(|cell| {
+        let mut slot = cell.borrow_mut();
         let still_ours = slot
             .as_ref()
             .is_some_and(|current| Arc::ptr_eq(current, flag));
         if still_ours {
             *slot = previous;
         }
-    }
+        still_ours
+    })
 }
 
-/// Serializes unit tests that publish into the process-wide job-cancel slot so
-/// parallel libtest threads do not clobber each other's assertions. Held for the
-/// lifetime of an installed transcription control under `cfg(test)`. Production
-/// install/drop paths never take this lock.
-#[cfg(test)]
-pub(crate) type JobCancelSlotTestGuard = std::sync::MutexGuard<'static, ()>;
+/// Raw `abort_callback` data pointer for backends on this thread: `Arc::as_ptr`
+/// of the armed job cancel atomic, or null when no control is installed (CLI /
+/// no-control path stays bit-identical: trampoline always false).
+///
+/// SAFETY for consumers: the pointer remains valid while the corresponding
+/// [`Arc`] is held in this thread's slot and/or by the install guard that armed
+/// it. Callers must re-arm backends to null (or a still-live previous flag)
+/// before the last owning [`Arc`] drops.
+pub(crate) fn thread_job_cancel_flag_data() -> *mut c_void {
+    ACTIVE_JOB_CANCEL.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .map(|flag| Arc::as_ptr(flag) as *mut c_void)
+            .unwrap_or(std::ptr::null_mut())
+    })
+}
 
-#[cfg(test)]
-static JOB_CANCEL_TEST_LOCK: Mutex<()> = Mutex::new(());
+/// Wait-free cancel check used by the ggml abort trampoline.
+///
+/// `data` is either null (no job / disarmed) or `Arc::as_ptr` of the job's
+/// [`AtomicBool`]. Pause never writes that atomic, so pause cannot trip abort.
+/// Panic-free for use under `catch_unwind` in the C trampoline.
+#[inline]
+pub(crate) fn cancel_flag_requested_from_data(data: *mut c_void) -> bool {
+    if data.is_null() {
+        return false;
+    }
+    // SAFETY: install paths only pass Arc::as_ptr of a job AtomicBool kept alive
+    // for the full backend-callback arm window (guard + thread slot).
+    unsafe { (*(data as *const AtomicBool)).load(Ordering::SeqCst) }
+}
 
-/// Acquire the test-only job-cancel slot lock.
+/// True when this thread's armed job cancel atomic is set. False when no control
+/// is installed. Test/helper path only -- production trampoline reads `data`.
 #[cfg(test)]
-pub(crate) fn lock_job_cancel_slot_for_test() -> JobCancelSlotTestGuard {
-    JOB_CANCEL_TEST_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+pub(crate) fn thread_job_cancel_requested() -> bool {
+    ACTIVE_JOB_CANCEL.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::SeqCst))
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
 
     #[test]
-    fn publish_cancel_and_unpublish_are_visible() {
-        let _exclusive = lock_job_cancel_slot_for_test();
-        let _ = publish_job_cancel_flag(None);
-        assert!(!job_cancel_requested());
+    fn arm_cancel_and_disarm_are_visible_on_thread_data_pointer() {
+        let _ = arm_thread_job_cancel_flag(None);
+        assert!(thread_job_cancel_flag_data().is_null());
+        assert!(!cancel_flag_requested_from_data(std::ptr::null_mut()));
+        assert!(!thread_job_cancel_requested());
+
         let flag = Arc::new(AtomicBool::new(false));
-        let prev = publish_job_cancel_flag(Some(Arc::clone(&flag)));
+        let prev = arm_thread_job_cancel_flag(Some(Arc::clone(&flag)));
         assert!(prev.is_none());
-        assert!(!job_cancel_requested());
+        let data = thread_job_cancel_flag_data();
+        assert!(!data.is_null());
+        assert!(!cancel_flag_requested_from_data(data));
+        assert!(!thread_job_cancel_requested());
+
         flag.store(true, Ordering::SeqCst);
-        assert!(job_cancel_requested());
-        unpublish_job_cancel_flag_if_current(&flag, None);
-        assert!(!job_cancel_requested());
+        assert!(cancel_flag_requested_from_data(data));
+        assert!(thread_job_cancel_requested());
+
+        assert!(disarm_thread_job_cancel_flag_if_current(&flag, None));
+        assert!(thread_job_cancel_flag_data().is_null());
+        // Stale data pointer would dangle after disarm+drop; only null is safe
+        // once the Arc is gone. While `flag` still lives, the old data still
+        // reads true -- backends must be re-armed to null on disarm (cpu_graph).
+        assert!(cancel_flag_requested_from_data(data));
+        assert!(!thread_job_cancel_requested());
+    }
+
+    #[test]
+    fn stale_disarm_does_not_clear_newer_thread_arm() {
+        let flag = Arc::new(AtomicBool::new(false));
         let other = Arc::new(AtomicBool::new(true));
-        let _ = publish_job_cancel_flag(Some(Arc::clone(&other)));
-        unpublish_job_cancel_flag_if_current(&flag, None);
+        let _ = arm_thread_job_cancel_flag(Some(Arc::clone(&other)));
+        assert!(!disarm_thread_job_cancel_flag_if_current(&flag, None));
         assert!(
-            job_cancel_requested(),
-            "newer publish must survive stale unpublish"
+            thread_job_cancel_requested(),
+            "newer arm must survive stale disarm"
         );
-        unpublish_job_cancel_flag_if_current(&other, None);
-        assert!(!job_cancel_requested());
+        assert!(cancel_flag_requested_from_data(
+            thread_job_cancel_flag_data()
+        ));
+        assert!(disarm_thread_job_cancel_flag_if_current(&other, None));
+        assert!(!thread_job_cancel_requested());
+    }
+
+    #[test]
+    fn cancel_job_b_does_not_abort_job_a_via_distinct_data_pointers() {
+        // Structural guarantee: each job's backends hold that job's AtomicBool
+        // pointer as callback data. Cancel B must not make A's trampoline true.
+        let flag_a = Arc::new(AtomicBool::new(false));
+        let flag_b = Arc::new(AtomicBool::new(false));
+        let data_a = Arc::as_ptr(&flag_a) as *mut c_void;
+        let data_b = Arc::as_ptr(&flag_b) as *mut c_void;
+
+        assert!(!cancel_flag_requested_from_data(data_a));
+        assert!(!cancel_flag_requested_from_data(data_b));
+
+        flag_b.store(true, Ordering::SeqCst);
+        assert!(
+            !cancel_flag_requested_from_data(data_a),
+            "cancel B must not abort A via trampoline data"
+        );
+        assert!(
+            cancel_flag_requested_from_data(data_b),
+            "cancel B must abort B"
+        );
+
+        flag_a.store(true, Ordering::SeqCst);
+        assert!(cancel_flag_requested_from_data(data_a));
+        assert!(cancel_flag_requested_from_data(data_b));
+    }
+
+    #[test]
+    fn interleaved_install_on_two_threads_keeps_cancel_isolated() {
+        // Fake parallel server jobs: each worker thread arms its own flag. Cancel
+        // on B must leave A's data-pointer read false without any global lock.
+        let flag_a = Arc::new(AtomicBool::new(false));
+        let flag_b = Arc::new(AtomicBool::new(false));
+        let barrier = Arc::new(Barrier::new(3));
+
+        let thread_a = {
+            let flag_a = Arc::clone(&flag_a);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let prev = arm_thread_job_cancel_flag(Some(Arc::clone(&flag_a)));
+                assert!(prev.is_none());
+                let data = thread_job_cancel_flag_data();
+                barrier.wait(); // both armed
+                barrier.wait(); // after B canceled
+                assert!(
+                    !cancel_flag_requested_from_data(data),
+                    "job A trampoline must stay false after cancel B"
+                );
+                assert!(!thread_job_cancel_requested());
+                assert!(disarm_thread_job_cancel_flag_if_current(&flag_a, None));
+            })
+        };
+
+        let thread_b = {
+            let flag_b = Arc::clone(&flag_b);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let prev = arm_thread_job_cancel_flag(Some(Arc::clone(&flag_b)));
+                assert!(prev.is_none());
+                let data = thread_job_cancel_flag_data();
+                barrier.wait(); // both armed
+                flag_b.store(true, Ordering::SeqCst);
+                assert!(
+                    cancel_flag_requested_from_data(data),
+                    "job B trampoline must observe its own cancel"
+                );
+                assert!(thread_job_cancel_requested());
+                barrier.wait(); // release A to check isolation
+                assert!(disarm_thread_job_cancel_flag_if_current(&flag_b, None));
+            })
+        };
+
+        barrier.wait();
+        barrier.wait();
+        thread_a.join().expect("job A thread");
+        thread_b.join().expect("job B thread");
+        assert!(!flag_a.load(Ordering::SeqCst));
+        assert!(flag_b.load(Ordering::SeqCst));
     }
 }

--- a/crates/openasr-core/src/ggml_runtime/job_cancel.rs
+++ b/crates/openasr-core/src/ggml_runtime/job_cancel.rs
@@ -52,8 +52,10 @@ pub(crate) fn disarm_thread_job_cancel_flag_if_current(
 }
 
 /// Raw `abort_callback` data pointer for backends on this thread: `Arc::as_ptr`
-/// of the armed job cancel atomic, or null when no control is installed (CLI /
-/// no-control path stays bit-identical: trampoline always false).
+/// of the armed job cancel atomic, or null when no control is installed.
+///
+/// Backend arm paths treat null as "clear the callback entirely" so the CLI /
+/// no-control path stays bit-identical to pre-L2 (no per-node abort poll).
 ///
 /// SAFETY for consumers: the pointer remains valid while the corresponding
 /// [`Arc`] is held in this thread's slot and/or by the install guard that armed
@@ -70,9 +72,10 @@ pub(crate) fn thread_job_cancel_flag_data() -> *mut c_void {
 
 /// Wait-free cancel check used by the ggml abort trampoline.
 ///
-/// `data` is either null (no job / disarmed) or `Arc::as_ptr` of the job's
+/// `data` is either null (defensive; production installs a null *callback* when
+/// disarmed, so the trampoline is not invoked) or `Arc::as_ptr` of the job's
 /// [`AtomicBool`]. Pause never writes that atomic, so pause cannot trip abort.
-/// Panic-free for use under `catch_unwind` in the C trampoline.
+/// Panic-free (null check + atomic load) for direct use from `extern "C"`.
 #[inline]
 pub(crate) fn cancel_flag_requested_from_data(data: *mut c_void) -> bool {
     if data.is_null() {

--- a/crates/openasr-core/src/ggml_runtime/mod.rs
+++ b/crates/openasr-core/src/ggml_runtime/mod.rs
@@ -8,6 +8,7 @@ mod gguf_metadata;
 mod gguf_tensor_data;
 mod gguf_tensor_index;
 mod gguf_write;
+mod job_cancel;
 mod kv_element;
 mod package_probe;
 mod runtime_source;
@@ -56,6 +57,11 @@ pub use gguf_tensor_index::{
 pub(crate) use gguf_write::{
     GgufWriteTensor, GgufWriteTensorType, GgufWriteValue, quantize_f32_to_ggml_tensor_data,
     write_gguf_file_v0,
+};
+#[cfg(test)]
+pub(crate) use job_cancel::{JobCancelSlotTestGuard, lock_job_cancel_slot_for_test};
+pub(crate) use job_cancel::{
+    job_cancel_requested, publish_job_cancel_flag, unpublish_job_cancel_flag_if_current,
 };
 pub(crate) use kv_element::GgmlKvElementType;
 #[cfg(test)]

--- a/crates/openasr-core/src/ggml_runtime/mod.rs
+++ b/crates/openasr-core/src/ggml_runtime/mod.rs
@@ -34,6 +34,7 @@ pub use cpu_graph::{
 pub(crate) use cpu_graph::{
     GgmlCpuGraphBuilder, GgmlCpuTensor, GgmlLoadedTensor, GgmlLoadedWeightContext,
     GgmlPersistentGraphSession, GgmlRopeExtParams, GgmlStaticTensor, GgmlStaticTensorArena,
+    arm_thread_local_backends_abort_callback,
 };
 pub(crate) use env_flags::{env_toggle_with_raw, env_var_truthy};
 pub(crate) use ffi::{GGML_TYPE_F16, GGML_TYPE_F32};
@@ -59,9 +60,10 @@ pub(crate) use gguf_write::{
     write_gguf_file_v0,
 };
 #[cfg(test)]
-pub(crate) use job_cancel::{JobCancelSlotTestGuard, lock_job_cancel_slot_for_test};
+pub(crate) use job_cancel::thread_job_cancel_requested;
 pub(crate) use job_cancel::{
-    job_cancel_requested, publish_job_cancel_flag, unpublish_job_cancel_flag_if_current,
+    arm_thread_job_cancel_flag, cancel_flag_requested_from_data,
+    disarm_thread_job_cancel_flag_if_current, thread_job_cancel_flag_data,
 };
 pub(crate) use kv_element::GgmlKvElementType;
 #[cfg(test)]

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -153,6 +153,17 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   code outside the advertised set reports `language: null` rather than a guess.
   SenseVoice also classifies emotion and audio events internally, but those
   tags are intentionally not exposed on the API surface yet.
+- Cooperative cancel of an in-flight offline transcription is layered: long-form
+  slice boundaries (L0), shared seq2seq greedy token / prefill chunk checks (L1),
+  and a ggml `abort_callback` on graph compute (L2). CPU graphs poll the callback
+  between nodes and can return a typed abort mid-graph. **Apple Metal mid-graph
+  cancel is not effective today**: ggml's production Metal path does not return
+  `GGML_STATUS_ABORTED` outside the capture/gputrace branch, so cancel on Metal
+  lands at the next Rust-level graph boundary (typically the next decode token
+  or encoder/prefill chunk). Discrete GPU backends that lack a
+  `ggml_backend_set_abort_callback` proc are a silent no-op at L2 and likewise
+  rely on L0/L1. Pause still only blocks at slice boundaries; it never arms the
+  ggml abort callback.
 
 ## What works now
 


### PR DESCRIPTION
## Summary

Wire L2 cooperative cancel through ggml's `abort_callback` so long CPU graphs can abort between nodes instead of only at Rust token/slice boundaries.

- FFI: `GGML_STATUS_ABORTED`, panic-safe trampoline (`catch_unwind` -> false), registry proc `ggml_backend_set_abort_callback`, macOS Metal direct-symbol fallback gated by `ggml_backend_is_metal`
- Job-scoped heap `Arc<AtomicBool>` dual-written by `TranscriptionControl::request_cancel` and published on install / disarmed on Drop (no TLS for ggml workers; cached backends keep the callback without dangling pointers)
- All graph-compute sites map SUCCESS / ABORTED / else via `map_compute_status`; `Aborted` rewrites to `BackendError::TranscriptionCanceled`
- Callback honors cancel only (pause stays L0 slice-boundary)
- Docs: Metal mid-graph abort is an upstream no-op; cancel lands at graph/CPU-node boundaries

## Why

L1 (#233) already cancels at seq2seq token boundaries. Long single CPU graphs (encoder / bulk prefill) still had no cooperative yield. L2 closes that gap on CPU without pretending Metal mid-graph abort works today.

## Changes

- `crates/openasr-core/src/ggml_runtime/ffi.rs` - status constant, abort callback type, Metal symbols
- `crates/openasr-core/src/ggml_runtime/job_cancel.rs` - process-wide job cancel publish slot
- `crates/openasr-core/src/ggml_runtime/cpu_graph.rs` - install callback on backend init, `map_compute_status`, `Aborted` error
- `crates/openasr-core/src/api/backend/transcription_control.rs` - dual-write atomic + publish on install
- `crates/openasr-core/src/api/backend/native_transcribe.rs` - recognize `aborted by cancel request`
- `docs/KNOWN_LIMITATIONS.md` - Metal mid-graph cancel limitation

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core --lib -- cancel abort_callback transcription_control map_compute_status job_cancel` (24 passed)
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

None (unit-level FFI/status/publish wiring only; no RTF / weight runs).

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No upstream Metal production `GGML_STATUS_ABORTED` path (still capture/gputrace only)
- No discrete-GPU vendor abort APIs
- No RTF measurement, catalog, or release changes
- Pause remains slice-boundary only

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implementation assistance for FFI wiring and tests; human owns review and merge.