### PR TITLE
feat(qwen): add qwen3-asr reference dumper

### DIFF
--- a/tooling/qwen-reference-dumper/README.md
+++ b/tooling/qwen-reference-dumper/README.md
@@ -1,0 +1,187 @@
+# qwen3-asr reference dumper
+
+Runs the **official** `qwen_asr` python reference implementation (the
+transformers backend of `QwenLM/Qwen3-ASR`) on real fixture wavs and dumps its
+output, so the ggml side (`crates/openasr-core/src/models/qwen/`) can be diffed
+against ground truth. Two scripts:
+
+- `dump_golden.py`: full greedy `model.generate()` -> golden transcript JSON
+  (prompt / generated / full token ids, decoded text with and without special
+  tokens, parsed `language` + transcript `asr_text`). This is the script that
+  produces the records the `GOLDEN_*_TEXT` constants pinned in
+  `ggml_executor.rs`'s golden-diff tests are transcribed from -- the qwen
+  family does not yet pin golden transcripts in-tree, so this script makes that
+  generation reproducible rather than leaving it as an untracked one-off (same
+  role `../moss-reference-dumper/dump_golden.py` plays for
+  moss-transcribe-diarize).
+- `dump_intermediate.py`: single-clip stage-by-stage activation dump (mel
+  frontend output, audio-encoder output post-`ln_post`, projector/adaptor
+  output, first prefill-step logits) as `.npy` files, for diffing individual
+  ggml execution stages against the reference forward pass.
+
+Both are this family's "reference dumper" required by
+[`docs/model-audits/TEMPLATE.md`](../../docs/model-audits/TEMPLATE.md)
+section 10 ("Reference dumper exists for this family").
+
+Nothing here is vendored into the repo: no third-party code, no weights, no
+dump output. All of that lives outside the tracked tree (see below).
+
+## Official reference source (do not vendor -- clone locally)
+
+- Code: <https://github.com/QwenLM/Qwen3-ASR>, pinned commit
+  `7c6daf77a2421100f5fb066495372c00129d39ff` (2026-06-26). Clone it yourself:
+
+  ```bash
+  git clone https://github.com/QwenLM/Qwen3-ASR.git /path/to/Qwen3-ASR
+  cd /path/to/Qwen3-ASR && git checkout 7c6daf77a2421100f5fb066495372c00129d39ff
+  ```
+
+  `import qwen_asr` from that clone registers the family's `Qwen3ASRConfig` /
+  `Qwen3ASRForConditionalGeneration` / `Qwen3ASRProcessor` with transformers'
+  Auto classes, after which `AutoModel.from_pretrained` /
+  `AutoProcessor.from_pretrained` resolve the model straight off the checkpoint
+  directory. Unlike moss, the checkpoint ships **no** `modeling_*.py` of its own
+  (its `config.json` has `architectures: ["Qwen3ASRForConditionalGeneration"]`
+  and `model_type: "qwen3_asr"` but no `trust_remote_code` module set) -- the
+  modeling lives in the pip-installable `qwen_asr` package, so that package is
+  the single source of the forward pass both scripts run.
+
+- Weights: <https://huggingface.co/Qwen/Qwen3-ASR-0.6B> (open, Apache-2.0).
+  Point `--weights-dir` at a local copy laid out exactly like the upstream HF
+  repo:
+
+  ```text
+  <weights-dir>/
+    config.json
+    generation_config.json
+    chat_template.json
+    preprocessor_config.json
+    tokenizer_config.json
+    special_tokens_map.json          # if present
+    vocab.json
+    merges.txt
+    model.safetensors                # single shard, ~1.2GB fp16 on disk
+  ```
+
+## Setup
+
+Host python (this repo has no dedicated venv for tooling scripts, matching
+`firered2-reference-dumper` / `moss-reference-dumper` convention). **Note the
+transformers pin differs from moss**: `qwen_asr` requires `transformers==4.57.6`
+(its `AutoConfig.register("qwen3_asr", ...)` would collide with the model type
+transformers later merged natively), so pin that exact version rather than
+moss's `transformers>=5.0`:
+
+```bash
+python3 -m pip install --user "transformers==4.57.6" "torch>=2.8" numpy \
+    librosa soundfile nagisa
+```
+
+`librosa`/`soundfile` come from `qwen_asr.inference.utils`' audio loading and
+`nagisa` from its forced-aligner module import -- both are pulled in by a plain
+`import qwen_asr` even though neither script runs the aligner. `soynlp`,
+`gradio`, `flask`, and `vllm` are NOT needed here. Alternatively,
+`python3 -m pip install --user -e /path/to/Qwen3-ASR` installs the official full
+dependency set (including the gradio/flask the dumper does not use).
+
+## Memory
+
+The whole checkpoint (~0.6B params: 18-layer Whisper-style audio encoder +
+audio projector + 28-layer Qwen3 text decoder) fits comfortably in fp32 on a
+16GB dev machine -- well under 4GB resident. Unlike
+`firered2-reference-dumper`'s 7B-parameter Qwen2 decoder, this family needs none
+of that dumper's meta-device layer-streaming trick or `vm_stat`-gated wait loop:
+`AutoModel.from_pretrained(..., dtype=torch.float32)` loads the whole model
+directly, so neither script here has a `--stage` flag or memory gate to make
+that trade-off with.
+
+## `dump_golden.py` usage
+
+```bash
+cd tooling/qwen-reference-dumper
+python3 dump_golden.py \
+  --qwen-repo /path/to/Qwen3-ASR \
+  --weights-dir /path/to/qwen3-asr-0.6b-weights \
+  --samples-dir ../../fixtures \
+  --sample jfk=jfk.wav \
+  --out-dir /path/to/scratch/qwen-golden
+```
+
+`--sample NAME=RELATIVE_WAV_PATH` is repeatable; each path resolves against
+`--samples-dir`. Writes `<out-dir>/<name>.json`, one record per sample: prompt
+token ids, full/generated token ids, decoded text (with and without special
+tokens), parsed `language` + transcript `asr_text`, elapsed time, and
+environment versions -- the same field-for-field shape as moss's golden records,
+with qwen's `language` / `asr_text` in place of moss's speaker/timestamp
+`segments`.
+
+**Which field is the future golden constant?** The ggml executor strips the
+`language <name><asr_text>` control prefix and emits just the transcript (see
+`greedy_decode_strips_qwen_asr_control_prefix` in `greedy_decode.rs`). That
+transcript is byte-for-byte what `parse_asr_output` returns as its second
+element, so the `asr_text` field -- not the raw `text` field, which still carries
+the control prefix -- is the one a future `GOLDEN_*_TEXT` constant in
+`ggml_executor.rs` should match. Both are recorded so the relationship is
+auditable.
+
+Greedy (`do_sample=False`), CPU, fp32, seeded (`--seed`, default `0`) for
+determinism -- matches the golden-diff convention every other builtin family's
+dev-only reference dump uses (see `../moss-reference-dumper/dump_golden.py` and
+`../firered2-reference-dumper/dump_reference.py`'s `llm` stage).
+
+## `dump_intermediate.py` usage
+
+```bash
+cd tooling/qwen-reference-dumper
+python3 dump_intermediate.py \
+  --qwen-repo /path/to/Qwen3-ASR \
+  --weights-dir /path/to/qwen3-asr-0.6b-weights \
+  --wav ../../fixtures/jfk.wav \
+  --out-dir /path/to/scratch/qwen-dump
+```
+
+Dumps `input_features.npy`, `feature_attention_mask.npy`, `audio_encoder.npy`,
+`audio_adaptor.npy`, and `prefill_last_logits.npy` -- see the script's module doc
+for exact shapes and semantics.
+
+Encoder/adaptor boundary: in the official `Qwen3ASRAudioEncoder.forward` the
+adaptor is fused at the tail of the encoder module --
+`... -> encoder layers -> ln_post -> proj1 -> act -> proj2 -> output`. So
+`audio_encoder.npy` is the `ln_post` output (the encoder proper, 896-dim, tapped
+with a forward hook) and `audio_adaptor.npy` is the projector output
+(896 -> 1024-dim, matching the LLM `d_model`) spliced into the LLM prompt at the
+audio-pad token positions.
+
+The greedy-decode stage of the fbank -> encoder -> adaptor -> LLM-prefill ->
+greedy-decode pipeline is `dump_golden.py`'s full `model.generate()` call, not
+this script (mirrors moss, whose `dump_intermediate.py` likewise stops at the
+prefill logits and leaves the full decode to `dump_golden.py`).
+
+Unlike the moss dumper, there is no single-chunk (<=30s) restriction here:
+`Qwen3ASRAudioEncoder` does its own windowed-attention chunking (`n_window=50`,
+i.e. 100-frame / 1s chunks), so `get_audio_features` handles arbitrarily long
+clips (up to the reference stack's 1200s cap) and the dumped tensors are the real
+packed valid-frame sequence, not a single-chunk trim.
+
+## Verification status
+
+Neither script has been run against the real checkpoint yet: doing so requires
+downloading the ~1.2GB `Qwen/Qwen3-ASR-0.6B` weights, which is deferred to a
+dedicated measurement window. Both byte-compile (`python3 -m py_compile`) and
+follow the official `qwen_asr` transformers-backend call path exactly
+(`AutoModel.from_pretrained` + `processor.apply_chat_template` +
+`processor(text=..., audio=...)` + `model.generate`, and
+`thinker.get_audio_features` / `thinker(...)` for the per-stage taps), but the
+numeric cross-check against the ggml runtime's `golden_diff_*` tests is still
+outstanding. Do not treat the dump shapes as verified until a real run lands.
+
+## Scope
+
+Neither script here has a self-test: both are thin, mostly-I/O wrappers around
+the official reference stack's own `generate()` / module forward calls (unlike
+`firered2-reference-dumper/dump_reference.py`, which has enough standalone
+arithmetic to make a weight-free unit test worthwhile). The actual correctness
+check for this dumper is a real run against the real checkpoint,
+cross-referenced against the ggml runtime's own committed `golden_diff_*` tests
+in `ggml_executor.rs` (once those pin `GOLDEN_*_TEXT` constants transcribed from
+`dump_golden.py`'s output).

--- a/tooling/qwen-reference-dumper/dump_golden.py
+++ b/tooling/qwen-reference-dumper/dump_golden.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Reference-implementation golden-transcript dumper for qwen3-asr
+(Qwen/Qwen3-ASR-0.6B).
+
+Runs the *official* python reference stack (not a reimplementation) -- the
+`qwen_asr` package's transformers backend, i.e. its registered
+`Qwen3ASRForConditionalGeneration.generate()` plus its own `Qwen3ASRProcessor`
+chat template and `parse_asr_output` helper -- on real fixture wavs, greedy /
+deterministic, CPU, fp32, and dumps one JSON record per sample: full generated
+token ids, decoded text (with and without special tokens), prompt token ids,
+and the parsed `language` + transcript `asr_text`. This is the script intended
+to produce the records the committed
+`crates/openasr-core/src/models/qwen/ggml_executor.rs` `GOLDEN_*_TEXT`
+constants are transcribed from (the qwen family does not yet pin golden
+transcripts in-tree -- this dumper makes that generation reproducible rather
+than leaving it as an untracked one-off, exactly the role
+`../moss-reference-dumper/dump_golden.py` plays for moss-transcribe-diarize).
+Satisfies the "Reference dumper exists for this family" row in
+`docs/model-audits/TEMPLATE.md` section 10.
+
+Which field is the future golden constant? The ggml executor strips the
+`language <name><asr_text>` control prefix from the decoded token stream (see
+`greedy_decode_strips_qwen_asr_control_prefix` in `greedy_decode.rs`) and emits
+just the transcript. That transcript is byte-for-byte what `parse_asr_output`
+returns as its second element, so the `asr_text` JSON field below -- not the raw
+`text` field, which still carries the control prefix -- is the one a future
+`GOLDEN_*_TEXT` constant should match. Both are recorded so the relationship is
+auditable.
+
+Official reference source (do not vendor -- clone locally)
+-----------------------------------------------------------
+Code:    https://github.com/QwenLM/Qwen3-ASR
+         pinned commit 7c6daf77a2421100f5fb066495372c00129d39ff (2026-06-26).
+         `import qwen_asr` from that clone registers the family's config /
+         model / processor with transformers' Auto classes (the checkpoint
+         ships no `modeling_*.py` of its own, so there is nothing to
+         `trust_remote_code` -- the modeling lives in the pip-installable
+         `qwen_asr` package, unlike moss whose modeling ships in the checkpoint
+         via `trust_remote_code=True`).
+Weights: https://huggingface.co/Qwen/Qwen3-ASR-0.6B (open, Apache-2.0; download
+         the standard HF layout: `config.json`, `model.safetensors` (single
+         shard, ~1.2GB fp16 on disk, loaded fp32 here), `generation_config.json`,
+         `chat_template.json`, `preprocessor_config.json`,
+         `tokenizer_config.json`, `special_tokens_map.json` (if present),
+         `vocab.json`, `merges.txt`).
+
+This script does NOT vendor the official repo or any weights into the repo
+(both are third-party).
+
+Setup (host python, matches `tooling/publish-model` /
+`firered2-reference-dumper` / `moss-reference-dumper` convention -- no dedicated
+venv in this repo). NOTE the transformers pin differs from moss: `qwen_asr`
+requires `transformers==4.57.6` (its `AutoConfig.register("qwen3_asr", ...)`
+would collide with the model type transformers later merged natively), so pin
+that exact version rather than moss's `transformers>=5.0`:
+
+    python3 -m pip install --user "transformers==4.57.6" "torch>=2.8" numpy \\
+        librosa soundfile nagisa
+
+(`librosa`/`soundfile` come from `qwen_asr.inference.utils`' audio loading,
+`nagisa` from its forced-aligner module import -- both are pulled in by the
+plain `import qwen_asr` even though this dumper never runs the aligner.
+`soynlp`, `gradio`, `flask`, `vllm` are NOT needed here. Alternatively,
+`python3 -m pip install --user -e /path/to/Qwen3-ASR` installs the official
+full dependency set, including the gradio/flask the dumper does not use.)
+
+Usage
+-----
+    cd tooling/qwen-reference-dumper
+    python3 dump_golden.py \\
+      --qwen-repo /path/to/Qwen3-ASR \\
+      --weights-dir /path/to/qwen3-asr-0.6b-weights \\
+      --samples-dir ../../fixtures \\
+      --sample jfk=jfk.wav \\
+      --out-dir /path/to/scratch/qwen-golden
+
+`--sample NAME=RELATIVE_WAV_PATH` may be repeated; each is resolved against
+`--samples-dir`. Every sample writes `<out-dir>/<name>.json` (prompt token ids,
+full/generated token ids, decoded text with and without special tokens, parsed
+language + transcript, elapsed time, environment versions).
+
+Greedy (`do_sample=False`), CPU, fp32, seeded (`--seed`, default `0`) for
+determinism -- matches the golden-diff convention every other builtin family's
+dev-only reference dump uses (see `../moss-reference-dumper/dump_golden.py` and
+`../firered2-reference-dumper/dump_reference.py`'s `llm` stage).
+
+Memory
+------
+The whole checkpoint (~0.6B params: 18-layer Whisper-style audio encoder +
+audio projector + 28-layer Qwen3 text decoder) fits comfortably in fp32 on a
+16GB dev machine (well under 4GB resident) -- unlike firered2-llm's 7B-parameter
+Qwen2 decoder, this family needs none of that dumper's meta-device
+layer-streaming trick. `AutoModel.from_pretrained(..., dtype=torch.float32)`
+loads the whole model directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import torch
+import transformers
+
+
+def parse_sample_arg(raw: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise argparse.ArgumentTypeError(f"--sample expects NAME=RELATIVE_WAV_PATH, got '{raw}'")
+    name, _, relative_wav = raw.partition("=")
+    name = name.strip()
+    relative_wav = relative_wav.strip()
+    if not name or not relative_wav:
+        raise argparse.ArgumentTypeError(f"--sample expects NAME=RELATIVE_WAV_PATH, got '{raw}'")
+    return name, relative_wav
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--qwen-repo",
+        type=Path,
+        required=True,
+        help="local clone of QwenLM/Qwen3-ASR (provides the `qwen_asr` package)",
+    )
+    parser.add_argument(
+        "--weights-dir",
+        type=Path,
+        required=True,
+        help="local HF checkpoint directory (config.json, model.safetensors, ...)",
+    )
+    parser.add_argument("--samples-dir", type=Path, required=True, help="base dir for --sample wav paths")
+    parser.add_argument(
+        "--sample",
+        dest="samples",
+        action="append",
+        type=parse_sample_arg,
+        required=True,
+        help="NAME=RELATIVE_WAV_PATH, repeatable",
+    )
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--max-new-tokens", type=int, default=512)
+    return parser
+
+
+def build_transcription_messages() -> list[dict]:
+    """Mirror `Qwen3ASRModel._build_messages` (empty system context, one audio)."""
+    return [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": [{"type": "audio", "audio": ""}]},
+    ]
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
+    sys.path.insert(0, str(args.qwen_repo))
+    # `import qwen_asr` registers Qwen3ASRConfig / Qwen3ASRForConditionalGeneration
+    # / Qwen3ASRProcessor with transformers' Auto classes, so AutoModel /
+    # AutoProcessor below resolve the family off the plain checkpoint dir.
+    import qwen_asr  # noqa: F401
+    from qwen_asr.inference.utils import normalize_audios, parse_asr_output
+    from transformers import AutoModel, AutoProcessor
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cpu")
+    dtype = torch.float32
+
+    print(f"transformers={transformers.__version__} torch={torch.__version__}")
+    print(f"loading {args.weights_dir} on CPU (fp32, deterministic)...")
+    t0 = time.time()
+    torch.manual_seed(args.seed)
+    model = (
+        AutoModel.from_pretrained(args.weights_dir, dtype=dtype).to(device=device).eval()
+    )
+    processor = AutoProcessor.from_pretrained(args.weights_dir, fix_mistral_regex=True)
+    print(f"model loaded in {time.time() - t0:.1f}s")
+
+    prompt_text = processor.apply_chat_template(
+        build_transcription_messages(), add_generation_prompt=True, tokenize=False
+    )
+
+    for name, relative_wav in args.samples:
+        audio_path = args.samples_dir / relative_wav
+        if not audio_path.exists():
+            print(f"SKIP {name}: {audio_path} not found")
+            continue
+        print(f"\n=== {name} ({audio_path}) ===")
+        torch.manual_seed(args.seed)
+        wav = normalize_audios(str(audio_path))[0]
+        batch = processor(text=[prompt_text], audio=[wav], return_tensors="pt", padding=True)
+        # Cast only floating-point tensors (input_features) to fp32; the id /
+        # mask tensors must stay integral. (BatchFeature.to(dtype) already skips
+        # ints on recent transformers, but be explicit rather than rely on it.)
+        inputs = {
+            key: (tensor.to(device).to(dtype) if torch.is_floating_point(tensor) else tensor.to(device))
+            for key, tensor in batch.items()
+        }
+        prompt_len = int(inputs["input_ids"].shape[1])
+        prompt_ids = inputs["input_ids"][0].tolist()
+
+        t0 = time.time()
+        with torch.inference_mode():
+            outputs = model.generate(
+                **inputs,
+                do_sample=False,
+                max_new_tokens=args.max_new_tokens,
+            )
+        elapsed = time.time() - t0
+
+        full_ids = outputs.sequences[0].tolist()
+        generated_ids = full_ids[prompt_len:]
+        text = processor.batch_decode(
+            [generated_ids], skip_special_tokens=True, clean_up_tokenization_spaces=False
+        )[0].strip()
+        text_with_special = processor.batch_decode([generated_ids], skip_special_tokens=False)[0]
+
+        # `parse_asr_output` splits the raw "language <name><asr_text>..." decode
+        # into (language, transcript); its transcript is exactly what the ggml
+        # executor emits after stripping the control prefix, so it is the future
+        # golden-constant field.
+        language, asr_text = parse_asr_output(text)
+
+        print(f"language: {language}")
+        print(f"asr_text:\n{asr_text}")
+        print(f"prompt_len={prompt_len} generated_tokens={len(generated_ids)} elapsed={elapsed:.1f}s")
+
+        record = {
+            "sample_name": name,
+            "audio_path": str(audio_path),
+            "device": "cpu",
+            "dtype": "float32",
+            "seed": args.seed,
+            "transformers_version": transformers.__version__,
+            "torch_version": torch.__version__,
+            "do_sample": False,
+            "max_new_tokens": args.max_new_tokens,
+            "prompt_len": prompt_len,
+            "generated_tokens": len(generated_ids),
+            "elapsed_seconds": elapsed,
+            "prompt_input_ids": prompt_ids,
+            "generated_token_ids": generated_ids,
+            "full_token_ids": full_ids,
+            "text": text,
+            "text_with_special_tokens": text_with_special,
+            "language": language,
+            "asr_text": asr_text,
+        }
+        out_path = args.out_dir / f"{name}.json"
+        out_path.write_text(json.dumps(record, ensure_ascii=False, indent=2))
+        print(f"saved -> {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/qwen-reference-dumper/dump_intermediate.py
+++ b/tooling/qwen-reference-dumper/dump_intermediate.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Reference-implementation intermediate-activation dumper for qwen3-asr
+(Qwen/Qwen3-ASR-0.6B).
+
+Runs the *official* python reference stack (the `qwen_asr` package's
+transformers backend) on one fixture wav and dumps the mel frontend output,
+the audio-encoder output (post `ln_post`, pre-projector), the audio-adaptor
+output (the projector's `proj1 -> act -> proj2` result spliced into the LLM
+prompt at the audio-pad token positions), and the first prefill step's logits
+as `.npy` files -- so the ggml side
+(`crates/openasr-core/src/models/qwen/frontend.rs`, `audio_encoder.rs`,
+`llm_prefill.rs`) can be diffed against ground truth stage by stage, the same
+role `dump_reference.py`'s `fbank` / `encoder` / `adapter` / `llm` stages play
+for firered2-llm (see `../firered2-reference-dumper/README.md`) and
+`dump_intermediate.py` plays for moss-transcribe-diarize (see
+`../moss-reference-dumper/README.md`). Like the moss dumper this is a single
+fixed pipeline run rather than a `--stage`-selectable one: this family's whole
+checkpoint (~0.6B params) is small enough that dumping every stage costs
+nothing extra, so there is no `--stage`-driven memory trade-off to make (see
+`dump_golden.py`'s module doc "Memory" section for why the checkpoint size
+makes firered2-llm's meta-device layer-streaming machinery unnecessary here).
+
+The greedy-decode stage of the fbank -> encoder -> adaptor -> LLM-prefill ->
+greedy-decode pipeline is NOT dumped here; it is `dump_golden.py`'s full
+`model.generate()` call (mirrors moss, whose `dump_intermediate.py` likewise
+stops at the prefill logits and leaves the full decode to `dump_golden.py`).
+
+Encoder/adaptor boundary: in the official `Qwen3ASRAudioEncoder.forward` the
+adaptor is fused at the tail of the encoder module --
+`... -> encoder layers -> ln_post -> proj1 -> act -> proj2 -> output`. So the
+stage boundary the ggml side diffs against is the `ln_post` output (the encoder
+proper, 896-dim), and the projector (`proj1/act/proj2`) is the adaptor
+(896 -> 1024-dim, matching the LLM `d_model`). We tap that boundary with a
+forward hook on `audio_tower.ln_post` rather than reimplementing the encoder.
+
+Official reference source (do not vendor -- clone locally)
+-----------------------------------------------------------
+Code:    https://github.com/QwenLM/Qwen3-ASR
+         pinned commit 7c6daf77a2421100f5fb066495372c00129d39ff (2026-06-26)
+Weights: https://huggingface.co/Qwen/Qwen3-ASR-0.6B (see `dump_golden.py`'s
+         module doc for the expected local layout)
+
+Setup: same as `dump_golden.py` (note the `transformers==4.57.6` pin):
+
+    python3 -m pip install --user "transformers==4.57.6" "torch>=2.8" numpy \\
+        librosa soundfile nagisa
+
+Usage
+-----
+    cd tooling/qwen-reference-dumper
+    python3 dump_intermediate.py \\
+      --qwen-repo /path/to/Qwen3-ASR \\
+      --weights-dir /path/to/qwen3-asr-0.6b-weights \\
+      --wav ../../fixtures/jfk.wav \\
+      --out-dir /path/to/scratch/qwen-dump
+
+Dumps, into `--out-dir`:
+
+| file | contents | shape |
+| --- | --- | --- |
+| `input_features.npy` | mel frontend output fed to the audio encoder (128 mel bins) | `[1, 128, mel_frames]` |
+| `feature_attention_mask.npy` | valid-frame mask for `input_features` | `[1, mel_frames]` |
+| `audio_encoder.npy` | audio encoder's `ln_post` output (pre-projector) | `[n_audio_tokens, 896]` |
+| `audio_adaptor.npy` | projector (`proj1 -> act -> proj2`) output spliced into the LLM prompt at the audio-pad token positions | `[n_audio_tokens, 1024]` |
+| `prefill_last_logits.npy` | full-prompt forward's last-position logits (pre-generation, one token's worth) | `[vocab_size]` |
+
+Unlike the moss dumper, there is no single-chunk (<=30s) restriction here:
+`Qwen3ASRAudioEncoder` does its own windowed-attention chunking (`n_window=50`,
+i.e. 100-frame / 1s chunks), so `get_audio_features` handles arbitrarily long
+clips (up to the reference stack's 1200s cap) and the dumped tensors are the
+real packed valid-frame sequence, not a single-chunk trim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--qwen-repo", type=Path, required=True)
+    parser.add_argument("--weights-dir", type=Path, required=True)
+    parser.add_argument("--wav", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
+    sys.path.insert(0, str(args.qwen_repo))
+    import qwen_asr  # noqa: F401  (registers the family with transformers' Auto classes)
+    from qwen_asr.inference.utils import normalize_audios
+    from transformers import AutoModel, AutoProcessor
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cpu")
+    dtype = torch.float32
+
+    torch.manual_seed(0)
+    model = AutoModel.from_pretrained(args.weights_dir, dtype=dtype).to(device=device).eval()
+    processor = AutoProcessor.from_pretrained(args.weights_dir, fix_mistral_regex=True)
+    thinker = model.thinker
+
+    messages = [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": [{"type": "audio", "audio": ""}]},
+    ]
+    prompt_text = processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+
+    wav = normalize_audios(str(args.wav))[0]
+    batch = processor(text=[prompt_text], audio=[wav], return_tensors="pt", padding=True)
+    # Cast only floating-point tensors (input_features) to fp32; id / mask
+    # tensors must stay integral.
+    inputs = {
+        key: (tensor.to(device).to(dtype) if torch.is_floating_point(tensor) else tensor.to(device))
+        for key, tensor in batch.items()
+    }
+
+    input_features = inputs["input_features"]
+    feature_attention_mask = inputs["feature_attention_mask"]
+    print("input_features", tuple(input_features.shape), input_features.dtype)
+    print("feature_attention_mask", tuple(feature_attention_mask.shape), "valid_frames", int(feature_attention_mask.sum()))
+    np.save(args.out_dir / "input_features.npy", input_features.to(torch.float32).numpy())
+    np.save(args.out_dir / "feature_attention_mask.npy", feature_attention_mask.numpy())
+
+    captured: dict[str, torch.Tensor] = {}
+
+    def capture_ln_post(_module, _inputs, output):
+        captured["encoder"] = output.detach()
+
+    def capture_adaptor(_module, _inputs, output):
+        captured["adaptor"] = output.last_hidden_state.detach()
+
+    ln_post_handle = thinker.audio_tower.ln_post.register_forward_hook(capture_ln_post)
+    tower_handle = thinker.audio_tower.register_forward_hook(capture_adaptor)
+    with torch.inference_mode():
+        audio_features = thinker.get_audio_features(
+            input_features, feature_attention_mask=feature_attention_mask
+        )
+    ln_post_handle.remove()
+    tower_handle.remove()
+
+    n_audio_pad = int((inputs["input_ids"] == processor.audio_token_id).sum())
+    print("encoder (ln_post out)", tuple(captured["encoder"].shape))
+    print("adaptor (projector out)", tuple(captured["adaptor"].shape))
+    print("audio_features", tuple(audio_features.shape), "n_audio_pad_tokens", n_audio_pad)
+    np.save(args.out_dir / "audio_encoder.npy", captured["encoder"].to(torch.float32).numpy())
+    np.save(args.out_dir / "audio_adaptor.npy", captured["adaptor"].to(torch.float32).numpy())
+
+    with torch.inference_mode():
+        out = thinker(
+            input_ids=inputs["input_ids"],
+            attention_mask=inputs["attention_mask"],
+            input_features=input_features,
+            feature_attention_mask=feature_attention_mask,
+        )
+    logits = out.logits[0, -1].to(torch.float32).numpy()
+    np.save(args.out_dir / "prefill_last_logits.npy", logits)
+    topk = np.argsort(logits)[::-1][:10]
+    print("prefill top10 tokens:", [(int(t), float(logits[t])) for t in topk])
+
+    for name in ["audio_encoder", "audio_adaptor"]:
+        a = np.load(args.out_dir / f"{name}.npy")
+        print(f"{name}: shape={a.shape} mean={a.mean():.5f} std={a.std():.5f} min={a.min():.4f} max={a.max():.4f}")
+    print("DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Ports the existing moss / firered2 reference-dumper pattern to the qwen3-asr
family, adding `tooling/qwen-reference-dumper/` with two scripts plus a README.
Both run the **official** `qwen_asr` transformers backend (QwenLM/Qwen3-ASR,
pinned `7c6daf7`) on CPU / fp32 / greedy so the ggml side
(`crates/openasr-core/src/models/qwen/`) can be diffed against ground truth.

## Why

The qwen3-asr audit form has the section-10 "Reference dumper exists for this
family" row Deferred. This lands the in-tree, reproducible dumper that produces
the records future `GOLDEN_*_TEXT` constants in `ggml_executor.rs` are
transcribed from, matching what `tooling/moss-reference-dumper/` and
`tooling/firered2-reference-dumper/` already provide for their families.

## Changes

- `dump_golden.py` - full greedy `model.generate()` -> per-sample golden JSON
  (prompt / generated / full token ids, decoded text with and without special
  tokens, parsed `language` + transcript `asr_text`).
- `dump_intermediate.py` - single-clip stage-by-stage `.npy` dump (mel frontend,
  audio-encoder `ln_post` output, projector / adaptor output, prefill logits).
- `README.md` - reference-source pin, setup, usage, stage shapes, and the
  delta vs the moss / firered2 dumpers.

## Tests run

N/A for the cargo checks - this is pure Python tooling with no Rust changes.

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Ran: `python3 -m py_compile tooling/qwen-reference-dumper/*.py` (both pass).

## Manual smoke checks

None yet - the scripts are not run against the real checkpoint (that requires
downloading the ~1.2GB `Qwen/Qwen3-ASR-0.6B` weights, deferred to a dedicated
measurement window). Both scripts follow the official `qwen_asr`
transformers-backend call path exactly and byte-compile, but the numeric
cross-check against the ggml runtime is still outstanding.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

The README's "Verification status" section explicitly states the dumper has not
yet been run against the real checkpoint.

## Scope / non-goals

- Does not download the model or run the actual dump.
- Does not change any Rust code.
- Does not yet pin `GOLDEN_*_TEXT` constants or add a `golden_diff_*` test
  (that needs a real run first).
- Does not add a qwen audit form / flip the section-10 row (no form exists in
  tree yet; that lands with the measurement-window run).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - AI drafted the two dumper scripts and README by porting the existing moss / firered2 dumper pattern; not run against the real checkpoint.