### PR TITLE
feat(docker): CUDA image, GHCR release workflow, and compose GPU profile

### DIFF
--- a/.github/workflows/docker-cuda-release.yml
+++ b/.github/workflows/docker-cuda-release.yml
@@ -1,0 +1,129 @@
+name: Docker CUDA release
+
+# Manual-only: builds Dockerfile.cuda (the NVIDIA GPU image; see that file for
+# why it compiles from source instead of assembling the released
+# linux-x86_64-cuda binary) and, when explicitly asked to, pushes it to GHCR.
+#
+# GitHub-hosted runners have no GPU, so this validates "compiles + links +
+# packages" only -- exactly like the `linux-x86_64-cuda` leg in
+# release-binaries.yml, which already compiles the same `cuda` feature
+# successfully on a GPU-less hosted runner today (nvcc device-code
+# compilation does not require a physical GPU, only a matching driver at
+# *run* time). Real GPU execution is validated on real hardware, e.g. via
+# `docker compose --profile gpu up openasr-cuda` on a machine with an NVIDIA
+# card and the NVIDIA Container Toolkit installed -- see compose.yaml and
+# scripts/docker-cuda-entrypoint.sh for the fail-closed GPU-visibility gate
+# that guards against a silent CPU fallback there.
+#
+# Dispatch manually from the Actions tab or `gh workflow run docker-cuda-release.yml`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch, tag, or SHA) to build; empty = default branch"
+        required: false
+        default: ""
+      push:
+        description: "Push the built image to ghcr.io (false = build-only dry run, no registry writes)"
+        required: false
+        default: false
+        type: boolean
+      mark_latest:
+        description: "Also tag/push cuda-latest (only meaningful when push is true; use for a real release ref, not an arbitrary dev branch)"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: docker-cuda-release-${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build (and optionally push) the CUDA image
+    # Only the canonical repo may push to its GHCR namespace; forks can still
+    # dispatch this for a build-only dry run since `packages: write` is not
+    # granted below unless this check passes.
+    if: github.repository_owner == 'QuintinShaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: recursive
+
+      - name: Resolve workspace version
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+          if [ -z "${version}" ]; then
+            echo "could not read workspace version from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: inputs.push
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${IMAGE_NAME}"
+          # Lowercase (GHCR requires lowercase repository paths); github.repository
+          # is already QuintinShaw/openasr (mixed case owner), so normalize.
+          image="$(printf '%s' "${image}" | tr '[:upper:]' '[:lower:]')"
+          short_sha="$(git rev-parse --short HEAD)"
+          tags="${image}:cuda-${{ steps.version.outputs.version }},${image}:cuda-sha-${short_sha}"
+          if [ "${{ inputs.mark_latest }}" = "true" ]; then
+            tags="${tags},${image}:cuda-latest"
+          fi
+          echo "tags=${tags}" >> "${GITHUB_OUTPUT}"
+
+      # linux/amd64 only: matches release-binaries.yml's Linux CUDA leg
+      # (x86_64-only -- there is no aarch64 desktop/server NVIDIA CUDA leg
+      # there either; Jetson uses a separate l4t base image, out of scope).
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.cuda
+          platforms: linux/amd64
+          push: ${{ inputs.push }}
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          {
+            echo "### Docker CUDA image"
+            echo
+            if [ "${{ inputs.push }}" = "true" ]; then
+              echo "Pushed: \`${{ steps.tags.outputs.tags }}\`"
+            else
+              echo "Build-only dry run (push=false) -- no registry writes. Tags that would have been pushed:"
+              echo "\`${{ steps.tags.outputs.tags }}\`"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,97 @@
+# CUDA-enabled image for NVIDIA GPUs (Turing/sm_75 and up -- RTX 20xx, GTX
+# 16xx, T4, and newer Ampere/Ada/Hopper cards).
+#
+# Why compile from source here instead of assembling the released
+# `openasr-<version>-linux-x86_64-cuda.tar.gz` binary (release-binaries.yml
+# does publish one): that release binary is compiled against
+# `openasr-core/build.rs`'s current default CUDA arch list, which does not
+# include sm_75 on `main` today, so it silently drops Turing cards ("no
+# kernel image available" at runtime) -- exactly the failure this image
+# exists to fix. Building in-image with an explicit OPENASR_CUDA_GPU_TARGETS
+# below decouples this image from that default and guarantees Turing support
+# regardless of upstream's current state. Once a released binary is built
+# with sm_75 included, switching this Dockerfile to "download + unpack the
+# release asset" becomes a valid, lighter-weight alternative -- revisit then.
+#
+# CUDA toolkit version (13.2.0) and base OS (Ubuntu 22.04) match the
+# `linux-x86_64-cuda` leg in .github/workflows/release-binaries.yml so the
+# build environment stays consistent with what CI already validates.
+
+ARG CUDA_VERSION=13.2.0
+ARG UBUNTU_CODENAME=ubuntu22.04
+
+FROM nvidia/cuda:${CUDA_VERSION}-devel-${UBUNTU_CODENAME} AS builder
+
+ARG RUST_VERSION=1.95.0
+# CUDA architectures to generate device code for. Includes sm_75 (Turing:
+# RTX 20xx / GTX 16xx / T4 / 2080 Ti) alongside the upstream default
+# (Ampere/Ada/Hopper). See crates/openasr-core/build.rs's
+# `cuda_gpu_targets_from_raw` for why the floor sits at 75 (CUDA 13 dropped
+# Volta/Pascal/Maxwell device-code generation) and how this env var is read.
+ARG OPENASR_CUDA_GPU_TARGETS="75;80;86;89;90"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl ca-certificates build-essential cmake pkg-config git \
+        libasound2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:${PATH}
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --profile minimal --default-toolchain "${RUST_VERSION}"
+
+WORKDIR /app
+COPY . .
+
+ENV OPENASR_CUDA_GPU_TARGETS=${OPENASR_CUDA_GPU_TARGETS}
+RUN cargo build --release -p openasr-cli --features cuda
+
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-${UBUNTU_CODENAME} AS runtime
+
+# The "runtime" nvidia/cuda tag already ships libcudart/libcublas/etc (the
+# CUDA redistributable math libraries); it does not ship libcuda.so (the
+# driver), which the NVIDIA Container Toolkit mounts in from the host at
+# `docker run --gpus ...` time. libasound2/libgomp1 match the CPU Dockerfile
+# (ALSA + OpenMP runtime deps of the openasr binary).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libasound2 libgomp1 ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 10001 openasr \
+    && mkdir -p /app /data \
+    && chown -R openasr:openasr /app /data
+
+WORKDIR /app
+COPY --from=builder /app/target/release/openasr /usr/local/bin/openasr
+COPY --from=builder /app/model-registry ./model-registry
+COPY scripts/docker-cuda-entrypoint.sh /usr/local/bin/docker-cuda-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-cuda-entrypoint.sh
+
+ENV OPENASR_HOME=/data
+# See the CPU Dockerfile for why this opt-in is safe: binding 0.0.0.0 inside
+# the container is the standard Docker exposure pattern (the operator
+# controls exposure via port-publish/orchestration); the server stays
+# fail-closed against non-loopback plaintext unless this is set. Front it
+# with TLS (or a TLS-terminating proxy) for untrusted networks.
+ENV OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1
+
+# NVIDIA Container Toolkit contract: request GPU capability + full visibility
+# by default (overridable by the operator via `--gpus`/`NVIDIA_VISIBLE_DEVICES`).
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+EXPOSE 8080
+
+USER openasr
+
+# Fail-closed GPU gate: refuses to start (and to keep passing its healthcheck)
+# if the container cannot see a real GPU device, instead of silently falling
+# back to CPU. See scripts/docker-cuda-entrypoint.sh.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+    CMD /usr/local/bin/docker-cuda-entrypoint.sh --gpu-check-only || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-cuda-entrypoint.sh"]
+CMD ["serve", "--addr", "0.0.0.0:8080"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,5 +11,37 @@ services:
       - openasr-data:/data
     command: ["serve", "--addr", "0.0.0.0:8080"]
 
+  # NVIDIA GPU variant (Dockerfile.cuda). Requires the NVIDIA Container
+  # Toolkit on the host (https://github.com/NVIDIA/nvidia-container-toolkit)
+  # and a driver compatible with CUDA 13.2. Opt in explicitly:
+  #   docker compose --profile gpu up openasr-cuda
+  # The entrypoint (scripts/docker-cuda-entrypoint.sh) runs `openasr doctor`
+  # before serving and refuses to start if no GPU device is visible inside
+  # the container -- it will NOT silently fall back to CPU. If startup fails
+  # with "no GPU device reported", the `deploy.resources.reservations.devices`
+  # block below did not actually grant a GPU (check `nvidia-smi` on the host
+  # and `docker info | grep -i runtime`).
+  openasr-cuda:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.cuda
+    image: openasr:cuda-local
+    ports:
+      - "8080:8080"
+    environment:
+      OPENASR_HOME: /data
+    volumes:
+      - openasr-cuda-data:/data
+    command: ["serve", "--addr", "0.0.0.0:8080"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: ["gpu"]
+
 volumes:
   openasr-data:
+  openasr-cuda-data:

--- a/scripts/docker-cuda-entrypoint.sh
+++ b/scripts/docker-cuda-entrypoint.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Fail-closed GPU gate for the CUDA Docker image (Dockerfile.cuda).
+#
+# Why this exists: openasr's per-request execution target (`auto` / `cpu` /
+# `accelerated`) is a request-level API field, not a server-wide CLI flag --
+# there is no single "did the server pick CUDA" switch to check at startup.
+# What we *can* check unconditionally, offline, and without a loaded model is
+# `openasr doctor`'s device enumeration: it calls into ggml's CUDA backend
+# init and lists every device it actually found, tagged with a `kind` (see
+# crates/openasr-core/src/ggml_runtime/backend.rs's `GgmlBackendKind` and
+# crates/openasr-cli/src/doctor_cli.rs's `device_kind_label`, which prints
+# GPU devices as "(gpu, ...)"). This image only ever compiles the `cuda`
+# ggml backend in, so any device doctor reports with kind "gpu" is a CUDA
+# device -- there is no other GPU backend in this binary to confuse it with.
+#
+# If no such device shows up, the most likely causes are: the container
+# was not started with `--gpus ...` / a `deploy.resources.reservations.devices`
+# GPU reservation, the NVIDIA Container Toolkit is not installed on the host,
+# or the host driver does not support this image's CUDA arch list. In every
+# one of those cases we refuse to silently serve on CPU -- that would turn a
+# broken GPU passthrough into a silent, much-slower-than-expected transcription
+# service instead of a loud, immediately-diagnosable startup failure.
+set -euo pipefail
+
+fail() {
+    echo "docker-cuda-entrypoint: $*" >&2
+    exit 1
+}
+
+run_gpu_check() {
+    local doctor_output
+    if ! doctor_output="$(openasr doctor 2>&1)"; then
+        echo "${doctor_output}" >&2
+        fail "'openasr doctor' exited non-zero; cannot verify GPU availability."
+    fi
+
+    if ! printf '%s\n' "${doctor_output}" | grep -Eq '\(gpu,|\(integrated-gpu,'; then
+        echo "${doctor_output}" >&2
+        fail "no GPU device reported by 'openasr doctor'. This image only" \
+             "runs GPU-accelerated (see Dockerfile.cuda); it refuses to fall" \
+             "back to CPU silently. Start the container with GPU access" \
+             "(e.g. 'docker run --gpus all ...', or the compose 'gpu' profile" \
+             "in compose.yaml) and confirm the NVIDIA Container Toolkit is" \
+             "installed and the host driver is compatible."
+    fi
+}
+
+# The HEALTHCHECK directive invokes this script with --gpu-check-only so it
+# can re-verify GPU visibility on a running container without touching the
+# main process; the normal container startup path (no args, or the compose
+# `command:` override) runs the same check once, fail-closed, before execing
+# the real openasr command.
+if [ "${1:-}" = "--gpu-check-only" ]; then
+    run_gpu_check
+    exit 0
+fi
+
+run_gpu_check
+exec openasr "$@"


### PR DESCRIPTION
## Summary
CUDA Docker image for #196 (2080Ti): GPU Dockerfile, a manual GHCR release workflow, a compose gpu profile, and a fail-closed GPU-vs-CPU startup assertion.

## Changes
- Dockerfile.cuda: two-stage build, in-image CUDA source compile with explicit OPENASR_CUDA_GPU_TARGETS=75;80;86;89;90 (independent of the build.rs default, so Turing/2080Ti is guaranteed regardless); nvidia/cuda:13.2.0 devel/runtime, non-root, NVIDIA Container Toolkit env.
- scripts/docker-cuda-entrypoint.sh: runs 'openasr doctor' and refuses to start (exit 1) if no GPU device is enumerated -- never silently falls back to CPU. HEALTHCHECK re-checks at runtime.
- .github/workflows/docker-cuda-release.yml: workflow_dispatch only, owner-gated, push defaults to false (dry-run build), GHCR login only when pushing.
- compose.yaml: openasr-cuda service under the 'gpu' profile with NVIDIA device reservation.

## Scope / non-goals
- Not built/validated on this machine (Apple M1, no NVIDIA). CUDA compile + 2080Ti end-to-end verification is left to the workflow's CI dispatch and the #196 user environment. Structural checks (shellcheck/actionlint/compose config/yaml) pass.

## AI usage disclosure
YES -- implemented with AI assistance.