### PR TITLE
feat(core): swap-aware host-memory admission and reclaim leaked admission permits

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -2263,12 +2263,35 @@ fn enforce_native_host_memory_admission(
         required_positions,
         pack_metadata.len(),
         host_total_memory_bytes,
+        host_memory_admission_domain_for_backend(backend),
     ) {
         return Err(BackendError::NativeInsufficientHostMemory {
             reason: rejection.user_message(),
         });
     }
     Ok(())
+}
+
+/// Classify the resolved dispatch backend into the memory pool its resident
+/// decode state draws from, so admission budgets against the right ceiling.
+/// CPU and Apple-Silicon `Metal` are unified memory (host RAM, swap-backed);
+/// only the discrete `Gpu` lane (CUDA/HIP/Vulkan) has dedicated VRAM that
+/// cannot page. Metal must NOT land in the discrete bucket -- doing so would
+/// hard-reject Macs that a swap-backed budget would admit.
+fn host_memory_admission_domain_for_backend(
+    backend: crate::ggml_runtime::GgmlCpuGraphBackend,
+) -> crate::capacity::MemoryAdmissionDomain {
+    match backend {
+        crate::ggml_runtime::GgmlCpuGraphBackend::Cpu
+        | crate::ggml_runtime::GgmlCpuGraphBackend::Metal => {
+            crate::capacity::MemoryAdmissionDomain::UnifiedMemory {
+                swap_bytes: crate::host::host_total_swap_bytes().unwrap_or(0),
+            }
+        }
+        crate::ggml_runtime::GgmlCpuGraphBackend::Gpu => {
+            crate::capacity::MemoryAdmissionDomain::DiscreteVram
+        }
+    }
 }
 
 fn shared_native_ggml_execution_dispatch() -> &'static GgmlAsrExecutionDispatch {
@@ -3381,6 +3404,10 @@ mod tests {
             "fixture host must not admit the overstated (DEFAULT) footprint"
         );
 
+        // The fixture host is sized against the 75% budget (`budget_bytes`
+        // above); exercise the admission through the domain whose budget is
+        // that same 75% figure so the accept/reject split stays about the spec
+        // (Q8_0 vs DEFAULT), not about the swap-aware budget.
         assert!(
             crate::capacity::evaluate_host_memory_admission(
                 &geometry,
@@ -3388,6 +3415,7 @@ mod tests {
                 required_positions,
                 pack_bytes_on_disk,
                 host_total_memory_bytes,
+                crate::capacity::MemoryAdmissionDomain::DiscreteVram,
             )
             .is_ok(),
             "the real Q8_0 footprint must be admitted"
@@ -3399,6 +3427,7 @@ mod tests {
                 required_positions,
                 pack_bytes_on_disk,
                 host_total_memory_bytes,
+                crate::capacity::MemoryAdmissionDomain::DiscreteVram,
             )
             .is_err(),
             "the overstated DEFAULT footprint would have been falsely rejected on this host"

--- a/crates/openasr-core/src/capacity.rs
+++ b/crates/openasr-core/src/capacity.rs
@@ -447,6 +447,43 @@ pub(crate) fn derive_integral_seconds(derivation: &IntegralWindowDerivation) -> 
     largest_fitting.map(|chunks| chunks as f32 * derivation.chunk_seconds)
 }
 
+/// The physical memory pool a request's decode state draws from -- the fact
+/// that decides whether the OS can page it out under pressure, and thus how
+/// [`evaluate_host_memory_admission`] forms its budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MemoryAdmissionDomain {
+    /// CPU or Apple-Silicon Metal. Decode state lives in host RAM -- on Metal
+    /// the unified-memory pool is the SAME physical RAM the mmap'd pack sits
+    /// in, not a separate VRAM space -- which every supported OS backs with
+    /// swap. The budget is total RAM plus total swap, so a request that
+    /// overflows RAM but still fits RAM+swap is admitted silently: the OS
+    /// pages colder pages out and the decode runs (slower) instead of being
+    /// refused (the reject-not-degrade line moves to "cannot fit even with
+    /// swap"). `swap_bytes` is the probed total swap
+    /// (`crate::host::host_total_swap_bytes`), zero when unprobeable, which
+    /// reverts to a RAM-only budget -- conservative, never unsafe. Metal
+    /// belongs HERE, never with discrete GPUs: Apple Silicon has no separate
+    /// VRAM to overflow, so classifying it as a "GPU backend" and hard-
+    /// rejecting it would wrongly refuse every Mac.
+    UnifiedMemory { swap_bytes: u64 },
+    /// A discrete GPU whose resident decode state lives in dedicated VRAM
+    /// (`GgmlCpuGraphBackend::Gpu` -- the CUDA/HIP/Vulkan discrete lane, never
+    /// Metal). VRAM cannot be paged to swap, so an over-budget request is a
+    /// hard failure with no "run it slower" fallback; swap is never added.
+    ///
+    /// NOTE (device-aware accounting, still partial): a true VRAM budget is
+    /// not yet plumbed to this function, so the discrete path still charges the
+    /// KV and pack bytes against a fraction of HOST RAM
+    /// (`host_memory_budget_bytes`) as a conservative stand-in. That is
+    /// conservative-to-a-fault (it can refuse a request that a large VRAM
+    /// would actually hold) but never unsafe, and no family that runs
+    /// meaningfully large on a discrete GPU is wired to this check today
+    /// (moss-transcribe-diarize, the only wired family, runs CPU/Metal and
+    /// stays small). Wiring a real per-device VRAM budget here is the
+    /// remaining follow-up.
+    DiscreteVram,
+}
+
 /// A family's decoder KV footprint for THIS request clearly does not fit this
 /// host's memory budget -- the reject-not-degrade admission outcome (design
 /// review 2026-07-27, point A: refuse rather than silently reslice/requant,
