### PR TITLE
perf(qwen): shrink encoder graph context from 256MB to precise allocation

### DIFF
--- a/crates/openasr-core/src/models/qwen/audio_encoder.rs
+++ b/crates/openasr-core/src/models/qwen/audio_encoder.rs
@@ -51,7 +51,22 @@ const QWEN3_AUDIO_CONV_STRIDE: usize = 2;
 const QWEN3_AUDIO_CONV_PADDING: usize = 1;
 const QWEN3_AUDIO_CONV_DILATION: usize = 1;
 const QWEN3_AUDIO_LAYER_NORM_EPSILON: f32 = 1.0e-5;
-const QWEN3_AUDIO_GRAPH_CONTEXT_BYTES: usize = 256 * 1024 * 1024;
+
+/// Worst-case forward-graph node budget for the qwen3-asr audio encoder, used to
+/// right-size the runner's `no_alloc` metadata context (via
+/// [`GgmlCpuGraphConfig::metadata_context_bytes`]) instead of the historical flat
+/// 256 MB. The graph topology is architecture-bound, not sequence-length-bound:
+/// 18 layers x ~30 ops (flash) / ~39 ops (the naive fallback under
+/// `OPENASR_QWEN_GGML_DISABLE_AUDIO_ENCODER_FLASH_ATTN`) plus ~17 conv-front and
+/// ~8 post-processing nodes ~= 565-727 nodes regardless of audio length -- longer
+/// audio grows tensor DIMENSIONS, not the op count. 2048 keeps >2x headroom over
+/// the naive worst case. `ggml_init` always mallocs the full `mem_size` even with
+/// `no_alloc=true`, so the old 256 MB committed ~256 MB of metadata context that
+/// only ever holds bookkeeping for <1k tensors: resident-memory waste on the
+/// 16 GB target plus a cold-start runtime-init cost, for a graph that needs <1 MB.
+/// Mirrors the xasr_zipformer encoder sizing
+/// (`models/xasr_zipformer/graph_config.rs`).
+const QWEN3_AUDIO_ENCODER_GRAPH_SIZE: usize = 2048;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Qwen3AsrAudioEncoderOutput {
@@ -164,12 +179,31 @@ pub(crate) struct Qwen3AsrAudioEncoderRuntime {
     loaded: Option<GgmlLoadedWeightContext>,
 }
 
+/// The audio-encoder runner's graph config: the family `EncoderPrelude` tier (see
+/// `qwen_encoder_graph_config`) with the `no_alloc` metadata context right-sized
+/// from the encoder's forward-graph node count instead of the historical flat
+/// 256 MB. `ggml_init` always mallocs the full `mem_size` even with
+/// `no_alloc=true`, so sizing from [`QWEN3_AUDIO_ENCODER_GRAPH_SIZE`] (via
+/// [`GgmlCpuGraphConfig::metadata_context_bytes`]) drops the committed context
+/// from 256 MB to <1 MB without touching the graph the encoder builds. The
+/// `.max()` keeps the default floor and any larger override intact, mirroring
+/// `xasr_zipformer_encoder_graph_config_with_overrides`.
+fn qwen_audio_encoder_runtime_graph_config() -> GgmlCpuGraphConfig {
+    let mut config = qwen_encoder_graph_config();
+    config.graph_size = config.graph_size.max(QWEN3_AUDIO_ENCODER_GRAPH_SIZE);
+    config.context_bytes = config
+        .context_bytes
+        .max(GgmlCpuGraphConfig::metadata_context_bytes(
+            config.graph_size,
+        ));
+    config
+}
+
 impl Qwen3AsrAudioEncoderRuntime {
     pub(crate) fn new(runtime_path: Option<&Path>) -> Result<Self, Qwen3AsrAudioEncoderError> {
-        // See `qwen_encoder_graph_config` for the `EncoderPrelude` threading
-        // tier rationale.
-        let mut config = qwen_encoder_graph_config();
-        config.context_bytes = QWEN3_AUDIO_GRAPH_CONTEXT_BYTES;
+        // See `qwen_audio_encoder_runtime_graph_config` for the `EncoderPrelude`
+        // threading tier and the right-sized metadata-context rationale.
+        let config = qwen_audio_encoder_runtime_graph_config();
         let runner = GgmlCpuGraphRunner::new(config).map_err(|source| {
             Qwen3AsrAudioEncoderError::GraphBuildFailed {
                 step: "runner_init",
@@ -1358,6 +1392,33 @@ mod tests {
         assert_eq!(values.len(), 8 * 13);
         assert_eq!(values[0], 0.0);
         assert_eq!(values[4], 1.0);
+    }
+
+    /// Regression guard for the right-sized encoder metadata context (the
+    /// historical flat 256 MB over-reserved a context that only holds bookkeeping
+    /// for <1k tensors; `ggml_init` mallocs the full `mem_size` even with
+    /// `no_alloc=true`). The context must still cover the worst-case forward graph
+    /// (architecture-bound, see [`QWEN3_AUDIO_ENCODER_GRAPH_SIZE`]) while staying a
+    /// small fraction of the old 256 MB. Only touches `context_bytes`/`graph_size`
+    /// (thread-independent), so it is stable against parallel-test env mutation.
+    #[test]
+    fn encoder_graph_context_is_right_sized_not_flat_256mb() {
+        let config = qwen_audio_encoder_runtime_graph_config();
+
+        // Covers the worst-case forward graph (node budget + the metadata its
+        // tensors need)...
+        assert!(config.graph_size >= QWEN3_AUDIO_ENCODER_GRAPH_SIZE);
+        assert!(
+            config.context_bytes
+                >= GgmlCpuGraphConfig::metadata_context_bytes(QWEN3_AUDIO_ENCODER_GRAPH_SIZE)
+        );
+        // ...while staying a small fraction of the historical 256 MB (the precise
+        // value is <1 MB; bound generously so the guard is not brittle).
+        assert!(
+            config.context_bytes < 16 * 1024 * 1024,
+            "encoder metadata context regrew toward the old flat 256 MB: {}",
+            config.context_bytes
+        );
     }
 
     /// Stage 2 bisection gate: run the ggml audio encoder (24 layers/1024/16


### PR DESCRIPTION
## Summary

Right-size the qwen3-asr audio encoder's `no_alloc` graph metadata context from a
flat 256 MB to a value derived from the encoder's actual forward-graph node count,
via the existing shared `GgmlCpuGraphConfig::metadata_context_bytes`.

## Why

The audio encoder reserved a flat `QWEN3_AUDIO_GRAPH_CONTEXT_BYTES = 256 MB` for
its graph metadata context. `ggml_init` always mallocs the full `mem_size` even
with `no_alloc=true`, but the encoder forward graph only needs bookkeeping for well
under 1k tensors: 18 layers x ~30 ops (flash) / ~39 ops (the naive fallback) plus
~17 conv-front and ~8 post-processing nodes ~= 565-727 architecture-bound nodes,
independent of audio length. The flat 256 MB therefore committed ~256 MB of
resident memory for a context that needs <1 MB - waste on the 16 GB target plus a
cold-start runtime-init cost. This mirrors the sizing the xasr_zipformer encoder
already uses after hitting the same over-reservation problem.

## Changes

- `crates/openasr-core/src/models/qwen/audio_encoder.rs`
  - Replace the flat `QWEN3_AUDIO_GRAPH_CONTEXT_BYTES` (256 MB) with a documented
    `QWEN3_AUDIO_ENCODER_GRAPH_SIZE` node budget (2048, >2x headroom over the
    naive-attention worst case).
  - Add `qwen_audio_encoder_runtime_graph_config()` which sizes `graph_size` and
    `context_bytes` from that budget via `metadata_context_bytes`, keeping the
    default floor / any larger override with `.max()` (same idiom as
    `xasr_zipformer_encoder_graph_config_with_overrides`).
  - `Qwen3AsrAudioEncoderRuntime::new` now uses that helper instead of overriding
    `context_bytes` to 256 MB.
  - Add a regression guard asserting the context still covers the worst-case graph
    while staying a small fraction of the old 256 MB.

The graph the encoder builds is unchanged; only the metadata-context reservation
shrinks, so encoder output stays identical.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

The change is confined to `openasr-core`, so the gates were run at `-p openasr-core`
scope: `cargo fmt -p openasr-core -- --check` (clean),
`cargo clippy -p openasr-core --all-targets -- -D warnings` (clean), and
`cargo nextest run -p openasr-core` (2433 passed, 0 failed, 140 skipped - the
real-pack encoder harnesses skip without a model fixture). The full `--workspace`
nextest/doc run and `cargo deny` were not run for this change.

## Manual smoke checks

None beyond the package suite. The change is metadata-context sizing only; it is
covered by the new `encoder_graph_context_is_right_sized_not_flat_256mb` unit test
plus the full `openasr-core` suite. A real-pack encode smoke (e.g. transcribing a
clip with `OPENASR_QWEN_ENCODER_PROFILE=1`) is a sensible confirmation before merge.

## Docs updated

- [x] No docs overclaim current capabilities.

No user-facing behavior changes; no docs updates needed.

## Scope / non-goals

- Encoder weight persistence across `encode()` calls is intentionally out of scope.
  The conv stem and 1D norms/biases are re-uploaded each call (~12 MB), but encoder
  setup is only ~7-8 ms (not the bottleneck) and persisting the WEIGHTS-usage arena
  touches the GPU-offload weight-placement path, so it is deferred to a separate
  change with dedicated validation.
- Other families still carry a flat 256 MB context (`firered_punc`, `dolphin`
  joint-decode, `mimo_asr` input-local graph, xasr `encoder_graph.rs`); those are
  untouched here to keep the scope to the qwen audio encoder.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [ ] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [ ] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - AI assisted in drafting the change and this PR text; the human submitter reviews, understands, and owns the change before converting this draft to ready.
