### PR TITLE
fix(qwen): cooperative cancel between prefill chunks

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -959,6 +959,13 @@ pub enum GgmlCpuGraphError {
         "ggml_flash_attn_rel_pos is CPU-only; backend={backend:?} must keep the naive mul_mat + rel_shift fallback"
     )]
     FlashAttnRelPosCpuOnly { backend: GgmlCpuGraphBackend },
+    /// Cooperative cancel observed between multi-chunk graph computes (Rust
+    /// L1.2 prefill/encoder chunk boundaries). Distinct from a hard
+    /// `ComputeFailed` so callers can map it to
+    /// [`crate::BackendError::TranscriptionCanceled`]. Pause is intentionally
+    /// not handled here -- pause stays at the long-form slice boundary.
+    #[error("ggml graph compute canceled by transcription control")]
+    Canceled,
 }
 
 pub struct GgmlCpuGraphRunner {

--- a/crates/openasr-core/src/models/qwen/batched_decode.rs
+++ b/crates/openasr-core/src/models/qwen/batched_decode.rs
@@ -72,6 +72,13 @@ pub(super) struct Qwen3AsrServeBatchJob {
     pub text_postprocess_kind: BuiltinDecodePolicySeq2SeqTextPostprocessKind,
     pub word_timestamps: bool,
     pub audio_duration_seconds: f32,
+    /// Submit-thread capture of the active transcription control.
+    ///
+    /// Serve-batch prefill runs on the owner thread, which never installs the
+    /// request's thread-local control. The submit path snapshots
+    /// `current_transcription_control()` into this field so chunk-boundary
+    /// polls observe the same `Arc` the HTTP cancel handler flips.
+    pub control: Option<Arc<crate::TranscriptionControl>>,
 }
 
 #[derive(Debug, Error)]
@@ -122,12 +129,16 @@ impl Qwen3AsrServeBatchError {
     }
 }
 
-/// Poll the active transcription control at a serve-batch prefill chunk
+/// Poll a job-carried transcription control at a serve-batch prefill chunk
 /// boundary. Typed `Canceled` keeps cancel off the generic decode-failed path.
