### PR TITLE
fix(qwen): gate serve-batch on adapter presence and remove dead prefill payloads

### DIFF
--- a/crates/openasr-core/src/models/qwen/batched_decode.rs
+++ b/crates/openasr-core/src/models/qwen/batched_decode.rs
@@ -2363,21 +2363,10 @@ mod tests {
         let token_major_embeddings = token_embedding_table
             .gather_rows(prompt_tokens)
             .expect("qwen prompt embeddings");
-        let position_ids = (0..token_count)
-            .map(|idx| i32::try_from(idx).expect("position id"))
-            .collect::<Vec<_>>();
-        let mut causal_mask = vec![-1.0e30_f32; token_count * token_count];
-        for query_idx in 0..token_count {
-            for key_idx in 0..=query_idx {
-                causal_mask[query_idx * token_count + key_idx] = 0.0;
-            }
-        }
         Qwen3AsrLlmPrefillInput {
             token_count,
             hidden_size,
             token_major_embeddings,
-            position_ids,
-            causal_mask,
         }
     }
 

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -427,6 +427,15 @@ impl Qwen3AsrGgmlExecutor {
             validate_stacks_started_at,
         );
         let serve_batch_graph_config = super::graph_config::qwen_runtime_graph_config();
+        // An active LoRA adapter (request --adapter or the OPENASR_ADAPTER env
+        // fallback) must never take the serve-batch lane: the batch worker resolves
+        // weights before this point and has no adapter plumbing, so it would
+        // silently run on base weights. Resolve the active source up front and fail
+        // closed onto the serial lane below, matching moonshine's adapter bypass.
+        let adapter_active = crate::adapter_pack::active_adapter_path(
+            request.request_options.adapter_path.as_deref(),
+        )
+        .is_some();
         if let Some(serve_batch_config) =
             Qwen3AsrServeBatchConfig::from_policy(request.request_options.serve_batch)
                 // Serve-batch needs the unified GPU lane on the direct reusable graph.
@@ -435,8 +444,12 @@ impl Qwen3AsrGgmlExecutor {
                 // stay serial without claiming batch width.
                 .filter(|_| {
                     // Streaming bypasses the batch worker so live sessions stay on the
-                    // direct greedy loop below.
+                    // direct greedy loop below; an active adapter bypasses it too
+                    // (see adapter_active above).
+                    // TODO(serve-batch): plumb LoRA adapters through the batch worker
+                    // so adapter-bearing requests can share the batched GPU lane.
                     !skip_serve_batch
+                        && !adapter_active
                         && serve_batch_graph_config.backend.is_gpu_class()
                         && !serve_batch_graph_config.use_scheduler
                 })

--- a/crates/openasr-core/src/models/qwen/llm_prefill.rs
+++ b/crates/openasr-core/src/models/qwen/llm_prefill.rs
@@ -2,19 +2,12 @@ use thiserror::Error;
 
 use super::prompt_embedding::Qwen3AsrPromptEmbeddings;
 
-const MASK_ALLOW: f32 = 0.0;
-const MASK_BLOCK: f32 = -1.0e30;
-
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Qwen3AsrLlmPrefillInput {
     pub token_count: usize,
     pub hidden_size: usize,
     // Layout: token-major row-contiguous ([token][hidden]) f32.
     pub token_major_embeddings: Vec<f32>,
-    // Layout: token-major ([token]) i32.
-    pub position_ids: Vec<i32>,
-    // Layout: row-major ([query_token][key_token]) f32.
-    pub causal_mask: Vec<f32>,
 }
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -27,10 +20,6 @@ pub(crate) enum Qwen3AsrLlmPrefillInputError {
         hidden_size: usize,
         values_len: usize,
     },
-    #[error("qwen3-asr llm prefill token_count={token_count} does not fit i32 position ids")]
-    TokenCountOutOfI32Range { token_count: usize },
-    #[error("qwen3-asr llm prefill token_count={token_count} overflows causal mask allocation")]
-    CausalMaskAllocationOverflow { token_count: usize },
     #[error("qwen3-asr llm prefill embeddings contain non-finite values")]
     NonFiniteEmbeddings,
 }
