### PR TITLE
perf(core): shrink 256MB graph context in firered-punc, dolphin, mimo, xasr

### DIFF
--- a/crates/openasr-core/src/models/dolphin/joint_decode.rs
+++ b/crates/openasr-core/src/models/dolphin/joint_decode.rs
@@ -165,6 +165,33 @@ pub(crate) fn joint_decode(
 
 // --- CTC head projection ---------------------------------------------------
 
+/// Worst-case forward-graph node budget for the dolphin CTC head: the graph is
+/// one `mul_mat` + one bias `add` over `encoder_out` (a handful of nodes), so
+/// 2048 keeps >500x headroom and right-sizes the runner's `no_alloc` metadata
+/// context via [`GgmlCpuGraphConfig::metadata_context_bytes`] instead of the
+/// historical flat 256 MB. `ggml_init` always mallocs the full `mem_size`
+/// even with `no_alloc=true`, so the old 256 MB committed ~256 MB of metadata
+/// context for a graph that needs <0.1 MB. Mirrors the qwen audio-encoder
+/// (`models/qwen/audio_encoder.rs`) and xasr_zipformer encoder
+/// (`models/xasr_zipformer/graph_config.rs`) sizing.
+const DOLPHIN_CTC_HEAD_GRAPH_SIZE: usize = 2048;
+
+fn dolphin_ctc_head_graph_config(backend: GgmlCpuGraphBackend) -> GgmlCpuGraphConfig {
+    GgmlCpuGraphConfig {
+        context_bytes: GgmlCpuGraphConfig::metadata_context_bytes(DOLPHIN_CTC_HEAD_GRAPH_SIZE),
+        graph_size: DOLPHIN_CTC_HEAD_GRAPH_SIZE,
+        n_threads: GgmlCpuGraphConfig::resolve_runtime_thread_count_for(
+            backend,
+            crate::ggml_runtime::GgmlCpuGraphThreadingWorkload::Default,
+        ),
+        backend,
+        // See the matching comment in encoder_graph.rs: unconditionally
+        // enabling the gallocr scheduler only bounds memory footprint, never
+        // the CTC head's computed output.
+        use_scheduler: true,
+    }
+}
+
 /// `ctc.ctc_lo(encoder_out)` -> `log_softmax`, returned row-major `[frames, vocab]`
 /// (vocab innermost). The linear runs in the CPU ggml graph (like the encoder);
 /// the softmax is a cheap Rust pass.
@@ -184,19 +211,7 @@ fn compute_ctc_log_probs(
     };
     let bias = fetch(provider, "ctc.ctc_lo.bias", vocab)?;
 
-    let graph_config = GgmlCpuGraphConfig {
-        context_bytes: 256 * 1024 * 1024,
-        graph_size: 2048,
-        n_threads: GgmlCpuGraphConfig::resolve_runtime_thread_count_for(
-            backend,
-            crate::ggml_runtime::GgmlCpuGraphThreadingWorkload::Default,
-        ),
-        backend,
-        // See the matching comment in encoder_graph.rs: unconditionally
-        // enabling the gallocr scheduler only bounds memory footprint, never
-        // the CTC head's computed output.
-        use_scheduler: true,
-    };
+    let graph_config = dolphin_ctc_head_graph_config(backend);
     let ggml = |stage: &'static str| move |source| DolphinJointDecodeError::Ggml { stage, source };
     let mut runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml("runner_init"))?;
 
@@ -606,5 +621,25 @@ mod tests {
             .map(|s| s.to_string())
             .collect();
         assert_eq!(detokenize_char_tokens(&[1, 2, 3, 4], &tokens), "学校");
+    }
+
+    /// Regression guard for the right-sized CTC-head metadata context (the
+    /// historical flat 256 MB over-reserved a bookkeeping-only context;
+    /// `ggml_init` mallocs the full `mem_size` even with `no_alloc=true`).
+    /// Only touches `context_bytes`/`graph_size` (thread-independent), so it
+    /// is stable against parallel-test env mutation.
+    #[test]
+    fn ctc_head_graph_context_is_right_sized_not_flat_256mb() {
+        let config = dolphin_ctc_head_graph_config(GgmlCpuGraphBackend::Cpu);
+        assert!(config.graph_size >= DOLPHIN_CTC_HEAD_GRAPH_SIZE);
+        assert!(
+            config.context_bytes
+                >= GgmlCpuGraphConfig::metadata_context_bytes(DOLPHIN_CTC_HEAD_GRAPH_SIZE)
+        );
+        assert!(
+            config.context_bytes < 16 * 1024 * 1024,
+            "dolphin CTC-head metadata context regrew toward the old flat 256 MB: {}",
+            config.context_bytes
+        );
     }
 }