-fn ensure_serve_batch_prefill_not_canceled() -> Result<(), Qwen3AsrServeBatchError> {
-    if crate::api::backend::current_transcription_control()
-        .is_some_and(|control| control.is_canceled())
-    {
+///
+/// Must read the `Arc` snapped into [`Qwen3AsrServeBatchJob::control`] at
+/// submit time -- the owner thread has no thread-local install, so
+/// `current_transcription_control()` is always `None` here in production.
+fn ensure_serve_batch_prefill_not_canceled(
+    control: Option<&Arc<crate::TranscriptionControl>>,
+) -> Result<(), Qwen3AsrServeBatchError> {
+    if control.is_some_and(|control| control.is_canceled()) {
         return Err(Qwen3AsrServeBatchError::Canceled);
     }
     Ok(())
@@ -823,14 +834,20 @@ impl Qwen3AsrOwnerThreadState {
                     if let Err(error) =
                         Self::prefill_and_select_batched_group(decoder, entries, &group, chunk_size)
                     {
-                        let reason = error.to_string();
                         failures.extend(group.into_iter().map(|entry_index| {
-                            (
-                                entries[entry_index].slot_index,
-                                Qwen3AsrServeBatchError::DecodeFailed {
-                                    reason: reason.clone(),
+                            let mapped = match &error {
+                                // Preserve typed cancel so dispatch keeps the
+                                // TranscriptionCanceled path (not a generic
+                                // decode failure) for every group member that
+                                // shared the multi-query prefill.
+                                Qwen3AsrServeBatchError::Canceled => {
+                                    Qwen3AsrServeBatchError::Canceled
+                                }
+                                other => Qwen3AsrServeBatchError::DecodeFailed {
+                                    reason: other.to_string(),
                                 },
-                            )
+                            };
+                            (entries[entry_index].slot_index, mapped)
                         }));
                     }
                 } else {
@@ -888,7 +905,13 @@ impl Qwen3AsrOwnerThreadState {
         let mut final_hidden_by_sequence = vec![None; n_seq];
         while position_offset < token_count {
             // L1.2 cooperative cancel between multi-query prefill chunks.
-            ensure_serve_batch_prefill_not_canceled()?;
+            // Multi-query groups share one graph step, so any member cancel
+            // aborts the shared chunk (existing all-or-nothing group model).
+            for &entry_index in group {
+                ensure_serve_batch_prefill_not_canceled(
+                    entries[entry_index].slot.job.control.as_ref(),
+                )?;
+            }
             let remaining = token_count - position_offset;
             let chunk_len = if require_even_chunks {
                 super::even_prefill_chunk_len(remaining, chunk_size)
@@ -1593,7 +1616,7 @@ impl Qwen3AsrBatchSlot {
         let mut final_hidden = None;
         while position_offset < token_count {
             // L1.2 cooperative cancel between single-slot host-cache chunks.
-            ensure_serve_batch_prefill_not_canceled()?;
+            ensure_serve_batch_prefill_not_canceled(self.job.control.as_ref())?;
             let remaining = token_count - position_offset;
             let chunk_len = if require_even_chunks {
                 super::even_prefill_chunk_len(remaining, chunk_size)
@@ -1659,7 +1682,7 @@ impl Qwen3AsrBatchSlot {
         for token_position in 0..token_count {
             // Serial host-step prefill is the chunk-size-1 fallback; poll the
             // same cancel boundary so cancel does not wait for the full prompt.
-            ensure_serve_batch_prefill_not_canceled()?;
+            ensure_serve_batch_prefill_not_canceled(self.job.control.as_ref())?;
             let hidden = self.prefill_prompt_hidden_at(token_position)?;
             let step = decoder
                 .run_step(
@@ -2394,6 +2417,7 @@ mod tests {
             text_postprocess_kind: BuiltinDecodePolicySeq2SeqTextPostprocessKind::Identity,
             word_timestamps: false,
             audio_duration_seconds: 1.0,
+            control: None,
         }
     }
 
@@ -2781,17 +2805,16 @@ mod tests {
     fn serve_batch_prefill_cancel_poll_returns_typed_canceled() {
         use std::sync::Arc;
 
-        use crate::api::backend::{TranscriptionControl, install_active_transcription_control};
+        use crate::api::backend::TranscriptionControl;
         use crate::ggml_runtime::GgmlCpuGraphError;
 
-        assert!(super::ensure_serve_batch_prefill_not_canceled().is_ok());
+        assert!(super::ensure_serve_batch_prefill_not_canceled(None).is_ok());
 
         let control = Arc::new(TranscriptionControl::new());
-        let _guard = install_active_transcription_control(Arc::clone(&control));
-        assert!(super::ensure_serve_batch_prefill_not_canceled().is_ok());
+        assert!(super::ensure_serve_batch_prefill_not_canceled(Some(&control)).is_ok());
         control.request_cancel();
         assert!(matches!(
-            super::ensure_serve_batch_prefill_not_canceled(),
+            super::ensure_serve_batch_prefill_not_canceled(Some(&control)),
             Err(Qwen3AsrServeBatchError::Canceled)
         ));
         assert!(matches!(
@@ -2815,17 +2838,16 @@ mod tests {
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
-        use crate::api::backend::{TranscriptionControl, install_active_transcription_control};
+        use crate::api::backend::TranscriptionControl;
 
         let control = Arc::new(TranscriptionControl::new());
-        let _guard = install_active_transcription_control(Arc::clone(&control));
         let chunks_run = AtomicUsize::new(0);
         let token_count = 10usize;
         let chunk_size = 3usize;
         let mut position_offset = 0usize;
         let mut canceled = false;
         while position_offset < token_count {
-            if let Err(error) = super::ensure_serve_batch_prefill_not_canceled() {
+            if let Err(error) = super::ensure_serve_batch_prefill_not_canceled(Some(&control)) {
                 assert!(matches!(error, Qwen3AsrServeBatchError::Canceled));
                 canceled = true;
                 break;
@@ -2840,5 +2862,60 @@ mod tests {
         assert!(canceled);
         assert_eq!(chunks_run.load(Ordering::SeqCst), 2);
         assert!(position_offset < token_count);
+    }
+
+    /// Production cancel must travel via the job-carried Arc: the owner thread
+    /// never installs the submitter's thread-local TranscriptionControl.
+    #[test]
+    fn serve_batch_job_control_cancel_visible_on_owner_thread() {
+        use std::sync::Arc;
+        use std::thread;
+
+        use crate::api::backend::{
+            TranscriptionControl, current_transcription_control,
+            install_active_transcription_control,
+        };
+
+        let control = Arc::new(TranscriptionControl::new());
+        // Submit-side snapshot while the request worker has TLS installed.
+        let job_control = {
+            let _guard = install_active_transcription_control(Arc::clone(&control));
+            current_transcription_control()
+        };
+        assert!(
+            job_control.is_some(),
+            "submit must capture the active control Arc"
+        );
+        // Guard dropped: submit thread TLS is cleared, matching real request end.
+        assert!(
+            current_transcription_control().is_none(),
+            "TLS must not be the production cancel path for the owner"
+        );
+        control.request_cancel();
+
+        // Owner thread: no TLS install; only the job-carried Arc is readable.
+        let owner = thread::spawn(move || {
+            assert!(
+                current_transcription_control().is_none(),
+                "owner thread must not see submit-thread TLS"
+            );
+            // TLS-only poll (the rejected pattern) stays green even after cancel.
+            assert!(
+                super::ensure_serve_batch_prefill_not_canceled(
+                    current_transcription_control().as_ref()
+                )
+                .is_ok(),
+                "TLS poll on owner is a false-green path"
+            );
+            // Job-carried Arc observes the cancel flipped on the other thread.
+            assert!(
+                matches!(
+                    super::ensure_serve_batch_prefill_not_canceled(job_control.as_ref()),
+                    Err(Qwen3AsrServeBatchError::Canceled)
+                ),
+                "job-carried control must surface cancel across threads"
+            );
+        });
+        owner.join().expect("owner thread");
     }
 }

--- a/crates/openasr-core/src/models/qwen/batched_decode.rs
+++ b/crates/openasr-core/src/models/qwen/batched_decode.rs
@@ -101,6 +101,11 @@ pub(super) enum Qwen3AsrServeBatchError {
     OwnerFailed { reason: String },
     #[error("qwen serve batch decode failed: {reason}")]
     DecodeFailed { reason: String },
+    /// Cooperative cancel observed between prefill chunks. Display text carries
+    /// the stable "canceled by transcription control" marker so
+    /// `dispatch_error_to_backend` rewrites to `TranscriptionCanceled`.
+    #[error("qwen serve batch canceled by transcription control")]
+    Canceled,
 }
 
 impl Qwen3AsrServeBatchError {
@@ -114,6 +119,28 @@ impl Qwen3AsrServeBatchError {
             Self::OwnerDisconnected | Self::ReplyTimedOut => Some(false),
             _ => None,
         }
+    }
+}
+
+/// Poll the active transcription control at a serve-batch prefill chunk
+/// boundary. Typed `Canceled` keeps cancel off the generic decode-failed path.
+fn ensure_serve_batch_prefill_not_canceled() -> Result<(), Qwen3AsrServeBatchError> {
+    if crate::api::backend::current_transcription_control()
+        .is_some_and(|control| control.is_canceled())
+    {
+        return Err(Qwen3AsrServeBatchError::Canceled);
+    }
+    Ok(())
+}
+
+fn map_serve_batch_graph_error(
+    error: crate::ggml_runtime::GgmlCpuGraphError,
+) -> Qwen3AsrServeBatchError {
+    match error {
+        crate::ggml_runtime::GgmlCpuGraphError::Canceled => Qwen3AsrServeBatchError::Canceled,
+        other => Qwen3AsrServeBatchError::DecodeFailed {
+            reason: other.to_string(),
+        },
     }
 }
 
@@ -860,6 +887,8 @@ impl Qwen3AsrOwnerThreadState {
         let mut position_offset = 0usize;
         let mut final_hidden_by_sequence = vec![None; n_seq];
         while position_offset < token_count {
+            // L1.2 cooperative cancel between multi-query prefill chunks.
+            ensure_serve_batch_prefill_not_canceled()?;
             let remaining = token_count - position_offset;
             let chunk_len = if require_even_chunks {
                 super::even_prefill_chunk_len(remaining, chunk_size)
@@ -914,9 +943,7 @@ impl Qwen3AsrOwnerThreadState {
                         &layer_cache_refs,
                         QWEN_ROPE_THETA,
                     )
-                    .map_err(|error| Qwen3AsrServeBatchError::DecodeFailed {
-                        reason: error.to_string(),
-                    })?
+                    .map_err(map_serve_batch_graph_error)?
             };
             for (sequence_index, &entry_index) in group.iter().enumerate() {
                 let final_hidden = entries[entry_index]
@@ -1557,9 +1584,7 @@ impl Qwen3AsrBatchSlot {
                     token_count,
                     QWEN_ROPE_THETA,
                 )
-                .map_err(|error| Qwen3AsrServeBatchError::DecodeFailed {
-                    reason: error.to_string(),
-                })?;
+                .map_err(map_serve_batch_graph_error)?;
             return self.write_prefill_step_outputs(token_count, step);
         }
         let hidden_size = self.job.llm_prefill_input.hidden_size;
@@ -1567,6 +1592,8 @@ impl Qwen3AsrBatchSlot {
         let mut position_offset = 0usize;
         let mut final_hidden = None;
         while position_offset < token_count {
+            // L1.2 cooperative cancel between single-slot host-cache chunks.
+            ensure_serve_batch_prefill_not_canceled()?;
             let remaining = token_count - position_offset;
             let chunk_len = if require_even_chunks {
                 super::even_prefill_chunk_len(remaining, chunk_size)
@@ -1602,9 +1629,7 @@ impl Qwen3AsrBatchSlot {
                     &self.layer_kv_caches,
                     QWEN_ROPE_THETA,
                 )
-                .map_err(|error| Qwen3AsrServeBatchError::DecodeFailed {
-                    reason: error.to_string(),
-                })?;
+                .map_err(map_serve_batch_graph_error)?;
             final_hidden =
                 Some(self.write_prefill_chunk_outputs(position_offset, chunk_len, step)?);
             position_offset = total_token_count;
@@ -1632,6 +1657,9 @@ impl Qwen3AsrBatchSlot {
         let token_count = self.job.llm_prefill_input.token_count;
         let mut final_hidden = None;
         for token_position in 0..token_count {
+            // Serial host-step prefill is the chunk-size-1 fallback; poll the
+            // same cancel boundary so cancel does not wait for the full prompt.
+            ensure_serve_batch_prefill_not_canceled()?;
             let hidden = self.prefill_prompt_hidden_at(token_position)?;
             let step = decoder
                 .run_step(
@@ -1640,9 +1668,7 @@ impl Qwen3AsrBatchSlot {
                     &self.layer_kv_caches,
                     QWEN_ROPE_THETA,
                 )
-                .map_err(|error| Qwen3AsrServeBatchError::DecodeFailed {
-                    reason: error.to_string(),
-                })?;
+                .map_err(map_serve_batch_graph_error)?;
             for (layer_index, (projected_k, projected_v)) in step.layer_kv.iter().enumerate() {
                 self.layer_kv_caches[layer_index]
                     .write(token_position, projected_k, projected_v)
@@ -2749,5 +2775,70 @@ mod tests {
         assert_qwen_selected_backend_direct_for_real_pack_harness();
         let fixture = load_qwen_serve_batch_real_pack_fixture();
         assert_qwen_generated_host_kv_replay(&fixture);
+    }
+
+    #[test]
+    fn serve_batch_prefill_cancel_poll_returns_typed_canceled() {
+        use std::sync::Arc;
+
+        use crate::api::backend::{TranscriptionControl, install_active_transcription_control};
+        use crate::ggml_runtime::GgmlCpuGraphError;
+
+        assert!(super::ensure_serve_batch_prefill_not_canceled().is_ok());
+
+        let control = Arc::new(TranscriptionControl::new());
+        let _guard = install_active_transcription_control(Arc::clone(&control));
+        assert!(super::ensure_serve_batch_prefill_not_canceled().is_ok());
+        control.request_cancel();
+        assert!(matches!(
+            super::ensure_serve_batch_prefill_not_canceled(),
+            Err(Qwen3AsrServeBatchError::Canceled)
+        ));
+        assert!(matches!(
+            super::map_serve_batch_graph_error(GgmlCpuGraphError::Canceled),
+            Qwen3AsrServeBatchError::Canceled
+        ));
+        assert!(
+            Qwen3AsrServeBatchError::Canceled
+                .to_string()
+                .contains("canceled by transcription control")
+        );
+        // Cancel is not a transient serve-batch unavailable class.
+        assert_eq!(
+            Qwen3AsrServeBatchError::Canceled.unavailable_retryable(),
+            None
+        );
+    }
+
+    #[test]
+    fn serve_batch_prefill_chunk_loop_harness_stops_between_chunks_on_cancel() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::api::backend::{TranscriptionControl, install_active_transcription_control};
+
+        let control = Arc::new(TranscriptionControl::new());
+        let _guard = install_active_transcription_control(Arc::clone(&control));
+        let chunks_run = AtomicUsize::new(0);
+        let token_count = 10usize;
+        let chunk_size = 3usize;
+        let mut position_offset = 0usize;
+        let mut canceled = false;
+        while position_offset < token_count {
+            if let Err(error) = super::ensure_serve_batch_prefill_not_canceled() {
+                assert!(matches!(error, Qwen3AsrServeBatchError::Canceled));
+                canceled = true;
+                break;
+            }
+            let chunk_len = (token_count - position_offset).min(chunk_size);
+            let seen = chunks_run.fetch_add(1, Ordering::SeqCst) + 1;
+            if seen == 2 {
+                control.request_cancel();
+            }
+            position_offset = position_offset.saturating_add(chunk_len);
+        }
+        assert!(canceled);
+        assert_eq!(chunks_run.load(Ordering::SeqCst), 2);
+        assert!(position_offset < token_count);
     }
 }

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -38,7 +38,9 @@ use crate::arch::shape_orchestrator::{
     LayerCountResolver, OpenAsrStageRole, StageBuildPlan, validate_stage_against_descriptor,
 };
 use crate::arch::{OpenAsrArchitectureRegistry, QWEN3_ASR_GGML_ARCHITECTURE_ID};
-use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig, env_var_truthy};
+use crate::ggml_runtime::{
+    GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphError, env_var_truthy,
+};
 use crate::models::decode_policy_component_registry::{
     BuiltinSeq2SeqDecodePolicyConfigInput, build_builtin_seq2seq_decode_policy_config,
     resolve_builtin_decode_policy,
@@ -963,9 +965,17 @@ impl Seq2SeqGreedyDecodeStepExecutor for Qwen3AsrPrefillOnlyGreedyStepExecutor {
     > {
         if !self.consumed_prefill_step && input.step_index == 0 && input.generated_tokens.is_empty()
         {
+            // Preserve typed cancel from the prefill chunk loop so the shared
+            // greedy driver (and dispatch_error_to_backend) see Canceled, not a
+            // generic DecoderStepFailed.
             let logits = self.prefill_prompt_and_compute_last_logits().map_err(|error| {
-                crate::models::seq2seq_greedy_decode::Seq2SeqGreedyDecodeError::DecoderStepFailed {
-                    reason: error.to_string(),
+                match error {
+                    Qwen3AsrGreedyDecodeError::Canceled => {
+                        crate::models::seq2seq_greedy_decode::Seq2SeqGreedyDecodeError::Canceled
+                    }
+                    other => crate::models::seq2seq_greedy_decode::Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                        reason: other.to_string(),
+                    },
                 }
             })?;
             self.consumed_prefill_step = true;
@@ -1022,6 +1032,27 @@ impl Seq2SeqGreedyDecodeStepExecutor for Qwen3AsrPrefillOnlyGreedyStepExecutor {
     }
 }
 
+/// Poll the active transcription control at a host-cache prefill chunk
+/// boundary. Distinct from a graph/compute failure so cancel maps to
+/// [`crate::BackendError::TranscriptionCanceled`] end-to-end.
+fn ensure_prefill_chunk_not_canceled() -> Result<(), Qwen3AsrGreedyDecodeError> {
+    if crate::api::backend::current_transcription_control()
+        .is_some_and(|control| control.is_canceled())
+    {
+        return Err(Qwen3AsrGreedyDecodeError::Canceled);
+    }
+    Ok(())
+}
+
+fn map_prefill_graph_error(error: GgmlCpuGraphError) -> Qwen3AsrGreedyDecodeError {
+    match error {
+        GgmlCpuGraphError::Canceled => Qwen3AsrGreedyDecodeError::Canceled,
+        other => Qwen3AsrGreedyDecodeError::DecoderStepFailed {
+            reason: other.to_string(),
+        },
+    }
+}
+
 impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
     fn prefill_prompt_and_compute_last_logits(
         &mut self,
@@ -1057,9 +1088,7 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
                 &self.layer_kv_caches,
                 1_000_000.0,
             )
-            .map_err(|error| Qwen3AsrGreedyDecodeError::DecoderStepFailed {
-                reason: error.to_string(),
-            })?
+            .map_err(map_prefill_graph_error)?
         {
             self.cache_prompt_tokens = token_count;
             qwen_decode_profile_log_opt("prefill_prompt_resident_bulk", resident_started_at);
@@ -1101,9 +1130,7 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
                 token_count,
                 1_000_000.0,
             )
-            .map_err(|error| Qwen3AsrGreedyDecodeError::DecoderStepFailed {
-                reason: error.to_string(),
-            })?;
+            .map_err(map_prefill_graph_error)?;
         qwen_decode_profile_log_prefill_chunk(0, token_count, profile_started_at);
         let result = self.write_prefill_step_outputs_and_compute_last_logits(token_count, step);
         qwen_decode_profile_log_opt("prefill_prompt_bulk_host", profile_started_at);
@@ -1130,9 +1157,7 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
                     token_count,
                     1_000_000.0,
                 )
-                .map_err(|error| Qwen3AsrGreedyDecodeError::DecoderStepFailed {
-                    reason: error.to_string(),
-                })?;
+                .map_err(map_prefill_graph_error)?;
             qwen_decode_profile_log_prefill_chunk(0, token_count, chunk_started_at);
             let result = self.write_prefill_step_outputs_and_compute_last_logits(token_count, step);
             qwen_decode_profile_log_opt("prefill_prompt_chunked", profile_started_at);
@@ -1143,6 +1168,8 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
         let mut position_offset = 0usize;
         let mut final_hidden = None;
         while position_offset < token_count {
+            // L1.2 cooperative cancel between host-cache prefill chunks.
+            ensure_prefill_chunk_not_canceled()?;
             let remaining = token_count - position_offset;
             let chunk_len = if require_even_chunks {
                 super::even_prefill_chunk_len(remaining, chunk_size)
@@ -1180,9 +1207,7 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
                     &self.layer_kv_caches,
                     1_000_000.0,
                 )
-                .map_err(|error| Qwen3AsrGreedyDecodeError::DecoderStepFailed {
-                    reason: error.to_string(),
-                })?;
+                .map_err(map_prefill_graph_error)?;
             qwen_decode_profile_log_prefill_chunk(position_offset, chunk_len, chunk_started_at);
             final_hidden =
                 Some(self.write_prefill_chunk_outputs(position_offset, chunk_len, step)?);
@@ -1890,6 +1915,80 @@ mod tests {
             "QWEN3_ASR_AB backend={backend_preference:?} audio={audio_duration_seconds:.2}s \
              elapsed={elapsed:?} RTF={rtf:.3} text={}",
             result.transcription.text
+        );
+    }
+
+    #[test]
+    fn prefill_chunk_cancel_poll_returns_typed_canceled() {
+        use std::sync::Arc;
+
+        use crate::api::backend::{TranscriptionControl, install_active_transcription_control};
+        use crate::ggml_runtime::GgmlCpuGraphError;
+
+        // No control installed: poll is a no-op.
+        assert!(super::ensure_prefill_chunk_not_canceled().is_ok());
+
+        let control = Arc::new(TranscriptionControl::new());
+        let _guard = install_active_transcription_control(Arc::clone(&control));
+        assert!(super::ensure_prefill_chunk_not_canceled().is_ok());
+        control.request_cancel();
+        assert_eq!(
+            super::ensure_prefill_chunk_not_canceled(),
+            Err(super::Qwen3AsrGreedyDecodeError::Canceled)
+        );
+        // Graph-level cancel maps to the same typed family error.
+        assert_eq!(
+            super::map_prefill_graph_error(GgmlCpuGraphError::Canceled),
+            super::Qwen3AsrGreedyDecodeError::Canceled
+        );
+        // Stable marker used by dispatch_error_to_backend.
+        assert!(
+            super::Qwen3AsrGreedyDecodeError::Canceled
+                .to_string()
+                .contains("canceled by transcription control")
+        );
+    }
+
+    #[test]
+    fn prefill_chunk_loop_harness_stops_between_chunks_on_cancel() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use crate::api::backend::{TranscriptionControl, install_active_transcription_control};
+
+        // Lightweight stand-in for the host-cache chunk walk: each "chunk" is a
+        // pure counter bump with the same cancel poll the production loop uses.
+        // Cancel after the second chunk completes; the third poll must abort
+        // before another chunk runs.
+        let control = Arc::new(TranscriptionControl::new());
+        let _guard = install_active_transcription_control(Arc::clone(&control));
+        let chunks_run = AtomicUsize::new(0);
+        let token_count = 12usize;
+        let chunk_size = 4usize;
+        let mut position_offset = 0usize;
+        let mut canceled = false;
+        while position_offset < token_count {
+            if let Err(error) = super::ensure_prefill_chunk_not_canceled() {
+                assert_eq!(error, super::Qwen3AsrGreedyDecodeError::Canceled);
+                canceled = true;
+                break;
+            }
+            let chunk_len = (token_count - position_offset).min(chunk_size);
+            let seen = chunks_run.fetch_add(1, Ordering::SeqCst) + 1;
+            if seen == 2 {
+                control.request_cancel();
+            }
+            position_offset = position_offset.saturating_add(chunk_len);
+        }
+        assert!(canceled, "cancel must abort the harness loop");
+        assert_eq!(
+            chunks_run.load(Ordering::SeqCst),
+            2,
+            "exactly two chunks should run before the next boundary poll aborts"
+        );
+        assert!(
+            position_offset < token_count,
+            "cancel must leave residual tokens unprocessed"
         );
     }
 }

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -478,6 +478,9 @@ impl Qwen3AsrGgmlExecutor {
                     text_postprocess_kind: decode_policy.seq2seq_text_postprocess_kind,
                     word_timestamps: request.request_options.word_timestamps,
                     audio_duration_seconds: audio_duration_seconds(&request.prepared_audio),
+                    // Owner-thread prefill cannot see this thread's TLS control;
+                    // snapshot the Arc so chunk-boundary polls observe cancel.
+                    control: crate::api::backend::current_transcription_control(),
                 },
             )
             .map_err(|error| match error.unavailable_retryable() {

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -2395,6 +2395,14 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         }
         let mut final_step = None;
         for position_offset in (0..token_count).step_by(RESIDENT_PREFILL_MAX_QUERY_TOKENS) {
+            // L1.2 cooperative cancel: poll between resident prefill chunks so
+            // stop lands at a chunk boundary instead of waiting for the whole
+            // prompt bulk (or the long-form slice boundary). Pause stays L0-only.
+            if crate::api::backend::current_transcription_control()
+                .is_some_and(|control| control.is_canceled())
+            {
+                return Err(GgmlCpuGraphError::Canceled);
+            }
             let chunk_tokens =
                 (token_count - position_offset).min(RESIDENT_PREFILL_MAX_QUERY_TOKENS);
             let chunk_hidden = Self::sequence_major_prefill_chunk(


### PR DESCRIPTION
## Summary

Poll `TranscriptionControl` at qwen-family prefill **chunk** boundaries so cancel lands after the current chunk instead of waiting for the long-form slice boundary. Builds on the shared greedy token-boundary cancel path.

## Why

Long prompts spend substantial wall time in multi-chunk prefill (resident reused bulk, host-cache chunked, serve-batch). Token-loop cancel alone cannot interrupt that work. Chunk-boundary polls collapse cancel latency to one prefill chunk on every backend (including Metal, where mid-graph abort is not available).

## Changes

- `GgmlCpuGraphError::Canceled` with the stable `canceled by transcription control` marker
- Poll before each chunk in:
  - `run_prefill_into_reused_batched` (shared resident bulk; also covers mimo/firered/moss/hymt2 callers)
  - qwen host-cache `prefill_prompt_chunked_and_compute_last_logits`
  - serve-batch multi-query group, single-slot chunked, and serial fallback loops
- Map typed `Canceled` through qwen greedy / serve-batch bridges so `dispatch_error_to_backend` yields `BackendError::TranscriptionCanceled` (HTTP 409)
- Preserve typed cancel when prefill fails on step 0 of the shared greedy driver (do not stringify into generic `DecoderStepFailed`)
- Weight-free unit tests: poll predicate + multi-chunk harness abort after N chunks

## Tests run

- [x] `cargo fmt --check` (openasr-core)
- [x] `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [x] focused lib tests:
  - `prefill_chunk_cancel_poll_returns_typed_canceled`
  - `prefill_chunk_loop_harness_stops_between_chunks_on_cancel`
  - `serve_batch_prefill_cancel_poll_returns_typed_canceled`
  - `serve_batch_prefill_chunk_loop_harness_stops_between_chunks_on_cancel`
  - `seq2seq_greedy_decode_cancels_at_token_boundary_when_control_requests_cancel`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

None (no weights / no RTF). Cancel path is proven with installed `TranscriptionControl` + chunk-loop harnesses.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No ggml abort_callback FFI / mid-graph CPU abort wiring
- No RTF claims
- No moss-only host prefill walk residual (resident path covered via shared reused bulk)
- Pause still L0-only (slice boundary); prefill polls cancel only

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implementation assistance; human owns review and merge.