### PR TITLE
fix(core): key resident runtime caches on pack content fingerprint

### DIFF
--- a/crates/openasr-core/src/models/cohere/ggml_executor.rs
+++ b/crates/openasr-core/src/models/cohere/ggml_executor.rs
@@ -1,9 +1,11 @@
 use std::cell::RefCell;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Instant;
 
 use thiserror::Error;
 
+#[cfg(test)]
+use std::path::PathBuf;
 #[cfg(test)]
 use std::sync::Arc;
 
@@ -49,8 +51,8 @@ use crate::models::runtime_prepared_registry::{
     BuiltinPreparedRuntimeCache, BuiltinPreparedRuntimeRegistryError,
 };
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    canonical_runtime_cache_path, runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 
 const COHERE_EXECUTOR_ID: &str = "cohere-transcribe-ggml-executor-v1";
@@ -66,8 +68,11 @@ thread_local! {
         RefCell::new(BoundedRuntimeCache::new());
 }
 
-type CohereEncoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
-/// (canonical pack path, backend). Used to be `(path, backend, frame_count,
+type CohereEncoderRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
+/// (pack path identity: canonical path + content fingerprint, backend). The
+/// content fingerprint ([`runtime_cache_path_identity`]) keeps an in-place
+/// pack replacement at the same path from reusing a runtime built from the
+/// old bytes. Used to be `(path, backend, frame_count,
 /// hidden_size)`: the decoder's cross-KV cache is now allocated ONCE per pack
 /// at this architecture's chunk-cap capacity (see
 /// `CohereDecoderGraphRuntime::new` / `cohere_decoder_cross_capacity_frames`),
@@ -75,7 +80,7 @@ type CohereEncoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
 /// is reusable across every VAD/longform chunk regardless of its actual frame
 /// count. `hidden_size` was always redundant too -- it is a pack-constant
 /// (`metadata.decoder_d_model`), never a per-utterance value.