--- a/crates/openasr-core/src/models/firered_punc/graph.rs
+++ b/crates/openasr-core/src/models/firered_punc/graph.rs
@@ -26,7 +26,50 @@ use crate::nn::norm::{AffineLayerNormSteps, apply_affine_layer_norm};
 use super::config::{FIRERED_PUNC_LAYER_NORM_EPSILON, FireRedPuncExecutionMetadata};
 use super::weights::{FireRedPuncLayerWeights, FireRedPuncWeights, NamedTensor};
 
-const FIRERED_PUNC_GRAPH_CONTEXT_BYTES: usize = 256 * 1024 * 1024;
+/// Fixed weight-arena tensors: token / token-type / position embeddings, the
+/// post-embedding LayerNorm weight+bias and the classification-head
+/// weight+bias.
+const FIRERED_PUNC_FIXED_ARENA_TENSORS: usize = 7;
+/// Weight-arena tensors per BERT block, mirroring [`LayerArena`]: the q/k/v,
+/// output, ffn-up and ffn-down weight+bias pairs plus the attention and FFN
+/// LayerNorm weight+bias pairs.
+const FIRERED_PUNC_ARENA_TENSORS_PER_LAYER: usize = 16;
+
+/// The runner's graph config, right-sized from the BERT forward-graph node
+/// budget instead of the historical flat 256 MB. Each post-norm BERT block
+/// builds ~45-50 ggml ops (q/k/v linear projections, per-head
+/// reshape/permute/cont, scaled dot-product attention, output projection, two
+/// affine LayerNorms and the erf-GELU FFN); `layers * 64 + 512` keeps headroom
+/// over the per-layer count plus the fixed embed-sum/LayerNorm front and the
+/// classification head, and longer sequences grow tensor DIMENSIONS, not the
+/// op count. `ggml_init` always mallocs the full `mem_size` even with
+/// `no_alloc=true`, so the old 256 MB committed ~256 MB of metadata context
+/// that only ever holds bookkeeping for <3k tensors: resident-memory waste on
+/// the 16 GB target, for a graph that needs <1 MB (see
+/// [`GgmlCpuGraphConfig::metadata_context_bytes`]). Mirrors the qwen
+/// audio-encoder (`models/qwen/audio_encoder.rs`) and xasr_zipformer encoder
+/// (`models/xasr_zipformer/graph_config.rs`) sizing.
+fn firered_punc_graph_config(layers: usize) -> GgmlCpuGraphConfig {
+    let mut config = GgmlCpuGraphConfig::default();
+    config.graph_size = config.graph_size.max(layers * 64 + 512);
+    config.context_bytes = config
+        .context_bytes
+        .max(GgmlCpuGraphConfig::metadata_context_bytes(
+            config.graph_size,
+        ));
+    config
+}
+
+/// Exact byte capacity the weight arena's `no_alloc` metadata context needs
+/// for the architecture-bound tensor count: [`FIRERED_PUNC_FIXED_ARENA_TENSORS`]
+/// fixed tensors plus [`FIRERED_PUNC_ARENA_TENSORS_PER_LAYER`] per BERT block.
+/// Over-counting only sizes the (cheap) tensor-overhead context; the real
+/// weight bytes land in the backend buffer.
+fn firered_punc_weight_arena_context_bytes(layers: usize) -> usize {
+    let tensor_count = FIRERED_PUNC_FIXED_ARENA_TENSORS
+        .saturating_add(FIRERED_PUNC_ARENA_TENSORS_PER_LAYER.saturating_mul(layers));
+    GgmlCpuGraphConfig::metadata_context_bytes(tensor_count)
+}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum FireRedPuncGraphError {
@@ -121,12 +164,10 @@ impl FireRedPuncGraph {
         weights: &FireRedPuncWeights,
         metadata: FireRedPuncExecutionMetadata,
     ) -> Result<Self, FireRedPuncGraphError> {
-        let mut config = GgmlCpuGraphConfig::default();
-        config.context_bytes = FIRERED_PUNC_GRAPH_CONTEXT_BYTES;
-        config.graph_size = config.graph_size.max(metadata.layers * 64 + 512);
+        let config = firered_punc_graph_config(metadata.layers);
         let runner = GgmlCpuGraphRunner::new(config).map_err(bf("runner_init"))?;
         let mut arena = runner
-            .start_static_tensor_arena(FIRERED_PUNC_GRAPH_CONTEXT_BYTES)
+            .start_static_tensor_arena(firered_punc_weight_arena_context_bytes(metadata.layers))
             .map_err(bf("arena_init"))?;
 
         let d = metadata.d_model;
@@ -713,5 +754,32 @@ mod tests {
             graph.forward(&too_long),
             Err(FireRedPuncGraphError::SequenceTooLong { .. })
         ));
+    }
+
+    /// Regression guard for the right-sized metadata contexts (the historical
+    /// flat 256 MB over-reserved bookkeeping-only contexts; `ggml_init`
+    /// mallocs the full `mem_size` even with `no_alloc=true`). A
+    /// production-scale 24-block BERT stack is far above the 1-block fixture
+    /// and bounds any real FireRedPunc pack. Only touches
+    /// `context_bytes`/`graph_size` (thread-independent), so it is stable
+    /// against parallel-test env mutation.
+    #[test]
+    fn graph_context_is_right_sized_not_flat_256mb() {
+        let layers = 24;
+        let config = firered_punc_graph_config(layers);
+        assert!(config.graph_size >= layers * 64 + 512);
+        assert!(
+            config.context_bytes >= GgmlCpuGraphConfig::metadata_context_bytes(config.graph_size)
+        );
+        assert!(
+            config.context_bytes < 16 * 1024 * 1024,
+            "firered-punc runner metadata context regrew toward the old flat 256 MB: {}",
+            config.context_bytes
+        );
+        assert!(
+            firered_punc_weight_arena_context_bytes(layers) < 16 * 1024 * 1024,
+            "firered-punc weight-arena metadata context regrew toward the old flat 256 MB: {}",
+            firered_punc_weight_arena_context_bytes(layers)
+        );
     }
 }

