### PR TITLE
fix(core): derive quant-floor audit tables and harden required-file gates

### DIFF
--- a/crates/openasr-core/src/models/aux_pack_registry.rs
+++ b/crates/openasr-core/src/models/aux_pack_registry.rs
@@ -96,9 +96,17 @@ fn validate_forced_aligner(_path: &Path, metadata: &GgufMetadata) -> Result<(), 
         .map_err(|error| error.to_string())
 }
 
+/// `general.architecture` value ReDimNet2-B6 speaker-embedder packs carry.
+/// No dedicated `models::redimnet2` module owns this constant (the model
+/// forward pass lives in `crate::diarize::embed::redimnet`, and packaging is
+/// the family-agnostic `models::diarize_pack_import`), so this aux registry
+/// -- the only production reader of the string -- is its home. Referenced by
+/// `models::pack_quant_audit` too, so both stay in sync.
+pub(crate) const REDIMNET2_GGML_ARCHITECTURE_ID: &str = "redimnet2";
+
 const AUX_PACK_DESCRIPTORS: &[AuxPackDescriptor] = &[
     AuxPackDescriptor {
-        architecture_id: "redimnet2",
+        architecture_id: REDIMNET2_GGML_ARCHITECTURE_ID,
         kind: AuxPackKind::Diarization,
         validate: validate_redimnet2,
     },
@@ -123,6 +131,18 @@ const AUX_PACK_DESCRIPTORS: &[AuxPackDescriptor] = &[
         validate: validate_forced_aligner,
     },
 ];
+
+/// Every aux family's `general.architecture` id. Lets a caller that needs the
+/// full non-ASR family list (e.g. `models::pack_quant_audit`'s quant-floor
+/// coverage test) enumerate it without depending on `AuxPackKind` or
+/// `validate_aux_runtime_pack_contract`'s metadata-driven dispatch.
+/// Test-only today (no non-test caller needs the full list yet).
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn aux_pack_architecture_ids() -> impl Iterator<Item = &'static str> {
+    AUX_PACK_DESCRIPTORS
+        .iter()
+        .map(|descriptor| descriptor.architecture_id)
+}
 
 /// Pull-time contract dispatch for auxiliary (non-ASR) runtime packs.
 ///

--- a/crates/openasr-core/src/models/cohere/mod.rs
+++ b/crates/openasr-core/src/models/cohere/mod.rs
@@ -27,6 +27,7 @@ pub(crate) use frontend::{
     CohereTranscribeFrontendPlan, load_cohere_transcribe_frontend_plan_from_reader,
 };
 pub(crate) use ggml_executor::CohereTranscribeGgmlExecutor;