-type CohereDecoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+type CohereDecoderRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 #[derive(Debug, Error)]
 enum CohereTranscribeGgmlExecutorError {
@@ -412,7 +417,7 @@ fn encode_with_cached_cohere_encoder_runtime(
     features: &CohereTranscribeMelFeatures,
 ) -> Result<super::encoder_graph::CohereTranscribeEncoderOutput, CohereTranscribeEncoderError> {
     let encoder_backend = cohere_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(runtime_path), encoder_backend);
+    let key = (runtime_cache_path_identity(runtime_path), encoder_backend);
     with_thread_local_cached_mut_by_key(
         &COHERE_ENCODER_RUNTIME_BY_KEY,
         key,
@@ -443,7 +448,7 @@ fn decode_with_cached_cohere_decoder_runtime(
     audio_duration_seconds: f32,
 ) -> Result<super::decoder_graph::CohereDecoderGraphDecodeOutput, CohereDecoderGraphError> {
     let decoder_backend = cohere_decoder_graph_config(prefer_cpu_backend).backend;
-    let key = (canonical_runtime_cache_path(runtime_path), decoder_backend);
+    let key = (runtime_cache_path_identity(runtime_path), decoder_backend);
     with_thread_local_cached_mut_by_key(
         &COHERE_DECODER_RUNTIME_BY_KEY,
         key,

--- a/crates/openasr-core/src/models/firered_aed/executor.rs
+++ b/crates/openasr-core/src/models/firered_aed/executor.rs
@@ -25,7 +25,7 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use thiserror::Error;
 
@@ -42,8 +42,8 @@ use crate::models::incremental_streaming_driver::{
 };
 use crate::models::runtime_preflight::build_runtime_tensor_reader_from_preflight;
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 
 use super::decoder_graph::{
@@ -70,8 +70,11 @@ thread_local! {
         RefCell::new(BoundedRuntimeCache::new());
 }
 
-type FireRedAedEncoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
-/// (canonical pack path, backend). The decoder's cross-KV cache is now
+type FireRedAedEncoderRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
+/// (pack path identity: canonical path + content fingerprint, backend). The
+/// content fingerprint ([`runtime_cache_path_identity`]) keeps an in-place
+/// pack replacement at the same path from reusing a runtime built from the
+/// old bytes. The decoder's cross-KV cache is now
 /// allocated ONCE per pack at this architecture's chunk-cap capacity (see
 /// [`FireRedDecoderGraphRuntime::new`] / `firered_decoder_cross_capacity_frames`),
 /// not at any one utterance's exact encoder frame count -- so a cached
@@ -80,7 +83,7 @@ type FireRedAedEncoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
 /// shared longform safety policy already guarantees). Frame count therefore
 /// no longer belongs in this key (see issue tracking the VAD 0%-cache-hit
 /// regression this fixes).
-type FireRedAedDecoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+type FireRedAedDecoderRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 fn encode_with_cached_runtime(
     runtime_path: &Path,
@@ -89,7 +92,7 @@ fn encode_with_cached_runtime(
     n_frames: usize,
 ) -> Result<FireRedEncoderOutput, super::encoder_graph::FireRedEncoderError> {
     let key = (
-        canonical_runtime_cache_path(runtime_path),
+        runtime_cache_path_identity(runtime_path),
         firered_encoder_graph_config().backend,
     );
     with_thread_local_cached_mut_by_key(
@@ -112,7 +115,7 @@ fn decode_with_cached_runtime(
     super::decoder_graph::FireRedDecoderError,
 > {
     let key = (
-        canonical_runtime_cache_path(runtime_path),
+        runtime_cache_path_identity(runtime_path),
         firered_decoder_graph_config().backend,
     );
     with_thread_local_cached_mut_by_key(

--- a/crates/openasr-core/src/models/firered_llm/executor.rs
+++ b/crates/openasr-core/src/models/firered_llm/executor.rs
@@ -23,7 +23,6 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 use thiserror::Error;
 
@@ -59,7 +58,8 @@ use crate::models::seq2seq_greedy_decode::{
     Seq2SeqGreedyDecodeStepLogitsOutput,
 };
 use crate::models::thread_local_runtime_cache::{
-    canonical_runtime_cache_path, current_unload_generation, take_generation_tagged,
+    RuntimeCachePathIdentity, current_unload_generation, runtime_cache_path_identity,
+    take_generation_tagged,
 };
 
 use super::adapter_graph::FireRedLlmAdapterGraphRuntime;
@@ -80,7 +80,11 @@ use super::tokenizer::FireRedLlmTokenizer;
 /// `docs/model-audits/firered2-llm.md` SS3) purely to re-derive state that
 /// does not change between requests. Keyed by (pack path, backend): unlike
 /// qwen this family has no LoRA/adapter input, so the key omits qwen's third
-/// (adapter fingerprint) component.
+/// (adapter fingerprint) component. The path half is a
+/// [`RuntimeCachePathIdentity`] (canonical path + pack content fingerprint):
+/// an in-place `.oasr` replacement at the same path fingerprints differently,
+/// so the next lookup misses and rebuilds instead of reusing a decoder whose
+/// device-uploaded weights came from the old bytes.
 ///
 /// This reuses the same session/model split transcribe.cpp uses for its own
 /// Qwen-family LLM decoder (`references/transcribe.cpp@b6a6acad`,
@@ -101,7 +105,7 @@ use super::tokenizer::FireRedLlmTokenizer;
 /// decoder built before the last unload instead of handing it back out --
 /// this is how the resident 8B decoder becomes evictable under memory
 /// pressure without a bespoke eviction policy.
-type FireRedLlmDecoderCacheKey = (PathBuf, GgmlCpuGraphBackend);
+type FireRedLlmDecoderCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 thread_local! {
     static FIRERED_LLM_DECODER_BY_KEY: RefCell<HashMap<FireRedLlmDecoderCacheKey, (u64, FireRedLlmDecoderRuntime)>> =
@@ -386,7 +390,7 @@ impl FireRedLlmGgmlExecutor {
         // reflects the backend the decoder actually builds on (matches
         // qwen's `WholeDecoderCacheKey` ordering).
         let decoder_cache_key: FireRedLlmDecoderCacheKey = (
-            canonical_runtime_cache_path(runtime_path),
+            runtime_cache_path_identity(runtime_path),
             GgmlCpuGraphConfig::resolve_runtime_backend(),
         );
         // Sampled before the cache take and reused for the store-back below:

--- a/crates/openasr-core/src/models/moonshine/decoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/decoder_graph.rs
@@ -1,8 +1,7 @@
-use std::{
-    cell::RefCell,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{cell::RefCell, path::Path, sync::Arc};
+
+#[cfg(test)]
+use std::path::PathBuf;
 
 use thiserror::Error;
 
@@ -22,8 +21,8 @@ use crate::models::seq2seq_greedy_decode::{
 };
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 use crate::nn::decoder::{
     LlmResidentKvArena, Seq2SeqReusableDecodeGraph, allocate_zeroed_llm_resident_kv_arena,
@@ -52,11 +51,15 @@ const MOONSHINE_LAYER_NORM_EPSILON: f32 = 1.0e-5;
 /// `16_384` headroom (`moonshine_encoder_graph_config`).
 const MOONSHINE_DECODER_GRAPH_SIZE_FLOOR: usize = 16_384;
 
-/// (canonical pack path, backend, cross frame count, adapter fingerprint).
-/// The adapter fingerprint MUST stay in this key: the runtime owns prepared
-/// cgraphs with the adapter tensors baked in, so reuse keyed only on the base
-/// pack would serve stale adapter graphs (correctness bug).
-type MoonshineDecoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend, usize, String);
+/// (pack path identity: canonical path + content fingerprint, backend, cross
+/// frame count, adapter fingerprint). The content fingerprint
+/// ([`runtime_cache_path_identity`]) keeps an in-place pack replacement at the
+/// same path from reusing a runtime built from the old bytes. The adapter
+/// fingerprint MUST stay in this key: the runtime owns prepared cgraphs with
+/// the adapter tensors baked in, so reuse keyed only on the base pack would
+/// serve stale adapter graphs (correctness bug).
+type MoonshineDecoderRuntimeCacheKey =
+    (RuntimeCachePathIdentity, GgmlCpuGraphBackend, usize, String);
 
 thread_local! {
     static MOONSHINE_DECODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<MoonshineDecoderRuntimeCacheKey, MoonshineDecoderGraphRuntime>> =
@@ -159,7 +162,7 @@ fn moonshine_decoder_runtime_cache_key(
     adapter: Option<&MoonshineLoraAdapter>,
 ) -> MoonshineDecoderRuntimeCacheKey {
     (
-        canonical_runtime_cache_path(runtime_path),
+        runtime_cache_path_identity(runtime_path),
         moonshine_decoder_graph_config(prefer_cpu_backend).backend,
         cross_frame_count,
         moonshine_adapter_cache_fingerprint(adapter),

--- a/crates/openasr-core/src/models/moonshine/ggml_executor.rs
+++ b/crates/openasr-core/src/models/moonshine/ggml_executor.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use thiserror::Error;
@@ -35,8 +35,8 @@ use crate::models::incremental_streaming_driver::{
 };
 use crate::models::prepared_runtime_cache::PreparedRuntimeCache;
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    canonical_runtime_cache_path, runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 
 const MOONSHINE_EXECUTOR_ID: &str = "moonshine-ggml-executor-v1";
@@ -47,11 +47,14 @@ thread_local! {
         RefCell::new(BoundedRuntimeCache::new());
 }
 
-/// (canonical pack path, backend, adapter fingerprint). The adapter
-/// fingerprint MUST stay in this key — prepared encoder graphs embed the
+/// (pack path identity: canonical path + content fingerprint, backend,
+/// adapter fingerprint). The content fingerprint
+/// ([`runtime_cache_path_identity`]) keeps an in-place pack replacement at the
+/// same path from reusing a runtime built from the old bytes. The adapter
+/// fingerprint MUST stay in this key -- prepared encoder graphs embed the
 /// adapter tensors, so reuse keyed only on the base pack would be a
 /// correctness bug.
-type MoonshineEncoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend, String);
+type MoonshineEncoderRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend, String);
 
 #[derive(Debug, Error)]
 enum MoonshineGgmlExecutorError {
@@ -251,7 +254,7 @@ fn encode_with_cached_runtime(
 ) -> Result<MoonshineEncoderOutput, MoonshineEncoderError> {
     let encoder_backend = moonshine_encoder_graph_config().backend;
     let key = (
-        canonical_runtime_cache_path(runtime_path),
+        runtime_cache_path_identity(runtime_path),
         encoder_backend,
         moonshine_adapter_cache_fingerprint(adapter),
     );

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -20,7 +20,7 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use thiserror::Error;
 
@@ -45,8 +45,8 @@ use crate::models::seq2seq_greedy_decode::{
     Seq2SeqGreedyDecodeStepLogitsOutput,
 };
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 use crate::models::whisper::whisper_log_mel_spectrogram_16khz_mono_v0;
 
@@ -218,8 +218,12 @@ impl Seq2SeqGreedyDecodeStepExecutor for MossTdGreedyStepExecutor<'_> {
 /// pack, re-read every encoder tensor off disk, and re-uploaded every decoder
 /// layer's weights, on every single call (including every chunk of the same
 /// longform request).
-type MossTdEncoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
-type MossTdDecoderRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+/// Keyed by (pack path identity: canonical path + content fingerprint,
+/// backend); the content fingerprint ([`runtime_cache_path_identity`]) keeps
+/// an in-place pack replacement at the same path from reusing a runtime whose
+/// mmapped weights came from the old bytes.
+type MossTdEncoderRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
+type MossTdDecoderRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 thread_local! {
     static MOSS_TD_ENCODER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<MossTdEncoderRuntimeCacheKey, MossEncoderRuntime>> =
@@ -435,7 +439,7 @@ fn encode_moss_td_chunks_with_cached_runtime(
     samples: &[f32],
 ) -> Result<(Vec<f32>, usize), MossTdExecutorError> {
     let key = (
-        canonical_runtime_cache_path(runtime_path),
+        runtime_cache_path_identity(runtime_path),
         moss_td_encoder_graph_config().backend,
     );
     // Upstream `_compute_audio_token_length`'s stride: hop_length * the
@@ -507,7 +511,7 @@ fn run_moss_td_decoder_with_cached_runtime(
     tokenizer: &MossTdTokenizer,
 ) -> Result<String, MossTdExecutorError> {
     let key = (
-        canonical_runtime_cache_path(runtime_path),
+        runtime_cache_path_identity(runtime_path),
         moss_td_runtime_graph_config().backend,
     );
     with_thread_local_cached_mut_by_key(

--- a/crates/openasr-core/src/models/parakeet_ctc/executor.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/executor.rs
@@ -7,7 +7,7 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::PARAKEET_CTC_DECODE_POLICY_ID;
 use crate::PhraseBiasConfig;
@@ -30,8 +30,8 @@ use crate::models::ggml_asr_executor::{
 use crate::models::ggml_streaming_session::GgmlAsrStreamingTranscriptSession;
 use crate::models::incremental_streaming_driver::STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT;
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 use crate::{NativeAsrSession, PARAKEET_CTC_GGML_ADAPTER_ID};
 
@@ -44,7 +44,7 @@ use super::runtime_contract::{
 };
 use super::tokenizer::ParakeetTokenizer;
 
-type ParakeetRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+type ParakeetRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 thread_local! {
     static PARAKEET_CTC_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<ParakeetRuntimeCacheKey, ParakeetCtcPreparedRuntime>> =
@@ -128,7 +128,7 @@ fn transcribe_parakeet_ctc_pcm_cached(
     word_timestamps: bool,
 ) -> Result<ParakeetCtcTranscription, String> {
     let backend = parakeet_ctc_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(pack_path), backend);
+    let key = (runtime_cache_path_identity(pack_path), backend);
     with_thread_local_cached_mut_by_key(
         &PARAKEET_CTC_RUNTIME_BY_KEY,
         key,
@@ -144,7 +144,7 @@ fn decode_parakeet_ctc_pcm_cached(
     phrase_bias: Option<&PhraseBiasConfig>,
 ) -> Result<CtcGreedyDecodeResult, String> {
     let backend = parakeet_ctc_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(pack_path), backend);
+    let key = (runtime_cache_path_identity(pack_path), backend);
     with_thread_local_cached_mut_by_key(
         &PARAKEET_CTC_RUNTIME_BY_KEY,
         key,

--- a/crates/openasr-core/src/models/parakeet_tdt/executor.rs
+++ b/crates/openasr-core/src/models/parakeet_tdt/executor.rs
@@ -2,7 +2,7 @@
 //! joint encoder projection) -> host TDT greedy decode -> detokenize.
 
 use std::cell::RefCell;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::api::backend::WordTimestamp;
 use crate::ggml_runtime::GgmlCpuGraphBackend;
@@ -15,8 +15,8 @@ use crate::models::incremental_streaming_driver::{
 };
 use crate::models::parakeet_ctc::frontend::ParakeetFrontend;
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 use crate::{NativeAsrSession, PARAKEET_TDT_GGML_ADAPTER_ID};
 
@@ -33,7 +33,7 @@ use super::runtime_contract::{
 };
 use super::tokenizer::ParakeetTdtTokenizer;
 
-type ParakeetTdtRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+type ParakeetTdtRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 thread_local! {
     static PARAKEET_TDT_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<ParakeetTdtRuntimeCacheKey, ParakeetTdtPreparedRuntime>> =
@@ -133,14 +133,17 @@ impl ParakeetTdtPreparedRuntime {
 }
 
 /// Transcribe 16 kHz mono f32 PCM through a cached prepared runtime keyed by
-/// `(canonical pack path, backend)`.
+/// `(pack path identity: canonical path + content fingerprint, backend)`. The
+/// content fingerprint ([`runtime_cache_path_identity`]) keeps an in-place
+/// pack replacement at the same path from reusing a runtime built from the
+/// old bytes.
 pub(crate) fn transcribe_parakeet_tdt_pcm_cached(
     samples: &[f32],
     pack_path: &Path,
     word_timestamps: bool,
 ) -> Result<ParakeetTdtTranscription, String> {
     let backend = parakeet_tdt_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(pack_path), backend);
+    let key = (runtime_cache_path_identity(pack_path), backend);
     with_thread_local_cached_mut_by_key(
         &PARAKEET_TDT_RUNTIME_BY_KEY,
         key,

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -1,6 +1,5 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
@@ -58,8 +57,9 @@ use crate::models::seq2seq_greedy_decode::{
 };
 use crate::models::seq2seq_word_timestamps::seq2seq_word_timestamps_from_generated_tokens;
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    current_unload_generation, take_generation_tagged, with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    current_unload_generation, runtime_cache_path_identity, take_generation_tagged,
+    with_thread_local_cached_mut_by_key,
 };
 use crate::{
     GgmlAsrExecutionError, GgmlAsrExecutionRequest, GgmlAsrExecutionResult, GgmlAsrExecutor,
@@ -79,16 +79,21 @@ use crate::models::runtime_prepared_registry::build_builtin_prepared_runtime;
 /// are identical across every `execute()` for the same pack. Without this, the
 /// longform path rebuilt the decoder and re-uploaded every layer's weights to
 /// the GPU on every chunk (the "~1GB re-upload per chunk" cost). Keyed by
-/// (pack path, backend, adapter fingerprint) so a CPU-validate then GPU-run in
-/// the same process does not reuse a backend-mismatched decoder, and a run with
-/// an adapter does not reuse a graph built without one (correctness: the LoRA
-/// tensors are baked into the arena at construction time).
-type WholeDecoderCacheKey = (PathBuf, GgmlCpuGraphBackend, String);
-type AudioEncoderCacheKey = (PathBuf, GgmlCpuGraphBackend);
+/// (pack path identity, backend, adapter fingerprint) so a CPU-validate then
+/// GPU-run in the same process does not reuse a backend-mismatched decoder,
+/// and a run with an adapter does not reuse a graph built without one
+/// (correctness: the LoRA tensors are baked into the arena at construction
+/// time). The path identity is the canonical path PLUS the pack content
+/// fingerprint ([`runtime_cache_path_identity`]): an in-place `.oasr`
+/// replacement at the same path fingerprints differently, so the next lookup
+/// misses and rebuilds instead of reusing a decoder whose device-uploaded
+/// weights came from the old bytes.
+type WholeDecoderCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend, String);
+type AudioEncoderCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 thread_local! {
     // Kept as a plain `HashMap` (not the shared bounded LRU): keyed by
-    // (pack path, backend, adapter fingerprint), which does not explode
+    // (pack path identity, backend, adapter fingerprint), which does not explode
     // per audio chunk the way a frame-count-keyed cache does -- one entry is
     // built and reused across the whole longform run for a given pack, so
     // there is no unbounded-growth hazard to bound here. Entries are tagged
@@ -349,9 +354,14 @@ impl Qwen3AsrGgmlExecutor {
         skip_serve_batch: bool,
     ) -> Result<GgmlAsrExecutionResult, Qwen3AsrGgmlExecutorError> {
         let profile_started_at = qwen_decode_profile_start();
-        let runtime_cache_path = canonical_runtime_cache_path(&request.runtime_source_path);
+        // Canonical path + pack content fingerprint: both cache keys below
+        // carry the fingerprint so an in-place pack replacement misses.
+        let runtime_cache_identity = runtime_cache_path_identity(&request.runtime_source_path);
+        // The serve-batch owner loads the pack itself; it needs the path, not
+        // the fingerprint.
+        let runtime_cache_path = runtime_cache_identity.path.clone();
         let audio_encoder_cache_key: AudioEncoderCacheKey = (
-            runtime_cache_path.clone(),
+            runtime_cache_identity.clone(),
             GgmlCpuGraphConfig::resolve_runtime_backend(),
         );
         let audio_encoder_started_at = qwen_decode_profile_start();
@@ -517,7 +527,7 @@ impl Qwen3AsrGgmlExecutor {
         )?;
         let adapter_fingerprint = qwen_adapter_cache_fingerprint(adapter.as_deref());
         let decoder_cache_key: WholeDecoderCacheKey = (
-            runtime_cache_path,
+            runtime_cache_identity,
             GgmlCpuGraphConfig::resolve_runtime_backend(),
             adapter_fingerprint,
         );

--- a/crates/openasr-core/src/models/qwen/logits_head.rs
+++ b/crates/openasr-core/src/models/qwen/logits_head.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, fmt, path::PathBuf};
+use std::{cell::RefCell, fmt};
 
 use thiserror::Error;
 
@@ -7,8 +7,8 @@ use crate::ggml_runtime::{
     GgmlStaticTensorArena, GgufTensorDataReadError, GgufTensorDataReader, env_toggle_with_raw,
 };
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 
 use super::graph_config::{qwen_decoder_graph_config, qwen_runtime_graph_config};
@@ -21,11 +21,13 @@ const DEFAULT_RMS_NORM_EPSILON: f32 = 1e-6;
 const QWEN3_LLM_LOGITS_GRAPH_CONTEXT_BYTES: usize = 16 * 1024 * 1024;
 const OPENASR_QWEN3_LLM_LOGITS_GGML_ENV: &str = "OPENASR_QWEN3_LLM_LOGITS_GGML";
 
-/// (canonical pack path, backend): identifies the resident fused logits-head
-/// graph executor for a loaded pack, mirroring the `(PathBuf,
-/// GgmlCpuGraphBackend)` key convention used by the qwen audio-encoder and
-/// firered-aed encoder/decoder runtime caches.
-type QwenLogitsHeadExecutorCacheKey = (PathBuf, GgmlCpuGraphBackend);
+/// (pack path identity: canonical path + content fingerprint, backend):
+/// identifies the resident fused logits-head graph executor for a loaded pack,
+/// mirroring the `(RuntimeCachePathIdentity, GgmlCpuGraphBackend)` key
+/// convention used by the qwen audio-encoder and firered-aed encoder/decoder
+/// runtime caches. The fingerprint keeps an in-place pack replacement at the
+/// same path from reusing an executor built from the old bytes.
+type QwenLogitsHeadExecutorCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 #[derive(Debug, Clone)]
 pub(crate) struct Qwen3AsrLlmLogitsHead {
@@ -332,7 +334,7 @@ pub(crate) fn load_llm_logits_head_from_reader_with_tensor_names(
         output_weight_layout,
         ggml_executor_cache_key: raw_output_weight.as_ref().map(|_| {
             (
-                canonical_runtime_cache_path(reader.tensor_index().path()),
+                runtime_cache_path_identity(reader.tensor_index().path()),
                 qwen_runtime_graph_config().backend,
             )
         }),
@@ -693,6 +695,8 @@ fn resolve_output_weight_layout(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     #[test]
@@ -835,7 +839,13 @@ mod tests {
 
     fn ggml_logits_head_test_cache_key(id: usize) -> QwenLogitsHeadExecutorCacheKey {
         (
-            PathBuf::from(format!("/tmp/openasr-test-logits-head-cache-{id}.gguf")),
+            // Test-only identity: the fake path does not exist, so a stable
+            // fixture fingerprint stands in for the content fingerprint the
+            // production path (`runtime_cache_path_identity`) would compute.
+            RuntimeCachePathIdentity {
+                path: PathBuf::from(format!("/tmp/openasr-test-logits-head-cache-{id}.gguf")),
+                fingerprint: format!("test:logits-head-{id}"),
+            },
             GgmlCpuGraphBackend::Cpu,
         )
     }

--- a/crates/openasr-core/src/models/runtime_cache_coordinator.rs
+++ b/crates/openasr-core/src/models/runtime_cache_coordinator.rs
@@ -183,6 +183,122 @@ impl PackContentEpochKey {
     }
 }
 
+/// Byte budget for each of the leading/trailing pack slices mixed into
+/// [`pack_content_fingerprint`].
+///
+/// 64 KiB per edge keeps the per-lookup cost O(1) for multi-GB packs (unlike
+/// the full-file sha256 behind [`pack_content_id_for_runtime_path`]) while
+/// still covering both ends of a `.oasr` zip: the leading slice carries the
+/// first stored entry's GGUF magic/header/metadata, and the trailing slice
+/// carries the zip central directory, whose per-entry CRC32s change on any
+/// content replacement -- so a same-size in-place swap whose head bytes are
+/// identical is still caught through the tail.
+const PACK_CONTENT_FINGERPRINT_EDGE_BYTES: usize = 64 * 1024;
+
+/// Source of never-equal tokens for packs whose fingerprint cannot be read.
+static PACK_FINGERPRINT_UNREADABLE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Lightweight pack content fingerprint for the path-keyed thread-local
+/// runtime caches (whole-decoder / encoder / persistent-session / process
+/// pool keys).
+///
+/// This is the cheap per-request sibling of the full content proof in
+/// [`pack_content_id_for_runtime_path`]: it mixes the file length, the full
+/// mtime (seconds + nanoseconds), and a sha256 over the first and last
+/// [`PACK_CONTENT_FINGERPRINT_EDGE_BYTES`] bytes. A runtime cache key that
+/// includes this fingerprint can never hand a runtime built from one pack's
+/// bytes to a request against different bytes at the same path (an in-place
+/// `.oasr` replacement): the replacement moves the mtime and/or size and/or
+/// edge bytes, so the next lookup misses and rebuilds. The trade-offs:
+///
+/// - A rewrite with byte-identical content also moves the mtime and therefore
+///   invalidates once. That conservative miss (one rebuild) is intentional --
+///   mtime equality cannot be trusted as a same-content proof.
+/// - Hashing the full file here would re-read multi-GB weights on every cache
+///   lookup after each replacement; the edge slices cap that at 128 KiB. The
+///   full-file proof stays where its one-shot cost is acceptable
+///   ([`pack_content_id_for_runtime_path`], memoized by path + size + mtime,
+///   for prepared/process-pool keys).
+///
+/// Unreadable packs fail closed: every call returns a fresh `unreadable:*`
+/// token that never equals any previously stored fingerprint, so the lookup
+/// always misses and the (almost certainly failing) build is retried rather
+/// than a stale runtime reused.
+pub(crate) fn pack_content_fingerprint(runtime_path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    use std::io::{Read, Seek, SeekFrom};
+
+    let Ok(metadata) = std::fs::metadata(runtime_path) else {
+        return unreadable_pack_content_fingerprint();
+    };
+    let Ok(modified) = metadata.modified() else {
+        return unreadable_pack_content_fingerprint();
+    };
+    let Ok(since_epoch) = modified.duration_since(std::time::UNIX_EPOCH) else {
+        return unreadable_pack_content_fingerprint();
+    };
+    let Ok(mut file) = std::fs::File::open(runtime_path) else {
+        return unreadable_pack_content_fingerprint();
+    };
+
+    let len = metadata.len();
+    let edge = PACK_CONTENT_FINGERPRINT_EDGE_BYTES as u64;
+    let head_len = len.min(edge);
+    let mut hasher = Sha256::new();
+    // Domain separation: a fingerprint digest must never collide with a raw
+    // byte digest (e.g. the full-file `sha256:` content ids) for the same pack.
+    hasher.update(b"openasr-pack-content-fingerprint-v1");
+    hasher.update(len.to_le_bytes());
+    hasher.update(since_epoch.as_secs().to_le_bytes());
+    hasher.update(since_epoch.subsec_nanos().to_le_bytes());
+
+    let mut head = vec![0_u8; head_len as usize];
+    if file.read_exact(&mut head).is_err() {
+        return unreadable_pack_content_fingerprint();
+    }
+    hasher.update(&head);
+
+    // Trailing slice (zip central directory); skipped when the head already
+    // covered the whole file.
+    if len > head_len && file.seek(SeekFrom::End(-(edge as i64))).is_ok() {
+        let mut tail = vec![0_u8; edge as usize];
+        if file.read_exact(&mut tail).is_err() {
+            return unreadable_pack_content_fingerprint();
+        }
+        hasher.update(&tail);
+    }
+    format!("fp1:{:x}", hasher.finalize())
+}
+
+fn unreadable_pack_content_fingerprint() -> String {
+    format!(
+        "unreadable:{}",
+        PACK_FINGERPRINT_UNREADABLE_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+/// Canonical path + content fingerprint identity half of a path-keyed
+/// thread-local runtime cache key.
+///
+/// The path alone only proves "same file name"; a runtime built from one
+/// pack's bytes must not be reused after the file at that path is replaced in
+/// place, so every runtime cache key carries the [`pack_content_fingerprint`]
+/// observed when the key was built. Lookup against a replaced pack computes a
+/// different fingerprint, misses, and rebuilds.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RuntimeCachePathIdentity {
+    pub(crate) path: PathBuf,
+    pub(crate) fingerprint: String,
+}
+
+/// Resolve the cache-key identity (canonical path + current content
+/// fingerprint) for `runtime_path`.
+pub(crate) fn runtime_cache_path_identity(runtime_path: &Path) -> RuntimeCachePathIdentity {
+    let path = std::fs::canonicalize(runtime_path).unwrap_or_else(|_| runtime_path.to_path_buf());
+    let fingerprint = pack_content_fingerprint(&path);
+    RuntimeCachePathIdentity { path, fingerprint }
+}
+
 fn installed_pack_sha256_for_path(canonical_path: &Path) -> Option<String> {
     let home = crate::openasr_home().ok()?;
     let packs = crate::list_installed_packs(home).ok()?;
@@ -362,6 +478,91 @@ mod tests {
         assert!(after > before);
         assert_eq!(current_runtime_build_generation(), after);
         assert_eq!(current_unload_generation(), after);
+    }
+
+    #[test]
+    fn pack_content_fingerprint_is_stable_while_the_pack_is_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("pack.oasr");
+        std::fs::write(&path, b"stable-pack-bytes").expect("write");
+        let first = pack_content_fingerprint(&path);
+        let second = pack_content_fingerprint(&path);
+        assert!(first.starts_with("fp1:"), "got {first}");
+        assert_eq!(first, second, "no file change between the two lookups");
+    }
+
+    #[test]
+    fn pack_content_fingerprint_misses_in_place_byte_replacement() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("same-path.oasr");
+        std::fs::write(&path, b"content-a-bytes").expect("write a");
+        let before = pack_content_fingerprint(&path);
+        std::fs::write(&path, b"content-b-bytes-different").expect("write b");
+        let after = pack_content_fingerprint(&path);
+        assert!(before.starts_with("fp1:"), "got {before}");
+        assert!(after.starts_with("fp1:"), "got {after}");
+        assert_ne!(
+            before, after,
+            "an in-place replacement at the same path must not fingerprint equal"
+        );
+    }
+
+    #[test]
+    fn pack_content_fingerprint_misses_same_length_replacement() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("same-length.oasr");
+        // 192 KiB: bigger than both edge windows, so the changed byte sits in
+        // the middle, covered by neither the head nor the tail slice -- the
+        // size-stable replacement is still caught (by the mtime move).
+        let edge = PACK_CONTENT_FINGERPRINT_EDGE_BYTES;
+        let mut bytes = vec![7_u8; edge * 3];
+        std::fs::write(&path, &bytes).expect("write v1");
+        let before = pack_content_fingerprint(&path);
+        bytes[edge + edge / 2] = 9;
+        std::fs::write(&path, &bytes).expect("write v2");
+        let after = pack_content_fingerprint(&path);
+        assert_ne!(
+            before, after,
+            "a same-length in-place replacement must not fingerprint equal"
+        );
+    }
+
+    #[test]
+    fn pack_content_fingerprint_unreadable_pack_never_matches() {
+        let missing = PathBuf::from("/tmp/openasr-definitely-missing-fingerprint-pack.oasr");
+        let first = pack_content_fingerprint(&missing);
+        let second = pack_content_fingerprint(&missing);
+        assert!(first.starts_with("unreadable:"), "got {first}");
+        assert!(second.starts_with("unreadable:"), "got {second}");
+        assert_ne!(
+            first, second,
+            "unreadable tokens must be unique per call so no lookup can ever hit on them"
+        );
+    }
+
+    #[test]
+    fn runtime_cache_path_identity_changes_on_in_place_replacement() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("pack.oasr");
+        std::fs::write(&path, b"identity-content-v1").expect("write v1");
+        let before = runtime_cache_path_identity(&path);
+        assert_eq!(
+            before.path,
+            std::fs::canonicalize(&path).expect("canonicalize"),
+            "identity carries the canonical path half"
+        );
+        assert!(before.fingerprint.starts_with("fp1:"));
+
+        let unchanged = runtime_cache_path_identity(&path);
+        assert_eq!(before, unchanged, "unchanged pack keeps the same identity");
+
+        std::fs::write(&path, b"identity-content-v2").expect("write v2");
+        let after = runtime_cache_path_identity(&path);
+        assert_eq!(before.path, after.path, "same path half");
+        assert_ne!(
+            before, after,
+            "replaced bytes must change the identity (via the fingerprint)"
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/models/sensevoice/executor.rs
+++ b/crates/openasr-core/src/models/sensevoice/executor.rs
@@ -2,7 +2,7 @@
 //! splice -> SAN-M encoder graph -> CTC greedy decode -> tag-prefix strip.
 //!
 //! Mirrors `parakeet_ctc::executor` (prepared-runtime cache keyed by
-//! `(canonical path, backend)`, shared CTC decode policy, snapshot/incremental
+//! `(pack path identity, backend)`, shared CTC decode policy, snapshot/incremental
 //! streaming driver). SenseVoice-specific: the request language selects the
 //! 4-token prompt fail-closed (`language::build_sensevoice_prompt`), and the
 //! decoded text's leading `<|lang|><|emotion|><|event|><|itn|>` tags are parsed
@@ -16,7 +16,10 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+#[cfg(test)]
+use std::path::PathBuf;
 
 use crate::PhraseBiasConfig;
 use crate::arch::block_stack::{OpenAsrBlockKind, OpenAsrOrchestrationShape};
@@ -37,8 +40,8 @@ use crate::models::ggml_asr_executor::{
 use crate::models::ggml_streaming_session::GgmlAsrStreamingTranscriptSession;
 use crate::models::incremental_streaming_driver::STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT;
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 use crate::{NativeAsrSession, SENSEVOICE_GGML_ADAPTER_ID};
 
@@ -50,7 +53,7 @@ use super::runtime_contract::{SenseVoiceExecutionMetadata, parse_sensevoice_exec
 use super::tokenizer::SenseVoiceTokenizer;
 use super::{SenseVoiceTagShadow, strip_sensevoice_tag_prefix};
 
-type SenseVoiceRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+type SenseVoiceRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 thread_local! {
     static SENSEVOICE_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<SenseVoiceRuntimeCacheKey, SenseVoicePreparedRuntime>> =
@@ -258,7 +261,7 @@ fn decode_sensevoice_pcm_cached(
     phrase_bias: Option<&PhraseBiasConfig>,
 ) -> Result<CtcGreedyDecodeResult, String> {
     let backend = super::graph_config::sensevoice_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(pack_path), backend);
+    let key = (runtime_cache_path_identity(pack_path), backend);
     with_thread_local_cached_mut_by_key(
         &SENSEVOICE_RUNTIME_BY_KEY,
         key,
@@ -275,7 +278,7 @@ fn transcribe_sensevoice_pcm_cached(
     phrase_bias: Option<&PhraseBiasConfig>,
 ) -> Result<SenseVoiceTranscription, String> {
     let backend = super::graph_config::sensevoice_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(pack_path), backend);
+    let key = (runtime_cache_path_identity(pack_path), backend);
     with_thread_local_cached_mut_by_key(
         &SENSEVOICE_RUNTIME_BY_KEY,
         key,

--- a/crates/openasr-core/src/models/thread_local_runtime_cache.rs
+++ b/crates/openasr-core/src/models/thread_local_runtime_cache.rs
@@ -8,6 +8,16 @@ pub(crate) fn canonical_runtime_cache_path(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
+// Runtime cache keys must be built from [`runtime_cache_path_identity`]
+// (canonical path + pack content fingerprint), never from the canonical path
+// alone: the fingerprint is what makes an in-place `.oasr` replacement at the
+// same path miss and rebuild instead of handing back a runtime built from the
+// old bytes. `canonical_runtime_cache_path` stays for callers that need the
+// path itself (e.g. the path a serve-batch owner loads from), not a key.
+pub(crate) use crate::models::runtime_cache_coordinator::{
+    RuntimeCachePathIdentity, runtime_cache_path_identity,
+};
+
 // Idle-unload generation is the unified runtime-cache coordinator epoch.
 // Historical dual counters (`RUNTIME_CACHE_UNLOAD_GENERATION` here and
 // `RUNTIME_BUILD_GENERATION` on serve-batch keys) collapsed into one clock so
@@ -296,6 +306,48 @@ mod tests {
     fn canonical_runtime_cache_path_falls_back_to_original_path() {
         let path = Path::new("/tmp/openasr-missing-runtime-cache-path.gguf");
         assert_eq!(canonical_runtime_cache_path(path), path.to_path_buf());
+    }
+
+    #[test]
+    fn fingerprinted_identity_key_misses_after_in_place_replacement_and_hits_when_unchanged() {
+        let _generation_guard = unload_generation_test_lock();
+        thread_local! {
+            static FINGERPRINT_CACHE: RefCell<
+                BoundedRuntimeCache<(RuntimeCachePathIdentity, usize), Vec<usize>>,
+            > = RefCell::new(BoundedRuntimeCache::new());
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pack = dir.path().join("pack.oasr");
+        std::fs::write(&pack, b"pack-content-v1").expect("write v1");
+        let builds = std::cell::Cell::new(0_usize);
+
+        let access = |pack: &Path| {
+            let key = (runtime_cache_path_identity(pack), 0_usize);
+            with_thread_local_cached_mut_by_key(
+                &FINGERPRINT_CACHE,
+                key,
+                DEFAULT_RUNTIME_CACHE_CAPACITY,
+                || {
+                    builds.set(builds.get() + 1);
+                    Ok::<_, &'static str>(vec![builds.get()])
+                },
+                |cached| Ok::<_, &'static str>(cached.len()),
+            )
+        };
+
+        access(&pack).expect("first access builds");
+        access(&pack).expect("second access reuses");
+        assert_eq!(builds.get(), 1, "unchanged pack must stay a cache hit");
+
+        std::fs::write(&pack, b"pack-content-v2-different").expect("write v2");
+        access(&pack).expect("access after replacement rebuilds");
+        assert_eq!(
+            builds.get(),
+            2,
+            "in-place byte replacement at the same path must force a cache miss"
+        );
+        access(&pack).expect("access after rebuild reuses");
+        assert_eq!(builds.get(), 2, "the rebuilt entry is reused again");
     }
 
     /// Records how many live `DropRecorder` instances exist (via a shared

--- a/crates/openasr-core/src/models/wav2vec2_ctc/executor.rs
+++ b/crates/openasr-core/src/models/wav2vec2_ctc/executor.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::PhraseBiasConfig;
 use crate::WAV2VEC2_CTC_DECODE_POLICY_ID;
@@ -28,8 +28,8 @@ use crate::models::ggml_asr_executor::{
 use crate::models::ggml_streaming_session::GgmlAsrStreamingTranscriptSession;
 use crate::models::incremental_streaming_driver::STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT;
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 use crate::{NativeAsrSession, WAV2VEC2_CTC_GGML_ADAPTER_ID};
 
@@ -42,7 +42,7 @@ use super::runtime_contract::{
 };
 use super::tokenizer::Wav2Vec2Tokenizer;
 
-type Wav2Vec2RuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+type Wav2Vec2RuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 thread_local! {
     static WAV2VEC2_CTC_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<Wav2Vec2RuntimeCacheKey, Wav2Vec2CtcPreparedRuntime>> =
@@ -124,7 +124,7 @@ fn transcribe_wav2vec2_ctc_pcm_cached(
     word_timestamps: bool,
 ) -> Result<Wav2Vec2CtcTranscription, String> {
     let backend = wav2vec2_ctc_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(pack_path), backend);
+    let key = (runtime_cache_path_identity(pack_path), backend);
     with_thread_local_cached_mut_by_key(
         &WAV2VEC2_CTC_RUNTIME_BY_KEY,
         key,
@@ -140,7 +140,7 @@ fn decode_wav2vec2_ctc_pcm_cached(
     phrase_bias: Option<&PhraseBiasConfig>,
 ) -> Result<CtcGreedyDecodeResult, String> {
     let backend = wav2vec2_ctc_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(pack_path), backend);
+    let key = (runtime_cache_path_identity(pack_path), backend);
     with_thread_local_cached_mut_by_key(
         &WAV2VEC2_CTC_RUNTIME_BY_KEY,
         key,

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -20,7 +20,7 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -38,7 +38,8 @@ use crate::models::incremental_streaming_driver::{
 use crate::models::prepared_runtime_cache::PreparedRuntimeCache;
 use crate::models::runtime_contract::MetadataContractError;
 use crate::models::thread_local_runtime_cache::{
-    UnloadGenerationGated, canonical_runtime_cache_path,
+    RuntimeCachePathIdentity, UnloadGenerationGated, canonical_runtime_cache_path,
+    runtime_cache_path_identity,
 };
 use crate::models::tokenizer_component_registry::materialize_builtin_tokenizer_for_architecture;
 use crate::nn::attn::{
@@ -320,8 +321,12 @@ struct WhisperDecoderPersistentStaticSession {
     plan: WhisperDecoderGraphPlan,
 }
 
-type WhisperEncoderPersistentSessionKey = (PathBuf, GgmlCpuGraphBackend);
-type WhisperDecoderPersistentSessionKey = (PathBuf, GgmlCpuGraphBackend);
+/// (pack path identity: canonical path + content fingerprint, backend). The
+/// content fingerprint ([`runtime_cache_path_identity`]) keeps an in-place
+/// pack replacement at the same path from reusing a persistent session whose
+/// resident weights came from the old bytes.
+type WhisperEncoderPersistentSessionKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
+type WhisperDecoderPersistentSessionKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 thread_local! {
     // Gated on the idle-unload generation: these sessions pin the resident
@@ -3379,7 +3384,7 @@ fn take_whisper_encoder_persistent_static_session(
         sessions
             .borrow_mut()
             .synced()
-            .remove(&(canonical_runtime_cache_path(runtime_path), backend))
+            .remove(&(runtime_cache_path_identity(runtime_path), backend))
     })
 }
 
@@ -3389,7 +3394,7 @@ fn store_whisper_encoder_persistent_static_session(
 ) {
     WHISPER_ENCODER_PERSISTENT_SESSION_BY_KEY.with(|sessions| {
         let key = (
-            canonical_runtime_cache_path(runtime_path),
+            runtime_cache_path_identity(runtime_path),
             session.graph_config.backend,
         );
         sessions.borrow_mut().synced().insert(key, session);
@@ -3562,7 +3567,7 @@ fn take_or_build_whisper_decoder_persistent_static_session(
     let runtime_path = runtime_source.path();
     let graph_config = whisper_decoder_graph_config();
     let key = (
-        canonical_runtime_cache_path(runtime_path),
+        runtime_cache_path_identity(runtime_path),
         graph_config.backend,
     );
     WHISPER_DECODER_PERSISTENT_SESSION_BY_KEY.with(|sessions| {
@@ -3603,7 +3608,7 @@ fn store_whisper_decoder_persistent_static_session(
         let mut sessions = sessions.borrow_mut();
         let sessions = sessions.synced();
         let key = (
-            canonical_runtime_cache_path(runtime_path),
+            runtime_cache_path_identity(runtime_path),
             session.graph_config.backend,
         );
         let pool = sessions.entry(key).or_default();

--- a/crates/openasr-core/src/models/whisper/ggml_executor/tests.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor/tests.rs
@@ -1322,6 +1322,11 @@ fn decoder_quantized_tensor_with_empty_bytes_fails_closed() {
 fn encoder_persistent_session_cache_is_backend_scoped() {
     let temp = tempfile::tempdir().expect("tempdir");
     let runtime_path = temp.path().join("whisper-backend-scope.gguf");
+    // The pack file must exist: cache keys carry the pack content
+    // fingerprint, and an unreadable pack fails closed (a session stored
+    // under it must never be handed back out), so store + take only observe
+    // the same key against a readable path.
+    std::fs::write(&runtime_path, b"whisper-backend-scope-fixture").expect("write fixture pack");
     let cpu_config = GgmlCpuGraphConfig::conservative_default();
     let session = WhisperEncoderPersistentStaticSession {
         runner: GgmlCpuGraphRunner::new(cpu_config).expect("runner"),

--- a/crates/openasr-core/src/models/xasr_zipformer/executor.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/executor.rs
@@ -2,7 +2,7 @@
 //! stateless RNN-T greedy decode.
 
 use std::cell::RefCell;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::NativeAsrSession;
 use crate::PhraseBiasConfig;
@@ -15,8 +15,8 @@ use crate::models::ggml_asr_executor::{
 };
 use crate::models::ggml_streaming_session::GgmlAsrStreamingTranscriptSession;
 use crate::models::thread_local_runtime_cache::{
-    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, canonical_runtime_cache_path,
-    with_thread_local_cached_mut_by_key,
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, RuntimeCachePathIdentity,
+    runtime_cache_path_identity, with_thread_local_cached_mut_by_key,
 };
 
 use super::frontend::{XASR_FINAL_FLUSH_TAIL_PAD_SAMPLES, XASR_SAMPLE_RATE_HZ};
@@ -26,7 +26,11 @@ use super::runtime::{
 };
 use super::streaming_decoder::XasrIncrementalDecoder;
 
-type XasrRuntimeCacheKey = (PathBuf, GgmlCpuGraphBackend);
+/// (pack path identity: canonical path + content fingerprint, backend). The
+/// content fingerprint ([`runtime_cache_path_identity`]) keeps an in-place
+/// pack replacement at the same path from reusing a runtime built from the
+/// old bytes.
+type XasrRuntimeCacheKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 
 thread_local! {
     static XASR_ZIPFORMER_RUNTIME_BY_KEY: RefCell<BoundedRuntimeCache<XasrRuntimeCacheKey, XasrZipformerPreparedRuntime>> =
@@ -106,7 +110,7 @@ fn transcribe_xasr_zipformer_pcm_cached(
         return Err("xasr-zipformer phrase bias is not supported".to_string());
     }
     let backend = xasr_zipformer_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(pack_path), backend);
+    let key = (runtime_cache_path_identity(pack_path), backend);
     with_thread_local_cached_mut_by_key(
         &XASR_ZIPFORMER_RUNTIME_BY_KEY,
         key,

--- a/crates/openasr-core/src/models/xasr_zipformer/runtime.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/runtime.rs
@@ -1,11 +1,16 @@
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+#[cfg(test)]
+use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use crate::ggml_runtime::{GgmlCpuGraphBackend, GgufMetadata, GgufTensorDataReader};
-use crate::models::thread_local_runtime_cache::canonical_runtime_cache_path;
+use crate::models::thread_local_runtime_cache::{
+    RuntimeCachePathIdentity, runtime_cache_path_identity,
+};
 
 use super::decoder::XasrDecoder;
 use super::encoder_graph::{
@@ -28,10 +33,13 @@ const XASR_ZIPFORMER_STREAMING_WARMUP_FRAMES: usize = 13;
 const XASR_PROFILE_ENV: &str = "OPENASR_XASR_PROFILE";
 const MAX_IDLE_RUNTIMES_PER_KEY: usize = 2;
 
-/// Pool key: pack path + the backend the runtime's prepared encoder graph was
-/// built for. CPU and Metal runtimes must never conflate — a checkout for an
-/// accelerated session must not receive a CPU-frozen runtime (or vice versa).
-type RuntimePoolKey = (PathBuf, GgmlCpuGraphBackend);
+/// Pool key: pack path identity (canonical path + content fingerprint) + the
+/// backend the runtime's prepared encoder graph was built for. CPU and Metal
+/// runtimes must never conflate -- a checkout for an accelerated session must
+/// not receive a CPU-frozen runtime (or vice versa). The content fingerprint
+/// ([`runtime_cache_path_identity`]) keeps an in-place pack replacement at the
+/// same path from checking out a runtime built from the old bytes.
+type RuntimePoolKey = (RuntimeCachePathIdentity, GgmlCpuGraphBackend);
 type RuntimePool = HashMap<RuntimePoolKey, Vec<SendableRuntime>>;
 
 static XASR_PROCESS_RUNTIME_POOL: OnceLock<Mutex<RuntimePool>> = OnceLock::new();
@@ -177,7 +185,7 @@ impl Drop for PooledRuntime {
 
 pub(super) fn checkout_prepared_runtime(pack_path: &Path) -> Result<PooledRuntime, String> {
     let backend = xasr_zipformer_encoder_graph_config().backend;
-    let key = (canonical_runtime_cache_path(pack_path), backend);
+    let key = (runtime_cache_path_identity(pack_path), backend);
     if let Some(runtime) = runtime_pool()
         .lock()
         .map_err(|_| "xasr runtime pool lock poisoned".to_string())?
@@ -610,7 +618,7 @@ mod tests {
         };
 
         let key = (
-            canonical_runtime_cache_path(&pack),
+            runtime_cache_path_identity(&pack),
             xasr_zipformer_encoder_graph_config().backend,
         );
 


### PR DESCRIPTION
## Summary

The thread-local resident runtime caches across every model family (and the X-ASR streaming process pool) keyed on (canonical pack path, backend) alone. This adds a pack content fingerprint to those keys so an in-place `.oasr` replacement at the same path invalidates the cached runtime instead of silently reusing one built from the old bytes.

## Why

If a pack is replaced in place (same path, same backend), every resident runtime cache hit and handed back a runtime whose device-uploaded / mmap'd weights came from the previous bytes -- wrong transcription output with no error. Affected keys: qwen whole-decoder + audio encoder + fused logits-head executors, firered-aed encoder/decoder, firered-llm decoder, cohere encoder/decoder, moonshine encoder/decoder, whisper encoder/decoder persistent sessions, moss encoder/decoder, parakeet-ctc, parakeet-tdt, sensevoice, wav2vec2-ctc, and the X-ASR process pool. Replacement through the pull/import path was already covered by the runtime-cache coordinator epoch bump (`invalidate_after_pack_install_or_replace`); external in-place replacement (a user overwriting the file) was not. This is the cross-family follow-up the firered-aed and firered2-llm model audits recorded ("path-only cache key lacks a content fingerprint").

## Changes

- `runtime_cache_coordinator`: new `pack_content_fingerprint` -- sha256 over a domain-separation tag, the file length, the full mtime (seconds + nanoseconds), and the first and last 64 KiB of the pack. The edge slices keep the per-lookup cost O(1) for multi-GB packs (the full-file `sha256:` content id stays where its one-shot cost is acceptable: prepared-runtime / process-pool keys). The trailing slice covers the `.oasr` zip central directory, so a same-size replacement whose head bytes are identical is still caught through its per-entry CRC32s. Unreadable packs fail closed with a unique never-equal token per call, so no lookup can ever hit on them.
- New `RuntimeCachePathIdentity` (canonical path + fingerprint) with `runtime_cache_path_identity()`, re-exported through `thread_local_runtime_cache`; it replaces the bare canonical-path half of all 13 path-keyed runtime cache key types. Serve-batch owner load paths stay plain paths (the owner needs the path itself, not a key).
- Key-type doc comments updated to describe the fingerprint half.

Notes on the trade-offs (also in the doc comments):

- A rewrite with byte-identical content moves the mtime and therefore invalidates once (one rebuild). That conservative miss is intentional -- mtime equality is not a same-content proof.
- Eviction policy is unchanged; this only adds fingerprint validation to the key.
- LoRA adapter fingerprints were already content-based and stay as they were.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

New tests:

- Coordinator: fingerprint stability while the pack is unchanged; miss on in-place byte replacement (different-length and same-length-with-middle-byte-change); unreadable packs produce unique never-matching tokens; `RuntimeCachePathIdentity` path half + replacement behavior.
- `thread_local_runtime_cache`: end-to-end through the shared bounded cache -- same path with unchanged content stays a hit, an overwrite at the same path forces exactly one rebuild, then hits again.

## Manual smoke checks

None required: with an unchanged pack the fingerprint is stable, so default runs keep the existing hit behavior; the new path only activates when the pack bytes at a path actually change.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. (Doc comments only; no user-facing docs described the old path-only behavior. The firered-aed / firered2-llm audit-form lines that queued this follow-up can be updated alongside merge.)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No cache eviction-policy change (fingerprint check only).
- No full-file hashing on the per-request path.
- Does not touch serve-batch / prepared-runtime keys (already content-id'd) or the LoRA adapter cache (already content-fingerprinted).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- implemented with AI coding assistance (drafting + verification); reviewed and owned by the maintainer.