--- a/crates/openasr-core/src/models/mimo_asr/input_local_graph.rs
+++ b/crates/openasr-core/src/models/mimo_asr/input_local_graph.rs
@@ -34,7 +34,29 @@ use super::tensor_names::{
 };
 
 const RMS_NORM_EPSILON: f32 = 1.0e-6;
-const GRAPH_CONTEXT_BYTES: usize = 256 * 1024 * 1024;
+
+/// The input-local runner's graph config, right-sized from the 6L
+/// transformer's forward-graph node budget instead of the historical flat
+/// 256 MB. Each Qwen2-shaped block builds ~35-45 ggml ops (RMSNorm, qkv
+/// projections + bias, per-head reshape/RoPE/permute/cont, scaled dot-product
+/// attention, output projection, SwiGLU FFN and two residuals); the default
+/// `graph_size` (4096) keeps >60x headroom over the 6-block graph, and longer
+/// audio grows tensor DIMENSIONS, not the op count.
+/// [`GgmlCpuGraphConfig::metadata_context_bytes`] sizes the `no_alloc`
+/// metadata context from that node budget: `ggml_init` always mallocs the
+/// full `mem_size` even with `no_alloc=true`, so the old 256 MB committed
+/// ~256 MB of metadata context for a graph that needs ~2 MB. Mirrors the qwen
+/// audio-encoder (`models/qwen/audio_encoder.rs`) and xasr_zipformer encoder
+/// (`models/xasr_zipformer/graph_config.rs`) sizing.
+fn mimo_input_local_graph_config() -> GgmlCpuGraphConfig {
+    let mut config = GgmlCpuGraphConfig::default();
+    config.context_bytes = config
+        .context_bytes
+        .max(GgmlCpuGraphConfig::metadata_context_bytes(
+            config.graph_size,
+        ));
+    config
+}
 
 #[derive(Debug, Error)]
 pub(crate) enum MimoInputLocalError {
@@ -212,13 +234,7 @@ impl MimoInputLocalRuntime {
         runtime_path: &std::path::Path,
         metadata: MimoInlocalMetadata,
     ) -> Result<Self, MimoInputLocalError> {
-        let mut config = GgmlCpuGraphConfig::default();
-        config.context_bytes = config
-            .context_bytes
-            .max(GgmlCpuGraphConfig::metadata_context_bytes(
-                config.graph_size,
-            ))
-            .max(GRAPH_CONTEXT_BYTES);
+        let config = mimo_input_local_graph_config();
         let runner =
             GgmlCpuGraphRunner::new(config).map_err(|source| build_err("runner_init", source))?;
         let loaded_weights = runner
@@ -630,5 +646,23 @@ mod tests {
         let frame_count = 6usize;
         let group_size = 4usize;
         assert!(!frame_count.is_multiple_of(group_size));
+    }
+
+    /// Regression guard for the right-sized input-local metadata context (the
+    /// historical flat 256 MB over-reserved a bookkeeping-only context;
+    /// `ggml_init` mallocs the full `mem_size` even with `no_alloc=true`).
+    /// Only touches `context_bytes`/`graph_size` (thread-independent), so it
+    /// is stable against parallel-test env mutation.
+    #[test]
+    fn input_local_graph_context_is_right_sized_not_flat_256mb() {
+        let config = mimo_input_local_graph_config();
+        assert!(
+            config.context_bytes >= GgmlCpuGraphConfig::metadata_context_bytes(config.graph_size)
+        );
+        assert!(
+            config.context_bytes < 16 * 1024 * 1024,
+            "mimo input-local metadata context regrew toward the old flat 256 MB: {}",
+            config.context_bytes
+        );
     }
 }

--- a/crates/openasr-core/src/models/xasr_zipformer/encoder_graph.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/encoder_graph.rs
@@ -8924,9 +8924,21 @@ mod tests {
         let metadata = read_gguf_metadata(&pack).expect("metadata");
         let metadata = parse_xasr_zipformer_execution_metadata(&metadata).expect("metadata parse");
         let weights = load_xasr_encoder_weights(&reader, &metadata).expect("weights");
+        // Right-sized like the runtime path (see
+        // `xasr_zipformer_encoder_graph_config`): stack0 is a strict subset of
+        // the full encoder, so the full-encoder node budget covers it with >5x
+        // headroom. The old flat 256 MB over-reserved the `no_alloc` metadata
+        // context, which only holds tensor bookkeeping.
         let mut config = GgmlCpuGraphConfig::conservative_default();
-        config.context_bytes = 256 * 1024 * 1024;
-        config.graph_size = 262_144;
+        config.graph_size = config
+            .graph_size
+            .max(crate::models::xasr_zipformer::graph_config::FULL_ENCODER_GRAPH_SIZE);
+        config.context_bytes =
+            config
+                .context_bytes
+                .max(GgmlCpuGraphConfig::metadata_context_bytes(
+                    config.graph_size,
+                ));
         let graph = XasrZipformerEncoderGraph::new_ggml_cpu_stack0(metadata, weights, config)
             .expect("graph");
 
@@ -8958,9 +8970,20 @@ mod tests {
         let metadata = read_gguf_metadata(&pack).expect("metadata");
         let metadata = parse_xasr_zipformer_execution_metadata(&metadata).expect("metadata parse");
         let weights = load_xasr_encoder_weights(&reader, &metadata).expect("weights");
+        // Match the runtime path's right-sized config (see
+        // `xasr_zipformer_encoder_graph_config`); the old flat 2 GiB /
+        // 2,000,000-node values were the pre-fix over-reservation that OOM'd
+        // CPU transcription.
         let mut config = GgmlCpuGraphConfig::conservative_default();
-        config.context_bytes = 2 * 1024 * 1024 * 1024;
-        config.graph_size = 2_000_000;
+        config.graph_size = config
+            .graph_size
+            .max(crate::models::xasr_zipformer::graph_config::FULL_ENCODER_GRAPH_SIZE);
+        config.context_bytes =
+            config
+                .context_bytes
+                .max(GgmlCpuGraphConfig::metadata_context_bytes(
+                    config.graph_size,
+                ));
         let graph = XasrZipformerEncoderGraph::new_ggml_cpu_full_encoder(metadata, weights, config)
             .expect("graph");
 
@@ -9006,9 +9029,20 @@ mod tests {
         let metadata = parse_xasr_zipformer_execution_metadata(&metadata).expect("metadata parse");
         let total_layers = metadata.total_encoder_layers();
         let weights = load_xasr_encoder_weights(&reader, &metadata).expect("weights");
+        // Match the runtime path's right-sized config (see
+        // `xasr_zipformer_encoder_graph_config`); the old flat 2 GiB /
+        // 2,000,000-node values were the pre-fix over-reservation that OOM'd
+        // CPU transcription.
         let mut config = GgmlCpuGraphConfig::conservative_default();
-        config.context_bytes = 2 * 1024 * 1024 * 1024;
-        config.graph_size = 2_000_000;
+        config.graph_size = config
+            .graph_size
+            .max(crate::models::xasr_zipformer::graph_config::FULL_ENCODER_GRAPH_SIZE);
+        config.context_bytes =
+            config
+                .context_bytes
+                .max(GgmlCpuGraphConfig::metadata_context_bytes(
+                    config.graph_size,
+                ));
         let graph = XasrZipformerEncoderGraph::new_ggml_cpu_full_encoder(metadata, weights, config)
             .expect("graph");
         let features = XasrEncoderFeatureInput::new(61, 80, input).expect("features");

--- a/crates/openasr-core/src/models/xasr_zipformer/graph_config.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/graph_config.rs
@@ -12,7 +12,7 @@ use crate::models::graph_runtime_config::{
 /// tensor counts. The previous 2,000,000 over-reserved the cgraph object alone
 /// by ~79 MB and, paired with a hand-tuned 2 GiB context (see
 /// [`GgmlCpuGraphConfig::metadata_context_bytes`]), OOM'd CPU transcription.
-const FULL_ENCODER_GRAPH_SIZE: usize = 65_536;
+pub(super) const FULL_ENCODER_GRAPH_SIZE: usize = 65_536;
 
 /// Auto prefers the accelerator on the generic GPU lane (HIP/CUDA/Vulkan),
 /// and only falls back to CPU when no accelerator is present or the request


### PR DESCRIPTION
## Summary

Shrinks the remaining flat 256 MB `no_alloc` graph-context allocations in four model families to precise, node-count-derived sizes, mirroring the qwen encoder fix in #244.

## Why

`ggml_init` always mallocs the full `mem_size` even with `no_alloc=true`, and these contexts only ever hold tensor bookkeeping (cgraph + per-tensor overhead), never weight bytes. A flat 256 MB therefore commits ~256 MB of resident memory for graphs that need <2 MB - resident-memory waste on the 16 GB target plus cold-start init cost. #244 fixed the qwen encoder; a sweep found the same pattern still live in firered-punc, dolphin, mimo-asr and (in host-local oracle tests only) xasr_zipformer.

## Changes

- `models/firered_punc/graph.rs`: replace `FIRERED_PUNC_GRAPH_CONTEXT_BYTES` (256 MB, used for both the runner context and the weight arena) with `firered_punc_graph_config(layers)` - keeps the existing `layers * 64 + 512` forward-graph node budget and sizes `context_bytes` via `GgmlCpuGraphConfig::metadata_context_bytes` - and `firered_punc_weight_arena_context_bytes(layers)` sized from the architecture-bound arena tensor count (7 fixed + 16 per BERT block).
- `models/dolphin/joint_decode.rs`: replace the flat 256 MB CTC-head context with `dolphin_ctc_head_graph_config()`; the head graph is one `mul_mat` + one bias `add`, so the existing `graph_size: 2048` (>500x headroom) now sizes the context via `metadata_context_bytes` (~0.9 MB).
- `models/mimo_asr/input_local_graph.rs`: drop the `.max(GRAPH_CONTEXT_BYTES)` (256 MB) floor; the 6L input-local transformer (~300 ops) is covered by the default `graph_size` (4096, >60x headroom) and the context is sized via `metadata_context_bytes` (~1.7 MB).
- `models/xasr_zipformer/encoder_graph.rs`: the three host-local ONNX-oracle tests now reuse `FULL_ENCODER_GRAPH_SIZE` (65,536, the measured full-encoder budget from `graph_config.rs`, made `pub(super)`) with `metadata_context_bytes`, matching the runtime path. This also retires the pre-fix 2 GiB / 2,000,000-node values in the two full-encoder oracle tests - the exact over-reservation that `graph_config.rs` documents as having OOM'd CPU transcription.
- Added `*_is_right_sized_not_flat_256mb` regression guards (context < 16 MB, node budget covered) for firered-punc, dolphin and mimo-asr; xasr_zipformer already has its budget guards in `graph_config.rs`.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (run as `-p openasr-core --all-targets`; the change is core-only)
- [x] `cargo nextest run --workspace` (run as `-p openasr-core`: 2450 passed, 1 failed - see note below)
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Note: the one failure, `models::family_integration_audit::source_tree_audit::pre_audit_families_embedded_ssot_is_non_empty` (`families.contains("qwen")`), is pre-existing on `origin/main` - reproduced on a clean stash of 0220415, where #238 removed `qwen` from `docs/model-audits/pre_audit_families.txt` but left the hardcoded assertion. Unrelated to this change.

## Manual smoke checks

None needed: pure context-sizing changes, byte-identical graphs. The firered-punc synthetic-forward tests and the dolphin/mimo unit tests exercise the runtime paths end to end.

## Docs updated

- [x] No docs overclaim current capabilities. (No behavior change; comments updated in-code.)

## Scope / non-goals

- Out of scope: dolphin's `decoder_graph.rs` (128 MB) and `encoder_graph.rs` / `hotword_context.rs` (64 MB) flat contexts are the same anti-pattern at smaller sizes; flagged for a follow-up.
- Out of scope: fixing the pre-existing #238 test failure noted above.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