+pub(crate) use package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES;
 pub use package_import::{
     CohereLocalSourceError, CohereLocalSourceImportRequest, CohereLocalSourceImportRuntimeResult,
     CohereRuntimeQuantizationMode, convert_local_cohere_source_to_runtime_pack,

--- a/crates/openasr-core/src/models/cohere/package_import.rs
+++ b/crates/openasr-core/src/models/cohere/package_import.rs
@@ -551,11 +551,18 @@ fn quantized_tensor_type_for_cohere_tensor(
     classify_quant_tensor(ne0, quantization, cohere_quant_component(name))
 }
 
-/// Encoder/audio-front-end tensors map onto the `enc.*` namespace (`enc.pre.*`,
-/// `enc.proj`, `enc.blk.*`); the transformer decoder is `dec.*`. The encoder
-/// carries the shared Q8_0 floor (see `classify_quant_tensor`).
+/// Runtime tensor name prefixes for the cohere-transcribe audio front end
+/// (`enc.pre.*`, `enc.proj`, `enc.blk.*`); the transformer decoder is `dec.*`.
+/// Shared with `models::pack_quant_audit`'s encoder-floor rule -- the single
+/// source of truth for "which cohere-transcribe tensors are audio-encoder".
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["enc."];
+
+/// The encoder carries the shared Q8_0 floor (see `classify_quant_tensor`).
 fn cohere_quant_component(name: &str) -> QuantComponent {
-    if name.starts_with("enc.") {
+    if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder

--- a/crates/openasr-core/src/models/dolphin/package_import.rs
+++ b/crates/openasr-core/src/models/dolphin/package_import.rs
@@ -727,13 +727,22 @@ fn dolphin_quant_type_for_tensor(
     let ne0 = *shape.last()?;
     // dolphin keeps WeNet source names: the acoustic encoder is `encoder.*`;
     // `decoder.*` / `ctc.*` / `context_module.*` (hotword) are downstream.
-    let component = if name.starts_with("encoder.") {
+    let component = if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder
     };
     classify_quant_tensor(ne0, quantization, component)
 }
+
+/// Runtime tensor name prefix for the dolphin (WeNet E-Branchformer) acoustic
+/// encoder (`encoder.*`). Shared with `models::pack_quant_audit`'s
+/// encoder-floor rule -- the single source of truth for "which dolphin
+/// tensors are audio-encoder".
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["encoder."];
 
 /// Build one runtime tensor. Quantizable rank-2 `.weight` matrices are block-
 /// quantized with **reversed dims** (ne0 = the contiguous `in` axis); the runtime

--- a/crates/openasr-core/src/models/firered_aed/package_import.rs
+++ b/crates/openasr-core/src/models/firered_aed/package_import.rs
@@ -719,11 +719,22 @@ fn quantized_tensor_type_for_firered_tensor(
     classify_quant_tensor(ne0, quantization, component)
 }
 
-/// Conformer encoder tensors map onto `enc.*` (`enc.blk.*`, `enc.subsample.*`,
-/// `enc.pos_enc.pe`); the Transformer decoder is `dec.*` (`dec.blk.*`,
-/// `dec.tok_emb`, `dec.out_proj`). The encoder carries the shared Q8_0 floor.
+/// Runtime tensor name prefix for the firered-aed conformer encoder (`enc.*`:
+/// `enc.blk.*`, `enc.subsample.*`, `enc.pos_enc.pe`); the Transformer decoder
+/// is `dec.*` (`dec.blk.*`, `dec.tok_emb`, `dec.out_proj`). Shared with
+/// `models::pack_quant_audit`'s encoder-floor rule -- the single source of
+/// truth for "which firered-aed tensors are audio-encoder". Also reused by
+/// `models::firered_llm` (see that module's `AUDIO_ENCODER_TENSOR_NAME_PREFIXES`),
+/// which imports the byte-identical conformer encoder under the same `enc.*`
+/// naming.
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["enc."];
+
+/// The encoder carries the shared Q8_0 floor.
 fn firered_quant_component(target_name: &str) -> QuantComponent {
-    if target_name.starts_with("enc.") {
+    if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| target_name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder

--- a/crates/openasr-core/src/models/firered_llm/package_import.rs
+++ b/crates/openasr-core/src/models/firered_llm/package_import.rs
@@ -597,6 +597,25 @@ fn quantized_tensor_type_for_encoder_adapter_tensor(
     classify_quant_tensor(ne0, quantization, QuantComponent::Encoder)
 }
 
+/// Runtime tensor name prefixes for the two halves this importer combines
+/// into one pack: `map_firered_encoder_tensor_name` targets `enc.*` (shared
+/// with `models::firered_aed`, the byte-identical conformer encoder) and
+/// `map_adapter_tensor_name` targets `adapter.*`
+/// (`ADAPTER_LINEAR{1,2}_{WEIGHT,BIAS}` in `tensor_names`). Both halves come
+/// from `build_encoder_adapter_runtime_tensors` and always carry the Q8_0
+/// floor (`quantized_tensor_type_for_encoder_adapter_tensor` above always
+/// classifies `QuantComponent::Encoder`). The `llm.*` tensors from the
+/// separate `build_llm_runtime_tensors` half (`remap_qwen2_tensor_name` /
+/// `qwen2_llm_layer_tensor_names`) are the Qwen2 text decoder, classified
+/// `QuantComponent::Decoder` and NOT covered by this list -- they keep the
+/// full requested rung, so a pack's `.oasr` legitimately mixes Q8_0
+/// encoder/adapter tensors with e.g. Q4_K `llm.*` tensors. Shared with
+/// `models::pack_quant_audit`'s encoder-floor rule -- the single source of
+/// truth for "which firered-llm tensors are audio-encoder" (this replaces an
+/// earlier `EntirePack` audit rule that incorrectly floored every `llm.*`
+/// tensor too; see `firered_llm_prefixes_exclude_the_llm_decoder_half` below).
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["enc.", "adapter."];
+
 fn build_encoder_adapter_runtime_tensors(
     safetensors: &SafetensorsFile,
     quantization: FireRedLlmQuantizationMode,
@@ -1534,6 +1553,74 @@ mod tests {
             remap_qwen2_tensor_name("model.layers.0.self_attn.q_norm.weight").unwrap(),
             None
         );
+    }
+
+    /// Reconciles `AUDIO_ENCODER_TENSOR_NAME_PREFIXES` (consumed by
+    /// `models::pack_quant_audit`) against what the two real builders in this
+    /// file actually produce: every encoder/adapter target name must match a
+    /// declared prefix, and every Qwen2 LLM target name must NOT -- the
+    /// invariant an earlier `EntirePack` audit rule got wrong (it floored
+    /// `llm.*` tensors too, which this importer legitimately quantizes to the
+    /// full requested rung via `QuantComponent::Decoder`).
+    #[test]
+    fn audio_encoder_tensor_name_prefixes_match_the_encoder_adapter_half_only() {
+        let is_encoder_name = |name: &str| {
+            AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+                .iter()
+                .any(|prefix| name.starts_with(prefix))
+        };
+
+        // Encoder half: every branch of `map_firered_encoder_tensor_name`.
+        for source_name in [
+            "encoder.input_preprocessor.conv.0.weight",
+            "encoder.input_preprocessor.out.weight",
+            "encoder.positional_encoding.pe",
+            "encoder.layer_stack.0.mhsa.w_qs.weight",
+            "encoder.layer_stack.15.ffn2.net.4.weight",
+        ] {
+            let (target_name, _) = map_firered_encoder_tensor_name(source_name)
+                .unwrap_or_else(|| panic!("expected a mapping for '{source_name}'"));
+            assert!(
+                is_encoder_name(&target_name),
+                "encoder target '{target_name}' (from '{source_name}') must match an \
+                 audio-encoder prefix"
+            );
+        }
+
+        // Adapter half: every branch of `map_adapter_tensor_name`.
+        for source_name in [
+            "encoder_projector.linear1.weight",
+            "encoder_projector.linear1.bias",
+            "encoder_projector.linear2.weight",
+            "encoder_projector.linear2.bias",
+        ] {
+            let (target_name, _) = map_adapter_tensor_name(source_name)
+                .unwrap_or_else(|| panic!("expected a mapping for '{source_name}'"));
+            assert!(
+                is_encoder_name(&target_name),
+                "adapter target '{target_name}' (from '{source_name}') must match an \
+                 audio-encoder prefix"
+            );
+        }
+
+        // Qwen2 LLM half: every branch of `remap_qwen2_tensor_name` must NOT
+        // match -- these tensors carry the full requested rung, not the floor.
+        for source_name in [
+            "model.embed_tokens.weight",
+            "model.norm.weight",
+            "lm_head.weight",
+            "model.layers.0.self_attn.q_proj.weight",
+            "model.layers.0.mlp.gate_proj.weight",
+        ] {
+            let target_name = remap_qwen2_tensor_name(source_name)
+                .unwrap()
+                .unwrap_or_else(|| panic!("expected a mapping for '{source_name}'"));
+            assert!(
+                !is_encoder_name(&target_name),
+                "llm target '{target_name}' (from '{source_name}') must NOT match an \
+                 audio-encoder prefix -- it keeps the full requested quant rung"
+            );
+        }
     }
 
     #[test]

--- a/crates/openasr-core/src/models/hymt2/package_import.rs
+++ b/crates/openasr-core/src/models/hymt2/package_import.rs
@@ -20,7 +20,9 @@ use std::{
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-use super::config::{HYMT2_EXPECTED_LAYERS, HYMT2_EXPECTED_VOCAB_SIZE};
+use super::config::{
+    HUNYUAN_DENSE_ARCHITECTURE_VALUE, HYMT2_EXPECTED_LAYERS, HYMT2_EXPECTED_VOCAB_SIZE,
+};
 use crate::models::oasr_metadata::{OASR_METADATA_KEY_PACKAGE_VERSION, OASR_PACKAGE_VERSION_V1};
 
 /// Pinned upstream base (safetensors) repository for provenance metadata.
@@ -48,7 +50,6 @@ const HYMT2_EXPECTED_TOKENIZER_PRE: &str = "hunyuan-dense";
 const GENERAL_ARCHITECTURE_KEY: &str = "general.architecture";
 const GENERAL_FILE_TYPE_KEY: &str = "general.file_type";
 const GENERAL_ALIGNMENT_KEY: &str = "general.alignment";
-const HUNYUAN_DENSE_ARCHITECTURE: &str = "hunyuan-dense";
 const OPENASR_KEY_PREFIX: &str = "openasr.";
 
 const GGUF_TYPE_UINT8: u32 = 0;
@@ -454,7 +455,7 @@ impl SourceMetadataValidator {
         require_value(
             GENERAL_ARCHITECTURE_KEY,
             self.architecture.as_deref(),
-            HUNYUAN_DENSE_ARCHITECTURE,
+            HUNYUAN_DENSE_ARCHITECTURE_VALUE,
         )?;
         require_value(
             "tokenizer.ggml.model",
@@ -751,7 +752,7 @@ mod tests {
     impl Default for SyntheticOverrides {
         fn default() -> Self {
             Self {
-                architecture: HUNYUAN_DENSE_ARCHITECTURE,
+                architecture: HUNYUAN_DENSE_ARCHITECTURE_VALUE,
                 file_type: HYMT2_EXPECTED_GENERAL_FILE_TYPE,
                 block_count: HYMT2_EXPECTED_LAYERS as u32,
                 token_count: HYMT2_EXPECTED_VOCAB_SIZE,

--- a/crates/openasr-core/src/models/moonshine/mod.rs
+++ b/crates/openasr-core/src/models/moonshine/mod.rs
@@ -16,6 +16,7 @@ mod weights;
 pub const MOONSHINE_MODEL_FAMILY: &str = "moonshine";
 
 pub(crate) use ggml_executor::MoonshineGgmlExecutor;
+pub(crate) use package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES;
 pub use package_import::{
     MoonshineLocalSourceError, MoonshineLocalSourceImportRequest,
     MoonshineLocalSourceImportRuntimeResult, MoonshineRuntimeQuantizationMode,

--- a/crates/openasr-core/src/models/moonshine/package_import.rs
+++ b/crates/openasr-core/src/models/moonshine/package_import.rs
@@ -415,13 +415,21 @@ fn quantized_tensor_type_for_moonshine_tensor(
     }
     // The acoustic encoder is `enc.*`; `dec.*` (incl. the encoder cross-attention
     // mapped to `dec.blk.{i}.cross_*`) is the decoder side.
-    let component = if name.starts_with("enc.") {
+    let component = if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder
     };
     classify_quant_tensor(ne0, quantization, component)
 }
+
+/// Runtime tensor name prefix for the moonshine acoustic encoder (`enc.*`).
+/// Shared with `models::pack_quant_audit`'s encoder-floor rule -- the single
+/// source of truth for "which moonshine tensors are audio-encoder".
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["enc."];
 
 #[derive(Debug, Clone)]
 struct MoonshineMetadataFields {

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/package_import.rs
@@ -425,12 +425,19 @@ fn quantized_linear_tensor_type(
     classify_quant_tensor(ne0, quantization, component)
 }
 
-/// The acoustic path is the whisper encoder (`moss.enc.*`) plus its
-/// encoder->LLM projector (`moss.adaptor.*`, the analogue of qwen's
-/// `audio.proj*`); both carry the shared Q8_0 floor. The `moss.llm.*` text
-/// decoder keeps the full requested rung.
+/// Runtime tensor name prefixes for the moss acoustic path: the whisper
+/// encoder (`moss.enc.*`) plus its encoder->LLM projector (`moss.adaptor.*`,
+/// the analogue of qwen's `audio.proj*`); both carry the shared Q8_0 floor.
+/// The `moss.llm.*` text decoder keeps the full requested rung. Shared with
+/// `models::pack_quant_audit`'s encoder-floor rule -- the single source of
+/// truth for "which moss tensors are audio-encoder".
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["moss.enc.", "moss.adaptor."];
+
 fn moss_quant_component(target_name: &str) -> QuantComponent {
-    if target_name.starts_with("moss.enc.") || target_name.starts_with("moss.adaptor.") {
+    if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| target_name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder

--- a/crates/openasr-core/src/models/pack_quant.rs
+++ b/crates/openasr-core/src/models/pack_quant.rs
@@ -82,6 +82,14 @@ pub(crate) fn classify_quant_tensor(
     quantization: PackQuant,
     component: QuantComponent,
 ) -> Option<GgufWriteTensorType> {
+    // Every real call site already guards this (checked ahead of the family's
+    // own eligibility test), but the guard belongs on the policy itself: a
+    // caller-less consumer (e.g. the quant-floor audit deriving a declared
+    // tier's producible rungs) must get `None` for `Fp16`, not silently fall
+    // through to the block-quant arms below.
+    if quantization == PackQuant::Fp16 {
+        return None;
+    }
     if !ne0.is_multiple_of(32_u64) {
         return None;
     }
@@ -99,6 +107,18 @@ pub(crate) fn classify_quant_tensor(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fp16_tier_never_produces_a_block_quant() {
+        assert_eq!(
+            classify_quant_tensor(256, PackQuant::Fp16, QuantComponent::Decoder),
+            None
+        );
+        assert_eq!(
+            classify_quant_tensor(256, PackQuant::Fp16, QuantComponent::Encoder),
+            None
+        );
+    }
 
     #[test]
     fn unaligned_ne0_falls_back_to_fp16_representation() {

--- a/crates/openasr-core/src/models/pack_quant_audit.rs
+++ b/crates/openasr-core/src/models/pack_quant_audit.rs
@@ -12,13 +12,21 @@
 //! so it also runs against published, remotely-hosted, read-only packs via an
 //! HTTP `Range` prefix fetch, with no source weights and no inference.
 //!
-//! The encoder/decoder split mirrors each family's importer classification
-//! (`QuantComponent` at import time) but keyed on the RUNTIME tensor names
-//! written into the pack and on the pack's `openasr.model.architecture`
-//! metadata, so the check needs no source checkout. The floor itself is the
-//! same policy [`crate::models::pack_quant::classify_quant_tensor`] enforces
-//! at build time; a pack that violates it was built by code predating the
-//! floor (or by a regression), and must not ship.
+//! The encoder/decoder split is keyed on the RUNTIME tensor names written
+//! into the pack and on the pack's `openasr.model.architecture` metadata, so
+//! the check needs no source checkout -- but it is NOT a hand-copied guess at
+//! each family's importer classification. `audio_encoder_tensors_for_architecture`
+//! below references each family's own `AUDIO_ENCODER_TENSOR_NAME_PREFIXES`
+//! constant (declared beside that family's `QuantComponent` classification in
+//! its `package_import` module), so the two can never drift apart silently:
+//! a renamed encoder namespace moves both call sites at once, and a family
+//! with no such constant simply does not compile. The tier-ceiling check
+//! (`declared_tier_allows`) is likewise derived by calling the shared policy
+//! function directly (see below) instead of re-deriving its per-tier rung
+//! table by hand. The floor policy itself is
+//! [`crate::models::pack_quant::classify_quant_tensor`]; a pack that violates
+//! it was built by code predating the floor (or by a regression), and must
+//! not ship.
 
 use std::borrow::Cow;
 use std::io::Read;
@@ -26,8 +34,9 @@ use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
+use crate::ggml_runtime::GgufWriteTensorType;
 use crate::ggml_runtime::gguf_header::{GgufHeaderError, GgufHeaderView, parse_gguf_header};
-use crate::models::pack_quant::PackQuant;
+use crate::models::pack_quant::{PackQuant, QuantComponent, classify_quant_tensor};
 
 // --- ggml type ids (stable ggml ABI wire values) ---------------------------
 
@@ -116,45 +125,74 @@ pub fn is_block_quant_type(ggml_type: u32) -> bool {
     )
 }
 
-/// True when the type satisfies the audio-encoder Q8_0 floor: Q8_0/Q8_1/Q8_K
-/// (or any non-block storage, checked by the caller). Anything below -- the
-/// Q2..Q6 and IQ* rungs -- is the behavioral cliff the floor exists to
-/// prevent.
-pub fn meets_encoder_q8_floor(ggml_type: u32) -> bool {
-    matches!(ggml_type, GGML_TYPE_Q8_0 | GGML_TYPE_Q8_1 | GGML_TYPE_Q8_K)
+/// The wire ggml type ids that satisfy a given writer tensor type's *safety*
+/// class, for the audit's purposes. Q8_0-class output accepts ANY 8-bit
+/// block-quant rung (Q8_0/Q8_1/Q8_K): the audit also reads packs this repo's
+/// own writer never produced (published packs, future writers), so it accepts
+/// any rung at the writer's precision class rather than demanding the exact
+/// ggml type `classify_quant_tensor` happens to emit today. Each K-quant rung
+/// above Q8 has no such sibling -- it maps onto exactly its own wire id.
+fn wire_types_equivalent_to(tensor_type: GgufWriteTensorType) -> &'static [u32] {
+    match tensor_type {
+        GgufWriteTensorType::Q8_0 => &[GGML_TYPE_Q8_0, GGML_TYPE_Q8_1, GGML_TYPE_Q8_K],
+        GgufWriteTensorType::Q3_K => &[GGML_TYPE_Q3_K],
+        GgufWriteTensorType::Q4_K => &[GGML_TYPE_Q4_K],
+        GgufWriteTensorType::Q5_K => &[GGML_TYPE_Q5_K],
+        GgufWriteTensorType::Q6_K => &[GGML_TYPE_Q6_K],
+        // `classify_quant_tensor` never returns these for a block-quantized
+        // tensor (F32/F16 are its "keep the fp16-mode representation" `None`
+        // case, not a `Some` block-quant type); listed for exhaustiveness.
+        GgufWriteTensorType::F32 | GgufWriteTensorType::F16 => &[],
+    }
 }
 
-/// The block-quant rungs a declared pack tier may contain, mirroring
-/// [`crate::models::pack_quant::classify_quant_tensor`]: a tier is a CEILING
-/// (the importer never selects a rung above the request), with Q8_0 always
-/// available as the alignment-fallback / encoder-floor rung. `Fp16` writes no
-/// block quants at all.
+/// True when the type satisfies the audio-encoder Q8_0 floor. Anything below
+/// -- the Q2..Q6 and IQ* rungs -- is the behavioral cliff the floor exists to
+/// prevent.
+pub fn meets_encoder_q8_floor(ggml_type: u32) -> bool {
+    wire_types_equivalent_to(GgufWriteTensorType::Q8_0).contains(&ggml_type)
+}
+
+/// Representative `ne0` values covering both alignment classes
+/// `classify_quant_tensor` branches on: 32-aligned-but-not-256 (falls back to
+/// the Q8_0 alignment rung) and 256-aligned (unlocks a tier's own K-quant
+/// rung, for `Decoder`).
+const REPRESENTATIVE_NE0_VALUES: [u64; 2] = [32, 256];
+const QUANT_COMPONENTS: [QuantComponent; 2] = [QuantComponent::Encoder, QuantComponent::Decoder];
+
+/// The block-quant rungs a declared pack tier may contain, DERIVED from
+/// [`crate::models::pack_quant::classify_quant_tensor`] -- the same policy
+/// function every importer's build-time quantization calls -- rather than a
+/// hand-copied per-tier table. `classify_quant_tensor` returns `None` for
+/// every `(ne0, component)` sample under `PackQuant::Fp16`, so the `Fp16`
+/// ceiling falls out of the same loop as an empty set (no block quants
+/// allowed) with no special-casing needed here.
 fn declared_tier_allows(declared: PackQuant, ggml_type: u32) -> bool {
-    match declared {
-        PackQuant::Fp16 => false,
-        PackQuant::Q8_0 => matches!(ggml_type, GGML_TYPE_Q8_0 | GGML_TYPE_Q8_1 | GGML_TYPE_Q8_K),
-        PackQuant::Q3_K => matches!(
-            ggml_type,
-            GGML_TYPE_Q8_0 | GGML_TYPE_Q8_1 | GGML_TYPE_Q8_K | GGML_TYPE_Q3_K
-        ),
-        PackQuant::Q4_K => matches!(
-            ggml_type,
-            GGML_TYPE_Q8_0 | GGML_TYPE_Q8_1 | GGML_TYPE_Q8_K | GGML_TYPE_Q4_K
-        ),
-    }
+    REPRESENTATIVE_NE0_VALUES.iter().any(|&ne0| {
+        QUANT_COMPONENTS.iter().any(|&component| {
+            classify_quant_tensor(ne0, declared, component).is_some_and(|tensor_type| {
+                wire_types_equivalent_to(tensor_type).contains(&ggml_type)
+            })
+        })
+    })
 }
 
 // --- per-architecture audio-encoder tensor rules ---------------------------
 
 /// Which tensors of a pack are audio-encoder weights for the Q8_0 floor,
-/// keyed on the RUNTIME tensor names written into the pack. Mirrors each
-/// family importer's `QuantComponent::Encoder` classification at build time.
+/// keyed on the RUNTIME tensor names written into the pack.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AudioEncoderTensors {
     /// Encoder tensors are the rank-2 weights under these name prefixes.
+    /// Sourced from each family's own `AUDIO_ENCODER_TENSOR_NAME_PREFIXES`
+    /// constant (declared beside that family's `QuantComponent`
+    /// classification in its `package_import` module) -- never a literal
+    /// re-typed here -- so the audit can never silently drift from what the
+    /// importer actually classifies as `QuantComponent::Encoder`.
     NamePrefixes(&'static [&'static str]),
-    /// The whole pack is the acoustic path (e.g. firered-llm's encoder +
-    /// adapter pack): every block-quant tensor carries the floor.
+    /// The whole pack is the acoustic path (e.g. redimnet2's speaker
+    /// embedder, which has no separate decoder): every block-quant tensor
+    /// carries the floor.
     EntirePack,
     /// No audio encoder in the ASR-floor sense (translation / punctuation /
     /// segmentation packs): the floor is vacuous.
@@ -172,41 +210,87 @@ use AudioEncoderTensors as Rule;
 /// is unknown to this table. `None` is NOT "no encoder" -- it is "cannot
 /// verify", and the audit fails closed when such a pack contains any
 /// block-quant tensor at all.
+///
+/// Coverage over every shipped architecture (ASR decode families from
+/// `crate::arch::OpenAsrArchitectureRegistry` plus the auxiliary families
+/// from `crate::models::aux_pack_registry`) is enforced by
+/// `every_shipped_architecture_has_an_encoder_rule` below, derived from those
+/// two registries rather than a hand-counted literal list.
 pub fn audio_encoder_tensors_for_architecture(architecture: &str) -> Option<AudioEncoderTensors> {
     let rule = match architecture {
-        crate::arch::WHISPER_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["model.encoder."]),
-        crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["audio."]),
+        crate::arch::WHISPER_GGML_ARCHITECTURE_ID => {
+            Rule::NamePrefixes(crate::models::whisper::AUDIO_ENCODER_TENSOR_NAME_PREFIXES)
+        }
+        crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID => {
+            Rule::NamePrefixes(crate::models::qwen::AUDIO_ENCODER_TENSOR_NAME_PREFIXES)
+        }
         crate::models::qwen::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID => {
-            Rule::NamePrefixes(&["audio."])
+            Rule::NamePrefixes(crate::models::qwen::AUDIO_ENCODER_TENSOR_NAME_PREFIXES)
         }
-        crate::arch::DOLPHIN_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["encoder."]),
-        crate::arch::SENSEVOICE_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["enc.", "tp."]),
-        crate::arch::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["enc."]),
-        crate::arch::MOONSHINE_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["enc."]),
-        crate::arch::PARAKEET_CTC_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["enc."]),
-        crate::arch::PARAKEET_TDT_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["enc."]),
-        crate::arch::WAV2VEC2_CTC_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["enc."]),
-        crate::arch::XASR_ZIPFORMER_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["encoder."]),
-        crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&["enc."]),
-        // The firered-llm pack carries ONLY the acoustic encoder + its
-        // encoder->LLM adapter (the Qwen2 LLM is the same builder's output
-        // too, imported as encoder-classified tensors end to end): every
-        // block-quant tensor in the pack carries the floor.
-        crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID => Rule::EntirePack,
-        crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID => {
-            Rule::NamePrefixes(&["moss.enc.", "moss.adaptor."])
+        crate::arch::DOLPHIN_GGML_ARCHITECTURE_ID => {
+            Rule::NamePrefixes(crate::models::dolphin::package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES)
         }
+        crate::arch::SENSEVOICE_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(
+            crate::models::sensevoice::package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES,
+        ),
+        crate::arch::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID => {
+            Rule::NamePrefixes(crate::models::cohere::AUDIO_ENCODER_TENSOR_NAME_PREFIXES)
+        }
+        crate::arch::MOONSHINE_GGML_ARCHITECTURE_ID => {
+            Rule::NamePrefixes(crate::models::moonshine::AUDIO_ENCODER_TENSOR_NAME_PREFIXES)
+        }
+        crate::arch::PARAKEET_CTC_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(
+            crate::models::parakeet_ctc::package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES,
+        ),
+        crate::arch::PARAKEET_TDT_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(
+            crate::models::parakeet_tdt::package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES,
+        ),
+        crate::arch::WAV2VEC2_CTC_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(
+            crate::models::wav2vec2_ctc::package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES,
+        ),
+        crate::arch::XASR_ZIPFORMER_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(
+            crate::models::xasr_zipformer::package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES,
+        ),
+        crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(
+            crate::models::firered_aed::package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES,
+        ),
+        // firered-llm combines TWO independently quantized halves into one
+        // pack: the conformer encoder + encoder->LLM adapter (always floored
+        // to Q8_0) and the separately-imported Qwen2 LLM backbone (`llm.*`,
+        // which legitimately keeps the full requested rung, e.g. Q4_K). An
+        // earlier `EntirePack` rule here incorrectly floored the `llm.*`
+        // tensors too; `firered_llm::AUDIO_ENCODER_TENSOR_NAME_PREFIXES`
+        // covers only the encoder/adapter half, reconciled against the real
+        // importer in
+        // `firered_llm::package_import::audio_encoder_tensor_name_prefixes_match_the_encoder_adapter_half_only`.
+        crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(
+            crate::models::firered_llm::package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES,
+        ),
+        crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(
+            crate::models::moss_transcribe_diarize::package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES,
+        ),
         // MiMo's external converter quantizes ONLY the Qwen2 backbone; the
         // whole audio side (tokenizer encoder, input-local layers, speech
-        // embeddings) stays f16/f32 for encode fidelity. The rule pins that:
-        // a future converter that block-quantizes the acoustic path fails
-        // the floor instead of shipping a decode cliff.
+        // embeddings) stays f16/f32 for encode fidelity. Unlike the families
+        // above, MiMo has no in-repo Rust importer to source a shared
+        // constant from (see `models::mimo_asr`'s module docs), so this list
+        // is declared here directly: a future converter that block-quantizes
+        // the acoustic path fails the floor instead of shipping a decode
+        // cliff.
         crate::arch::MIMO_ASR_GGML_ARCHITECTURE_ID => Rule::NamePrefixes(&[
             "audiotok.",
             "inlocal.",
             "speech_embd.",
             "speech_group_proj.",
         ]),
+        // ReDimNet2-B6 (speaker embedder): ships F32-only today (see
+        // `models::diarize_pack_import`, which has no `PackQuant` tier at
+        // all), so no real pack should ever carry a block-quant tensor here.
+        // `EntirePack` gives the right answer if it ever gains a quant tier:
+        // the whole checkpoint is one acoustic-similarity backbone with no
+        // separate decoder, so any block-quant tensor it does produce
+        // correctly carries the Q8_0 floor.
+        crate::models::aux_pack_registry::REDIMNET2_GGML_ARCHITECTURE_ID => Rule::EntirePack,
         // Translation / punctuation / segmentation packs have no acoustic
         // encoder in the ASR-floor sense.
         crate::models::hymt2::config::HUNYUAN_DENSE_ARCHITECTURE_VALUE => Rule::NoAudioEncoder,
@@ -518,10 +602,10 @@ pub fn audit_remote_pack_quant_floor(
 #[cfg(test)]
 mod tests {
     use super::{
-        AudioEncoderTensors, GGML_TYPE_F16, GGML_TYPE_F32, GGML_TYPE_Q4_K, GGML_TYPE_Q6_K,
-        GGML_TYPE_Q8_0, QuantFloorAuditError, QuantFloorViolationKind,
-        audio_encoder_tensors_for_architecture, audit_quant_floor, ggml_type_name,
-        is_block_quant_type, meets_encoder_q8_floor,
+        AudioEncoderTensors, GGML_TYPE_F16, GGML_TYPE_F32, GGML_TYPE_Q3_K, GGML_TYPE_Q4_K,
+        GGML_TYPE_Q6_K, GGML_TYPE_Q8_0, GGML_TYPE_Q8_1, GGML_TYPE_Q8_K, QuantFloorAuditError,
+        QuantFloorViolationKind, audio_encoder_tensors_for_architecture, audit_quant_floor,
+        declared_tier_allows, ggml_type_name, is_block_quant_type, meets_encoder_q8_floor,
     };
     use crate::ggml_runtime::gguf_header::{GgufHeaderTensor, GgufHeaderView};
     use crate::models::pack_quant::PackQuant;
@@ -571,41 +655,115 @@ mod tests {
         assert_eq!(ggml_type_name(999), "ggml-type-999");
     }
 
+    /// Pins `declared_tier_allows`'s derived rungs against the same
+    /// expectations the old hand-written per-tier table encoded, so the
+    /// switch to deriving from `classify_quant_tensor` is a proven
+    /// behavior-preserving refactor, not just a structural one.
     #[test]
-    fn every_shipped_architecture_has_an_encoder_rule() {
-        // The full set of architectures the importers write today; a new
-        // builtin family must add its rule here before its packs can ship.
-        for arch in [
-            crate::arch::WHISPER_GGML_ARCHITECTURE_ID,
-            crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID,
-            crate::models::qwen::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
-            crate::arch::DOLPHIN_GGML_ARCHITECTURE_ID,
-            crate::arch::SENSEVOICE_GGML_ARCHITECTURE_ID,
-            crate::arch::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
-            crate::arch::MOONSHINE_GGML_ARCHITECTURE_ID,
-            crate::arch::PARAKEET_CTC_GGML_ARCHITECTURE_ID,
-            crate::arch::PARAKEET_TDT_GGML_ARCHITECTURE_ID,
-            crate::arch::WAV2VEC2_CTC_GGML_ARCHITECTURE_ID,
-            crate::arch::XASR_ZIPFORMER_GGML_ARCHITECTURE_ID,
-            crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID,
-            crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID,
-            crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID,
-            crate::arch::MIMO_ASR_GGML_ARCHITECTURE_ID,
-            crate::models::hymt2::config::HUNYUAN_DENSE_ARCHITECTURE_VALUE,
-            crate::models::pyannote::PYANNOTE_GGML_ARCHITECTURE_ID,
-            crate::models::firered_punc::config::FIRERED_PUNC_ARCHITECTURE_VALUE,
+    fn declared_tier_allows_matches_the_pre_derivation_rung_table() {
+        // fp16: no block quant is ever allowed.
+        for ggml_type in [
+            GGML_TYPE_Q8_0,
+            GGML_TYPE_Q8_1,
+            GGML_TYPE_Q8_K,
+            GGML_TYPE_Q3_K,
+            GGML_TYPE_Q4_K,
+            GGML_TYPE_Q6_K,
         ] {
-            assert_ne!(
-                audio_encoder_tensors_for_architecture(arch),
-                None,
-                "architecture '{arch}' has no encoder rule"
+            assert!(!declared_tier_allows(PackQuant::Fp16, ggml_type));
+        }
+        // q8_0: only the 8-bit safety class.
+        for ggml_type in [GGML_TYPE_Q8_0, GGML_TYPE_Q8_1, GGML_TYPE_Q8_K] {
+            assert!(declared_tier_allows(PackQuant::Q8_0, ggml_type));
+        }
+        for ggml_type in [GGML_TYPE_Q3_K, GGML_TYPE_Q4_K, GGML_TYPE_Q6_K] {
+            assert!(!declared_tier_allows(PackQuant::Q8_0, ggml_type));
+        }
+        // q3_k: the 8-bit safety class plus its own rung.
+        for ggml_type in [
+            GGML_TYPE_Q8_0,
+            GGML_TYPE_Q8_1,
+            GGML_TYPE_Q8_K,
+            GGML_TYPE_Q3_K,
+        ] {
+            assert!(declared_tier_allows(PackQuant::Q3_K, ggml_type));
+        }
+        assert!(!declared_tier_allows(PackQuant::Q3_K, GGML_TYPE_Q4_K));
+        assert!(!declared_tier_allows(PackQuant::Q3_K, GGML_TYPE_Q6_K));
+        // q4_k: the 8-bit safety class plus its own rung.
+        for ggml_type in [
+            GGML_TYPE_Q8_0,
+            GGML_TYPE_Q8_1,
+            GGML_TYPE_Q8_K,
+            GGML_TYPE_Q4_K,
+        ] {
+            assert!(declared_tier_allows(PackQuant::Q4_K, ggml_type));
+        }
+        assert!(!declared_tier_allows(PackQuant::Q4_K, GGML_TYPE_Q3_K));
+        assert!(!declared_tier_allows(PackQuant::Q4_K, GGML_TYPE_Q6_K));
+    }
+
+    /// Assert every architecture in `architectures` has a quant-floor
+    /// encoder rule, panicking with the offending id otherwise. Factored out
+    /// so `coverage_check_fails_closed_on_an_unruled_architecture` can prove
+    /// this mechanism is not vacuous without needing to register a throwaway
+    /// architecture in the real builtin/aux registries.
+    fn assert_every_architecture_has_an_encoder_rule(
+        architectures: impl Iterator<Item = &'static str>,
+    ) {
+        for architecture in architectures {
+            assert!(
+                audio_encoder_tensors_for_architecture(architecture).is_some(),
+                "architecture '{architecture}' has no quant-floor encoder rule; add one to \
+                 pack_quant_audit::audio_encoder_tensors_for_architecture before shipping"
             );
         }
+    }
+
+    /// Coverage over every shipped architecture, DERIVED from the two
+    /// registries that between them enumerate every builtin family: ASR
+    /// decode architectures (`OpenAsrArchitectureRegistry::with_builtins`)
+    /// and auxiliary non-ASR families (`aux_pack_registry::aux_pack_architecture_ids`,
+    /// diarization/translation/punctuation/forced-alignment). Unlike a
+    /// hand-counted literal list, adding a new builtin family to either
+    /// registry without adding its quant-floor rule here makes this test red
+    /// -- see `coverage_check_fails_closed_on_an_unruled_architecture` for
+    /// the proof that the mechanism actually fires.
+    #[test]
+    fn every_shipped_architecture_has_an_encoder_rule() {
+        let asr_registry = crate::arch::OpenAsrArchitectureRegistry::with_builtins();
+        assert_every_architecture_has_an_encoder_rule(
+            asr_registry
+                .descriptors()
+                .iter()
+                .map(|descriptor| descriptor.model_architecture),
+        );
+        assert_every_architecture_has_an_encoder_rule(
+            crate::models::aux_pack_registry::aux_pack_architecture_ids(),
+        );
+
         assert_eq!(
             audio_encoder_tensors_for_architecture(QWEN_ARCH),
             Some(AudioEncoderTensors::NamePrefixes(&["audio."]))
         );
         assert_eq!(audio_encoder_tensors_for_architecture("not-a-family"), None);
+    }
+
+    /// Proves `assert_every_architecture_has_an_encoder_rule` is not vacuous:
+    /// an architecture id with no entry in `audio_encoder_tensors_for_architecture`
+    /// makes the check panic. This is the permanent stand-in for "add a new
+    /// builtin family without filling in its quant-floor rule" -- adding a
+    /// throwaway descriptor to the real `BUILTIN_ARCHITECTURE_DESCRIPTORS` /
+    /// `AUX_PACK_DESCRIPTORS` tables would also need to satisfy those
+    /// registries' own unrelated exhaustiveness checks (capacity model,
+    /// decode policy, tensor contract, ...), so this test isolates just the
+    /// mechanism this change adds.
+    #[test]
+    #[should_panic(expected = "has no quant-floor encoder rule")]
+    fn coverage_check_fails_closed_on_an_unruled_architecture() {
+        assert_every_architecture_has_an_encoder_rule(
+            ["definitely-not-a-real-architecture-id"].into_iter(),
+        );
     }
 
     #[test]
@@ -704,15 +862,18 @@ mod tests {
 
     #[test]
     fn entire_pack_rule_floors_every_tensor() {
+        // redimnet2 (speaker embedder): a single acoustic backbone with no
+        // decoder side, so EVERY block-quant tensor is encoder regardless of
+        // name.
         let view = view_with(
-            Some(crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID),
+            Some(crate::models::aux_pack_registry::REDIMNET2_GGML_ARCHITECTURE_ID),
             vec![
-                tensor("enc.blk.0.attn.weight", GGML_TYPE_Q8_0),
-                tensor("adapter.mlp.weight", GGML_TYPE_Q6_K),
+                tensor("resnet.tdnn.0.weight", GGML_TYPE_Q8_0),
+                tensor("resnet.pool.weight", GGML_TYPE_Q6_K),
             ],
         );
         let report = audit_quant_floor(&view, Some(PackQuant::Q4_K)).expect("auditable");
-        // The adapter tensor is still acoustic path: a sub-Q8 rung anywhere in
+        // The pool tensor is still acoustic path: a sub-Q8 rung anywhere in
         // this pack violates BOTH the encoder floor and the declared q4_k
         // ceiling (Q6_K is outside its rung set), so it counts twice.
         assert_eq!(report.violations.len(), 2);
@@ -720,11 +881,49 @@ mod tests {
             report
                 .violations
                 .iter()
-                .all(|violation| violation.tensor == "adapter.mlp.weight")
+                .all(|violation| violation.tensor == "resnet.pool.weight")
         );
         let kinds: Vec<_> = report.violations.iter().map(|v| v.kind).collect();
         assert!(kinds.contains(&QuantFloorViolationKind::EncoderBelowQ8Floor));
         assert!(kinds.contains(&QuantFloorViolationKind::ExceedsDeclaredTier));
+    }
+
+    /// The bug this change fixes: firered-llm's `llm.*` Qwen2 decoder tensors
+    /// keep the full requested rung and must NOT be floored, even though an
+    /// earlier hand-written `EntirePack` rule treated the whole pack
+    /// (including `llm.*`) as encoder. This is the real shape of the
+    /// published `firered2-llm-q4_k.oasr` pack: `enc.*`/`adapter.*` at Q8_0,
+    /// `llm.*` at Q4_K.
+    #[test]
+    fn firered_llm_decoder_tensors_keep_the_declared_tier_and_are_not_floored() {
+        let view = view_with(
+            Some(crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID),
+            vec![
+                tensor("enc.blk.0.attn.q.weight", GGML_TYPE_Q8_0),
+                tensor("adapter.linear1.weight", GGML_TYPE_Q8_0),
+                tensor("llm.blk.0.attn_q.weight", GGML_TYPE_Q4_K),
+                tensor("llm.lm_head.weight", GGML_TYPE_Q4_K),
+            ],
+        );
+        let report = audit_quant_floor(&view, Some(PackQuant::Q4_K)).expect("auditable");
+        assert!(report.passed(), "violations: {:?}", report.violations);
+        assert_eq!(report.block_quant_tensors, 4);
+        // Only the two encoder/adapter tensors are floor-relevant; the two
+        // `llm.*` Q4_K tensors must not be counted as encoder.
+        assert_eq!(report.encoder_block_quant_tensors, 2);
+    }
+
+    /// A regression pin for the specific bug: an `EntirePack`-style rule
+    /// would flag this `llm.*` Q4_K tensor as `EncoderBelowQ8Floor`.
+    #[test]
+    fn firered_llm_llm_prefix_is_never_classified_as_encoder() {
+        let view = view_with(
+            Some(crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID),
+            vec![tensor("llm.blk.3.ffn_gate.weight", GGML_TYPE_Q4_K)],
+        );
+        let report = audit_quant_floor(&view, Some(PackQuant::Q4_K)).expect("auditable");
+        assert!(report.passed(), "violations: {:?}", report.violations);
+        assert_eq!(report.encoder_block_quant_tensors, 0);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/parakeet_ctc/package_import.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/package_import.rs
@@ -355,13 +355,22 @@ fn quantized_tensor_type_for_parakeet_tensor(
     let ne0 = dims.first().copied()?;
     // Only the conformer encoder linears (`enc.blk.*`) are quantizable here
     // (the subsampling prelude and CTC head are f32); they carry the floor.
-    let component = if name.starts_with("enc.") {
+    let component = if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder
     };
     classify_quant_tensor(ne0, quantization, component)
 }
+
+/// Runtime tensor name prefix for the parakeet-ctc conformer encoder
+/// (`enc.*`). Shared with `models::pack_quant_audit`'s encoder-floor rule --
+/// the single source of truth for "which parakeet-ctc tensors are
+/// audio-encoder".
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["enc."];
 
 fn parakeet_runtime_gguf_metadata(
     config: &ParakeetConfigJson,

--- a/crates/openasr-core/src/models/parakeet_tdt/package_import.rs
+++ b/crates/openasr-core/src/models/parakeet_tdt/package_import.rs
@@ -421,13 +421,22 @@ fn quantized_tensor_type_for_tensor(
     // Only the conformer encoder linears (`enc.blk.*`) are F16Quantizable; the
     // predictor (`dec.*`) and joint (`joint.*`) stay F16, so every tensor that
     // reaches here is encoder and carries the floor.
-    let component = if name.starts_with("enc.") {
+    let component = if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder
     };
     classify_quant_tensor(ne0, quantization, component)
 }
+
+/// Runtime tensor name prefix for the parakeet-tdt conformer encoder
+/// (`enc.*`). Shared with `models::pack_quant_audit`'s encoder-floor rule --
+/// the single source of truth for "which parakeet-tdt tensors are
+/// audio-encoder".
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["enc."];
 
 fn parakeet_tdt_runtime_gguf_metadata(
     config: &ParakeetTdtConfigJson,

--- a/crates/openasr-core/src/models/qwen/mod.rs
+++ b/crates/openasr-core/src/models/qwen/mod.rs
@@ -51,6 +51,7 @@ pub(crate) use logits_head::{
     load_llm_logits_head_from_reader_with_tensor_names, load_qwen3_llm_logits_head_from_reader,
     load_qwen3_llm_logits_head_from_reader_with_output_tensor,
 };
+pub(crate) use package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES;
 pub use package_import::{
     Qwen3AsrLocalSourceError, Qwen3AsrLocalSourceImportRequest,
     Qwen3AsrLocalSourceImportRuntimeResult, Qwen3AsrRuntimeQuantizationMode,

--- a/crates/openasr-core/src/models/qwen/package_import.rs
+++ b/crates/openasr-core/src/models/qwen/package_import.rs
@@ -774,12 +774,24 @@ fn quantized_tensor_type_for_qwen(
     classify_quant_tensor(ne0, quantization, qwen_quant_component(name))
 }
 
-/// Encoder/audio-tower tensors map onto the `audio.*` runtime namespace
-/// (`audio.conv*`, `audio.proj*`, `audio.blk.*`, `audio.ln_post`); everything
+/// Runtime tensor name prefixes for the qwen3 audio tower (`audio.conv*`,
+/// `audio.proj*`, `audio.blk.*`, `audio.ln_post`). Shared with
+/// `models::pack_quant_audit`'s encoder-floor rule for both
+/// `QWEN3_ASR_GGML_ARCHITECTURE_ID` and
+/// `QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID` (the forced-aligner shares this
+/// importer's audio tower) -- the single source of truth for "which qwen3
+/// tensors are audio-encoder", so the audit can never drift from what this
+/// importer actually classifies as `QuantComponent::Encoder`.
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["audio."];
+
+/// Everything under the audio-tower namespace is the encoder side; everything
 /// else (`blk.*` LLM layers, `token_embd`, `output*`) is the decoder side. The
 /// audio tower carries the shared Q8_0 floor (see `classify_quant_tensor`).
 fn qwen_quant_component(name: &str) -> QuantComponent {
-    if name.starts_with("audio.") {
+    if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder

--- a/crates/openasr-core/src/models/sensevoice/package_import.rs
+++ b/crates/openasr-core/src/models/sensevoice/package_import.rs
@@ -596,13 +596,22 @@ fn quantized_tensor_type_for_sensevoice_tensor(
     let ne0 = dims.first().copied()?;
     // The SAN-M encoder (`enc.blk.*`) and the two-pass encoder (`tp.blk.*`) are
     // the acoustic front end; `ctc.head` / `embed.prompt` are downstream.
-    let component = if name.starts_with("enc.") || name.starts_with("tp.") {
+    let component = if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder
     };
     classify_quant_tensor(ne0, quantization, component)
 }
+
+/// Runtime tensor name prefixes for the SenseVoice SAN-M encoder (`enc.*`)
+/// and two-pass encoder (`tp.*`). Shared with `models::pack_quant_audit`'s
+/// encoder-floor rule -- the single source of truth for "which SenseVoice
+/// tensors are audio-encoder".
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["enc.", "tp."];
 
 fn sensevoice_runtime_gguf_metadata(
     hparams: &SenseVoiceDerivedHparams,

--- a/crates/openasr-core/src/models/wav2vec2_ctc/package_import.rs
+++ b/crates/openasr-core/src/models/wav2vec2_ctc/package_import.rs
@@ -566,13 +566,21 @@ fn quantized_tensor_type_for_wav2vec2_tensor(
     let ne0 = dims.first().copied()?;
     // The wav2vec2 backbone is `enc.*` (feature projection, transformer layers,
     // norm); `ctc.head` is the output projection. The encoder carries the floor.
-    let component = if name.starts_with("enc.") {
+    let component = if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder
     };
     classify_quant_tensor(ne0, quantization, component)
 }
+
+/// Runtime tensor name prefix for the wav2vec2-ctc backbone (`enc.*`). Shared
+/// with `models::pack_quant_audit`'s encoder-floor rule -- the single source
+/// of truth for "which wav2vec2-ctc tensors are audio-encoder".
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["enc."];
 
 fn wav2vec2_runtime_gguf_metadata(
     config: &Wav2Vec2ConfigJson,

--- a/crates/openasr-core/src/models/whisper/mod.rs
+++ b/crates/openasr-core/src/models/whisper/mod.rs
@@ -21,6 +21,7 @@ mod tokenizer;
 pub use frontend::whisper_log_mel_spectrogram_16khz_mono_v0;
 pub(crate) use ggml_executor::WhisperGgmlExecutor;
 pub use local_source::WhisperLocalSourceError;
+pub(crate) use package_import::AUDIO_ENCODER_TENSOR_NAME_PREFIXES;
 pub use package_import::{
     WhisperLocalSourceImportRequest, WhisperLocalSourceImportRuntimeResult,
     WhisperRuntimeQuantizationMode, convert_local_whisper_hf_source_to_runtime_pack,

--- a/crates/openasr-core/src/models/whisper/package_import.rs
+++ b/crates/openasr-core/src/models/whisper/package_import.rs
@@ -267,6 +267,19 @@ fn gguf_runtime_tensor_dims_from_source_tensor(tensor: &SafetensorsTensorHeader)
     tensor.shape.clone()
 }
 
+/// Runtime tensor namespace prefix for the whisper audio encoder. Broader
+/// than [`is_whisper_encoder_linear_weight`] on purpose: that function also
+/// gates *quantization eligibility* (rank-2 `.weight`, specific projections),
+/// but the audit's question is "is this tensor part of the audio encoder at
+/// all" -- e.g. `model.encoder.conv1.weight` is encoder but not
+/// linear-eligible today. Keeping the audit rule at the namespace level means
+/// it stays correct even if a future change block-quantizes a
+/// currently-untouched encoder tensor; `whisper_encoder_linear_weights_stay_within_the_audit_namespace`
+/// below pins the containment the other way (every linear-eligible name is
+/// also inside this namespace). Shared with `models::pack_quant_audit`'s
+/// encoder-floor rule.
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["model.encoder."];
+
 fn is_whisper_encoder_linear_weight(name: &str) -> bool {
     name.starts_with("model.encoder.layers.")
         && matches!(
@@ -1184,6 +1197,58 @@ mod tests {
             u16::from_le_bytes([gguf_tensor.data[0], gguf_tensor.data[1]]),
             0x3c00
         );
+    }
+
+    /// `AUDIO_ENCODER_TENSOR_NAME_PREFIXES` (consumed by
+    /// `models::pack_quant_audit`) is deliberately broader than
+    /// `is_whisper_encoder_linear_weight` (see that constant's doc comment):
+    /// every name the eligibility check accepts must fall inside the audit
+    /// namespace, so the two can never silently diverge on the direction that
+    /// matters (a linear-quantizable encoder tensor escaping the floor).
+    #[test]
+    fn whisper_encoder_linear_weights_stay_within_the_audit_namespace() {
+        let is_audit_encoder_name = |name: &str| {
+            AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+                .iter()
+                .any(|prefix| name.starts_with(prefix))
+        };
+        for name in [
+            "model.encoder.layers.0.self_attn.q_proj.weight",
+            "model.encoder.layers.0.self_attn.k_proj.weight",
+            "model.encoder.layers.0.self_attn.v_proj.weight",
+            "model.encoder.layers.0.self_attn.out_proj.weight",
+            "model.encoder.layers.5.fc1.weight",
+            "model.encoder.layers.5.fc2.weight",
+            // Non-linear encoder tensors the eligibility check never touches
+            // today must still be caught by the broader namespace rule.
+            "model.encoder.conv1.weight",
+            "model.encoder.conv2.weight",
+            "model.encoder.embed_positions.weight",
+        ] {
+            assert!(
+                is_audit_encoder_name(name),
+                "'{name}' must be inside the audit's audio-encoder namespace"
+            );
+        }
+        assert!(is_whisper_encoder_linear_weight(
+            "model.encoder.layers.0.self_attn.q_proj.weight"
+        ));
+        assert!(is_audit_encoder_name(
+            "model.encoder.layers.0.self_attn.q_proj.weight"
+        ));
+        // Decoder names (incl. the cross-attention "encoder_attn" tensors,
+        // which read FROM the encoder but live in the decoder stack) must
+        // stay outside the namespace.
+        for name in [
+            "model.decoder.layers.0.self_attn.q_proj.weight",
+            "model.decoder.layers.0.encoder_attn.q_proj.weight",
+            "model.decoder.output_projection.weight",
+        ] {
+            assert!(
+                !is_audit_encoder_name(name),
+                "'{name}' must NOT be inside the audio-encoder namespace"
+            );
+        }
     }
 
     #[test]

--- a/crates/openasr-core/src/models/xasr_zipformer/package_import.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/package_import.rs
@@ -372,13 +372,22 @@ fn quantized_tensor_type_for_xasr_tensor(
     let ne0 = dims.first().copied()?;
     // The zipformer acoustic encoder is `encoder.*`; the chunk decoder
     // (`decoder.embedding.weight`, `decoder.conv.weight`) is downstream.
-    let component = if name.starts_with("encoder.") {
+    let component = if AUDIO_ENCODER_TENSOR_NAME_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
         QuantComponent::Encoder
     } else {
         QuantComponent::Decoder
     };
     classify_quant_tensor(ne0, quantization, component)
 }
+
+/// Runtime tensor name prefix for the xasr-zipformer acoustic encoder
+/// (`encoder.*`). Shared with `models::pack_quant_audit`'s encoder-floor
+/// rule -- the single source of truth for "which xasr-zipformer tensors are
+/// audio-encoder".
+pub(crate) const AUDIO_ENCODER_TENSOR_NAME_PREFIXES: &[&str] = &["encoder."];
 
 fn join_u32(values: &[u32]) -> String {
     values

--- a/tooling/publish-model/scripts/_require_files.py
+++ b/tooling/publish-model/scripts/_require_files.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Fail-closed completeness + integrity gate for staged/converted model files.
+
+  _require_files.py <root> <pattern> [<pattern> ...]
+
+Backs the `require_files` bash helper in lib.sh (used by download.sh and
+convert.sh). A glob match alone is not enough: a tokenless fetch of a private
+HF repo can land a small captured HTTP response (an error page, a login
+redirect body) at exactly the filename the pipeline expected, and a plain
+`glob.glob()` truth check reports that as present. This module adds two
+independent checks on every matched file:
+
+  1. A per-category minimum size. A weight/checkpoint file (safetensors, .pt,
+     .onnx, .gguf) that is not multi-megabyte is never real; a small JSON/text
+     config can legitimately be tiny, so its floor stays low.
+  2. A content sniff for known captured-failure signatures (HTML error pages,
+     JSON error envelopes, auth-rejection text), independent of size, so a
+     moderately sized error body does not slip through on size alone.
+
+Exits 0 when every pattern matches at least one file under <root> and every
+matched file clears both checks; exits 1 with every problem listed on stderr
+otherwise. Never partial -- this is a hard gate, not a warning.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import sys
+
+# --- size floors, by category ------------------------------------------
+#
+# One global magic number cannot serve both classes of required file: a
+# weight shard that has shrunk to a few KB is always corrupt (real shards are
+# multi-megabyte at minimum), while a legitimate config/tokenizer JSON can be
+# genuinely tiny (a minimal special_tokens_map.json can be well under 200
+# bytes). Categorizing by extension gives each its own floor sized to what a
+# REAL file of that kind looks like, instead of one number that is either too
+# loose for weights or too tight for small configs.
+
+# Weight/checkpoint formats the harness imports (safetensors shards, .pt /
+# .pth.tar checkpoints, .onnx exports, the one vendored .gguf repackage).
+# Every real one is realistically tens of megabytes or larger; 1 MiB only
+# excludes literal garbage, so it can never misfire on a legitimate model.
+WEIGHT_MIN_BYTES = 1024 * 1024
+WEIGHT_SUFFIXES = (".safetensors", ".pt", ".onnx", ".gguf", ".bin")
+WEIGHT_COMPOUND_SUFFIXES = (".pth.tar",)
+
+# Numeric feature-normalization archives (Kaldi CMVN stats, npz stat blobs).
+# Small next to weights, but a real one always carries a per-dimension
+# mean/variance array -- at least a few hundred bytes for any model with a
+# non-trivial feature dimension.
+STATS_MIN_BYTES = 256
+STATS_SUFFIXES = (".npz", ".ark", ".mvn")
+
+# Catch-all for text/JSON/YAML/vocab files (config.json, tokenizer.json,
+# *.txt, *.model, *.yaml, a sharded-weights index.json, license text, ...).
+# Deliberately low: several of these are legitimately tiny, so this floor
+# exists only to catch a captured HTTP error page landing on the expected
+# filename (the class of incident this module fixes -- see module docstring
+# and the 2026-07 qwen3-forced-aligner q4_k rebuild, where a tokenless fetch
+# of a private repo landed a 29-byte error page under a required filename).
+#
+# Sized against the smallest LEGITIMATE file in this category, not against the
+# incident: this repo's own staged inputs include a 21-byte hf_repo.txt and a
+# 29-byte one, and 29 is exactly the size of the captured error page that
+# started all this. A floor tuned to catch that page by size would reject real
+# files of the same length -- it cannot separate them, because length is not
+# what distinguishes them. Only emptiness is unambiguous here, so that is all
+# this floor claims; THE CONTENT SNIFF BELOW IS THE DEFENSE for this category,
+# and it catches the incident body by its text regardless of length.
+DEFAULT_MIN_BYTES = 1
+
+
+def min_bytes_for(path: str) -> int:
+    lower = path.lower()
+    if lower.endswith(WEIGHT_COMPOUND_SUFFIXES) or lower.endswith(WEIGHT_SUFFIXES):
+        return WEIGHT_MIN_BYTES
+    if lower.endswith(STATS_SUFFIXES):
+        return STATS_MIN_BYTES
+    return DEFAULT_MIN_BYTES
+
+
+# --- content sniff: known captured-failure signatures --------------------
+#
+# Independent of size: a moderately sized HTML/JSON error body (an
+# authenticated-only repo's login page, an API error envelope) can clear the
+# byte floor above yet still not be the file the pipeline asked for. Sniffing
+# the leading bytes for known error-response shapes catches that case
+# regardless of category. This is a targeted denylist for captured failure
+# responses, not a general HTML/JSON validator -- the importer and
+# `openasr verify` downstream are what validate the file is actually usable.
+SNIFF_WINDOW_BYTES = 4096
+ERROR_SIGNATURES = (
+    b"<!doctype html",
+    b"<html",
+    b'"error":',
+    b"invalid username or password",
+    b"repository not found",
+    b"401 unauthorized",
+    b"403 forbidden",
+    b"404 not found",
+    b"<error>",  # S3/GCS-style XML error envelopes
+    b"access denied",
+)
+
+
+def looks_like_error_page(path: str) -> str | None:
+    """Return the matched signature (decoded, for the diagnostic) or None."""
+    try:
+        with open(path, "rb") as handle:
+            window = handle.read(SNIFF_WINDOW_BYTES)
+    except OSError:
+        return None
+    lowered = window.lower()
+    for signature in ERROR_SIGNATURES:
+        if signature in lowered:
+            return signature.decode("ascii", errors="replace")
+    return None
+
+
+def check_required_files(root: str, patterns: list[str]) -> list[str]:
+    """Return a list of human-readable problems; empty means everything
+    required is present, large enough for its category, and does not look
+    like a captured error response."""
+    problems: list[str] = []
+    for pattern in patterns:
+        matches = sorted(glob.glob(os.path.join(root, pattern)))
+        if not matches:
+            problems.append(f"missing: {pattern}")
+            continue
+        for match in matches:
+            if not os.path.isfile(match):
+                continue  # a directory match is not this gate's concern
+            rel = os.path.relpath(match, root)
+            size = os.path.getsize(match)
+            floor = min_bytes_for(match)
+            if size < floor:
+                problems.append(
+                    f"too small: {rel} is {size} byte(s), expected at least {floor} "
+                    f"(matched required pattern {pattern!r}) -- looks like a truncated "
+                    "download or a captured error response, not the real file"
+                )
+                continue
+            signature = looks_like_error_page(match)
+            if signature is not None:
+                problems.append(
+                    f"looks like an error page: {rel} ({size} byte(s), matched required "
+                    f"pattern {pattern!r}) contains the signature {signature!r}"
+                )
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        sys.stderr.write("usage: _require_files.py <root> <pattern> [<pattern> ...]\n")
+        return 2
+    root, patterns = argv[0], argv[1:]
+    if not patterns:
+        return 0
+    problems = check_required_files(root, patterns)
+    if problems:
+        sys.stderr.write(
+            f"required file(s) failed the completeness/integrity gate under {root}:\n"
+            + "\n".join(f"  - {problem}" for problem in problems)
+            + "\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tooling/publish-model/scripts/_require_files_test.py
+++ b/tooling/publish-model/scripts/_require_files_test.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from _require_files import (
+    DEFAULT_MIN_BYTES,
+    STATS_MIN_BYTES,
+    WEIGHT_MIN_BYTES,
+    check_required_files,
+    looks_like_error_page,
+    min_bytes_for,
+)
+
+# The real 2026-07 incident: a tokenless fetch of a private HF repo landed a
+# 29-byte captured error body at the filename the pipeline expected, and a
+# plain glob-existence check recorded it as "ok" (see models-core.toml's
+# qwen3-forced-aligner-0.6b q4_k history note). Reconstruct that exact size
+# here as a JSON error envelope, the shape hf-mirror/HF actually return.
+TWENTY_NINE_BYTE_ERROR_PAGE = b'{"error":"no such repo!!"}'.ljust(29, b" ")
+assert len(TWENTY_NINE_BYTE_ERROR_PAGE) == 29
+
+
+class MinBytesForTests(unittest.TestCase):
+    def test_weight_extensions_get_the_megabyte_floor(self) -> None:
+        for name in (
+            "model.safetensors",
+            "model-00001-of-00002.safetensors",
+            "small.cn.pt",
+            "b6-vb2+vox2+cnc2_v0-lm.pt",
+            "model.onnx",
+            "Hy-MT2-1.8B-Q4_K_M.gguf",
+        ):
+            self.assertEqual(min_bytes_for(name), WEIGHT_MIN_BYTES, name)
+
+    def test_compound_pth_tar_suffix_gets_the_megabyte_floor(self) -> None:
+        self.assertEqual(min_bytes_for("model.pth.tar"), WEIGHT_MIN_BYTES)
+        self.assertEqual(min_bytes_for("asr_encoder.pth.tar"), WEIGHT_MIN_BYTES)
+
+    def test_stats_extensions_get_the_stats_floor(self) -> None:
+        for name in ("feats_stats.npz", "cmvn.ark", "am.mvn"):
+            self.assertEqual(min_bytes_for(name), STATS_MIN_BYTES, name)
+
+    def test_config_and_text_files_get_the_low_default_floor(self) -> None:
+        for name in (
+            "config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "model.safetensors.index.json",
+            "units.txt",
+            "dict.txt",
+            "bpe.model",
+            "config.yaml",
+            "LICENSE.txt",
+            "chinese-lert-base/vocab.txt",
+        ):
+            self.assertEqual(min_bytes_for(name), DEFAULT_MIN_BYTES, name)
+
+
+class LooksLikeErrorPageTests(unittest.TestCase):
+    def test_detects_html_error_page(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.json"
+            path.write_bytes(b"<!DOCTYPE html><html><body>404</body></html>")
+            self.assertIsNotNone(looks_like_error_page(str(path)))
+
+    def test_detects_json_error_envelope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.json"
+            path.write_bytes(b'{"error":"Repository Not Found"}')
+            self.assertIsNotNone(looks_like_error_page(str(path)))
+
+    def test_detects_auth_rejection_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "model.safetensors"
+            path.write_bytes(b"Invalid username or password.")
+            self.assertIsNotNone(looks_like_error_page(str(path)))
+
+    def test_real_looking_json_config_is_not_flagged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.json"
+            path.write_bytes(
+                b'{"architectures": ["Wav2Vec2ForCTC"], "model_type": "wav2vec2", '
+                b'"vocab_size": 32, "hidden_size": 768}'
+            )
+            self.assertIsNone(looks_like_error_page(str(path)))
+
+
+class CheckRequiredFilesTests(unittest.TestCase):
+    def test_passes_when_every_pattern_matches_a_real_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "config.json").write_bytes(
+                b'{"architectures": ["Wav2Vec2ForCTC"], "model_type": "wav2vec2"}'
+            )
+            (root / "model.safetensors").write_bytes(b"\x00" * (WEIGHT_MIN_BYTES + 1))
+            problems = check_required_files(str(root), ["config.json", "model.safetensors"])
+            self.assertEqual(problems, [])
+
+    def test_legitimately_tiny_text_file_is_not_rejected(self) -> None:
+        # False-positive guard sized against this repo's own staged inputs:
+        # a 20-byte hf_repo.txt is a real, complete file. An earlier 32-byte
+        # default floor rejected it -- that floor had been reverse-engineered
+        # from the incident's 29 bytes rather than from what a legitimate
+        # small file looks like.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tiny = b"OpenASR/whisper-tiny"
+            self.assertLess(len(tiny), 64)
+            (root / "hf_repo.txt").write_bytes(tiny)
+            problems = check_required_files(str(root), ["hf_repo.txt"])
+            self.assertEqual(problems, [])
+
+    def test_missing_pattern_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_required_files(tmp, ["model.safetensors"])
+            self.assertEqual(len(problems), 1)
+            self.assertIn("missing", problems[0])
+            self.assertIn("model.safetensors", problems[0])
+
+    def test_29_byte_captured_error_page_on_a_weight_pattern_is_rejected(self) -> None:
+        # The core regression case: a tokenless fetch of a private repo lands
+        # a 29-byte error page at the filename a weight glob expects. The
+        # size floor alone (33 bytes < 1 MiB) must fail this closed.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "model.safetensors").write_bytes(TWENTY_NINE_BYTE_ERROR_PAGE)
+            problems = check_required_files(str(root), ["model.safetensors"])
+            self.assertEqual(len(problems), 1)
+            self.assertIn("too small", problems[0])
+            self.assertIn("model.safetensors", problems[0])
+
+    def test_29_byte_captured_error_page_on_a_config_pattern_is_rejected(self) -> None:
+        # Same incident shape, but landing on a text/JSON category, where a
+        # size floor cannot help: this repo stages legitimate 21- and 29-byte
+        # hf_repo.txt files, so 29 bytes is not by itself a defect. The
+        # content sniff is what has to catch it here.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "config.json").write_bytes(TWENTY_NINE_BYTE_ERROR_PAGE)
+            problems = check_required_files(str(root), ["config.json"])
+            self.assertEqual(len(problems), 1)
+            self.assertIn("looks like an error page", problems[0])
+
+    def test_oversized_error_page_on_a_config_pattern_is_caught_by_content_sniff(self) -> None:
+        # A larger captured error body clears the low default size floor but
+        # must still be caught by the content sniff -- this is the case the
+        # size floor alone cannot handle.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            body = b"<!DOCTYPE html><html><head><title>401</title></head>" \
+                   b"<body>Invalid username or password</body></html>"
+            self.assertGreater(len(body), DEFAULT_MIN_BYTES)
+            (root / "config.json").write_bytes(body)
+            problems = check_required_files(str(root), ["config.json"])
+            self.assertEqual(len(problems), 1)
+            self.assertIn("looks like an error page", problems[0])
+
+    def test_one_bad_shard_among_several_fails_the_whole_pattern(self) -> None:
+        # A sharded weight glob (model-*.safetensors) must reject the whole
+        # requirement if even one matched shard is corrupt/replaced, not just
+        # skip the bad one because a sibling shard is fine.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "model-00001-of-00002.safetensors").write_bytes(b"\x00" * (WEIGHT_MIN_BYTES + 1))
+            (root / "model-00002-of-00002.safetensors").write_bytes(TWENTY_NINE_BYTE_ERROR_PAGE)
+            problems = check_required_files(str(root), ["model-*.safetensors"])
+            self.assertEqual(len(problems), 1)
+            self.assertIn("00002-of-00002", problems[0])
+
+    def test_directory_match_is_not_treated_as_a_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Qwen2-7B-Instruct").mkdir()
+            problems = check_required_files(str(root), ["Qwen2-7B-Instruct"])
+            self.assertEqual(problems, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/publish-model/scripts/lib.sh
+++ b/tooling/publish-model/scripts/lib.sh
@@ -39,27 +39,19 @@ cat_quants() { python3 "$CATALOG_PY" quants "$1"; }
 quant_token(){ python3 "$CATALOG_PY" token "$1"; }    # q8_0 -> q8-0
 quant_suffix(){ python3 "$CATALOG_PY" suffix "$1"; }  # q8_0 -> q8
 
-# Fail-closed completeness guard: every glob pattern must match at least one
-# existing file under the given dir. This is the wall between "a stage
-# returned rc=0" and "the files the next stage needs actually exist" -- the
-# class of bug where an exclude rule strips the only checkpoint (or a
-# tokenless fetch lands a 29-byte error page) while the exit code says fine.
+# Fail-closed completeness + integrity guard: every glob pattern must match at
+# least one existing file under the given dir, AND every matched file must
+# clear a size-category floor and not look like a captured HTTP error page.
+# This is the wall between "a stage returned rc=0" and "the files the next
+# stage needs actually exist and are real" -- the class of bug where an
+# exclude rule strips the only checkpoint, or a tokenless fetch of a private
+# repo lands a small error page at the expected filename while the exit code
+# still says fine (see _require_files.py for the categorization and the
+# 2026-07 incident that motivated it).
 require_files() {
   local dir="$1"; shift
   [[ $# -gt 0 ]] || return 0
-  python3 - "$dir" "$@" <<'PY'
-import glob
-import os
-import sys
-
-root, patterns = sys.argv[1], sys.argv[2:]
-missing = [pattern for pattern in patterns if not glob.glob(os.path.join(root, pattern))]
-if missing:
-    sys.stderr.write(
-        "required source file(s) missing under %s: %s\n" % (root, ", ".join(missing))
-    )
-    sys.exit(1)
-PY
+  python3 "$PUB_DIR/_require_files.py" "$dir" "$@"
 }
 
 # retry <attempts> <cmd...>: run a command until it succeeds with exponential


### PR DESCRIPTION
## Summary

Derives the quantization-floor audit's rule tables from the code that already owns those facts instead of hand-copied duplicates, and gives the publish pipeline's required-file gates a content check so a captured error response can no longer pass as a present file.

## Why

Both changes close a "the gate cannot fail where it should" gap, and the first one turned out to be actively wrong.

`pack_quant_audit` carried two tables retyped by hand from `classify_quant_tensor` and from each importer's `QuantComponent` classification, and its coverage test walked an 18-element array typed into the test file. A new family, or a renamed encoder prefix, would not have turned that test red. Deriving the tables surfaced a real defect immediately: `firered-llm` was classified `EntirePack`, so every `llm.*` tensor in the shipped `firered2-llm-q4_k.oasr` -- a separately quantized Qwen2 decoder that legitimately keeps the requested rung -- was reported as an audio-encoder floor violation. Against the shipped pack the pre-change audit fails with 198 violations; after the change it reports none. `firered2-llm` is public and ships only a q4_k tier, and `openasr verify` runs this audit and fails closed, so this would have told every user of that model their pack was corrupt. The audit is new in this cycle, so no released version is affected.

The same switch to a registry-derived sweep showed `redimnet2` had no rule at all despite shipping through the aux-pack table.

`require_files` matched a glob and stopped there. The 2026-07 forced-aligner audit fetched a private repo without a token, landed a 29-byte error page under the expected filename, and recorded it as ok -- exactly what this gate exists to prevent.

## Changes

- `declared_tier_allows` derives a tier's allowed rungs by calling `classify_quant_tensor` at representative samples; `classify_quant_tensor` gained the `Fp16` guard every caller was applying externally.
- `audio_encoder_tensors_for_architecture` references each family's own `AUDIO_ENCODER_TENSOR_NAME_PREFIXES`, declared beside that family's `QuantComponent` classification. Two entries stay declared rather than derived, with the reason in-line: MiMo has no in-repo Rust classifier, and whisper's audit rule is deliberately broader than its linear-eligibility check (reconciled by a superset test). These constants are static strings, so the audit still reads nothing but the GGUF header -- no source weights, no importer execution.
- The coverage test now walks the architecture registry unioned with the aux-pack table, and a `should_panic` test proves the assertion fires on an unruled architecture rather than passing vacuously.
- `firered-llm` corrected to `NamePrefixes(["enc.", "adapter."])`, reconciled against every real target name the three tensor-name mappers produce; `redimnet2` given a rule; hymt2's duplicate architecture-id constant removed in favor of the one in `config`.
- `require_files` moved into a testable module with a per-category size floor and a content sniff for known captured-failure signatures. Weight and stats formats get a real floor; text and JSON only have to be non-empty, because this repo stages legitimate 21- and 29-byte files and length cannot separate those from a 29-byte error page. The sniff catches that class by its text at any length.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (3239 passed / 148 skipped; 7 more than main)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

Also run: `regenerate_all.sh --check`, and the publish-model Python suite (219 tests, 16 new).

## Manual smoke checks

- Built the pre-change CLI in a separate worktree and ran `model-pack audit-quant` against the shipped `firered2-llm-q4_k.oasr`: 198 violations before, none after, same pack and same flags.
- `audit-quant` against the rebuilt forced-aligner q4_k pack is byte-identical before and after the derivation change.
- A 29-byte error body under `model.safetensors` is rejected by the size floor; the same body under `config.json` is rejected by the content sniff; a 20-byte `hf_repo.txt` and other genuinely small staged files pass.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- The older crate-wide pattern of a family declaring its own architecture-id constant alongside the one in `runtime_contract` remains for cohere and moonshine; that spans many more files than this change touches and is left alone deliberately.
- No catalog content, model pack or release artifact is published here.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- AI tooling assisted implementation and review; the submitter owns the change.
