### PR TITLE
feat(server): expose recognized_audio_extensions on /health and recognize .mov

### DIFF
--- a/crates/openasr-core/src/audio/types.rs
+++ b/crates/openasr-core/src/audio/types.rs
@@ -8,7 +8,9 @@ use crate::BackendKind;
 // `qta` is macOS QuickTime Player's audio recording extension -- a MOV
 // container (ffmpeg's `mov,mp4,m4a,3gp,3g2,mj2` demuxer probes and decodes it
 // like any other MOV/M4A file, no special handling needed beyond recognizing
-// the extension). `m4b` (audiobook) is the same ISO/MP4 container under a
+// the extension). `mov` itself (QuickTime movies with an audio track, e.g. a
+// screen recording) rides the exact same demuxer and needs the same nothing.
+// `m4b` (audiobook) is the same ISO/MP4 container under a
 // different extension -- symphonia's `isomp4` reader already lists it as a
 // recognized extension alongside `mp4`/`m4a` (see
 // `symphonia_format_isomp4::demuxer::IsoMp4Reader::query`), so no extra
@@ -34,8 +36,8 @@ use crate::BackendKind;
 // ffmpeg decodes both, so this only changes whether that fallback is ever
 // attempted, not whether every upload of one succeeds.
 pub(crate) const RECOGNIZED_EXTENSIONS: &[&str] = &[
-    "wav", "mp3", "mp4", "m4a", "m4b", "webm", "flac", "ogg", "opus", "qta", "aac", "aiff", "aif",
-    "aifc", "caf", "wma", "amr",
+    "wav", "mp3", "mp4", "m4a", "m4b", "mov", "webm", "flac", "ogg", "opus", "qta", "aac", "aiff",
+    "aif", "aifc", "caf", "wma", "amr",
 ];
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/openasr-core/src/batch_tests.rs
+++ b/crates/openasr-core/src/batch_tests.rs
@@ -104,8 +104,8 @@ fn no_supported_files_returns_friendly_error_with_supported_extensions() {
 
     assert!(error.contains("No supported audio or video files found in:"));
     assert!(error.contains(
-        "Supported extensions: wav, mp3, mp4, m4a, m4b, webm, flac, ogg, opus, qta, aac, aiff, \
-         aif, aifc, caf, wma, amr."
+        "Supported extensions: wav, mp3, mp4, m4a, m4b, mov, webm, flac, ogg, opus, qta, aac, \
+         aiff, aif, aifc, caf, wma, amr."
     ));
 }
 

--- a/crates/openasr-server/generated/http-wire/HealthResponse.ts
+++ b/crates/openasr-server/generated/http-wire/HealthResponse.ts
@@ -85,4 +85,18 @@ catalog_degraded: string | null,
  * the pre-0.1.25 contract, in which case a client should keep whatever
  * figure it last shipped with rather than treat the daemon as degraded.
  */
-voice_id_min_enrollment_speech_seconds: number, };
+voice_id_min_enrollment_speech_seconds: number, 
+/**
+ * The audio/video file extensions this daemon's decode pipeline
+ * recognizes as media input (`openasr_core::recognized_audio_extensions()`,
+ * lowercase, no leading dot). The single source of truth a UI's file
+ * pickers and drag-and-drop router should read instead of hand-copying a
+ * list that drifts from core -- so the desktop transcribe picker, the
+ * Voice ID enrollment picker, and the window drop router all agree with
+ * exactly what this build can decode. Not per-request state (a build
+ * constant), surfaced here because `/health` is the one contract every
+ * client already polls at startup. Additive: absent in the pre-0.1.26
+ * contract, in which case a client should fall back to the list it last
+ * shipped with rather than treat the daemon as degraded.
+ */
+recognized_audio_extensions: Array<string>, };

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1887,6 +1887,10 @@ async fn health(
         catalog_degraded: catalog_degraded_reason(&distribution),
         voice_id_min_enrollment_speech_seconds:
             openasr_core::diarize::voice_id::MIN_SAMPLE_SPEECH_SECONDS,
+        recognized_audio_extensions: openasr_core::recognized_audio_extensions()
+            .iter()
+            .map(|extension| (*extension).to_string())
+            .collect(),
     })
 }
 
