### PR TITLE
fix(core): floor audio-encoder quantization at Q8_0

### DIFF
--- a/crates/openasr-core/src/models/cohere/package_import.rs
+++ b/crates/openasr-core/src/models/cohere/package_import.rs
@@ -22,7 +22,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1, OasrMetadataBuilder,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 use crate::models::runtime_tensor_contract_registry::validate_builtin_runtime_tensor_contract_for_architecture;
 use crate::models::{cohere::COHERE_TRANSCRIBE_MODEL_FAMILY, cohere::runtime_contract};
 use crate::{read_gguf_metadata_from_runtime_source, read_gguf_tensor_index_from_runtime_source};
@@ -548,7 +548,18 @@ fn quantized_tensor_type_for_cohere_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    classify_quant_tensor(ne0, quantization, cohere_quant_component(name))
+}
+
+/// Encoder/audio-front-end tensors map onto the `enc.*` namespace (`enc.pre.*`,
+/// `enc.proj`, `enc.blk.*`); the transformer decoder is `dec.*`. The encoder
+/// carries the shared Q8_0 floor (see `classify_quant_tensor`).
+fn cohere_quant_component(name: &str) -> QuantComponent {
+    if name.starts_with("enc.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/openasr-core/src/models/dolphin/package_import.rs
+++ b/crates/openasr-core/src/models/dolphin/package_import.rs
@@ -72,7 +72,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 use crate::nn::half::f32_to_f16_bits;
 
 // --- E-Branchformer / Transformer configuration -------------------------------
@@ -725,7 +725,14 @@ fn dolphin_quant_type_for_tensor(
     }
     // Reversed ne0 == the safetensors innermost (last) dim == `in`.
     let ne0 = *shape.last()?;
-    classify_quant_tensor(ne0, quantization)
+    // dolphin keeps WeNet source names: the acoustic encoder is `encoder.*`;
+    // `decoder.*` / `ctc.*` / `context_module.*` (hotword) are downstream.
+    let component = if name.starts_with("encoder.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    };
+    classify_quant_tensor(ne0, quantization, component)
 }
 
 /// Build one runtime tensor. Quantizable rank-2 `.weight` matrices are block-
@@ -1048,11 +1055,12 @@ mod tests {
             ),
             Some(GgufWriteTensorType::Q8_0)
         );
-        // q4_k: in-dim 256-aligned -> Q4_K; only 32- (not 256-) aligned -> Q8_0.
+        // q4_k on a decoder tensor: in-dim 256-aligned -> Q4_K; only 32- (not
+        // 256-) aligned -> Q8_0.
         assert_eq!(
             dolphin_quant_type_for_tensor(
-                "encoder.encoders.0.feed_forward.w_2.weight",
-                &[768, 3072],
+                "decoder.output_layer.weight",
+                &[18173, 768],
                 DolphinQuantizationMode::Q4_K
             ),
             Some(GgufWriteTensorType::Q4_K)
@@ -1061,6 +1069,17 @@ mod tests {
             dolphin_quant_type_for_tensor(
                 "some.proj.weight",
                 &[10, 96],
+                DolphinQuantizationMode::Q4_K
+            ),
+            Some(GgufWriteTensorType::Q8_0)
+        );
+        // The audio encoder carries a Q8_0 floor: a 256-aligned encoder linear
+        // that would otherwise take q4_k clamps to q8_0 (sub-Q8 encoder weights
+        // collapse long-audio greedy decode).
+        assert_eq!(
+            dolphin_quant_type_for_tensor(
+                "encoder.encoders.0.feed_forward.w_2.weight",
+                &[768, 3072],
                 DolphinQuantizationMode::Q4_K
             ),
             Some(GgufWriteTensorType::Q8_0)

--- a/crates/openasr-core/src/models/firered_aed/package_import.rs
+++ b/crates/openasr-core/src/models/firered_aed/package_import.rs
@@ -61,7 +61,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 
 const SOURCE_MODEL_SAFETENSORS: &str = "model.safetensors";
 const SOURCE_DICT_TXT: &str = "dict.txt";
@@ -704,6 +704,7 @@ fn quantized_tensor_type_for_firered_tensor(
     class: TensorClass,
     dims: &[u64],
     quantization: FireRedAedQuantizationMode,
+    component: QuantComponent,
 ) -> Option<GgufWriteTensorType> {
     if quantization == FireRedAedQuantizationMode::Fp16 {
         return None;
@@ -715,7 +716,18 @@ fn quantized_tensor_type_for_firered_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    classify_quant_tensor(ne0, quantization, component)
+}
+
+/// Conformer encoder tensors map onto `enc.*` (`enc.blk.*`, `enc.subsample.*`,
+/// `enc.pos_enc.pe`); the Transformer decoder is `dec.*` (`dec.blk.*`,
+/// `dec.tok_emb`, `dec.out_proj`). The encoder carries the shared Q8_0 floor.
+fn firered_quant_component(target_name: &str) -> QuantComponent {
+    if target_name.starts_with("enc.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    }
 }
 
 fn build_firered_runtime_tensors(
@@ -757,6 +769,7 @@ fn build_firered_runtime_tensors(
             class,
             &target_dims,
             quantization,
+            firered_quant_component(&target_name),
         ) {
             Some(qtype) => {
                 let values = decode_safetensors_payload_as_f32(&tensor.name, &tensor.dtype, data)?;
@@ -1010,7 +1023,8 @@ mod tests {
             quantized_tensor_type_for_firered_tensor(
                 Linear,
                 &[1280, 5120],
-                FireRedAedQuantizationMode::Q4_K
+                FireRedAedQuantizationMode::Q4_K,
+                QuantComponent::Decoder
             ),
             Some(GgufWriteTensorType::Q4_K)
         );
@@ -1018,7 +1032,8 @@ mod tests {
             quantized_tensor_type_for_firered_tensor(
                 PointwiseConvSqueeze,
                 &[1280, 5120],
-                FireRedAedQuantizationMode::Q8_0
+                FireRedAedQuantizationMode::Q8_0,
+                QuantComponent::Decoder
             ),
             Some(GgufWriteTensorType::Q8_0)
         );
@@ -1027,7 +1042,8 @@ mod tests {
             quantized_tensor_type_for_firered_tensor(
                 Linear,
                 &[1280, 5120],
-                FireRedAedQuantizationMode::Fp16
+                FireRedAedQuantizationMode::Fp16,
+                QuantComponent::Decoder
             ),
             None
         );
@@ -1035,7 +1051,8 @@ mod tests {
             quantized_tensor_type_for_firered_tensor(
                 ConvKernel,
                 &[33, 1, 2560],
-                FireRedAedQuantizationMode::Q4_K
+                FireRedAedQuantizationMode::Q4_K,
+                QuantComponent::Decoder
             ),
             None
         );
@@ -1043,7 +1060,8 @@ mod tests {
             quantized_tensor_type_for_firered_tensor(
                 F16Table,
                 &[1280, 7832, 1],
-                FireRedAedQuantizationMode::Q4_K
+                FireRedAedQuantizationMode::Q4_K,
+                QuantComponent::Decoder
             ),
             None
         );
@@ -1052,9 +1070,25 @@ mod tests {
             quantized_tensor_type_for_firered_tensor(
                 Linear,
                 &[100, 5120],
-                FireRedAedQuantizationMode::Q8_0
+                FireRedAedQuantizationMode::Q8_0,
+                QuantComponent::Decoder
             ),
             None
+        );
+    }
+
+    #[test]
+    fn encoder_linear_carries_a_q8_0_floor_in_a_q4_k_pack() {
+        // A 256-aligned encoder linear would take q4_k on the decoder side, but
+        // the shared encoder floor clamps it to q8_0.
+        assert_eq!(
+            quantized_tensor_type_for_firered_tensor(
+                Linear,
+                &[1280, 5120],
+                FireRedAedQuantizationMode::Q4_K,
+                QuantComponent::Encoder
+            ),
+            Some(GgufWriteTensorType::Q8_0)
         );
     }
 

--- a/crates/openasr-core/src/models/firered_llm/package_import.rs
+++ b/crates/openasr-core/src/models/firered_llm/package_import.rs
@@ -83,7 +83,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 
 use super::tensor_names::{
     ADAPTER_LINEAR1_BIAS, ADAPTER_LINEAR1_WEIGHT, ADAPTER_LINEAR2_BIAS, ADAPTER_LINEAR2_WEIGHT,
@@ -592,7 +592,9 @@ fn quantized_tensor_type_for_encoder_adapter_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    // This builder emits only the acoustic encoder + its adapter (the audio
+    // tower feeding the Qwen2 LLM), so every tensor here carries the floor.
+    classify_quant_tensor(ne0, quantization, QuantComponent::Encoder)
 }
 
 fn build_encoder_adapter_runtime_tensors(
@@ -925,7 +927,9 @@ fn quantized_tensor_type_for_qwen2(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    // This builder emits only the Qwen2 text decoder/LLM, which keeps the full
+    // requested rung (the audio encoder floor does not apply here).
+    classify_quant_tensor(ne0, quantization, QuantComponent::Decoder)
 }
 
 fn build_llm_runtime_tensors(
@@ -1550,13 +1554,16 @@ mod tests {
 
     #[test]
     fn quantizes_only_linear_encoder_adapter_classes_with_aligned_ne0() {
+        // The encoder/adapter is the audio tower, so it carries the Q8_0 floor:
+        // a q4_k request on an aligned linear clamps to q8_0 (still quantized,
+        // just not sub-Q8).
         assert_eq!(
             quantized_tensor_type_for_encoder_adapter_tensor(
                 TensorClass::Linear,
                 &[1280, 5120],
                 FireRedLlmQuantizationMode::Q4_K
             ),
-            Some(GgufWriteTensorType::Q4_K)
+            Some(GgufWriteTensorType::Q8_0)
         );
         assert_eq!(
             quantized_tensor_type_for_encoder_adapter_tensor(

--- a/crates/openasr-core/src/models/moonshine/package_import.rs
+++ b/crates/openasr-core/src/models/moonshine/package_import.rs
@@ -24,7 +24,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1, insert_metadata,
     insert_metadata_string_array as insert_string_array, insert_metadata_u32 as insert_u32,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 use crate::{read_gguf_metadata_from_runtime_source, read_gguf_tensor_index_from_runtime_source};
 
 const SOURCE_CONFIG_JSON: &str = "config.json";
@@ -413,7 +413,14 @@ fn quantized_tensor_type_for_moonshine_tensor(
     if name == "dec.emb.weight" {
         return Some(GgufWriteTensorType::Q8_0);
     }
-    classify_quant_tensor(ne0, quantization)
+    // The acoustic encoder is `enc.*`; `dec.*` (incl. the encoder cross-attention
+    // mapped to `dec.blk.{i}.cross_*`) is the decoder side.
+    let component = if name.starts_with("enc.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    };
+    classify_quant_tensor(ne0, quantization, component)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
@@ -78,7 +78,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1, OasrMetadataBuilder,
     TOKENIZER_GGML_MERGES_KEY, TOKENIZER_GGML_MODEL_KEY, TOKENIZER_GGML_TOKENS_KEY,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 
 use super::runtime_contract::moss_td_kv_cache_positions;
 use super::tensor_names::{
@@ -416,12 +416,25 @@ fn reversed_dims(shape: &[u64]) -> Vec<u64> {
 fn quantized_linear_tensor_type(
     dims: &[u64],
     quantization: MossTdQuantizationMode,
+    component: QuantComponent,
 ) -> Option<GgufWriteTensorType> {
     if quantization == MossTdQuantizationMode::Fp16 {
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    classify_quant_tensor(ne0, quantization, component)
+}
+
+/// The acoustic path is the whisper encoder (`moss.enc.*`) plus its
+/// encoder->LLM projector (`moss.adaptor.*`, the analogue of qwen's
+/// `audio.proj*`); both carry the shared Q8_0 floor. The `moss.llm.*` text
+/// decoder keeps the full requested rung.
+fn moss_quant_component(target_name: &str) -> QuantComponent {
+    if target_name.starts_with("moss.enc.") || target_name.starts_with("moss.adaptor.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    }
 }
 
 fn maybe_quantized_linear_tensor(
@@ -431,7 +444,11 @@ fn maybe_quantized_linear_tensor(
     target_dims: Vec<u64>,
     quantization: MossTdQuantizationMode,
 ) -> Result<GgufWriteTensor, LocalSourceImportError> {
-    match quantized_linear_tensor_type(&target_dims, quantization) {
+    match quantized_linear_tensor_type(
+        &target_dims,
+        quantization,
+        moss_quant_component(target_name),
+    ) {
         Some(tensor_type) => {
             let values = decode_safetensors_payload_as_f32(&tensor.name, &tensor.dtype, data)?;
             let expected = tensor_element_count(&tensor.name, &target_dims)?;

--- a/crates/openasr-core/src/models/pack_quant.rs
+++ b/crates/openasr-core/src/models/pack_quant.rs
@@ -44,6 +44,25 @@ impl PackQuant {
     }
 }
 
+/// Which side of a model a quantizable tensor lives on, used to apply the
+/// audio-encoder Q8_0 floor.
+///
+/// Sub-Q8 block quantization of *audio-encoder* weights is a behavioral cliff
+/// rather than a gradual WER loss: long-audio greedy decode collapses into
+/// repetition or empty output (e.g. the qwen3-asr 1.7b q4_k pack degrading to a
+/// "Today, today" text collapse). The audio encoder therefore carries a hard
+/// Q8_0 floor regardless of the requested rung, while decoder / LLM / CTC /
+/// joint / embedding / output-head tensors keep the full requested rung.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QuantComponent {
+    /// Audio encoder / audio-tower weights: the acoustic feature extractor that
+    /// feeds the decoder, including any encoder->LLM projector.
+    Encoder,
+    /// Everything downstream of the encoder: text decoder / LLM layers, CTC /
+    /// joint heads, token embeddings, and output projections.
+    Decoder,
+}
+
 /// Shared 32/256-alignment + K-quant-rung selection tail.
 ///
 /// Callers first resolve their own family-specific tensor eligibility
@@ -52,14 +71,21 @@ impl PackQuant {
 /// decides, given an already-eligible rank-2 axis length, whether
 /// q8_0/q3_k/q4_k applies or the tensor falls back to `None` (its fp16-mode
 /// representation).
+///
+/// `component` carries the audio-encoder Q8_0 floor: an `Encoder` tensor never
+/// takes the Q3_K/Q4_K rungs and always lands on Q8_0 once 32-aligned, while a
+/// `Decoder` tensor keeps the full requested rung. Each family supplies the
+/// classification (it owns the tensor-naming knowledge); the floor policy itself
+/// lives here so every importer applies it identically.
 pub(crate) fn classify_quant_tensor(
     ne0: u64,
     quantization: PackQuant,
+    component: QuantComponent,
 ) -> Option<GgufWriteTensorType> {
     if !ne0.is_multiple_of(32_u64) {
         return None;
     }
-    if ne0.is_multiple_of(256_u64) {
+    if ne0.is_multiple_of(256_u64) && component == QuantComponent::Decoder {
         if quantization == PackQuant::Q3_K {
             return Some(GgufWriteTensorType::Q3_K);
         }
@@ -76,21 +102,30 @@ mod tests {
 
     #[test]
     fn unaligned_ne0_falls_back_to_fp16_representation() {
-        assert_eq!(classify_quant_tensor(31, PackQuant::Q8_0), None);
         assert_eq!(
-            classify_quant_tensor(32, PackQuant::Q8_0),
+            classify_quant_tensor(31, PackQuant::Q8_0, QuantComponent::Decoder),
+            None
+        );
+        assert_eq!(
+            classify_quant_tensor(32, PackQuant::Q8_0, QuantComponent::Decoder),
             Some(GgufWriteTensorType::Q8_0)
+        );
+        // Encoder alignment gating is unchanged: an unaligned encoder tensor
+        // still keeps its (higher-precision) fp16-mode representation.
+        assert_eq!(
+            classify_quant_tensor(31, PackQuant::Q4_K, QuantComponent::Encoder),
+            None
         );
     }
 
     #[test]
     fn q4_k_requires_256_alignment_else_falls_back_to_q8_0() {
         assert_eq!(
-            classify_quant_tensor(32, PackQuant::Q4_K),
+            classify_quant_tensor(32, PackQuant::Q4_K, QuantComponent::Decoder),
             Some(GgufWriteTensorType::Q8_0)
         );
         assert_eq!(
-            classify_quant_tensor(256, PackQuant::Q4_K),
+            classify_quant_tensor(256, PackQuant::Q4_K, QuantComponent::Decoder),
             Some(GgufWriteTensorType::Q4_K)
         );
     }
@@ -98,11 +133,47 @@ mod tests {
     #[test]
     fn q3_k_requires_256_alignment_else_falls_back_to_q8_0() {
         assert_eq!(
-            classify_quant_tensor(32, PackQuant::Q3_K),
+            classify_quant_tensor(32, PackQuant::Q3_K, QuantComponent::Decoder),
             Some(GgufWriteTensorType::Q8_0)
         );
         assert_eq!(
-            classify_quant_tensor(256, PackQuant::Q3_K),
+            classify_quant_tensor(256, PackQuant::Q3_K, QuantComponent::Decoder),
+            Some(GgufWriteTensorType::Q3_K)
+        );
+    }
+
+    #[test]
+    fn encoder_carries_a_q8_0_floor_below_the_requested_rung() {
+        // A 256-aligned encoder tensor would normally take the K-quant rungs,
+        // but the floor clamps it to Q8_0 so long-audio greedy decode never sees
+        // a sub-Q8 acoustic encoder.
+        assert_eq!(
+            classify_quant_tensor(256, PackQuant::Q4_K, QuantComponent::Encoder),
+            Some(GgufWriteTensorType::Q8_0)
+        );
+        assert_eq!(
+            classify_quant_tensor(256, PackQuant::Q3_K, QuantComponent::Encoder),
+            Some(GgufWriteTensorType::Q8_0)
+        );
+        // Q8_0 and 32-aligned (non-256) cases are unaffected by the floor.
+        assert_eq!(
+            classify_quant_tensor(256, PackQuant::Q8_0, QuantComponent::Encoder),
+            Some(GgufWriteTensorType::Q8_0)
+        );
+        assert_eq!(
+            classify_quant_tensor(32, PackQuant::Q4_K, QuantComponent::Encoder),
+            Some(GgufWriteTensorType::Q8_0)
+        );
+    }
+
+    #[test]
+    fn decoder_keeps_the_full_requested_rung() {
+        assert_eq!(
+            classify_quant_tensor(256, PackQuant::Q4_K, QuantComponent::Decoder),
+            Some(GgufWriteTensorType::Q4_K)
+        );
+        assert_eq!(
+            classify_quant_tensor(256, PackQuant::Q3_K, QuantComponent::Decoder),
             Some(GgufWriteTensorType::Q3_K)
         );
     }

--- a/crates/openasr-core/src/models/parakeet_ctc/package_import.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/package_import.rs
@@ -35,7 +35,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 
 use super::{PARAKEET_CTC_GGML_ARCHITECTURE_ID, PARAKEET_CTC_MODEL_FAMILY};
 
@@ -353,7 +353,14 @@ fn quantized_tensor_type_for_parakeet_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    // Only the conformer encoder linears (`enc.blk.*`) are quantizable here
+    // (the subsampling prelude and CTC head are f32); they carry the floor.
+    let component = if name.starts_with("enc.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    };
+    classify_quant_tensor(ne0, quantization, component)
 }
 
 fn parakeet_runtime_gguf_metadata(

--- a/crates/openasr-core/src/models/parakeet_tdt/package_import.rs
+++ b/crates/openasr-core/src/models/parakeet_tdt/package_import.rs
@@ -34,7 +34,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 
 use super::runtime_contract::{
     PARAKEET_TDT_BLANK_TOKEN_ID_KEY, PARAKEET_TDT_CONV_KERNEL_KEY, PARAKEET_TDT_DURATIONS_KEY,
@@ -418,7 +418,15 @@ fn quantized_tensor_type_for_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    // Only the conformer encoder linears (`enc.blk.*`) are F16Quantizable; the
+    // predictor (`dec.*`) and joint (`joint.*`) stay F16, so every tensor that
+    // reaches here is encoder and carries the floor.
+    let component = if name.starts_with("enc.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    };
+    classify_quant_tensor(ne0, quantization, component)
 }
 
 fn parakeet_tdt_runtime_gguf_metadata(
@@ -560,6 +568,8 @@ mod tests {
         let up = remap_parakeet_tdt_tensor_name("encoder.layers.3.feed_forward1.linear1.weight")
             .expect("ff1 up");
         assert_eq!(up.storage, TensorStorage::F16Quantizable);
+        // Encoder linears are quantizable but carry the Q8_0 floor: a q4_k
+        // request clamps to q8_0 so the acoustic encoder never goes sub-Q8.
         assert_eq!(
             quantized_tensor_type_for_tensor(
                 &up.target_name,
@@ -567,7 +577,7 @@ mod tests {
                 up.storage,
                 ParakeetTdtQuantizationMode::Q4_K,
             ),
-            Some(GgufWriteTensorType::Q4_K)
+            Some(GgufWriteTensorType::Q8_0)
         );
         let head = remap_parakeet_tdt_tensor_name("joint.head.weight").expect("joint head");
         assert_eq!(head.storage, TensorStorage::F16);

--- a/crates/openasr-core/src/models/qwen/package_import.rs
+++ b/crates/openasr-core/src/models/qwen/package_import.rs
@@ -31,7 +31,7 @@ use crate::models::oasr_metadata::{
 pub(super) use crate::models::oasr_metadata::{
     insert_metadata, insert_metadata_string_array, insert_metadata_u32,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 use crate::models::runtime_tensor_contract_registry::validate_builtin_runtime_tensor_contract_for_architecture;
 use crate::models::{qwen::QWEN3_ASR_MODEL_FAMILY, qwen::runtime_contract};
 
@@ -771,7 +771,19 @@ fn quantized_tensor_type_for_qwen(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    classify_quant_tensor(ne0, quantization, qwen_quant_component(name))
+}
+
+/// Encoder/audio-tower tensors map onto the `audio.*` runtime namespace
+/// (`audio.conv*`, `audio.proj*`, `audio.blk.*`, `audio.ln_post`); everything
+/// else (`blk.*` LLM layers, `token_embd`, `output*`) is the decoder side. The
+/// audio tower carries the shared Q8_0 floor (see `classify_quant_tensor`).
+fn qwen_quant_component(name: &str) -> QuantComponent {
+    if name.starts_with("audio.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    }
 }
 
 fn f32_tensor(name: &str, dims: Vec<u64>, values: Vec<f32>) -> GgufWriteTensor {
@@ -873,7 +885,56 @@ fn slaney_mel_filterbank(
 
 #[cfg(test)]
 mod tests {
-    use super::should_reverse_qwen_tensor_dims;
+    use super::{quantized_tensor_type_for_qwen, should_reverse_qwen_tensor_dims};
+    use crate::ggml_runtime::GgufWriteTensorType;
+    use crate::models::pack_quant::PackQuant;
+
+    #[test]
+    fn audio_tower_weights_carry_a_q8_0_floor_in_a_q4_k_pack() {
+        // A 256-aligned audio-tower weight would otherwise take q4_k; the
+        // encoder floor clamps it to q8_0 so a sub-Q8 acoustic encoder can never
+        // drive long-audio greedy decode into a repetition loop.
+        for name in [
+            "audio.proj2.weight",
+            "audio.blk.7.attn_q.weight",
+            "audio.conv_out.weight",
+        ] {
+            assert_eq!(
+                quantized_tensor_type_for_qwen(name, &[2048, 896], false, PackQuant::Q4_K),
+                Some(GgufWriteTensorType::Q8_0),
+                "{name}"
+            );
+            assert_eq!(
+                quantized_tensor_type_for_qwen(name, &[2048, 896], false, PackQuant::Q3_K),
+                Some(GgufWriteTensorType::Q8_0),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn decoder_weights_keep_the_requested_q4_k_rung() {
+        // The floor must not touch the LLM/decoder side: a 256-aligned blk
+        // weight still quantizes to q4_k.
+        assert_eq!(
+            quantized_tensor_type_for_qwen(
+                "blk.0.attn_q.weight",
+                &[2048, 2048],
+                false,
+                PackQuant::Q4_K
+            ),
+            Some(GgufWriteTensorType::Q4_K)
+        );
+        assert_eq!(
+            quantized_tensor_type_for_qwen(
+                "blk.5.ffn_down.weight",
+                &[2048, 4096],
+                false,
+                PackQuant::Q4_K
+            ),
+            Some(GgufWriteTensorType::Q4_K)
+        );
+    }
 
     #[test]
     fn qwen_tensor_dim_orientation_matches_runtime_contract() {

--- a/crates/openasr-core/src/models/sensevoice/package_import.rs
+++ b/crates/openasr-core/src/models/sensevoice/package_import.rs
@@ -40,7 +40,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 
 use crate::arch::{SENSEVOICE_GGML_ARCHITECTURE_ID, SENSEVOICE_MODEL_FAMILY};
 
@@ -594,7 +594,14 @@ fn quantized_tensor_type_for_sensevoice_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    // The SAN-M encoder (`enc.blk.*`) and the two-pass encoder (`tp.blk.*`) are
+    // the acoustic front end; `ctc.head` / `embed.prompt` are downstream.
+    let component = if name.starts_with("enc.") || name.starts_with("tp.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    };
+    classify_quant_tensor(ne0, quantization, component)
 }
 
 fn sensevoice_runtime_gguf_metadata(

--- a/crates/openasr-core/src/models/wav2vec2_ctc/package_import.rs
+++ b/crates/openasr-core/src/models/wav2vec2_ctc/package_import.rs
@@ -32,7 +32,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 use crate::nn::half::f32_to_f16_bits;
 use crate::nn::wav2vec2::fold_pos_conv_weight_norm;
 
@@ -564,7 +564,14 @@ fn quantized_tensor_type_for_wav2vec2_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    // The wav2vec2 backbone is `enc.*` (feature projection, transformer layers,
+    // norm); `ctc.head` is the output projection. The encoder carries the floor.
+    let component = if name.starts_with("enc.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    };
+    classify_quant_tensor(ne0, quantization, component)
 }
 
 fn wav2vec2_runtime_gguf_metadata(

--- a/crates/openasr-core/src/models/whisper/package_import.rs
+++ b/crates/openasr-core/src/models/whisper/package_import.rs
@@ -25,7 +25,7 @@ use crate::models::{
         OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1, insert_metadata,
         insert_metadata_string_array, insert_metadata_u32, insert_metadata_u32_array,
     },
-    pack_quant::{PackQuant, classify_quant_tensor},
+    pack_quant::{PackQuant, QuantComponent, classify_quant_tensor},
     whisper::WHISPER_MODEL_FAMILY,
 };
 use crate::nn::half::{f16_bits_slice_to_f32, f32_to_f16_bits};
@@ -206,12 +206,18 @@ fn quantization_tensor_type_for_whisper_tensor(
         return None;
     }
     let name = tensor.name.as_str();
-    if !is_whisper_encoder_linear_weight(name) && !is_whisper_decoder_linear_weight(name) {
+    let is_encoder = is_whisper_encoder_linear_weight(name);
+    if !is_encoder && !is_whisper_decoder_linear_weight(name) {
         return None;
     }
+    let component = if is_encoder {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    };
     let dims = gguf_runtime_tensor_dims_from_source_tensor(tensor);
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    classify_quant_tensor(ne0, quantization, component)
 }
 
 fn gguf_quantized_tensor_from_safetensors(
@@ -1206,7 +1212,10 @@ mod tests {
     }
 
     #[test]
-    fn quantized_encoder_linear_import_q4_k_is_smaller_than_q8_0() {
+    fn quantized_encoder_linear_q4_k_request_is_floored_to_q8_0() {
+        // A q4_k pack must NOT push the audio encoder below q8_0: sub-Q8 encoder
+        // weights collapse long-audio greedy decode, so the q4_k request is
+        // floored to a byte-identical q8_0 payload.
         let tensor = SafetensorsTensorHeader {
             name: "model.encoder.layers.0.fc1.weight".to_string(),
             dtype: "F32".to_string(),
@@ -1232,9 +1241,42 @@ mod tests {
         .expect("q4_k tensor should import");
 
         assert_eq!(q8.tensor_type, GgufWriteTensorType::Q8_0);
+        assert_eq!(q4.tensor_type, GgufWriteTensorType::Q8_0);
+        assert_eq!(q4.data.len(), q8.data.len());
+        assert!(q8.data.len() < (256 * 2 * 2));
+    }
+
+    #[test]
+    fn quantized_decoder_linear_q4_k_is_smaller_than_q8_0() {
+        // The floor is encoder-only: a decoder linear still honors the q4_k rung
+        // and stays smaller than its q8_0 form.
+        let tensor = SafetensorsTensorHeader {
+            name: "model.decoder.layers.0.fc1.weight".to_string(),
+            dtype: "F32".to_string(),
+            shape: vec![2, 256],
+            data_offsets: [0, 2 * 256 * 4],
+        };
+        let data = (0..(2 * 256))
+            .map(|index| (index as f32) * 0.002 - 0.5)
+            .flat_map(f32::to_le_bytes)
+            .collect::<Vec<_>>();
+
+        let q8 = gguf_tensor_from_safetensors_tensor(
+            &tensor,
+            &data,
+            WhisperRuntimeQuantizationMode::Q8_0,
+        )
+        .expect("q8_0 tensor should import");
+        let q4 = gguf_tensor_from_safetensors_tensor(
+            &tensor,
+            &data,
+            WhisperRuntimeQuantizationMode::Q4_K,
+        )
+        .expect("q4_k tensor should import");
+
+        assert_eq!(q8.tensor_type, GgufWriteTensorType::Q8_0);
         assert_eq!(q4.tensor_type, GgufWriteTensorType::Q4_K);
         assert!(q4.data.len() < q8.data.len());
-        assert!(q8.data.len() < (256 * 2 * 2));
     }
 
     #[test]

--- a/crates/openasr-core/src/models/xasr_zipformer/package_import.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/package_import.rs
@@ -44,7 +44,7 @@ use crate::models::oasr_metadata::{
     OASR_METADATA_KEY_MODEL_ARCHITECTURE, OASR_METADATA_KEY_MODEL_FAMILY,
     OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1,
 };
-use crate::models::pack_quant::{PackQuant, classify_quant_tensor};
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 
 const SOURCE_CONFIG_JSON: &str = "config.json";
 const SOURCE_TOKENS_TXT: &str = "tokens.txt";
@@ -370,7 +370,14 @@ fn quantized_tensor_type_for_xasr_tensor(
         return None;
     }
     let ne0 = dims.first().copied()?;
-    classify_quant_tensor(ne0, quantization)
+    // The zipformer acoustic encoder is `encoder.*`; the chunk decoder
+    // (`decoder.embedding.weight`, `decoder.conv.weight`) is downstream.
+    let component = if name.starts_with("encoder.") {
+        QuantComponent::Encoder
+    } else {
+        QuantComponent::Decoder
+    };
+    classify_quant_tensor(ne0, quantization, component)
 }
 
 fn join_u32(values: &[u32]) -> String {


### PR DESCRIPTION
## Summary

Floor audio-encoder / audio-tower tensor quantization at Q8_0 across every model-family importer, so a q3_k/q4_k pack request can never push the acoustic encoder below 8-bit. Decoder / LLM / CTC / joint / embedding tensors keep the full requested rung.

## Why

Sub-Q8 block quantization of the audio encoder is a behavioral cliff rather than a gradual WER loss: long-audio greedy decode collapses into repetition or empty output. Concretely, the qwen3-asr 1.7b q4_k pack degrades to a "Today, today" text collapse on en_zh_mixed audio, and the collapse is identical under Q8 and F32 KV - so the KV cache is not the cause; the sub-Q8 encoder is the remaining suspect. CrispASR independently observed the same encoder cliff.

The shared `classify_quant_tensor` returned Q4_K/Q3_K for any 256-aligned rank-2 `.weight`, including encoder tensors. This is a shared-layer bug, so the fix is centralized: every family with an audio encoder benefits and no importer can silently drift.

## Changes

- `models/pack_quant.rs`: add `QuantComponent { Encoder, Decoder }` and a third `component` argument to `classify_quant_tensor`. An `Encoder` tensor skips the Q3_K/Q4_K rungs and lands on Q8_0 once 32-aligned; a `Decoder` tensor keeps the existing rung math unchanged. The floor policy lives here (single source of truth); each family supplies the encoder/decoder classification from its own tensor naming.
- Wire the component through all 14 importer call sites:
  - qwen: `audio.*` = encoder (audio.conv*, audio.proj*, audio.blk.*, audio.ln_post); `blk.*` / `token_embd` / `output*` = decoder.
  - whisper: reuses the existing `is_whisper_encoder_linear_weight` predicate (`model.encoder.*`).
  - cohere: `enc.*` = encoder, `dec.*` = decoder.
  - dolphin: `encoder.*` = encoder; `decoder.*` / `ctc.*` / `context_module.*` = decoder.
  - moonshine: `enc.*` = encoder, `dec.*` = decoder (the existing `dec.emb.weight` Q8_0 special case is untouched).
  - moss-transcribe-diarize: `moss.enc.*` plus the `moss.adaptor.*` encoder->LLM projector (analogue of qwen `audio.proj*`) = encoder; `moss.llm.*` = decoder.
  - xasr-zipformer: `encoder.*` = encoder; `decoder.*` = decoder.
  - sensevoice: `enc.blk.*` (SAN-M) and `tp.blk.*` (two-pass) = encoder; `ctc.head` / `embed.prompt` = decoder.
  - parakeet-ctc / parakeet-tdt: `enc.*` = encoder (only encoder linears are quantizable; CTC/joint/predictor stay f32/f16).
  - firered-aed: `enc.*` = encoder, `dec.*` = decoder.
  - firered-llm: encoder/adapter builder = encoder; Qwen2 LLM builder = decoder.
  - wav2vec2-ctc: `enc.*` = encoder; `ctc.head` = decoder.
- Decoder/LLM quantization behavior is unchanged everywhere.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (run on `-p openasr-core`, the only crate touched; `classify_quant_tensor`/`QuantComponent` are `pub(crate)`, and `cargo check --workspace` passes)
- [x] `cargo nextest run --workspace` (run as `cargo test -p openasr-core --lib`: 2436 passed. One unrelated pre-existing flaky test, `native_transcribe::token_step_progress_sink_reports_monotonically_inside_its_window`, fails intermittently under the full parallel suite but passes in isolation; it is untouched by this change)
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

New / updated tests:
- `pack_quant`: encoder floor (Q4_K/Q3_K -> Q8_0) and decoder-keeps-rung cases.
- qwen: audio_tower weights -> Q8_0 in a q4_k pack; `blk.*` decoder weights stay Q4_K.
- whisper: an encoder linear q4_k request is floored to a byte-identical Q8_0; a decoder linear still yields Q4_K and stays smaller than Q8_0.
- dolphin / firered-aed / firered-llm / parakeet-tdt: encoder floor cases; existing per-family tests that asserted the old sub-Q8 encoder behavior updated to the floored Q8_0.

## Manual smoke checks

None - this changes importer tensor-type selection only. No published `.oasr` pack is repacked here (that is a separate release action).

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does NOT repack or republish any already-released `.oasr` pack.
- Does NOT change decoder / LLM / CTC / joint / embedding quantization.
- Does NOT run RTF / performance benchmarks.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [ ] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [ ] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implementation drafted with AI assistance; human maintainer to review, verify, and take ownership before merge.