@@ -62,29 +51,10 @@ pub(crate) fn build_qwen3_llm_prefill_input(
         return Err(Qwen3AsrLlmPrefillInputError::NonFiniteEmbeddings);
     }
 
-    let mut position_ids = Vec::with_capacity(token_count);
-    for idx in 0..token_count {
-        let id = i32::try_from(idx)
-            .map_err(|_| Qwen3AsrLlmPrefillInputError::TokenCountOutOfI32Range { token_count })?;
-        position_ids.push(id);
-    }
-
-    let mask_len = token_count
-        .checked_mul(token_count)
-        .ok_or(Qwen3AsrLlmPrefillInputError::CausalMaskAllocationOverflow { token_count })?;
-    let mut causal_mask = vec![MASK_BLOCK; mask_len];
-    for query_idx in 0..token_count {
-        for key_idx in 0..=query_idx {
-            causal_mask[query_idx * token_count + key_idx] = MASK_ALLOW;
-        }
-    }
-
     Ok(Qwen3AsrLlmPrefillInput {
         token_count,
         hidden_size,
         token_major_embeddings: prompt_embeddings.token_major_values.clone(),
-        position_ids,
-        causal_mask,
     })
 }
 
@@ -93,7 +63,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn llm_prefill_builds_monotonic_positions_and_causal_mask() {
+    fn llm_prefill_passes_through_token_major_embeddings() {
         let prompt = Qwen3AsrPromptEmbeddings {
             hidden_size: 2,
             token_count: 3,
@@ -104,13 +74,14 @@ mod tests {
             ],
         };
         let input = build_qwen3_llm_prefill_input(&prompt).expect("prefill input");
-        assert_eq!(input.position_ids, vec![0, 1, 2]);
+        assert_eq!(input.token_count, 3);
+        assert_eq!(input.hidden_size, 2);
         assert_eq!(
-            input.causal_mask,
+            input.token_major_embeddings,
             vec![
-                0.0, -1.0e30, -1.0e30, //
-                0.0, 0.0, -1.0e30, //
-                0.0, 0.0, 0.0
+                1.0, 2.0, //
+                3.0, 4.0, //
+                5.0, 6.0,
             ]
         );
     }


### PR DESCRIPTION
## Summary

Two independent qwen fixes on the serve-batch / LLM-prefill path: a
fail-closed gate so LoRA adapter requests never run on base weights, and
removal of two dead prefill payloads that allocated large buffers no
consumer ever read.

## Why

- LoRA adapter gate: the serve-batch eligibility filter returned before
  adapter resolution. With batching enabled, a request carrying
  `adapter_path` was served on base weights and the adapter was silently
  dropped - a fail-open correctness bug on a trust-relevant path.
- Dead prefill payloads: `Qwen3AsrLlmPrefillInput` carried a
  `causal_mask` (`token_count^2` f32, ~210MB for a 10-minute clip) and a
  `position_ids` buffer that no downstream consumer ever read, wasting a
  large allocation on every prefill.

## Changes

- `models/qwen/ggml_executor.rs`: exclude adapter-bearing requests
  (`request_options.adapter_path.is_some()`) from serve-batch eligibility
  so they fall through to the serial lane, which resolves and applies the
  adapter. Add a TODO to plumb adapters through the batch worker later.
- `models/qwen/llm_prefill.rs`: remove the `causal_mask` and
  `position_ids` fields, their construction, the now-unreachable
  `TokenCountOutOfI32Range` / `CausalMaskAllocationOverflow` error
  variants, and the mask constants. The prefill input now holds only the
  token-major embeddings actually consumed downstream. Update the unit
  test to assert the embedding passthrough.
- `models/qwen/batched_decode.rs`: drop the dead fields from the test
  fixture.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-core`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

None - behavior is covered by the existing qwen serve-batch and
llm_prefill unit tests; the adapter gate only redirects eligible traffic
to the already-tested serial lane.

## Docs updated

- [x] No behavior or limitation docs changed; no docs overclaim.

## Scope / non-goals

- Does not add LoRA adapter support to the serve-batch worker; adapter
  requests fall back to the serial lane for now (see the TODO).
- No changes to other model families.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
