### PR TITLE
perf(qwen): splice prompt embeddings in place on encoder-to-prefill path

### DIFF
--- a/crates/openasr-core/src/models/firered_llm/executor.rs
+++ b/crates/openasr-core/src/models/firered_llm/executor.rs
@@ -444,7 +444,7 @@ impl FireRedLlmGgmlExecutor {
         let prompt_embeddings = build_qwen3_prompt_embeddings_with_audio_splice(
             &decode_prompt,
             decoder_metadata.d_model,
-            &token_rows,
+            token_rows,
             &speech_rows,
         )
         .map_err(|error| FireRedLlmExecutorError::PromptEmbeddingFailed {

--- a/crates/openasr-core/src/models/mimo_asr/executor.rs
+++ b/crates/openasr-core/src/models/mimo_asr/executor.rs
@@ -358,7 +358,7 @@ impl MimoAsrGgmlExecutor {
         let prompt_embeddings = build_qwen3_prompt_embeddings_with_audio_splice(
             &decode_prompt,
             llm_metadata.d_model,
-            &token_rows,
+            token_rows,
             &speech_rows,
         )
         .map_err(|error| MimoAsrExecutorError::PromptEmbeddingFailed {

--- a/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
@@ -407,10 +407,10 @@ pub(crate) fn align_forced(
     let prompt_embeddings = build_qwen3_prompt_embeddings_with_audio_splice(
         &decode_prompt,
         assets.token_embedding_table.d_model(),
-        &token_rows,
+        token_rows,
         &audio_embeddings.rows,
     )?;
-    let prefill_input = build_qwen3_llm_prefill_input(&prompt_embeddings)?;
+    let prefill_input = build_qwen3_llm_prefill_input(prompt_embeddings)?;
 
     let mut whole_decoder = Qwen3AsrLlmWholeDecoderGraphExecutor::new(
         &assets.layer_attention_projections,
@@ -429,7 +429,7 @@ pub(crate) fn align_forced(
             reason: error.to_string(),
         })?;
 
-    let hidden_size = prompt_embeddings.hidden_size;
+    let hidden_size = prefill_input.hidden_size;
     let expected_timestamp_positions = word_list.len() * 2;
     if timestamp_positions.len() != expected_timestamp_positions {
         return Err(

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -392,14 +392,14 @@ impl Qwen3AsrGgmlExecutor {
         let prompt_embeddings = build_qwen3_prompt_embeddings_with_audio_splice(
             &decode_prompt,
             token_embedding_table.d_model(),
-            &token_rows,
+            token_rows,
             &audio_embeddings.rows,
         )
         .map_err(map_prompt_embedding_error)?;
         qwen_decode_profile_log_opt("prompt_embedding_splice", prompt_embedding_started_at);
         let llm_prefill_started_at = qwen_decode_profile_start();
         let llm_prefill_input =
-            build_qwen3_llm_prefill_input(&prompt_embeddings).map_err(map_llm_prefill_error)?;
+            build_qwen3_llm_prefill_input(prompt_embeddings).map_err(map_llm_prefill_error)?;
         qwen_decode_profile_log_opt("llm_prefill_input", llm_prefill_started_at);
         if layer_attention_projections.is_empty() {
             return Err(Qwen3AsrGgmlExecutorError::RuntimeContractViolation {

--- a/crates/openasr-core/src/models/qwen/llm_prefill.rs
+++ b/crates/openasr-core/src/models/qwen/llm_prefill.rs
@@ -24,8 +24,17 @@ pub(crate) enum Qwen3AsrLlmPrefillInputError {
     NonFiniteEmbeddings,
 }
 
+/// Build the LLM prefill input, consuming the prompt embeddings by value.
+///
+/// The embeddings are single-use on every call path (the qwen executor and
+/// the forced aligner both drop them right after this call), so the embedded
+/// `token_count x hidden` value buffer is MOVED instead of cloned -- this was
+/// the second redundant full-prompt f32 clone on the encoder-to-prefill path
+/// (the first was the splice's `to_vec()`, see
+/// `build_qwen3_prompt_embeddings_with_audio_splice`). Shape and non-finite
+/// validation still runs over the moved buffer before the hand-off.
 pub(crate) fn build_qwen3_llm_prefill_input(
-    prompt_embeddings: &Qwen3AsrPromptEmbeddings,
+    prompt_embeddings: Qwen3AsrPromptEmbeddings,
 ) -> Result<Qwen3AsrLlmPrefillInput, Qwen3AsrLlmPrefillInputError> {
     let token_count = prompt_embeddings.token_count;
     let hidden_size = prompt_embeddings.hidden_size;
@@ -54,7 +63,7 @@ pub(crate) fn build_qwen3_llm_prefill_input(
     Ok(Qwen3AsrLlmPrefillInput {
         token_count,
         hidden_size,
-        token_major_embeddings: prompt_embeddings.token_major_values.clone(),
+        token_major_embeddings: prompt_embeddings.token_major_values,
     })
 }
 
@@ -73,7 +82,7 @@ mod tests {
                 5.0, 6.0,
             ],
         };
-        let input = build_qwen3_llm_prefill_input(&prompt).expect("prefill input");
+        let input = build_qwen3_llm_prefill_input(prompt).expect("prefill input");
         assert_eq!(input.token_count, 3);
         assert_eq!(input.hidden_size, 2);
         assert_eq!(
@@ -93,7 +102,7 @@ mod tests {
             token_count: 1,
             token_major_values: vec![f32::NAN],
         };
-        let error = build_qwen3_llm_prefill_input(&prompt).expect_err("must fail");
+        let error = build_qwen3_llm_prefill_input(prompt).expect_err("must fail");
         assert!(matches!(
             error,
             Qwen3AsrLlmPrefillInputError::NonFiniteEmbeddings

--- a/crates/openasr-core/src/models/qwen/prompt_embedding.rs
+++ b/crates/openasr-core/src/models/qwen/prompt_embedding.rs
@@ -40,10 +40,23 @@ pub(crate) enum Qwen3AsrPromptEmbeddingError {
     NonFiniteValues,
 }
 
+/// Splice the audio-encoder rows into the token-embedding buffer at the decode
+/// prompt's audio pad span, producing the combined prompt embeddings.
+///
+/// `token_rows` is consumed by value and spliced IN PLACE: every family
+/// executor (qwen / firered-llm / mimo / forced-aligner) gathers an owned
+/// token-row buffer it never touches again, so the historical `to_vec()`
+/// copy was a pure per-utterance `token_count x hidden` clone on the
+/// encoder-to-prefill critical path (and the result was cloned once more by
+/// `build_qwen3_llm_prefill_input`). Both buffers are row-major
+/// `[token|frame][hidden]`, so the audio span is contiguous on each side and
+/// the splice is a single span copy. All fail-closed validation (shape,
+/// checked span arithmetic, non-finite elements) runs unchanged before the
+/// copy.
 pub(crate) fn build_qwen3_prompt_embeddings_with_audio_splice(
     decode_prompt: &Qwen3AsrDecodePrompt,
     hidden_size: usize,
-    token_rows: &[f32],
+    mut token_rows: Vec<f32>,
     audio_rows: &[f32],
 ) -> Result<Qwen3AsrPromptEmbeddings, Qwen3AsrPromptEmbeddingError> {
     if hidden_size == 0 {
@@ -108,44 +121,31 @@ pub(crate) fn build_qwen3_prompt_embeddings_with_audio_splice(
         });
     }
 
-    let mut combined = token_rows.to_vec();
-    for frame_idx in 0..audio_frame_count {
-        let src_start = frame_idx.checked_mul(hidden_size).ok_or(
-            Qwen3AsrPromptEmbeddingError::InvalidAudioRowsShape {
-                audio_frame_count,
-                hidden_size,
-                values_len: audio_rows.len(),
-            },
-        )?;
-        let src_end = src_start.checked_add(hidden_size).ok_or(
-            Qwen3AsrPromptEmbeddingError::InvalidAudioRowsShape {
-                audio_frame_count,
-                hidden_size,
-                values_len: audio_rows.len(),
-            },
-        )?;
-        let dst_token_idx = pad_start + frame_idx;
-        let dst_start = dst_token_idx.checked_mul(hidden_size).ok_or(
-            Qwen3AsrPromptEmbeddingError::InvalidTokenRowsShape {
-                token_count,
-                hidden_size,
-                values_len: combined.len(),
-            },
-        )?;
-        let dst_end = dst_start.checked_add(hidden_size).ok_or(
-            Qwen3AsrPromptEmbeddingError::InvalidTokenRowsShape {
-                token_count,
-                hidden_size,
-                values_len: combined.len(),
-            },
-        )?;
-        combined[dst_start..dst_end].copy_from_slice(&audio_rows[src_start..src_end]);
-    }
+    // The audio span is contiguous on both sides (row-major [token][hidden]),
+    // and the checks above pin it inside both buffers:
+    // `expected_audio_values == audio_rows.len()` and `pad_end <= token_count`
+    // (so the dst span ends within `token_rows`). The checked offsets keep the
+    // overflow guard the per-frame loop used to carry.
+    let dst_start = pad_start.checked_mul(hidden_size).ok_or(
+        Qwen3AsrPromptEmbeddingError::InvalidAudioPadSpan {
+            audio_pad_start_index: pad_start,
+            audio_pad_count: audio_frame_count,
+            token_count,
+        },
+    )?;
+    let dst_end = dst_start.checked_add(expected_audio_values).ok_or(
+        Qwen3AsrPromptEmbeddingError::InvalidAudioPadSpan {
+            audio_pad_start_index: pad_start,
+            audio_pad_count: audio_frame_count,
+            token_count,
+        },
+    )?;
+    token_rows[dst_start..dst_end].copy_from_slice(&audio_rows[..expected_audio_values]);
 
     Ok(Qwen3AsrPromptEmbeddings {
         hidden_size,
         token_count,
-        token_major_values: combined,
+        token_major_values: token_rows,
     })
 }
 
@@ -172,7 +172,7 @@ mod tests {
             200.0, 201.0,
         ];
         let spliced =
-            build_qwen3_prompt_embeddings_with_audio_splice(&prompt, 2, &token_rows, &audio_rows)
+            build_qwen3_prompt_embeddings_with_audio_splice(&prompt, 2, token_rows, &audio_rows)
                 .expect("splice");
         assert_eq!(
             spliced.token_major_values,
@@ -193,7 +193,7 @@ mod tests {
             audio_pad_count: 2,
         };
         let error =
-            build_qwen3_prompt_embeddings_with_audio_splice(&prompt, 2, &[0.0; 8], &[0.0; 3])
+            build_qwen3_prompt_embeddings_with_audio_splice(&prompt, 2, vec![0.0; 8], &[0.0; 3])
                 .expect_err("audio shape mismatch must fail");
         assert!(matches!(
             error,


### PR DESCRIPTION
## Summary

Removes two redundant full-prompt f32 clones from the encoder-to-prefill path shared by the qwen3-asr executor and its sibling families: the audio splice now consumes the gathered token-embedding buffer by value and splices the audio rows in place, and `build_qwen3_llm_prefill_input` moves the embedding buffer instead of cloning it.

## Why

Per the 2026-07-24 Metal profiling pass (M1 16GB, qwen3-asr 0.6B q4_k, jfk.wav), the encoder-to-prefill boundary allocates and copies the whole `token_count x hidden` prompt-embedding buffer twice per utterance: once by the splice's `to_vec()` (`prompt_embedding_splice` measured ~0.5ms) and once by the prefill-input builder. Every splice caller (qwen, firered-llm, mimo, forced-aligner) already owns the gathered token-row buffer and never touches it again, so both copies are pure overhead.

Two larger proposals evaluated alongside this change were analyzed and rejected - see Scope / non-goals.

## Changes

- `models/qwen/prompt_embedding.rs`: `build_qwen3_prompt_embeddings_with_audio_splice` takes `token_rows: Vec<f32>` by value and splices in place. The audio span is contiguous on both sides (row-major `[token][hidden]`), so the per-frame copy loop becomes one span copy; the checked span arithmetic keeps the old overflow guard. All fail-closed validation (shape, span bounds, non-finite elements) is unchanged, and the output bytes are identical.
- `models/qwen/llm_prefill.rs`: `build_qwen3_llm_prefill_input` consumes the embeddings by value and moves the buffer.
- Call sites updated: qwen executor, firered-llm executor, mimo executor, forced aligner (which now reads `hidden_size` from the prefill input).

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-core` - 2447/2448 pass. The one failure (`pre_audit_families_embedded_ssot_is_non_empty`) also fails on the base commit 0220415 without this change (verified via stash): a pre-existing follow-up miss from #238, unrelated to this diff.
- [x] `cargo test -p openasr-core --doc`
- [x] `cargo deny check`

## Manual smoke checks

Behavior is byte-identical: the existing splice unit tests (pad-span replacement, shape rejection) and the executor/golden paths exercise the same output bytes. A dedicated `OPENASR_QWEN_DECODE_PROFILE=1` before/after comparison in an exclusive benchmark window is recommended to quantify the stage delta (`prompt_embedding_splice` + `llm_prefill_input` expected to drop ~0.2-0.4ms).

## Docs updated

- [x] No behavior or limitation changed; no docs update needed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No full encoder-decoder GPU-buffer sharing. On Apple unified memory the vendored ggml Metal backend allocates shared-storage buffers (`MTLResourceStorageModeShared`, since `use_shared_buffers = has_unified_memory`), so `set_tensor`/`get_tensor` are plain host memcpys with no blit or extra GPU sync, and `graph_compute` already funnels through one `synchronize` per graph. The measured cost this could remove is the ~0.5ms splice stage itself - not the 100-200ms estimated earlier - while cross-runner buffer aliasing would add lifetime coupling between the TLS encoder/decoder caches and bypass the CPU-side non-finite fail-closed gate. Not worth the trust-adjacent surface at this benefit.
- No prefill chunk pipelining with early decode. Under causal attention the first generated token attends to the full prompt KV span (mask built from absolute positions in `run_prefill_chunk_into_reused_batched`), so decoding before the prompt KV is complete would produce wrong output. Prefill is already chunked at 256 tokens with cooperative cancel between chunks; on one Metal command queue smaller chunks would only add graph rebuilds and sync points with zero GPU overlap.
- The measured fixed-overhead gap vs. peers lives in encoder compute (413-617ms) and prefill compute (528ms), i.e. GPU dispatch-bound compute - untouched by boundary data movement. Encoder weight persistence and short-sequence flash-attention A/B remain the higher-leverage follow-ups from the profiling doc.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