@@ -2121,6 +2125,18 @@ struct HealthResponse {
     /// the pre-0.1.25 contract, in which case a client should keep whatever
     /// figure it last shipped with rather than treat the daemon as degraded.
     voice_id_min_enrollment_speech_seconds: f32,
+    /// The audio/video file extensions this daemon's decode pipeline
+    /// recognizes as media input (`openasr_core::recognized_audio_extensions()`,
+    /// lowercase, no leading dot). The single source of truth a UI's file
+    /// pickers and drag-and-drop router should read instead of hand-copying a
+    /// list that drifts from core -- so the desktop transcribe picker, the
+    /// Voice ID enrollment picker, and the window drop router all agree with
+    /// exactly what this build can decode. Not per-request state (a build
+    /// constant), surfaced here because `/health` is the one contract every
+    /// client already polls at startup. Additive: absent in the pre-0.1.26
+    /// contract, in which case a client should fall back to the list it last
+    /// shipped with rather than treat the daemon as degraded.
+    recognized_audio_extensions: Vec<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -2762,14 +2762,22 @@ async fn health_returns_identity_json_without_instance_token() {
         parsed["model_resident"], true,
         "the mock backend has no runtime to unload, so it reads resident whenever bound"
     );
+    let recognized = parsed["recognized_audio_extensions"]
+        .as_array()
+        .expect("recognized_audio_extensions array");
+    assert!(
+        recognized.iter().any(|value| value == "wav"),
+        "recognized_audio_extensions mirrors core's recognized_audio_extensions() and must list wav"
+    );
     assert_eq!(
         parsed.as_object().expect("health response object").len(),
-        11,
+        12,
         "status/server_version/pid/instance_token/model_installed/model_resident \
          plus the 0.1.14 additive native_active_count/idle_seconds, the 0.1.15 \
          additive abandoned_worker_count debug field, the 0.1.16 additive \
-         catalog_degraded field, and the 0.1.25 additive \
-         voice_id_min_enrollment_speech_seconds field"
+         catalog_degraded field, the 0.1.25 additive \
+         voice_id_min_enrollment_speech_seconds field, and the 0.1.26 additive \
+         recognized_audio_extensions field"
     );
 }
 
@@ -2804,12 +2812,13 @@ async fn health_echoes_launch_instance_token_without_env() {
     );
     assert_eq!(
         parsed.as_object().expect("health response object").len(),
-        11,
+        12,
         "status/server_version/pid/instance_token/model_installed/model_resident \
          plus the 0.1.14 additive native_active_count/idle_seconds, the 0.1.15 \
          additive abandoned_worker_count debug field, the 0.1.16 additive \
-         catalog_degraded field, and the 0.1.25 additive \
-         voice_id_min_enrollment_speech_seconds field"
+         catalog_degraded field, the 0.1.25 additive \
+         voice_id_min_enrollment_speech_seconds field, and the 0.1.26 additive \
+         recognized_audio_extensions field"
     );
 }
 
@@ -2846,12 +2855,13 @@ async fn health_prefers_env_instance_token_over_launch_option() {
     );
     assert_eq!(
         parsed.as_object().expect("health response object").len(),
-        11,
+        12,
         "status/server_version/pid/instance_token/model_installed/model_resident \
          plus the 0.1.14 additive native_active_count/idle_seconds, the 0.1.15 \
          additive abandoned_worker_count debug field, the 0.1.16 additive \
-         catalog_degraded field, and the 0.1.25 additive \
-         voice_id_min_enrollment_speech_seconds field"
+         catalog_degraded field, the 0.1.25 additive \
+         voice_id_min_enrollment_speech_seconds field, and the 0.1.26 additive \
+         recognized_audio_extensions field"
     );
 }
 


### PR DESCRIPTION
## Summary
Single-source the recognized audio-input extension set: expose `openasr_core::recognized_audio_extensions()` on the `/health` response so clients (the desktop file pickers, drag-drop) stop hardcoding a list that drifts from core.

## Changes
- server: `/health` gains `recognized_audio_extensions: string[]` (additive; older clients ignore it), populated from core's authoritative list. ts-rs wire binding regenerated; api.rs health key-count assertions updated (11 -> 12).
- core: recognize `.mov` as media input -- same MOV/ISO-BMFF container as the already-supported `.qta`/`.mp4`/`.m4a`, same demux path, no new decode capability needed. The desktop already listed `.mov`; adding it to core makes the single-source migration lossless.

## Scope / non-goals
- Additive only; no trust-boundary change. The extension list answers "is this decodable", not "is this safe" -- the upload-accept path is deliberately not gated on it.

## Tests run
- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo nextest run --workspace (3288 passed / 0 failed)
- [x] cargo test --workspace --doc

## AI usage disclosure
YES -- implemented with AI assistance (code, tests, adversarial review).