@@ -460,11 +497,16 @@ pub(crate) struct HostMemoryCapacityRejection {
     /// KV bytes at `required_positions` plus the pack's own on-disk bytes --
     /// the two quantities [`evaluate_host_memory_admission`] actually knows.
     pub needed_bytes: u64,
-    /// `host_total_memory_bytes * 3/4` (`crate::host::host_memory_budget_bytes`).
+    /// The budget `needed_bytes` was compared against: total RAM + swap on a
+    /// unified-memory host, `host_total_memory_bytes * 3/4` on the discrete
+    /// (no-swap) path (see [`MemoryAdmissionDomain`]).
     pub budget_bytes: u64,
     pub host_total_memory_bytes: u64,
     pub pack_bytes_on_disk: u64,
     pub required_positions: usize,
+    /// Which memory pool the budget was formed from -- so the message can name
+    /// RAM+swap vs VRAM correctly and the trailer records the classification.
+    pub domain: MemoryAdmissionDomain,
 }
 
 impl HostMemoryCapacityRejection {
@@ -473,11 +515,17 @@ impl HostMemoryCapacityRejection {
     /// elsewhere in this crate -- the full arithmetic a bug report needs,
     /// in one line.
     pub(crate) fn provenance(&self) -> String {
+        let (domain, swap_bytes) = match self.domain {
+            MemoryAdmissionDomain::UnifiedMemory { swap_bytes } => ("unified", swap_bytes),
+            MemoryAdmissionDomain::DiscreteVram => ("discrete_vram", 0),
+        };
         format!(
-            "core.native.capacity.admission:reject,needed_bytes={},budget_bytes={},host_total_memory_bytes={},pack_bytes_on_disk={},required_positions={}",
+            "core.native.capacity.admission:reject,domain={},needed_bytes={},budget_bytes={},host_total_memory_bytes={},swap_bytes={},pack_bytes_on_disk={},required_positions={}",
+            domain,
             self.needed_bytes,
             self.budget_bytes,
             self.host_total_memory_bytes,
+            swap_bytes,
             self.pack_bytes_on_disk,
             self.required_positions,
         )
@@ -490,19 +538,33 @@ impl HostMemoryCapacityRejection {
     /// pack-does-not-fit-this-host's-budget message already uses.
     pub(crate) fn user_message(&self) -> String {
         const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+        let needed_gib = self.needed_bytes as f64 / GIB;
+        let budget_gib = self.budget_bytes as f64 / GIB;
+        let host_gib = self.host_total_memory_bytes as f64 / GIB;
+        let headline = match self.domain {
+            MemoryAdmissionDomain::UnifiedMemory { swap_bytes } => format!(
+                "This request needs about {needed_gib:.1} GiB (the model pack plus its decode \
+                 context for {positions} decoder positions), but this host's admission budget is \
+                 only {budget_gib:.1} GiB ({host_gib:.1} GiB RAM + {swap_gib:.1} GiB swap). It \
+                 does not fit even after paging to swap.",
+                positions = self.required_positions,
+                swap_gib = swap_bytes as f64 / GIB,
+            ),
+            MemoryAdmissionDomain::DiscreteVram => format!(
+                "This request needs about {needed_gib:.1} GiB (the model pack plus its decode \
+                 context for {positions} decoder positions), but this discrete GPU's admission \
+                 budget is only {budget_gib:.1} GiB. GPU VRAM cannot page to swap, so it cannot \
+                 be run slower to fit.",
+                positions = self.required_positions,
+            ),
+        };
         format!(
-            "This request needs about {needed_gib:.1} GiB (the model pack plus its decode \
-             context for {positions} decoder positions), but this host's admission budget is \
-             only {budget_gib:.1} GiB ({host_gib:.1} GiB total RAM x 75%).\n\
+            "{headline}\n\
              Try a smaller quantization (q8_0 or q4_k instead of fp16), a smaller model, or \
              close other memory-heavy applications and retry.\n\
              The request was rejected before building the decode graph, instead of failing \
              later with an opaque ggml allocation error.\n\
              {provenance}",
-            needed_gib = self.needed_bytes as f64 / GIB,
-            positions = self.required_positions,
-            budget_gib = self.budget_bytes as f64 / GIB,
-            host_gib = self.host_total_memory_bytes as f64 / GIB,
             provenance = self.provenance(),
         )
     }
@@ -510,47 +572,55 @@ impl HostMemoryCapacityRejection {
 
 /// Evaluate whether `required_positions` decoder positions at `spec` for
 /// `geometry`, alongside `pack_bytes_on_disk` already resident from the
-/// mmap'd pack file, fit this host's memory budget
-/// (`crate::host::host_memory_budget_bytes`: 75% of total RAM, never
-/// `host_available_memory_bytes` -- see this module's invariants and
-/// `host_available_memory_bytes`'s own doc comment forbidding admission use).
+/// mmap'd pack file, fit this host's memory budget for the given `domain`.
+/// The budget is never `host_available_memory_bytes` (see this module's
+/// invariants and that probe's own doc forbidding admission use).
+///
+/// The budget is `domain`-aware (see [`MemoryAdmissionDomain`]):
+///
+/// - **Unified memory (CPU / Apple-Silicon Metal):** budget = total RAM +
+///   total swap. A machine with swap must not refuse a decode just because it
+///   overflows physical RAM -- the OS pages colder pages out and runs it
+///   (slower). The reject-not-degrade line therefore moves to "cannot fit even
+///   with all of swap" (`needed > RAM + swap`); a request in the band above
+///   RAM but within RAM+swap is admitted silently, with no prompt. This
+///   deliberately spends the old 25% RAM headroom (the 75% budget) that used
+///   to cover the un-modeled encoder/mel/compute working set: on a host with
+///   swap that working set pages out too, and the point of this path is to let
+///   a large decode run rather than be refused. When swap is unprobeable the
+///   domain carries zero, reverting to a RAM-only budget (conservative).
+/// - **Discrete VRAM (CUDA/HIP/Vulkan):** budget = 75% of host RAM, no swap
+///   added (VRAM cannot page). This is a conservative stand-in until a real
+///   per-device VRAM budget is plumbed here; see [`MemoryAdmissionDomain`].
 ///
 /// Fails OPEN on a degenerate geometry (`kv_bytes_at_positions` erring):
 /// geometry validity is enforced elsewhere (pack import), not here, and
 /// "uncertain" always resolves to "allow" per invariant 1 -- refusing only
-/// when certain it will not fit. Deliberately omits any reserve for encoder
-/// activations / mel / compute graph beyond the two quantities exactly known
-/// here: inventing a family-general "working set" constant with no measured
-/// figure to draw from would either be large enough to risk rejecting a
-/// request that would actually fit (the one outcome invariant 1 forbids) or
-/// small enough not to matter, so the 25% of total memory the 75% budget
-/// already sets aside is left to cover it instead of a second guessed number.
-///
-/// Assumes unified memory: `needed_bytes` sums KV cache and pack bytes as if
-/// both draw from the same host RAM pool the mmap'd pack resides in and the
-/// budget bounds. On a host with a discrete GPU, resident decoder state can
-/// instead live in VRAM (a separate budget this function does not see) while
-/// the mmap'd pack's pages stay reclaimable host-side, so this arithmetic is
-/// conservative-to-a-fault there rather than wrong in the unsafe direction --
-/// but it has not been exercised against a discrete-GPU host yet (moss-
-/// transcribe-diarize, the only family wired to this check so far, stays
-/// small enough that it does not matter in practice). Before wiring a family
-/// that runs meaningfully large on a discrete GPU (e.g. qwen3-asr at fp16,
-/// ~4.7 GiB), this needs device-aware accounting: a separate VRAM budget for
-/// resident state, and the pack's on-disk bytes should not be charged against
-/// host RAM at their full mmap size once they are known to be reclaimable.
+/// when certain it will not fit.
 pub(crate) fn evaluate_host_memory_admission(
     geometry: &KvGeometry,
     spec: LlmKvCacheSpec,
     required_positions: usize,
     pack_bytes_on_disk: u64,
     host_total_memory_bytes: u64,
+    domain: MemoryAdmissionDomain,
 ) -> Result<(), HostMemoryCapacityRejection> {
     let Ok(kv_bytes) = kv_bytes_at_positions(geometry, spec, required_positions) else {
         return Ok(());
     };
     let needed_bytes = kv_bytes.total().saturating_add(pack_bytes_on_disk);
-    let budget_bytes = crate::host::host_memory_budget_bytes(host_total_memory_bytes);
+    let budget_bytes = match domain {
+        // Unified memory can page to swap, so the physical ceiling a decode can
+        // draw on is RAM + swap -- not the 75% RAM budget the discrete path and
+        // the quant recommender use.
+        MemoryAdmissionDomain::UnifiedMemory { swap_bytes } => {
+            host_total_memory_bytes.saturating_add(swap_bytes)
+        }
+        // VRAM cannot swap; keep the conservative host-RAM stand-in budget.
+        MemoryAdmissionDomain::DiscreteVram => {
+            crate::host::host_memory_budget_bytes(host_total_memory_bytes)
+        }
+    };
     if needed_bytes <= budget_bytes {
         return Ok(());
     }
@@ -560,6 +630,7 @@ pub(crate) fn evaluate_host_memory_admission(
         host_total_memory_bytes,
         pack_bytes_on_disk,
         required_positions,
+        domain,
     })
 }
 
@@ -765,17 +836,23 @@ mod tests {
         assert_eq!(derive_integral_seconds(&derivation), Some(300.0));
     }
 
-    /// The pack-alone-does-not-fit shape: a multi-gigabyte pack on a host
-    /// whose budget cannot possibly hold it, independent of how many KV
-    /// positions the request needs -- the pack bytes alone (qwen3-asr-1.7b's
-    /// real shipped fp16 size, used here only as a realistic oversized-pack
-    /// figure; this admission check does not run for qwen3-asr yet) already
-    /// exceed a 1 GiB host's 75% budget. Reproduces the scenario with an
-    /// injected test-constructed budget rather than a real 16 GiB machine.
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    fn unified(swap_bytes: u64) -> MemoryAdmissionDomain {
+        MemoryAdmissionDomain::UnifiedMemory { swap_bytes }
+    }
+
+    /// The pack-alone-does-not-fit shape: a multi-gigabyte pack on a host whose
+    /// budget cannot possibly hold it, independent of how many KV positions the
+    /// request needs -- the pack bytes alone (qwen3-asr-1.7b's real shipped
+    /// fp16 size, used here only as a realistic oversized-pack figure; this
+    /// admission check does not run for qwen3-asr yet) already exceed a 1 GiB
+    /// host's RAM even before adding any swap. Also pins the swap-unprobeable
+    /// fallback: with zero swap the unified budget is exactly total RAM.
     #[test]
     fn host_memory_admission_rejects_a_pack_that_plainly_does_not_fit_a_tiny_host() {
         let geometry = moss_geometry();
-        let tiny_host_total_memory_bytes: u64 = 1024 * 1024 * 1024; // 1 GiB
+        let tiny_host_total_memory_bytes: u64 = GIB; // 1 GiB
         let oversized_pack_bytes_on_disk: u64 = 4_704_801_920; // qwen3-asr-1.7b fp16 .oasr
         let rejection = evaluate_host_memory_admission(
             &geometry,
@@ -783,22 +860,25 @@ mod tests {
             512,
             oversized_pack_bytes_on_disk,
             tiny_host_total_memory_bytes,
+            unified(0),
         )
-        .expect_err("a multi-GiB pack cannot fit a 1 GiB host's budget");
-        assert_eq!(
-            rejection.budget_bytes,
-            crate::host::host_memory_budget_bytes(tiny_host_total_memory_bytes)
-        );
+        .expect_err("a multi-GiB pack cannot fit a 1 GiB host, swap unprobeable");
+        // Swap unprobeable (0) -> the unified budget is exactly total RAM, the
+        // conservative RAM-only fallback.
+        assert_eq!(rejection.budget_bytes, tiny_host_total_memory_bytes);
         assert!(rejection.needed_bytes > rejection.budget_bytes);
 
         let message = rejection.user_message();
         assert!(message.contains("needs about"), "{message}");
         assert!(message.contains("admission budget is only"), "{message}");
+        assert!(message.contains("RAM +"), "{message}");
         assert!(message.contains("Try a smaller quantization"), "{message}");
         assert!(
             message.contains("core.native.capacity.admission:reject"),
             "{message}"
         );
+        assert!(message.contains("domain=unified"), "{message}");
+        assert!(message.contains("swap_bytes=0"), "{message}");
         assert!(
             message.contains(&format!("needed_bytes={}", rejection.needed_bytes)),
             "{message}"
@@ -809,6 +889,112 @@ mod tests {
         );
     }
 
+    /// The swap-aware admission the whole change exists for: a request that
+    /// overflows physical RAM but still fits RAM + swap is admitted silently,
+    /// while the SAME request on a swapless host (swap = 0) is rejected -- so
+    /// it is swap, not some other slack, that lets it through.
+    #[test]
+    fn host_memory_admission_admits_the_over_ram_swap_band_and_only_because_of_swap() {
+        let geometry = moss_geometry();
+        let host_ram: u64 = 4 * GIB;
+        let pack_bytes: u64 = 4 * GIB;
+        let required_positions = 3000; // ~0.96 GiB of DEFAULT KV
+        // needed = pack + KV ~= 4.96 GiB: above 4 GiB RAM, below 8 GiB RAM+swap.
+        evaluate_host_memory_admission(
+            &geometry,
+            LlmKvCacheSpec::DEFAULT,
+            required_positions,
+            pack_bytes,
+            host_ram,
+            unified(4 * GIB),
+        )
+        .expect("a request that overflows RAM but fits RAM+swap must be admitted silently");
+
+        evaluate_host_memory_admission(
+            &geometry,
+            LlmKvCacheSpec::DEFAULT,
+            required_positions,
+            pack_bytes,
+            host_ram,
+            unified(0),
+        )
+        .expect_err("the same request on a swapless host must be rejected");
+    }
+
+    /// Reject only when it does not fit even after paging: needed > RAM + swap.
+    /// The message names both RAM and swap and the swap-exhausted phrasing.
+    #[test]
+    fn host_memory_admission_rejects_when_over_ram_plus_swap() {
+        let geometry = moss_geometry();
+        let host_ram: u64 = 4 * GIB;
+        let swap: u64 = GIB; // budget = 5 GiB
+        let pack_bytes: u64 = 5 * GIB;
+        let rejection = evaluate_host_memory_admission(
+            &geometry,
+            LlmKvCacheSpec::DEFAULT,
+            512,
+            pack_bytes,
+            host_ram,
+            unified(swap),
+        )
+        .expect_err("pack alone (5 GiB) plus KV exceeds the 5 GiB RAM+swap budget");
+        assert_eq!(rejection.budget_bytes, host_ram + swap);
+        let message = rejection.user_message();
+        assert!(message.contains("RAM +"), "{message}");
+        assert!(message.contains("swap"), "{message}");
+        assert!(
+            message.contains("does not fit even after paging to swap"),
+            "{message}"
+        );
+        assert!(message.contains("domain=unified"), "{message}");
+        assert!(message.contains(&format!("swap_bytes={swap}")), "{message}");
+    }
+
+    /// Discrete VRAM cannot page: swap never enters its budget, and the
+    /// rejection message says so. A budget that would trivially admit the same
+    /// request as unified-with-swap still rejects here.
+    #[test]
+    fn host_memory_admission_discrete_vram_never_uses_swap() {
+        let geometry = moss_geometry();
+        let host_ram: u64 = 8 * GIB; // 75% budget = 6 GiB
+        let pack_bytes: u64 = 5 * GIB;
+        // 8192 DEFAULT positions ~= 2.6 GiB KV -> needed ~= 7.6 GiB > 6 GiB.
+        let rejection = evaluate_host_memory_admission(
+            &geometry,
+            LlmKvCacheSpec::DEFAULT,
+            8192,
+            pack_bytes,
+            host_ram,
+            MemoryAdmissionDomain::DiscreteVram,
+        )
+        .expect_err("VRAM budget (75% of host RAM stand-in) cannot hold this request");
+        // No swap term -- budget is the 75% RAM stand-in, unchanged by swap.
+        assert_eq!(
+            rejection.budget_bytes,
+            crate::host::host_memory_budget_bytes(host_ram)
+        );
+        let message = rejection.user_message();
+        assert!(
+            message.contains("GPU VRAM cannot page to swap"),
+            "{message}"
+        );
+        assert!(message.contains("domain=discrete_vram"), "{message}");
+        assert!(message.contains("swap_bytes=0"), "{message}");
+
+        // The identical footprint on a unified host WITH ample swap is admitted
+        // -- proving the discrete path's refusal is the no-swap rule, not the
+        // footprint itself.
+        evaluate_host_memory_admission(
+            &geometry,
+            LlmKvCacheSpec::DEFAULT,
+            8192,
+            pack_bytes,
+            host_ram,
+            unified(8 * GIB),
+        )
+        .expect("the same footprint fits a unified host with 8 GiB of swap");
+    }
+
     /// Reverse case: the family's own worst-case ceiling (8192 positions,
     /// `DEFAULT` policy) plus a modest pack size must still fit the repo's own
     /// 8 GiB min-spec floor -- the same fact
@@ -816,7 +1002,7 @@ mod tests {
     /// `moss_transcribe_diarize::capacity` already pins, exercised here
     /// through the admission function a real request calls rather than the
     /// raw KV arithmetic. Currently-working combos on a min-spec machine must
-    /// stay working.
+    /// stay working -- even with zero swap.
     #[test]
     fn host_memory_admission_allows_the_shipped_worst_case_on_a_min_spec_host() {
         let geometry = moss_geometry();
@@ -827,6 +1013,7 @@ mod tests {
             8192,
             modest_pack_bytes_on_disk,
             crate::host::MIN_SPEC_TOTAL_MEMORY_BYTES,
+            unified(0),
         )
         .expect(
             "the shipped worst-case ceiling plus a modest pack must fit the 8 GiB min-spec budget",
@@ -845,8 +1032,15 @@ mod tests {
             head_dim: 128,
         };
         assert!(
-            evaluate_host_memory_admission(&degenerate, LlmKvCacheSpec::DEFAULT, 8192, 0, 1024)
-                .is_ok()
+            evaluate_host_memory_admission(
+                &degenerate,
+                LlmKvCacheSpec::DEFAULT,
+                8192,
+                0,
+                1024,
+                unified(0),
+            )
+            .is_ok()
         );
     }
 }

--- a/crates/openasr-core/src/host.rs
+++ b/crates/openasr-core/src/host.rs
@@ -79,6 +79,70 @@ pub fn host_total_memory_bytes() -> Option<u64> {
     }
 }
 
+/// Best-effort total swap (paging) space of the host in bytes, or `None` on a
+/// platform without a probe. Used only to widen the host-memory admission
+/// budget on unified-memory hosts (CPU / Apple-Silicon Metal), where the OS
+/// can page colder pages out to make room for a large decode: admission adds
+/// this to physical RAM so a request that overflows RAM but fits RAM+swap is
+/// allowed to run (slower) instead of refused. Fails safe: any probe failure
+/// returns `None`, which the admission side treats as zero swap -- reverting
+/// to the RAM-only budget, conservative but never wrong in the unsafe
+/// direction. Never used for a discrete GPU's VRAM budget, which cannot swap.
+pub fn host_total_swap_bytes() -> Option<u64> {
+    #[cfg(target_os = "macos")]
+    {
+        // `vm.swapusage` writes a `struct xsw_usage`; `xsu_total` is the total
+        // configured swap in bytes (dynamically grown by macOS as needed, so
+        // this reflects the current swap file total, which is what a decode
+        // about to page out can actually draw on).
+        let mut usage: libc::xsw_usage = unsafe { std::mem::zeroed() };
+        let mut size = std::mem::size_of::<libc::xsw_usage>();
+        // SAFETY: vm.swapusage fills a caller-owned `xsw_usage`; `size` is set
+        // to its width and passed as the buffer capacity, per the sysctl API.
+        let ret = unsafe {
+            libc::sysctlbyname(
+                c"vm.swapusage".as_ptr(),
+                (&mut usage as *mut libc::xsw_usage).cast::<libc::c_void>(),
+                &mut size,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        (ret == 0).then_some(usage.xsu_total)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+        meminfo.lines().find_map(|line| {
+            line.strip_prefix("SwapTotal:")?
+                .split_whitespace()
+                .next()?
+                .parse::<u64>()
+                .ok()
+                .map(|kb| kb.saturating_mul(1024))
+        })
+    }
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+
+        // Windows has no single "swap size" field; the page file is the swap
+        // analog. `ullTotalPageFile` is the system commit limit (physical RAM
+        // plus all page files), so the page-file (swap) size is that minus
+        // physical RAM. `saturating_sub` guards the (rare, transient) case
+        // where the reported commit limit dips below physical RAM.
+        // SAFETY: same contract as `host_total_memory_bytes`'s Windows arm.
+        let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+        status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+        let ok = unsafe { GlobalMemoryStatusEx(&mut status) };
+        (ok != 0).then_some(status.ullTotalPageFile.saturating_sub(status.ullTotalPhys))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    {
+        None
+    }
+}
+
 /// A quant-recommendation profile budgeting ~75% of host RAM (mirroring the
 /// desktop install picker). Empty (no budget) when RAM cannot be probed, which
 /// makes `recommend_catalog_quant` fall back to the catalog default.
@@ -440,6 +504,24 @@ mod tests {
                     "available ({available}) must not exceed total ({total})"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn host_total_swap_is_plausible_on_supported_platforms() {
+        // Best-effort: a probe may legitimately return `None` (unsupported
+        // platform, a locked-down sandbox, or a host with swap disabled that
+        // reports nothing), and zero swap is valid (swap turned off). The only
+        // hard requirement is that when a total RAM figure is also available,
+        // the probed swap does not read as an implausible multiple of RAM,
+        // which would signal a units/field mistake in the probe.
+        if let Some(swap) = host_total_swap_bytes()
+            && let Some(total) = host_total_memory_bytes()
+        {
+            assert!(
+                swap <= total.saturating_mul(64),
+                "implausible swap ({swap}) vs total RAM ({total}) -- likely a units bug"
+            );
         }
     }
 

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -143,29 +143,70 @@ pub(crate) struct NativeStreamingWorkerHandle {
 ///   Being per-attach rather than a single per-worker flag is the core
 ///   structural fix (BLOCKER 1): abandoning one attach can no longer poison a
 ///   healthy queued sibling on the same worker thread.
+/// - `permit`: this attach's model-capacity admission permit (limit-1 per
+///   model identity). Held here rather than as a bare local on the worker
+///   thread's stack so that when a decode watchdog abandons a wedged worker it
+///   can reclaim the permit immediately, instead of waiting on an OS thread
+///   stuck in an uninterruptible decode that will never drop its stack local
+///   (and would otherwise leak the admission slot, locking every later attach
+///   for the same identity out at limit-1 until the daemon restarts). The
+///   `Mutex<Option<...>>` is a single-owner hand-off: whichever of the worker
+///   thread (normal finish) and `abandon` (watchdog / same-key preemption)
+///   calls `take_permit` first gets `Some` and drops it, releasing the slot
+///   exactly once; the loser gets `None`, so a late-returning wedged decode can
+///   never double-release the slot nor touch a permit a fresh session has since
+///   acquired. Nothing else takes the permit -- the owning WS's own disconnect
+///   paths (`join` / `detach_cancel`) deliberately leave it with the worker so
+///   a merely-disconnected transport cannot release capacity while the model is
+///   still executing.
 pub(crate) struct AttachToken {
     pub(crate) cancel_requested: Arc<AtomicBool>,
     pub(crate) activity: crate::idle_activity::SharedNativeActivityGuard,
     pub(crate) abandoned: AtomicBool,
+    pub(crate) permit: Mutex<Option<ModelSessionPermit>>,
 }
 
 impl AttachToken {
-    fn new(activity: crate::idle_activity::SharedNativeActivityGuard) -> Arc<Self> {
+    fn new(
+        activity: crate::idle_activity::SharedNativeActivityGuard,
+        permit: Option<ModelSessionPermit>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             cancel_requested: Arc::new(AtomicBool::new(false)),
             activity,
             abandoned: AtomicBool::new(false),
+            permit: Mutex::new(permit),
         })
     }
 
+    /// Take this attach's model-capacity permit out of the token, if it is
+    /// still here. Returns it so the caller drops it where it chooses; dropping
+    /// the returned permit is what actually releases the admission slot.
+    /// Idempotent by construction -- the `Option::take` under the mutex hands
+    /// the permit to exactly one caller, so whichever of the worker thread
+    /// (normal completion) and `abandon` (watchdog / same-key preemption)
+    /// reaches it first frees the slot once and the loser gets `None`; never a
+    /// double-release, even if a wedged decode thread returns long after the
+    /// watchdog reclaimed its permit.
+    fn take_permit(&self) -> Option<ModelSessionPermit> {
+        self.permit
+            .lock()
+            .expect("native streaming attach permit mutex poisoned")
+            .take()
+    }
+
     /// Abandon this one attach: mark it (so the worker stops servicing it and a
-    /// late warm-up stays inert) and force-release its `idle_unload` guard (so
-    /// a stuck, uninterruptible decode thread stops pinning the reaper).
-    /// Idempotent -- the guard release is idempotent and the flag is a
-    /// monotonic set.
+    /// late warm-up stays inert), force-release its `idle_unload` guard (so a
+    /// stuck, uninterruptible decode thread stops pinning the reaper), and
+    /// reclaim its model-capacity permit (so that same stuck thread stops
+    /// pinning the admission slot). Idempotent -- the guard release is
+    /// idempotent, the flag is a monotonic set, and `take_permit` releases the
+    /// slot at most once no matter how many triggers fire or how late the
+    /// wedged thread eventually returns.
     fn abandon(&self) {
         self.abandoned.store(true, Ordering::Release);
         self.activity.release();
+        drop(self.take_permit());
     }
 }
 
@@ -364,19 +405,21 @@ pub(crate) enum NativeStreamingWorkerMessage {
         outcomes: mpsc::Sender<NativeStreamingOutcome>,
         finalize_requested: Arc<AtomicBool>,
         /// This attach's supervision token (cancel flag, `idle_unload` guard,
-        /// per-attach `abandoned` flag -- see [`AttachToken`]). Carried by
-        /// value so, if this message is never received (the `mpsc::Sender::send`
-        /// error path returns the whole message), the token -- and the guard
-        /// inside it -- drops on the sender side and the activity count still
-        /// retires. Once the worker thread receives it, the worker records it
-        /// as the current occupant (`begin_occupant`) and drives the session
-        /// against it; the WS session and any external supervisor hold their
-        /// own clones of the same `Arc<AttachToken>`.
+        /// per-attach `abandoned` flag, and this attach's model-capacity permit
+        /// -- see [`AttachToken`]). Carried by value so, if this message is
+        /// never received (the `mpsc::Sender::send` error path returns the whole
+        /// message), the token -- and the guard and permit inside it -- drop on
+        /// the sender side and both the activity count and the admission slot
+        /// still retire. Once the worker thread receives it, the worker records
+        /// it as the current occupant (`begin_occupant`) and drives the session
+        /// against it, then reclaims the permit (`take_permit`) once the session
+        /// has actually returned; the WS session and any external supervisor
+        /// hold their own clones of the same `Arc<AttachToken>`. The worker
+        /// effectively owns the permit until this attached session returns,
+        /// including after the WS transport has disconnected, so a detached
+        /// blocking decode cannot be overlapped -- only a decode watchdog or a
+        /// same-key preemption may reclaim it earlier, via `AttachToken::abandon`.
         token: Arc<AttachToken>,
-        /// The model-capacity permit. The worker owns it until this attached
-        /// session has actually returned, including after the WS transport has
-        /// disconnected, so a detached blocking decode cannot be overlapped.
-        model_session_permit: Option<ModelSessionPermit>,
     },
 }
 
@@ -433,13 +476,14 @@ impl NativeStreamingDecodeWorker {
         // as the worker's current occupant here -- the worker thread does that
         // itself when it actually begins processing this attach, so a queued
         // attach never stomps the occupant record of the one still running.
-        let token = AttachToken::new(worker.activity);
-        // On success the worker thread owns retiring the guard (once, after it
-        // finishes this session, or earlier if a watchdog/preemption trigger
-        // releases it first -- release is idempotent). On failure `send` hands
-        // the whole message -- token included -- back in its `Err`; we release
-        // this attach's guard explicitly so the activity count retires without
-        // waiting on the token clones to all drop.
+        let token = AttachToken::new(worker.activity, model_session_permit);
+        // On success the worker thread owns retiring the guard and the permit
+        // (once, after it finishes this session, or earlier if a
+        // watchdog/preemption trigger releases them first -- both releases are
+        // idempotent). On failure `send` hands the whole message -- token
+        // included -- back in its `Err`; we release this attach's guard and
+        // reclaim its permit explicitly so the activity count and the admission
+        // slot retire now, without waiting on the token clones to all drop.
         if let Err(send_error) = worker
             .sender
             .send(NativeStreamingWorkerMessage::Attach {
@@ -448,12 +492,12 @@ impl NativeStreamingDecodeWorker {
                 outcomes: outcome_tx,
                 finalize_requested: Arc::clone(&finalize_requested),
                 token: Arc::clone(&token),
-                model_session_permit,
             })
             .await
         {
             drop(send_error);
             token.activity.release();
+            drop(token.take_permit());
             worker.state.release();
             return Err("native streaming worker stopped before session attach".to_string());
         }
@@ -803,16 +847,17 @@ pub(crate) fn spawn_native_streaming_worker(
                         outcomes,
                         finalize_requested,
                         token,
-                        model_session_permit,
                     } => {
-                        // Keep the capacity permit owned by this worker thread
-                        // until `run_native_streaming_session_on_worker` returns.
-                        // A disconnected WS cannot release it early.
-                        let _model_session_permit = model_session_permit;
                         // Record this attach as the current occupant only now,
                         // as the thread actually begins driving it -- so
                         // external supervisors always act on the attach that
                         // holds the thread, never one still queued behind it.
+                        // This attach's model-capacity permit lives in `token`
+                        // and stays owned effectively by this worker thread
+                        // until `run_native_streaming_session_on_worker`
+                        // returns; a disconnected WS cannot release it early
+                        // (only a decode watchdog / same-key preemption may, via
+                        // `AttachToken::abandon`).
                         state.begin_occupant(Arc::clone(&token));
                         run_native_streaming_session_on_worker(
                             session,
@@ -822,16 +867,21 @@ pub(crate) fn spawn_native_streaming_worker(
                             &token,
                         );
                         // Clear the occupant record first, then retire the
-                        // per-key acquire count and this attach's activity
-                        // guard. `token.activity.release()` (rather than
-                        // relying on `Drop`) makes the enter/exit pairing
-                        // unconditional and is idempotent -- a no-op if a
-                        // decode watchdog, same-key preemption, or the owning
-                        // WS's own disconnect path already released this same
-                        // guard while this call was stuck.
+                        // per-key acquire count, this attach's activity guard,
+                        // and its model-capacity permit.
+                        // `token.activity.release()` and `token.take_permit()`
+                        // (rather than relying on `Drop`) make the enter/exit
+                        // and acquire/release pairings unconditional and are
+                        // idempotent -- each is a no-op if a decode watchdog,
+                        // same-key preemption, or the owning WS's own disconnect
+                        // path already released this same guard / reclaimed this
+                        // permit while this call was stuck. This is what keeps a
+                        // late-returning wedged decode from double-releasing the
+                        // admission slot.
                         state.clear_occupant();
                         state.release();
                         token.activity.release();
+                        drop(token.take_permit());
                     }
                 }
             }

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -1477,6 +1477,100 @@ async fn native_streaming_same_key_preemption_frees_new_attach_after_client_disc
     release_sender.send(()).expect("release blocked decode");
 }
 
+#[tokio::test]
+async fn watchdog_abandon_reclaims_admission_permit_and_late_return_does_not_double_release() {
+    // The decode watchdog must reclaim a wedged worker's model-capacity permit
+    // when it abandons it -- otherwise a decode stuck in an uninterruptible
+    // Metal call (which never drops the worker thread's permit) leaks the
+    // admission slot, and every later attach for the same identity is rejected
+    // at limit-1 until the daemon restarts. Reclaiming must also be safe against
+    // the wedged thread finally returning long afterwards: the token's
+    // single-owner `take_permit` hand-off guarantees the slot is released
+    // exactly once, never double-released onto whatever fresh session took over.
+    let supervisor = NativeExecutionSupervisor::new(NonZeroUsize::new(1).unwrap());
+    let model_identity = "native:test-permit-reclaim@pack".to_string();
+    let permit = supervisor
+        .try_acquire(model_identity.clone())
+        .expect("first attach acquires the single model slot");
+    assert!(
+        supervisor.try_acquire(model_identity.clone()).is_err(),
+        "limit-1 admission must reject a second concurrent session for the same identity"
+    );
+
+    let key = test_native_streaming_worker_key("watchdog-permit-reclaim");
+    let (started_sender, started_receiver) = std::sync::mpsc::channel();
+    let (release_sender, release_receiver) = std::sync::mpsc::channel();
+    let worker = NativeStreamingDecodeWorker::attach_admitted(
+        key,
+        Box::new(BlockingCancelableNativeSession {
+            session_id: "watchdog-permit-reclaim".to_string(),
+            started: started_sender,
+            release: Arc::new(Mutex::new(release_receiver)),
+        }),
+        Some(permit),
+    )
+    .await
+    .expect("attach must succeed");
+
+    // Drive the worker into a wedged decode that still owns the permit: the stub
+    // blocks inside push_audio until released, exactly like a Metal decode that
+    // never completes.
+    worker
+        .commands
+        .send(NativeStreamingCommandEnvelope {
+            kind: NativeStreamingCommandKind::PushAudio,
+            command: NativeStreamingCommand::PushAudio(frame(1, 0, 1)),
+        })
+        .await
+        .expect("worker must accept the command");
+    started_receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("blocked decode started");
+    assert!(
+        supervisor.try_acquire(model_identity.clone()).is_err(),
+        "a wedged worker must still hold its admission permit"
+    );
+
+    // Decode watchdog fires: evict the wedged worker and reclaim its permit,
+    // even though the OS thread is still stuck inside push_audio.
+    abandon_stuck_native_streaming_worker(&worker.key, &worker.state, "test-permit-reclaim");
+    let reclaimed = supervisor
+        .try_acquire(model_identity.clone())
+        .expect("the watchdog must reclaim the wedged worker's admission permit");
+    assert!(
+        supervisor.try_acquire(model_identity.clone()).is_err(),
+        "the reclaimed slot is now held by the fresh session; admission stays at limit-1"
+    );
+
+    // Let the wedged thread finally return, long after the watchdog reclaimed
+    // its permit. Dropping the worker closes its channels so the thread exits
+    // its loop once push_audio returns; the per-key acquire count dropping to
+    // zero is the deterministic signal that the thread ran its late cleanup
+    // (which calls `take_permit` again -- and must find `None`).
+    let state = worker.state.clone();
+    drop(worker);
+    release_sender.send(()).expect("release the blocked decode");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while state.active_or_attaching.load(Ordering::Acquire) != 0 {
+        assert!(
+            Instant::now() < deadline,
+            "the abandoned worker thread must eventually return after release"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert!(
+        supervisor.try_acquire(model_identity.clone()).is_err(),
+        "a late-returning wedged decode must not double-release the admission slot \
+         the fresh session now holds"
+    );
+
+    drop(reclaimed);
+    assert!(
+        supervisor.try_acquire(model_identity).is_ok(),
+        "releasing the fresh session's permit frees the single slot exactly once"
+    );
+}
+
 #[test]
 fn abandoned_worker_warm_up_does_not_mark_model_resident() {
     // Regression test for the "late write-back after abandonment" hazard
@@ -2566,6 +2660,7 @@ async fn failed_native_streaming_attach_send_retires_the_activity_guard() {
         cancel_requested: Arc::new(AtomicBool::new(false)),
         activity,
         abandoned: AtomicBool::new(false),
+        permit: Mutex::new(None),
     });
     let send_result = sender
         .send(NativeStreamingWorkerMessage::Attach {
@@ -2576,7 +2671,6 @@ async fn failed_native_streaming_attach_send_retires_the_activity_guard() {
             outcomes: outcome_tx,
             finalize_requested: Arc::new(AtomicBool::new(false)),
             token,
-            model_session_permit: None,
         })
         .await;
     assert!(


### PR DESCRIPTION
## Summary
Two host-memory / session-admission fixes for 0.1.26.

## Changes
- core: host-memory admission is now swap-aware for unified memory. CPU and Metal (Apple Silicon unified memory) use a RAM + swap budget and silently proceed in the swap band -- a request that fits within RAM + swap runs (paging other processes out) instead of being refused because free RAM looks tight. Only a request that exceeds RAM + swap is rejected. Discrete GPU VRAM cannot page to swap, so it keeps a hard VRAM-based reject. Swap size is probed per platform (macOS vm.swapusage / Linux SwapTotal / Windows page file), fail-safe to 0 (RAM-only) when unavailable. The clear, build-time #159 rejection (needed/budget/suggest a smaller quant) is preserved for the truly-impossible case.
- server: the decode watchdog now reclaims the admission permit when it abandons a wedged worker. The permit lives in the per-attach token behind a single-owner Option::take handoff, so a permit is released exactly once whether the worker exits normally, is abandoned by the watchdog, or returns late -- no double-release, and a stuck worker no longer leaks the limit-1 slot until a daemon restart.

## Tests run
- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo nextest run --workspace (3294 passed / 0 failed)
- [x] cargo test --workspace --doc

## AI usage disclosure
YES -- implemented with AI assistance (code, tests, adversarial review).