### PR TITLE
feat(core): integrate 0.1.27 engine batch (perf, admission, slice-pipeline, dictation, gates)

### DIFF
--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -1513,47 +1513,20 @@ fn hip_gpu_targets() -> String {
         })
 }
 
+// Pure CUDA-arch-list parsing/defaults (`cuda_gpu_targets_from_raw`,
+// `normalize_cuda_gpu_targets`, `DEFAULT_CUDA_GPU_TARGETS`) live in
+// `src/cuda_targets.rs`, not here: that file is `include!`d verbatim (this
+// build script cannot depend on the crate it configures) and is ALSO
+// compiled as an ordinary `#[cfg(test)] mod` of this crate (see `lib.rs`),
+// so its regression canary -- guarding the class of bug fixed in #255/#196
+// where OpenASR's own CUDA arch-list default silently narrowed below
+// vendored ggml's sm_75 floor -- actually runs under `cargo nextest`. A
+// `#[cfg(test)] mod tests` living only in a build script is never collected
+// by any test runner, so before this the canary had no teeth.
+include!("src/cuda_targets.rs");
+
 fn cuda_gpu_targets() -> String {
     cuda_gpu_targets_from_raw(env::var("OPENASR_CUDA_GPU_TARGETS").ok().as_deref())
-}
-
-fn cuda_gpu_targets_from_raw(raw: Option<&str>) -> String {
-    raw.map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(normalize_cuda_gpu_targets)
-        .unwrap_or_else(|| {
-            // Default CUDA arch list for a released binary: sm_75 through sm_90.
-            // Floor is 75 (Turing: RTX 20xx, GTX 16xx, T4, 2080 Ti), not 70
-            // (Volta) or lower, because CUDA 13 removed device-code generation
-            // for Volta/Pascal/Maxwell outright -- those need a CUDA 12
-            // toolchain, which is a separate build leg (tracked, not this one).
-            // 75 itself is deprecated-but-still-buildable on CUDA 13.2: nvcc
-            // warns, but still emits working sm_75 SASS and PTX. No explicit
-            // `-real`/`-virtual` suffix means CMake emits both device code and
-            // PTX for every listed number, so this default also carries
-            // 75-virtual PTX that the CUDA driver JITs forward to any newer,
-            // unlisted architecture at load time -- the same forward-compat
-            // mechanism vendored ggml's own (non-native) CMakeLists.txt default
-            // relies on. Upper bound stops at 90 (Hopper): 120 (Blackwell)
-            // needs CUDA 12.8+ and a CMake new enough for the `f`/`a` suffix
-            // regex, which this default does not assume. Override with
-            // OPENASR_CUDA_GPU_TARGETS for a narrower/wider/newer set.
-            "75;80;86;89;90".to_string()
-        })
-}
-
-fn normalize_cuda_gpu_targets(raw: &str) -> String {
-    raw.split([',', ';', ' '])
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(|value| {
-            value
-                .strip_prefix("sm_")
-                .or_else(|| value.strip_prefix("SM_"))
-                .unwrap_or(value)
-        })
-        .collect::<Vec<_>>()
-        .join(";")
 }
 
 fn prepare_windows_hip_sdk_shim(target: &str, hip_path: &Path, out_dir: &Path) -> PathBuf {
@@ -1805,9 +1778,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        CudaTuning, HipTuning, cuda_gpu_targets_from_raw, ios_deployment_target_from,
-        macos_deployment_target_from, parse_bool_env, resolve_ggml_native_enabled, target_is_x86,
-        version_at_least,
+        CudaTuning, HipTuning, ios_deployment_target_from, macos_deployment_target_from,
+        parse_bool_env, resolve_ggml_native_enabled, target_is_x86, version_at_least,
     };
 
     #[test]
@@ -1884,49 +1856,11 @@ mod tests {
         assert!(!target_is_x86("aarch64-apple-darwin"));
     }
 
-    #[test]
-    fn cuda_targets_default_to_common_cloud_and_consumer_arches() {
-        assert_eq!(cuda_gpu_targets_from_raw(None), "75;80;86;89;90");
-        assert_eq!(cuda_gpu_targets_from_raw(Some("   ")), "75;80;86;89;90");
-    }
-
-    #[test]
-    fn cuda_targets_accept_common_arch_spellings() {
-        assert_eq!(
-            cuda_gpu_targets_from_raw(Some("sm_80,86; SM_89 90")),
-            "80;86;89;90"
-        );
-    }
-
-    #[test]
-    fn cuda_default_targets_are_not_narrower_than_vendored_ggml_default() {
-        // Regression guard for the class of bug in #255/#196: OpenASR's own
-        // default CUDA arch list silently excluded sm_75 (Turing), so a
-        // released CUDA binary hit "no kernel image available" on every
-        // 2080 Ti / T4 / RTX 20xx / GTX 16xx card. Cross-check against
-        // vendored ggml's own (non-native) CMakeLists.txt default, which is
-        // the actual upstream source of truth this default is trying to
-        // track: if a future ggml bump drops or narrows its own sm_75 floor,
-        // this test's first assertion fails and flags that our comment/
-        // reasoning in `cuda_gpu_targets_from_raw` needs re-deriving; if
-        // OpenASR's own default regresses below that floor, the second
-        // assertion fails instead.
-        let vendored_ggml_cmake =
-            include_str!("third_party/openasr-ggml/src/ggml-cuda/CMakeLists.txt");
-        assert!(
-            vendored_ggml_cmake.contains("75-virtual"),
-            "vendored ggml CMakeLists.txt no longer defaults to sm_75; re-check \
-             whether OpenASR's own CUDA_GPU_TARGETS floor of 75 is still \
-             upstream-aligned before changing it"
-        );
-        assert!(
-            cuda_gpu_targets_from_raw(None)
-                .split(';')
-                .any(|arch| arch == "75"),
-            "OpenASR's default CUDA arch list narrowed below upstream ggml's \
-             own sm_75 floor"
-        );
-    }
+    // The CUDA-arch-target parsing/default tests (including the sm_75-floor
+    // regression canary for #255/#196) moved to `src/cuda_targets.rs`, which
+    // this build script `include!`s -- see that file's doc comment for why:
+    // a `#[cfg(test)] mod` defined only in a build script is never collected
+    // by `cargo test`/`cargo nextest`, so it ran nowhere.
 
     #[test]
     fn cuda_tuning_defaults_match_fast_compile_safe_defaults() {

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1209,9 +1209,12 @@ fn run_native_transcription_impl(
     // by CLI and server -- both funnel through this function -- and runs
     // before `resolve_native_longform_policy` / dispatch, i.e. before the
     // real graph build, not in the server route layer (which the CLI never
-    // goes through). Wired per family via `native_capacity_admission_facts`
-    // (moss-transcribe-diarize, qwen3-asr); families without a wired deriver
-    // fall through to "allow".
+    // goes through). Wired per family via `native_capacity_admission_facts`;
+    // families without a wired deriver fall through to "allow". A request
+    // whose speaker plan runs the external attribution pass is additionally
+    // charged that pass's co-resident embedder footprint
+    // (`external_speaker_attribution_admission_bytes`) -- the pass this very
+    // check must run ahead of.
     let audio_duration_seconds = prepared_audio.len() as f32 / 16_000.0;
     // The backend this request will actually dispatch on, resolved the same
     // way `resolved_runtime_for_request` further down resolves it (explicit
@@ -1235,6 +1238,7 @@ fn run_native_transcription_impl(
         runtime_source.path(),
         audio_duration_seconds,
         admission_backend,
+        external_speaker_attribution_admission_bytes(speaker_plan),
     )?;
 
     // Compute speaker turns up front (independent of the transcript) so they can
@@ -2149,6 +2153,24 @@ fn apply_speaker_turns(
     transcription
 }
 
+/// One family's decoder-KV admission facts, derived from the loaded pack by
+/// the per-family dispatch ([`native_capacity_admission_facts`]) and consumed
+/// by [`enforce_native_host_memory_admission`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NativeKvAdmissionFacts {
+    geometry: crate::capacity::KvGeometry,
+    spec: crate::nn::decoder::LlmKvCacheSpec,
+    /// Decoder positions charged through the shared positional KV model
+    /// (`crate::capacity::kv_bytes_at_positions`).
+    required_positions: usize,
+    /// Exact resident bytes of decode state the family allocates at fixed
+    /// per-pack ceilings outside the positional model (the AED families'
+    /// full-span f16 self-KV arenas; see `cohere::capacity` /
+    /// `firered_aed::capacity`). Zero for the Qwen-shaped LLM families, whose
+    /// entire decode KV state is positional.
+    fixed_decode_state_bytes: u64,
+}
+
 /// This request's decoder KV admission facts for `moss-transcribe-diarize`,
 /// assembled from the loaded pack's decoder + adaptor metadata. `None` leaves
 /// the request admission-unchecked (fail open). See
@@ -2158,11 +2180,7 @@ fn moss_native_capacity_admission_facts(
     metadata: &crate::ggml_runtime::GgufMetadata,
     audio_duration_seconds: f32,
     backend: crate::ggml_runtime::GgmlCpuGraphBackend,
-) -> Option<(
-    crate::capacity::KvGeometry,
-    crate::nn::decoder::LlmKvCacheSpec,
-    usize,
-)> {
+) -> Option<NativeKvAdmissionFacts> {
     let decoder =
         crate::models::moss_transcribe_diarize::runtime_contract::parse_decoder_metadata(metadata)
             .ok()?;
@@ -2215,7 +2233,12 @@ fn moss_native_capacity_admission_facts(
         geometry.head_dim,
     )
     .to_spec();
-    Some((geometry, spec, required_positions))
+    Some(NativeKvAdmissionFacts {
+        geometry,
+        spec,
+        required_positions,
+        fixed_decode_state_bytes: 0,
+    })
 }
 
 /// This request's decoder KV admission facts for `qwen3-asr`, assembled from
@@ -2232,11 +2255,7 @@ fn qwen3_native_capacity_admission_facts(
     metadata: &crate::ggml_runtime::GgufMetadata,
     audio_duration_seconds: f32,
     backend: crate::ggml_runtime::GgmlCpuGraphBackend,
-) -> Option<(
-    crate::capacity::KvGeometry,
-    crate::nn::decoder::LlmKvCacheSpec,
-    usize,
-)> {
+) -> Option<NativeKvAdmissionFacts> {
     let execution_metadata =
         crate::models::qwen::runtime_contract::parse_qwen3_execution_metadata(metadata).ok()?;
     let geometry = crate::models::qwen::capacity::qwen3_kv_geometry(&execution_metadata);
@@ -2249,37 +2268,201 @@ fn qwen3_native_capacity_admission_facts(
         geometry.head_dim,
     )
     .to_spec();
-    Some((geometry, spec, required_positions))
+    Some(NativeKvAdmissionFacts {
+        geometry,
+        spec,
+        required_positions,
+        fixed_decode_state_bytes: 0,
+    })
+}
+
+/// This request's decoder KV admission facts for `firered-llm`, assembled
+/// from the loaded pack's Qwen2 decoder + adapter metadata
+/// (`crate::models::firered_llm::capacity`). `None` (a pack whose firered-llm
+/// metadata does not parse) leaves the request admission-unchecked (fail
+/// open). The KV element-type policy is resolved from the SAME
+/// `resolve_qwen_family_production_kv_cache_policy(backend, head_dim)` the
+/// real decoder allocates against
+/// (`Qwen3AsrLlmWholeDecoderGraphExecutor` construction).
+fn firered_llm_native_capacity_admission_facts(
+    metadata: &crate::ggml_runtime::GgufMetadata,
+    audio_duration_seconds: f32,
+    backend: crate::ggml_runtime::GgmlCpuGraphBackend,
+) -> Option<NativeKvAdmissionFacts> {
+    let decoder =
+        crate::models::firered_llm::runtime_contract::parse_firered_llm_decoder_metadata(metadata)
+            .ok()?;
+    let adapter =
+        crate::models::firered_llm::runtime_contract::parse_firered_llm_adapter_metadata(metadata)
+            .ok()?;
+    let geometry = crate::models::firered_llm::capacity::firered_llm_kv_geometry(&decoder);
+    let required_positions =
+        crate::models::firered_llm::capacity::firered_llm_admission_required_positions(
+            &adapter,
+            audio_duration_seconds,
+        );
+    let spec = crate::models::qwen::resolve_qwen_family_production_kv_cache_policy(
+        backend,
+        geometry.head_dim,
+    )
+    .to_spec();
+    Some(NativeKvAdmissionFacts {
+        geometry,
+        spec,
+        required_positions,
+        fixed_decode_state_bytes: 0,
+    })
+}
+
+/// This request's decoder KV admission facts for `mimo-asr`, assembled from
+/// the loaded pack's Qwen2 backbone + mel/tokenizer/input-local metadata
+/// (`crate::models::mimo_asr::capacity`). `None` (a pack whose mimo metadata
+/// does not parse) leaves the request admission-unchecked (fail open). Spec
+/// resolution matches the real decoder's constructor, as for the other
+/// Qwen-shaped families.
+fn mimo_asr_native_capacity_admission_facts(
+    metadata: &crate::ggml_runtime::GgufMetadata,
+    audio_duration_seconds: f32,
+    backend: crate::ggml_runtime::GgmlCpuGraphBackend,
+) -> Option<NativeKvAdmissionFacts> {
+    let llm = crate::models::mimo_asr::runtime_contract::parse_mimo_llm_metadata(metadata).ok()?;
+    let mel = crate::models::mimo_asr::runtime_contract::parse_mimo_mel_metadata(metadata).ok()?;
+    let audiotok =
+        crate::models::mimo_asr::runtime_contract::parse_mimo_audiotok_metadata(metadata).ok()?;
+    let inlocal =
+        crate::models::mimo_asr::runtime_contract::parse_mimo_inlocal_metadata(metadata).ok()?;
+    let geometry = crate::models::mimo_asr::capacity::mimo_asr_kv_geometry(&llm);
+    let required_positions =
+        crate::models::mimo_asr::capacity::mimo_asr_admission_required_positions(
+            &mel,
+            &audiotok,
+            &inlocal,
+            audio_duration_seconds,
+        );
+    let spec = crate::models::qwen::resolve_qwen_family_production_kv_cache_policy(
+        backend,
+        geometry.head_dim,
+    )
+    .to_spec();
+    Some(NativeKvAdmissionFacts {
+        geometry,
+        spec,
+        required_positions,
+        fixed_decode_state_bytes: 0,
+    })
+}
+
+/// This request's decoder KV admission facts for `cohere-transcribe`
+/// (`crate::models::cohere::capacity`): the fixed per-pack allocations the
+/// AED decoder runtime makes at construction -- chunk-cap cross-KV frames
+/// through the positional model, the full-context f16 self-KV arena as exact
+/// fixed bytes. Request-independent (see the capacity module's doc), and
+/// backend-independent (the arena element types do not vary by backend).
+/// `None` (unparseable cohere metadata) leaves the request
+/// admission-unchecked (fail open).
+fn cohere_native_capacity_admission_facts(
+    metadata: &crate::ggml_runtime::GgufMetadata,
+) -> Option<NativeKvAdmissionFacts> {
+    let execution_metadata =
+        crate::models::cohere::runtime_contract::parse_cohere_transcribe_execution_metadata(
+            metadata,
+        )
+        .ok()?;
+    Some(NativeKvAdmissionFacts {
+        geometry: crate::models::cohere::capacity::cohere_kv_geometry(&execution_metadata),
+        spec: crate::models::cohere::capacity::COHERE_ADMISSION_KV_SPEC,
+        required_positions: crate::models::cohere::capacity::cohere_admission_required_positions(
+            &execution_metadata,
+        ),
+        fixed_decode_state_bytes:
+            crate::models::cohere::capacity::cohere_admission_fixed_self_kv_bytes(
+                &execution_metadata,
+            ),
+    })
+}
+
+/// This request's decoder KV admission facts for `firered-aed`
+/// (`crate::models::firered_aed::capacity`): same fixed-allocation shape as
+/// cohere-transcribe -- chunk-cap cross-KV frames through the positional
+/// model, the full `decoder_pe_len` f16 self-KV arena as exact fixed bytes.
+/// `None` (unparseable firered-aed metadata) leaves the request
+/// admission-unchecked (fail open).
+fn firered_aed_native_capacity_admission_facts(
+    metadata: &crate::ggml_runtime::GgufMetadata,
+) -> Option<NativeKvAdmissionFacts> {
+    let execution_metadata =
+        crate::models::firered_aed::runtime_contract::parse_firered_aed_execution_metadata(
+            metadata,
+        )
+        .ok()?;
+    Some(NativeKvAdmissionFacts {
+        geometry: crate::models::firered_aed::capacity::firered_aed_kv_geometry(
+            &execution_metadata,
+        ),
+        spec: crate::models::firered_aed::capacity::FIRERED_AED_ADMISSION_KV_SPEC,
+        required_positions:
+            crate::models::firered_aed::capacity::firered_aed_admission_required_positions(
+                &execution_metadata,
+            ),
+        fixed_decode_state_bytes:
+            crate::models::firered_aed::capacity::firered_aed_admission_fixed_self_kv_bytes(
+                &execution_metadata,
+            ),
+    })
 }
 
 /// The per-family KV admission facts deriver for `model_architecture`, or
 /// `None` when this architecture has no wired deriver (fail open -- left
 /// admission-unchecked, exactly as before this check existed). Each wired arm
-/// derives `(KvGeometry, kv-cache spec, required decoder positions)` from the
-/// loaded pack; a new family opts in by adding an arm plus its own family-level
-/// `capacity` deriver, keeping the model-agnostic admission machinery
-/// (`crate::capacity`) free of family geometry.
+/// derives its [`NativeKvAdmissionFacts`] from the loaded pack; a new family
+/// opts in by adding an arm plus its own family-level `capacity` deriver,
+/// keeping the model-agnostic admission machinery (`crate::capacity`) free of
+/// family geometry.
 ///
-/// Wired today: moss-transcribe-diarize and qwen3-asr. The remaining `Derived`
-/// families (firered-llm, mimo-asr, cohere-transcribe) still carry only a
-/// `PackCarried` frontend-rate placeholder in `crate::capacity`'s registry and
-/// stay unchecked until their audio-token rate is derived.
+/// Wired today: every `Derived`-capacity family (moss-transcribe-diarize,
+/// qwen3-asr, firered-llm, mimo-asr, cohere-transcribe) plus firered-aed
+/// (whose fixed-ceiling decoder arenas are large enough to matter even
+/// though its audio bound lives elsewhere). Families that keep no
+/// per-request decoder KV state worth charging (CTC/transducer shapes, the
+/// small `BoundedElsewhere` decoders) stay unchecked.
 fn native_capacity_admission_facts(
     model_architecture: &str,
     metadata: &crate::ggml_runtime::GgufMetadata,
     audio_duration_seconds: f32,
     backend: crate::ggml_runtime::GgmlCpuGraphBackend,
-) -> Option<(
-    crate::capacity::KvGeometry,
-    crate::nn::decoder::LlmKvCacheSpec,
-    usize,
-)> {
+) -> Option<NativeKvAdmissionFacts> {
     if model_architecture == crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID {
         moss_native_capacity_admission_facts(metadata, audio_duration_seconds, backend)
     } else if model_architecture == crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID {
         qwen3_native_capacity_admission_facts(metadata, audio_duration_seconds, backend)
+    } else if model_architecture == crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID {
+        firered_llm_native_capacity_admission_facts(metadata, audio_duration_seconds, backend)
+    } else if model_architecture == crate::arch::MIMO_ASR_GGML_ARCHITECTURE_ID {
+        mimo_asr_native_capacity_admission_facts(metadata, audio_duration_seconds, backend)
+    } else if model_architecture == crate::arch::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID {
+        cohere_native_capacity_admission_facts(metadata)
+    } else if model_architecture == crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID {
+        firered_aed_native_capacity_admission_facts(metadata)
     } else {
         None
+    }
+}
+
+/// The auxiliary resident bytes this request's speaker plan adds to the
+/// admission charge: the VAD + speaker-embedder attribution pass
+/// (`compute_speaker_attribution`) runs right after admission for the
+/// `External` plan only, so only that plan is charged
+/// (`crate::diarize::embed::speaker_attribution_admission_bytes`'s
+/// conservative pack-size-based estimate). `Off` and `InDecoder` requests
+/// never run that pass and must not be made stricter by it. (The `InDecoder`
+/// plan's later voice-id naming stage can also touch the embedder; its
+/// working set is bounded by the same figure but is deliberately not charged
+/// -- degrading naming is that stage's own documented fallback, never an
+/// admission failure.)
+fn external_speaker_attribution_admission_bytes(speaker_plan: SpeakerPlan) -> u64 {
+    match speaker_plan {
+        SpeakerPlan::External => crate::diarize::embed::speaker_attribution_admission_bytes(),
+        SpeakerPlan::Off | SpeakerPlan::InDecoder => 0,
     }
 }
 
@@ -2288,20 +2471,25 @@ fn native_capacity_admission_facts(
 /// KV cache plus weights exceed the host memory budget, the root cause class
 /// behind an opaque `ggml cpu graph backend buffer allocation failed` instead
 /// of an actionable error (issue #159 on CPU). Wired per family through
-/// [`native_capacity_admission_facts`] (moss-transcribe-diarize, qwen3-asr);
-/// families without a wired deriver stay unchecked. Fails OPEN whenever the
-/// answer is uncertain rather than definite -- an unresolvable family,
-/// unprobeable host RAM, or an unreadable pack file all fall through to
-/// "allow" (`crate::capacity`'s invariant: refuse only when certain it will
-/// not fit; the worst case is then no worse than today's raw ggml error).
+/// [`native_capacity_admission_facts`]; families without a wired deriver stay
+/// unchecked. `external_speaker_attribution_bytes` is the extra resident
+/// charge for a request that will run the VAD + speaker-embedder attribution
+/// pass right after admission
+/// ([`external_speaker_attribution_admission_bytes`]; `0` for every other
+/// request). Fails OPEN whenever the answer is uncertain rather than
+/// definite -- an unresolvable family, unprobeable host RAM, or an
+/// unreadable pack file all fall through to "allow" (`crate::capacity`'s
+/// invariant: refuse only when certain it will not fit; the worst case is
+/// then no worse than today's raw ggml error).
 fn enforce_native_host_memory_admission(
     model_architecture: &str,
     metadata: &crate::ggml_runtime::GgufMetadata,
     pack_path: &Path,
     audio_duration_seconds: f32,
     backend: crate::ggml_runtime::GgmlCpuGraphBackend,
+    external_speaker_attribution_bytes: u64,
 ) -> Result<(), BackendError> {
-    let Some((geometry, spec, required_positions)) = native_capacity_admission_facts(
+    let Some(facts) = native_capacity_admission_facts(
         model_architecture,
         metadata,
         audio_duration_seconds,
@@ -2316,10 +2504,13 @@ fn enforce_native_host_memory_admission(
         return Ok(());
     };
     if let Err(rejection) = crate::capacity::evaluate_host_memory_admission(
-        &geometry,
-        spec,
-        required_positions,
+        &facts.geometry,
+        facts.spec,
+        facts.required_positions,
         pack_metadata.len(),
+        facts
+            .fixed_decode_state_bytes
+            .saturating_add(external_speaker_attribution_bytes),
         host_total_memory_bytes,
         host_memory_admission_domain_for_backend(backend),
     ) {
@@ -3354,18 +3545,18 @@ mod tests {
         let backend = crate::ggml_runtime::GgmlCpuGraphBackend::Cpu;
 
         // A short recording costs far fewer positions than the ceiling.
-        let (short_geometry, short_spec, short_positions) =
-            moss_native_capacity_admission_facts(&metadata, 11.04, backend)
-                .expect("shipped-shaped metadata must derive admission facts");
+        let short = moss_native_capacity_admission_facts(&metadata, 11.04, backend)
+            .expect("shipped-shaped metadata must derive admission facts");
         assert_eq!(
-            short_geometry,
+            short.geometry,
             crate::capacity::KvGeometry {
                 n_layers: 28,
                 kv_heads: 8,
                 head_dim: 128,
             }
         );
-        assert_eq!(short_spec, crate::nn::decoder::LlmKvCacheSpec::Q8_0);
+        assert_eq!(short.spec, crate::nn::decoder::LlmKvCacheSpec::Q8_0);
+        assert_eq!(short.fixed_decode_state_bytes, 0);
         // Cross-check against the same derivation function, called directly
         // on the fixture the capacity module's own regression anchors use --
         // not a hand-computed magic number.
@@ -3374,17 +3565,19 @@ mod tests {
                 &crate::models::moss_transcribe_diarize::capacity::shipped_pack_decoder_fixture(),
                 crate::models::moss_transcribe_diarize::capacity::SHIPPED_MERGE_SIZE,
             );
-        assert_eq!(short_positions, derivation.required_positions_for_chunks(1));
+        assert_eq!(
+            short.required_positions,
+            derivation.required_positions_for_chunks(1)
+        );
 
         // A multi-hour recording is clamped at the 300s integral window (10
         // chunks -> 7806 positions, the same number
         // `required_positions_walks_the_moss_window_from_both_sides` pins in
         // `crate::capacity`'s own tests) rather than judged by its full length.
-        let (_, _, long_positions) =
-            moss_native_capacity_admission_facts(&metadata, 3600.0, backend)
-                .expect("shipped-shaped metadata must derive admission facts");
-        assert_eq!(long_positions, 7806);
-        assert!(short_positions < long_positions);
+        let long = moss_native_capacity_admission_facts(&metadata, 3600.0, backend)
+            .expect("shipped-shaped metadata must derive admission facts");
+        assert_eq!(long.required_positions, 7806);
+        assert!(short.required_positions < long.required_positions);
     }
 
     /// A discrete GPU backend must stay on `DEFAULT`: phase-1 Q8_0 KV is
@@ -3394,13 +3587,13 @@ mod tests {
     #[test]
     fn moss_capacity_admission_facts_stay_default_on_discrete_gpu_backend() {
         let metadata = moss_shipped_pack_metadata_for_test();
-        let (_, spec, _) = moss_native_capacity_admission_facts(
+        let facts = moss_native_capacity_admission_facts(
             &metadata,
             11.04,
             crate::ggml_runtime::GgmlCpuGraphBackend::Gpu,
         )
         .expect("shipped-shaped metadata must derive admission facts");
-        assert_eq!(spec, crate::nn::decoder::LlmKvCacheSpec::DEFAULT);
+        assert_eq!(facts.spec, crate::nn::decoder::LlmKvCacheSpec::DEFAULT);
     }
 
     /// The false-reject regression this fix closes: at the real Q8_0 spec a
@@ -3415,18 +3608,25 @@ mod tests {
         // Derive both specs' facts from the same production dispatch real
         // requests go through, at the two backends that produce each spec,
         // rather than hand-typing geometry/positions here.
-        let (geometry, q8_spec, required_positions) = moss_native_capacity_admission_facts(
+        let q8_facts = moss_native_capacity_admission_facts(
             &metadata,
             3600.0,
             crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
         )
         .expect("shipped-shaped metadata must derive admission facts");
-        let (_, default_spec, default_positions) = moss_native_capacity_admission_facts(
+        let default_facts = moss_native_capacity_admission_facts(
             &metadata,
             3600.0,
             crate::ggml_runtime::GgmlCpuGraphBackend::Gpu,
         )
         .expect("shipped-shaped metadata must derive admission facts");
+        let (geometry, q8_spec, required_positions) = (
+            q8_facts.geometry,
+            q8_facts.spec,
+            q8_facts.required_positions,
+        );
+        let (default_spec, default_positions) =
+            (default_facts.spec, default_facts.required_positions);
         assert_eq!(q8_spec, crate::nn::decoder::LlmKvCacheSpec::Q8_0);
         assert_eq!(default_spec, crate::nn::decoder::LlmKvCacheSpec::DEFAULT);
         assert_eq!(required_positions, default_positions);
@@ -3472,6 +3672,7 @@ mod tests {
                 crate::nn::decoder::LlmKvCacheSpec::Q8_0,
                 required_positions,
                 pack_bytes_on_disk,
+                0,
                 host_total_memory_bytes,
                 crate::capacity::MemoryAdmissionDomain::DiscreteVram,
             )
@@ -3484,6 +3685,7 @@ mod tests {
                 crate::nn::decoder::LlmKvCacheSpec::DEFAULT,
                 required_positions,
                 pack_bytes_on_disk,
+                0,
                 host_total_memory_bytes,
                 crate::capacity::MemoryAdmissionDomain::DiscreteVram,
             )
@@ -3492,25 +3694,32 @@ mod tests {
         );
     }
 
-    /// A family this round has not wired (its frontend audio-token rate is
-    /// still an unresolved `PackCarried` placeholder, see
-    /// `crate::capacity`'s frontend registry) must return `None`, not guess --
-    /// opt-in, not a blanket check. firered-llm stands in for the still-unwired
-    /// `Derived` families (firered-llm / mimo-asr / cohere-transcribe).
+    /// A family without a wired deriver must be allowed through
+    /// unconditionally, not guessed at -- opt-in, not a blanket check
+    /// (whisper's fixed 30s window keeps its decode state small enough that
+    /// no deriver is wired). And a WIRED family whose pack metadata does not
+    /// parse must equally fall through to "allow" (fail open), never refuse
+    /// on a guess -- firered-llm against moss-shaped metadata exercises that.
     #[test]
     fn enforce_native_host_memory_admission_skips_unwired_families() {
         let metadata = moss_shipped_pack_metadata_for_test();
-        assert!(
-            enforce_native_host_memory_admission(
-                crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID,
-                &metadata,
-                Path::new("/nonexistent/does-not-matter.oasr"),
-                3600.0,
-                crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
-            )
-            .is_ok(),
-            "an unwired family must be allowed through unconditionally, not guessed at"
-        );
+        for architecture in [
+            crate::arch::WHISPER_GGML_ARCHITECTURE_ID,
+            crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID,
+        ] {
+            assert!(
+                enforce_native_host_memory_admission(
+                    architecture,
+                    &metadata,
+                    Path::new("/nonexistent/does-not-matter.oasr"),
+                    3600.0,
+                    crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+                    0,
+                )
+                .is_ok(),
+                "'{architecture}' must be allowed through unconditionally, not guessed at"
+            );
+        }
     }
 
     /// Synthetic GGUF metadata carrying the real 1.7B qwen3-asr checkpoint's
@@ -3560,7 +3769,7 @@ mod tests {
     #[test]
     fn qwen3_capacity_admission_facts_derive_from_pack_metadata() {
         let metadata = qwen3_shipped_pack_metadata_for_test();
-        let (geometry, spec, positions) = native_capacity_admission_facts(
+        let facts = native_capacity_admission_facts(
             crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID,
             &metadata,
             30.0,
@@ -3568,17 +3777,18 @@ mod tests {
         )
         .expect("qwen3-shaped metadata must derive admission facts");
         assert_eq!(
-            geometry,
+            facts.geometry,
             crate::capacity::KvGeometry {
                 n_layers: 28,
                 kv_heads: 8,
                 head_dim: 128,
             }
         );
-        assert_eq!(spec, crate::nn::decoder::LlmKvCacheSpec::Q8_0);
+        assert_eq!(facts.spec, crate::nn::decoder::LlmKvCacheSpec::Q8_0);
+        assert_eq!(facts.fixed_decode_state_bytes, 0);
         // Cross-checked against the family deriver directly (not a magic number).
         assert_eq!(
-            positions,
+            facts.required_positions,
             crate::models::qwen::capacity::qwen3_admission_required_positions(
                 &crate::models::qwen::runtime_contract::parse_qwen3_execution_metadata(&metadata)
                     .expect("parses"),
@@ -3594,13 +3804,14 @@ mod tests {
     #[test]
     fn enforce_native_host_memory_admission_rejects_oversized_qwen3_on_tiny_host() {
         let metadata = qwen3_shipped_pack_metadata_for_test();
-        let (geometry, spec, positions) = native_capacity_admission_facts(
+        let facts = native_capacity_admission_facts(
             crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID,
             &metadata,
             30.0,
             crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
         )
         .expect("qwen3-shaped metadata must derive admission facts");
+        let (geometry, spec, positions) = (facts.geometry, facts.spec, facts.required_positions);
         // The real shipped qwen3-asr-1.7b fp16 pack is ~4.7 GiB; on a 2 GiB
         // host the pack alone plainly overflows RAM + (unprobeable) swap.
         let pack_bytes_on_disk: u64 = 4_704_801_920;
@@ -3610,6 +3821,7 @@ mod tests {
             spec,
             positions,
             pack_bytes_on_disk,
+            0,
             tiny_host_bytes,
             crate::capacity::MemoryAdmissionDomain::UnifiedMemory { swap_bytes: 0 },
         )
@@ -3630,11 +3842,446 @@ mod tests {
                 spec,
                 positions,
                 pack_bytes_on_disk,
+                0,
                 roomy_host_bytes,
                 crate::capacity::MemoryAdmissionDomain::UnifiedMemory { swap_bytes: 0 },
             )
             .is_ok(),
             "the same qwen3 request must be admitted on a 64 GiB host"
+        );
+    }
+
+    /// Synthetic GGUF metadata carrying the real FireRedASR2-LLM checkpoint's
+    /// decoder + adapter facts (the same values `firered_llm::runtime_contract`'s
+    /// own fixture parses), so the admission dispatch reads real pack metadata
+    /// deterministically and without a pack file. Encoder keys are omitted on
+    /// purpose: the admission deriver only parses the decoder + adapter
+    /// subset.
+    fn firered_llm_shipped_pack_metadata_for_test() -> crate::ggml_runtime::GgufMetadata {
+        use crate::ggml_runtime::GgufMetadataValue as V;
+        use crate::models::firered_llm::runtime_contract::*;
+
+        let mut values = std::collections::BTreeMap::new();
+        for (key, value) in [
+            (FIRERED_LLM_ADAPTER_DOWNSAMPLE_RATE_KEY, 2u64),
+            (FIRERED_LLM_ADAPTER_LLM_DIM_KEY, 3584),
+            (FIRERED_LLM_LLM_N_LAYERS_KEY, 28),
+            (FIRERED_LLM_LLM_D_MODEL_KEY, 3584),
+            (FIRERED_LLM_LLM_N_HEADS_KEY, 28),
+            (FIRERED_LLM_LLM_N_KV_HEADS_KEY, 4),
+            (FIRERED_LLM_LLM_HEAD_DIM_KEY, 128),
+            (FIRERED_LLM_LLM_FFN_DIM_KEY, 18_944),
+            (FIRERED_LLM_LLM_VOCAB_SIZE_KEY, 152_064),
+            (FIRERED_LLM_LLM_MAX_POSITIONS_KEY, 32_768),
+            (FIRERED_LLM_CHATML_IM_START_TOKEN_ID_KEY, 151_644),
+            (FIRERED_LLM_CHATML_IM_END_TOKEN_ID_KEY, 151_645),
+            (FIRERED_LLM_ENDOFTEXT_TOKEN_ID_KEY, 151_643),
+            (FIRERED_LLM_SPEECH_TOKEN_ID_KEY, 151_646),
+        ] {
+            values.insert(key.to_string(), V::U64(value));
+        }
+        crate::ggml_runtime::GgufMetadata::from_values_for_test(values)
+    }
+
+    /// firered-llm is now wired: geometry off the pack's Qwen2 decoder keys,
+    /// spec from the same resolver the real decoder allocates against (Q8_0
+    /// on CPU at head_dim 128), positions cross-checked against the family
+    /// deriver, and the single-decode clamp holding for a multi-hour file.
+    #[test]
+    fn firered_llm_capacity_admission_facts_derive_from_pack_metadata() {
+        let metadata = firered_llm_shipped_pack_metadata_for_test();
+        let facts = native_capacity_admission_facts(
+            crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID,
+            &metadata,
+            40.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("firered-llm-shaped metadata must derive admission facts");
+        assert_eq!(
+            facts.geometry,
+            crate::capacity::KvGeometry {
+                n_layers: 28,
+                kv_heads: 4,
+                head_dim: 128,
+            }
+        );
+        assert_eq!(facts.spec, crate::nn::decoder::LlmKvCacheSpec::Q8_0);
+        assert_eq!(facts.fixed_decode_state_bytes, 0);
+        let adapter =
+            crate::models::firered_llm::runtime_contract::parse_firered_llm_adapter_metadata(
+                &metadata,
+            )
+            .expect("parses");
+        assert_eq!(
+            facts.required_positions,
+            crate::models::firered_llm::capacity::firered_llm_admission_required_positions(
+                &adapter, 40.0,
+            )
+        );
+        // A multi-hour recording clamps to the 40s single-decode window.
+        let at_hour = native_capacity_admission_facts(
+            crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID,
+            &metadata,
+            3600.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("facts");
+        assert_eq!(at_hour, facts);
+    }
+
+    /// Synthetic GGUF metadata carrying the real MiMo-Audio checkpoint's
+    /// facts (the same values `mimo_asr::runtime_contract`'s own fixture
+    /// parses), value-typed exactly as the converter bakes them (u32 scalars,
+    /// f32 hparams, bool flags, the u32 codebook-size array).
+    fn mimo_shipped_pack_metadata_for_test() -> crate::ggml_runtime::GgufMetadata {
+        use crate::ggml_runtime::GgufMetadataValue as V;
+
+        let mut values = std::collections::BTreeMap::new();
+        for (key, value) in [
+            ("mimo.llm.block_count", 36u32),
+            ("mimo.llm.embedding_length", 4096),
+            ("mimo.llm.feed_forward_length", 11_008),
+            ("mimo.llm.attention.head_count", 32),
+            ("mimo.llm.attention.head_count_kv", 8),
+            ("mimo.llm.attention.key_length", 128),
+            ("mimo.llm.vocab_size", 151_680),
+            ("mimo.llm.context_length", 8192),
+            ("mimo.audio.channels", 8),
+            ("mimo.audio.group_size", 4),
+            ("mimo.inlocal.block_count", 6),
+            ("mimo.inlocal.embedding_length", 1024),
+            ("mimo.inlocal.attention.head_count", 64),
+            ("mimo.inlocal.attention.head_dim", 16),
+            ("mimo.inlocal.feed_forward_length", 4096),
+            ("mimo.tok.block_count", 32),
+            ("mimo.tok.embedding_length", 1280),
+            ("mimo.tok.attention.head_count", 20),
+            ("mimo.tok.feed_forward_length", 5120),
+            ("mimo.tok.encoder.skip_layer_id", 3),
+            ("mimo.tok.conv.kernel_size", 3),
+            ("mimo.tok.conv1.stride", 1),
+            ("mimo.tok.conv2.stride", 2),
+            ("mimo.tok.down_sample.stride", 2),
+            ("mimo.tok.rvq.num_quantizers_packed", 8),
+            ("mimo.mel.sample_rate", 24_000),
+            ("mimo.mel.n_fft", 960),
+            ("mimo.mel.hop_length", 240),
+            ("mimo.mel.win_length", 960),
+            ("mimo.mel.n_mels", 128),
+            ("mimo.special.eos_id", 151_643),
+            ("mimo.special.im_start_id", 151_644),
+            ("mimo.special.im_end_id", 151_645),
+            ("mimo.special.sosp_id", 151_665),
+            ("mimo.special.eosp_id", 151_666),
+            ("mimo.special.empty_id", 151_667),
+            ("mimo.special.eot_id", 151_672),
+            ("mimo.special.eostm_id", 151_671),
+        ] {
+            values.insert(key.to_string(), V::U32(value));
+        }
+        for (key, value) in [
+            ("mimo.llm.attention.layer_norm_rms_epsilon", 1e-6f32),
+            ("mimo.llm.rope.freq_base", 640_000.0),
+            ("mimo.inlocal.rope.freq_base", 640_000.0),
+            ("mimo.tok.rope.freq_base", 10_000.0),
+            ("mimo.mel.log_clip", 1e-7),
+        ] {
+            values.insert(key.to_string(), V::F32(value));
+        }
+        for (key, value) in [
+            ("mimo.llm.attention.qkv_bias", true),
+            ("mimo.llm.attention.qk_norm", false),
+            ("mimo.inlocal.full_attention", true),
+        ] {
+            values.insert(key.to_string(), V::Bool(value));
+        }
+        values.insert(
+            "mimo.tok.rvq.codebook_sizes".to_string(),
+            V::U32Array(vec![1024, 1024, 128, 128, 128, 128, 128, 128]),
+        );
+        crate::ggml_runtime::GgufMetadata::from_values_for_test(values)
+    }
+
+    /// mimo-asr is now wired: geometry off the pack's Qwen2 backbone keys,
+    /// spec from the shared resolver (Q8_0 on CPU at head_dim 128), positions
+    /// cross-checked against the family deriver, and the single-decode clamp
+    /// holding for a multi-hour file.
+    #[test]
+    fn mimo_asr_capacity_admission_facts_derive_from_pack_metadata() {
+        let metadata = mimo_shipped_pack_metadata_for_test();
+        let facts = native_capacity_admission_facts(
+            crate::arch::MIMO_ASR_GGML_ARCHITECTURE_ID,
+            &metadata,
+            30.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("mimo-shaped metadata must derive admission facts");
+        assert_eq!(
+            facts.geometry,
+            crate::capacity::KvGeometry {
+                n_layers: 36,
+                kv_heads: 8,
+                head_dim: 128,
+            }
+        );
+        assert_eq!(facts.spec, crate::nn::decoder::LlmKvCacheSpec::Q8_0);
+        assert_eq!(facts.fixed_decode_state_bytes, 0);
+        let mel = crate::models::mimo_asr::runtime_contract::parse_mimo_mel_metadata(&metadata)
+            .expect("parses");
+        let audiotok =
+            crate::models::mimo_asr::runtime_contract::parse_mimo_audiotok_metadata(&metadata)
+                .expect("parses");
+        let inlocal =
+            crate::models::mimo_asr::runtime_contract::parse_mimo_inlocal_metadata(&metadata)
+                .expect("parses");
+        assert_eq!(
+            facts.required_positions,
+            crate::models::mimo_asr::capacity::mimo_asr_admission_required_positions(
+                &mel, &audiotok, &inlocal, 30.0,
+            )
+        );
+        let at_hour = native_capacity_admission_facts(
+            crate::arch::MIMO_ASR_GGML_ARCHITECTURE_ID,
+            &metadata,
+            3600.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("facts");
+        assert_eq!(at_hour, facts);
+    }
+
+    /// Synthetic GGUF metadata carrying the real cohere-transcribe
+    /// checkpoint's facts (the same values `cohere::runtime_contract`'s
+    /// `base_metadata` fixture parses).
+    fn cohere_shipped_pack_metadata_for_test() -> crate::ggml_runtime::GgufMetadata {
+        use crate::arch::hparams::*;
+        use crate::ggml_runtime::GgufMetadataValue as V;
+
+        let mut values = std::collections::BTreeMap::new();
+        values.insert(
+            crate::arch::GENERAL_ARCHITECTURE_KEY.to_string(),
+            V::String(COHERE_TRANSCRIBE_ARCHITECTURE_VALUE.to_string()),
+        );
+        for (key, value) in [
+            (COHERE_TRANSCRIBE_VOCAB_SIZE_KEY, 50_000u64),
+            (COHERE_TRANSCRIBE_ENCODER_LAYERS_KEY, 48),
+            (COHERE_TRANSCRIBE_ENCODER_D_MODEL_KEY, 1280),
+            (COHERE_TRANSCRIBE_ENCODER_HEADS_KEY, 8),
+            (COHERE_TRANSCRIBE_ENCODER_HEAD_DIM_KEY, 160),
+            (COHERE_TRANSCRIBE_ENCODER_FFN_DIM_KEY, 5120),
+            (COHERE_TRANSCRIBE_ENCODER_CONV_KERNEL_KEY, 9),
+            (COHERE_TRANSCRIBE_DECODER_LAYERS_KEY, 8),
+            (COHERE_TRANSCRIBE_DECODER_D_MODEL_KEY, 1024),
+            (COHERE_TRANSCRIBE_DECODER_HEADS_KEY, 8),
+            (COHERE_TRANSCRIBE_DECODER_HEAD_DIM_KEY, 128),
+            (COHERE_TRANSCRIBE_DECODER_FFN_DIM_KEY, 4096),
+            (COHERE_TRANSCRIBE_DECODER_MAX_CONTEXT_KEY, 1024),
+            (COHERE_TRANSCRIBE_DECODER_START_TOKEN_ID_KEY, 13_764),
+            (COHERE_TRANSCRIBE_AUDIO_SAMPLE_RATE_KEY, 16_000),
+            (COHERE_TRANSCRIBE_AUDIO_MELS_COUNT_KEY, 128),
+            (COHERE_TRANSCRIBE_AUDIO_N_FFT_KEY, 512),
+            (COHERE_TRANSCRIBE_AUDIO_HOP_LENGTH_KEY, 160),
+            (COHERE_TRANSCRIBE_AUDIO_WIN_LENGTH_KEY, 400),
+        ] {
+            values.insert(key.to_string(), V::U64(value));
+        }
+        crate::ggml_runtime::GgufMetadata::from_values_for_test(values)
+    }
+
+    /// Synthetic GGUF metadata carrying the real FireRedASR-AED-L
+    /// checkpoint's facts (the same values `firered_aed::runtime_contract`'s
+    /// own fixture parses, decoder PE span 5000).
+    fn firered_aed_shipped_pack_metadata_for_test() -> crate::ggml_runtime::GgufMetadata {
+        use crate::ggml_runtime::GgufMetadataValue as V;
+        use crate::models::firered_aed::runtime_contract::*;
+
+        let mut values = std::collections::BTreeMap::new();
+        for (key, value) in [
+            (FIRERED_ENCODER_N_LAYERS_KEY, 16u64),
+            (FIRERED_ENCODER_D_MODEL_KEY, 1280),
+            (FIRERED_ENCODER_N_HEADS_KEY, 20),
+            (FIRERED_ENCODER_HEAD_DIM_KEY, 64),
+            (FIRERED_ENCODER_FFN_DIM_KEY, 5120),
+            (FIRERED_ENCODER_CONV_KERNEL_KEY, 33),
+            (FIRERED_ENCODER_SUBSAMPLE_CHANNELS_KEY, 32),
+            (FIRERED_ENCODER_SUBSAMPLE_OUT_DIM_KEY, 608),
+            (FIRERED_ENCODER_FEATURE_DIM_KEY, 80),
+            (FIRERED_ENCODER_PE_LEN_KEY, 9999),
+            (FIRERED_DECODER_N_LAYERS_KEY, 16),
+            (FIRERED_DECODER_FFN_DIM_KEY, 5120),
+            (FIRERED_DECODER_PE_LEN_KEY, 5000),
+            (FIRERED_VOCAB_SIZE_KEY, 7832),
+            (FIRERED_SOS_TOKEN_ID_KEY, 3),
+            (FIRERED_EOS_TOKEN_ID_KEY, 4),
+            (FIRERED_PAD_TOKEN_ID_KEY, 2),
+        ] {
+            values.insert(key.to_string(), V::U64(value));
+        }
+        crate::ggml_runtime::GgufMetadata::from_values_for_test(values)
+    }
+
+    /// The two AED families charge their decoder state as the fixed per-pack
+    /// allocations the runtime actually makes at construction: chunk-cap
+    /// cross-KV frames through the positional model, the full-span f16
+    /// self-KV arena as exact fixed bytes -- request-independent, so a
+    /// multi-hour file derives the identical facts as a short clip.
+    #[test]
+    fn aed_families_charge_fixed_decode_state_and_chunk_cap_cross_kv() {
+        let cohere_metadata = cohere_shipped_pack_metadata_for_test();
+        let cohere = native_capacity_admission_facts(
+            crate::arch::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
+            &cohere_metadata,
+            5.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("cohere-shaped metadata must derive admission facts");
+        assert_eq!(
+            cohere.geometry,
+            crate::capacity::KvGeometry {
+                n_layers: 8,
+                kv_heads: 8,
+                head_dim: 128,
+            }
+        );
+        assert_eq!(
+            cohere.spec,
+            crate::models::cohere::capacity::COHERE_ADMISSION_KV_SPEC
+        );
+        // The f16 self-KV arena at the full 1024-position context: 32 MiB.
+        assert_eq!(cohere.fixed_decode_state_bytes, 8 * 2 * 8 * 1024 * 128 * 2);
+        assert!(cohere.required_positions > 0);
+        assert_eq!(
+            native_capacity_admission_facts(
+                crate::arch::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
+                &cohere_metadata,
+                3600.0,
+                crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+            ),
+            Some(cohere)
+        );
+
+        let aed_metadata = firered_aed_shipped_pack_metadata_for_test();
+        let aed = native_capacity_admission_facts(
+            crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID,
+            &aed_metadata,
+            5.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("firered-aed-shaped metadata must derive admission facts");
+        assert_eq!(
+            aed.geometry,
+            crate::capacity::KvGeometry {
+                n_layers: 16,
+                kv_heads: 20,
+                head_dim: 64,
+            }
+        );
+        assert_eq!(
+            aed.spec,
+            crate::models::firered_aed::capacity::FIRERED_AED_ADMISSION_KV_SPEC
+        );
+        // The f16 self-KV arena at the full 5000-position PE span: ~390 MiB.
+        assert_eq!(aed.fixed_decode_state_bytes, 16 * 2 * 20 * 5000 * 64 * 2);
+        assert!(aed.required_positions > 0);
+        assert_eq!(
+            native_capacity_admission_facts(
+                crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID,
+                &aed_metadata,
+                3600.0,
+                crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+            ),
+            Some(aed)
+        );
+    }
+
+    /// The gap this round closes for every newly wired family: a pack whose
+    /// on-disk bytes plainly exceed any host budget is refused with the
+    /// typed, actionable `NativeInsufficientHostMemory` error BEFORE the
+    /// graph build -- through the real `enforce_native_host_memory_admission`
+    /// entry a request goes through, against a real (sparse) pack file --
+    /// while a small pack with the identical metadata is admitted.
+    #[test]
+    fn enforce_native_host_memory_admission_rejects_each_new_family_on_an_oversized_pack() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oversized = dir.path().join("oversized.oasr");
+        let file = std::fs::File::create(&oversized).expect("create sparse pack");
+        // 1 PiB sparse: larger than any host's RAM + swap, no disk cost.
+        file.set_len(1 << 50).expect("sparse set_len");
+        drop(file);
+        let modest = dir.path().join("modest.oasr");
+        std::fs::write(&modest, vec![0u8; 4096]).expect("write modest pack");
+
+        let cases: [(&str, crate::ggml_runtime::GgufMetadata); 4] = [
+            (
+                crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID,
+                firered_llm_shipped_pack_metadata_for_test(),
+            ),
+            (
+                crate::arch::MIMO_ASR_GGML_ARCHITECTURE_ID,
+                mimo_shipped_pack_metadata_for_test(),
+            ),
+            (
+                crate::arch::COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
+                cohere_shipped_pack_metadata_for_test(),
+            ),
+            (
+                crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID,
+                firered_aed_shipped_pack_metadata_for_test(),
+            ),
+        ];
+        for (architecture, metadata) in &cases {
+            let error = enforce_native_host_memory_admission(
+                architecture,
+                metadata,
+                &oversized,
+                30.0,
+                crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+                0,
+            )
+            .expect_err("a 1 PiB pack cannot fit any host");
+            match error {
+                BackendError::NativeInsufficientHostMemory { reason } => {
+                    assert!(
+                        reason.contains("core.native.capacity.admission:reject"),
+                        "'{architecture}' rejection must carry the provenance trailer: {reason}"
+                    );
+                    assert!(
+                        reason.contains("Try a smaller quantization"),
+                        "'{architecture}' rejection must stay actionable: {reason}"
+                    );
+                }
+                other => panic!("'{architecture}' must reject typed, got {other:?}"),
+            }
+            enforce_native_host_memory_admission(
+                architecture,
+                metadata,
+                &modest,
+                30.0,
+                crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+                0,
+            )
+            .unwrap_or_else(|error| {
+                panic!("'{architecture}' must admit a modest pack on this host: {error:?}")
+            });
+        }
+    }
+
+    /// Only a request whose speaker plan actually runs the external VAD +
+    /// speaker-embedder pass is charged its co-resident footprint; `Off` and
+    /// `InDecoder` requests must never be made stricter by it.
+    #[test]
+    fn external_speaker_attribution_bytes_charged_only_for_the_external_plan() {
+        assert_eq!(
+            external_speaker_attribution_admission_bytes(SpeakerPlan::Off),
+            0
+        );
+        assert_eq!(
+            external_speaker_attribution_admission_bytes(SpeakerPlan::InDecoder),
+            0
+        );
+        assert_eq!(
+            external_speaker_attribution_admission_bytes(SpeakerPlan::External),
+            crate::diarize::embed::speaker_attribution_admission_bytes()
         );
     }
 

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1209,9 +1209,9 @@ fn run_native_transcription_impl(
     // by CLI and server -- both funnel through this function -- and runs
     // before `resolve_native_longform_policy` / dispatch, i.e. before the
     // real graph build, not in the server route layer (which the CLI never
-    // goes through). Currently only wired for moss-transcribe-diarize; other
-    // native families fall through to "allow" until their frontend audio-
-    // token rate is derived (see `moss_native_capacity_admission_facts`).
+    // goes through). Wired per family via `native_capacity_admission_facts`
+    // (moss-transcribe-diarize, qwen3-asr); families without a wired deriver
+    // fall through to "allow".
     let audio_duration_seconds = prepared_audio.len() as f32 / 16_000.0;
     // The backend this request will actually dispatch on, resolved the same
     // way `resolved_runtime_for_request` further down resolves it (explicit
@@ -2149,17 +2149,11 @@ fn apply_speaker_turns(
     transcription
 }
 
-/// This request's decoder KV admission facts for
-/// `moss-transcribe-diarize` -- the only family whose frontend audio-token
-/// rate is actually derived and pinned today (see `crate::capacity`'s
-/// frontend registry doc comment: the other four `Derived` families,
-/// qwen3-asr, firered-llm, mimo-asr, cohere-transcribe, still only carry a
-/// `PackCarried` provenance placeholder, not a computed rate). `None` means
-/// this family stays admission-unchecked this round -- opt-in, matching
-/// `CapacityModelDeclaration`'s own philosophy, not an oversight; wiring a
-/// family here without a real derived rate would either guess (risking a
-/// false rejection) or check nothing, so it is left for that family's own
-/// frontend-geometry follow-up.
+/// This request's decoder KV admission facts for `moss-transcribe-diarize`,
+/// assembled from the loaded pack's decoder + adaptor metadata. `None` leaves
+/// the request admission-unchecked (fail open). See
+/// [`native_capacity_admission_facts`] for how the per-family derivers are
+/// dispatched and which families are wired.
 fn moss_native_capacity_admission_facts(
     metadata: &crate::ggml_runtime::GgufMetadata,
     audio_duration_seconds: f32,
@@ -2224,18 +2218,82 @@ fn moss_native_capacity_admission_facts(
     Some((geometry, spec, required_positions))
 }
 
+/// This request's decoder KV admission facts for `qwen3-asr`, assembled from
+/// the loaded pack's LLM decoder metadata (`crate::models::qwen::capacity`).
+/// qwen3's audio-token rate IS derivable from pack metadata (the mel
+/// hop/sample-rate plus the fixed 3x stride-2 conv stem), so unlike the other
+/// still-`PackCarried` `Derived` families it is wired here. `None` (a pack
+/// whose qwen metadata does not parse) leaves the request admission-unchecked
+/// (fail open). The KV element-type policy is resolved from the SAME
+/// `resolve_qwen_family_production_kv_cache_policy(backend, head_dim)` the real
+/// decoder allocates against, so admission's spec matches the runtime's (q8_0
+/// on CPU/Metal with native GQA at head_dim 128, not the worst-case DEFAULT).
+fn qwen3_native_capacity_admission_facts(
+    metadata: &crate::ggml_runtime::GgufMetadata,
+    audio_duration_seconds: f32,
+    backend: crate::ggml_runtime::GgmlCpuGraphBackend,
+) -> Option<(
+    crate::capacity::KvGeometry,
+    crate::nn::decoder::LlmKvCacheSpec,
+    usize,
+)> {
+    let execution_metadata =
+        crate::models::qwen::runtime_contract::parse_qwen3_execution_metadata(metadata).ok()?;
+    let geometry = crate::models::qwen::capacity::qwen3_kv_geometry(&execution_metadata);
+    let required_positions = crate::models::qwen::capacity::qwen3_admission_required_positions(
+        &execution_metadata,
+        audio_duration_seconds,
+    );
+    let spec = crate::models::qwen::resolve_qwen_family_production_kv_cache_policy(
+        backend,
+        geometry.head_dim,
+    )
+    .to_spec();
+    Some((geometry, spec, required_positions))
+}
+
+/// The per-family KV admission facts deriver for `model_architecture`, or
+/// `None` when this architecture has no wired deriver (fail open -- left
+/// admission-unchecked, exactly as before this check existed). Each wired arm
+/// derives `(KvGeometry, kv-cache spec, required decoder positions)` from the
+/// loaded pack; a new family opts in by adding an arm plus its own family-level
+/// `capacity` deriver, keeping the model-agnostic admission machinery
+/// (`crate::capacity`) free of family geometry.
+///
+/// Wired today: moss-transcribe-diarize and qwen3-asr. The remaining `Derived`
+/// families (firered-llm, mimo-asr, cohere-transcribe) still carry only a
+/// `PackCarried` frontend-rate placeholder in `crate::capacity`'s registry and
+/// stay unchecked until their audio-token rate is derived.
+fn native_capacity_admission_facts(
+    model_architecture: &str,
+    metadata: &crate::ggml_runtime::GgufMetadata,
+    audio_duration_seconds: f32,
+    backend: crate::ggml_runtime::GgmlCpuGraphBackend,
+) -> Option<(
+    crate::capacity::KvGeometry,
+    crate::nn::decoder::LlmKvCacheSpec,
+    usize,
+)> {
+    if model_architecture == crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID {
+        moss_native_capacity_admission_facts(metadata, audio_duration_seconds, backend)
+    } else if model_architecture == crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID {
+        qwen3_native_capacity_admission_facts(metadata, audio_duration_seconds, backend)
+    } else {
+        None
+    }
+}
+
 /// Reject this request before building its decode graph if its decoder KV
 /// footprint plainly does not fit this host's memory budget -- a pack whose
 /// KV cache plus weights exceed the host memory budget, the root cause class
 /// behind an opaque `ggml cpu graph backend buffer allocation failed` instead
-/// of an actionable error. Only wired for moss-transcribe-diarize today (see
-/// `moss_native_capacity_admission_facts`); qwen3-asr and the other native
-/// families are left unchecked until their frontend audio-token rate is
-/// derived. Fails OPEN whenever the answer is uncertain rather than
-/// definite -- an unresolvable family, unprobeable host RAM, or an unreadable
-/// pack file all fall through to "allow" (`crate::capacity`'s invariant:
-/// refuse only when certain it will not fit; the worst case is then no worse
-/// than today's raw ggml error).
+/// of an actionable error (issue #159 on CPU). Wired per family through
+/// [`native_capacity_admission_facts`] (moss-transcribe-diarize, qwen3-asr);
+/// families without a wired deriver stay unchecked. Fails OPEN whenever the
+/// answer is uncertain rather than definite -- an unresolvable family,
+/// unprobeable host RAM, or an unreadable pack file all fall through to
+/// "allow" (`crate::capacity`'s invariant: refuse only when certain it will
+/// not fit; the worst case is then no worse than today's raw ggml error).
 fn enforce_native_host_memory_admission(
     model_architecture: &str,
     metadata: &crate::ggml_runtime::GgufMetadata,
@@ -2243,12 +2301,12 @@ fn enforce_native_host_memory_admission(
     audio_duration_seconds: f32,
     backend: crate::ggml_runtime::GgmlCpuGraphBackend,
 ) -> Result<(), BackendError> {
-    if model_architecture != crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID {
-        return Ok(());
-    }
-    let Some((geometry, spec, required_positions)) =
-        moss_native_capacity_admission_facts(metadata, audio_duration_seconds, backend)
-    else {
+    let Some((geometry, spec, required_positions)) = native_capacity_admission_facts(
+        model_architecture,
+        metadata,
+        audio_duration_seconds,
+        backend,
+    ) else {
         return Ok(());
     };
     let Some(host_total_memory_bytes) = crate::host::host_total_memory_bytes() else {
@@ -3437,13 +3495,14 @@ mod tests {
     /// A family this round has not wired (its frontend audio-token rate is
     /// still an unresolved `PackCarried` placeholder, see
     /// `crate::capacity`'s frontend registry) must return `None`, not guess --
-    /// opt-in, not a blanket check.
+    /// opt-in, not a blanket check. firered-llm stands in for the still-unwired
+    /// `Derived` families (firered-llm / mimo-asr / cohere-transcribe).
     #[test]
     fn enforce_native_host_memory_admission_skips_unwired_families() {
         let metadata = moss_shipped_pack_metadata_for_test();
         assert!(
             enforce_native_host_memory_admission(
-                crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID,
+                crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID,
                 &metadata,
                 Path::new("/nonexistent/does-not-matter.oasr"),
                 3600.0,
@@ -3451,6 +3510,131 @@ mod tests {
             )
             .is_ok(),
             "an unwired family must be allowed through unconditionally, not guessed at"
+        );
+    }
+
+    /// Synthetic GGUF metadata carrying the real 1.7B qwen3-asr checkpoint's
+    /// shape (the same values `qwen::capacity`'s reference fixture and
+    /// `runtime_contract`'s tests use), so the admission dispatch reads real
+    /// pack metadata through `parse_qwen3_execution_metadata` deterministically
+    /// and without a pack file.
+    fn qwen3_shipped_pack_metadata_for_test() -> crate::ggml_runtime::GgufMetadata {
+        use crate::ggml_runtime::GgufMetadataValue as V;
+        use crate::models::qwen::runtime_contract::*;
+
+        let mut values = std::collections::BTreeMap::new();
+        values.insert(
+            crate::arch::GENERAL_ARCHITECTURE_KEY.to_string(),
+            V::String(QWEN3_ARCHITECTURE_VALUE.to_string()),
+        );
+        for (key, value) in [
+            (QWEN3_SAMPLE_RATE_KEY, 16_000u64),
+            (QWEN3_MELS_COUNT_KEY, 128),
+            (QWEN3_N_FFT_KEY, 400),
+            (QWEN3_WIN_LENGTH_KEY, 400),
+            (QWEN3_HOP_LENGTH_KEY, 160),
+            (QWEN3_AUDIO_LAYERS_KEY, 18),
+            (QWEN3_AUDIO_D_MODEL_KEY, 1280),
+            (QWEN3_AUDIO_HEADS_KEY, 20),
+            (QWEN3_LLM_LAYERS_KEY, 28),
+            (QWEN3_LLM_D_MODEL_KEY, 2048),
+            (QWEN3_LLM_HEADS_KEY, 16),
+            (QWEN3_LLM_KV_HEADS_KEY, 8),
+            (QWEN3_LLM_HEAD_DIM_KEY, 128),
+            (QWEN3_LLM_VOCAB_SIZE_KEY, 152_064),
+            (QWEN3_LLM_MAX_POSITIONS_KEY, 40_960),
+            (QWEN3_AUDIO_START_TOKEN_ID_KEY, 151_647),
+            (QWEN3_AUDIO_END_TOKEN_ID_KEY, 151_648),
+            (QWEN3_AUDIO_PAD_TOKEN_ID_KEY, 151_649),
+            (QWEN3_EOS_TOKEN_ID_KEY, 151_645),
+            (QWEN3_PAD_TOKEN_ID_KEY, 151_643),
+        ] {
+            values.insert(key.to_string(), V::U64(value));
+        }
+        crate::ggml_runtime::GgufMetadata::from_values_for_test(values)
+    }
+
+    /// qwen3-asr is now wired: the dispatch derives real facts from pack
+    /// metadata (KV geometry off the LLM decoder keys, spec from the same
+    /// resolver the decoder allocates against -- Q8_0 on CPU at head_dim 128).
+    #[test]
+    fn qwen3_capacity_admission_facts_derive_from_pack_metadata() {
+        let metadata = qwen3_shipped_pack_metadata_for_test();
+        let (geometry, spec, positions) = native_capacity_admission_facts(
+            crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID,
+            &metadata,
+            30.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("qwen3-shaped metadata must derive admission facts");
+        assert_eq!(
+            geometry,
+            crate::capacity::KvGeometry {
+                n_layers: 28,
+                kv_heads: 8,
+                head_dim: 128,
+            }
+        );
+        assert_eq!(spec, crate::nn::decoder::LlmKvCacheSpec::Q8_0);
+        // Cross-checked against the family deriver directly (not a magic number).
+        assert_eq!(
+            positions,
+            crate::models::qwen::capacity::qwen3_admission_required_positions(
+                &crate::models::qwen::runtime_contract::parse_qwen3_execution_metadata(&metadata)
+                    .expect("parses"),
+                30.0,
+            )
+        );
+    }
+
+    /// The gap this fix closes for qwen3: a pack whose weights plus decode KV
+    /// plainly exceed a small host's budget is refused with a typed,
+    /// actionable `NativeInsufficientHostMemory` error BEFORE the graph build,
+    /// not left to surface as an opaque ggml allocation failure (issue #159).
+    #[test]
+    fn enforce_native_host_memory_admission_rejects_oversized_qwen3_on_tiny_host() {
+        let metadata = qwen3_shipped_pack_metadata_for_test();
+        let (geometry, spec, positions) = native_capacity_admission_facts(
+            crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID,
+            &metadata,
+            30.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("qwen3-shaped metadata must derive admission facts");
+        // The real shipped qwen3-asr-1.7b fp16 pack is ~4.7 GiB; on a 2 GiB
+        // host the pack alone plainly overflows RAM + (unprobeable) swap.
+        let pack_bytes_on_disk: u64 = 4_704_801_920;
+        let tiny_host_bytes: u64 = 2 * 1024 * 1024 * 1024;
+        let rejection = crate::capacity::evaluate_host_memory_admission(
+            &geometry,
+            spec,
+            positions,
+            pack_bytes_on_disk,
+            tiny_host_bytes,
+            crate::capacity::MemoryAdmissionDomain::UnifiedMemory { swap_bytes: 0 },
+        )
+        .expect_err("a 4.7 GiB pack cannot fit a 2 GiB host");
+        let message = rejection.user_message();
+        assert!(message.contains("needs about"), "{message}");
+        assert!(message.contains("Try a smaller quantization"), "{message}");
+        assert!(
+            message.contains("core.native.capacity.admission:reject"),
+            "{message}"
+        );
+
+        // A comfortable host (64 GiB) admits the identical request.
+        let roomy_host_bytes: u64 = 64 * 1024 * 1024 * 1024;
+        assert!(
+            crate::capacity::evaluate_host_memory_admission(
+                &geometry,
+                spec,
+                positions,
+                pack_bytes_on_disk,
+                roomy_host_bytes,
+                crate::capacity::MemoryAdmissionDomain::UnifiedMemory { swap_bytes: 0 },
+            )
+            .is_ok(),
+            "the same qwen3 request must be admitted on a 64 GiB host"
         );
     }
 

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1,7 +1,11 @@
 use std::{
     collections::BTreeMap,
     path::Path,
-    sync::{Arc, Mutex, OnceLock},
+    sync::{
+        Arc, Mutex, OnceLock,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        mpsc,
+    },
     time::Instant,
 };
 
@@ -290,7 +294,15 @@ fn publish_align_progress(id: Option<&str>) {
 struct DecodeProgress {
     id: Option<String>,
     total_samples: u64,
-    decoded_samples: u64,
+    // Atomic so the concurrent slice pipeline (see `run_concurrent_slice_pipeline`)
+    // can accumulate completed-slice shares from several worker threads at once
+    // without a lock. Reports remain monotonic and race-free: the
+    // progress-registry already clamps every published fraction upward
+    // (`ProgressRegistry::raise`), so overlapping in-flight windows from
+    // concurrent slices can never move the bar backward. Under the serial path
+    // (`decoded_samples` touched from one thread only) the observable sequence is
+    // byte-identical to the previous plain-`u64` field.
+    decoded_samples: AtomicU64,
     decode_ceil: f32,
 }
 
@@ -305,19 +317,24 @@ impl DecodeProgress {
         Self {
             id,
             total_samples,
-            decoded_samples: 0,
+            decoded_samples: AtomicU64::new(0),
             decode_ceil,
         }
     }
 
     /// Mark one slice decoded (or skipped as silent -- silence still consumes its
     /// share of the audio timeline), advancing the bar by that slice's sample share.
-    fn complete_slice(&mut self, slice_samples: u64) {
-        self.decoded_samples = self.decoded_samples.saturating_add(slice_samples);
+    /// `&self` (not `&mut self`) so concurrent slice workers can each fold their
+    /// completed slice's share in; `fetch_add` makes the accumulation atomic.
+    fn complete_slice(&self, slice_samples: u64) {
+        let decoded = self
+            .decoded_samples
+            .fetch_add(slice_samples, Ordering::Relaxed)
+            .saturating_add(slice_samples);
         let ratio = if self.total_samples == 0 {
             1.0
         } else {
-            (self.decoded_samples as f32 / self.total_samples as f32).clamp(0.0, 1.0)
+            (decoded as f32 / self.total_samples as f32).clamp(0.0, 1.0)
         };
         publish_progress(
             self.id.as_deref(),
@@ -334,7 +351,8 @@ impl DecodeProgress {
     /// slice's full share regardless of where token interpolation left off.
     fn slice_progress_window(&self, slice_samples: u64) -> SliceProgressWindow {
         let total = (self.total_samples.max(1)) as f32;
-        let start_ratio = (self.decoded_samples as f32 / total).clamp(0.0, 1.0);
+        let decoded = self.decoded_samples.load(Ordering::Relaxed);
+        let start_ratio = (decoded as f32 / total).clamp(0.0, 1.0);
         let span_ratio = (slice_samples as f32 / total).clamp(0.0, 1.0 - start_ratio);
         SliceProgressWindow {
             start_fraction: self.decode_ceil * start_ratio,
@@ -421,7 +439,7 @@ fn run_dispatch_once_with_progress(
     request_options: GgmlAsrExecutionOptions,
     backend_preference: GgmlAsrBackendPreference,
     execution_context: &Arc<crate::RequestExecutionContext>,
-    decode_progress: &mut DecodeProgress,
+    decode_progress: &DecodeProgress,
     slice_samples: u64,
 ) -> Result<GgmlAsrExecutionResult, BackendError> {
     let window = decode_progress.slice_progress_window(slice_samples);
@@ -587,7 +605,7 @@ fn run_dispatch_once_with_progress_and_gpu_fallback(
     request_options: GgmlAsrExecutionOptions,
     backend_preference: GgmlAsrBackendPreference,
     execution_context: &Arc<crate::RequestExecutionContext>,
-    decode_progress: &mut DecodeProgress,
+    decode_progress: &DecodeProgress,
     slice_samples: u64,
     slice_label: &str,
     tracker: &mut GpuAllocationFallbackTracker,
@@ -672,6 +690,404 @@ fn run_dispatch_once_with_progress_and_gpu_fallback(
             Ok((result, Some(fallback)))
         }
     }
+}
+
+/// Upper bound on concurrent long-audio slice workers. Kept small: the win is
+/// filling encode/decode GPU bubbles (2-4 in-flight slices saturate a single
+/// GPU's execution pipeline, the same admission-concurrency effect the server
+/// path already relies on), not unbounded fan-out, and every extra worker costs
+/// another resident decoder runtime + KV cache.
+const SLICE_PIPELINE_MAX_WIDTH: usize = 4;
+
+/// Memory head-room the concurrent slice pipeline always leaves free when
+/// deciding how many workers fit, so it never claims the last of available
+/// memory and pushes the host into swap thrash.
+const SLICE_PIPELINE_MEMORY_RESERVE_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Floor for the per-worker memory estimate when the runtime pack size cannot be
+/// stat'd, so the capacity gate never divides available memory by an
+/// unrealistically small number and over-admits workers.
+const SLICE_PIPELINE_PER_WORKER_BYTES_FLOOR: u64 = 256 * 1024 * 1024;
+
+/// Requested concurrent slice-pipeline width from `OPENASR_SLICE_PIPELINE_WIDTH`.
+///
+/// Opt-in and conservative by default: unset, "0", "1", or an unparseable value
+/// all mean 1 -- the byte-identical serial + prompt-carry path. A value >= 2
+/// enables the carry-light concurrent path (subject to the capacity and
+/// slice-count gates in [`effective_slice_pipeline_width`]), clamped to
+/// [`SLICE_PIPELINE_MAX_WIDTH`]. Deliberately a runtime knob rather than a
+/// hard-coded default so the short-audio carry-vs-carry-light quality audit can
+/// pick the shipping default without a code change.
+fn slice_pipeline_requested_width() -> usize {
+    std::env::var("OPENASR_SLICE_PIPELINE_WIDTH")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(1)
+        .clamp(1, SLICE_PIPELINE_MAX_WIDTH)
+}
+
+/// Pure capacity gate for the concurrent slice pipeline: how many workers may
+/// run at once given `available_bytes` of head-room and a conservative
+/// `per_worker_bytes` estimate. Returns >= 1 and never exceeds `requested_width`
+/// or `decode_slice_count`. When nothing fits it falls back to 1 (serial), never
+/// 0 -- the gate can only ever reduce concurrency, so it cannot OOM the host.
+fn slice_pipeline_capped_width(
+    requested_width: usize,
+    decode_slice_count: usize,
+    available_bytes: Option<u64>,
+    per_worker_bytes: u64,
+    reserve_bytes: u64,
+) -> usize {
+    let ceiling = requested_width.min(decode_slice_count);
+    if ceiling <= 1 {
+        return 1;
+    }
+    // No memory probe on this host: honor the explicit opt-in rather than
+    // silently disabling it, matching the serve-batch VRAM-cap precedent
+    // (`serve_batch_vram_capped_max_batch` returns the request unchanged when no
+    // memory sample is available). The reserve plus the conservative per-worker
+    // estimate still bound the real risk.
+    let Some(available) = available_bytes else {
+        return ceiling;
+    };
+    if per_worker_bytes == 0 {
+        return ceiling;
+    }
+    let usable = available.saturating_sub(reserve_bytes);
+    let fits = (usable / per_worker_bytes).min(ceiling as u64) as usize;
+    fits.max(1)
+}
+
+/// Conservative per-worker memory estimate for the capacity gate: one runtime
+/// pack's on-disk size (with a floor). The mmapped weights are actually shared
+/// across workers, so charging each worker a whole pack over-estimates the true
+/// marginal cost (KV cache + compute buffers) and errs toward fewer workers --
+/// the safe direction for an OOM gate.
+fn slice_pipeline_per_worker_bytes(runtime_preflight: &GgmlAsrRuntimeSourcePreflight) -> u64 {
+    let pack_bytes = std::fs::metadata(runtime_preflight.runtime_source.path())
+        .map(|meta| meta.len())
+        .unwrap_or(0);
+    pack_bytes.max(SLICE_PIPELINE_PER_WORKER_BYTES_FLOOR)
+}
+
+/// Concurrent-width decision wired to the live host: caps `requested_width` by
+/// swap-aware available memory ([`crate::host::host_available_memory_bytes`], the
+/// capacity source) against the conservative per-worker estimate, and by the
+/// slice count. Returns 1 (serial) whenever concurrency is not worth it or does
+/// not fit. `slices.len()` is an upper bound on decodable slices (some may be
+/// suppressed as silent at run time); the gate only ever caps downward, so the
+/// bound is safe.
+fn effective_slice_pipeline_width(
+    requested_width: usize,
+    slices: &[crate::longform::AudioSlice],
+    runtime_preflight: &GgmlAsrRuntimeSourcePreflight,
+) -> usize {
+    if requested_width <= 1 || slices.len() <= 1 {
+        return 1;
+    }
+    slice_pipeline_capped_width(
+        requested_width,
+        slices.len(),
+        crate::host::host_available_memory_bytes(),
+        slice_pipeline_per_worker_bytes(runtime_preflight),
+        SLICE_PIPELINE_MEMORY_RESERVE_BYTES,
+    )
+}
+
+/// One slice's place in the concurrent pipeline: the slice itself, its sample
+/// weight for progress, and whether it was suppressed as silent (silence is
+/// decided once up front on the main thread, exactly as the serial loop does).
+struct SlicePlanItem {
+    slice: crate::longform::AudioSlice,
+    slice_samples: u64,
+    silent: bool,
+}
+
+/// A worker's decoded output for one slice, carried back to the main thread for
+/// in-order assembly. Deliberately owns only the plain data the ordered
+/// integration needs -- text, segments, truncation, GPU-fallback tag -- so
+/// nothing family-specific or non-`Send` crosses the thread boundary.
+struct DecodedSlice {
+    text: String,
+    segments: Vec<Segment>,
+    truncation: Option<DecodeTruncation>,
+    fallback: Option<SliceGpuFallback>,
+}
+
+/// Borrowed context for one concurrent long-audio slice-pipeline run. Grouped
+/// into a struct so the entry point stays one readable call instead of a
+/// twenty-argument function.
+struct ConcurrentSlicePipeline<'a> {
+    width: usize,
+    slices: Vec<crate::longform::AudioSlice>,
+    plan_audio: &'a [f32],
+    timeline: &'a crate::longform::TimelineMap,
+    dispatch: &'a GgmlAsrExecutionDispatch,
+    runtime_preflight: &'a GgmlAsrRuntimeSourcePreflight,
+    selected_family: &'a GgmlFamilyAdapterDescriptor,
+    request_options: &'a GgmlAsrExecutionOptions,
+    backend_preference: GgmlAsrBackendPreference,
+    execution_context: &'a Arc<crate::RequestExecutionContext>,
+    longform_options: &'a crate::LongFormOptions,
+    speaker_plan: SpeakerPlan,
+    decode_progress: &'a DecodeProgress,
+    assembler: &'a mut TranscriptAssembler,
+    ran_any_slice: &'a mut bool,
+    suppressed_slice_count: &'a mut usize,
+    degraded_slice_fallbacks: &'a mut Vec<(usize, SliceGpuFallback)>,
+    truncated_slices: &'a mut Vec<String>,
+    truncated_decodes: &'a mut Vec<TruncatedDecode>,
+    speaker_scope_starts: &'a mut Vec<f32>,
+}
+
+/// Long-audio slice pipeline: decode up to `width` slices concurrently and
+/// assemble their results in slice order.
+///
+/// This is the carry-light path (see module notes on `carry_prompt_mode`): the
+/// cross-slice prompt carry the serial loop threads between slices is a strict
+/// serial dependency, so the concurrent path drops it -- slice N+1 no longer
+/// waits on slice N's transcript. The output is otherwise assembled from the
+/// same per-slice results, in the same order, so it is byte-identical to the
+/// serial path except where a family's decode genuinely depended on the carried
+/// prompt.
+///
+/// The six correctness properties the concurrent path must preserve:
+/// 1. Ordered assembly: workers finish out of order, results are routed back by
+///    slice position and integrated strictly in slice order.
+/// 2. Cancel / pause: each worker gates on the shared control at every slice
+///    boundary (pause blocks it, cancel stops it), arms the ggml abort callback
+///    on its own thread for mid-graph cancel, and the shared greedy driver still
+///    polls cancel per token via the job-carried control.
+/// 3. Progress: `DecodeProgress` accumulates atomically and the registry clamps
+///    every report upward, so concurrent completions never move the bar back.
+/// 4. GPU-fallback tracker: each worker owns its own tracker, so one worker's
+///    fallback streak cannot corrupt another's backend choice.
+/// 5. Memory: `width` is already capacity-gated by the caller
+///    (`effective_slice_pipeline_width`).
+/// 6. Errors / truncation: a worker's error and truncated-slice facts are routed
+///    back and integrated in order; the first (lowest-index) error fails the run
+///    closed, exactly like the serial `?`.
+fn run_concurrent_slice_pipeline(pipeline: ConcurrentSlicePipeline) -> Result<(), BackendError> {
+    let ConcurrentSlicePipeline {
+        width,
+        slices,
+        plan_audio,
+        timeline,
+        dispatch,
+        runtime_preflight,
+        selected_family,
+        request_options,
+        backend_preference,
+        execution_context,
+        longform_options,
+        speaker_plan,
+        decode_progress,
+        assembler,
+        ran_any_slice,
+        suppressed_slice_count,
+        degraded_slice_fallbacks,
+        truncated_slices,
+        truncated_decodes,
+        speaker_scope_starts,
+    } = pipeline;
+
+    // Pre-scan on the main thread: decide silence once (identical predicate to
+    // the serial loop), fold each silent slice's share into progress up front,
+    // and record which positions actually need a decode worker.
+    let mut plan_items: Vec<SlicePlanItem> = Vec::with_capacity(slices.len());
+    let mut decode_positions: Vec<usize> = Vec::new();
+    for slice in slices {
+        let slice_samples = slice.duration_samples() as u64;
+        let relative_start = slice
+            .content_start_sample
+            .saturating_sub(slice.start_sample);
+        let relative_end = slice
+            .content_end_sample
+            .saturating_sub(slice.start_sample)
+            .min(slice.duration_samples());
+        let chunk = &plan_audio[slice.start_sample..slice.end_sample];
+        let silent = longform_options.suppress_silent_slices
+            && is_effectively_silent(
+                &chunk[relative_start..relative_end],
+                longform_options.energy_silence_threshold_db,
+            );
+        if silent {
+            decode_progress.complete_slice(slice_samples);
+        } else {
+            decode_positions.push(plan_items.len());
+        }
+        plan_items.push(SlicePlanItem {
+            slice,
+            slice_samples,
+            silent,
+        });
+    }
+
+    // Results routed back by slice position; silent positions stay `None`.
+    let mut results: Vec<Option<Result<DecodedSlice, BackendError>>> =
+        (0..plan_items.len()).map(|_| None).collect();
+
+    if !decode_positions.is_empty() {
+        let cursor = AtomicUsize::new(0);
+        // Set on cancel or the first worker error so peers stop pulling new work
+        // promptly instead of decoding slices whose result will be discarded.
+        let stop = AtomicBool::new(false);
+        let worker_count = width.min(decode_positions.len()).max(1);
+        let (result_tx, result_rx) = mpsc::channel::<(usize, Result<DecodedSlice, BackendError>)>();
+        let items = &plan_items;
+        let decode_positions_ref = &decode_positions;
+        let cursor_ref = &cursor;
+        let stop_ref = &stop;
+        std::thread::scope(|scope| {
+            for _ in 0..worker_count {
+                let result_tx = result_tx.clone();
+                scope.spawn(move || {
+                    // Arm this worker thread's ggml abort callback so a cancel
+                    // that arrives mid-graph aborts this worker's compute too;
+                    // between-step cancel is already covered by the shared
+                    // greedy driver's per-token poll of the job-carried control.
+                    let _abort_guard = execution_context.control.arm_for_native_decode();
+                    // Per-worker fallback tracker (property 4): the GPU-allocation
+                    // streak is meaningful only within one worker's own sequence
+                    // of slices, and sharing it across threads would be a data
+                    // race.
+                    let mut tracker = GpuAllocationFallbackTracker::default();
+                    loop {
+                        if stop_ref.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        // Slice-boundary pause/cancel gate, mirroring the serial
+                        // loop: pause blocks this worker here; cancel stops it.
+                        if execution_context.control.wait_at_slice_boundary()
+                            == super::transcription_control::SliceBoundaryControl::Canceled
+                        {
+                            stop_ref.store(true, Ordering::Relaxed);
+                            break;
+                        }
+                        let next = cursor_ref.fetch_add(1, Ordering::Relaxed);
+                        if next >= decode_positions_ref.len() {
+                            break;
+                        }
+                        let pos = decode_positions_ref[next];
+                        let item = &items[pos];
+                        // Carry-light: no cross-slice prompt carry in the
+                        // concurrent path (that is the serial dependency this
+                        // path trades away for overlap).
+                        let slice_options = request_options.clone();
+                        let chunk =
+                            plan_audio[item.slice.start_sample..item.slice.end_sample].to_vec();
+                        let outcome = run_dispatch_once_with_progress_and_gpu_fallback(
+                            dispatch,
+                            runtime_preflight,
+                            selected_family,
+                            chunk,
+                            slice_options,
+                            backend_preference,
+                            execution_context,
+                            decode_progress,
+                            item.slice_samples,
+                            &format!("concurrent-pos={pos}"),
+                            &mut tracker,
+                        )
+                        .map(|(result, fallback)| DecodedSlice {
+                            text: result.transcription.text,
+                            segments: result.transcription.segments,
+                            truncation: result.decode_truncation,
+                            fallback,
+                        });
+                        let is_err = outcome.is_err();
+                        if result_tx.send((pos, outcome)).is_err() {
+                            break;
+                        }
+                        if is_err {
+                            // First failure stops the pipeline (property 6):
+                            // peers stop pulling, and the main thread returns the
+                            // lowest-index error, matching the serial `?`.
+                            stop_ref.store(true, Ordering::Relaxed);
+                            break;
+                        }
+                    }
+                });
+            }
+            // Drop the main thread's spare sender so the receiver below ends once
+            // every worker has finished and dropped its clone.
+            drop(result_tx);
+            for (pos, outcome) in result_rx {
+                results[pos] = Some(outcome);
+            }
+        });
+    }
+
+    // Ordered integration on the main thread (property 1): replay the serial
+    // loop's post-decode bookkeeping in slice order, so `slice_index`, the
+    // provenance vectors, and the assembler see exactly the serial sequence.
+    // `slice_index` is bumped only on a decoded (non-silent) slice, exactly as
+    // the serial loop does, so the 1-based indices stamped into truncation and
+    // GPU-fallback provenance match byte-for-byte.
+    let mut slice_index = 0usize;
+    let mut first_error: Option<BackendError> = None;
+    for (position, item) in plan_items.into_iter().enumerate() {
+        if item.silent {
+            *suppressed_slice_count += 1;
+            assembler.push_slice_result(SliceTranscript {
+                slice: item.slice,
+                text: String::new(),
+                segments: Vec::new(),
+                time_domain: SegmentTimeDomain::AbsoluteOriginal,
+            });
+            continue;
+        }
+        match results[position].take() {
+            Some(Ok(decoded)) => {
+                slice_index += 1;
+                if let Some(fallback) = decoded.fallback {
+                    degraded_slice_fallbacks.push((slice_index, fallback));
+                }
+                if let Some(truncation) = decoded.truncation {
+                    truncated_slices
+                        .push(format_truncated_slice_provenance(slice_index, &truncation));
+                    truncated_decodes.push(TruncatedDecode {
+                        slice_index: Some(slice_index),
+                        truncation,
+                    });
+                }
+                *ran_any_slice = true;
+                if speaker_plan == SpeakerPlan::InDecoder {
+                    speaker_scope_starts.push(timeline.map_processed_to_original_seconds(
+                        item.slice.content_start_sample as f32 / 16_000.0,
+                    ));
+                }
+                assembler.push_slice_result(SliceTranscript {
+                    slice: item.slice,
+                    text: decoded.text,
+                    segments: decoded.segments,
+                    time_domain: SegmentTimeDomain::RelativeToSliceContent,
+                });
+            }
+            // Keep the first (lowest-index) error so the returned failure matches
+            // the serial `?`, which fails at the earliest bad slice.
+            Some(Err(err)) if first_error.is_none() => {
+                first_error = Some(err);
+            }
+            Some(Err(_)) => {}
+            None => {
+                // A decodable position with no result only happens when a worker
+                // stopped early (a peer error already set `first_error`, or a
+                // cancel, checked below). Nothing to integrate here.
+            }
+        }
+    }
+
+    // Cancel wins over a partial assembly (property 2 + 6): a cancel that raced
+    // the workers leaves some positions undecoded, so surface it as the typed
+    // cancel rather than a truncated transcript.
+    if execution_context.is_canceled() {
+        return Err(BackendError::TranscriptionCanceled);
+    }
+    if let Some(err) = first_error {
+        return Err(err);
+    }
+    Ok(())
 }
 
 /// RAII cleanup for one native transcription's progress-registry entry:
@@ -1448,7 +1864,7 @@ fn run_native_transcription_impl(
                 .iter()
                 .map(|slice| slice.duration_samples() as u64)
                 .sum();
-            let mut decode_progress = DecodeProgress::begin(
+            let decode_progress = DecodeProgress::begin(
                 execution_context.request_id.clone(),
                 total_decode_samples,
                 with_align,
@@ -1481,139 +1897,175 @@ fn run_native_transcription_impl(
             // one whole-recording external pass has a single scope and leaves
             // this empty.
             let mut speaker_scope_starts: Vec<f32> = Vec::new();
-            for slice in plan.slices {
-                if execution_context.control.wait_at_slice_boundary()
-                    == super::transcription_control::SliceBoundaryControl::Canceled
-                {
-                    return Err(BackendError::TranscriptionCanceled);
-                }
-                let slice_samples = slice.duration_samples() as u64;
-                let relative_start = slice
-                    .content_start_sample
-                    .saturating_sub(slice.start_sample);
-                let relative_end = slice
-                    .content_end_sample
-                    .saturating_sub(slice.start_sample)
-                    .min(slice.duration_samples());
-                let chunk = plan_audio[slice.start_sample..slice.end_sample].to_vec();
-                if longform_options.suppress_silent_slices
-                    && is_effectively_silent(
-                        &chunk[relative_start..relative_end],
-                        longform_options.energy_silence_threshold_db,
-                    )
-                {
-                    suppressed_slice_count += 1;
+            // P1 long-audio slice pipeline: when opted in and it fits, decode K
+            // slices concurrently to overlap the encode/decode GPU bubbles (the
+            // admission-concurrency win, applied to one file's slices). Width 1
+            // -- the default -- runs the byte-identical serial + prompt-carry
+            // path in the `else` below.
+            let pipeline_width = effective_slice_pipeline_width(
+                slice_pipeline_requested_width(),
+                &plan.slices,
+                &runtime_preflight,
+            );
+            if pipeline_width > 1 {
+                run_concurrent_slice_pipeline(ConcurrentSlicePipeline {
+                    width: pipeline_width,
+                    slices: plan.slices,
+                    plan_audio,
+                    timeline: &plan.timeline,
+                    dispatch,
+                    runtime_preflight: &runtime_preflight,
+                    selected_family: &selected_family,
+                    request_options: &request_options,
+                    backend_preference,
+                    execution_context: &execution_context,
+                    longform_options: &longform_options,
+                    speaker_plan,
+                    decode_progress: &decode_progress,
+                    assembler: &mut assembler,
+                    ran_any_slice: &mut ran_any_slice,
+                    suppressed_slice_count: &mut suppressed_slice_count,
+                    degraded_slice_fallbacks: &mut degraded_slice_fallbacks,
+                    truncated_slices: &mut truncated_slices,
+                    truncated_decodes: &mut truncated_decodes,
+                    speaker_scope_starts: &mut speaker_scope_starts,
+                })?;
+            } else {
+                for slice in plan.slices {
+                    if execution_context.control.wait_at_slice_boundary()
+                        == super::transcription_control::SliceBoundaryControl::Canceled
+                    {
+                        return Err(BackendError::TranscriptionCanceled);
+                    }
+                    let slice_samples = slice.duration_samples() as u64;
+                    let relative_start = slice
+                        .content_start_sample
+                        .saturating_sub(slice.start_sample);
+                    let relative_end = slice
+                        .content_end_sample
+                        .saturating_sub(slice.start_sample)
+                        .min(slice.duration_samples());
+                    let chunk = plan_audio[slice.start_sample..slice.end_sample].to_vec();
+                    if longform_options.suppress_silent_slices
+                        && is_effectively_silent(
+                            &chunk[relative_start..relative_end],
+                            longform_options.energy_silence_threshold_db,
+                        )
+                    {
+                        suppressed_slice_count += 1;
+                        assembler.push_slice_result(SliceTranscript {
+                            slice,
+                            text: String::new(),
+                            segments: Vec::new(),
+                            time_domain: SegmentTimeDomain::AbsoluteOriginal,
+                        });
+                        decode_progress.complete_slice(slice_samples);
+                        continue;
+                    }
+                    let mut slice_options = request_options.clone();
+                    match carry_prompt_mode {
+                        LongformPromptCarryMode::Disabled => {}
+                        LongformPromptCarryMode::Text => {
+                            let trimmed = rolling_prompt.trim();
+                            if !trimmed.is_empty() {
+                                slice_options.prompt = Some(trimmed.to_string());
+                            }
+                        }
+                        LongformPromptCarryMode::TokenHistory => {
+                            if !rolling_prompt_token_ids.is_empty() {
+                                slice_options.prompt = None;
+                                slice_options.prompt_token_ids =
+                                    Some(rolling_prompt_token_ids.clone());
+                            }
+                        }
+                    }
+                    slice_index += 1;
+                    let slice_decode_started = Instant::now();
+                    let (result, slice_gpu_fallback) =
+                        run_dispatch_once_with_progress_and_gpu_fallback(
+                            dispatch,
+                            &runtime_preflight,
+                            &selected_family,
+                            chunk,
+                            slice_options,
+                            backend_preference,
+                            &execution_context,
+                            &decode_progress,
+                            slice_samples,
+                            &format!("index={slice_index}"),
+                            &mut gpu_fallback_tracker,
+                        )?;
+                    if let Some(fallback) = slice_gpu_fallback {
+                        degraded_slice_fallbacks.push((slice_index, fallback));
+                    }
+                    // OPENASR_TIMING=1 detail: per-longform-slice decode time.
+                    // Coarse by default (only the whole-request `inference` stage
+                    // is logged unconditionally) since a long recording can chunk
+                    // into many slices -- one line per slice would be noisy for
+                    // the always-on tier.
+                    crate::stage_timing::log_detail_event(
+                        "native_transcribe",
+                        format_args!(
+                            "stage=longform_slice_decode index={slice_index} samples={slice_samples} duration_ms={:.3}",
+                            slice_decode_started.elapsed().as_secs_f64() * 1000.0
+                        ),
+                    );
+                    // Destructure instead of `result.clone().into_transcription()`:
+                    // the fields are consumed below and nothing needs `result`
+                    // as a whole afterwards, so there is nothing left to clone.
+                    let GgmlAsrExecutionResult {
+                        transcription,
+                        carry_context,
+                        decode_truncation,
+                    } = result;
+                    if let Some(truncation) = decode_truncation {
+                        // A slice whose decode gave up partway is a degraded
+                        // result, not a normal one: the audio after this point is
+                        // absent from the transcript. Carried structurally on the
+                        // returned transcript (so every output format can see it)
+                        // AND summarized in the same provenance channel as the
+                        // other "this run did not behave like the naive default"
+                        // facts, rather than left as a log line the caller never
+                        // sees.
+                        truncated_slices
+                            .push(format_truncated_slice_provenance(slice_index, &truncation));
+                        truncated_decodes.push(TruncatedDecode {
+                            slice_index: Some(slice_index),
+                            truncation,
+                        });
+                    }
+                    ran_any_slice = true;
+                    match carry_prompt_mode {
+                        LongformPromptCarryMode::Disabled => {}
+                        LongformPromptCarryMode::Text => {
+                            if !transcription.text.trim().is_empty() {
+                                rolling_prompt = append_context_tail(
+                                    &rolling_prompt,
+                                    &transcription.text,
+                                    longform_options.max_context_chars,
+                                );
+                            }
+                        }
+                        LongformPromptCarryMode::TokenHistory => {
+                            if let Some(prompt_token_ids) =
+                                carry_context.and_then(|context| context.prompt_token_ids)
+                            {
+                                rolling_prompt_token_ids = prompt_token_ids;
+                            }
+                        }
+                    }
+                    if speaker_plan == SpeakerPlan::InDecoder {
+                        speaker_scope_starts.push(plan.timeline.map_processed_to_original_seconds(
+                            slice.content_start_sample as f32 / 16_000.0,
+                        ));
+                    }
                     assembler.push_slice_result(SliceTranscript {
                         slice,
-                        text: String::new(),
-                        segments: Vec::new(),
-                        time_domain: SegmentTimeDomain::AbsoluteOriginal,
-                    });
-                    decode_progress.complete_slice(slice_samples);
-                    continue;
-                }
-                let mut slice_options = request_options.clone();
-                match carry_prompt_mode {
-                    LongformPromptCarryMode::Disabled => {}
-                    LongformPromptCarryMode::Text => {
-                        let trimmed = rolling_prompt.trim();
-                        if !trimmed.is_empty() {
-                            slice_options.prompt = Some(trimmed.to_string());
-                        }
-                    }
-                    LongformPromptCarryMode::TokenHistory => {
-                        if !rolling_prompt_token_ids.is_empty() {
-                            slice_options.prompt = None;
-                            slice_options.prompt_token_ids = Some(rolling_prompt_token_ids.clone());
-                        }
-                    }
-                }
-                slice_index += 1;
-                let slice_decode_started = Instant::now();
-                let (result, slice_gpu_fallback) =
-                    run_dispatch_once_with_progress_and_gpu_fallback(
-                        dispatch,
-                        &runtime_preflight,
-                        &selected_family,
-                        chunk,
-                        slice_options,
-                        backend_preference,
-                        &execution_context,
-                        &mut decode_progress,
-                        slice_samples,
-                        &format!("index={slice_index}"),
-                        &mut gpu_fallback_tracker,
-                    )?;
-                if let Some(fallback) = slice_gpu_fallback {
-                    degraded_slice_fallbacks.push((slice_index, fallback));
-                }
-                // OPENASR_TIMING=1 detail: per-longform-slice decode time.
-                // Coarse by default (only the whole-request `inference` stage
-                // is logged unconditionally) since a long recording can chunk
-                // into many slices -- one line per slice would be noisy for
-                // the always-on tier.
-                crate::stage_timing::log_detail_event(
-                    "native_transcribe",
-                    format_args!(
-                        "stage=longform_slice_decode index={slice_index} samples={slice_samples} duration_ms={:.3}",
-                        slice_decode_started.elapsed().as_secs_f64() * 1000.0
-                    ),
-                );
-                // Destructure instead of `result.clone().into_transcription()`:
-                // the fields are consumed below and nothing needs `result`
-                // as a whole afterwards, so there is nothing left to clone.
-                let GgmlAsrExecutionResult {
-                    transcription,
-                    carry_context,
-                    decode_truncation,
-                } = result;
-                if let Some(truncation) = decode_truncation {
-                    // A slice whose decode gave up partway is a degraded
-                    // result, not a normal one: the audio after this point is
-                    // absent from the transcript. Carried structurally on the
-                    // returned transcript (so every output format can see it)
-                    // AND summarized in the same provenance channel as the
-                    // other "this run did not behave like the naive default"
-                    // facts, rather than left as a log line the caller never
-                    // sees.
-                    truncated_slices
-                        .push(format_truncated_slice_provenance(slice_index, &truncation));
-                    truncated_decodes.push(TruncatedDecode {
-                        slice_index: Some(slice_index),
-                        truncation,
+                        text: transcription.text,
+                        segments: transcription.segments,
+                        time_domain: SegmentTimeDomain::RelativeToSliceContent,
                     });
                 }
-                ran_any_slice = true;
-                match carry_prompt_mode {
-                    LongformPromptCarryMode::Disabled => {}
-                    LongformPromptCarryMode::Text => {
-                        if !transcription.text.trim().is_empty() {
-                            rolling_prompt = append_context_tail(
-                                &rolling_prompt,
-                                &transcription.text,
-                                longform_options.max_context_chars,
-                            );
-                        }
-                    }
-                    LongformPromptCarryMode::TokenHistory => {
-                        if let Some(prompt_token_ids) =
-                            carry_context.and_then(|context| context.prompt_token_ids)
-                        {
-                            rolling_prompt_token_ids = prompt_token_ids;
-                        }
-                    }
-                }
-                if speaker_plan == SpeakerPlan::InDecoder {
-                    speaker_scope_starts.push(plan.timeline.map_processed_to_original_seconds(
-                        slice.content_start_sample as f32 / 16_000.0,
-                    ));
-                }
-                assembler.push_slice_result(SliceTranscript {
-                    slice,
-                    text: transcription.text,
-                    segments: transcription.segments,
-                    time_domain: SegmentTimeDomain::RelativeToSliceContent,
-                });
             }
             // Decode done; the merge/resegment tail below runs uncounted otherwise,
             // which is where the bar used to sit frozen at the last slice count.
@@ -1742,7 +2194,7 @@ fn run_native_transcription_impl(
     // all, forcing the UI onto a pure time estimate that had no way to know
     // decode had actually finished (issue: short-audio progress bar).
     let single_pass_total_samples = prepared_audio.len() as u64;
-    let mut single_pass_decode_progress = DecodeProgress::begin(
+    let single_pass_decode_progress = DecodeProgress::begin(
         execution_context.request_id.clone(),
         single_pass_total_samples,
         request.word_timestamps_refine,
@@ -1761,7 +2213,7 @@ fn run_native_transcription_impl(
         request_options,
         backend_preference,
         &execution_context,
-        &mut single_pass_decode_progress,
+        &single_pass_decode_progress,
         single_pass_total_samples,
         "single-pass",
         &mut single_pass_gpu_fallback_tracker,
@@ -3643,7 +4095,7 @@ mod tests {
             let _handle = ProgressRegistryHandle::new(Some(id.to_string()));
             // Decode phase, weighted by sample share; a run that will forced-align
             // reserves headroom above the decode ceiling.
-            let mut decode = DecodeProgress::begin(Some(id.to_string()), 1000, true);
+            let decode = DecodeProgress::begin(Some(id.to_string()), 1000, true);
             let start = native_transcription_progress_for_id(id).expect("run is active");
             assert_eq!(start.phase, NativeTranscriptionPhase::Decode);
             assert_eq!(start.fraction, 0.0);
@@ -3735,7 +4187,7 @@ mod tests {
     #[test]
     fn native_progress_detached_request_never_publishes() {
         let _handle = ProgressRegistryHandle::new(None);
-        let mut decode = DecodeProgress::begin(None, 1000, false);
+        let decode = DecodeProgress::begin(None, 1000, false);
         decode.complete_slice(500);
         publish_assemble_progress(None, false);
         publish_align_progress(None);
@@ -3954,7 +4406,7 @@ mod tests {
         // registry entry, so -- unlike the old global-slot design -- a unique
         // id here needs no lock or guard to stay isolated from every other
         // test.
-        let mut decode =
+        let decode =
             DecodeProgress::begin(Some("slice-window-back-to-back".to_string()), 1000, false);
         let first = decode.slice_progress_window(400);
         assert!((first.start_fraction - 0.0).abs() < 1e-6);
@@ -5540,7 +5992,7 @@ mod tests {
             "compute buffer allocation failed (backend: Vulkan0)",
         ));
         let (dispatch, preflight, family) = gpu_fallback_test_fixture(dir.path(), executor.clone());
-        let mut decode_progress = DecodeProgress::begin(None, 1_000, false);
+        let decode_progress = DecodeProgress::begin(None, 1_000, false);
         let mut tracker = GpuAllocationFallbackTracker::default();
 
         let (result, fallback) = run_dispatch_once_with_progress_and_gpu_fallback(
@@ -5551,7 +6003,7 @@ mod tests {
             GgmlAsrExecutionOptions::default(),
             GgmlAsrBackendPreference::Auto,
             &uncancellable_execution_context_for_test(),
-            &mut decode_progress,
+            &decode_progress,
             1_000,
             "index=1",
             &mut tracker,
@@ -5582,7 +6034,7 @@ mod tests {
             calls: Mutex::new(0),
         });
         let (dispatch, preflight, family) = gpu_fallback_test_fixture(dir.path(), executor.clone());
-        let mut decode_progress = DecodeProgress::begin(None, 1_000, false);
+        let decode_progress = DecodeProgress::begin(None, 1_000, false);
         let mut tracker = GpuAllocationFallbackTracker::default();
 
         let error = run_dispatch_once_with_progress_and_gpu_fallback(
@@ -5593,7 +6045,7 @@ mod tests {
             GgmlAsrExecutionOptions::default(),
             GgmlAsrBackendPreference::Auto,
             &uncancellable_execution_context_for_test(),
-            &mut decode_progress,
+            &decode_progress,
             1_000,
             "index=1",
             &mut tracker,
@@ -5647,7 +6099,7 @@ mod tests {
         });
         let (dispatch, preflight, family) =
             gpu_fallback_test_fixture(dir.path(), cpu_executor.clone());
-        let mut decode_progress = DecodeProgress::begin(None, 1_000, false);
+        let decode_progress = DecodeProgress::begin(None, 1_000, false);
         let mut tracker = GpuAllocationFallbackTracker::default();
 
         let error = run_dispatch_once_with_progress_and_gpu_fallback(
@@ -5658,7 +6110,7 @@ mod tests {
             GgmlAsrExecutionOptions::default(),
             GgmlAsrBackendPreference::CpuOnly,
             &uncancellable_execution_context_for_test(),
-            &mut decode_progress,
+            &decode_progress,
             1_000,
             "index=1",
             &mut tracker,
@@ -5684,7 +6136,7 @@ mod tests {
             "compute buffer allocation failed (backend: Vulkan0)",
         ));
         let (dispatch, preflight, family) = gpu_fallback_test_fixture(dir.path(), executor.clone());
-        let mut decode_progress = DecodeProgress::begin(None, 3_000, false);
+        let decode_progress = DecodeProgress::begin(None, 3_000, false);
         let mut tracker = GpuAllocationFallbackTracker::default();
 
         for slice_index in 1..=3 {
@@ -5696,7 +6148,7 @@ mod tests {
                 GgmlAsrExecutionOptions::default(),
                 GgmlAsrBackendPreference::Auto,
                 &uncancellable_execution_context_for_test(),
-                &mut decode_progress,
+                &decode_progress,
                 1_000,
                 &format!("index={slice_index}"),
                 &mut tracker,
@@ -5717,6 +6169,307 @@ mod tests {
                 GgmlAsrBackendPreference::CpuOnly,
                 GgmlAsrBackendPreference::CpuOnly,
             ]
+        );
+    }
+
+    // ---- P1 concurrent slice pipeline ----
+
+    #[test]
+    fn capacity_gate_caps_by_slice_count_and_never_returns_zero() {
+        // Plenty of memory: width is bounded only by the slice count.
+        assert_eq!(
+            slice_pipeline_capped_width(4, 2, Some(64 << 30), 1 << 20, 0),
+            2,
+            "cannot run more workers than there are slices"
+        );
+        // Tight memory: only one worker fits, and the gate floors at 1 (serial),
+        // never 0 -- it can only reduce concurrency, so it cannot OOM.
+        assert_eq!(
+            slice_pipeline_capped_width(4, 8, Some(1_200 << 20), 1 << 30, 512 << 20),
+            1,
+            "one worker's worth of head-room -> serial, never zero"
+        );
+        // Enough memory for exactly three workers.
+        assert_eq!(
+            slice_pipeline_capped_width(4, 8, Some((3 << 30) + (512 << 20)), 1 << 30, 512 << 20),
+            3
+        );
+        // No memory probe: honor the explicit opt-in (serve-batch precedent).
+        assert_eq!(
+            slice_pipeline_capped_width(3, 8, None, 1 << 30, 512 << 20),
+            3
+        );
+        // A zero per-worker estimate cannot divide; fall back to the ceiling.
+        assert_eq!(slice_pipeline_capped_width(3, 8, Some(1 << 30), 0, 0), 3);
+        // A width-1 request is always serial regardless of memory.
+        assert_eq!(
+            slice_pipeline_capped_width(1, 8, Some(64 << 30), 1 << 20, 0),
+            1
+        );
+    }
+
+    #[test]
+    fn requested_width_defaults_to_serial_and_clamps() {
+        // SAFETY: nextest runs each test in its own process, so mutating this
+        // process-global env var cannot race another test.
+        unsafe {
+            std::env::remove_var("OPENASR_SLICE_PIPELINE_WIDTH");
+        }
+        assert_eq!(
+            slice_pipeline_requested_width(),
+            1,
+            "unset -> serial (conservative default)"
+        );
+        for (value, expected) in [
+            ("0", 1),
+            ("1", 1),
+            ("2", 2),
+            ("4", 4),
+            ("9", 4),
+            ("junk", 1),
+        ] {
+            unsafe {
+                std::env::set_var("OPENASR_SLICE_PIPELINE_WIDTH", value);
+            }
+            assert_eq!(
+                slice_pipeline_requested_width(),
+                expected,
+                "OPENASR_SLICE_PIPELINE_WIDTH={value}"
+            );
+        }
+        unsafe {
+            std::env::remove_var("OPENASR_SLICE_PIPELINE_WIDTH");
+        }
+    }
+
+    /// Deterministic executor for the concurrent-pipeline tests: echoes the
+    /// slice's audio marker (the constant its region is filled with, see
+    /// [`concurrent_pipeline_slices`]) back as its transcript text, so a test
+    /// can prove each slice's result is paired with the right slice and
+    /// assembled in slice order. Fails on a configured set of markers to
+    /// exercise error routing.
+    struct ConcurrentPipelineStubExecutor {
+        fail_markers: std::collections::BTreeSet<i32>,
+    }
+
+    impl ConcurrentPipelineStubExecutor {
+        fn echoing() -> Self {
+            Self {
+                fail_markers: std::collections::BTreeSet::new(),
+            }
+        }
+
+        fn failing_on(markers: &[i32]) -> Self {
+            Self {
+                fail_markers: markers.iter().copied().collect(),
+            }
+        }
+
+        fn marker_of(request: &GgmlAsrExecutionRequest) -> i32 {
+            request
+                .prepared_audio
+                .samples_f32
+                .first()
+                .copied()
+                .unwrap_or(0.0)
+                .round() as i32
+        }
+    }
+
+    impl GgmlAsrExecutor for ConcurrentPipelineStubExecutor {
+        fn executor_id(&self) -> &'static str {
+            "concurrent-pipeline-stub"
+        }
+
+        fn supports_phrase_bias(&self) -> bool {
+            true
+        }
+
+        fn execute(
+            &self,
+            request: &GgmlAsrExecutionRequest,
+        ) -> Result<GgmlAsrExecutionResult, GgmlAsrExecutionError> {
+            let marker = Self::marker_of(request);
+            if self.fail_markers.contains(&marker) {
+                return Err(GgmlAsrExecutionError::ExecutorFailed {
+                    executor_id: "concurrent-pipeline-stub",
+                    adapter_id: request.selected_family.adapter_id,
+                    reason: format!("stub failure marker={marker}"),
+                });
+            }
+            Ok(GgmlAsrExecutionResult {
+                transcription: Transcription {
+                    truncated_decodes: Vec::new(),
+                    unnamed_speakers: Vec::new(),
+                    text: format!("w{marker}"),
+                    segments: Vec::new(),
+                    longform: None,
+                    language: None,
+                },
+                carry_context: None,
+                decode_truncation: None,
+            })
+        }
+    }
+
+    /// `count` back-to-back 1000-sample slices; slice `i`'s audio region is
+    /// filled with the constant `(i + 1)` so the stub echoes a per-slice marker.
+    fn concurrent_pipeline_slices(count: usize) -> (Vec<f32>, Vec<crate::longform::AudioSlice>) {
+        let slice_len = 1000usize;
+        let mut audio = vec![0.0f32; count * slice_len];
+        let mut slices = Vec::with_capacity(count);
+        for i in 0..count {
+            let start = i * slice_len;
+            let end = start + slice_len;
+            for sample in &mut audio[start..end] {
+                *sample = (i + 1) as f32;
+            }
+            slices.push(crate::longform::AudioSlice {
+                index: i,
+                kind: AudioSliceKind::Fixed,
+                start_sample: start,
+                end_sample: end,
+                content_start_sample: start,
+                content_end_sample: end,
+            });
+        }
+        (audio, slices)
+    }
+
+    #[derive(Debug)]
+    struct ConcurrentPipelineOutcome {
+        assembled: Transcription,
+        ran_any_slice: bool,
+        suppressed: usize,
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_concurrent_pipeline_for_test(
+        width: usize,
+        audio: &[f32],
+        slices: Vec<crate::longform::AudioSlice>,
+        executor: Arc<dyn GgmlAsrExecutor>,
+        execution_context: &Arc<crate::RequestExecutionContext>,
+        longform_options: &crate::LongFormOptions,
+        progress_id: Option<String>,
+    ) -> Result<ConcurrentPipelineOutcome, BackendError> {
+        let dir = tempfile::tempdir().unwrap();
+        let (dispatch, preflight, family) = gpu_fallback_test_fixture(dir.path(), executor);
+        let timeline = crate::longform::TimelineMap::identity();
+        let mut assembler =
+            TranscriptAssembler::new(timeline.clone(), SegmentMergePolicy::default());
+        let total: u64 = slices.iter().map(|s| s.duration_samples() as u64).sum();
+        let decode_progress = DecodeProgress::begin(progress_id, total, false);
+        let request_options = GgmlAsrExecutionOptions::default();
+        let mut ran_any_slice = false;
+        let mut suppressed = 0usize;
+        let mut degraded = Vec::new();
+        let mut truncated_slices = Vec::new();
+        let mut truncated_decodes = Vec::new();
+        let mut speaker_scope_starts = Vec::new();
+        run_concurrent_slice_pipeline(ConcurrentSlicePipeline {
+            width,
+            slices,
+            plan_audio: audio,
+            timeline: &timeline,
+            dispatch: &dispatch,
+            runtime_preflight: &preflight,
+            selected_family: &family,
+            request_options: &request_options,
+            backend_preference: GgmlAsrBackendPreference::CpuOnly,
+            execution_context,
+            longform_options,
+            speaker_plan: SpeakerPlan::Off,
+            decode_progress: &decode_progress,
+            assembler: &mut assembler,
+            ran_any_slice: &mut ran_any_slice,
+            suppressed_slice_count: &mut suppressed,
+            degraded_slice_fallbacks: &mut degraded,
+            truncated_slices: &mut truncated_slices,
+            truncated_decodes: &mut truncated_decodes,
+            speaker_scope_starts: &mut speaker_scope_starts,
+        })?;
+        let (assembled, _stats) = assembler.into_parts();
+        Ok(ConcurrentPipelineOutcome {
+            assembled,
+            ran_any_slice,
+            suppressed,
+        })
+    }
+
+    #[test]
+    fn concurrent_pipeline_assembles_slices_in_order_and_reaches_progress_ceiling() {
+        let id = "concurrent-pipeline-ordered";
+        let _handle = ProgressRegistryHandle::new(Some(id.to_string()));
+        let (audio, slices) = concurrent_pipeline_slices(6);
+        let outcome = run_concurrent_pipeline_for_test(
+            4,
+            &audio,
+            slices,
+            Arc::new(ConcurrentPipelineStubExecutor::echoing()),
+            &uncancellable_execution_context_for_test(),
+            &crate::LongFormOptions::default(),
+            Some(id.to_string()),
+        )
+        .expect("all slices decode successfully");
+        // Out-of-order worker completion, but each result is paired with its own
+        // slice and integrated in slice order (property 1).
+        assert_eq!(outcome.assembled.text, "w1 w2 w3 w4 w5 w6");
+        assert!(outcome.ran_any_slice);
+        assert_eq!(outcome.suppressed, 0);
+        // Progress accumulated atomically across workers and reached the decode
+        // ceiling (property 3); the registry clamp keeps it monotonic.
+        let progress = native_transcription_progress_for_id(id).expect("run published progress");
+        assert!(
+            (progress.fraction - DECODE_CEIL_NO_ALIGN).abs() < 1e-6,
+            "decode progress should reach the ceiling, got {}",
+            progress.fraction
+        );
+    }
+
+    #[test]
+    fn concurrent_pipeline_returns_the_lowest_index_worker_error_and_fails_closed() {
+        let (audio, slices) = concurrent_pipeline_slices(6);
+        // Slices with markers 2 and 4 fail; the lowest-index failure (marker 2,
+        // the second slice) is the one surfaced, matching the serial `?`.
+        let error = run_concurrent_pipeline_for_test(
+            4,
+            &audio,
+            slices,
+            Arc::new(ConcurrentPipelineStubExecutor::failing_on(&[2, 4])),
+            &uncancellable_execution_context_for_test(),
+            &crate::LongFormOptions::default(),
+            None,
+        )
+        .expect_err("a worker failure must fail the whole run closed");
+        assert!(
+            error.to_string().contains("marker=2"),
+            "the earliest (lowest-index) slice error must be returned: {error}"
+        );
+    }
+
+    #[test]
+    fn concurrent_pipeline_surfaces_cancel_without_decoding() {
+        let control = Arc::new(crate::api::backend::TranscriptionControl::new());
+        control.request_cancel();
+        let execution_context = Arc::new(crate::RequestExecutionContext::new(
+            None,
+            Arc::clone(&control),
+        ));
+        let (audio, slices) = concurrent_pipeline_slices(6);
+        let error = run_concurrent_pipeline_for_test(
+            4,
+            &audio,
+            slices,
+            Arc::new(ConcurrentPipelineStubExecutor::echoing()),
+            &execution_context,
+            &crate::LongFormOptions::default(),
+            None,
+        )
+        .expect_err("a pre-canceled run must stop at the slice-boundary gate");
+        assert!(
+            matches!(error, BackendError::TranscriptionCanceled),
+            "cancel must surface as the typed TranscriptionCanceled: {error}"
         );
     }
 }

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -6472,4 +6472,398 @@ mod tests {
             "cancel must surface as the typed TranscriptionCanceled: {error}"
         );
     }
+
+    /// Deterministic executor that echoes each slice's marker as BOTH its text
+    /// (`w{marker}`) and a single segment at a fixed slice-relative time, so a
+    /// test proves the concurrent path's ordered *segment* assembly and
+    /// per-slice time-domain remap -- not just the flat text -- matches the
+    /// serial path. Like [`ConcurrentPipelineStubExecutor`] it reads nothing
+    /// but the audio marker, so it is completely insensitive to the request
+    /// prompt / cross-slice carry: the ONLY variable it can react to is which
+    /// slice it was handed.
+    struct SegmentEchoStubExecutor;
+
+    impl GgmlAsrExecutor for SegmentEchoStubExecutor {
+        fn executor_id(&self) -> &'static str {
+            "segment-echo-stub"
+        }
+
+        fn supports_phrase_bias(&self) -> bool {
+            true
+        }
+
+        fn execute(
+            &self,
+            request: &GgmlAsrExecutionRequest,
+        ) -> Result<GgmlAsrExecutionResult, GgmlAsrExecutionError> {
+            let marker = ConcurrentPipelineStubExecutor::marker_of(request);
+            Ok(GgmlAsrExecutionResult {
+                transcription: Transcription {
+                    truncated_decodes: Vec::new(),
+                    unnamed_speakers: Vec::new(),
+                    text: format!("w{marker}"),
+                    segments: vec![segment(0.10, 0.20, &format!("w{marker}"))],
+                    longform: None,
+                    language: None,
+                },
+                carry_context: None,
+                decode_truncation: None,
+            })
+        }
+    }
+
+    /// Concurrency-vs-serial equivalence with a carry-insensitive deterministic
+    /// backend (supplement 1, mock tier): running the SAME slices through the
+    /// real assembly code path at width 1 (a single worker pulling slices in
+    /// order == the serial reference) and at widths 2/3/4 (workers finishing
+    /// out of order) must produce a BYTE-IDENTICAL assembled transcription --
+    /// text AND segments AND their remapped timings. Because the stub reads
+    /// only the audio marker and ignores the prompt/carry entirely, the sole
+    /// difference between the width-1 and width-N runs is concurrency itself,
+    /// so equality isolates and proves that concurrency alone does not change
+    /// the output (the carry variable that separates the production serial and
+    /// carry-light paths is held constant here at "no carry").
+    #[test]
+    fn concurrent_pipeline_output_is_byte_identical_across_widths() {
+        let (audio, slices) = concurrent_pipeline_slices(7);
+        let run = |width: usize| {
+            run_concurrent_pipeline_for_test(
+                width,
+                &audio,
+                slices.clone(),
+                Arc::new(SegmentEchoStubExecutor),
+                &uncancellable_execution_context_for_test(),
+                &crate::LongFormOptions::default(),
+                None,
+            )
+            .expect("all slices decode")
+        };
+
+        // Width 1 == single worker, strictly serial slice order: the reference.
+        let serial = run(1);
+        assert_eq!(
+            serial.assembled.text, "w1 w2 w3 w4 w5 w6 w7",
+            "serial (width=1) reference text"
+        );
+        assert_eq!(
+            serial.assembled.segments.len(),
+            7,
+            "one segment per decoded slice survives assembly"
+        );
+        assert!(serial.ran_any_slice);
+        assert_eq!(serial.suppressed, 0);
+
+        for width in [2usize, 3, 4] {
+            let concurrent = run(width);
+            assert_eq!(
+                concurrent.assembled, serial.assembled,
+                "width={width} concurrent output must be byte-identical to the \
+                 serial (width=1) reference: text, segments, and remapped timings"
+            );
+            assert_eq!(concurrent.suppressed, serial.suppressed);
+            assert_eq!(concurrent.ran_any_slice, serial.ran_any_slice);
+        }
+    }
+
+    /// Same equivalence, but with a suppressed silent slice in the middle: the
+    /// concurrent path decides silence once up front on the main thread and
+    /// leaves that position empty, then integrates in slice order. Width 1 and
+    /// width 4 must agree byte-for-byte on both the assembled transcript and
+    /// the suppressed-slice count, proving the concurrent silence bookkeeping
+    /// matches the serial loop's.
+    #[test]
+    fn concurrent_pipeline_silent_slice_handling_matches_across_widths() {
+        let (mut audio, slices) = concurrent_pipeline_slices(6);
+        // Zero slice index 2's audio region so it reads as silence (marker 0),
+        // while every other slice keeps its distinct non-zero marker.
+        for sample in &mut audio[2 * 1000..3 * 1000] {
+            *sample = 0.0;
+        }
+        let longform = crate::LongFormOptions {
+            suppress_silent_slices: true,
+            ..crate::LongFormOptions::default()
+        };
+        let run = |width: usize| {
+            run_concurrent_pipeline_for_test(
+                width,
+                &audio,
+                slices.clone(),
+                Arc::new(SegmentEchoStubExecutor),
+                &uncancellable_execution_context_for_test(),
+                &longform,
+                None,
+            )
+            .expect("non-silent slices decode")
+        };
+
+        let serial = run(1);
+        // Slice index 2 is suppressed; the rest echo their markers in order.
+        assert_eq!(serial.assembled.text, "w1 w2 w4 w5 w6");
+        assert_eq!(serial.suppressed, 1);
+
+        let concurrent = run(4);
+        assert_eq!(
+            concurrent.assembled, serial.assembled,
+            "concurrent silent-slice suppression must be byte-identical to serial"
+        );
+        assert_eq!(concurrent.suppressed, serial.suppressed);
+    }
+
+    /// Shared handshake between a blocking test executor and the test thread:
+    /// counts how many decodes have entered `execute` (so the test can wait
+    /// until a worker is genuinely mid-decode before flipping a control) and
+    /// lets the test release those blocked decodes. Used only to construct
+    /// deterministic in-flight timings for the cancel / pause tests.
+    struct DecodeGate {
+        entered: Mutex<usize>,
+        entered_cv: std::sync::Condvar,
+        release: Mutex<bool>,
+        release_cv: std::sync::Condvar,
+    }
+
+    impl DecodeGate {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                entered: Mutex::new(0),
+                entered_cv: std::sync::Condvar::new(),
+                release: Mutex::new(false),
+                release_cv: std::sync::Condvar::new(),
+            })
+        }
+
+        fn mark_entered(&self) {
+            *self.entered.lock().unwrap() += 1;
+            self.entered_cv.notify_all();
+        }
+
+        fn wait_entered_at_least(&self, count: usize) {
+            let mut entered = self.entered.lock().unwrap();
+            while *entered < count {
+                entered = self.entered_cv.wait(entered).unwrap();
+            }
+        }
+
+        fn release_all(&self) {
+            *self.release.lock().unwrap() = true;
+            self.release_cv.notify_all();
+        }
+
+        fn wait_for_release(&self) {
+            let mut released = self.release.lock().unwrap();
+            while !*released {
+                released = self.release_cv.wait(released).unwrap();
+            }
+        }
+    }
+
+    /// Executor that parks inside `execute` (a worker genuinely mid-decode)
+    /// until the test releases it, then echoes the slice marker. Lets the
+    /// pause/resume test place a worker in-flight before pausing.
+    struct PauseGateExecutor {
+        gate: Arc<DecodeGate>,
+    }
+
+    impl GgmlAsrExecutor for PauseGateExecutor {
+        fn executor_id(&self) -> &'static str {
+            "pause-gate-stub"
+        }
+
+        fn supports_phrase_bias(&self) -> bool {
+            true
+        }
+
+        fn execute(
+            &self,
+            request: &GgmlAsrExecutionRequest,
+        ) -> Result<GgmlAsrExecutionResult, GgmlAsrExecutionError> {
+            let marker = ConcurrentPipelineStubExecutor::marker_of(request);
+            self.gate.mark_entered();
+            self.gate.wait_for_release();
+            Ok(GgmlAsrExecutionResult {
+                transcription: Transcription {
+                    truncated_decodes: Vec::new(),
+                    unnamed_speakers: Vec::new(),
+                    text: format!("w{marker}"),
+                    segments: Vec::new(),
+                    longform: None,
+                    language: None,
+                },
+                carry_context: None,
+                decode_truncation: None,
+            })
+        }
+    }
+
+    /// Executor that simulates a real ggml graph observing a mid-compute
+    /// cancel: it blocks inside `execute` (past the slice-boundary gate, i.e.
+    /// genuinely in-flight) and spins on the per-worker abort flag the pipeline
+    /// arms via `arm_for_native_decode`, exactly the flag a real ggml
+    /// abort_callback reads. When the cancel trips it returns an aborted error,
+    /// as an aborted graph would. A 30s safety valve keeps a regression from
+    /// hanging the suite forever.
+    struct CancelGateExecutor {
+        gate: Arc<DecodeGate>,
+    }
+
+    impl GgmlAsrExecutor for CancelGateExecutor {
+        fn executor_id(&self) -> &'static str {
+            "cancel-gate-stub"
+        }
+
+        fn supports_phrase_bias(&self) -> bool {
+            true
+        }
+
+        fn execute(
+            &self,
+            request: &GgmlAsrExecutionRequest,
+        ) -> Result<GgmlAsrExecutionResult, GgmlAsrExecutionError> {
+            self.gate.mark_entered();
+            let started = Instant::now();
+            loop {
+                if crate::ggml_runtime::thread_job_cancel_requested() {
+                    return Err(GgmlAsrExecutionError::ExecutorFailed {
+                        executor_id: "cancel-gate-stub",
+                        adapter_id: request.selected_family.adapter_id,
+                        reason: "aborted mid-flight by cancel".to_string(),
+                    });
+                }
+                if started.elapsed() > std::time::Duration::from_secs(30) {
+                    return Err(GgmlAsrExecutionError::ExecutorFailed {
+                        executor_id: "cancel-gate-stub",
+                        adapter_id: request.selected_family.adapter_id,
+                        reason: "cancel never observed within 30s (test safety valve)".to_string(),
+                    });
+                }
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
+        }
+    }
+
+    /// Run the concurrent pipeline on a scratch thread and hand its result back
+    /// through a channel so the caller can bound the wait -- a hang (deadlock,
+    /// lost worker, dropped channel) surfaces as a test failure instead of a
+    /// frozen suite.
+    fn spawn_pipeline_bounded(
+        width: usize,
+        audio: Vec<f32>,
+        slices: Vec<crate::longform::AudioSlice>,
+        executor: Arc<dyn GgmlAsrExecutor>,
+        execution_context: Arc<crate::RequestExecutionContext>,
+        longform: crate::LongFormOptions,
+    ) -> mpsc::Receiver<Result<ConcurrentPipelineOutcome, BackendError>> {
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let outcome = run_concurrent_pipeline_for_test(
+                width,
+                &audio,
+                slices,
+                executor,
+                &execution_context,
+                &longform,
+                None,
+            );
+            // Receiver may already be gone if the test timed out; ignore.
+            let _ = tx.send(outcome);
+        });
+        rx
+    }
+
+    /// Supplement 2, mid-flight cancel: a cancel that arrives while workers are
+    /// genuinely inside a decode (past the slice-boundary gate) must abort the
+    /// in-flight workers promptly, converge every worker, and surface the typed
+    /// `TranscriptionCanceled` -- without hanging or panicking a channel. The
+    /// existing cancel test only covers a cancel observed *before* any decode
+    /// starts (at the boundary gate); this covers the in-flight/abort path.
+    #[test]
+    fn concurrent_pipeline_mid_flight_cancel_aborts_in_flight_workers() {
+        let control = Arc::new(crate::api::backend::TranscriptionControl::new());
+        let execution_context = Arc::new(crate::RequestExecutionContext::new(
+            None,
+            Arc::clone(&control),
+        ));
+        let gate = DecodeGate::new();
+        let (audio, slices) = concurrent_pipeline_slices(4);
+
+        let rx = spawn_pipeline_bounded(
+            2,
+            audio,
+            slices,
+            Arc::new(CancelGateExecutor {
+                gate: Arc::clone(&gate),
+            }),
+            Arc::clone(&execution_context),
+            crate::LongFormOptions::default(),
+        );
+
+        // Wait until at least one worker is genuinely mid-decode, then cancel.
+        gate.wait_entered_at_least(1);
+        control.request_cancel();
+
+        let outcome = rx
+            .recv_timeout(std::time::Duration::from_secs(15))
+            .expect("mid-flight cancel must not hang the pipeline");
+        let error = outcome.expect_err("a canceled run must fail closed");
+        assert!(
+            matches!(error, BackendError::TranscriptionCanceled),
+            "mid-flight cancel must surface as the typed TranscriptionCanceled: {error}"
+        );
+    }
+
+    /// Supplement 2, pause/resume: a pause requested while the pipeline is
+    /// running must park every worker at a slice boundary (the whole run
+    /// suspends, no deadlock and no further slices decoded), and a later resume
+    /// must let it run to completion with the correct in-order output. Pause
+    /// was previously uncovered.
+    #[test]
+    fn concurrent_pipeline_pause_parks_workers_then_resume_completes() {
+        let control = Arc::new(crate::api::backend::TranscriptionControl::new());
+        let execution_context = Arc::new(crate::RequestExecutionContext::new(
+            None,
+            Arc::clone(&control),
+        ));
+        let gate = DecodeGate::new();
+        let (audio, slices) = concurrent_pipeline_slices(4);
+
+        let rx = spawn_pipeline_bounded(
+            2,
+            audio,
+            slices,
+            Arc::new(PauseGateExecutor {
+                gate: Arc::clone(&gate),
+            }),
+            Arc::clone(&execution_context),
+            crate::LongFormOptions::default(),
+        );
+
+        // A worker is mid-decode of its first slice. Request the pause now, then
+        // release the in-flight decode(s): each worker finishes its current
+        // slice, loops back to the boundary, and parks on the pending pause
+        // instead of pulling the remaining slices.
+        gate.wait_entered_at_least(1);
+        control.request_pause();
+        gate.release_all();
+
+        // The run must NOT complete while paused: with width 2 at most two
+        // slices could have been in flight, so slices remain and the workers are
+        // parked at the boundary.
+        assert!(
+            matches!(
+                rx.recv_timeout(std::time::Duration::from_millis(300)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "the pipeline must stay parked while paused, not complete"
+        );
+
+        // Resume: parked workers wake, drain the remaining slices, and the run
+        // completes with the byte-identical in-order transcript.
+        control.request_resume();
+        let outcome = rx
+            .recv_timeout(std::time::Duration::from_secs(15))
+            .expect("resume must let the paused pipeline finish, not hang")
+            .expect("a resumed run completes successfully");
+        assert_eq!(outcome.assembled.text, "w1 w2 w3 w4");
+        assert!(outcome.ran_any_slice);
+        assert_eq!(outcome.suppressed, 0);
+    }
 }

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -709,21 +709,45 @@ const SLICE_PIPELINE_MEMORY_RESERVE_BYTES: u64 = 512 * 1024 * 1024;
 /// unrealistically small number and over-admits workers.
 const SLICE_PIPELINE_PER_WORKER_BYTES_FLOOR: u64 = 256 * 1024 * 1024;
 
-/// Requested concurrent slice-pipeline width from `OPENASR_SLICE_PIPELINE_WIDTH`.
+/// Explicit slice-pipeline width override from `OPENASR_SLICE_PIPELINE_WIDTH`.
 ///
-/// Opt-in and conservative by default: unset, "0", "1", or an unparseable value
-/// all mean 1 -- the byte-identical serial + prompt-carry path. A value >= 2
-/// enables the carry-light concurrent path (subject to the capacity and
-/// slice-count gates in [`effective_slice_pipeline_width`]), clamped to
-/// [`SLICE_PIPELINE_MAX_WIDTH`]. Deliberately a runtime knob rather than a
-/// hard-coded default so the short-audio carry-vs-carry-light quality audit can
-/// pick the shipping default without a code change.
-fn slice_pipeline_requested_width() -> usize {
+/// `None` when the variable is unset or unparseable -- the carry-gated default
+/// in [`slice_pipeline_requested_width`] then decides. A parsed value is
+/// clamped to `1..=`[`SLICE_PIPELINE_MAX_WIDTH`], so "0" and "1" both mean an
+/// explicit serial pin. The override wins in both directions: it can force the
+/// concurrent path onto a carry-active run (accepting the carry-light quality
+/// cost) and force serial onto a carry-disabled run.
+fn slice_pipeline_explicit_width() -> Option<usize> {
     std::env::var("OPENASR_SLICE_PIPELINE_WIDTH")
         .ok()
         .and_then(|value| value.trim().parse::<usize>().ok())
-        .unwrap_or(1)
-        .clamp(1, SLICE_PIPELINE_MAX_WIDTH)
+        .map(|value| value.clamp(1, SLICE_PIPELINE_MAX_WIDTH))
+}
+
+/// Requested concurrent slice-pipeline width for one run, gated on that run's
+/// normalized effective prompt-carry state ([`longform_prompt_carry_mode`],
+/// which already folds the request option and the family's decode policy
+/// together -- deliberately not a per-family list).
+///
+/// - Carry `Disabled`: the serial loop threads no cross-slice prompt anyway,
+///   so the carry-light concurrent path is transcript-equivalent (proven
+///   byte-identical by `concurrent_slice_pipeline_equivalence`). Default to
+///   [`SLICE_PIPELINE_MAX_WIDTH`] and let the capacity and slice-count gates
+///   in [`effective_slice_pipeline_width`] pick what actually fits.
+/// - Carry active (`Text` / `TokenHistory`): the concurrent path would drop
+///   the carry and change the transcript (the short-audio audit measured
+///   whole-clause deletions), so the default stays 1 -- the byte-identical
+///   serial + prompt-carry path. Only an explicit
+///   `OPENASR_SLICE_PIPELINE_WIDTH>=2` overrides that, and the run then
+///   records the dropped carry in its provenance.
+fn slice_pipeline_requested_width(carry_prompt_mode: LongformPromptCarryMode) -> usize {
+    if let Some(explicit) = slice_pipeline_explicit_width() {
+        return explicit;
+    }
+    match carry_prompt_mode {
+        LongformPromptCarryMode::Disabled => SLICE_PIPELINE_MAX_WIDTH,
+        LongformPromptCarryMode::Text | LongformPromptCarryMode::TokenHistory => 1,
+    }
 }
 
 /// Pure capacity gate for the concurrent slice pipeline: how many workers may
@@ -742,7 +766,7 @@ fn slice_pipeline_capped_width(
     if ceiling <= 1 {
         return 1;
     }
-    // No memory probe on this host: honor the explicit opt-in rather than
+    // No memory probe on this host: honor the requested width rather than
     // silently disabling it, matching the serve-batch VRAM-cap precedent
     // (`serve_batch_vram_capped_max_batch` returns the request unchanged when no
     // memory sample is available). The reserve plus the conservative per-worker
@@ -1897,17 +1921,32 @@ fn run_native_transcription_impl(
             // one whole-recording external pass has a single scope and leaves
             // this empty.
             let mut speaker_scope_starts: Vec<f32> = Vec::new();
-            // P1 long-audio slice pipeline: when opted in and it fits, decode K
-            // slices concurrently to overlap the encode/decode GPU bubbles (the
-            // admission-concurrency win, applied to one file's slices). Width 1
-            // -- the default -- runs the byte-identical serial + prompt-carry
-            // path in the `else` below.
+            // P1 long-audio slice pipeline: decode K slices concurrently to
+            // overlap the encode/decode GPU bubbles (the admission-concurrency
+            // win, applied to one file's slices). The default is gated on this
+            // run's effective prompt-carry state (see
+            // `slice_pipeline_requested_width`): a carry-disabled run goes
+            // concurrent up to the capacity gate, a carry-active run stays on
+            // the byte-identical serial + prompt-carry path in the `else`
+            // below unless `OPENASR_SLICE_PIPELINE_WIDTH` overrides.
             let pipeline_width = effective_slice_pipeline_width(
-                slice_pipeline_requested_width(),
+                slice_pipeline_requested_width(carry_prompt_mode),
                 &plan.slices,
                 &runtime_preflight,
             );
             if pipeline_width > 1 {
+                let carry_note = if carry_prompt_mode == LongformPromptCarryMode::Disabled {
+                    "carry=disabled"
+                } else {
+                    // Explicit escape hatch on a carry-active run: the
+                    // concurrent path is carry-light, so the cross-slice
+                    // prompt carry this run would otherwise thread is dropped
+                    // -- an accepted quality cost, recorded for diagnosis.
+                    "carry=dropped-by-explicit-width"
+                };
+                longform_provenance.push(format!(
+                    "core.native.longform.slice-pipeline:width={pipeline_width},{carry_note}"
+                ));
                 run_concurrent_slice_pipeline(ConcurrentSlicePipeline {
                     width: pipeline_width,
                     slices: plan.slices,
@@ -6209,34 +6248,91 @@ mod tests {
     }
 
     #[test]
-    fn requested_width_defaults_to_serial_and_clamps() {
+    fn requested_width_default_is_gated_on_the_run_carry_state() {
         // SAFETY: nextest runs each test in its own process, so mutating this
         // process-global env var cannot race another test.
         unsafe {
             std::env::remove_var("OPENASR_SLICE_PIPELINE_WIDTH");
         }
+        // Carry disabled: concurrent is transcript-equivalent, so the default
+        // requests the maximum and lets the capacity gate pick K.
         assert_eq!(
-            slice_pipeline_requested_width(),
-            1,
-            "unset -> serial (conservative default)"
+            slice_pipeline_requested_width(LongformPromptCarryMode::Disabled),
+            SLICE_PIPELINE_MAX_WIDTH,
+            "carry-disabled run defaults to the concurrent pipeline"
         );
-        for (value, expected) in [
-            ("0", 1),
-            ("1", 1),
-            ("2", 2),
-            ("4", 4),
-            ("9", 4),
-            ("junk", 1),
-        ] {
+        // ... which still flows through the capacity gate: plenty of memory
+        // admits the full width, tight memory caps it back to serial.
+        assert_eq!(
+            slice_pipeline_capped_width(
+                slice_pipeline_requested_width(LongformPromptCarryMode::Disabled),
+                8,
+                Some(64 << 30),
+                1 << 20,
+                0,
+            ),
+            SLICE_PIPELINE_MAX_WIDTH,
+        );
+        assert_eq!(
+            slice_pipeline_capped_width(
+                slice_pipeline_requested_width(LongformPromptCarryMode::Disabled),
+                8,
+                Some(1_200 << 20),
+                1 << 30,
+                512 << 20,
+            ),
+            1,
+        );
+        // Carry active: the concurrent path would drop the carry, so the
+        // default stays on the byte-identical serial + prompt-carry path.
+        assert_eq!(
+            slice_pipeline_requested_width(LongformPromptCarryMode::Text),
+            1,
+            "text-carry run defaults to serial"
+        );
+        assert_eq!(
+            slice_pipeline_requested_width(LongformPromptCarryMode::TokenHistory),
+            1,
+            "token-history-carry run defaults to serial"
+        );
+    }
+
+    #[test]
+    fn requested_width_env_overrides_both_directions_and_clamps() {
+        // Explicit widths override the carry-gated default in both directions:
+        // ">=2" forces the carry-light concurrent path onto a carry-active
+        // run, and "0"/"1" pin a carry-disabled run to serial.
+        for (value, expected) in [("0", 1), ("1", 1), ("2", 2), ("4", 4), ("9", 4)] {
+            // SAFETY: nextest runs each test in its own process, so mutating
+            // this process-global env var cannot race another test.
             unsafe {
                 std::env::set_var("OPENASR_SLICE_PIPELINE_WIDTH", value);
             }
-            assert_eq!(
-                slice_pipeline_requested_width(),
-                expected,
-                "OPENASR_SLICE_PIPELINE_WIDTH={value}"
-            );
+            for carry_mode in [
+                LongformPromptCarryMode::Disabled,
+                LongformPromptCarryMode::Text,
+                LongformPromptCarryMode::TokenHistory,
+            ] {
+                assert_eq!(
+                    slice_pipeline_requested_width(carry_mode),
+                    expected,
+                    "OPENASR_SLICE_PIPELINE_WIDTH={value} carry={carry_mode:?}"
+                );
+            }
         }
+        // An unparseable value is not an explicit choice: fall back to the
+        // carry-gated default rather than guessing a width.
+        unsafe {
+            std::env::set_var("OPENASR_SLICE_PIPELINE_WIDTH", "junk");
+        }
+        assert_eq!(
+            slice_pipeline_requested_width(LongformPromptCarryMode::Disabled),
+            SLICE_PIPELINE_MAX_WIDTH,
+        );
+        assert_eq!(
+            slice_pipeline_requested_width(LongformPromptCarryMode::TokenHistory),
+            1,
+        );
         unsafe {
             std::env::remove_var("OPENASR_SLICE_PIPELINE_WIDTH");
         }

--- a/crates/openasr-core/src/capacity.rs
+++ b/crates/openasr-core/src/capacity.rs
@@ -494,8 +494,9 @@ pub(crate) enum MemoryAdmissionDomain {
 /// reverse-engineered by a test asserting on message text alone.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct HostMemoryCapacityRejection {
-    /// KV bytes at `required_positions` plus the pack's own on-disk bytes --
-    /// the two quantities [`evaluate_host_memory_admission`] actually knows.
+    /// KV bytes at `required_positions` plus the pack's own on-disk bytes plus
+    /// `auxiliary_resident_bytes` -- the quantities
+    /// [`evaluate_host_memory_admission`] actually knows.
     pub needed_bytes: u64,
     /// The budget `needed_bytes` was compared against: total RAM + swap on a
     /// unified-memory host, `host_total_memory_bytes * 3/4` on the discrete
@@ -503,6 +504,13 @@ pub(crate) struct HostMemoryCapacityRejection {
     pub budget_bytes: u64,
     pub host_total_memory_bytes: u64,
     pub pack_bytes_on_disk: u64,
+    /// Resident decode-state bytes charged beyond the positional KV model and
+    /// the pack file: fixed-size arena caches an AED-family decoder allocates
+    /// at its full ceiling regardless of the request, and co-resident
+    /// auxiliary models a request is known to load (the VAD +
+    /// speaker-embedder attribution pass). Zero for families/requests with
+    /// neither.
+    pub auxiliary_resident_bytes: u64,
     pub required_positions: usize,
     /// Which memory pool the budget was formed from -- so the message can name
     /// RAM+swap vs VRAM correctly and the trailer records the classification.
@@ -520,13 +528,14 @@ impl HostMemoryCapacityRejection {
             MemoryAdmissionDomain::DiscreteVram => ("discrete_vram", 0),
         };
         format!(
-            "core.native.capacity.admission:reject,domain={},needed_bytes={},budget_bytes={},host_total_memory_bytes={},swap_bytes={},pack_bytes_on_disk={},required_positions={}",
+            "core.native.capacity.admission:reject,domain={},needed_bytes={},budget_bytes={},host_total_memory_bytes={},swap_bytes={},pack_bytes_on_disk={},auxiliary_resident_bytes={},required_positions={}",
             domain,
             self.needed_bytes,
             self.budget_bytes,
             self.host_total_memory_bytes,
             swap_bytes,
             self.pack_bytes_on_disk,
+            self.auxiliary_resident_bytes,
             self.required_positions,
         )
     }
@@ -572,7 +581,11 @@ impl HostMemoryCapacityRejection {
 
 /// Evaluate whether `required_positions` decoder positions at `spec` for
 /// `geometry`, alongside `pack_bytes_on_disk` already resident from the
-/// mmap'd pack file, fit this host's memory budget for the given `domain`.
+/// mmap'd pack file and `auxiliary_resident_bytes` of additional
+/// request-known resident state (fixed-ceiling AED arena caches, the
+/// speaker-embedder attribution pass -- see
+/// [`HostMemoryCapacityRejection::auxiliary_resident_bytes`]), fit this
+/// host's memory budget for the given `domain`.
 /// The budget is never `host_available_memory_bytes` (see this module's
 /// invariants and that probe's own doc forbidding admission use).
 ///
@@ -602,13 +615,17 @@ pub(crate) fn evaluate_host_memory_admission(
     spec: LlmKvCacheSpec,
     required_positions: usize,
     pack_bytes_on_disk: u64,
+    auxiliary_resident_bytes: u64,
     host_total_memory_bytes: u64,
     domain: MemoryAdmissionDomain,
 ) -> Result<(), HostMemoryCapacityRejection> {
     let Ok(kv_bytes) = kv_bytes_at_positions(geometry, spec, required_positions) else {
         return Ok(());
     };
-    let needed_bytes = kv_bytes.total().saturating_add(pack_bytes_on_disk);
+    let needed_bytes = kv_bytes
+        .total()
+        .saturating_add(pack_bytes_on_disk)
+        .saturating_add(auxiliary_resident_bytes);
     let budget_bytes = match domain {
         // Unified memory can page to swap, so the physical ceiling a decode can
         // draw on is RAM + swap -- not the 75% RAM budget the discrete path and
@@ -629,6 +646,7 @@ pub(crate) fn evaluate_host_memory_admission(
         budget_bytes,
         host_total_memory_bytes,
         pack_bytes_on_disk,
+        auxiliary_resident_bytes,
         required_positions,
         domain,
     })
@@ -859,6 +877,7 @@ mod tests {
             LlmKvCacheSpec::DEFAULT,
             512,
             oversized_pack_bytes_on_disk,
+            0,
             tiny_host_total_memory_bytes,
             unified(0),
         )
@@ -905,6 +924,7 @@ mod tests {
             LlmKvCacheSpec::DEFAULT,
             required_positions,
             pack_bytes,
+            0,
             host_ram,
             unified(4 * GIB),
         )
@@ -915,6 +935,7 @@ mod tests {
             LlmKvCacheSpec::DEFAULT,
             required_positions,
             pack_bytes,
+            0,
             host_ram,
             unified(0),
         )
@@ -934,6 +955,7 @@ mod tests {
             LlmKvCacheSpec::DEFAULT,
             512,
             pack_bytes,
+            0,
             host_ram,
             unified(swap),
         )
@@ -950,6 +972,47 @@ mod tests {
         assert!(message.contains(&format!("swap_bytes={swap}")), "{message}");
     }
 
+    /// Auxiliary resident bytes (fixed AED arena state, the co-resident
+    /// speaker-embedder pass) are charged into the same needed-vs-budget
+    /// comparison: a request that fits without them and overflows with them
+    /// must be rejected, and the rejection must carry the figure in both the
+    /// struct and the provenance trailer.
+    #[test]
+    fn host_memory_admission_charges_auxiliary_resident_bytes() {
+        let geometry = moss_geometry();
+        let host_ram: u64 = 4 * GIB;
+        let pack_bytes: u64 = 3 * GIB + GIB / 2;
+        // 512 DEFAULT positions ~= 168 MiB of KV: pack + KV fits 4 GiB...
+        evaluate_host_memory_admission(
+            &geometry,
+            LlmKvCacheSpec::DEFAULT,
+            512,
+            pack_bytes,
+            0,
+            host_ram,
+            unified(0),
+        )
+        .expect("without auxiliary bytes the request fits");
+        // ...and one added GiB of auxiliary resident state tips it over.
+        let auxiliary: u64 = GIB;
+        let rejection = evaluate_host_memory_admission(
+            &geometry,
+            LlmKvCacheSpec::DEFAULT,
+            512,
+            pack_bytes,
+            auxiliary,
+            host_ram,
+            unified(0),
+        )
+        .expect_err("the auxiliary charge must tip the same request over the budget");
+        assert_eq!(rejection.auxiliary_resident_bytes, auxiliary);
+        let message = rejection.user_message();
+        assert!(
+            message.contains(&format!("auxiliary_resident_bytes={auxiliary}")),
+            "{message}"
+        );
+    }
+
     /// Discrete VRAM cannot page: swap never enters its budget, and the
     /// rejection message says so. A budget that would trivially admit the same
     /// request as unified-with-swap still rejects here.
@@ -964,6 +1027,7 @@ mod tests {
             LlmKvCacheSpec::DEFAULT,
             8192,
             pack_bytes,
+            0,
             host_ram,
             MemoryAdmissionDomain::DiscreteVram,
         )
@@ -989,6 +1053,7 @@ mod tests {
             LlmKvCacheSpec::DEFAULT,
             8192,
             pack_bytes,
+            0,
             host_ram,
             unified(8 * GIB),
         )
@@ -1012,6 +1077,7 @@ mod tests {
             LlmKvCacheSpec::DEFAULT,
             8192,
             modest_pack_bytes_on_disk,
+            0,
             crate::host::MIN_SPEC_TOTAL_MEMORY_BYTES,
             unified(0),
         )
@@ -1036,6 +1102,7 @@ mod tests {
                 &degenerate,
                 LlmKvCacheSpec::DEFAULT,
                 8192,
+                0,
                 0,
                 1024,
                 unified(0),

--- a/crates/openasr-core/src/cuda_targets.rs
+++ b/crates/openasr-core/src/cuda_targets.rs
@@ -1,0 +1,114 @@
+// CUDA GPU-architecture target-list defaults and parsing.
+//
+// `build.rs` needs this logic to set CMake's `CUDA_ARCHITECTURES` when it
+// compiles vendored ggml's CUDA backend, but a build script is not a test
+// target: a `#[cfg(test)] mod tests` living only inside `build.rs` is never
+// collected by `cargo test`/`cargo nextest`, so a regression there (e.g. the
+// default arch list silently narrowing below vendored ggml's own floor, the
+// class of bug fixed in #255/#196) would never fail CI. This file is the
+// single implementation, `include!`d verbatim by `build.rs` (see its
+// `cuda_gpu_targets()`) and compiled into this crate as an ordinary module
+// (see `mod cuda_targets;` in `lib.rs`) so the canary test below actually
+// runs as part of this crate's normal `cargo nextest` unit-test binary.
+//
+// Only `std` is used here (no crate-internal imports) so the exact same
+// source text compiles cleanly in both contexts. Plain `//` comments only
+// (not `//!` inner doc comments): this file is spliced into build.rs mid-file
+// via `include!`, where an inner doc comment is a hard error (E0753) since it
+// is not the first thing in that compilation unit.
+
+/// Default CUDA arch list for a released binary: sm_75 through sm_90. Floor
+/// is 75 (Turing: RTX 20xx, GTX 16xx, T4, 2080 Ti), not 70 (Volta) or lower,
+/// because CUDA 13 removed device-code generation for Volta/Pascal/Maxwell
+/// outright -- those need a CUDA 12 toolchain, which is a separate build leg
+/// (tracked, not this one). 75 itself is deprecated-but-still-buildable on
+/// CUDA 13.2: nvcc warns, but still emits working sm_75 SASS and PTX. No
+/// explicit `-real`/`-virtual` suffix means CMake emits both device code and
+/// PTX for every listed number, so this default also carries 75-virtual PTX
+/// that the CUDA driver JITs forward to any newer, unlisted architecture at
+/// load time -- the same forward-compat mechanism vendored ggml's own
+/// (non-native) CMakeLists.txt default relies on. Upper bound stops at 90
+/// (Hopper): 120 (Blackwell) needs CUDA 12.8+ and a CMake new enough for the
+/// `f`/`a` suffix regex, which this default does not assume. Override with
+/// `OPENASR_CUDA_GPU_TARGETS` for a narrower/wider/newer set.
+pub(crate) const DEFAULT_CUDA_GPU_TARGETS: &str = "75;80;86;89;90";
+
+pub(crate) fn cuda_gpu_targets_from_raw(raw: Option<&str>) -> String {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(normalize_cuda_gpu_targets)
+        .unwrap_or_else(|| DEFAULT_CUDA_GPU_TARGETS.to_string())
+}
+
+pub(crate) fn normalize_cuda_gpu_targets(raw: &str) -> String {
+    raw.split([',', ';', ' '])
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            value
+                .strip_prefix("sm_")
+                .or_else(|| value.strip_prefix("SM_"))
+                .unwrap_or(value)
+        })
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_CUDA_GPU_TARGETS, cuda_gpu_targets_from_raw};
+
+    #[test]
+    fn cuda_targets_default_to_common_cloud_and_consumer_arches() {
+        assert_eq!(cuda_gpu_targets_from_raw(None), "75;80;86;89;90");
+        assert_eq!(cuda_gpu_targets_from_raw(Some("   ")), "75;80;86;89;90");
+    }
+
+    #[test]
+    fn cuda_targets_accept_common_arch_spellings() {
+        assert_eq!(
+            cuda_gpu_targets_from_raw(Some("sm_80,86; SM_89 90")),
+            "80;86;89;90"
+        );
+    }
+
+    #[test]
+    fn cuda_default_targets_are_not_narrower_than_vendored_ggml_default() {
+        // Regression guard for the class of bug in #255/#196: OpenASR's own
+        // default CUDA arch list silently excluded sm_75 (Turing), so a
+        // released CUDA binary hit "no kernel image available" on every
+        // 2080 Ti / T4 / RTX 20xx / GTX 16xx card. Cross-check against
+        // vendored ggml's own (non-native) CMakeLists.txt default, which is
+        // the actual upstream source of truth this default is trying to
+        // track: if a future ggml bump drops or narrows its own sm_75 floor,
+        // this test's first assertion fails and flags that our comment/
+        // reasoning in `cuda_gpu_targets_from_raw` needs re-deriving; if
+        // OpenASR's own default regresses below that floor, the second
+        // assertion fails instead.
+        //
+        // `env!("CARGO_MANIFEST_DIR")` (not a plain relative path) because
+        // this file is compiled from two different locations -- as a normal
+        // module of this crate, and `include!`d into `build.rs` -- and only
+        // an absolute, manifest-anchored path resolves identically both ways.
+        let vendored_ggml_cmake = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/third_party/openasr-ggml/src/ggml-cuda/CMakeLists.txt"
+        ));
+        assert!(
+            vendored_ggml_cmake.contains("75-virtual"),
+            "vendored ggml CMakeLists.txt no longer defaults to sm_75; re-check \
+             whether OpenASR's own CUDA_GPU_TARGETS floor of 75 is still \
+             upstream-aligned before changing it"
+        );
+        assert!(
+            cuda_gpu_targets_from_raw(None)
+                .split(';')
+                .any(|arch| arch == "75"),
+            "OpenASR's default CUDA arch list narrowed below upstream ggml's \
+             own sm_75 floor"
+        );
+        // Keep the constant and the canary's own literal from silently
+        // drifting apart.
+        assert_eq!(cuda_gpu_targets_from_raw(None), DEFAULT_CUDA_GPU_TARGETS);
+    }
+}

--- a/crates/openasr-core/src/diarize/embed/mod.rs
+++ b/crates/openasr-core/src/diarize/embed/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod weights;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use pack::speaker_attribution_admission_bytes;
 pub use pack::{
     DIARIZATION_EMBEDDER_LOAD_FAILED_REASON, REALTIME_DIARIZATION_EMBEDDER_MISSING_REASON,
     SPEAKER_EMBEDDER_PACK_ID, SPEAKER_EMBEDDER_PACK_LABEL, SpeakerEmbedderIdentity,

--- a/crates/openasr-core/src/diarize/embed/pack.rs
+++ b/crates/openasr-core/src/diarize/embed/pack.rs
@@ -77,6 +77,37 @@ pub fn embedder_pack_installed() -> bool {
     redimnet_pack_path().is_some()
 }
 
+/// Conservative multiplier from the embedder pack's on-disk bytes to the
+/// resident memory the speaker-attribution pass is charged at admission time:
+/// the pack's (fp16) weights are dequantized/uploaded as working f32 state by
+/// the ggml graph (up to 2x the file), plus frontend/activation working
+/// buffers and the VAD model. 4x the ~27 MiB shipped pack is ~110 MiB -- a
+/// deliberate upper bound that still sits far below any realistic admission
+/// budget (min-spec is 8 GiB), so it cannot introduce a new false-reject band
+/// on its own; it only tips requests that were already within that margin of
+/// the ceiling.
+const SPEAKER_ATTRIBUTION_ADMISSION_PACK_MULTIPLIER: u64 = 4;
+
+/// Resident bytes the host-memory admission check charges for the VAD +
+/// speaker-embedder attribution pass (`compute_speaker_attribution`) a
+/// diarize-routed request runs right after admission: a conservative multiple
+/// of the resolved embedder pack's on-disk size (see
+/// [`SPEAKER_ATTRIBUTION_ADMISSION_PACK_MULTIPLIER`]). `0` when no pack
+/// resolves or it cannot be stat'ed -- "uncertain" resolves to "allow", the
+/// admission side's fail-open invariant (and a request without the pack fails
+/// closed on its own `DiarizationNotSupported` gate before admission anyway).
+pub(crate) fn speaker_attribution_admission_bytes() -> u64 {
+    let Some(path) = redimnet_pack_path() else {
+        return 0;
+    };
+    let Ok(metadata) = std::fs::metadata(&path) else {
+        return 0;
+    };
+    metadata
+        .len()
+        .saturating_mul(SPEAKER_ATTRIBUTION_ADMISSION_PACK_MULTIPLIER)
+}
+
 /// The process-wide active ReDimNet2-B6 embedder, or `None` if the pack is not
 /// installed.
 ///
@@ -174,6 +205,29 @@ mod tests {
     fn redimnet_pack_env_name_is_stable() {
         assert_eq!(REDIMNET_PACK_ENV, "OPENASR_REDIMNET_PACK");
         assert_eq!(REDIMNET_INSTALLED_MODEL_ID_HINT, "redimnet");
+    }
+
+    /// The admission estimate is the resolved pack's on-disk size times the
+    /// conservative multiplier -- pinned against the env-override resolution
+    /// path (nextest's per-test process isolation makes the env mutation
+    /// safe), with an empty `OPENASR_HOME` so no installed pack can shadow
+    /// the override or make the no-pack half nondeterministic.
+    #[test]
+    fn speaker_attribution_admission_bytes_scale_the_resolved_pack_size() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        unsafe { std::env::set_var("OPENASR_HOME", dir.path()) };
+
+        // No pack anywhere: uncertain resolves to zero (fail open).
+        unsafe { std::env::remove_var(REDIMNET_PACK_ENV) };
+        assert_eq!(speaker_attribution_admission_bytes(), 0);
+
+        let pack = dir.path().join("redimnet-fixture.oasr");
+        std::fs::write(&pack, vec![0u8; 1000]).expect("write fixture pack");
+        unsafe { std::env::set_var(REDIMNET_PACK_ENV, &pack) };
+        assert_eq!(
+            speaker_attribution_admission_bytes(),
+            1000 * SPEAKER_ATTRIBUTION_ADMISSION_PACK_MULTIPLIER
+        );
     }
 
     fn sha256_hex(bytes: &[u8]) -> String {

--- a/crates/openasr-core/src/ggml_runtime/gguf_tensor_data.rs
+++ b/crates/openasr-core/src/ggml_runtime/gguf_tensor_data.rs
@@ -620,6 +620,73 @@ pub struct GgufHostTensorPayload<'a> {
     pub bytes: &'a [u8],
 }
 
+/// Byte length of one quantized/typed ggml row of `ne0` elements, or `None` on
+/// overflow. Mirrors `ggml_row_size` so callers can slice a stored quantized
+/// tensor into per-row spans without re-opening the reader.
+pub(crate) fn ggml_row_size_bytes(ggml_type: i32, ne0: usize) -> Option<usize> {
+    let ne0_i64 = i64::try_from(ne0).ok()?;
+    Some(unsafe { ffi::ggml_row_size(ggml_type, ne0_i64) })
+}
+
+/// Dequantize one typed/quantized ggml row -- `row_bytes` must be exactly
+/// `ggml_row_size(ggml_type, ne0)` long -- into `ne0` f32 values appended to
+/// `out`. This is the lazy-gather primitive that lets a quantized
+/// token-embedding table dequantize only the rows a decode step touches instead
+/// of materializing the whole `[d_model, vocab]` table to f32.
+pub(crate) fn dequantize_ggml_row_to_f32(
+    ggml_type: i32,
+    row_bytes: &[u8],
+    ne0: usize,
+    out: &mut Vec<f32>,
+) -> Result<(), GgufQuantizedRowDequantizeError> {
+    let ne0_i64 =
+        i64::try_from(ne0).map_err(|_| GgufQuantizedRowDequantizeError::Ne0Overflow { ne0 })?;
+    let row_size = unsafe { ffi::ggml_row_size(ggml_type, ne0_i64) };
+    if row_bytes.len() != row_size {
+        return Err(GgufQuantizedRowDequantizeError::RowLengthMismatch {
+            ggml_type,
+            expected: row_size,
+            actual: row_bytes.len(),
+        });
+    }
+    let traits_ptr = unsafe { ffi::ggml_get_type_traits(ggml_type) };
+    if traits_ptr.is_null() {
+        return Err(GgufQuantizedRowDequantizeError::UnsupportedType { ggml_type });
+    }
+    let to_float = unsafe { (*traits_ptr).to_float }
+        .ok_or(GgufQuantizedRowDequantizeError::UnsupportedType { ggml_type })?;
+    let start = out.len();
+    out.resize(start + ne0, 0.0_f32);
+    // SAFETY: `row_bytes.len() == ggml_row_size(ggml_type, ne0)` (checked above)
+    // and `out[start..]` holds exactly `ne0` freshly-zeroed f32 slots, matching
+    // the `(src, dst, ne0)` contract of ggml's `to_float` trait.
+    unsafe {
+        to_float(
+            row_bytes.as_ptr().cast::<std::ffi::c_void>(),
+            out[start..].as_mut_ptr(),
+            ne0_i64,
+        );
+    }
+    Ok(())
+}
+
+/// Failure dequantizing a single ggml row via [`dequantize_ggml_row_to_f32`].
+#[derive(Debug, Error)]
+pub(crate) enum GgufQuantizedRowDequantizeError {
+    #[error(
+        "quantized row dequantize length mismatch for ggml_type {ggml_type}: row is {actual} bytes, expected {expected}"
+    )]
+    RowLengthMismatch {
+        ggml_type: i32,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("quantized row dequantize ne0 {ne0} does not fit i64")]
+    Ne0Overflow { ne0: usize },
+    #[error("ggml_type {ggml_type} has no to_float trait for row dequantize")]
+    UnsupportedType { ggml_type: i32 },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GgufWeightTensorElementType {
     F32,

--- a/crates/openasr-core/src/ggml_runtime/mod.rs
+++ b/crates/openasr-core/src/ggml_runtime/mod.rs
@@ -51,6 +51,7 @@ pub use gguf_tensor_data::{
     GgufHostTensorPayload, GgufOwnedWeightTensorPayload, GgufTensorDataReadError,
     GgufTensorDataReader, GgufWeightTensorElementType, GgufWeightTensorPayload,
 };
+pub(crate) use gguf_tensor_data::{dequantize_ggml_row_to_f32, ggml_row_size_bytes};
 pub use gguf_tensor_index::{
     GgufTensorIndex, GgufTensorIndexReadError, GgufTensorMetadata, read_gguf_tensor_index,
     read_gguf_tensor_index_from_runtime_source,

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -2,6 +2,15 @@ mod atomic_file;
 mod backends_manifest_security;
 mod catalog_security;
 mod catalog_series;
+// This module exists in the compiled library only to host a regression test:
+// the actual CUDA-arch-target logic runs at build-script time, not at
+// runtime, and `build.rs` gets its own copy via `include!` (see
+// `cuda_targets.rs`'s doc comment) since a build script cannot depend on the
+// crate it configures. Gating the whole module on `cfg(test)` keeps a plain
+// (non-test) build free of otherwise-dead-code warnings for functions this
+// crate's runtime never calls.
+#[cfg(test)]
+mod cuda_targets;
 mod http;
 
 // Module visibility is scoped to the actual external API surface. Modules that

--- a/crates/openasr-core/src/models.rs
+++ b/crates/openasr-core/src/models.rs
@@ -46,6 +46,8 @@ pub(crate) mod phrase_bias_decode;
 pub(crate) mod prepared_runtime_cache;
 pub(crate) mod pyannote;
 pub mod qwen;
+#[cfg(test)]
+mod resident_runtime_audit;
 pub(crate) mod runtime_asset_bootstrap;
 pub(crate) mod runtime_cache_coordinator;
 pub(crate) mod runtime_component_bootstrap;

--- a/crates/openasr-core/src/models/cohere/capacity.rs
+++ b/crates/openasr-core/src/models/cohere/capacity.rs
@@ -1,0 +1,155 @@
+//! cohere-transcribe capacity derivation for the shared host-memory admission
+//! check ([`crate::capacity::evaluate_host_memory_admission`]).
+//!
+//! Unlike the Qwen-shaped LLM families, this AED decoder's KV state is
+//! allocated at FIXED per-pack ceilings the moment the decoder runtime is
+//! built, independent of the request's audio length (see
+//! `super::decoder_graph`):
+//!
+//! - the self-attention KV cache is f16 at the full `decoder_max_context`
+//!   span per layer, and
+//! - the cross-attention KV cache is f32 over the pack's chunk-cap encoder
+//!   frame capacity ([`super::decoder_graph::cohere_decoder_cross_capacity_frames`],
+//!   the shared longform safety ceiling plus margin).
+//!
+//! Admission therefore charges those exact allocations, not a per-request
+//! position walk. The split between the two return channels keeps every byte
+//! exact:
+//!
+//! - the cross-KV cache maps onto the shared position model byte-for-byte:
+//!   one "position" = one encoder frame costing `layers x 2 x d_model` f32
+//!   values, and [`COHERE_ADMISSION_KV_SPEC`] (two f16 copies, 4 B/value
+//!   total) equals one f32 copy exactly;
+//! - the f16 self-KV ceiling cannot be expressed at 2 B/value through the
+//!   two-copy spec model, so it is returned as exact fixed bytes instead
+//!   (charging it through the spec would overstate it 2x -- the false-reject
+//!   direction the admission invariant forbids).
+//!
+//! A `longform mode=off` request larger than the chunk cap can still grow
+//! the cross cache past this estimate at runtime; admission's under-estimate
+//! for that opt-in path resolves to "allow" (fail open), never to a false
+//! rejection of the default path.
+
+use crate::capacity::KvGeometry;
+use crate::ggml_runtime::GgmlKvElementType;
+use crate::nn::decoder::LlmKvCacheSpec;
+
+use super::decoder_graph::cohere_decoder_cross_capacity_frames;
+use super::runtime_contract::CohereTranscribeExecutionMetadata;
+
+/// Two f16 copies = 4 B/value total: byte-for-byte the single f32 copy the
+/// cross-KV cache actually allocates (see the module doc). Only
+/// [`crate::capacity::KvBytesPerPosition::total`] is consumed by admission,
+/// so the host/resident split is a modeling stand-in, not a claim that a
+/// host-side copy exists.
+pub(crate) const COHERE_ADMISSION_KV_SPEC: LlmKvCacheSpec = LlmKvCacheSpec {
+    host: GgmlKvElementType::F16,
+    resident: GgmlKvElementType::F16,
+};
+
+/// The decoder KV geometry the loaded pack advertises (MHA: `kv_heads` equals
+/// `decoder_heads`, so `layers x 2 x kv_heads x head_dim` values per position
+/// equals the `layers x 2 x d_model` values one cross-KV frame costs).
+pub(crate) fn cohere_kv_geometry(metadata: &CohereTranscribeExecutionMetadata) -> KvGeometry {
+    KvGeometry {
+        n_layers: metadata.decoder_layers,
+        kv_heads: metadata.decoder_heads,
+        head_dim: metadata.decoder_head_dim,
+    }
+}
+
+/// The cross-KV positions admission charges through the shared position
+/// model: the pack's chunk-cap encoder frame capacity, the same figure the
+/// decoder runtime allocates its cross cache at (request-independent).
+pub(crate) fn cohere_admission_required_positions(
+    metadata: &CohereTranscribeExecutionMetadata,
+) -> usize {
+    cohere_decoder_cross_capacity_frames(*metadata)
+}
+
+/// Exact bytes of the f16 self-attention KV cache the decoder runtime
+/// allocates at construction: K + V planes of
+/// `head_dim x decoder_max_context x decoder_heads` f16 values per layer
+/// (`new_persistent_self_kv_tensor_in_arena`'s exact shape). `0` on
+/// arithmetic failure -- an under-estimate resolves to "allow", per
+/// `crate::capacity`'s fail-open invariant.
+pub(crate) fn cohere_admission_fixed_self_kv_bytes(
+    metadata: &CohereTranscribeExecutionMetadata,
+) -> u64 {
+    let plane = GgmlKvElementType::F16
+        .plane_nbytes(
+            metadata.decoder_head_dim,
+            metadata.decoder_max_context,
+            metadata.decoder_heads,
+        )
+        .unwrap_or(0) as u64;
+    plane
+        .saturating_mul(2) // K + V
+        .saturating_mul(metadata.decoder_layers as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capacity::kv_bytes_per_position;
+
+    /// Real-checkpoint-shaped metadata (the same values `runtime_contract`'s
+    /// `base_metadata` fixture parses: 8-layer MHA decoder at head_dim 128,
+    /// 1024-position context, 16kHz/160-hop mel).
+    fn reference_metadata() -> CohereTranscribeExecutionMetadata {
+        CohereTranscribeExecutionMetadata {
+            vocab_size: 50_000,
+            encoder_layers: 48,
+            encoder_d_model: 1280,
+            encoder_heads: 8,
+            encoder_head_dim: 160,
+            encoder_ffn_dim: 5120,
+            encoder_conv_kernel: 9,
+            decoder_layers: 8,
+            decoder_d_model: 1024,
+            decoder_heads: 8,
+            decoder_head_dim: 128,
+            decoder_ffn_dim: 4096,
+            decoder_max_context: 1024,
+            decoder_start_token_id: 13_764,
+            sample_rate_hz: 16_000,
+            n_mels: 128,
+            n_fft: 512,
+            hop_length: 160,
+            win_length: 400,
+        }
+    }
+
+    #[test]
+    fn admission_spec_prices_one_f32_copy_per_cross_frame() {
+        let geometry = cohere_kv_geometry(&reference_metadata());
+        let per_position = kv_bytes_per_position(&geometry, COHERE_ADMISSION_KV_SPEC)
+            .expect("f16 spec accepts head_dim 128");
+        // layers x 2 x d_model f32 values per cross frame:
+        // 8 * 2 * 1024 * 4 B = 64 KiB -- exactly what the shared model
+        // charges per position under the two-f16-copy spec.
+        assert_eq!(per_position.total(), 8 * 2 * 1024 * 4);
+    }
+
+    #[test]
+    fn fixed_self_kv_bytes_match_the_arena_allocation() {
+        // 8 layers x 2 (K+V) x 8 heads x 1024 positions x 128 head_dim x 2 B
+        // (f16) = 32 MiB, the allocation `new_persistent_self_kv_tensor_in_arena`
+        // makes at construction.
+        assert_eq!(
+            cohere_admission_fixed_self_kv_bytes(&reference_metadata()),
+            8 * 2 * 8 * 1024 * 128 * 2
+        );
+    }
+
+    #[test]
+    fn required_positions_are_the_chunk_cap_cross_frames() {
+        let metadata = reference_metadata();
+        assert_eq!(
+            cohere_admission_required_positions(&metadata),
+            cohere_decoder_cross_capacity_frames(metadata)
+        );
+        // Request-independent, and non-degenerate for the shipped shape.
+        assert!(cohere_admission_required_positions(&metadata) > 0);
+    }
+}

--- a/crates/openasr-core/src/models/cohere/decoder_graph.rs
+++ b/crates/openasr-core/src/models/cohere/decoder_graph.rs
@@ -609,7 +609,9 @@ fn cohere_mel_frames_for_seconds(
 /// (`kv_init`: reserve at a known max, never reallocate per step) -- see
 /// `GgmlCpuStepBufferPool`'s doc in `ggml_runtime/cpu_graph.rs` for the
 /// sibling citation and `ACKNOWLEDGMENTS.md`.
-fn cohere_decoder_cross_capacity_frames(metadata: CohereTranscribeExecutionMetadata) -> usize {
+pub(crate) fn cohere_decoder_cross_capacity_frames(
+    metadata: CohereTranscribeExecutionMetadata,
+) -> usize {
     let chunk_seconds = crate::arch::DEFAULT_ENCODER_SAFE_CHUNK_SECONDS
         + COHERE_DECODER_CROSS_CAPACITY_MARGIN_SECONDS;
     let mel_frames = cohere_mel_frames_for_seconds(chunk_seconds, metadata);

--- a/crates/openasr-core/src/models/cohere/mod.rs
+++ b/crates/openasr-core/src/models/cohere/mod.rs
@@ -1,4 +1,5 @@
 mod batched_decode;
+pub(crate) mod capacity;
 mod decoder_graph;
 mod decoder_weights;
 pub(crate) mod encoder_graph;

--- a/crates/openasr-core/src/models/dolphin/decoder_graph.rs
+++ b/crates/openasr-core/src/models/dolphin/decoder_graph.rs
@@ -143,23 +143,26 @@ impl DolphinDecoderOutput {
 
 // --- persistent weight arena -------------------------------------------------
 //
-// Perf (P5, see joint_decode::attention_rescore): attention-rescoring calls this
-// decoder once per CTC n-best hypothesis (up to DOLPHIN_BEAM_SIZE). Only the
-// token ids / causal mask / sequence length actually differ across those calls
-// -- the ~200 decoder weight tensors and the encoder memory are identical for
-// every hypothesis of one utterance. Rebuilding a fresh graph AND re-uploading
-// every weight per hypothesis (the pre-P5 behavior) paid that upload cost
-// `beam_size` times over for no reason. This mirrors the firered_aed decoder's
-// `GgmlStaticTensorArena`-backed persistent weights (`decoder_weights.rs` /
-// `decoder_graph.rs`): weights (+ the encoder memory) are declared and uploaded
-// ONCE into a static arena by [`DolphinDecoderRescoreRuntime::new`]; each
-// [`DolphinDecoderRescoreRuntime::decode_prompt_logits`] call then only builds
-// the small per-hypothesis graph (token embed lookup, absolute-position view,
-// causal mask, the stacked layers, output projection) referencing those
-// already-resident static tensors -- no weight re-upload, no encoder-memory
-// re-upload. The forward math (`decoder_layer`/`linear`/`affine_ln`/etc. below)
-// is untouched, so this is a pure execution-strategy change: same graph, same
-// numbers, golden-identical output.
+// Perf (P5, then extended -- see joint_decode::attention_rescore):
+// attention-rescoring teacher-forces up to DOLPHIN_BEAM_SIZE CTC n-best
+// hypotheses against the same decoder weights and the same encoder memory;
+// only the token ids / causal masks / sequence lengths differ. This mirrors
+// the firered_aed decoder's `GgmlStaticTensorArena`-backed persistent weights
+// (`decoder_weights.rs` / `decoder_graph.rs`): the ~200 weight tensors are
+// declared and uploaded ONCE into a static arena by
+// [`DolphinDecoderRescoreRuntime::new`], and the runtime itself is cached per
+// `(pack, backend)` by the executor, so later utterances skip the upload
+// entirely (the pre-cache behavior rebuilt runner + arena and re-uploaded
+// every weight per utterance). Each
+// [`DolphinDecoderRescoreRuntime::decode_nbest_prompt_logits`] call then
+// builds ONE fused per-utterance graph: the encoder memory is a transient
+// input uploaded once, the per-layer cross-attention K/V projections over it
+// are shared graph nodes computed once, and every hypothesis contributes only
+// its small chain (token embed lookup, absolute-position view, causal mask,
+// stacked layers, output projection) referencing the resident weights and the
+// shared K/V nodes. The forward math (`decoder_layer`/`linear`/`affine_ln`/
+// etc. below) is untouched, so this is a pure execution-strategy change: same
+// ops, same numbers, golden-identical output.
 
 type Upload<'p> = (GgmlStaticTensor, &'p [f32], &'static str);
 /// Pending native (quantized / f16) weight upload: `(tensor, raw-bytes,
@@ -448,7 +451,9 @@ fn build_layer_static_weights(
 /// per layer, 13 `(weight, bias)`-style pairs (norm1/self_q/self_k/self_v/
 /// self_o/norm2/src_q/src_k/src_v/src_o/norm3/ff_w1/ff_w2) = 26 tensors, plus
 /// the fixed token embedding, full position table, after_norm (2), output
-/// weight and output bias, plus one encoder-memory tensor.
+/// weight and output bias. The encoder memory is no longer arena-resident --
+/// it is a per-call transient graph input of [`DolphinDecoderRescoreRuntime::
+/// decode_nbest_prompt_logits`], uploaded once per utterance.
 const DOLPHIN_DECODER_ARENA_TENSORS_PER_LAYER: usize = 26;
 const DOLPHIN_DECODER_ARENA_FIXED_TENSORS: usize = 6;
 
@@ -558,16 +563,45 @@ fn attention<'a>(
     )
 }
 
+/// One layer's cross-attention K/V heads, projected from the encoder memory.
+/// These depend only on the encoder output (identical for every hypothesis of
+/// one utterance), so [`DolphinDecoderRescoreRuntime::decode_nbest_prompt_logits`]
+/// computes them once per utterance as shared graph nodes and every
+/// per-hypothesis chain consumes the same nodes -- the exact ops (same inputs,
+/// same order) each per-hypothesis graph used to run redundantly, so the
+/// values are unchanged; they are just no longer recomputed `beam_size` times.
+#[derive(Clone, Copy)]
+struct CrossAttentionHeads<'a> {
+    k_heads: GgmlCpuTensor<'a>,
+    v_heads: GgmlCpuTensor<'a>,
+}
+
+fn build_cross_attention_heads<'a>(
+    graph: &GgmlCpuGraphBuilder<'a>,
+    encoder_out: GgmlCpuTensor<'a>,
+    weights: &DecoderLayerWeights<'a>,
+    config: &DolphinDecoderConfig,
+    frames: usize,
+) -> Result<CrossAttentionHeads<'a>, DolphinDecoderError> {
+    let hd = config.head_dim;
+    let heads = config.attention_heads;
+    let k = linear(graph, &weights.src_k, encoder_out, "cross_attn_k")?;
+    let v = linear(graph, &weights.src_v, encoder_out, "cross_attn_v")?;
+    Ok(CrossAttentionHeads {
+        k_heads: reshape_heads(graph, k, hd, heads, frames)?,
+        v_heads: reshape_heads(graph, v, hd, heads, frames)?,
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn decoder_layer<'a>(
     graph: &mut GgmlCpuGraphBuilder<'a>,
     input: GgmlCpuTensor<'a>,
-    encoder_out: GgmlCpuTensor<'a>,
+    cross: CrossAttentionHeads<'a>,
     causal_mask: GgmlCpuTensor<'a>,
     weights: &DecoderLayerWeights<'a>,
     config: &DolphinDecoderConfig,
     tokens: usize,
-    frames: usize,
 ) -> Result<GgmlCpuTensor<'a>, DolphinDecoderError> {
     let eps = config.layer_norm_epsilon;
     let hd = config.head_dim;
@@ -586,15 +620,12 @@ fn decoder_layer<'a>(
     let self_out = linear(graph, &weights.self_o, context, "self_attn_out")?;
     let x = graph.add(input, self_out).map_err(map)?;
 
-    // Cross-attention sub-block: residual + src_attn(norm2(x)) over encoder_out.
+    // Cross-attention sub-block: residual + src_attn(norm2(x)) over the
+    // shared, per-utterance K/V heads (see [`CrossAttentionHeads`]).
     let cross_norm = affine_ln(graph, x, eps, &weights.norm2, "cross_attn_norm")?;
     let q = linear(graph, &weights.src_q, cross_norm, "cross_attn_q")?;
-    let k = linear(graph, &weights.src_k, encoder_out, "cross_attn_k")?;
-    let v = linear(graph, &weights.src_v, encoder_out, "cross_attn_v")?;
     let q = reshape_heads(graph, q, hd, heads, tokens)?;
-    let k = reshape_heads(graph, k, hd, heads, frames)?;
-    let v = reshape_heads(graph, v, hd, heads, frames)?;
-    let context = attention(graph, q, k, v, None, config, tokens)?;
+    let context = attention(graph, q, cross.k_heads, cross.v_heads, None, config, tokens)?;
     let cross_out = linear(graph, &weights.src_o, context, "cross_attn_out")?;
     let x = graph.add(x, cross_out).map_err(map)?;
 
@@ -649,11 +680,12 @@ fn dolphin_decoder_runner_config(backend: GgmlCpuGraphBackend) -> GgmlCpuGraphCo
     }
 }
 
-/// Build-once/run-many Dolphin decoder runtime for one utterance's rescoring
-/// pass (P5). [`Self::new`] loads every decoder weight tensor plus the
-/// encoder's memory into a persistent [`GgmlStaticTensorArena`] exactly once;
-/// [`Self::decode_prompt_logits`] can then be called once per CTC n-best
-/// hypothesis without re-uploading either. Owns a dedicated
+/// Build-once/run-many Dolphin decoder runtime for attention rescoring.
+/// [`Self::new`] loads every decoder weight tensor into a persistent
+/// [`GgmlStaticTensorArena`] exactly once; the runtime is then reusable
+/// across utterances (the executor caches it per `(pack, backend)`), and
+/// [`Self::decode_nbest_prompt_logits`] teacher-forces a whole CTC n-best in
+/// a single fused graph per utterance. Owns a dedicated
 /// [`GgmlCpuGraphRunner`] (rather than sharing the caller's) so the arena's
 /// backend buffer and the per-call transient graphs agree on the same backend
 /// instance.
@@ -661,41 +693,24 @@ pub(crate) struct DolphinDecoderRescoreRuntime {
     runner: GgmlCpuGraphRunner,
     arena: GgmlStaticTensorArena,
     config: DolphinDecoderConfig,
-    frames: usize,
     weights: DecoderStaticWeights,
-    encoder_mem: GgmlStaticTensor,
 }
 
 impl DolphinDecoderRescoreRuntime {
-    /// `encoder_out` is the frame-major `[frames, d_model]` encoder output
-    /// (d_model innermost), matching the golden `encoder_out` fixture layout;
-    /// it is uploaded once here and shared by every subsequent
-    /// [`Self::decode_prompt_logits`] call on this runtime.
     pub(crate) fn new(
         config: &DolphinDecoderConfig,
         provider: &dyn DolphinWeightProvider,
-        encoder_out: &[f32],
-        frames: usize,
         backend: GgmlCpuGraphBackend,
     ) -> Result<Self, DolphinDecoderError> {
         let d = config.d_model;
-        if frames == 0 || encoder_out.len() != frames * d {
-            return Err(DolphinDecoderError::Shape {
-                reason: format!(
-                    "encoder_out has {} values, expected {frames}x{d}",
-                    encoder_out.len()
-                ),
-            });
-        }
-
         let runner = GgmlCpuGraphRunner::new(dolphin_decoder_runner_config(backend))
             .map_err(ggml_err("runner_init"))?;
         let arena = runner
             .start_static_tensor_arena(dolphin_decoder_arena_context_bytes(config.num_layers))
             .map_err(ggml_err("static_tensor_arena"))?;
 
-        // Phase A: create every weight + encoder-memory tensor (must precede
-        // the arena's first buffer alloc, which freezes further creation).
+        // Phase A: create every weight tensor (must precede the arena's first
+        // buffer alloc, which freezes further creation).
         let mut builder = StaticWeightBuilder::new(provider);
         let token_embed =
             builder.w2_embedding(&arena, "decoder.embed.0.weight", d, config.vocab_size)?;
@@ -714,11 +729,8 @@ impl DolphinDecoderRescoreRuntime {
         let output_weight =
             builder.w2(&arena, "decoder.output_layer.weight", d, config.vocab_size)?;
         let output_bias = builder.w1(&arena, "decoder.output_layer.bias", config.vocab_size)?;
-        let encoder_mem = arena
-            .new_tensor_2d_f32(d, frames, "dolphin_dec_encoder_out")
-            .map_err(ggml_err("encoder_mem_alloc"))?;
 
-        // Phase B: upload every weight + the encoder memory exactly once.
+        // Phase B: upload every weight exactly once.
         let mut arena = arena;
         for (tensor, data, name) in &builder.uploads {
             arena
@@ -730,15 +742,11 @@ impl DolphinDecoderRescoreRuntime {
                 .set_bytes_slice(*tensor, bytes, name)
                 .map_err(ggml_err("upload_weight_native"))?;
         }
-        arena
-            .set_f32_slice(encoder_mem, encoder_out, "dolphin_dec_encoder_out")
-            .map_err(ggml_err("upload_encoder"))?;
 
         Ok(Self {
             runner,
             arena,
             config: *config,
-            frames,
             weights: DecoderStaticWeights {
                 token_embed,
                 pos_emb_full,
@@ -747,152 +755,228 @@ impl DolphinDecoderRescoreRuntime {
                 output_weight,
                 output_bias,
             },
-            encoder_mem,
         })
     }
 
-    /// Run the decoder over one teacher-forced prompt prefix and return the
-    /// per-position logits. Only token ids, the causal mask, and the absolute-
-    /// position view depend on `prompt_tokens`; every weight and the encoder
-    /// memory are the already-resident arena tensors from [`Self::new`].
-    pub(crate) fn decode_prompt_logits(
+    pub(crate) fn config(&self) -> &DolphinDecoderConfig {
+        &self.config
+    }
+
+    /// Teacher-force every prompt of one utterance's n-best in a single fused
+    /// graph and return each prompt's per-position logits (index-aligned with
+    /// `prompts`).
+    ///
+    /// `encoder_out` is the frame-major `[frames, d_model]` encoder output
+    /// (d_model innermost), uploaded once per call as a transient graph input
+    /// and shared by every prompt chain. Per decoder layer the cross-attention
+    /// K/V heads are projected from it once as shared graph nodes (they do not
+    /// depend on the prompt -- see [`CrossAttentionHeads`]); each prompt then
+    /// contributes its own chain (token embed, absolute-position view, causal
+    /// mask, self-attention, FFN, output projection) referencing those shared
+    /// nodes. Compared to the previous one-graph-per-hypothesis loop this
+    /// removes `beam_size - 1` redundant cross-K/V projections (the dominant
+    /// FLOPs: `frames >> tokens`) and `beam_size - 1` graph build + dispatch +
+    /// readback round-trips, while running the exact same ops on the exact
+    /// same values per prompt -- the logits are unchanged.
+    pub(crate) fn decode_nbest_prompt_logits(
         &mut self,
-        prompt_tokens: &[u32],
-    ) -> Result<DolphinDecoderOutput, DolphinDecoderError> {
+        encoder_out: &[f32],
+        frames: usize,
+        prompts: &[Vec<u32>],
+    ) -> Result<Vec<DolphinDecoderOutput>, DolphinDecoderError> {
         let config = &self.config;
         let d = config.d_model;
-        let tokens = prompt_tokens.len();
-        if tokens == 0 {
-            return Err(DolphinDecoderError::Shape {
-                reason: "prompt must contain at least one token".to_string(),
-            });
-        }
-        if tokens > config.max_positions {
+        if frames == 0 || encoder_out.len() != frames * d {
             return Err(DolphinDecoderError::Shape {
                 reason: format!(
-                    "prompt length {tokens} exceeds position table {}",
-                    config.max_positions
+                    "encoder_out has {} values, expected {frames}x{d}",
+                    encoder_out.len()
                 ),
             });
         }
-        if let Some(bad) = prompt_tokens
-            .iter()
-            .find(|&&t| t as usize >= config.vocab_size)
-        {
-            return Err(DolphinDecoderError::Shape {
-                reason: format!(
-                    "prompt token {bad} out of vocab range {}",
-                    config.vocab_size
-                ),
-            });
+        if prompts.is_empty() {
+            return Ok(Vec::new());
+        }
+        for prompt_tokens in prompts {
+            let tokens = prompt_tokens.len();
+            if tokens == 0 {
+                return Err(DolphinDecoderError::Shape {
+                    reason: "prompt must contain at least one token".to_string(),
+                });
+            }
+            if tokens > config.max_positions {
+                return Err(DolphinDecoderError::Shape {
+                    reason: format!(
+                        "prompt length {tokens} exceeds position table {}",
+                        config.max_positions
+                    ),
+                });
+            }
+            if let Some(bad) = prompt_tokens
+                .iter()
+                .find(|&&t| t as usize >= config.vocab_size)
+            {
+                return Err(DolphinDecoderError::Shape {
+                    reason: format!(
+                        "prompt token {bad} out of vocab range {}",
+                        config.vocab_size
+                    ),
+                });
+            }
         }
 
         let arena = &self.arena;
         let mut graph = self.runner.start_graph();
 
-        // Input tensors: token ids (i32) and the causal mask (f32) -- the only
-        // two things that actually differ per call. Weights and the encoder
-        // memory are arena-resident (real backend buffer already allocated),
-        // so unlike the transient inputs below they need no `set_input`.
-        let token_ids = graph
-            .new_tensor_1d_i32(tokens, "dolphin_dec_tokens")
-            .map_err(ggml_err("input_alloc_tokens"))?;
-        let causal_mask = graph
-            .new_tensor_2d_f32(tokens, tokens, "dolphin_dec_causal_mask")
-            .map_err(ggml_err("input_alloc_mask"))?;
+        // Transient inputs: the encoder memory (one per utterance) plus each
+        // prompt's token ids (i32) and causal mask (f32). Weights are
+        // arena-resident (real backend buffer already allocated), so unlike
+        // the transient inputs they need no `set_input`.
+        let encoder_mem = graph
+            .new_tensor_2d_f32(d, frames, "dolphin_dec_encoder_out")
+            .map_err(ggml_err("input_alloc_encoder"))?;
 
-        // Embedding: token_embed(ids) * sqrt(d_model) + absolute positional
-        // encoding, the latter a contiguous leading view (rows `0..tokens`) of
-        // the arena's full position table -- no re-upload, no re-slice.
-        let token_state = graph
-            .get_rows(arena.graph_tensor(self.weights.token_embed), token_ids)
-            .map_err(ggml_err("embed_get_rows"))?;
-        let scaled = graph
-            .scale(token_state, (d as f32).sqrt())
-            .map_err(ggml_err("embed_xscale"))?;
-        let row_stride = d * std::mem::size_of::<f32>();
-        let pos_view = graph
-            .view_2d(
-                arena.graph_tensor(self.weights.pos_emb_full),
-                d,
-                tokens,
-                row_stride,
-                0,
-            )
-            .map_err(ggml_err("embed_pos_view"))?;
-        let mut hidden = graph.add(scaled, pos_view).map_err(ggml_err("embed_pos"))?;
-        let encoder_mem = arena.graph_tensor(self.encoder_mem);
-        for layer in &self.weights.layers {
-            let layer = layer.to_transient(arena);
-            hidden = decoder_layer(
-                &mut graph,
-                hidden,
+        // Shared per-layer cross-attention K/V heads, projected once from the
+        // encoder memory and consumed by every prompt chain below.
+        let layer_transients: Vec<DecoderLayerWeights<'_>> = self
+            .weights
+            .layers
+            .iter()
+            .map(|layer| layer.to_transient(arena))
+            .collect();
+        let mut cross_heads = Vec::with_capacity(layer_transients.len());
+        for layer in &layer_transients {
+            cross_heads.push(build_cross_attention_heads(
+                &graph,
                 encoder_mem,
-                causal_mask,
-                &layer,
+                layer,
                 config,
-                tokens,
-                self.frames,
-            )?;
+                frames,
+            )?);
         }
+
         let after_norm = self.weights.after_norm.to_transient(arena);
-        let normed = affine_ln(
-            &graph,
-            hidden,
-            config.layer_norm_epsilon,
-            &after_norm,
-            "after_norm",
-        )?;
-        let logits = graph
-            .mul_mat(arena.graph_tensor(self.weights.output_weight), normed)
-            .map_err(ggml_err("output_layer"))?;
-        let logits = graph
-            .add(logits, arena.graph_tensor(self.weights.output_bias))
-            .map_err(ggml_err("output_layer_bias"))?;
-        graph.set_output(logits).map_err(ggml_err("set_output"))?;
+        let row_stride = d * std::mem::size_of::<f32>();
+        let mut prompt_inputs = Vec::with_capacity(prompts.len());
+        let mut logits_outputs = Vec::with_capacity(prompts.len());
+        for prompt_tokens in prompts {
+            let tokens = prompt_tokens.len();
+            let token_ids = graph
+                .new_tensor_1d_i32(tokens, "dolphin_dec_tokens")
+                .map_err(ggml_err("input_alloc_tokens"))?;
+            let causal_mask = graph
+                .new_tensor_2d_f32(tokens, tokens, "dolphin_dec_causal_mask")
+                .map_err(ggml_err("input_alloc_mask"))?;
+
+            // Embedding: token_embed(ids) * sqrt(d_model) + absolute positional
+            // encoding, the latter a contiguous leading view (rows `0..tokens`)
+            // of the arena's full position table -- no re-upload, no re-slice.
+            let token_state = graph
+                .get_rows(arena.graph_tensor(self.weights.token_embed), token_ids)
+                .map_err(ggml_err("embed_get_rows"))?;
+            let scaled = graph
+                .scale(token_state, (d as f32).sqrt())
+                .map_err(ggml_err("embed_xscale"))?;
+            let pos_view = graph
+                .view_2d(
+                    arena.graph_tensor(self.weights.pos_emb_full),
+                    d,
+                    tokens,
+                    row_stride,
+                    0,
+                )
+                .map_err(ggml_err("embed_pos_view"))?;
+            let mut hidden = graph.add(scaled, pos_view).map_err(ggml_err("embed_pos"))?;
+            for (layer, cross) in layer_transients.iter().zip(&cross_heads) {
+                hidden = decoder_layer(
+                    &mut graph,
+                    hidden,
+                    *cross,
+                    causal_mask,
+                    layer,
+                    config,
+                    tokens,
+                )?;
+            }
+            let normed = affine_ln(
+                &graph,
+                hidden,
+                config.layer_norm_epsilon,
+                &after_norm,
+                "after_norm",
+            )?;
+            let logits = graph
+                .mul_mat(arena.graph_tensor(self.weights.output_weight), normed)
+                .map_err(ggml_err("output_layer"))?;
+            let logits = graph
+                .add(logits, arena.graph_tensor(self.weights.output_bias))
+                .map_err(ggml_err("output_layer_bias"))?;
+            graph.set_output(logits).map_err(ggml_err("set_output"))?;
+            prompt_inputs.push((token_ids, causal_mask));
+            logits_outputs.push(logits);
+        }
+
         graph
-            .set_input(token_ids)
-            .map_err(ggml_err("mark_input(tokens)"))?;
-        graph
-            .set_input(causal_mask)
-            .map_err(ggml_err("mark_input(causal_mask)"))?;
+            .set_input(encoder_mem)
+            .map_err(ggml_err("mark_input(encoder_out)"))?;
+        for (token_ids, causal_mask) in &prompt_inputs {
+            graph
+                .set_input(*token_ids)
+                .map_err(ggml_err("mark_input(tokens)"))?;
+            graph
+                .set_input(*causal_mask)
+                .map_err(ggml_err("mark_input(causal_mask)"))?;
+        }
         // Allocate the forward graph through the scheduler's gallocr for
         // liveness-based buffer reuse before uploading inputs (mirrors the
-        // encoder above and the sibling cohere/moonshine decoders).
+        // encoder and the sibling cohere/moonshine decoders).
         graph
-            .prepare_outputs_for_upload(&[logits])
+            .prepare_outputs_for_upload(&logits_outputs)
             .map_err(ggml_err("prepare_outputs"))?;
 
-        let token_ids_i32: Vec<i32> = prompt_tokens.iter().map(|&t| t as i32).collect();
         graph
-            .set_i32_slice(token_ids, &token_ids_i32, "dolphin_dec_tokens")
-            .map_err(ggml_err("upload_tokens"))?;
-        graph
-            .set_f32_slice(
-                causal_mask,
-                &build_causal_mask(tokens),
-                "dolphin_dec_causal_mask",
-            )
-            .map_err(ggml_err("upload_mask"))?;
+            .set_f32_slice(encoder_mem, encoder_out, "dolphin_dec_encoder_out")
+            .map_err(ggml_err("upload_encoder"))?;
+        for (prompt_tokens, (token_ids, causal_mask)) in prompts.iter().zip(&prompt_inputs) {
+            let token_ids_i32: Vec<i32> = prompt_tokens.iter().map(|&t| t as i32).collect();
+            graph
+                .set_i32_slice(*token_ids, &token_ids_i32, "dolphin_dec_tokens")
+                .map_err(ggml_err("upload_tokens"))?;
+            graph
+                .set_f32_slice(
+                    *causal_mask,
+                    &build_causal_mask(prompt_tokens.len()),
+                    "dolphin_dec_causal_mask",
+                )
+                .map_err(ggml_err("upload_mask"))?;
+        }
 
-        let expected = tokens * config.vocab_size;
-        let logits = graph
-            .compute_output_f32(logits, expected)
+        let output_specs: Vec<(GgmlCpuTensor, usize)> = logits_outputs
+            .iter()
+            .zip(prompts)
+            .map(|(logits, prompt_tokens)| (*logits, prompt_tokens.len() * config.vocab_size))
+            .collect();
+        let outputs = graph
+            .compute_outputs_f32(&output_specs)
             .map_err(ggml_err("compute"))?;
 
-        Ok(DolphinDecoderOutput {
-            token_count: tokens,
-            vocab_size: config.vocab_size,
-            logits,
-        })
+        Ok(outputs
+            .into_iter()
+            .zip(prompts)
+            .map(|(logits, prompt_tokens)| DolphinDecoderOutput {
+                token_count: prompt_tokens.len(),
+                vocab_size: config.vocab_size,
+                logits,
+            })
+            .collect())
     }
 }
 
 /// One-shot convenience wrapper over [`DolphinDecoderRescoreRuntime`] for
 /// callers that only need a single prompt's logits (the `parity` dev
-/// harness). Attention-rescoring builds and reuses the runtime directly
-/// across its whole CTC n-best (see `joint_decode::attention_rescore`) instead
-/// of calling this per hypothesis.
+/// harness). Attention-rescoring reuses the executor-cached runtime and
+/// scores its whole CTC n-best in one fused call (see
+/// `joint_decode::attention_rescore`) instead of calling this per hypothesis.
 pub(crate) fn decode_prompt_logits(
     config: &DolphinDecoderConfig,
     provider: &dyn DolphinWeightProvider,
@@ -901,6 +985,174 @@ pub(crate) fn decode_prompt_logits(
     prompt_tokens: &[u32],
     backend: GgmlCpuGraphBackend,
 ) -> Result<DolphinDecoderOutput, DolphinDecoderError> {
-    DolphinDecoderRescoreRuntime::new(config, provider, encoder_out, frames, backend)?
-        .decode_prompt_logits(prompt_tokens)
+    let mut outputs = DolphinDecoderRescoreRuntime::new(config, provider, backend)?
+        .decode_nbest_prompt_logits(encoder_out, frames, &[prompt_tokens.to_vec()])?;
+    Ok(outputs.pop().expect("single prompt yields single output"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::encoder_graph::synthetic_test_tensor;
+    use super::*;
+    use std::collections::HashMap;
+
+    /// A tiny but structurally complete decoder config (2 layers, d_model 8)
+    /// for the CPU fused-rescore equivalence tests below.
+    fn tiny_config() -> DolphinDecoderConfig {
+        DolphinDecoderConfig {
+            d_model: 8,
+            attention_heads: 2,
+            head_dim: 4,
+            ffn_units: 16,
+            num_layers: 2,
+            vocab_size: 12,
+            max_positions: 16,
+            layer_norm_epsilon: 1e-5,
+        }
+    }
+
+    /// Every decoder tensor name at its exact expected length, filled with
+    /// deterministic synthetic values.
+    fn synthetic_provider(config: &DolphinDecoderConfig) -> HashMap<String, Vec<f32>> {
+        let d = config.d_model;
+        let ffn = config.ffn_units;
+        let vocab = config.vocab_size;
+        let mut map = HashMap::new();
+        let mut put = |name: String, len: usize| {
+            let values = synthetic_test_tensor(&name, len);
+            map.insert(name, values);
+        };
+        put("decoder.embed.0.weight".into(), d * vocab);
+        put("decoder.embed.1.pe".into(), d * config.max_positions);
+        for index in 0..config.num_layers {
+            let p = |suffix: &str| format!("decoder.decoders.{index}.{suffix}");
+            for norm in ["norm1", "norm2", "norm3"] {
+                put(p(&format!("{norm}.weight")), d);
+                put(p(&format!("{norm}.bias")), d);
+            }
+            for attn in ["self_attn", "src_attn"] {
+                for proj in ["linear_q", "linear_k", "linear_v", "linear_out"] {
+                    put(p(&format!("{attn}.{proj}.weight")), d * d);
+                    put(p(&format!("{attn}.{proj}.bias")), d);
+                }
+            }
+            put(p("feed_forward.w_1.weight"), d * ffn);
+            put(p("feed_forward.w_1.bias"), ffn);
+            put(p("feed_forward.w_2.weight"), ffn * d);
+            put(p("feed_forward.w_2.bias"), d);
+        }
+        put("decoder.after_norm.weight".into(), d);
+        put("decoder.after_norm.bias".into(), d);
+        put("decoder.output_layer.weight".into(), d * vocab);
+        put("decoder.output_layer.bias".into(), vocab);
+        map
+    }
+
+    fn bits(values: &[f32]) -> Vec<u32> {
+        values.iter().map(|v| v.to_bits()).collect()
+    }
+
+    /// The fused-rescore invariant the perf change rests on: teacher-forcing a
+    /// whole n-best in ONE fused graph (shared encoder memory upload, shared
+    /// per-layer cross-K/V nodes) must produce bit-identical per-prompt logits
+    /// to decoding each prompt independently in its own graph -- scores and
+    /// hypothesis selection cannot move. Also pins runtime reuse: a second
+    /// fused call on the same (weight-resident) runtime is bit-identical, and
+    /// batch composition does not leak between prompts (a different n-best
+    /// containing the same prompt yields the same logits for it).
+    #[test]
+    fn fused_nbest_logits_match_independent_per_prompt_decode_bit_for_bit() {
+        let config = tiny_config();
+        let provider = synthetic_provider(&config);
+        let frames = 5;
+        let encoder_out = synthetic_test_tensor("encoder_out", frames * config.d_model);
+        // Distinct lengths on purpose: the fused graph must keep each prompt's
+        // own causal mask / position view / logits shape.
+        let prompts: Vec<Vec<u32>> = vec![
+            vec![2, 5, 10, 4, 9],
+            vec![2, 5, 10],
+            vec![2, 5, 10, 4, 9, 1, 7, 3],
+            vec![11],
+        ];
+
+        let mut runtime =
+            DolphinDecoderRescoreRuntime::new(&config, &provider, GgmlCpuGraphBackend::Cpu)
+                .expect("runtime");
+        let fused = runtime
+            .decode_nbest_prompt_logits(&encoder_out, frames, &prompts)
+            .expect("fused decode");
+        assert_eq!(fused.len(), prompts.len());
+
+        for (prompt, fused_output) in prompts.iter().zip(&fused) {
+            assert_eq!(fused_output.token_count, prompt.len());
+            let single = decode_prompt_logits(
+                &config,
+                &provider,
+                &encoder_out,
+                frames,
+                prompt,
+                GgmlCpuGraphBackend::Cpu,
+            )
+            .expect("single decode");
+            assert_eq!(
+                bits(&fused_output.logits),
+                bits(&single.logits),
+                "fused n-best logits diverged from the independent decode for prompt {prompt:?}"
+            );
+        }
+
+        // Runtime reuse: the second fused call re-uploads nothing but inputs.
+        let again = runtime
+            .decode_nbest_prompt_logits(&encoder_out, frames, &prompts)
+            .expect("fused decode #2");
+        for (first, second) in fused.iter().zip(&again) {
+            assert_eq!(bits(&first.logits), bits(&second.logits));
+        }
+
+        // Batch-composition independence: the same prompt inside a different
+        // n-best must score identically.
+        let subset = vec![prompts[1].clone()];
+        let alone = runtime
+            .decode_nbest_prompt_logits(&encoder_out, frames, &subset)
+            .expect("subset decode");
+        assert_eq!(bits(&alone[0].logits), bits(&fused[1].logits));
+    }
+
+    /// Fail-closed validation of the fused entry point: empty prompt, over-long
+    /// prompt, out-of-vocab token, and a mismatched encoder buffer must all be
+    /// typed errors (never a partial compute), and an empty n-best is a no-op.
+    #[test]
+    fn fused_nbest_validates_prompts_and_encoder_shape() {
+        let config = tiny_config();
+        let provider = synthetic_provider(&config);
+        let frames = 4;
+        let encoder_out = synthetic_test_tensor("encoder_out", frames * config.d_model);
+        let mut runtime =
+            DolphinDecoderRescoreRuntime::new(&config, &provider, GgmlCpuGraphBackend::Cpu)
+                .expect("runtime");
+
+        assert!(
+            runtime
+                .decode_nbest_prompt_logits(&encoder_out, frames, &[])
+                .expect("empty n-best")
+                .is_empty()
+        );
+        for bad in [
+            vec![],                            // empty prompt
+            vec![1; config.max_positions + 1], // beyond position table
+            vec![config.vocab_size as u32],    // out of vocab
+        ] {
+            let result = runtime.decode_nbest_prompt_logits(
+                &encoder_out,
+                frames,
+                std::slice::from_ref(&bad),
+            );
+            assert!(
+                matches!(result, Err(DolphinDecoderError::Shape { .. })),
+                "prompt {bad:?} must fail closed, got {result:?}"
+            );
+        }
+        let result = runtime.decode_nbest_prompt_logits(&encoder_out, frames - 1, &[vec![1]]);
+        assert!(matches!(result, Err(DolphinDecoderError::Shape { .. })));
+    }
 }

--- a/crates/openasr-core/src/models/dolphin/encoder_graph.rs
+++ b/crates/openasr-core/src/models/dolphin/encoder_graph.rs
@@ -257,9 +257,10 @@ struct EmbedWeights<'a> {
     out_w: GgmlCpuTensor<'a>,
     out_b: GgmlCpuTensor<'a>,
     // `pos_emb` moved out of `EmbedWeights`: its scheme-dependent shape/source
-    // (a baked-table slice for `CnDialect`, a graph-build-time-computed
-    // rel-pos-v1 table for `Multilingual`) is built directly in `encode()`
-    // instead, see `dolphin_relative_positional_table`.
+    // (a baked-table view for `CnDialect`, a view of the runtime-computed
+    // rel-pos-v1 table for `Multilingual`) is built per call in
+    // [`DolphinEncoderRuntime::encode`] instead, see
+    // `dolphin_relative_positional_table`.
 }
 
 struct BlockWeights<'a> {
@@ -311,6 +312,135 @@ struct EncoderWeights<'a> {
     blocks: Vec<BlockWeights<'a>>,
     after_norm_w: GgmlCpuTensor<'a>,
     after_norm_b: GgmlCpuTensor<'a>,
+}
+
+/// Static (arena-resident) counterparts of [`EmbedWeights`] / [`BlockWeights`] /
+/// [`EncoderWeights`]: same shapes, but each field is a persistent
+/// [`GgmlStaticTensor`] handle instead of a per-graph transient borrow.
+/// `to_transient` reborrows every field into the current call's graph lifetime
+/// via [`GgmlStaticTensorArena::graph_tensor`], mirroring the sibling
+/// `decoder_graph::DecoderLayerStaticWeights` pattern exactly. This is what
+/// lets [`DolphinEncoderRuntime`] keep the whole encoder weight set resident
+/// in one backend buffer across calls instead of re-uploading it per encode.
+struct EmbedStaticWeights {
+    conv0_w: GgmlStaticTensor,
+    conv0_b: GgmlStaticTensor,
+    conv1_w: GgmlStaticTensor,
+    conv1_b: GgmlStaticTensor,
+    out_w: GgmlStaticTensor,
+    out_b: GgmlStaticTensor,
+}
+
+impl EmbedStaticWeights {
+    fn to_transient<'a>(&self, arena: &GgmlStaticTensorArena) -> EmbedWeights<'a> {
+        EmbedWeights {
+            conv0_w: arena.graph_tensor(self.conv0_w),
+            conv0_b: arena.graph_tensor(self.conv0_b),
+            conv1_w: arena.graph_tensor(self.conv1_w),
+            conv1_b: arena.graph_tensor(self.conv1_b),
+            out_w: arena.graph_tensor(self.out_w),
+            out_b: arena.graph_tensor(self.out_b),
+        }
+    }
+}
+
+struct BlockStaticWeights {
+    ff_macaron_norm_w: GgmlStaticTensor,
+    ff_macaron_norm_b: GgmlStaticTensor,
+    ff_macaron_w1_w: GgmlStaticTensor,
+    ff_macaron_w1_b: GgmlStaticTensor,
+    ff_macaron_w2_w: GgmlStaticTensor,
+    ff_macaron_w2_b: GgmlStaticTensor,
+    norm_mha_w: GgmlStaticTensor,
+    norm_mha_b: GgmlStaticTensor,
+    q_w: GgmlStaticTensor,
+    q_b: GgmlStaticTensor,
+    k_w: GgmlStaticTensor,
+    k_b: GgmlStaticTensor,
+    v_w: GgmlStaticTensor,
+    v_b: GgmlStaticTensor,
+    pos_w: GgmlStaticTensor,
+    pos_bias_u: GgmlStaticTensor,
+    pos_bias_v: GgmlStaticTensor,
+    out_w: GgmlStaticTensor,
+    out_b: GgmlStaticTensor,
+    norm_mlp_w: GgmlStaticTensor,
+    norm_mlp_b: GgmlStaticTensor,
+    cproj1_w: GgmlStaticTensor,
+    cproj1_b: GgmlStaticTensor,
+    csgu_norm_w: GgmlStaticTensor,
+    csgu_norm_b: GgmlStaticTensor,
+    csgu_conv_w: GgmlStaticTensor,
+    csgu_conv_b: GgmlStaticTensor,
+    cproj2_w: GgmlStaticTensor,
+    cproj2_b: GgmlStaticTensor,
+    fusion_conv_w: GgmlStaticTensor,
+    fusion_conv_b: GgmlStaticTensor,
+    merge_w: GgmlStaticTensor,
+    merge_b: GgmlStaticTensor,
+    norm_ff_w: GgmlStaticTensor,
+    norm_ff_b: GgmlStaticTensor,
+    ff_w1_w: GgmlStaticTensor,
+    ff_w1_b: GgmlStaticTensor,
+    ff_w2_w: GgmlStaticTensor,
+    ff_w2_b: GgmlStaticTensor,
+    norm_final_w: GgmlStaticTensor,
+    norm_final_b: GgmlStaticTensor,
+}
+
+impl BlockStaticWeights {
+    fn to_transient<'a>(&self, arena: &GgmlStaticTensorArena) -> BlockWeights<'a> {
+        BlockWeights {
+            ff_macaron_norm_w: arena.graph_tensor(self.ff_macaron_norm_w),
+            ff_macaron_norm_b: arena.graph_tensor(self.ff_macaron_norm_b),
+            ff_macaron_w1_w: arena.graph_tensor(self.ff_macaron_w1_w),
+            ff_macaron_w1_b: arena.graph_tensor(self.ff_macaron_w1_b),
+            ff_macaron_w2_w: arena.graph_tensor(self.ff_macaron_w2_w),
+            ff_macaron_w2_b: arena.graph_tensor(self.ff_macaron_w2_b),
+            norm_mha_w: arena.graph_tensor(self.norm_mha_w),
+            norm_mha_b: arena.graph_tensor(self.norm_mha_b),
+            q_w: arena.graph_tensor(self.q_w),
+            q_b: arena.graph_tensor(self.q_b),
+            k_w: arena.graph_tensor(self.k_w),
+            k_b: arena.graph_tensor(self.k_b),
+            v_w: arena.graph_tensor(self.v_w),
+            v_b: arena.graph_tensor(self.v_b),
+            pos_w: arena.graph_tensor(self.pos_w),
+            pos_bias_u: arena.graph_tensor(self.pos_bias_u),
+            pos_bias_v: arena.graph_tensor(self.pos_bias_v),
+            out_w: arena.graph_tensor(self.out_w),
+            out_b: arena.graph_tensor(self.out_b),
+            norm_mlp_w: arena.graph_tensor(self.norm_mlp_w),
+            norm_mlp_b: arena.graph_tensor(self.norm_mlp_b),
+            cproj1_w: arena.graph_tensor(self.cproj1_w),
+            cproj1_b: arena.graph_tensor(self.cproj1_b),
+            csgu_norm_w: arena.graph_tensor(self.csgu_norm_w),
+            csgu_norm_b: arena.graph_tensor(self.csgu_norm_b),
+            csgu_conv_w: arena.graph_tensor(self.csgu_conv_w),
+            csgu_conv_b: arena.graph_tensor(self.csgu_conv_b),
+            cproj2_w: arena.graph_tensor(self.cproj2_w),
+            cproj2_b: arena.graph_tensor(self.cproj2_b),
+            fusion_conv_w: arena.graph_tensor(self.fusion_conv_w),
+            fusion_conv_b: arena.graph_tensor(self.fusion_conv_b),
+            merge_w: arena.graph_tensor(self.merge_w),
+            merge_b: arena.graph_tensor(self.merge_b),
+            norm_ff_w: arena.graph_tensor(self.norm_ff_w),
+            norm_ff_b: arena.graph_tensor(self.norm_ff_b),
+            ff_w1_w: arena.graph_tensor(self.ff_w1_w),
+            ff_w1_b: arena.graph_tensor(self.ff_w1_b),
+            ff_w2_w: arena.graph_tensor(self.ff_w2_w),
+            ff_w2_b: arena.graph_tensor(self.ff_w2_b),
+            norm_final_w: arena.graph_tensor(self.norm_final_w),
+            norm_final_b: arena.graph_tensor(self.norm_final_b),
+        }
+    }
+}
+
+struct EncoderStaticWeights {
+    embed: EmbedStaticWeights,
+    blocks: Vec<BlockStaticWeights>,
+    after_norm_w: GgmlStaticTensor,
+    after_norm_b: GgmlStaticTensor,
 }
 
 /// Static-arena tensor count for [`GgmlCpuGraphConfig::metadata_context_bytes`].
@@ -382,18 +512,18 @@ impl<'p> WeightBuilder<'p> {
     }
 
     /// A 1-D weight (bias / norm gamma-beta / packed pos bias).
-    fn w1<'a>(
+    fn w1(
         &mut self,
         arena: &GgmlStaticTensorArena,
         name: &str,
         len: usize,
-    ) -> Result<GgmlCpuTensor<'a>, DolphinEncoderError> {
+    ) -> Result<GgmlStaticTensor, DolphinEncoderError> {
         let data = self.fetch(name, len)?;
         let handle = arena
             .new_tensor_1d_f32(len, "dolphin_weight")
             .map_err(ggml_err("weight_alloc_1d"))?;
         self.uploads.push((handle, data, "dolphin_weight"));
-        Ok(arena.graph_tensor(handle))
+        Ok(handle)
     }
 
     /// A 2-D `.weight` matmul operand bound as ggml `[ne0=in, ne1=out]` for
@@ -405,30 +535,30 @@ impl<'p> WeightBuilder<'p> {
     /// the f32 bind. Both stored layouts (fp16's `[out, in]`, quant's reversed
     /// `[in, out]`) share the same in-innermost byte order, so uploading raw into
     /// the `[ne0=in, ne1=out]` arena tensor is order-preserving in either case.
-    fn w2<'a>(
+    fn w2(
         &mut self,
         arena: &GgmlStaticTensorArena,
         name: &str,
         ne0: usize,
         ne1: usize,
-    ) -> Result<GgmlCpuTensor<'a>, DolphinEncoderError> {
+    ) -> Result<GgmlStaticTensor, DolphinEncoderError> {
         if let Some(native) = self.provider.native_weight(name) {
             let handle = arena
                 .new_matmul_weight_2d_typed(ne0, ne1, native.ggml_type, "dolphin_weight")
                 .map_err(ggml_err("weight_alloc_2d_native"))?;
             self.native_uploads
                 .push((handle, native.bytes, "dolphin_weight"));
-            return Ok(arena.graph_tensor(handle));
+            return Ok(handle);
         }
         let data = self.fetch(name, ne0 * ne1)?;
         let handle = arena
             .new_tensor_2d_f32(ne0, ne1, "dolphin_weight")
             .map_err(ggml_err("weight_alloc_2d"))?;
         self.uploads.push((handle, data, "dolphin_weight"));
-        Ok(arena.graph_tensor(handle))
+        Ok(handle)
     }
 
-    fn w4<'a>(
+    fn w4(
         &mut self,
         arena: &GgmlStaticTensorArena,
         name: &str,
@@ -436,31 +566,33 @@ impl<'p> WeightBuilder<'p> {
         ne1: usize,
         ne2: usize,
         ne3: usize,
-    ) -> Result<GgmlCpuTensor<'a>, DolphinEncoderError> {
+    ) -> Result<GgmlStaticTensor, DolphinEncoderError> {
         let data = self.fetch(name, ne0 * ne1 * ne2 * ne3)?;
         let handle = arena
             .new_tensor_4d_f32(ne0, ne1, ne2, ne3, "dolphin_weight")
             .map_err(ggml_err("weight_alloc_4d"))?;
         self.uploads.push((handle, data, "dolphin_weight"));
-        Ok(arena.graph_tensor(handle))
+        Ok(handle)
     }
 
-    /// The first `frames` rows of the `[1, max_len, d_model]` position table.
-    fn pos_slice<'a>(
+    /// The full `[1, max_len, d_model]` baked position table, uploaded once at
+    /// its baked length. Per-call encode takes a contiguous leading view of
+    /// the first `frames` rows (see [`DolphinEncoderRuntime::encode`]) instead
+    /// of this builder re-slicing and re-uploading a `frames`-sized copy every
+    /// call -- mirrors `decoder_graph::StaticWeightBuilder::pos_full`.
+    fn pos_full(
         &mut self,
         arena: &GgmlStaticTensorArena,
         name: &str,
         d_model: usize,
-        frames: usize,
         max_len: usize,
-    ) -> Result<GgmlCpuTensor<'a>, DolphinEncoderError> {
+    ) -> Result<GgmlStaticTensor, DolphinEncoderError> {
         let full = self.fetch(name, d_model * max_len)?;
-        let slice = &full[..d_model * frames];
         let handle = arena
-            .new_tensor_2d_f32(d_model, frames, "dolphin_weight")
+            .new_tensor_2d_f32(d_model, max_len, "dolphin_weight")
             .map_err(ggml_err("weight_alloc_pos"))?;
-        self.uploads.push((handle, slice, "dolphin_weight"));
-        Ok(arena.graph_tensor(handle))
+        self.uploads.push((handle, full, "dolphin_weight"));
+        Ok(handle)
     }
 
     /// Upload every collected weight into the arena's backend buffer exactly
@@ -483,14 +615,14 @@ impl<'p> WeightBuilder<'p> {
     }
 }
 
-fn build_embed_weights<'a, 'p>(
+fn build_embed_weights(
     arena: &GgmlStaticTensorArena,
-    builder: &mut WeightBuilder<'p>,
+    builder: &mut WeightBuilder<'_>,
     config: &DolphinEncoderConfig,
-) -> Result<EmbedWeights<'a>, DolphinEncoderError> {
+) -> Result<EmbedStaticWeights, DolphinEncoderError> {
     let d = config.d_model;
     let flat = d * subsample_width(config.feature_dim);
-    Ok(EmbedWeights {
+    Ok(EmbedStaticWeights {
         conv0_w: builder.w4(arena, "encoder.embed.conv.0.weight", 3, 3, 1, d)?,
         conv0_b: builder.w4(arena, "encoder.embed.conv.0.bias", 1, 1, d, 1)?,
         conv1_w: builder.w4(arena, "encoder.embed.conv.2.weight", 3, 3, d, d)?,
@@ -529,12 +661,12 @@ fn dolphin_relative_positional_table(d_model: usize, frames: usize) -> Option<Ve
     Some(table)
 }
 
-fn build_block_weights<'a, 'p>(
+fn build_block_weights(
     arena: &GgmlStaticTensorArena,
-    builder: &mut WeightBuilder<'p>,
+    builder: &mut WeightBuilder<'_>,
     config: &DolphinEncoderConfig,
     index: usize,
-) -> Result<BlockWeights<'a>, DolphinEncoderError> {
+) -> Result<BlockStaticWeights, DolphinEncoderError> {
     let d = config.d_model;
     let ffn = config.ffn_units;
     let cg = config.cgmlp_units;
@@ -542,7 +674,7 @@ fn build_block_weights<'a, 'p>(
     let ck = config.cgmlp_kernel;
     let mk = config.merge_kernel;
     let p = |suffix: &str| format!("encoder.encoders.{index}.{suffix}");
-    Ok(BlockWeights {
+    Ok(BlockStaticWeights {
         ff_macaron_norm_w: builder.w1(arena, &p("norm_ff_macaron.weight"), d)?,
         ff_macaron_norm_b: builder.w1(arena, &p("norm_ff_macaron.bias"), d)?,
         ff_macaron_w1_w: builder.w2(arena, &p("feed_forward_macaron.w_1.weight"), d, ffn)?,
@@ -1059,21 +1191,364 @@ fn subsample<'a>(
     Ok((scaled, frames))
 }
 
-/// Build and run the full encoder graph on the CPU backend. Always returns
-/// `encoder_out`; when `capture_taps` is true it additionally materializes
-/// `after_subsample` and every per-block hidden state for the parity harness
-/// (see [`DolphinEncoderOutput`]).
+// Perf (P6): every per-block tap unconditionally `set_output` + f32-materialized
+// used to pin ~200MB+ of intermediate hidden state resident for the whole graph
+// (plus a host copy per block) on every production call, even though the
+// executor (`executor::run_dolphin_pipeline`) only ever reads `encoder_out` --
+// `blocks`/`after_subsample` exist solely for `#[cfg(test)]` parity
+// (`parity::dolphin_encoder_parity`). With `capture_taps: false` (the
+// production default), only `encoder_out` is declared an output, so gallocr's
+// liveness-based allocator is free to recycle each block's buffer as soon as
+// the next block stops reading it, exactly like every other tap-free encoder
+// in this codebase.
+
+/// Build-once/run-many Dolphin encoder runtime (perf: arena residency).
 ///
-/// Perf (P6): every per-block tap unconditionally `set_output` + f32-materialized
-/// used to pin ~200MB+ of intermediate hidden state resident for the whole graph
-/// (plus a host copy per block) on every production call, even though the
-/// executor (`executor::run_dolphin_pipeline`) only ever reads `encoder_out` --
-/// `blocks`/`after_subsample` exist solely for `#[cfg(test)]` parity
-/// (`parity::dolphin_encoder_parity`). With `capture_taps: false` (the
-/// production default via `executor::encode_dolphin_encoder_from_pack`), only
-/// `encoder_out` is declared an output, so gallocr's liveness-based allocator is
-/// free to recycle each block's buffer as soon as the next block stops reading
-/// it, exactly like every other tap-free encoder in this codebase.
+/// [`Self::new`] loads every encoder weight tensor plus the full
+/// relative-position table into a persistent [`GgmlStaticTensorArena`] (a
+/// `GGML_BACKEND_BUFFER_USAGE_WEIGHTS` backend buffer) exactly once;
+/// [`Self::encode`] can then be called once per utterance / streaming tick
+/// without re-uploading any of it -- only the audio features are a per-call
+/// graph input. The pre-runtime `encode` rebuilt the runner + arena and
+/// re-uploaded the whole weight set on every call (~37 ms fixed cost on M1,
+/// up to 44% of a streaming tick), even though nothing but the features ever
+/// changes between calls. Mirrors [`super::decoder_graph::DolphinDecoderRescoreRuntime`]
+/// and the sibling `sensevoice::SenseVoiceEncoderGraph` prepared-runtime
+/// pattern. Weight placement and residency change no value the graph
+/// computes, so the encoder output stays golden-identical.
+///
+/// The position table is resident at full length and viewed per call:
+/// * `CnDialect`: the baked `[d_model, max_positions]` table, viewed at its
+///   first `frames` rows (a contiguous leading view -- byte-identical to the
+///   `frames`-sized slice the pre-runtime path uploaded per call).
+/// * `Multilingual`: the centered rel-pos-v1 table computed once for
+///   `pos_capacity_frames` (positions `+(cap-1) .. -(cap-1)`), viewed at the
+///   centered `2*frames-1` rows for this call's `frames`. Each row holds
+///   sin/cos of its absolute position only (independent of `frames`), so the
+///   view is bit-identical to the per-`frames` table the pre-runtime path
+///   computed fresh on every call (see `dolphin_relative_positional_table`).
+pub(crate) struct DolphinEncoderRuntime {
+    runner: GgmlCpuGraphRunner,
+    arena: GgmlStaticTensorArena,
+    config: DolphinEncoderConfig,
+    weights: EncoderStaticWeights,
+    pos_table: GgmlStaticTensor,
+    pos_capacity_frames: usize,
+}
+
+impl DolphinEncoderRuntime {
+    /// `pos_capacity_frames` is the largest post-subsample `frames` this
+    /// runtime's resident position table can serve (a [`Self::encode`] call
+    /// beyond it fails closed with a typed `Shape` error; the executor falls
+    /// back to a fresh one-shot runtime sized for that call). Only consulted
+    /// under [`DolphinLanguageScheme::Multilingual`], whose table is computed
+    /// rather than baked; `CnDialect`'s capacity is always the baked table's
+    /// own `max_positions` length.
+    ///
+    /// [`DolphinLanguageScheme::Multilingual`]: super::package_import::DolphinLanguageScheme::Multilingual
+    pub(crate) fn new(
+        config: &DolphinEncoderConfig,
+        provider: &dyn DolphinWeightProvider,
+        backend: GgmlCpuGraphBackend,
+        pos_capacity_frames: usize,
+    ) -> Result<Self, DolphinEncoderError> {
+        let graph_config = GgmlCpuGraphConfig {
+            context_bytes: 64 * 1024 * 1024,
+            graph_size: 16384,
+            n_threads: GgmlCpuGraphConfig::resolve_runtime_thread_count_for(
+                backend,
+                crate::ggml_runtime::GgmlCpuGraphThreadingWorkload::EncoderPrelude,
+            ),
+            backend,
+            // Ggml's gallocr scheduler reuses buffer space across tensors whose
+            // lifetimes don't overlap instead of giving every non-view tensor its
+            // own allocation; on the CPU backend both allocators produce
+            // identical results, so unconditionally enabling it (like the
+            // sibling cohere/moonshine encoders) only bounds memory footprint on
+            // long audio, never the encoder's output.
+            use_scheduler: true,
+        };
+        let runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml_err("runner_init"))?;
+        // Persistent weight arena (a WEIGHTS-usage backend buffer). Placing every
+        // encoder weight here -- instead of the per-call transient graph leaves the
+        // pre-arena encoder used -- is what lets the ggml multi-backend scheduler
+        // offload the E-Branchformer's matmuls to an accelerator (see
+        // `WeightBuilder`). The arena is an owned value carrying a raw pointer
+        // into the runner's backend, so it and the per-call graphs (a
+        // `&mut runner` borrow) coexist; `runner` outlives it.
+        let arena = runner
+            .start_static_tensor_arena(dolphin_encoder_arena_context_bytes(config.num_blocks))
+            .map_err(ggml_err("static_tensor_arena"))?;
+
+        // Phase A: allocate every weight tensor in the arena (allocation must
+        // precede the arena's first upload, which freezes further creation).
+        let mut builder = WeightBuilder::new(provider);
+        let embed = build_embed_weights(&arena, &mut builder, config)?;
+        let mut blocks = Vec::with_capacity(config.num_blocks);
+        for index in 0..config.num_blocks {
+            blocks.push(build_block_weights(&arena, &mut builder, config, index)?);
+        }
+        let after_norm_w = builder.w1(&arena, "encoder.after_norm.weight", config.d_model)?;
+        let after_norm_b = builder.w1(&arena, "encoder.after_norm.bias", config.d_model)?;
+        let weights = EncoderStaticWeights {
+            embed,
+            blocks,
+            after_norm_w,
+            after_norm_b,
+        };
+
+        // The encoder's relative-position table at full resident length: the
+        // baked table for `CnDialect` (via the provider, like every other
+        // weight), or the centered table computed once up to
+        // `pos_capacity_frames` for `Multilingual` (never baked -- see the
+        // struct doc comment). The computed one is uploaded separately below
+        // since it is an owned buffer, not a provider-borrowed slice
+        // `WeightBuilder` can hold.
+        let is_multilingual = matches!(
+            config.language_scheme,
+            super::package_import::DolphinLanguageScheme::Multilingual
+        );
+        let mut computed_pos: Option<(GgmlStaticTensor, Vec<f32>)> = None;
+        let (pos_table, pos_capacity_frames) =
+            if is_multilingual {
+                let capacity = pos_capacity_frames.max(1);
+                let table = dolphin_relative_positional_table(config.d_model, capacity)
+                    .ok_or_else(|| DolphinEncoderError::Shape {
+                        reason: "relative position table size overflow".to_string(),
+                    })?;
+                let handle = arena
+                    .new_tensor_2d_f32(config.d_model, 2 * capacity - 1, "dolphin_rel_pos")
+                    .map_err(ggml_err("weight_alloc_relpos"))?;
+                computed_pos = Some((handle, table));
+                (handle, capacity)
+            } else {
+                let handle = builder.pos_full(
+                    &arena,
+                    "encoder.embed.pos_enc.pe",
+                    config.d_model,
+                    config.max_positions,
+                )?;
+                (handle, config.max_positions)
+            };
+
+        // Phase B: upload every weight (+ the computed rel-pos table) into the
+        // arena backend buffer exactly once. This freezes the arena.
+        let mut arena = arena;
+        builder.upload(&mut arena)?;
+        if let Some((handle, table)) = &computed_pos {
+            arena
+                .set_f32_slice(*handle, table, "dolphin_rel_pos")
+                .map_err(ggml_err("upload_rel_pos"))?;
+        }
+
+        Ok(Self {
+            runner,
+            arena,
+            config: *config,
+            weights,
+            pos_table,
+            pos_capacity_frames,
+        })
+    }
+
+    /// The largest post-subsample `frames` the resident position table can
+    /// serve (see [`Self::new`]).
+    pub(crate) fn pos_capacity_frames(&self) -> usize {
+        self.pos_capacity_frames
+    }
+
+    /// Whether a [`Self::encode`] call over `frames_in` raw feature frames
+    /// fits this runtime's resident position table. An input too short for
+    /// the subsampling stem reports `true` so `encode` produces its own
+    /// typed fail-closed error (rather than the caller misrouting it to the
+    /// one-shot fallback, which would fail identically anyway).
+    pub(crate) fn supports_input_frames(&self, frames_in: usize) -> bool {
+        match subsample_len(frames_in) {
+            Ok(frames) => frames <= self.pos_capacity_frames,
+            Err(_) => true,
+        }
+    }
+
+    /// Build and run one forward graph over already-resident weights. Always
+    /// returns `encoder_out`; when `capture_taps` is true it additionally
+    /// materializes `after_subsample` and every per-block hidden state for the
+    /// parity harness (see [`DolphinEncoderOutput`] and the free [`encode`]'s
+    /// P6 note).
+    pub(crate) fn encode(
+        &mut self,
+        features: &[f32],
+        frames_in: usize,
+        capture_taps: bool,
+    ) -> Result<DolphinEncoderOutput, DolphinEncoderError> {
+        let config = self.config;
+        let feat = config.feature_dim;
+        if features.len() != frames_in * feat {
+            return Err(DolphinEncoderError::Shape {
+                reason: format!(
+                    "features has {} values, expected {frames_in}x{feat}",
+                    features.len()
+                ),
+            });
+        }
+        // Reject a frames_in too short for the two-layer k3/s2 subsampling stem
+        // before any graph allocation: ggml's `conv_2d`/`im2col` asserts
+        // `OH > 0` and aborts the whole process on an under-sized input rather
+        // than returning a Rust error, so this must fail closed here first (see
+        // `subsample_len`). A streaming FINAL over a too-short trailing window
+        // is the reachable real-world trigger (short press-to-talk after idle
+        // unload); the streaming driver also skips the encode call entirely in
+        // that case (see `incremental_streaming_driver`), so this is defense in
+        // depth for any other caller.
+        let frames = subsample_len(frames_in)?;
+        if frames > self.pos_capacity_frames {
+            return Err(DolphinEncoderError::Shape {
+                reason: format!(
+                    "{frames} frames exceed the resident position-table capacity {}",
+                    self.pos_capacity_frames
+                ),
+            });
+        }
+
+        let arena = &self.arena;
+        let weights = EncoderWeights {
+            embed: self.weights.embed.to_transient(arena),
+            blocks: self
+                .weights
+                .blocks
+                .iter()
+                .map(|block| block.to_transient(arena))
+                .collect(),
+            after_norm_w: arena.graph_tensor(self.weights.after_norm_w),
+            after_norm_b: arena.graph_tensor(self.weights.after_norm_b),
+        };
+        let is_multilingual = matches!(
+            config.language_scheme,
+            super::package_import::DolphinLanguageScheme::Multilingual
+        );
+
+        // Phase C: build the per-call forward graph. Only the audio features
+        // are a genuine per-call graph input; every weight and the position
+        // table are already resident in the arena's backend buffer, and the
+        // per-call `pos_emb` is a contiguous view of the resident table (see
+        // the struct doc comment for why each scheme's view is byte-identical
+        // to the table the pre-runtime path uploaded per call).
+        let mut graph = self.runner.start_graph();
+        let row_stride = config.d_model * F32_BYTES;
+        let pos_emb = if is_multilingual {
+            let offset_rows = self.pos_capacity_frames - frames;
+            graph
+                .view_2d(
+                    arena.graph_tensor(self.pos_table),
+                    config.d_model,
+                    2 * frames - 1,
+                    row_stride,
+                    offset_rows * row_stride,
+                )
+                .map_err(ggml_err("pos_view"))?
+        } else {
+            graph
+                .view_2d(
+                    arena.graph_tensor(self.pos_table),
+                    config.d_model,
+                    frames,
+                    row_stride,
+                    0,
+                )
+                .map_err(ggml_err("pos_view"))?
+        };
+        let input = graph
+            .new_tensor_2d_f32(feat, frames_in, "dolphin_features")
+            .map_err(ggml_err("input_alloc"))?;
+
+        let (after_subsample, frames_check) =
+            subsample(&graph, input, &weights.embed, &config, frames_in)?;
+        if frames_check != frames {
+            return Err(DolphinEncoderError::Shape {
+                reason: format!("subsample produced {frames_check} frames, expected {frames}"),
+            });
+        }
+        let mut taps: Vec<GgmlCpuTensor> = Vec::with_capacity(if capture_taps {
+            config.num_blocks + 2
+        } else {
+            1
+        });
+        if capture_taps {
+            taps.push(after_subsample);
+        }
+        let mut hidden = after_subsample;
+        for block in &weights.blocks {
+            hidden = encoder_block(&mut graph, hidden, pos_emb, block, &config, frames)?;
+            if capture_taps {
+                taps.push(hidden);
+            }
+        }
+        let encoder_out = affine_ln(
+            &graph,
+            hidden,
+            config.layer_norm_epsilon,
+            weights.after_norm_w,
+            weights.after_norm_b,
+            "after_norm",
+        )?;
+        // encoder_out is always the last (and, when `!capture_taps`, only) tap.
+        taps.push(encoder_out);
+
+        for tap in &taps {
+            graph.set_output(*tap).map_err(ggml_err("set_output"))?;
+        }
+        // Only the audio-feature leaf is a fresh per-call graph tensor with no
+        // buffer of its own; the weights and position table are arena-resident
+        // (their backend buffer is already allocated), so -- like the decoder's
+        // arena path -- they need no `set_input`.
+        graph
+            .set_input(input)
+            .map_err(ggml_err("mark_input(features)"))?;
+        // Allocate the forward graph through the scheduler's gallocr for
+        // liveness-based buffer reuse before uploading inputs -- every tap above
+        // is already marked as an output, so gallocr keeps each one's buffer
+        // resident instead of recycling it once a later block stops reading it.
+        graph
+            .prepare_outputs_for_upload(&taps)
+            .map_err(ggml_err("prepare_outputs"))?;
+
+        // Phase D: upload the audio features, then compute.
+        graph
+            .set_f32_slice(input, features, "dolphin_features")
+            .map_err(ggml_err("upload_features"))?;
+
+        let expected = frames * config.d_model;
+        let output_specs: Vec<(GgmlCpuTensor, usize)> =
+            taps.iter().map(|tap| (*tap, expected)).collect();
+        let mut outputs = graph
+            .compute_outputs_f32(&output_specs)
+            .map_err(ggml_err("compute"))?;
+
+        let encoder_out = outputs.pop().expect("encoder_out tap");
+        let (after_subsample, blocks) = if capture_taps {
+            let blocks = outputs.split_off(1);
+            let after_subsample = outputs.pop().expect("after_subsample tap");
+            (after_subsample, blocks)
+        } else {
+            (Vec::new(), Vec::new())
+        };
+
+        Ok(DolphinEncoderOutput {
+            frames,
+            dim: config.d_model,
+            after_subsample,
+            blocks,
+            encoder_out,
+        })
+    }
+}
+
+/// One-shot convenience wrapper over [`DolphinEncoderRuntime`] for callers
+/// that only need a single encode (the `parity` dev harness and the
+/// encoder-from-pack regression tests). The production pipeline builds and
+/// caches the runtime directly (see `executor::DolphinPreparedRuntime`)
+/// instead of paying the weight upload per call. The multilingual one-shot
+/// runtime is sized exactly for this call's `frames`, matching the
+/// per-request table the pre-runtime path computed.
 pub(crate) fn encode(
     config: &DolphinEncoderConfig,
     provider: &dyn DolphinWeightProvider,
@@ -1091,193 +1566,34 @@ pub(crate) fn encode(
             ),
         });
     }
-    // Reject a frames_in too short for the two-layer k3/s2 subsampling stem
-    // before any graph/runner allocation: ggml's `conv_2d`/`im2col` asserts
-    // `OH > 0` and aborts the whole process on an under-sized input rather
-    // than returning a Rust error, so this must fail closed here first (see
-    // `subsample_len`). A streaming FINAL over a too-short trailing window is
-    // the reachable real-world trigger (short press-to-talk after idle
-    // unload); the streaming driver also skips the encode call entirely in
-    // that case (see `incremental_streaming_driver`), so this is defense in
-    // depth for any other caller.
+    // Fail closed on an under-sized input BEFORE any weight is looked up or a
+    // runner is allocated (see `DolphinEncoderRuntime::encode`'s matching
+    // check and `subsample_len`).
     let frames = subsample_len(frames_in)?;
+    let mut runtime = DolphinEncoderRuntime::new(config, provider, backend, frames)?;
+    runtime.encode(features, frames_in, capture_taps)
+}
 
-    let graph_config = GgmlCpuGraphConfig {
-        context_bytes: 64 * 1024 * 1024,
-        graph_size: 16384,
-        n_threads: GgmlCpuGraphConfig::resolve_runtime_thread_count_for(
-            backend,
-            crate::ggml_runtime::GgmlCpuGraphThreadingWorkload::EncoderPrelude,
-        ),
-        backend,
-        // Ggml's gallocr scheduler reuses buffer space across tensors whose
-        // lifetimes don't overlap instead of giving every non-view tensor its
-        // own allocation; on the CPU backend both allocators produce
-        // identical results, so unconditionally enabling it (like the
-        // sibling cohere/moonshine encoders) only bounds memory footprint on
-        // long audio, never the encoder's output.
-        use_scheduler: true,
-    };
-    let mut runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml_err("runner_init"))?;
-    // Persistent weight arena (a WEIGHTS-usage backend buffer). Placing every
-    // encoder weight here -- instead of the per-call transient graph leaves the
-    // pre-arena encoder used -- is what lets the ggml multi-backend scheduler
-    // offload the E-Branchformer's matmuls to an accelerator (see
-    // `WeightBuilder`). Mirrors `decoder_graph::DolphinDecoderRescoreRuntime` and
-    // the sibling `sensevoice`/`cohere`/`moonshine` encoders. The arena is an
-    // owned value carrying a raw pointer into the runner's backend, so it and the
-    // per-call graph (a `&mut runner` borrow) coexist; `runner` outlives it.
-    let arena = runner
-        .start_static_tensor_arena(dolphin_encoder_arena_context_bytes(config.num_blocks))
-        .map_err(ggml_err("static_tensor_arena"))?;
-
-    // Phase A: allocate every weight tensor in the arena (allocation must precede
-    // the arena's first upload, which freezes further creation).
-    let mut builder = WeightBuilder::new(provider);
-    let embed = build_embed_weights(&arena, &mut builder, config)?;
-    let mut blocks = Vec::with_capacity(config.num_blocks);
-    for index in 0..config.num_blocks {
-        blocks.push(build_block_weights(&arena, &mut builder, config, index)?);
+/// Deterministic pseudo-random weight values for the synthetic tiny-model
+/// tests below (and `decoder_graph`'s): a per-name FNV seed mixed per index,
+/// mapped into `[-1, 1)`. Pure function of `(name, index)`, so every test run
+/// and every call site sees identical bytes.
+#[cfg(test)]
+pub(crate) fn synthetic_test_tensor(name: &str, len: usize) -> Vec<f32> {
+    let mut seed: u32 = 2166136261;
+    for byte in name.bytes() {
+        seed ^= byte as u32;
+        seed = seed.wrapping_mul(16777619);
     }
-    let after_norm_w = builder.w1(&arena, "encoder.after_norm.weight", config.d_model)?;
-    let after_norm_b = builder.w1(&arena, "encoder.after_norm.bias", config.d_model)?;
-    let weights = EncoderWeights {
-        embed,
-        blocks,
-        after_norm_w,
-        after_norm_b,
-    };
-
-    // The encoder's relative-position table: a baked-table slice for `CnDialect`
-    // (via the provider, like every other weight), or a table computed fresh for
-    // this request's `frames` for `Multilingual` (never baked -- see
-    // `dolphin_relative_positional_table`). Both live in the arena (constant for
-    // the whole call); the computed one is uploaded separately below since it is
-    // an owned buffer, not a provider-borrowed slice `WeightBuilder` can hold.
-    let is_multilingual = matches!(
-        config.language_scheme,
-        super::package_import::DolphinLanguageScheme::Multilingual
-    );
-    let mut computed_pos: Option<(GgmlStaticTensor, Vec<f32>)> = None;
-    let pos_emb = if is_multilingual {
-        let table = dolphin_relative_positional_table(config.d_model, frames).ok_or_else(|| {
-            DolphinEncoderError::Shape {
-                reason: "relative position table size overflow".to_string(),
-            }
-        })?;
-        let handle = arena
-            .new_tensor_2d_f32(config.d_model, 2 * frames - 1, "dolphin_rel_pos")
-            .map_err(ggml_err("weight_alloc_relpos"))?;
-        let tensor = arena.graph_tensor(handle);
-        computed_pos = Some((handle, table));
-        tensor
-    } else {
-        builder.pos_slice(
-            &arena,
-            "encoder.embed.pos_enc.pe",
-            config.d_model,
-            frames,
-            config.max_positions,
-        )?
-    };
-
-    // Phase B: upload every weight (+ the computed rel-pos table) into the arena
-    // backend buffer exactly once. This freezes the arena.
-    let mut arena = arena;
-    builder.upload(&mut arena)?;
-    if let Some((handle, table)) = &computed_pos {
-        arena
-            .set_f32_slice(*handle, table, "dolphin_rel_pos")
-            .map_err(ggml_err("upload_rel_pos"))?;
-    }
-
-    // Phase C: build the per-call forward graph. Only the audio features are a
-    // genuine per-call graph input; every weight and the position table are
-    // already resident in the arena's backend buffer.
-    let mut graph = runner.start_graph();
-    let input = graph
-        .new_tensor_2d_f32(feat, frames_in, "dolphin_features")
-        .map_err(ggml_err("input_alloc"))?;
-
-    let (after_subsample, frames_check) =
-        subsample(&graph, input, &weights.embed, config, frames_in)?;
-    if frames_check != frames {
-        return Err(DolphinEncoderError::Shape {
-            reason: format!("subsample produced {frames_check} frames, expected {frames}"),
-        });
-    }
-    let mut taps: Vec<GgmlCpuTensor> = Vec::with_capacity(if capture_taps {
-        config.num_blocks + 2
-    } else {
-        1
-    });
-    if capture_taps {
-        taps.push(after_subsample);
-    }
-    let mut hidden = after_subsample;
-    for block in &weights.blocks {
-        hidden = encoder_block(&mut graph, hidden, pos_emb, block, config, frames)?;
-        if capture_taps {
-            taps.push(hidden);
-        }
-    }
-    let encoder_out = affine_ln(
-        &graph,
-        hidden,
-        config.layer_norm_epsilon,
-        weights.after_norm_w,
-        weights.after_norm_b,
-        "after_norm",
-    )?;
-    // encoder_out is always the last (and, when `!capture_taps`, only) tap.
-    taps.push(encoder_out);
-
-    for tap in &taps {
-        graph.set_output(*tap).map_err(ggml_err("set_output"))?;
-    }
-    // Only the audio-feature leaf is a fresh per-call graph tensor with no buffer
-    // of its own; the weights and position table are arena-resident (their
-    // backend buffer is already allocated), so -- like the decoder's arena path
-    // -- they need no `set_input`.
-    graph
-        .set_input(input)
-        .map_err(ggml_err("mark_input(features)"))?;
-    // Allocate the forward graph through the scheduler's gallocr for
-    // liveness-based buffer reuse before uploading inputs -- every tap above
-    // is already marked as an output, so gallocr keeps each one's buffer
-    // resident instead of recycling it once a later block stops reading it.
-    graph
-        .prepare_outputs_for_upload(&taps)
-        .map_err(ggml_err("prepare_outputs"))?;
-
-    // Phase D: upload the audio features, then compute.
-    graph
-        .set_f32_slice(input, features, "dolphin_features")
-        .map_err(ggml_err("upload_features"))?;
-
-    let expected = frames * config.d_model;
-    let output_specs: Vec<(GgmlCpuTensor, usize)> =
-        taps.iter().map(|tap| (*tap, expected)).collect();
-    let mut outputs = graph
-        .compute_outputs_f32(&output_specs)
-        .map_err(ggml_err("compute"))?;
-
-    let encoder_out = outputs.pop().expect("encoder_out tap");
-    let (after_subsample, blocks) = if capture_taps {
-        let blocks = outputs.split_off(1);
-        let after_subsample = outputs.pop().expect("after_subsample tap");
-        (after_subsample, blocks)
-    } else {
-        (Vec::new(), Vec::new())
-    };
-
-    Ok(DolphinEncoderOutput {
-        frames,
-        dim: config.d_model,
-        after_subsample,
-        blocks,
-        encoder_out,
-    })
+    (0..len)
+        .map(|index| {
+            let mut x = seed ^ (index as u32).wrapping_mul(2654435761);
+            x ^= x >> 13;
+            x = x.wrapping_mul(1274126177);
+            x ^= x >> 16;
+            ((x % 2000) as f32 / 1000.0) - 1.0
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -1376,5 +1692,186 @@ mod tests {
         let table = dolphin_relative_positional_table(3, 2).expect("table");
         assert_eq!(table.len(), (2 * 2 - 1) * 3);
         assert!(table.iter().all(|v| v.is_finite()));
+    }
+
+    /// A tiny but structurally complete encoder config (1 E-Branchformer
+    /// block, d_model 8) for the CPU residency-equivalence tests below.
+    fn tiny_config(
+        scheme: super::super::package_import::DolphinLanguageScheme,
+    ) -> DolphinEncoderConfig {
+        DolphinEncoderConfig {
+            d_model: 8,
+            attention_heads: 2,
+            head_dim: 4,
+            ffn_units: 16,
+            cgmlp_units: 16,
+            cgmlp_kernel: 3,
+            merge_kernel: 3,
+            num_blocks: 1,
+            feature_dim: 16,
+            max_positions: 8,
+            layer_norm_epsilon: 1e-5,
+            language_scheme: scheme,
+        }
+    }
+
+    /// Every encoder tensor name at its exact expected length, filled with
+    /// deterministic synthetic values.
+    fn synthetic_provider(config: &DolphinEncoderConfig) -> HashMap<String, Vec<f32>> {
+        let d = config.d_model;
+        let ffn = config.ffn_units;
+        let cg = config.cgmlp_units;
+        let cg_half = cg / 2;
+        let flat = d * subsample_width(config.feature_dim);
+        let mut map = HashMap::new();
+        let mut put = |name: String, len: usize| {
+            let values = synthetic_test_tensor(&name, len);
+            map.insert(name, values);
+        };
+        put("encoder.embed.conv.0.weight".into(), 3 * 3 * d);
+        put("encoder.embed.conv.0.bias".into(), d);
+        put("encoder.embed.conv.2.weight".into(), 3 * 3 * d * d);
+        put("encoder.embed.conv.2.bias".into(), d);
+        put("encoder.embed.out.0.weight".into(), flat * d);
+        put("encoder.embed.out.0.bias".into(), d);
+        for index in 0..config.num_blocks {
+            let p = |suffix: &str| format!("encoder.encoders.{index}.{suffix}");
+            put(p("norm_ff_macaron.weight"), d);
+            put(p("norm_ff_macaron.bias"), d);
+            put(p("feed_forward_macaron.w_1.weight"), d * ffn);
+            put(p("feed_forward_macaron.w_1.bias"), ffn);
+            put(p("feed_forward_macaron.w_2.weight"), ffn * d);
+            put(p("feed_forward_macaron.w_2.bias"), d);
+            put(p("norm_mha.weight"), d);
+            put(p("norm_mha.bias"), d);
+            for proj in ["linear_q", "linear_k", "linear_v", "linear_out"] {
+                put(p(&format!("attn.{proj}.weight")), d * d);
+                put(p(&format!("attn.{proj}.bias")), d);
+            }
+            put(p("attn.linear_pos.weight"), d * d);
+            put(p("attn.pos_bias_u"), d);
+            put(p("attn.pos_bias_v"), d);
+            put(p("norm_mlp.weight"), d);
+            put(p("norm_mlp.bias"), d);
+            put(p("cgmlp.channel_proj1.0.weight"), d * cg);
+            put(p("cgmlp.channel_proj1.0.bias"), cg);
+            put(p("cgmlp.csgu.norm.weight"), cg_half);
+            put(p("cgmlp.csgu.norm.bias"), cg_half);
+            put(p("cgmlp.csgu.conv.weight"), config.cgmlp_kernel * cg_half);
+            put(p("cgmlp.csgu.conv.bias"), cg_half);
+            put(p("cgmlp.channel_proj2.weight"), cg_half * d);
+            put(p("cgmlp.channel_proj2.bias"), d);
+            put(
+                p("depthwise_conv_fusion.weight"),
+                config.merge_kernel * 2 * d,
+            );
+            put(p("depthwise_conv_fusion.bias"), 2 * d);
+            put(p("merge_proj.weight"), 2 * d * d);
+            put(p("merge_proj.bias"), d);
+            put(p("norm_ff.weight"), d);
+            put(p("norm_ff.bias"), d);
+            put(p("feed_forward.w_1.weight"), d * ffn);
+            put(p("feed_forward.w_1.bias"), ffn);
+            put(p("feed_forward.w_2.weight"), ffn * d);
+            put(p("feed_forward.w_2.bias"), d);
+            put(p("norm_final.weight"), d);
+            put(p("norm_final.bias"), d);
+        }
+        put("encoder.after_norm.weight".into(), d);
+        put("encoder.after_norm.bias".into(), d);
+        if matches!(
+            config.language_scheme,
+            super::super::package_import::DolphinLanguageScheme::CnDialect
+        ) {
+            put("encoder.embed.pos_enc.pe".into(), d * config.max_positions);
+        }
+        map
+    }
+
+    fn bits(values: &[f32]) -> Vec<u32> {
+        values.iter().map(|v| v.to_bits()).collect()
+    }
+
+    /// Residency equivalence (perf change must not change output): a cached
+    /// [`DolphinEncoderRuntime`] must produce bit-identical `encoder_out` on
+    /// repeated calls (arena reuse, no re-upload) AND bit-identical output to
+    /// the one-shot [`encode`] path, for both position-table schemes. The
+    /// multilingual case additionally pins the "view of a larger resident
+    /// centered table == exact per-`frames` table" equivalence: the runtime's
+    /// table is sized for `max_positions` (8 -> 15 rows) while the one-shot
+    /// builds the exact `frames`-sized table (3 -> 5 rows).
+    #[test]
+    fn encoder_runtime_reuse_is_bit_identical_to_one_shot_encode() {
+        use super::super::package_import::DolphinLanguageScheme;
+        for scheme in [
+            DolphinLanguageScheme::CnDialect,
+            DolphinLanguageScheme::Multilingual,
+        ] {
+            let config = tiny_config(scheme);
+            let provider = synthetic_provider(&config);
+            let frames_in = 15; // -> 3 subsampled frames, below max_positions 8
+            let features = synthetic_test_tensor("features", frames_in * config.feature_dim);
+
+            let one_shot = encode(
+                &config,
+                &provider,
+                &features,
+                frames_in,
+                GgmlCpuGraphBackend::Cpu,
+                false,
+            )
+            .expect("one-shot encode");
+
+            let mut runtime = DolphinEncoderRuntime::new(
+                &config,
+                &provider,
+                GgmlCpuGraphBackend::Cpu,
+                config.max_positions,
+            )
+            .expect("runtime");
+            let first = runtime
+                .encode(&features, frames_in, false)
+                .expect("runtime encode #1");
+            let second = runtime
+                .encode(&features, frames_in, false)
+                .expect("runtime encode #2");
+
+            assert_eq!(first.frames, one_shot.frames);
+            assert_eq!(
+                bits(&first.encoder_out),
+                bits(&one_shot.encoder_out),
+                "{scheme:?}: resident-runtime encode must be bit-identical to one-shot"
+            );
+            assert_eq!(
+                bits(&first.encoder_out),
+                bits(&second.encoder_out),
+                "{scheme:?}: repeated encode on the cached runtime must be bit-identical"
+            );
+        }
+    }
+
+    /// An utterance longer than the resident position table must fail closed
+    /// with a typed `Shape` error (the executor then falls back to a one-shot
+    /// runtime sized for that call), and `supports_input_frames` must report
+    /// the same boundary.
+    #[test]
+    fn encoder_runtime_rejects_frames_beyond_resident_pos_capacity() {
+        use super::super::package_import::DolphinLanguageScheme;
+        let config = tiny_config(DolphinLanguageScheme::Multilingual);
+        let provider = synthetic_provider(&config);
+        let mut runtime =
+            DolphinEncoderRuntime::new(&config, &provider, GgmlCpuGraphBackend::Cpu, 2)
+                .expect("runtime");
+        assert_eq!(runtime.pos_capacity_frames(), 2);
+        // 15 input frames subsample to 3 > capacity 2.
+        assert!(!runtime.supports_input_frames(15));
+        let features = synthetic_test_tensor("features", 15 * config.feature_dim);
+        let result = runtime.encode(&features, 15, false);
+        assert!(
+            matches!(result, Err(DolphinEncoderError::Shape { .. })),
+            "expected a typed Shape error, got {result:?}"
+        );
+        // Too-short input still reports supported so `encode` owns the error.
+        assert!(runtime.supports_input_frames(3));
     }
 }

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -13,6 +13,7 @@
 
 #![allow(dead_code)]
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -31,11 +32,14 @@ use crate::models::ggml_asr_executor::{
 use crate::models::incremental_streaming_driver::{
     STREAMING_PARTIAL_TUNING_HEAVY_SNAPSHOT, build_seq2seq_streaming_session,
 };
+use crate::models::thread_local_runtime_cache::{
+    BoundedRuntimeCache, DEFAULT_RUNTIME_CACHE_CAPACITY, with_thread_local_cached_mut_by_key,
+};
 
-use super::decoder_graph::DolphinDecoderConfig;
+use super::decoder_graph::{DolphinDecoderConfig, DolphinDecoderRescoreRuntime};
 use super::encoder_graph::{
-    DolphinEncoderConfig, DolphinEncoderOutput, DolphinNativeWeight, DolphinWeightProvider, encode,
-    minimum_subsample_input_frames,
+    DolphinEncoderConfig, DolphinEncoderOutput, DolphinEncoderRuntime, DolphinNativeWeight,
+    DolphinWeightProvider, encode, minimum_subsample_input_frames,
 };
 use super::frontend::{
     DolphinEspnetFrontend, DolphinFbankFrontend, apply_global_cmvn, espnet_min_samples_for_frames,
@@ -44,7 +48,9 @@ use super::frontend::{
 use super::hotword_context::{
     apply_hotword_deep_biasing, encode_hotword_context_embeddings, tokenize_hotword_phrase,
 };
-use super::joint_decode::{DolphinJointDecodeConfig, detokenize_char_tokens, joint_decode};
+use super::joint_decode::{
+    DolphinCtcHeadRuntime, DolphinJointDecodeConfig, detokenize_char_tokens, joint_decode,
+};
 use super::language::{build_dolphin_decode_prefix, build_dolphin_multilingual_decode_prefix};
 use super::package_import::DolphinLanguageScheme;
 use super::runtime_contract::parse_dolphin_execution_metadata;
@@ -336,11 +342,78 @@ pub(crate) fn cached_dolphin_runtime_weights(
     Ok(weights)
 }
 
+/// Prepared per-`(pack, backend)` graph runtimes: the encoder, CTC head, and
+/// rescore decoder each keep their weights resident in a persistent
+/// WEIGHTS-usage arena (see the respective runtime types). Cached thread-local
+/// by `(PackContentKey, backend)` -- the sensevoice/moonshine prepared-runtime
+/// pattern -- so a warm request (or a streaming tick, which re-enters
+/// `execute()` per snapshot) pays zero weight re-upload: only the per-call
+/// audio features / encoder memory / token ids travel to the backend.
+/// Residency changes no computed value; every output stays golden-identical.
+pub(crate) struct DolphinPreparedRuntime {
+    backend: GgmlCpuGraphBackend,
+    encoder: DolphinEncoderRuntime,
+    ctc_head: DolphinCtcHeadRuntime,
+    rescore: DolphinDecoderRescoreRuntime,
+}
+
+type DolphinPreparedRuntimeCacheKey = (
+    crate::models::runtime_cache_coordinator::PackContentKey,
+    GgmlCpuGraphBackend,
+);
+
+thread_local! {
+    static DOLPHIN_PREPARED_RUNTIME_BY_KEY: RefCell<
+        BoundedRuntimeCache<DolphinPreparedRuntimeCacheKey, DolphinPreparedRuntime>,
+    > = RefCell::new(BoundedRuntimeCache::new());
+}
+
+/// Build the three prepared graph runtimes for one pack + backend. The
+/// encoder's resident position-table capacity is sized to the pack's own
+/// `encoder.max_ctx`; a longer utterance (multilingual scheme only, whose
+/// table is computed rather than baked) falls back to a one-shot runtime in
+/// [`run_dolphin_pipeline`] instead of failing.
+pub(crate) fn build_dolphin_prepared_runtime(
+    weights: &DolphinRuntimeWeights,
+    metadata: &GgufMetadata,
+    backend: GgmlCpuGraphBackend,
+) -> Result<DolphinPreparedRuntime, String> {
+    let language_scheme = parse_dolphin_language_scheme(metadata)?;
+    let execution_metadata = parse_dolphin_execution_metadata(metadata, weights)
+        .map_err(|error| format!("dolphin runtime metadata contract failed: {error}"))?;
+    let encoder_config =
+        DolphinEncoderConfig::from_execution_metadata(&execution_metadata, language_scheme);
+    let decoder_config = DolphinDecoderConfig::from_execution_metadata(&execution_metadata);
+    let encoder = DolphinEncoderRuntime::new(
+        &encoder_config,
+        weights,
+        backend,
+        encoder_config.max_positions,
+    )
+    .map_err(|error| format!("dolphin encoder runtime build failed: {error}"))?;
+    let ctc_head = DolphinCtcHeadRuntime::new(
+        weights,
+        decoder_config.d_model,
+        decoder_config.vocab_size,
+        backend,
+    )
+    .map_err(|error| format!("dolphin ctc head runtime build failed: {error}"))?;
+    let rescore = DolphinDecoderRescoreRuntime::new(&decoder_config, weights, backend)
+        .map_err(|error| format!("dolphin rescore runtime build failed: {error}"))?;
+    Ok(DolphinPreparedRuntime {
+        backend,
+        encoder,
+        ctc_head,
+        rescore,
+    })
+}
+
 /// The complete Dolphin transcribe pipeline over 16 kHz mono PCM (`samples` in
 /// `[-1, 1]`): fbank + CMVN -> encoder -> CTC/attention joint decode -> detokenize.
-/// Loads the pack's weights from `reader` each call (the uncached path the parity
-/// harness drives); the executor uses [`cached_dolphin_runtime_weights`] +
-/// [`run_dolphin_pipeline`] to reuse weights across requests.
+/// Loads the pack's weights from `reader` and builds fresh prepared runtimes
+/// each call (the uncached path the parity harness drives); the executor uses
+/// [`cached_dolphin_runtime_weights`] + the thread-local
+/// [`DolphinPreparedRuntime`] cache to reuse both across requests.
 pub(crate) fn transcribe_dolphin_pcm(
     reader: &GgufTensorDataReader,
     metadata: &GgufMetadata,
@@ -352,12 +425,13 @@ pub(crate) fn transcribe_dolphin_pcm(
 ) -> Result<DolphinPipelineOutput, String> {
     let weights = load_dolphin_runtime_weights_from_pack(reader)
         .map_err(|error| format!("dolphin runtime weight load failed: {error}"))?;
+    let mut prepared = build_dolphin_prepared_runtime(&weights, metadata, backend)?;
     run_dolphin_pipeline(
+        &mut prepared,
         &weights,
         metadata,
         samples,
         ctc_weight,
-        backend,
         language,
         phrase_bias,
     )
@@ -396,17 +470,19 @@ fn parse_dolphin_language_scheme_value(
 }
 
 /// Run the fbank+CMVN -> encoder -> joint-decode -> detokenize pipeline over
-/// already-loaded `weights`. Split out from [`transcribe_dolphin_pcm`] so the
-/// executor can reuse pooled weights across requests without re-dequantizing.
+/// already-loaded `weights` and already-`prepared` graph runtimes. Split out
+/// from [`transcribe_dolphin_pcm`] so the executor can reuse both across
+/// requests without re-dequantizing or re-uploading.
 pub(crate) fn run_dolphin_pipeline(
+    prepared: &mut DolphinPreparedRuntime,
     weights: &DolphinRuntimeWeights,
     metadata: &GgufMetadata,
     samples: &[f32],
     ctc_weight: f32,
-    backend: GgmlCpuGraphBackend,
     language: Option<&str>,
     phrase_bias: Option<&PhraseBiasConfig>,
 ) -> Result<DolphinPipelineOutput, String> {
+    let backend = prepared.backend;
     let tokens = metadata
         .get_string_array(TOKENIZER_TOKENS_KEY)
         .ok_or_else(|| format!("dolphin pack is missing the '{TOKENIZER_TOKENS_KEY}' vocab"))?;
@@ -469,20 +545,30 @@ pub(crate) fn run_dolphin_pipeline(
 
     // Encoder (parity-verified for small.cn; shape-derived for every size;
     // `language_scheme` picks the rel-pos-attention flavor -- see
-    // `DolphinEncoderConfig`'s doc comment).
-    let encoder_config =
-        DolphinEncoderConfig::from_execution_metadata(&execution_metadata, language_scheme);
-    // Production transcription only ever reads `encoder.encoder_out` below;
-    // `after_subsample`/per-block taps exist solely for `#[cfg(test)]` parity,
-    // so they stay off here (P6: see `encoder_graph::encode`'s doc comment).
-    let encoder = encode(
-        &encoder_config,
-        weights,
-        &features.data,
-        features.n_frames,
-        backend,
-        false,
-    )
+    // `DolphinEncoderConfig`'s doc comment). The prepared runtime's weights
+    // are already backend-resident; only when an utterance outgrows its
+    // resident position table (multilingual scheme only, whose table is
+    // computed rather than baked -- see `DolphinEncoderRuntime`) does this
+    // fall back to a one-shot runtime sized for exactly this call, matching
+    // the pre-runtime per-call behavior. Production transcription only ever
+    // reads `encoder.encoder_out` below; `after_subsample`/per-block taps
+    // exist solely for `#[cfg(test)]` parity, so they stay off here (P6).
+    let encoder = if prepared.encoder.supports_input_frames(features.n_frames) {
+        prepared
+            .encoder
+            .encode(&features.data, features.n_frames, false)
+    } else {
+        let encoder_config =
+            DolphinEncoderConfig::from_execution_metadata(&execution_metadata, language_scheme);
+        encode(
+            &encoder_config,
+            weights,
+            &features.data,
+            features.n_frames,
+            backend,
+            false,
+        )
+    }
     .map_err(|error| format!("dolphin encoder graph failed: {error}"))?;
 
     // Hotword deep-biasing (native `context_module.*` fusion). Upstream's
@@ -514,8 +600,8 @@ pub(crate) fn run_dolphin_pipeline(
         _ => std::borrow::Cow::Borrowed(encoder.encoder_out.as_slice()),
     };
 
-    // CTC/attention joint decode.
-    let decoder_config = DolphinDecoderConfig::from_execution_metadata(&execution_metadata);
+    // CTC/attention joint decode over the prepared (weight-resident) CTC head
+    // and rescore runtimes.
     let decode_config = DolphinJointDecodeConfig {
         beam_size: DOLPHIN_BEAM_SIZE,
         ctc_weight,
@@ -524,13 +610,12 @@ pub(crate) fn run_dolphin_pipeline(
         blank_token_id,
     };
     let decoded = joint_decode(
-        &decoder_config,
-        weights,
+        &mut prepared.ctc_head,
+        &mut prepared.rescore,
         &encoder.encoder_out,
         &rescoring_encoder_out,
         encoder.frames,
         &decode_config,
-        backend,
     )
     .map_err(|error| format!("dolphin joint decode failed: {error}"))?;
 
@@ -617,16 +702,36 @@ impl GgmlAsrExecutor for DolphinGgmlExecutor {
         // ~0.4 s reload+dequant is paid once, later requests are compute-only.
         let weights =
             cached_dolphin_runtime_weights(&preflight.runtime_source, &reader).map_err(fail)?;
+        // Reuse the prepared graph runtimes (backend-resident encoder / CTC
+        // head / rescore decoder weights) across requests too, keyed by
+        // `(pack content id, backend)` in the shared thread-local runtime
+        // cache -- the sensevoice/moonshine pattern. A cold key builds them
+        // from the pooled weights; warm requests (and every streaming tick)
+        // skip the whole per-call weight re-upload.
+        let cache_key = (
+            crate::models::runtime_cache_coordinator::PackContentKey::for_runtime_source(
+                &preflight.runtime_source,
+            ),
+            backend,
+        );
         // Thread the request language into the decode prefix builder; an
         // unsupported code / missing region token fails closed here (typed).
-        let output = run_dolphin_pipeline(
-            &weights,
-            &preflight.metadata,
-            &request.prepared_audio.samples_f32,
-            DOLPHIN_REFERENCE_RESCORE_CTC_WEIGHT,
-            backend,
-            request.request_options.language.as_deref(),
-            request.request_options.phrase_bias.as_ref(),
+        let output = with_thread_local_cached_mut_by_key(
+            &DOLPHIN_PREPARED_RUNTIME_BY_KEY,
+            cache_key,
+            DEFAULT_RUNTIME_CACHE_CAPACITY,
+            || build_dolphin_prepared_runtime(&weights, &preflight.metadata, backend),
+            |prepared| {
+                run_dolphin_pipeline(
+                    prepared,
+                    &weights,
+                    &preflight.metadata,
+                    &request.prepared_audio.samples_f32,
+                    DOLPHIN_REFERENCE_RESCORE_CTC_WEIGHT,
+                    request.request_options.language.as_deref(),
+                    request.request_options.phrase_bias.as_ref(),
+                )
+            },
         )
         .map_err(fail)?;
 
@@ -1245,34 +1350,41 @@ mod tests {
             .max(1);
         let ctc_weight = DOLPHIN_REFERENCE_RESCORE_CTC_WEIGHT;
 
-        // Reuse == build the runtime pool once, reuse across runs (the pooled
-        // executor path). No-reuse == rebuild the pool every run (the cold
-        // per-request cost). Best-of-N wall time isolates the reuse delta.
-        let preloaded =
-            reuse.then(|| load_dolphin_runtime_weights_from_pack(&reader).expect("weights"));
+        // Reuse == build the weight pool + prepared graph runtimes once, reuse
+        // across runs (the cached executor path). No-reuse == rebuild both
+        // every run (the cold per-request cost). Best-of-N wall time isolates
+        // the reuse delta.
+        let mut preloaded = reuse.then(|| {
+            let weights = load_dolphin_runtime_weights_from_pack(&reader).expect("weights");
+            let prepared =
+                build_dolphin_prepared_runtime(&weights, &metadata, backend).expect("prepared");
+            (weights, prepared)
+        });
         let mut best = Duration::MAX;
         let mut text = String::new();
         for _ in 0..runs {
             let started = Instant::now();
-            let output = if let Some(weights) = preloaded.as_ref() {
+            let output = if let Some((weights, prepared)) = preloaded.as_mut() {
                 run_dolphin_pipeline(
+                    prepared,
                     weights,
                     &metadata,
                     &samples,
                     ctc_weight,
-                    backend,
                     Some("zh-sichuan"),
                     None,
                 )
             } else {
                 let weights =
                     load_dolphin_runtime_weights_from_pack(&reader).expect("weights reload");
+                let mut prepared = build_dolphin_prepared_runtime(&weights, &metadata, backend)
+                    .expect("prepared reload");
                 run_dolphin_pipeline(
+                    &mut prepared,
                     &weights,
                     &metadata,
                     &samples,
                     ctc_weight,
-                    backend,
                     Some("zh-sichuan"),
                     None,
                 )

--- a/crates/openasr-core/src/models/dolphin/joint_decode.rs
+++ b/crates/openasr-core/src/models/dolphin/joint_decode.rs
@@ -18,11 +18,10 @@ use std::collections::HashMap;
 
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner,
+    GgmlStaticTensor, GgmlStaticTensorArena,
 };
 
-use super::decoder_graph::{
-    DolphinDecoderConfig, DolphinDecoderError, DolphinDecoderRescoreRuntime,
-};
+use super::decoder_graph::{DolphinDecoderError, DolphinDecoderRescoreRuntime};
 use super::encoder_graph::DolphinWeightProvider;
 use crate::models::spm_decoder::{SpmDecoderConfig, decode_spm_pieces};
 
@@ -97,14 +96,14 @@ pub(crate) struct DolphinJointDecodeResult {
 /// `decode()` (which computes `ctc_logprobs` before `apply_deep_biasing` replaces
 /// `encoder_out`).
 pub(crate) fn joint_decode(
-    decoder_config: &DolphinDecoderConfig,
-    provider: &dyn DolphinWeightProvider,
+    ctc_head: &mut DolphinCtcHeadRuntime,
+    rescore: &mut DolphinDecoderRescoreRuntime,
     encoder_out: &[f32],
     rescoring_encoder_out: &[f32],
     frames: usize,
     decode_config: &DolphinJointDecodeConfig,
-    backend: GgmlCpuGraphBackend,
 ) -> Result<DolphinJointDecodeResult, DolphinJointDecodeError> {
+    let decoder_config = *rescore.config();
     let vocab = decoder_config.vocab_size;
     let d_model = decoder_config.d_model;
     if frames == 0 || encoder_out.len() != frames * d_model {
@@ -123,8 +122,7 @@ pub(crate) fn joint_decode(
             ),
         });
     }
-    let ctc_log_probs =
-        compute_ctc_log_probs(provider, encoder_out, frames, d_model, vocab, backend)?;
+    let ctc_log_probs = ctc_head.compute_log_probs(encoder_out, frames)?;
     let blank = decode_config.blank_token_id as usize;
     if blank >= vocab {
         return Err(DolphinJointDecodeError::Shape {
@@ -144,13 +142,11 @@ pub(crate) fn joint_decode(
     }
 
     let scored_nbest = attention_rescore(
-        decoder_config,
-        provider,
+        rescore,
         rescoring_encoder_out,
         frames,
         decode_config,
         &nbest,
-        backend,
     )?;
     let best_token_ids = scored_nbest
         .first()
@@ -192,115 +188,157 @@ fn dolphin_ctc_head_graph_config(backend: GgmlCpuGraphBackend) -> GgmlCpuGraphCo
     }
 }
 
-/// `ctc.ctc_lo(encoder_out)` -> `log_softmax`, returned row-major `[frames, vocab]`
-/// (vocab innermost). The linear runs in the CPU ggml graph (like the encoder);
-/// the softmax is a cheap Rust pass.
-fn compute_ctc_log_probs(
-    provider: &dyn DolphinWeightProvider,
-    encoder_out: &[f32],
-    frames: usize,
+/// Build-once/run-many CTC head runtime: `ctc.ctc_lo` weight + bias resident
+/// in a persistent WEIGHTS-usage arena, one small projection graph per call.
+/// The executor caches this per `(pack, backend)` alongside the encoder and
+/// rescore runtimes (see `executor::DolphinPreparedRuntime`), so warm calls
+/// skip the per-utterance weight re-upload the pre-runtime path paid.
+pub(crate) struct DolphinCtcHeadRuntime {
+    runner: GgmlCpuGraphRunner,
+    arena: GgmlStaticTensorArena,
+    weight: GgmlStaticTensor,
+    bias: GgmlStaticTensor,
     d_model: usize,
     vocab: usize,
-    backend: GgmlCpuGraphBackend,
-) -> Result<Vec<f32>, DolphinJointDecodeError> {
-    let native_weight = provider.native_weight("ctc.ctc_lo.weight");
-    let weight = if native_weight.is_some() {
-        None
-    } else {
-        Some(fetch(provider, "ctc.ctc_lo.weight", vocab * d_model)?)
-    };
-    let bias = fetch(provider, "ctc.ctc_lo.bias", vocab)?;
+}
 
-    let graph_config = dolphin_ctc_head_graph_config(backend);
-    let ggml = |stage: &'static str| move |source| DolphinJointDecodeError::Ggml { stage, source };
-    let mut runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml("runner_init"))?;
+impl DolphinCtcHeadRuntime {
+    pub(crate) fn new(
+        provider: &dyn DolphinWeightProvider,
+        d_model: usize,
+        vocab: usize,
+        backend: GgmlCpuGraphBackend,
+    ) -> Result<Self, DolphinJointDecodeError> {
+        let native_weight = provider.native_weight("ctc.ctc_lo.weight");
+        let weight = if native_weight.is_some() {
+            None
+        } else {
+            Some(fetch(provider, "ctc.ctc_lo.weight", vocab * d_model)?)
+        };
+        let bias = fetch(provider, "ctc.ctc_lo.bias", vocab)?;
 
-    // Persistent weight arena (a WEIGHTS-usage backend buffer): the CTC head's
-    // `ctc.ctc_lo.weight` matmul operand + bias live here so the ggml
-    // multi-backend scheduler can offload the projection to an accelerator, the
-    // same reason the encoder/decoder weights are arena-resident. Binding them as
-    // per-call transient graph leaves (the pre-arena path) pinned this matmul to
-    // the CPU even under an explicit Metal backend. Only `encoder_out` is a
-    // genuine per-call graph input. Weight placement changes no computed value,
-    // so the CTC log-probs stay golden-identical.
-    let arena = runner
-        .start_static_tensor_arena(GgmlCpuGraphConfig::metadata_context_bytes(2))
-        .map_err(ggml("static_tensor_arena"))?;
+        let graph_config = dolphin_ctc_head_graph_config(backend);
+        let ggml =
+            |stage: &'static str| move |source| DolphinJointDecodeError::Ggml { stage, source };
+        let runner = GgmlCpuGraphRunner::new(graph_config).map_err(ggml("runner_init"))?;
 
-    // Weight `[vocab, d_model]` binds as ggml `[ne0=d_model, ne1=vocab]` so
-    // `mul_mat(weight, enc)` projects each frame to the vocab logits. When the
-    // provider keeps it quantized/f16, it binds at the stored ggml type and the
-    // raw block bytes are uploaded verbatim (stays quantized in the buffer);
-    // otherwise it binds f32.
-    let weight_handle = match native_weight {
-        Some(native) => arena
-            .new_matmul_weight_2d_typed(d_model, vocab, native.ggml_type, "dolphin_ctc_weight")
-            .map_err(ggml("weight_alloc_native"))?,
-        None => arena
-            .new_tensor_2d_f32(d_model, vocab, "dolphin_ctc_weight")
-            .map_err(ggml("weight_alloc"))?,
-    };
-    let bias_handle = arena
-        .new_tensor_1d_f32(vocab, "dolphin_ctc_bias")
-        .map_err(ggml("bias_alloc"))?;
+        // Persistent weight arena (a WEIGHTS-usage backend buffer): the CTC
+        // head's `ctc.ctc_lo.weight` matmul operand + bias live here so the ggml
+        // multi-backend scheduler can offload the projection to an accelerator,
+        // the same reason the encoder/decoder weights are arena-resident.
+        // Binding them as per-call transient graph leaves (the pre-arena path)
+        // pinned this matmul to the CPU even under an explicit Metal backend.
+        // Only `encoder_out` is a genuine per-call graph input. Weight placement
+        // changes no computed value, so the CTC log-probs stay golden-identical.
+        let arena = runner
+            .start_static_tensor_arena(GgmlCpuGraphConfig::metadata_context_bytes(2))
+            .map_err(ggml("static_tensor_arena"))?;
 
-    // Upload the weight + bias into the arena backend buffer exactly once (the
-    // first upload freezes further tensor creation).
-    let mut arena = arena;
-    match (native_weight, weight) {
-        (Some(native), _) => arena
-            .set_bytes_slice(weight_handle, native.bytes, "dolphin_ctc_weight")
-            .map_err(ggml("upload_weight_native"))?,
-        (None, Some(weight)) => arena
-            .set_f32_slice(weight_handle, weight, "dolphin_ctc_weight")
-            .map_err(ggml("upload_weight"))?,
-        (None, None) => unreachable!("ctc weight is fetched f32 when not native"),
+        // Weight `[vocab, d_model]` binds as ggml `[ne0=d_model, ne1=vocab]` so
+        // `mul_mat(weight, enc)` projects each frame to the vocab logits. When
+        // the provider keeps it quantized/f16, it binds at the stored ggml type
+        // and the raw block bytes are uploaded verbatim (stays quantized in the
+        // buffer); otherwise it binds f32.
+        let weight_handle = match native_weight {
+            Some(native) => arena
+                .new_matmul_weight_2d_typed(d_model, vocab, native.ggml_type, "dolphin_ctc_weight")
+                .map_err(ggml("weight_alloc_native"))?,
+            None => arena
+                .new_tensor_2d_f32(d_model, vocab, "dolphin_ctc_weight")
+                .map_err(ggml("weight_alloc"))?,
+        };
+        let bias_handle = arena
+            .new_tensor_1d_f32(vocab, "dolphin_ctc_bias")
+            .map_err(ggml("bias_alloc"))?;
+
+        // Upload the weight + bias into the arena backend buffer exactly once
+        // (the first upload freezes further tensor creation).
+        let mut arena = arena;
+        match (native_weight, weight) {
+            (Some(native), _) => arena
+                .set_bytes_slice(weight_handle, native.bytes, "dolphin_ctc_weight")
+                .map_err(ggml("upload_weight_native"))?,
+            (None, Some(weight)) => arena
+                .set_f32_slice(weight_handle, weight, "dolphin_ctc_weight")
+                .map_err(ggml("upload_weight"))?,
+            (None, None) => unreachable!("ctc weight is fetched f32 when not native"),
+        }
+        arena
+            .set_f32_slice(bias_handle, bias, "dolphin_ctc_bias")
+            .map_err(ggml("upload_bias"))?;
+
+        Ok(Self {
+            runner,
+            arena,
+            weight: weight_handle,
+            bias: bias_handle,
+            d_model,
+            vocab,
+        })
     }
-    arena
-        .set_f32_slice(bias_handle, bias, "dolphin_ctc_bias")
-        .map_err(ggml("upload_bias"))?;
 
-    let mut graph = runner.start_graph();
-    let encoder_tensor = graph
-        .new_tensor_2d_f32(d_model, frames, "dolphin_ctc_encoder_out")
-        .map_err(ggml("encoder_alloc"))?;
-    let weight_tensor = arena.graph_tensor(weight_handle);
-    let bias_tensor = arena.graph_tensor(bias_handle);
+    /// `ctc.ctc_lo(encoder_out)` -> `log_softmax`, returned row-major
+    /// `[frames, vocab]` (vocab innermost). The linear runs in the ggml graph
+    /// (like the encoder); the softmax is a cheap Rust pass.
+    pub(crate) fn compute_log_probs(
+        &mut self,
+        encoder_out: &[f32],
+        frames: usize,
+    ) -> Result<Vec<f32>, DolphinJointDecodeError> {
+        let (d_model, vocab) = (self.d_model, self.vocab);
+        if frames == 0 || encoder_out.len() != frames * d_model {
+            return Err(DolphinJointDecodeError::Shape {
+                reason: format!(
+                    "encoder_out has {} values, expected {frames}x{d_model}",
+                    encoder_out.len()
+                ),
+            });
+        }
+        let ggml =
+            |stage: &'static str| move |source| DolphinJointDecodeError::Ggml { stage, source };
+        let arena = &self.arena;
+        let mut graph = self.runner.start_graph();
+        let encoder_tensor = graph
+            .new_tensor_2d_f32(d_model, frames, "dolphin_ctc_encoder_out")
+            .map_err(ggml("encoder_alloc"))?;
+        let weight_tensor = arena.graph_tensor(self.weight);
+        let bias_tensor = arena.graph_tensor(self.bias);
 
-    let logits = graph
-        .mul_mat(weight_tensor, encoder_tensor)
-        .map_err(ggml("ctc_mul_mat"))?;
-    let logits = graph
-        .add(logits, bias_tensor)
-        .map_err(ggml("ctc_bias_add"))?;
-    graph.set_output(logits).map_err(ggml("set_output"))?;
-    // Only `encoder_out` is a fresh per-call graph leaf with no buffer of its
-    // own; the weight + bias are arena-resident (backend buffer already
-    // allocated), so -- like the encoder/decoder arena paths -- they need no
-    // `set_input`.
-    graph
-        .set_input(encoder_tensor)
-        .map_err(ggml("mark_input(encoder_out)"))?;
-    // Allocate the forward graph through the scheduler's gallocr for
-    // liveness-based buffer reuse before uploading inputs (mirrors the
-    // encoder/decoder graphs).
-    graph
-        .prepare_outputs_for_upload(&[logits])
-        .map_err(ggml("prepare_outputs"))?;
+        let logits = graph
+            .mul_mat(weight_tensor, encoder_tensor)
+            .map_err(ggml("ctc_mul_mat"))?;
+        let logits = graph
+            .add(logits, bias_tensor)
+            .map_err(ggml("ctc_bias_add"))?;
+        graph.set_output(logits).map_err(ggml("set_output"))?;
+        // Only `encoder_out` is a fresh per-call graph leaf with no buffer of
+        // its own; the weight + bias are arena-resident (backend buffer already
+        // allocated), so -- like the encoder/decoder arena paths -- they need
+        // no `set_input`.
+        graph
+            .set_input(encoder_tensor)
+            .map_err(ggml("mark_input(encoder_out)"))?;
+        // Allocate the forward graph through the scheduler's gallocr for
+        // liveness-based buffer reuse before uploading inputs (mirrors the
+        // encoder/decoder graphs).
+        graph
+            .prepare_outputs_for_upload(&[logits])
+            .map_err(ggml("prepare_outputs"))?;
 
-    graph
-        .set_f32_slice(encoder_tensor, encoder_out, "dolphin_ctc_encoder_out")
-        .map_err(ggml("upload_encoder"))?;
+        graph
+            .set_f32_slice(encoder_tensor, encoder_out, "dolphin_ctc_encoder_out")
+            .map_err(ggml("upload_encoder"))?;
 
-    let mut logits = graph
-        .compute_output_f32(logits, frames * vocab)
-        .map_err(ggml("compute"))?;
+        let mut logits = graph
+            .compute_output_f32(logits, frames * vocab)
+            .map_err(ggml("compute"))?;
 
-    // In-place log_softmax over each frame's vocab row.
-    for row in logits.chunks_exact_mut(vocab) {
-        log_softmax_in_place(row);
+        // In-place log_softmax over each frame's vocab row.
+        for row in logits.chunks_exact_mut(vocab) {
+            log_softmax_in_place(row);
+        }
+        Ok(logits)
     }
-    Ok(logits)
 }
 
 fn fetch<'p>(
@@ -464,13 +502,11 @@ fn top_k_indices(row: &[f32], k: usize) -> Vec<usize> {
 /// position log-probs are a per-hypothesis constant and are excluded; the score is
 /// the sum of `log P(hyp[k] | prompt, hyp[<k])` plus `log P(eos | prompt, hyp)`.
 fn attention_rescore(
-    decoder_config: &DolphinDecoderConfig,
-    provider: &dyn DolphinWeightProvider,
+    runtime: &mut DolphinDecoderRescoreRuntime,
     encoder_out: &[f32],
     frames: usize,
     decode_config: &DolphinJointDecodeConfig,
     nbest: &[(Vec<u32>, f32)],
-    backend: GgmlCpuGraphBackend,
 ) -> Result<Vec<DolphinScoredHypothesis>, DolphinJointDecodeError> {
     let prompt = &decode_config.prompt_prefix;
     let prompt_len = prompt.len();
@@ -479,30 +515,35 @@ fn attention_rescore(
             reason: "prompt prefix must be non-empty".to_string(),
         });
     }
-    let vocab = decoder_config.vocab_size;
+    let vocab = runtime.config().vocab_size;
     let eos = decode_config.eos_token_id as usize;
 
-    // Build-once/run-many (P5): every hypothesis below teacher-forces the same
-    // decoder weights over the same encoder_out, differing only in the token
-    // sequence, so the ~200 decoder weight tensors + the encoder memory are
-    // loaded into the runtime's persistent arena exactly once here rather than
-    // rebuilt and re-uploaded per hypothesis (up to DOLPHIN_BEAM_SIZE times).
-    let mut runtime =
-        DolphinDecoderRescoreRuntime::new(decoder_config, provider, encoder_out, frames, backend)?;
+    // The whole n-best is teacher-forced in ONE fused graph per utterance: the
+    // decoder weights are already resident in the (executor-cached) runtime's
+    // arena, the encoder memory is uploaded once, and the per-layer cross K/V
+    // projections over it are computed once and shared by every hypothesis
+    // chain (see `DolphinDecoderRescoreRuntime::decode_nbest_prompt_logits`).
+    // An empty hypothesis teacher-forces the bare prompt: its score is just
+    // log P(eos | prompt), read from the same fused call.
+    let sequences: Vec<Vec<u32>> = nbest
+        .iter()
+        .map(|(tokens, _)| {
+            let mut sequence = Vec::with_capacity(prompt_len + tokens.len());
+            sequence.extend_from_slice(prompt);
+            sequence.extend_from_slice(tokens);
+            sequence
+        })
+        .collect();
+    let nbest_logits = runtime.decode_nbest_prompt_logits(encoder_out, frames, &sequences)?;
 
     let mut scored = Vec::with_capacity(nbest.len());
-    for (tokens, ctc_score) in nbest {
+    for ((tokens, ctc_score), logits) in nbest.iter().zip(&nbest_logits) {
         let attention_score = if tokens.is_empty() {
             // Empty hypothesis: score is just log P(eos | prompt).
-            let logits = runtime.decode_prompt_logits(prompt)?;
             let mut row = logits.last_token_logits().to_vec();
             log_softmax_in_place(&mut row);
             row[eos]
         } else {
-            let mut sequence = Vec::with_capacity(prompt_len + tokens.len());
-            sequence.extend_from_slice(prompt);
-            sequence.extend_from_slice(tokens);
-            let logits = runtime.decode_prompt_logits(&sequence)?;
             score_hypothesis(&logits.logits, vocab, prompt_len, tokens, eos)
         };
         let combined = attention_score + decode_config.ctc_weight * *ctc_score;

--- a/crates/openasr-core/src/models/firered_aed/capacity.rs
+++ b/crates/openasr-core/src/models/firered_aed/capacity.rs
@@ -1,0 +1,139 @@
+//! firered-aed capacity derivation for the shared host-memory admission
+//! check ([`crate::capacity::evaluate_host_memory_admission`]).
+//!
+//! Same shape as [`crate::models::cohere::capacity`] (see that module's doc
+//! for the full modeling rationale): this AED decoder allocates its KV state
+//! at fixed per-pack ceilings when the decoder runtime is built
+//! (`super::decoder_graph::build_firered_decoder_arena_state`), independent
+//! of the request's audio length --
+//!
+//! - the self-attention KV cache is f16 at the full `decoder_pe_len` span
+//!   per layer (the family's `BoundedElsewhere` positional-encoding bound,
+//!   5000 positions for the shipped pack), and
+//! - the cross-attention KV cache is f32 over the pack's chunk-cap encoder
+//!   frame capacity ([`super::decoder_graph::firered_decoder_cross_capacity_frames`]).
+//!
+//! Admission charges those exact allocations: the cross cache through the
+//! shared position model (one "position" = one encoder frame at
+//! `layers x 2 x d_model` f32 values, priced exactly by the two-f16-copy
+//! [`FIRERED_AED_ADMISSION_KV_SPEC`]), the f16 self ceiling as exact fixed
+//! bytes (a spec-based charge would overstate it 2x). A `longform mode=off`
+//! request larger than the chunk cap can grow the cross cache past this
+//! estimate; that under-estimate resolves to "allow" (fail open).
+
+use crate::capacity::KvGeometry;
+use crate::ggml_runtime::GgmlKvElementType;
+use crate::nn::decoder::LlmKvCacheSpec;
+
+use super::decoder_graph::firered_decoder_cross_capacity_frames;
+use super::runtime_contract::FireRedAedExecutionMetadata;
+
+/// Two f16 copies = 4 B/value total: byte-for-byte the single f32 copy the
+/// cross-KV cache actually allocates. Only
+/// [`crate::capacity::KvBytesPerPosition::total`] is consumed by admission;
+/// the host/resident split is a modeling stand-in (see
+/// `crate::models::cohere::capacity`'s identical convention).
+pub(crate) const FIRERED_AED_ADMISSION_KV_SPEC: LlmKvCacheSpec = LlmKvCacheSpec {
+    host: GgmlKvElementType::F16,
+    resident: GgmlKvElementType::F16,
+};
+
+/// The AED decoder KV geometry the loaded pack advertises (MHA: `kv_heads`
+/// equals `n_heads`, so `layers x 2 x kv_heads x head_dim` values per
+/// position equals the `layers x 2 x d_model` values one cross-KV frame
+/// costs).
+pub(crate) fn firered_aed_kv_geometry(metadata: &FireRedAedExecutionMetadata) -> KvGeometry {
+    KvGeometry {
+        n_layers: metadata.decoder_n_layers,
+        kv_heads: metadata.n_heads,
+        head_dim: metadata.head_dim,
+    }
+}
+
+/// The cross-KV positions admission charges through the shared position
+/// model: the pack's chunk-cap encoder frame capacity, the same figure the
+/// decoder runtime allocates its cross cache at (request-independent).
+pub(crate) fn firered_aed_admission_required_positions(
+    metadata: &FireRedAedExecutionMetadata,
+) -> usize {
+    firered_decoder_cross_capacity_frames(metadata)
+}
+
+/// Exact bytes of the f16 self-attention KV cache the decoder runtime
+/// allocates at construction: K + V planes of
+/// `head_dim x decoder_pe_len x n_heads` f16 values per layer (the exact
+/// shape `build_firered_decoder_arena_state` allocates). `0` on arithmetic
+/// failure -- an under-estimate resolves to "allow", per `crate::capacity`'s
+/// fail-open invariant.
+pub(crate) fn firered_aed_admission_fixed_self_kv_bytes(
+    metadata: &FireRedAedExecutionMetadata,
+) -> u64 {
+    let plane = GgmlKvElementType::F16
+        .plane_nbytes(metadata.head_dim, metadata.decoder_pe_len, metadata.n_heads)
+        .unwrap_or(0) as u64;
+    plane
+        .saturating_mul(2) // K + V
+        .saturating_mul(metadata.decoder_n_layers as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capacity::kv_bytes_per_position;
+
+    /// Real-checkpoint-shaped metadata (the same values `runtime_contract`'s
+    /// test fixture parses: 16-layer MHA decoder at d_model 1280 / 20 heads /
+    /// head_dim 64, decoder PE span 5000).
+    fn reference_metadata() -> FireRedAedExecutionMetadata {
+        FireRedAedExecutionMetadata {
+            encoder_n_layers: 16,
+            d_model: 1280,
+            n_heads: 20,
+            head_dim: 64,
+            encoder_ffn_dim: 5120,
+            conv_kernel: 33,
+            subsample_channels: 32,
+            subsample_out_dim: 608,
+            feature_dim: 80,
+            encoder_pe_len: 9999,
+            decoder_n_layers: 16,
+            decoder_ffn_dim: 5120,
+            decoder_pe_len: 5000,
+            vocab_size: 7832,
+            sos_token_id: 3,
+            eos_token_id: 4,
+            pad_token_id: 2,
+        }
+    }
+
+    #[test]
+    fn admission_spec_prices_one_f32_copy_per_cross_frame() {
+        let geometry = firered_aed_kv_geometry(&reference_metadata());
+        let per_position = kv_bytes_per_position(&geometry, FIRERED_AED_ADMISSION_KV_SPEC)
+            .expect("f16 spec accepts head_dim 64");
+        // layers x 2 x d_model f32 values per cross frame:
+        // 16 * 2 * 1280 * 4 B = 160 KiB.
+        assert_eq!(per_position.total(), 16 * 2 * 1280 * 4);
+    }
+
+    #[test]
+    fn fixed_self_kv_bytes_match_the_arena_allocation() {
+        // 16 layers x 2 (K+V) x 20 heads x 5000 positions x 64 head_dim x 2 B
+        // (f16) = ~390 MiB, the allocation `build_firered_decoder_arena_state`
+        // makes at construction.
+        assert_eq!(
+            firered_aed_admission_fixed_self_kv_bytes(&reference_metadata()),
+            16 * 2 * 20 * 5000 * 64 * 2
+        );
+    }
+
+    #[test]
+    fn required_positions_are_the_chunk_cap_cross_frames() {
+        let metadata = reference_metadata();
+        assert_eq!(
+            firered_aed_admission_required_positions(&metadata),
+            firered_decoder_cross_capacity_frames(&metadata)
+        );
+        assert!(firered_aed_admission_required_positions(&metadata) > 0);
+    }
+}

--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -134,7 +134,9 @@ fn firered_mel_frames_for_seconds(duration_seconds: f32) -> usize {
 /// (`kv_init`: reserve at a known max, never reallocate per step) -- see
 /// `GgmlCpuStepBufferPool`'s doc in `ggml_runtime/cpu_graph.rs` for the
 /// sibling citation and `ACKNOWLEDGMENTS.md`.
-fn firered_decoder_cross_capacity_frames(metadata: &FireRedAedExecutionMetadata) -> usize {
+pub(crate) fn firered_decoder_cross_capacity_frames(
+    metadata: &FireRedAedExecutionMetadata,
+) -> usize {
     let chunk_seconds = crate::arch::DEFAULT_ENCODER_SAFE_CHUNK_SECONDS
         + FIRERED_DECODER_CROSS_CAPACITY_MARGIN_SECONDS;
     let mel_frames = firered_mel_frames_for_seconds(chunk_seconds);

--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -14,11 +14,16 @@
 //! Built on the shared incremental seq2seq decoder block
 //! ([`crate::nn::decoder::seq2seq_layer`]): pre-norm causal self-attention
 //! with an f16 KV cache, pre-norm cross-attention over cross-KV precomputed
-//! once from the encoder output, and a GELU feed-forward. Rebuilds a fresh
-//! graph every decode step regardless of backend (see [`super::graph_config`]
-//! for the dynamic CPU/Metal backend selection -- unlike cohere's serve-batch
-//! path, this never reuses a fixed-span-KV graph across tokens, so it carries
-//! none of the reused-graph caveats that motivate CPU-only fallback there).
+//! once from the encoder output, and a GELU feed-forward. On the
+//! single-backend GPU path (`nn::decoder::reusable_decode_graph_supported`:
+//! GPU-class backend, scheduler off -- the Metal default, see
+//! [`super::graph_config`]) the single-token incremental step runs through a
+//! build-once/re-run [`Seq2SeqReusableDecodeGraph`] (fixed-span self-KV via
+//! `set_rows` + an externally-uploaded attention mask, the cohere/moonshine
+//! pattern), eliminating the per-token graph rebuild; prefill and every CPU
+//! (or scheduler-on) step keep the rebuild-per-step path, which stays the
+//! correctness baseline (CPU direct execution mis-recomputes reused graphs
+//! with in-place KV writes -- a ggml-level limit, not a firered one).
 
 #![allow(dead_code)]
 
@@ -40,7 +45,8 @@ use crate::models::seq2seq_greedy_decode::{
 };
 use crate::nn::decoder::{
     CrossKvHandle, SelfKvHandle, Seq2SeqLayerConfig, Seq2SeqLayerWeights,
-    build_causal_mask_f16_bits, seq2seq_layer,
+    Seq2SeqReusableDecodeGraph, build_causal_mask_f16_bits, build_fixed_kv_attention_mask_bits,
+    reusable_decode_graph_supported_for_runner, seq2seq_layer,
 };
 use crate::nn::ffn::FeedForwardActivation;
 use crate::nn::norm::{AffineLayerNormSteps, apply_affine_layer_norm};
@@ -171,10 +177,19 @@ struct FireRedDecoderSelfKvLayer {
 /// `cross_frame_count` (actual, current-utterance) columns of the current
 /// capacity on every call.
 pub(crate) struct FireRedDecoderGraphRuntime {
+    // `reuse` holds raw pointers into `runner`, `arena`, and the weight
+    // context, so it must be declared first and dropped first (same drop-order
+    // contract as cohere's decoder runtime).
+    reuse: Option<Seq2SeqReusableDecodeGraph>,
     runner: GgmlCpuGraphRunner,
     _loaded: GgmlLoadedWeightContext,
     weights: FireRedDecoderWeights,
     metadata: FireRedAedExecutionMetadata,
+    /// The `no_alloc` metadata context size used for `runner`'s own graph
+    /// context; reused verbatim for `start_persistent_graph_session` in
+    /// [`Self::build_reusable_decode_graph`] so it does not have to be
+    /// recomputed from a hardcoded constant.
+    persistent_graph_context_bytes: usize,
     arena: GgmlStaticTensorArena,
     /// Shared zero bias for the two bias-free K projections (self-attn and
     /// cross-attn `w_ks`), length `d_model`.
@@ -191,6 +206,14 @@ pub(crate) struct FireRedDecoderGraphRuntime {
     /// [`Self::compute_step_logits`]'s cross-attention view. `0` before the
     /// first populate call.
     cross_frame_count: usize,
+    /// The cross-frame-count [`Self::reuse`]'s persistent graph was last
+    /// built for (0 if never built). `compute_reused_incremental_step_logits`
+    /// compares this against the current [`Self::cross_frame_count`] and
+    /// rebuilds the (cheap, metadata-only) reusable graph whenever a
+    /// differently-sized chunk swaps in, since
+    /// [`Self::build_reusable_decode_graph`] bakes the cross-attention view's
+    /// frame count into the persistent graph's topology at build time.
+    reuse_cross_frame_count: usize,
     cached_positions: usize,
 }
 
@@ -268,6 +291,30 @@ fn build_firered_decoder_arena_state(
         )
         .map_err(|source| map_err("zero_bias_upload", source))?;
 
+    // Zero-fill the persistent self-KV tensors so the fixed-span reusable
+    // decode graph's masked (not-yet-written) rows never feed uninitialized
+    // f16 bit patterns (potentially NaN) into flash attention: the kernel
+    // skips fully `-inf`-masked KV blocks, but the partially masked boundary
+    // block is still computed lane-by-lane, and `NaN + (-inf)` poisons the
+    // softmax. Same convention as `allocate_zeroed_llm_resident_kv_arena`
+    // (the all-zero f16 bit pattern is 0.0). The rebuild-per-step path views
+    // only written rows, so this is invisible to it.
+    let self_kv_tensor_bytes = metadata
+        .head_dim
+        .checked_mul(metadata.decoder_pe_len)
+        .and_then(|value| value.checked_mul(metadata.n_heads))
+        .and_then(|value| value.checked_mul(std::mem::size_of::<u16>()))
+        .ok_or(FireRedDecoderError::ShapeOverflow)?;
+    let self_kv_zero = vec![0_u8; self_kv_tensor_bytes];
+    for self_kv in &self_kv_layers {
+        arena
+            .set_bytes_slice(self_kv.key, &self_kv_zero, "firered_dec_self_k")
+            .map_err(|source| map_err("self_k_zero_fill", source))?;
+        arena
+            .set_bytes_slice(self_kv.value, &self_kv_zero, "firered_dec_self_v")
+            .map_err(|source| map_err("self_v_zero_fill", source))?;
+    }
+
     Ok(FireRedDecoderArenaState {
         arena,
         zero_bias,
@@ -283,8 +330,10 @@ impl FireRedDecoderGraphRuntime {
         backend: crate::ggml_runtime::GgmlCpuGraphBackend,
     ) -> Result<Self, FireRedDecoderError> {
         let cross_capacity_frames = firered_decoder_cross_capacity_frames(&metadata);
-        let runner = GgmlCpuGraphRunner::new(firered_decoder_graph_config(backend))
-            .map_err(|source| map_err("runner_init", source))?;
+        let config = firered_decoder_graph_config(backend);
+        let persistent_graph_context_bytes = config.context_bytes;
+        let runner =
+            GgmlCpuGraphRunner::new(config).map_err(|source| map_err("runner_init", source))?;
         let loaded = runner
             .load_gguf_weight_context(runtime_source)
             .map_err(|source| map_err("load_gguf_weight_context", source))?;
@@ -293,16 +342,19 @@ impl FireRedDecoderGraphRuntime {
             build_firered_decoder_arena_state(&runner, &metadata, cross_capacity_frames)?;
 
         Ok(Self {
+            reuse: None,
             runner,
             _loaded: loaded,
             weights,
             metadata,
+            persistent_graph_context_bytes,
             arena: arena_state.arena,
             zero_bias: arena_state.zero_bias,
             cross_layers: arena_state.cross_layers,
             self_kv_layers: arena_state.self_kv_layers,
             cross_capacity_frames,
             cross_frame_count: 0,
+            reuse_cross_frame_count: 0,
             cached_positions: 0,
         })
     }
@@ -336,6 +388,14 @@ impl FireRedDecoderGraphRuntime {
             .min(max_frames);
         let arena_state =
             build_firered_decoder_arena_state(&self.runner, &self.metadata, new_capacity)?;
+        // The persistent reuse graph holds raw pointers into the OLD arena's
+        // cross-KV/self-KV tensors, which this call is about to free -- the
+        // `reuse_cross_frame_count` mismatch-triggered rebuild alone is not
+        // enough (that logic assumes the arena itself is stable), so drop it
+        // unconditionally and let the next reusable step rebuild against the
+        // new arena instead of dereferencing freed memory.
+        self.reuse = None;
+        self.reuse_cross_frame_count = 0;
         self.arena = arena_state.arena;
         self.zero_bias = arena_state.zero_bias;
         self.cross_layers = arena_state.cross_layers;
@@ -470,10 +530,40 @@ impl FireRedDecoderGraphRuntime {
     /// Compute logits for the next token given the full token prefix so far
     /// (prompt + already-generated tokens). Incremental: after the first call
     /// (which may prefill more than one token), every subsequent call must
-    /// append exactly one new token.
+    /// append exactly one new token. On the single-backend GPU path a
+    /// single-token incremental step runs through the build-once/re-run
+    /// reusable decode graph ([`Self::compute_reused_incremental_step_logits`]);
+    /// everywhere else (prefill, CPU, scheduler-on) it rebuilds a fresh graph.
     pub(crate) fn compute_step_logits(
         &mut self,
         decoder_tokens: &[u32],
+    ) -> Result<Vec<f32>, FireRedDecoderError> {
+        self.compute_step_logits_impl(decoder_tokens, true)
+    }
+
+    /// Test-only bypass of the reusable-graph dispatch: always rebuild a
+    /// fresh graph for this step, so the reused-vs-rebuilt byte-identity test
+    /// can drive both paths on the same backend against the same inputs.
+    #[cfg(test)]
+    pub(crate) fn compute_step_logits_forcing_fresh_graph(
+        &mut self,
+        decoder_tokens: &[u32],
+    ) -> Result<Vec<f32>, FireRedDecoderError> {
+        self.compute_step_logits_impl(decoder_tokens, false)
+    }
+
+    /// Whether this step went (or will go) through the reusable decode graph
+    /// -- exposed so tests can assert the reuse path is actually live rather
+    /// than silently falling back to the rebuild path.
+    #[cfg(test)]
+    pub(crate) fn has_active_reuse_graph(&self) -> bool {
+        self.reuse.is_some()
+    }
+
+    fn compute_step_logits_impl(
+        &mut self,
+        decoder_tokens: &[u32],
+        allow_reuse: bool,
     ) -> Result<Vec<f32>, FireRedDecoderError> {
         let total_prefix_tokens = decoder_tokens.len();
         if total_prefix_tokens == 0 {
@@ -509,6 +599,13 @@ impl FireRedDecoderGraphRuntime {
         let total_token_count = position_offset
             .checked_add(token_count)
             .ok_or(FireRedDecoderError::ShapeOverflow)?;
+        if allow_reuse
+            && position_offset > 0
+            && token_count == 1
+            && self.supports_reusable_decode_graph()
+        {
+            return self.compute_reused_incremental_step_logits(decode_tokens[0], position_offset);
+        }
         let d_model = self.metadata.d_model;
         let heads = self.metadata.n_heads;
         let head_dim = self.metadata.head_dim;
@@ -697,6 +794,267 @@ impl FireRedDecoderGraphRuntime {
             })?;
         self.cached_positions = total_token_count;
         Ok(output)
+    }
+
+    /// Reused decode graphs with in-place resident KV are only correct on the
+    /// single-backend GPU path (see `nn::decoder::reusable_decode_graph_supported`);
+    /// everywhere else the rebuild-per-step path above stays authoritative.
+    fn supports_reusable_decode_graph(&self) -> bool {
+        reusable_decode_graph_supported_for_runner(&self.runner)
+    }
+
+    /// Single-token incremental step through the build-once/re-run persistent
+    /// graph: refresh the token/row/position inputs and the fixed-span
+    /// attention mask, then recompute -- no graph construction, no
+    /// reallocation (the cohere/moonshine reuse pattern). Must produce
+    /// byte-identical logits to the rebuild path for the same step; the
+    /// masked (`-inf`) tail of the fixed `decoder_pe_len`-span self-KV view
+    /// contributes exactly zero attention weight, and the underlying
+    /// arithmetic per valid position is unchanged.
+    fn compute_reused_incremental_step_logits(
+        &mut self,
+        token_id: u32,
+        position: usize,
+    ) -> Result<Vec<f32>, FireRedDecoderError> {
+        let max_positions = self.metadata.decoder_pe_len;
+        if position >= max_positions {
+            return Err(FireRedDecoderError::InvalidInput {
+                reason: format!("decoder position {position} exceeds max context {max_positions}"),
+            });
+        }
+        let token_id_i32 =
+            i32::try_from(token_id).map_err(|_| FireRedDecoderError::InvalidInput {
+                reason: format!("token id {token_id} does not fit i32"),
+            })?;
+        let position_i32 =
+            i32::try_from(position).map_err(|_| FireRedDecoderError::InvalidInput {
+                reason: format!("decoder position {position} does not fit i32"),
+            })?;
+        let total_tokens = position
+            .checked_add(1)
+            .ok_or(FireRedDecoderError::ShapeOverflow)?;
+        // A cross-frame-count change also forces a rebuild:
+        // `build_reusable_decode_graph` bakes the current `cross_frame_count`
+        // into the persistent graph's cross-attention view topology, so a
+        // graph built for a different (earlier) chunk's frame count would
+        // silently attend over the wrong span for this one.
+        let needs_build = self
+            .reuse
+            .as_ref()
+            .map(|reuse| {
+                reuse.is_poisoned()
+                    || reuse.max_positions != max_positions
+                    || reuse.n_seq != 1
+                    || self.reuse_cross_frame_count != self.cross_frame_count
+            })
+            .unwrap_or(true);
+        if needs_build {
+            self.build_reusable_decode_graph()?;
+        }
+
+        let reuse = self
+            .reuse
+            .as_mut()
+            .expect("firered reusable decode graph built above");
+        let token_tensor = reuse.token_id;
+        let row_index = reuse.row_index;
+        let position_tensor = reuse.position;
+        let attention_mask = reuse.attention_mask;
+        let logits = reuse.logits;
+        let graph = reuse.builder();
+
+        graph
+            .set_i32_slice(token_tensor, &[token_id_i32], "firered_reuse_token")
+            .map_err(|source| map_err("reuse_token_upload", source))?;
+        graph
+            .set_i32_slice(row_index, &[position_i32], "firered_reuse_row")
+            .map_err(|source| map_err("reuse_row_upload", source))?;
+        graph
+            .set_i32_slice(position_tensor, &[position_i32], "firered_reuse_position")
+            .map_err(|source| map_err("reuse_position_upload", source))?;
+        let mask_bits = build_fixed_kv_attention_mask_bits(max_positions, total_tokens)
+            .map_err(|source| map_err("reuse_self_mask", source))?;
+        graph
+            .set_f16_bits_slice(attention_mask, &mask_bits, "firered_reuse_self_mask")
+            .map_err(|source| map_err("reuse_self_mask_upload", source))?;
+
+        let output = graph
+            .compute_output_f32(logits, self.metadata.vocab_size)
+            .map_err(|error| FireRedDecoderError::GraphExecutionFailed {
+                reason: error.to_string(),
+            })?;
+        self.cached_positions = total_tokens;
+        Ok(output)
+    }
+
+    /// Build the persistent single-token decode graph: the same op sequence as
+    /// one `token_count == 1` step of the rebuild path, except the self-KV
+    /// write goes through `set_rows` on a runtime row-index input (so the
+    /// write slot can move per step without rebuilding) and self-attention
+    /// reads the full fixed `decoder_pe_len` span under an externally-uploaded
+    /// `-inf` tail mask (so the graph shape is constant across steps). The
+    /// current `cross_frame_count` is baked into the cross-attention views;
+    /// `compute_reused_incremental_step_logits` rebuilds on mismatch.
+    fn build_reusable_decode_graph(&mut self) -> Result<(), FireRedDecoderError> {
+        let d_model = self.metadata.d_model;
+        let heads = self.metadata.n_heads;
+        let head_dim = self.metadata.head_dim;
+        let max_positions = self.metadata.decoder_pe_len;
+        let cross_frame_count = self.cross_frame_count;
+
+        let mut session = self
+            .runner
+            .start_persistent_graph_session(self.persistent_graph_context_bytes)
+            .map_err(|source| map_err("reuse_session", source))?;
+        let graph = session.builder();
+        let token_id = graph
+            .new_tensor_1d_i32(1, "firered_reuse_token")
+            .map_err(|source| map_err("reuse_token_alloc", source))?;
+        let row_index = graph
+            .new_tensor_1d_i32(1, "firered_reuse_row")
+            .map_err(|source| map_err("reuse_row_alloc", source))?;
+        let position = graph
+            .new_tensor_1d_i32(1, "firered_reuse_position")
+            .map_err(|source| map_err("reuse_position_alloc", source))?;
+        let attention_mask = graph
+            .new_tensor_3d_f16(max_positions, 1, 1, "firered_reuse_self_mask")
+            .map_err(|source| map_err("reuse_self_mask_alloc", source))?;
+        graph
+            .set_input(token_id)
+            .map_err(|source| map_err("reuse_token_input", source))?;
+        graph
+            .set_input(row_index)
+            .map_err(|source| map_err("reuse_row_input", source))?;
+        graph
+            .set_input(position)
+            .map_err(|source| map_err("reuse_position_input", source))?;
+        graph
+            .set_input(attention_mask)
+            .map_err(|source| map_err("reuse_self_mask_input", source))?;
+
+        let token_state = graph
+            .get_rows(self.weights.token_embedding.as_graph_tensor(), token_id)
+            .map_err(|source| map_err("reuse_embed_get_rows", source))?;
+        let scaled_token_state = graph
+            .scale(token_state, (d_model as f32).sqrt())
+            .map_err(|source| map_err("reuse_embed_xscale", source))?;
+        let position_state = graph
+            .get_rows(self.weights.positional_encoding.as_graph_tensor(), position)
+            .map_err(|source| map_err("reuse_position_get_rows", source))?;
+        let mut state = graph
+            .add(scaled_token_state, position_state)
+            .map_err(|source| map_err("reuse_embed_add_pos", source))?;
+
+        let zero_bias_tensor = self.arena.graph_tensor(self.zero_bias);
+        for (layer, (cross, self_kv)) in self
+            .weights
+            .layers
+            .iter()
+            .zip(self.cross_layers.iter().zip(&self.self_kv_layers))
+        {
+            let config = Seq2SeqLayerConfig {
+                hidden: d_model,
+                attention_heads: heads,
+                head_dim,
+                token_count: 1,
+                n_seq: 1,
+                // Fixed span: attend over the whole self-KV capacity; the
+                // per-step mask upload marks positions past the current
+                // prefix as `-inf`.
+                total_token_count: max_positions,
+                position_offset: 0,
+                layer_norm_epsilon: FIRERED_DECODER_LAYER_NORM_EPSILON,
+                ffn_activation: FeedForwardActivation::Gelu,
+                self_kv_max_positions: max_positions,
+                cross_frame_count,
+                cross_hidden_size: d_model,
+            };
+            let weights = Seq2SeqLayerWeights {
+                self_attn_norm_weight: layer.self_attn_norm_weight.as_graph_tensor(),
+                self_attn_norm_bias: layer.self_attn_norm_bias.as_graph_tensor(),
+                self_attn_q_weight: layer.self_attn_q_weight.as_graph_tensor(),
+                self_attn_q_bias: layer.self_attn_q_bias.as_graph_tensor(),
+                self_attn_k_weight: layer.self_attn_k_weight.as_graph_tensor(),
+                self_attn_k_bias: zero_bias_tensor,
+                self_attn_v_weight: layer.self_attn_v_weight.as_graph_tensor(),
+                self_attn_v_bias: layer.self_attn_v_bias.as_graph_tensor(),
+                self_attn_o_weight: layer.self_attn_out_weight.as_graph_tensor(),
+                self_attn_o_bias: layer.self_attn_out_bias.as_graph_tensor(),
+                cross_attn_norm_weight: layer.cross_attn_norm_weight.as_graph_tensor(),
+                cross_attn_norm_bias: layer.cross_attn_norm_bias.as_graph_tensor(),
+                cross_attn_q_weight: layer.cross_attn_q_weight.as_graph_tensor(),
+                cross_attn_q_bias: layer.cross_attn_q_bias.as_graph_tensor(),
+                cross_attn_o_weight: layer.cross_attn_out_weight.as_graph_tensor(),
+                cross_attn_o_bias: layer.cross_attn_out_bias.as_graph_tensor(),
+                ffn_norm_weight: layer.ffn_norm_weight.as_graph_tensor(),
+                ffn_norm_bias: layer.ffn_norm_bias.as_graph_tensor(),
+                ffn_up_weight: layer.ffn_up_weight.as_graph_tensor(),
+                ffn_up_bias: layer.ffn_up_bias.as_graph_tensor(),
+                ffn_down_weight: layer.ffn_down_weight.as_graph_tensor(),
+                ffn_down_bias: layer.ffn_down_bias.as_graph_tensor(),
+            };
+            let self_kv_handle = SelfKvHandle {
+                key: self.arena.graph_tensor(self_kv.key),
+                value: self.arena.graph_tensor(self_kv.value),
+                row_indices: Some(row_index),
+                attention_mask: Some(attention_mask),
+            };
+            let cross_kv_handle = CrossKvHandle {
+                key: self.arena.graph_tensor(cross.key),
+                value: self.arena.graph_tensor(cross.value),
+            };
+            let block = seq2seq_layer(
+                graph,
+                state,
+                config,
+                weights,
+                self_kv_handle,
+                cross_kv_handle,
+                map_err,
+            )?;
+            debug_assert!(
+                block.deferred_self_mask.is_none(),
+                "single-token reuse steps never emit a deferred per-layer mask"
+            );
+            state = block.output;
+        }
+
+        state = apply_affine_layer_norm(
+            graph,
+            state,
+            FIRERED_DECODER_LAYER_NORM_EPSILON,
+            self.weights.out_norm_weight.as_graph_tensor(),
+            self.weights.out_norm_bias.as_graph_tensor(),
+            AffineLayerNormSteps {
+                norm: "reuse_decoder_out_norm",
+                scale: "reuse_decoder_out_norm",
+                bias: "reuse_decoder_out_norm",
+            },
+            map_err,
+        )?;
+        let last_state = view_last_token_state(graph, state, d_model, 1)?;
+        let logits = graph
+            .mul_mat(self.weights.out_proj_weight.as_graph_tensor(), last_state)
+            .map_err(|source| map_err("reuse_output_proj", source))?;
+        graph
+            .set_output(logits)
+            .map_err(|source| map_err("reuse_set_output", source))?;
+        graph
+            .prepare_outputs_for_upload(&[logits])
+            .map_err(|source| map_err("reuse_prepare_outputs", source))?;
+
+        self.reuse = Some(Seq2SeqReusableDecodeGraph::new_with_borrowed_kv_arena(
+            session,
+            max_positions,
+            1,
+            token_id,
+            row_index,
+            position,
+            attention_mask,
+            logits,
+        ));
+        self.reuse_cross_frame_count = cross_frame_count;
+        Ok(())
     }
 }
 

--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -297,22 +297,34 @@ fn build_firered_decoder_arena_state(
     // skips fully `-inf`-masked KV blocks, but the partially masked boundary
     // block is still computed lane-by-lane, and `NaN + (-inf)` poisons the
     // softmax. Same convention as `allocate_zeroed_llm_resident_kv_arena`
-    // (the all-zero f16 bit pattern is 0.0). The rebuild-per-step path views
-    // only written rows, so this is invisible to it.
-    let self_kv_tensor_bytes = metadata
-        .head_dim
-        .checked_mul(metadata.decoder_pe_len)
-        .and_then(|value| value.checked_mul(metadata.n_heads))
-        .and_then(|value| value.checked_mul(std::mem::size_of::<u16>()))
-        .ok_or(FireRedDecoderError::ShapeOverflow)?;
-    let self_kv_zero = vec![0_u8; self_kv_tensor_bytes];
-    for self_kv in &self_kv_layers {
-        arena
-            .set_bytes_slice(self_kv.key, &self_kv_zero, "firered_dec_self_k")
-            .map_err(|source| map_err("self_k_zero_fill", source))?;
-        arena
-            .set_bytes_slice(self_kv.value, &self_kv_zero, "firered_dec_self_v")
-            .map_err(|source| map_err("self_v_zero_fill", source))?;
+    // (the all-zero f16 bit pattern is 0.0).
+    //
+    // Gated to runners where the reusable decode graph can actually activate
+    // (`reusable_decode_graph_supported_for_runner` is a pure function of the
+    // runner's backend + scheduler config, fixed for the runner's lifetime):
+    // the rebuild-per-step path views only written rows, so on CPU /
+    // scheduler-on runners no unwritten row is ever read and the fill is pure
+    // waste -- worse than waste, actually, because touching every byte of the
+    // full `decoder_pe_len`-span cache commits all of its pages up front
+    // (hundreds of MB of peak RSS) where the untouched malloc'd CPU arena
+    // pages would otherwise stay uncommitted until the decode actually wrote
+    // them.
+    if reusable_decode_graph_supported_for_runner(runner) {
+        let self_kv_tensor_bytes = metadata
+            .head_dim
+            .checked_mul(metadata.decoder_pe_len)
+            .and_then(|value| value.checked_mul(metadata.n_heads))
+            .and_then(|value| value.checked_mul(std::mem::size_of::<u16>()))
+            .ok_or(FireRedDecoderError::ShapeOverflow)?;
+        let self_kv_zero = vec![0_u8; self_kv_tensor_bytes];
+        for self_kv in &self_kv_layers {
+            arena
+                .set_bytes_slice(self_kv.key, &self_kv_zero, "firered_dec_self_k")
+                .map_err(|source| map_err("self_k_zero_fill", source))?;
+            arena
+                .set_bytes_slice(self_kv.value, &self_kv_zero, "firered_dec_self_v")
+                .map_err(|source| map_err("self_v_zero_fill", source))?;
+        }
     }
 
     Ok(FireRedDecoderArenaState {

--- a/crates/openasr-core/src/models/firered_aed/executor.rs
+++ b/crates/openasr-core/src/models/firered_aed/executor.rs
@@ -455,6 +455,180 @@ mod tests {
         assert_eq!(text, GOLDEN_ZH_TEXT);
     }
 
+    /// Proof that the Metal reusable single-token decode graph is
+    /// output-preserving: drive a full greedy decode twice against the same
+    /// encoder output -- one runtime on the default path (which must take the
+    /// persistent reuse graph for every incremental step) and one runtime
+    /// forced onto the rebuild-per-step path -- and require the logits of
+    /// every step to match BIT FOR BIT, not just the argmax token. Skips
+    /// (with a message) when the dev pack is absent or Metal is unavailable;
+    /// on Metal it also asserts the reuse graph actually engaged, so this
+    /// cannot silently pass by both sides falling back to the same path.
+    #[test]
+    #[ignore = "requires the private dev-only firered-aed-l-fp16.oasr pack and a Metal device; see module docs"]
+    fn metal_reused_decode_graph_logits_match_rebuilt_graph_bit_for_bit() {
+        let pack_path = dev_pack_path();
+        if !pack_path.exists() {
+            eprintln!("skipping: {} not present", pack_path.display());
+            return;
+        }
+        let samples = crate::api::audio_io::load_wav_16khz_mono_f32_v0(
+            jfk_wav_path(),
+            "firered-aed reuse-parity test",
+            "firered-aed reuse-parity test",
+        )
+        .expect("load jfk.wav");
+        let request = GgmlAsrExecutionRequest {
+            runtime_source_path: pack_path,
+            runtime_source_preflight: None,
+            selected_family: firered_aed_runtime_descriptor_v1(),
+            prepared_audio: GgmlAsrPreparedAudio::mono_16khz(samples.clone()),
+            request_options: Default::default(),
+            backend_preference: GgmlAsrBackendPreference::CpuOnly,
+            resolved_runtime: crate::ggml_runtime::ResolvedFamilyRuntimeInput::resolve(
+                (GgmlAsrBackendPreference::CpuOnly).request_backend_override(),
+                crate::ggml_runtime::AutoGpuPolicy::AllBackends,
+            ),
+            execution_context: std::sync::Arc::new(crate::RequestExecutionContext::uncancellable(
+                "test fixture",
+            )),
+        };
+        let preflight = request
+            .resolve_runtime_source_preflight()
+            .expect("resolve runtime source preflight");
+        let metadata = parse_firered_aed_execution_metadata(&preflight.metadata)
+            .expect("parse execution metadata");
+
+        // Frontend + CMVN + CPU encoder: one shared encoder output feeds both
+        // decoder runtimes, so any divergence below is decode-path-only.
+        let reader = build_runtime_tensor_reader_from_preflight(&preflight)
+            .expect("build runtime tensor reader");
+        let feature_dim_shape = [metadata.feature_dim as u64];
+        let neg_mean = reader
+            .host_tensor_f32_copy_dequantized_by_name(CMVN_NEG_MEAN_TENSOR, &feature_dim_shape)
+            .expect("cmvn neg_mean");
+        let inv_stddev = reader
+            .host_tensor_f32_copy_dequantized_by_name(CMVN_INV_STDDEV_TENSOR, &feature_dim_shape)
+            .expect("cmvn inv_stddev");
+        let frontend = FireRedFbankFrontend::new();
+        let mut features = frontend.compute(&samples).expect("fbank features");
+        apply_cmvn(&mut features.data, features.n_mels, &neg_mean, &inv_stddev)
+            .expect("apply cmvn");
+        let mut encoder_runtime = FireRedEncoderGraphRuntime::new(
+            &preflight.runtime_source,
+            metadata,
+            GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("build cpu encoder runtime");
+        let encoder_output = encoder_runtime
+            .encode(&features.data, features.n_frames)
+            .expect("encode");
+
+        // Two sequential passes over the SAME prefix sequence (the fresh
+        // pass's own greedy argmax drives both), so only one 2+ GiB Metal
+        // weight upload is resident at a time. Divergence cannot hide in the
+        // replay: every reused-pass step is asserted bitwise against the
+        // recorded fresh-pass logits for the identical prefix.
+        let max_steps = 256usize;
+        let mut fresh_runtime = match FireRedDecoderGraphRuntime::new(
+            &preflight.runtime_source,
+            metadata,
+            GgmlCpuGraphBackend::Metal,
+        ) {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                eprintln!("skipping: Metal decoder runtime unavailable: {error}");
+                return;
+            }
+        };
+        fresh_runtime
+            .populate_cross_attention_cache(&encoder_output.rows, encoder_output.frame_count)
+            .expect("populate cross cache (fresh runtime)");
+        let mut prefix = vec![metadata.sos_token_id];
+        let mut fresh_logits_by_step = Vec::new();
+        for _ in 0..max_steps {
+            let fresh_logits = fresh_runtime
+                .compute_step_logits_forcing_fresh_graph(&prefix)
+                .expect("fresh-path step logits");
+            let next = fresh_logits
+                .iter()
+                .enumerate()
+                .max_by(|(_, a), (_, b)| a.total_cmp(b))
+                .map(|(index, _)| index as u32)
+                .expect("non-empty logits");
+            fresh_logits_by_step.push(fresh_logits);
+            if next == metadata.eos_token_id {
+                break;
+            }
+            prefix.push(next);
+        }
+        assert!(
+            !fresh_runtime.has_active_reuse_graph(),
+            "the forced-fresh runtime must never have built a reuse graph"
+        );
+        drop(fresh_runtime);
+        let generated = prefix.len() - 1;
+        assert!(
+            generated >= 8,
+            "expected a non-trivial greedy decode to exercise many incremental steps, got {generated} tokens"
+        );
+
+        let mut reused_runtime = FireRedDecoderGraphRuntime::new(
+            &preflight.runtime_source,
+            metadata,
+            GgmlCpuGraphBackend::Metal,
+        )
+        .expect("build Metal decoder runtime (reused pass)");
+        reused_runtime
+            .populate_cross_attention_cache(&encoder_output.rows, encoder_output.frame_count)
+            .expect("populate cross cache (reused runtime)");
+        for (step, fresh_logits) in fresh_logits_by_step.iter().enumerate() {
+            let step_prefix = &prefix[..(step + 1).min(prefix.len())];
+            let reused_logits = reused_runtime
+                .compute_step_logits(step_prefix)
+                .expect("reused-path step logits");
+            assert_eq!(
+                reused_logits.len(),
+                fresh_logits.len(),
+                "step {step}: logits length mismatch"
+            );
+            for (index, (reused, fresh)) in
+                reused_logits.iter().zip(fresh_logits.iter()).enumerate()
+            {
+                assert_eq!(
+                    reused.to_bits(),
+                    fresh.to_bits(),
+                    "step {step}: logit {index} differs bitwise: reused={reused} fresh={fresh}"
+                );
+            }
+        }
+        assert!(
+            reused_runtime.has_active_reuse_graph(),
+            "the default-path Metal runtime must have engaged the persistent reuse graph"
+        );
+        // Transcript-level goldenness of the whole Metal decode path
+        // (scheduler-off + reuse graph): the greedy token sequence both paths
+        // agreed on must detokenize to the same reference transcript the CPU
+        // golden test pins.
+        let tokenizer = FireRedTokenizer::new(
+            preflight
+                .metadata
+                .get_string_array(TOKENIZER_TOKENS_KEY)
+                .expect("pack missing tokenizer.ggml.tokens")
+                .to_vec(),
+        );
+        let text = tokenizer
+            .decode(&prefix[1..])
+            .expect("detokenize greedy tokens")
+            .trim()
+            .to_string();
+        assert_eq!(
+            text, GOLDEN_JFK_TEXT,
+            "Metal reused-graph transcript must match the reference golden"
+        );
+        eprintln!("firered-aed reuse parity: {generated} incremental steps bit-identical on Metal");
+    }
+
     /// Demonstrates the thread-local encoder/decoder runtime cache: the
     /// second same-thread transcription of the same pack must be
     /// meaningfully faster than the first, because it skips re-loading the

--- a/crates/openasr-core/src/models/firered_aed/graph_config.rs
+++ b/crates/openasr-core/src/models/firered_aed/graph_config.rs
@@ -26,6 +26,8 @@
 //! enforced in `executor.rs`).
 
 use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphThreadingWorkload};
+#[cfg(test)]
+use crate::models::graph_runtime_config::configure_model_runtime_graph_config;
 use crate::models::graph_runtime_config::{
     ModelMetalRuntimeOverrides, configure_model_runtime_graph_config_from_env,
     gpu_stage_enabled_for_backend, has_explicit_thread_override,
@@ -39,11 +41,19 @@ const OPENASR_FIRERED_ENABLE_DECODER_METAL: &str = "OPENASR_FIRERED_ENABLE_DECOD
 const OPENASR_FIRERED_ENABLE_ENCODER_GPU: &str = "OPENASR_FIRERED_ENABLE_ENCODER_GPU";
 const OPENASR_FIRERED_ENABLE_DECODER_GPU: &str = "OPENASR_FIRERED_ENABLE_DECODER_GPU";
 
-pub(crate) fn firered_runtime_graph_config(backend: GgmlCpuGraphBackend) -> GgmlCpuGraphConfig {
+/// Shared base for both stages: everything except the Metal scheduler
+/// default, which the encoder and decoder set independently (see
+/// [`firered_encoder_graph_config`] / [`firered_decoder_graph_config`]) --
+/// the same encoder/decoder split moonshine's `graph_config` uses for the
+/// same reason (decode-graph reuse).
+fn firered_runtime_graph_config_with_scheduler_default(
+    backend: GgmlCpuGraphBackend,
+    default_use_scheduler_when_unset: Option<bool>,
+) -> GgmlCpuGraphConfig {
     configure_model_runtime_graph_config_from_env(
         GgmlCpuGraphConfig::runtime_default_for_resolved_backend(backend),
         ModelMetalRuntimeOverrides {
-            default_use_scheduler_when_unset: Some(true),
+            default_use_scheduler_when_unset,
             default_n_threads_when_unset: Some(1),
         },
     )
@@ -54,7 +64,12 @@ pub(crate) fn firered_encoder_graph_config(backend: GgmlCpuGraphBackend) -> Ggml
     // `GgmlCpuGraphConfig::metadata_context_bytes`); previously a flat
     // hardcoded 512 MiB per cached encoder runtime (see the thread-local
     // cache in `executor.rs`).
-    let mut config = firered_runtime_graph_config(backend);
+    //
+    // The encoder keeps the scheduler on for Metal: the conformer forward
+    // graph was built and parity-verified under multi-backend scheduling and
+    // has not been re-verified with the scheduler off. Only the decoder's
+    // `use_scheduler` default changed (see `firered_decoder_graph_config`).
+    let mut config = firered_runtime_graph_config_with_scheduler_default(backend, Some(true));
     config.graph_size = config.graph_size.max(FIRERED_ENCODER_GRAPH_SIZE);
     config.context_bytes = config
         .context_bytes
@@ -74,11 +89,27 @@ pub(crate) fn firered_encoder_graph_config(backend: GgmlCpuGraphBackend) -> Ggml
     config
 }
 
+/// Decode-graph reuse (`nn::decoder::reusable_decode_graph_supported`) only
+/// activates when the backend is GPU-class *and* the scheduler is off (a
+/// multi-backend scheduler's `sched_alloc_graph` drops the per-token inputs
+/// a reused, in-place-KV graph depends on). The decoder previously inherited
+/// the encoder's `default_use_scheduler_when_unset: Some(true)`, which would
+/// keep the reusable incremental-step graph in `decoder_graph` permanently
+/// disabled on Metal and force a full graph rebuild every decode token
+/// (measured at ~21% of the per-token decode step on l-v2 q4_k). Leaving
+/// this `None` keeps the base default (scheduler-off on GPU-class backends,
+/// see `configure_model_graph_config`), exactly mirroring moonshine's
+/// decoder-tier fix. This is a pure backend/scheduling choice: output must
+/// stay byte-identical (pinned by the reused-vs-fresh logits test in
+/// `decoder_graph` and the firered golden tests), since it does not change
+/// which arithmetic runs, only whether the graph is rebuilt per token.
+/// `OPENASR_GGML_USE_SCHEDULER=1` remains the explicit escape hatch (it also
+/// disables reuse, restoring the rebuild-per-token path).
 pub(crate) fn firered_decoder_graph_config(backend: GgmlCpuGraphBackend) -> GgmlCpuGraphConfig {
     // See the matching comment in `firered_encoder_graph_config`: this is a
     // `no_alloc` metadata pool sized from the actual node count, not the real
     // tensor bytes (those live in the arena's own backend buffer).
-    let mut config = firered_runtime_graph_config(backend);
+    let mut config = firered_runtime_graph_config_with_scheduler_default(backend, None);
     config.graph_size = config.graph_size.max(FIRERED_DECODER_GRAPH_SIZE);
     config.context_bytes = config
         .context_bytes
@@ -118,9 +149,86 @@ fn firered_decoder_gpu_enabled(backend: GgmlCpuGraphBackend) -> bool {
     )
 }
 
+/// Test-only mirror of [`firered_runtime_graph_config_with_scheduler_default`]
+/// with the env/TLS reads replaced by explicit flags, so the scheduler-default
+/// pins below stay deterministic regardless of the test environment (same
+/// pattern as `whisper::graph_config` / `qwen::graph_config`).
+#[cfg(test)]
+fn firered_runtime_graph_config_with_explicit_overrides(
+    base: GgmlCpuGraphConfig,
+    has_explicit_scheduler_override: bool,
+    has_explicit_thread_override: bool,
+    default_use_scheduler_when_unset: Option<bool>,
+) -> GgmlCpuGraphConfig {
+    configure_model_runtime_graph_config(
+        base,
+        has_explicit_scheduler_override,
+        has_explicit_thread_override,
+        ModelMetalRuntimeOverrides {
+            default_use_scheduler_when_unset,
+            default_n_threads_when_unset: Some(1),
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn metal_base(use_scheduler: bool) -> GgmlCpuGraphConfig {
+        GgmlCpuGraphConfig {
+            backend: GgmlCpuGraphBackend::Metal,
+            use_scheduler,
+            ..GgmlCpuGraphConfig::conservative_default()
+        }
+    }
+
+    /// Pin the decoder tier's Metal scheduler default to OFF: decode-graph
+    /// reuse (`nn::decoder::reusable_decode_graph_supported`) requires
+    /// `gpu_class && !scheduler`, so a scheduler-on default here would turn
+    /// the reusable incremental decode graph back into dead code (the exact
+    /// regression moonshine had before commit 879677ac).
+    #[test]
+    fn decoder_metal_scheduler_default_stays_off_for_decode_graph_reuse() {
+        let config = firered_runtime_graph_config_with_explicit_overrides(
+            metal_base(false),
+            false,
+            false,
+            None,
+        );
+        assert!(
+            !config.use_scheduler,
+            "firered decoder tier must default the Metal scheduler off so the reusable \
+             incremental decode graph stays reachable"
+        );
+    }
+
+    /// The encoder tier keeps the scheduler-on Metal default it was
+    /// parity-verified under.
+    #[test]
+    fn encoder_metal_scheduler_default_stays_on() {
+        let config = firered_runtime_graph_config_with_explicit_overrides(
+            metal_base(false),
+            false,
+            false,
+            Some(true),
+        );
+        assert!(config.use_scheduler);
+    }
+
+    /// An explicit `OPENASR_GGML_USE_SCHEDULER` override must keep winning on
+    /// the decoder tier (it is the escape hatch that restores the
+    /// rebuild-per-token decode path).
+    #[test]
+    fn decoder_metal_explicit_scheduler_override_still_wins() {
+        let config = firered_runtime_graph_config_with_explicit_overrides(
+            metal_base(true),
+            true,
+            false,
+            None,
+        );
+        assert!(config.use_scheduler);
+    }
 
     #[test]
     fn encoder_gpu_defaults_to_unified_gpu_lane() {

--- a/crates/openasr-core/src/models/firered_aed/mod.rs
+++ b/crates/openasr-core/src/models/firered_aed/mod.rs
@@ -16,6 +16,7 @@
 //! - The Conformer encoder graph ([`encoder_graph`]), the KV-cached decoder
 //!   ([`decoder_graph`]), and the dedicated [`executor`] complete the stage.
 
+pub(crate) mod capacity;
 pub(crate) mod decoder_graph;
 pub(crate) mod decoder_weights;
 pub(crate) mod encoder_graph;

--- a/crates/openasr-core/src/models/firered_llm/capacity.rs
+++ b/crates/openasr-core/src/models/firered_llm/capacity.rs
@@ -1,0 +1,174 @@
+//! firered-llm capacity derivation: the family's Qwen2 decoder KV geometry
+//! and the decoder positions a single decode of a given audio span needs,
+//! assembled from PACK METADATA (`FireRedLlmDecoderMetadata` +
+//! `FireRedLlmAdapterMetadata`) plus family constants, so the shared
+//! host-memory admission check
+//! ([`crate::capacity::evaluate_host_memory_admission`]) can refuse a request
+//! that plainly cannot fit BEFORE the ggml graph build turns the shortfall
+//! into an opaque allocation failure. The firered-llm analogue of
+//! [`crate::models::qwen::capacity`].
+//!
+//! Reuses, never re-derives:
+//! - KV geometry comes straight off the parsed pack (`firered_llm.llm.*` are
+//!   required metadata keys).
+//! - The audio-token count walks the exact runtime pipeline arithmetic:
+//!   snip-edges fbank framing (`firered_aed::frontend`'s constants), the
+//!   `2x Conv2d(k3,s2)` stem
+//!   ([`crate::models::firered_aed::encoder_graph::predicted_encoder_time_frames`],
+//!   the same function the real encoder path calls), and the adapter's
+//!   pack-carried `downsample_rate` frame stacking.
+//! - The generation budget and the single-decode window reuse the executor's
+//!   own constants ([`super::executor::FIRERED_LLM_MAX_GENERATED_TOKENS`],
+//!   [`super::executor::FIRERED_LLM_MAX_INPUT_SECONDS`]), so admission
+//!   charges the same `prompt + generation` KV capacity
+//!   `FireRedLlmDecoderRuntime::new_kv_caches` actually allocates.
+
+use crate::capacity::KvGeometry;
+use crate::models::firered_aed::encoder_graph::predicted_encoder_time_frames;
+use crate::models::firered_aed::frontend::{
+    FRAME_LENGTH_SAMPLES, FRAME_SHIFT_SAMPLES, SAMPLE_RATE_HZ,
+};
+
+use super::executor::{FIRERED_LLM_MAX_GENERATED_TOKENS, FIRERED_LLM_MAX_INPUT_SECONDS};
+use super::runtime_contract::{FireRedLlmAdapterMetadata, FireRedLlmDecoderMetadata};
+
+/// The audio a single firered-llm decode is estimated to fold in, for
+/// admission. The executor fails closed above this upstream hard cap
+/// (`FIRERED_LLM_MAX_INPUT_SECONDS`, "single 40s max input"), and longer
+/// recordings reach it only as longform slices each at or under this bound --
+/// so no single decode's KV cache ever spans more audio. Clamping here is the
+/// firered-llm analogue of qwen3's
+/// `QWEN3_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS` clamp: a multi-hour
+/// recording is judged by what one decode actually needs, never falsely
+/// rejected as if it decoded whole.
+pub(crate) const FIRERED_LLM_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS: f32 =
+    FIRERED_LLM_MAX_INPUT_SECONDS;
+
+/// Fixed ChatML wrapper tokens around the speech span
+/// (`<|im_start|>user\n` prefix + instruction + `<|im_end|>\n<|im_start|>
+/// assistant\n` suffix, see `super::decode_prompt::build_firered_llm_decode_prompt`).
+/// A small conservative figure, dwarfed by the speech-token term at any real
+/// duration; its exact value cannot swing an admission decision.
+const FIRERED_LLM_ADMISSION_FIXED_PROMPT_TOKENS: usize = 32;
+
+/// The decoder KV geometry the loaded pack advertises.
+pub(crate) fn firered_llm_kv_geometry(decoder: &FireRedLlmDecoderMetadata) -> KvGeometry {
+    KvGeometry {
+        n_layers: decoder.n_layers,
+        kv_heads: decoder.n_kv_heads,
+        head_dim: decoder.head_dim,
+    }
+}
+
+/// Decoder positions a single decode of `audio_duration_seconds` requires --
+/// the admission figure `evaluate_host_memory_admission` charges KV bytes
+/// against. Mirrors the runtime's own KV-capacity sizing
+/// (`decode_prompt.token_ids.len() + FIRERED_LLM_MAX_GENERATED_TOKENS` in
+/// `super::executor`): fixed wrapper + one speech token per adapter output
+/// frame + the full runaway-generation backstop, with the audio clamped to
+/// the family's single-decode window.
+pub(crate) fn firered_llm_admission_required_positions(
+    adapter: &FireRedLlmAdapterMetadata,
+    audio_duration_seconds: f32,
+) -> usize {
+    let admission_seconds =
+        audio_duration_seconds.clamp(0.0, FIRERED_LLM_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS);
+    let samples = (admission_seconds * SAMPLE_RATE_HZ as f32) as usize;
+    // snip_edges fbank framing: 1 + (len - frame_length) / frame_shift.
+    let mel_frames = samples
+        .checked_sub(FRAME_LENGTH_SAMPLES)
+        .map(|tail| 1 + tail / FRAME_SHIFT_SAMPLES)
+        .unwrap_or(0);
+    // The 2x Conv2d(k3,s2) stem, via the same prediction the real encoder
+    // path uses. A degenerate frame count (too-short audio) resolves to zero
+    // speech tokens -- an under-estimate resolves to "allow" per
+    // `crate::capacity`'s fail-open invariant.
+    let encoder_frames = predicted_encoder_time_frames(mel_frames).unwrap_or(0);
+    // Adapter frame stacking: `downsample_rate` adjacent frames concatenate
+    // into one LLM speech token (trailing remainder dropped, exactly the
+    // reshape `super::adapter_graph` performs).
+    let speech_tokens = encoder_frames / adapter.downsample_rate.max(1);
+    FIRERED_LLM_ADMISSION_FIXED_PROMPT_TOKENS
+        .saturating_add(speech_tokens)
+        .saturating_add(FIRERED_LLM_MAX_GENERATED_TOKENS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capacity::kv_bytes_per_position;
+    use crate::nn::decoder::LlmKvCacheSpec;
+
+    /// Real-checkpoint-shaped metadata (the Qwen2-7B decoder: 28 layers, GQA
+    /// with 4 KV heads, head_dim 128, 32768-position context -- the same
+    /// values `runtime_contract`'s `full_metadata` fixture parses).
+    fn reference_decoder() -> FireRedLlmDecoderMetadata {
+        FireRedLlmDecoderMetadata {
+            n_layers: 28,
+            d_model: 3584,
+            n_heads: 28,
+            n_kv_heads: 4,
+            head_dim: 128,
+            ffn_dim: 18944,
+            vocab_size: 152_064,
+            max_positions: 32_768,
+            chatml_im_start_token_id: 151_644,
+            chatml_im_end_token_id: 151_645,
+            endoftext_token_id: 151_643,
+            speech_token_id: 151_646,
+        }
+    }
+
+    fn reference_adapter() -> FireRedLlmAdapterMetadata {
+        FireRedLlmAdapterMetadata {
+            downsample_rate: 2,
+            llm_dim: 3584,
+        }
+    }
+
+    #[test]
+    fn kv_geometry_reads_the_llm_decoder_metadata() {
+        let geometry = firered_llm_kv_geometry(&reference_decoder());
+        assert_eq!(
+            geometry,
+            KvGeometry {
+                n_layers: 28,
+                kv_heads: 4,
+                head_dim: 128,
+            }
+        );
+        // Feeds the shared KV byte model without error (224 rows/position,
+        // the same shape the runtime_contract capacity anchor pins).
+        let default = kv_bytes_per_position(&geometry, LlmKvCacheSpec::DEFAULT).expect("default");
+        assert_eq!(default.total(), 224 * 768);
+    }
+
+    #[test]
+    fn required_positions_is_clamped_to_the_single_decode_window() {
+        let adapter = reference_adapter();
+        // 40s and 3600s clamp to the same single-decode window: the executor
+        // hard-caps a single decode at 40s and longform slices the rest, so a
+        // multi-hour recording is never judged as one giant decode.
+        let at_window = firered_llm_admission_required_positions(
+            &adapter,
+            FIRERED_LLM_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS,
+        );
+        let at_hour = firered_llm_admission_required_positions(&adapter, 3600.0);
+        assert_eq!(at_window, at_hour);
+        // A short clip needs strictly fewer positions than a full window.
+        let short = firered_llm_admission_required_positions(&adapter, 5.0);
+        assert!(short < at_window, "short={short} window={at_window}");
+        // Sanity: well under the pack's 32768 context ceiling at any window.
+        assert!(at_window < reference_decoder().max_positions);
+    }
+
+    #[test]
+    fn required_positions_walks_the_runtime_pipeline_arithmetic() {
+        // 40s at 16kHz snip-edges fbank: 1 + (640000-400)/160 = 3998 mel
+        // frames -> conv stem ((3998+6-1)/2 -> 2001, (2001-1)/2 -> 1000)
+        // -> /2 adapter stacking = 500 speech tokens.
+        // required = 32 fixed + 500 speech + 512 generation backstop = 1044.
+        let positions = firered_llm_admission_required_positions(&reference_adapter(), 40.0);
+        assert_eq!(positions, 1044);
+    }
+}

--- a/crates/openasr-core/src/models/firered_llm/executor.rs
+++ b/crates/openasr-core/src/models/firered_llm/executor.rs
@@ -140,11 +140,11 @@ const CMVN_INV_STDDEV_TENSOR: &str = "frontend.cmvn.inv_stddev";
 /// running an out-of-distribution multi-minute prefill; longer audio is the
 /// longform slicing orchestrator's job (see `FIRERED_LLM_DECODE_POLICY_ID`'s
 /// `ConservativeSeq2SeqV1` longform profile registration).
-const FIRERED_LLM_MAX_INPUT_SECONDS: f32 = 40.0;
+pub(crate) const FIRERED_LLM_MAX_INPUT_SECONDS: f32 = 40.0;
 /// Generous upper bound on generated tokens per utterance -- greedy decode
 /// stops at `<|im_end|>` well before this in practice; this is only the
 /// fail-closed backstop against a runaway (non-terminating) decode.
-const FIRERED_LLM_MAX_GENERATED_TOKENS: usize = 512;
+pub(crate) const FIRERED_LLM_MAX_GENERATED_TOKENS: usize = 512;
 
 #[derive(Debug, Error)]
 enum FireRedLlmExecutorError {

--- a/crates/openasr-core/src/models/firered_llm/executor.rs
+++ b/crates/openasr-core/src/models/firered_llm/executor.rs
@@ -218,15 +218,15 @@ impl Seq2SeqGreedyDecodeStepExecutor for FireRedLlmGreedyStepExecutor<'_> {
     ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyDecodeError> {
         if let Some(prompt_embeddings) = self.prompt_embeddings.take() {
             self.cache_prompt_tokens = prompt_embeddings.token_count;
-            let logits = self
+            let prefill = self
                 .decoder
                 .prefill(&prompt_embeddings, &mut self.layer_kv_caches, &self.control)
                 .map_err(|error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
                     reason: error.to_string(),
                 })?;
             return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
-                logits,
-                greedy_token_hint: None,
+                logits: prefill.logits,
+                greedy_token_hint: prefill.greedy_token_hint,
             });
         }
         let last_token = input.generated_tokens.last().copied().ok_or_else(|| {
@@ -241,6 +241,18 @@ impl Seq2SeqGreedyDecodeStepExecutor for FireRedLlmGreedyStepExecutor<'_> {
             .ok_or_else(|| Seq2SeqGreedyDecodeError::DecoderStepFailed {
                 reason: "firered-llm decode cache position underflowed".to_string(),
             })?;
+        if let Some(token_id) = self
+            .decoder
+            .decode_step_reused_top1(last_token, cache_position, &self.layer_kv_caches)
+            .map_err(|error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                reason: error.to_string(),
+            })?
+        {
+            return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: Some(token_id),
+            });
+        }
         let logits = self
             .decoder
             .decode_step(last_token, cache_position, &mut self.layer_kv_caches)

--- a/crates/openasr-core/src/models/firered_llm/llm_transformer.rs
+++ b/crates/openasr-core/src/models/firered_llm/llm_transformer.rs
@@ -117,6 +117,15 @@ pub(crate) struct FireRedLlmDecoderRuntime {
     metadata: FireRedLlmDecoderMetadata,
 }
 
+/// Prefill output for the shared greedy driver's step 0: the host logits row
+/// for the first generated token, or (on the fused Metal/GPU lane) a device
+/// argmax hint with no host row. Mirrors
+/// `moss_transcribe_diarize::llm_decoder::MossTdPrefillOutput`.
+pub(crate) struct FireRedLlmPrefillOutput {
+    pub(crate) logits: Vec<f32>,
+    pub(crate) greedy_token_hint: Option<u32>,
+}
+
 impl FireRedLlmDecoderRuntime {
     pub(crate) fn new(
         runtime_source: &crate::GgmlRuntimeSource,
@@ -126,17 +135,6 @@ impl FireRedLlmDecoderRuntime {
         let reader = crate::ggml_runtime::GgufTensorDataReader::from_runtime_source(runtime_source)
             .map_err(map_tensor_read_error)?;
         let projections = load_qwen2_layer_projections(&reader, &metadata)?;
-        let whole_decoder =
-            Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_rms_norm_epsilon_and_fused_logits_head(
-                &projections,
-                Some(runtime_source),
-                FIRERED_LLM_RMS_NORM_EPSILON,
-                None,
-                backend,
-            )
-            .map_err(|error| FireRedLlmDecoderError::GraphFailed {
-                reason: error.to_string(),
-            })?;
         let logits_head = load_llm_logits_head_from_reader_with_tensor_names(
             &reader,
             runtime_source,
@@ -150,6 +148,24 @@ impl FireRedLlmDecoderRuntime {
         .map_err(|error| FireRedLlmDecoderError::LogitsHeadFailed {
             reason: error.to_string(),
         })?;
+        // Keep the output projection in the same static arena as the resident
+        // decoder graph so Metal/GPU decode can return a device-side top-1
+        // token per step instead of building a separate full-vocab logits
+        // graph and reading the whole row back to the host -- mirrors
+        // `moss_transcribe_diarize::llm_decoder`'s identical wiring
+        // (firered-llm's registered policy has no suppression or phrase bias,
+        // so the shared driver can always honor the hint).
+        let whole_decoder =
+            Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_rms_norm_epsilon_and_fused_logits_head(
+                &projections,
+                Some(runtime_source),
+                FIRERED_LLM_RMS_NORM_EPSILON,
+                logits_head.fused_top1_spec(),
+                backend,
+            )
+            .map_err(|error| FireRedLlmDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?;
         let token_embedding = load_token_embedding_table_from_reader_with_tensor_name(
             &reader,
             LLM_TOKEN_EMBD_WEIGHT,
@@ -247,7 +263,7 @@ impl FireRedLlmDecoderRuntime {
         prompt_embeddings: &Qwen3AsrPromptEmbeddings,
         layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
         control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
-    ) -> Result<Vec<f32>, FireRedLlmDecoderError> {
+    ) -> Result<FireRedLlmPrefillOutput, FireRedLlmDecoderError> {
         let token_count = prompt_embeddings.token_count;
         if let Some(final_hidden) = self
             .whole_decoder
@@ -262,12 +278,28 @@ impl FireRedLlmDecoderRuntime {
                 reason: error.to_string(),
             })?
         {
-            return self
+            if let Some(token_id) = self
+                .whole_decoder
+                .fused_logits_top1_from_hidden(&final_hidden)
+                .map_err(|error| FireRedLlmDecoderError::GraphFailed {
+                    reason: error.to_string(),
+                })?
+            {
+                return Ok(FireRedLlmPrefillOutput {
+                    logits: Vec::new(),
+                    greedy_token_hint: Some(token_id),
+                });
+            }
+            let logits = self
                 .logits_head
                 .compute_logits_for_last_hidden(&final_hidden)
                 .map_err(|error| FireRedLlmDecoderError::LogitsHeadFailed {
                     reason: error.to_string(),
-                });
+                })?;
+            return Ok(FireRedLlmPrefillOutput {
+                logits,
+                greedy_token_hint: None,
+            });
         }
         let step = self
             .whole_decoder
@@ -280,11 +312,16 @@ impl FireRedLlmDecoderRuntime {
                 reason: error.to_string(),
             })?;
         let final_hidden = self.write_prefill_outputs(0, token_count, &step, layer_kv_caches)?;
-        self.logits_head
+        let logits = self
+            .logits_head
             .compute_logits_for_last_hidden(&final_hidden)
             .map_err(|error| FireRedLlmDecoderError::LogitsHeadFailed {
                 reason: error.to_string(),
-            })
+            })?;
+        Ok(FireRedLlmPrefillOutput {
+            logits,
+            greedy_token_hint: None,
+        })
     }
 
     /// Run one incremental decode step for `token_id` at `cache_position`
@@ -324,6 +361,42 @@ impl FireRedLlmDecoderRuntime {
             .map_err(|error| FireRedLlmDecoderError::LogitsHeadFailed {
                 reason: error.to_string(),
             })
+    }
+
+    /// On the resident Metal/GPU reuse graph, return the decoder's device-side
+    /// argmax directly. firered-llm's registered policy has no suppression or
+    /// phrase bias, so the shared greedy driver can safely consume this as a
+    /// validated `greedy_token_hint`; CPU and any non-reuse backend fall back
+    /// to the full host logits path above. Mirrors
+    /// `moss_transcribe_diarize::llm_decoder::decode_step_reused_top1`.
+    pub(crate) fn decode_step_reused_top1(
+        &mut self,
+        token_id: u32,
+        cache_position: usize,
+        layer_kv_caches: &[Qwen3AsrLayerKvCacheState],
+    ) -> Result<Option<u32>, FireRedLlmDecoderError> {
+        if !self.whole_decoder.supports_graph_reuse() || !self.whole_decoder.supports_fused_top1() {
+            return Ok(None);
+        }
+        let max_positions = layer_kv_caches
+            .first()
+            .map(Qwen3AsrLayerKvCacheState::max_positions)
+            .ok_or_else(|| FireRedLlmDecoderError::KvCacheFailed {
+                reason: "firered-llm decoder has no layer KV caches".to_string(),
+            })?;
+        let hidden = self.gather_token_embedding(token_id)?;
+        let step = self
+            .whole_decoder
+            .run_step_reused_batched_top1(
+                &hidden,
+                &[cache_position],
+                FIRERED_LLM_ROPE_THETA,
+                max_positions,
+            )
+            .map_err(|error| FireRedLlmDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?;
+        Ok(Some(step.token_id))
     }
 
     fn write_prefill_outputs(

--- a/crates/openasr-core/src/models/firered_llm/mod.rs
+++ b/crates/openasr-core/src/models/firered_llm/mod.rs
@@ -21,6 +21,7 @@
 //!   -- a pack produced by this importer is runnable by `openasr transcribe`.
 
 mod adapter_graph;
+pub(crate) mod capacity;
 mod decode_prompt;
 pub(crate) mod executor;
 mod llm_transformer;

--- a/crates/openasr-core/src/models/mimo_asr/capacity.rs
+++ b/crates/openasr-core/src/models/mimo_asr/capacity.rs
@@ -1,0 +1,198 @@
+//! mimo-asr capacity derivation: the family's Qwen2 backbone KV geometry and
+//! the decoder positions a single decode of a given audio span needs,
+//! assembled from PACK METADATA (`MimoLlmMetadata` + `MimoMelMetadata` +
+//! `MimoAudiotokMetadata` + `MimoInlocalMetadata`) plus family constants, for
+//! the shared host-memory admission check
+//! ([`crate::capacity::evaluate_host_memory_admission`]). The mimo-asr
+//! analogue of [`crate::models::qwen::capacity`].
+//!
+//! Reuses, never re-derives:
+//! - KV geometry comes straight off the parsed pack (`mimo.llm.*` keys).
+//! - The audio-token rate is the pack-carried stride product the registry row
+//!   in `crate::capacity` records: mel `sample_rate/hop_length` through the
+//!   tokenizer conv stem (`conv1_stride * conv2_stride * down_sample_stride`,
+//!   25Hz RVQ frames for the shipped pack) down to one LLM position per
+//!   `group_size` frames (the input-local group downcast).
+//! - The generation budget and the single-decode window reuse the executor's
+//!   own constants ([`super::executor::MIMO_ASR_MAX_GENERATED_TOKENS`],
+//!   [`super::executor::MIMO_ASR_MAX_INPUT_SECONDS`]), so admission charges
+//!   the same `prompt + generation` KV capacity
+//!   `MimoLlmDecoderRuntime::new_kv_caches` actually allocates.
+
+use crate::capacity::KvGeometry;
+
+use super::executor::{MIMO_ASR_MAX_GENERATED_TOKENS, MIMO_ASR_MAX_INPUT_SECONDS};
+use super::runtime_contract::{
+    MimoAudiotokMetadata, MimoInlocalMetadata, MimoLlmMetadata, MimoMelMetadata,
+};
+
+/// The audio a single mimo-asr decode is estimated to fold in, for admission.
+/// The executor fails closed above this per-chunk cap (the reference
+/// `preprocess_input`'s own 30s re-chunk bound), and longer recordings reach
+/// it only as longform slices each at or under this bound -- so no single
+/// decode's KV cache ever spans more audio. Same clamp rationale as qwen3's
+/// `QWEN3_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS`.
+pub(crate) const MIMO_ASR_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS: f32 = MIMO_ASR_MAX_INPUT_SECONDS;
+
+/// Fixed ChatML/`<|sosp|>`/`<|eosp|>` wrapper tokens around the audio span
+/// (see `super::decode_prompt::build_mimo_asr_decode_prompt`). A small
+/// conservative figure, dwarfed by the audio-group term at any real duration;
+/// its exact value cannot swing an admission decision.
+const MIMO_ASR_ADMISSION_FIXED_PROMPT_TOKENS: usize = 32;
+
+/// The backbone KV geometry the loaded pack advertises.
+pub(crate) fn mimo_asr_kv_geometry(llm: &MimoLlmMetadata) -> KvGeometry {
+    KvGeometry {
+        n_layers: llm.n_layers,
+        kv_heads: llm.n_kv_heads,
+        head_dim: llm.head_dim,
+    }
+}
+
+/// Decoder positions a single decode of `audio_duration_seconds` requires --
+/// the admission figure `evaluate_host_memory_admission` charges KV bytes
+/// against. Mirrors the runtime's own KV-capacity sizing
+/// (`decode_prompt.token_ids.len() + MIMO_ASR_MAX_GENERATED_TOKENS` in
+/// `super::executor`): fixed wrapper + one position per `group_size` RVQ
+/// frames + the full runaway-generation backstop, with the audio clamped to
+/// the family's single-decode window.
+pub(crate) fn mimo_asr_admission_required_positions(
+    mel: &MimoMelMetadata,
+    audiotok: &MimoAudiotokMetadata,
+    inlocal: &MimoInlocalMetadata,
+    audio_duration_seconds: f32,
+) -> usize {
+    let admission_seconds =
+        audio_duration_seconds.clamp(0.0, MIMO_ASR_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS);
+    let mel_frames =
+        (admission_seconds * mel.sample_rate_hz as f32 / mel.hop_length.max(1) as f32) as usize;
+    // The tokenizer conv stem's time-axis stride product (conv1 is stride 1
+    // for the shipped pack; all three are pack-carried facts).
+    let stem_stride = audiotok
+        .conv1_stride
+        .max(1)
+        .saturating_mul(audiotok.conv2_stride.max(1))
+        .saturating_mul(audiotok.down_sample_stride.max(1));
+    let rvq_frames = mel_frames / stem_stride;
+    // The input-local group downcast folds `group_size` RVQ frames into one
+    // spliced LLM position (trailing remainder truncated, exactly as the
+    // executor truncates codes to a whole-group multiple).
+    let audio_groups = rvq_frames / inlocal.group_size.max(1);
+    MIMO_ASR_ADMISSION_FIXED_PROMPT_TOKENS
+        .saturating_add(audio_groups)
+        .saturating_add(MIMO_ASR_MAX_GENERATED_TOKENS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capacity::kv_bytes_per_position;
+    use crate::nn::decoder::LlmKvCacheSpec;
+
+    /// Real-checkpoint-shaped facts (the same values `runtime_contract`'s
+    /// `full_metadata` fixture parses: 36L Qwen2 backbone with 8 KV heads at
+    /// head_dim 128; 24kHz/240-hop mel; stride-1/2/2 conv stem; group 4).
+    fn reference_llm() -> MimoLlmMetadata {
+        MimoLlmMetadata {
+            n_layers: 36,
+            d_model: 4096,
+            n_heads: 32,
+            n_kv_heads: 8,
+            head_dim: 128,
+            ffn_dim: 11008,
+            vocab_size: 151_680,
+            max_positions: 8192,
+            rms_norm_epsilon: 1e-6,
+            rope_theta: 640_000.0,
+        }
+    }
+
+    fn reference_mel() -> MimoMelMetadata {
+        MimoMelMetadata {
+            sample_rate_hz: 24_000,
+            n_fft: 960,
+            hop_length: 240,
+            win_length: 960,
+            n_mels: 128,
+            log_clip: 1e-7,
+        }
+    }
+
+    fn reference_audiotok() -> MimoAudiotokMetadata {
+        MimoAudiotokMetadata {
+            n_layers: 32,
+            d_model: 1280,
+            n_heads: 20,
+            head_dim: 64,
+            ffn_dim: 5120,
+            skip_layer_id: 3,
+            conv_kernel_size: 3,
+            conv1_stride: 1,
+            conv2_stride: 2,
+            down_sample_stride: 2,
+            rope_theta: 10_000.0,
+            rvq_packed: 8,
+            codebook_sizes: vec![1024, 1024, 128, 128, 128, 128, 128, 128],
+        }
+    }
+
+    fn reference_inlocal() -> MimoInlocalMetadata {
+        MimoInlocalMetadata {
+            n_layers: 6,
+            d_model: 1024,
+            n_heads: 64,
+            head_dim: 16,
+            ffn_dim: 4096,
+            rope_theta: 640_000.0,
+            group_size: 4,
+            audio_channels: 8,
+        }
+    }
+
+    #[test]
+    fn kv_geometry_reads_the_llm_metadata() {
+        let geometry = mimo_asr_kv_geometry(&reference_llm());
+        assert_eq!(
+            geometry,
+            KvGeometry {
+                n_layers: 36,
+                kv_heads: 8,
+                head_dim: 128,
+            }
+        );
+        // Feeds the shared KV byte model without error (576 rows/position,
+        // the same shape the runtime_contract capacity anchor pins).
+        let default = kv_bytes_per_position(&geometry, LlmKvCacheSpec::DEFAULT).expect("default");
+        assert_eq!(default.total(), 576 * 768);
+    }
+
+    #[test]
+    fn required_positions_is_clamped_to_the_single_decode_window() {
+        let (mel, audiotok, inlocal) = (reference_mel(), reference_audiotok(), reference_inlocal());
+        let at_window = mimo_asr_admission_required_positions(
+            &mel,
+            &audiotok,
+            &inlocal,
+            MIMO_ASR_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS,
+        );
+        let at_hour = mimo_asr_admission_required_positions(&mel, &audiotok, &inlocal, 3600.0);
+        assert_eq!(at_window, at_hour);
+        let short = mimo_asr_admission_required_positions(&mel, &audiotok, &inlocal, 5.0);
+        assert!(short < at_window, "short={short} window={at_window}");
+        assert!(at_window < reference_llm().max_positions);
+    }
+
+    #[test]
+    fn required_positions_walks_the_runtime_pipeline_arithmetic() {
+        // 30s at 24kHz/240-hop = 3000 mel frames -> stem stride 1*2*2 = 750
+        // RVQ frames (25Hz) -> group 4 = 187 audio groups (truncated).
+        // required = 32 fixed + 187 groups + 512 generation backstop = 731.
+        let positions = mimo_asr_admission_required_positions(
+            &reference_mel(),
+            &reference_audiotok(),
+            &reference_inlocal(),
+            30.0,
+        );
+        assert_eq!(positions, 731);
+    }
+}

--- a/crates/openasr-core/src/models/mimo_asr/executor.rs
+++ b/crates/openasr-core/src/models/mimo_asr/executor.rs
@@ -132,15 +132,15 @@ impl Seq2SeqGreedyDecodeStepExecutor for MimoAsrGreedyStepExecutor<'_> {
     ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, Seq2SeqGreedyDecodeError> {
         if let Some(prompt_embeddings) = self.prompt_embeddings.take() {
             self.cache_prompt_tokens = prompt_embeddings.token_count;
-            let logits = self
+            let prefill = self
                 .decoder
                 .prefill(&prompt_embeddings, &mut self.layer_kv_caches, &self.control)
                 .map_err(|error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
                     reason: error.to_string(),
                 })?;
             return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
-                logits,
-                greedy_token_hint: None,
+                logits: prefill.logits,
+                greedy_token_hint: prefill.greedy_token_hint,
             });
         }
         let last_token = input.generated_tokens.last().copied().ok_or_else(|| {
@@ -155,6 +155,18 @@ impl Seq2SeqGreedyDecodeStepExecutor for MimoAsrGreedyStepExecutor<'_> {
             .ok_or_else(|| Seq2SeqGreedyDecodeError::DecoderStepFailed {
                 reason: "mimo-asr decode cache position underflowed".to_string(),
             })?;
+        if let Some(token_id) = self
+            .decoder
+            .decode_step_reused_top1(last_token, cache_position, &self.layer_kv_caches)
+            .map_err(|error| Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                reason: error.to_string(),
+            })?
+        {
+            return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: Some(token_id),
+            });
+        }
         let logits = self
             .decoder
             .decode_step(last_token, cache_position, &mut self.layer_kv_caches)

--- a/crates/openasr-core/src/models/mimo_asr/executor.rs
+++ b/crates/openasr-core/src/models/mimo_asr/executor.rs
@@ -61,8 +61,8 @@ const MIMO_ASR_STREAMING_EXECUTOR_ID: &str = "mimo-asr-ggml-snapshot-streaming-e
 /// = 30 * sampling_rate`); this executor instead fails closed above that same
 /// bound and leaves multi-chunk orchestration to the shared longform slicer
 /// (mirrors `firered_llm`'s upstream-hard-cap precedent).
-const MIMO_ASR_MAX_INPUT_SECONDS: f32 = 30.0;
-const MIMO_ASR_MAX_GENERATED_TOKENS: usize = 512;
+pub(crate) const MIMO_ASR_MAX_INPUT_SECONDS: f32 = 30.0;
+pub(crate) const MIMO_ASR_MAX_GENERATED_TOKENS: usize = 512;
 
 #[derive(Debug, Error)]
 enum MimoAsrExecutorError {

--- a/crates/openasr-core/src/models/mimo_asr/executor.rs
+++ b/crates/openasr-core/src/models/mimo_asr/executor.rs
@@ -12,12 +12,16 @@
 
 #![allow(dead_code)]
 
+use std::cell::RefCell;
+use std::collections::HashMap;
+
 use thiserror::Error;
 
 use crate::NativeAsrError;
 use crate::NativeAsrSession;
 use crate::api::backend::{Segment, Transcription};
 use crate::arch::MIMO_ASR_DECODE_POLICY_ID;
+use crate::ggml_runtime::GgmlCpuGraphBackend;
 use crate::models::decode_policy_component_registry::{
     BuiltinDecodePolicyComponentRegistryError, BuiltinSeq2SeqDecodePolicyConfigInput,
     BuiltinSeq2SeqDecodePolicyTokenSource, run_builtin_seq2seq_decode_policy,
@@ -35,24 +39,30 @@ use crate::models::qwen::{
 };
 use crate::models::runtime_preflight::build_runtime_tensor_reader_from_preflight;
 use crate::models::seq2seq_greedy_decode::{
-    Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeStepExecutor, Seq2SeqGreedyDecodeStepInput,
-    Seq2SeqGreedyDecodeStepLogitsOutput,
+    Seq2SeqGreedyDecodeError, Seq2SeqGreedyDecodeResult, Seq2SeqGreedyDecodeStepExecutor,
+    Seq2SeqGreedyDecodeStepInput, Seq2SeqGreedyDecodeStepLogitsOutput,
+};
+use crate::models::thread_local_runtime_cache::{
+    PackContentKey, current_unload_generation, take_generation_tagged,
 };
 
 use super::audio_tokenizer_graph::MimoAudiotokEncoderRuntime;
 use super::decode_prompt::build_mimo_asr_decode_prompt;
 use super::input_local_graph::{
-    MimoInputLocalRuntime, load_speech_embedding_tables_from_reader, sum_speech_embeddings,
+    MimoInputLocalRuntime, MimoSpeechEmbeddingTables, load_speech_embedding_tables_from_reader,
+    sum_speech_embeddings,
 };
 use super::llm_transformer::MimoLlmDecoderRuntime;
 use super::mel_frontend::{
-    load_mimo_mel_frontend_plan_from_reader, mimo_mel_features_from_samples, resample_mono,
+    MimoMelFrontendPlan, load_mimo_mel_frontend_plan_from_reader, mimo_mel_features_from_samples,
+    resample_mono,
 };
 use super::runtime_contract::{
-    parse_mimo_audiotok_metadata, parse_mimo_inlocal_metadata, parse_mimo_llm_metadata,
-    parse_mimo_mel_metadata, parse_mimo_special_tokens,
+    MimoInlocalMetadata, MimoLlmMetadata, parse_mimo_audiotok_metadata,
+    parse_mimo_inlocal_metadata, parse_mimo_llm_metadata, parse_mimo_mel_metadata,
+    parse_mimo_special_tokens,
 };
-use super::rvq::{encode_rvq_codes, load_mimo_rvq_codebooks_from_reader};
+use super::rvq::{MimoRvqCodebooks, encode_rvq_codes, load_mimo_rvq_codebooks_from_reader};
 use super::tokenizer::MimoAsrTokenizer;
 
 const MIMO_ASR_EXECUTOR_ID: &str = "mimo-asr-ggml-executor-v1";
@@ -99,6 +109,74 @@ enum MimoAsrExecutorError {
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct MimoAsrGgmlExecutor;
+
+/// Everything mimo-asr materializes from a pack that does NOT depend on the
+/// per-request audio: all three graph runtimes (audio-tokenizer encoder,
+/// input-local transformer, 36L Qwen2 backbone decoder), their
+/// device-uploaded / arena-resident weights, plus the immutable derived data
+/// read once from the pack (RVQ codebooks, the 8 speech-embedding tables, the
+/// mel front-end plan, the tokenizer, and the two metadata groups the
+/// per-request path still consults). Before this cache, mimo-asr was the only
+/// family that rebuilt this ENTIRE set on every `execute()` -- three
+/// `Runtime::new()` calls plus a full re-read of the pack's codebooks/tables
+/// -- purely to re-derive state that never changes between requests against
+/// the same pack. Mirrors `firered_llm`'s resident-decoder cache (`FireRedLlm
+/// DecoderRuntime` there is one stage; here the whole prepared pipeline is
+/// resident because all three mimo stages are equally per-request-invariant).
+struct MimoAsrPreparedRuntime {
+    encoder_runtime: MimoAudiotokEncoderRuntime,
+    inlocal_runtime: MimoInputLocalRuntime,
+    decoder: MimoLlmDecoderRuntime,
+    tokenizer: MimoAsrTokenizer,
+    codebooks: MimoRvqCodebooks,
+    speech_embedding_tables: MimoSpeechEmbeddingTables,
+    mel_plan: MimoMelFrontendPlan,
+    llm_metadata: MimoLlmMetadata,
+    inlocal_metadata: MimoInlocalMetadata,
+}
+
+/// Resident prepared-runtime cache keyed by (pack content id, backend), the
+/// same design + idle-unload-generation tagging `firered_llm` uses for its
+/// resident decoder (see that module's `FIRERED_LLM_DECODER_BY_KEY` doc). The
+/// pack half is a [`PackContentKey`] from the request's already-open source,
+/// so an in-place `.oasr` replacement at the same path resolves a different id
+/// and the next lookup rebuilds instead of reusing runtimes built from the old
+/// bytes. Entries are tagged with the idle-unload generation they were built
+/// under: `take_generation_tagged` discards any prepared runtime built before
+/// the last idle unload (the reaper cannot reach this worker thread's TLS from
+/// its own thread), so the resident ~8B pipeline stays evictable under memory
+/// pressure through the shared central unload clock -- no bespoke policy.
+///
+/// A plain `HashMap` (not the bounded LRU): the key does not explode per audio
+/// chunk (one entry is built and reused across a whole longform run for a given
+/// pack/backend), so there is no unbounded-growth hazard to bound.
+type MimoAsrPreparedRuntimeCacheKey = (PackContentKey, GgmlCpuGraphBackend);
+
+thread_local! {
+    static MIMO_ASR_PREPARED_BY_KEY: RefCell<
+        HashMap<MimoAsrPreparedRuntimeCacheKey, (u64, MimoAsrPreparedRuntime)>,
+    > = RefCell::new(HashMap::new());
+}
+
+fn take_cached_prepared_runtime(
+    key: &MimoAsrPreparedRuntimeCacheKey,
+    unload_generation: u64,
+) -> Option<MimoAsrPreparedRuntime> {
+    MIMO_ASR_PREPARED_BY_KEY
+        .with(|cache| take_generation_tagged(&mut cache.borrow_mut(), key, unload_generation))
+}
+
+fn store_cached_prepared_runtime(
+    key: MimoAsrPreparedRuntimeCacheKey,
+    unload_generation: u64,
+    prepared: MimoAsrPreparedRuntime,
+) {
+    MIMO_ASR_PREPARED_BY_KEY.with(|cache| {
+        cache
+            .borrow_mut()
+            .insert(key, (unload_generation, prepared));
+    });
+}
 
 /// No-op phrase-bias shim: mimo-asr's decode policy never consults these (no
 /// phrase bias, single config-supplied eot token) -- mirrors
@@ -168,24 +246,17 @@ impl Seq2SeqGreedyDecodeStepExecutor for MimoAsrGreedyStepExecutor<'_> {
     }
 }
 
-impl MimoAsrGgmlExecutor {
-    fn execute_inner(
-        &self,
-        request: &GgmlAsrExecutionRequest,
-    ) -> Result<GgmlAsrExecutionResult, MimoAsrExecutorError> {
-        let expected_adapter = crate::arch::MIMO_ASR_GGML_ADAPTER_ID;
-        if request.selected_family.adapter_id != expected_adapter {
-            return Err(MimoAsrExecutorError::AdapterMismatch {
-                expected: expected_adapter,
-                found: request.selected_family.adapter_id.to_string(),
-            });
-        }
-        let preflight = request
-            .resolve_runtime_source_preflight()
-            .map_err(|error| MimoAsrExecutorError::RuntimePreflightFailed {
-                reason: error.to_string(),
-            })?;
-
+impl MimoAsrPreparedRuntime {
+    /// Materializes every per-request-invariant piece of the mimo-asr pipeline
+    /// from an already-resolved preflight: the three graph runtimes and their
+    /// resident weights, plus the RVQ codebooks, speech-embedding tables, mel
+    /// plan, tokenizer, and the two metadata groups the request path consults.
+    /// This is the whole cost the resident cache exists to pay exactly once per
+    /// (pack, backend).
+    fn build(
+        preflight: &crate::models::ggml_asr_executor::GgmlAsrRuntimeSourcePreflight,
+        backend: GgmlCpuGraphBackend,
+    ) -> Result<Self, MimoAsrExecutorError> {
         let llm_metadata = parse_mimo_llm_metadata(&preflight.metadata).map_err(|error| {
             MimoAsrExecutorError::RuntimeContractViolation {
                 reason: error.to_string(),
@@ -220,17 +291,7 @@ impl MimoAsrGgmlExecutor {
             }
         })?;
 
-        let samples = &request.prepared_audio.samples_f32;
-        let audio_duration_seconds =
-            samples.len() as f32 / request.prepared_audio.sample_rate_hz.max(1) as f32;
-        if audio_duration_seconds > MIMO_ASR_MAX_INPUT_SECONDS {
-            return Err(MimoAsrExecutorError::AudioTooLong {
-                seconds: audio_duration_seconds,
-                limit: MIMO_ASR_MAX_INPUT_SECONDS,
-            });
-        }
-
-        let reader = build_runtime_tensor_reader_from_preflight(&preflight).map_err(|error| {
+        let reader = build_runtime_tensor_reader_from_preflight(preflight).map_err(|error| {
             MimoAsrExecutorError::EncoderFailed {
                 reason: error.to_string(),
             }
@@ -242,38 +303,13 @@ impl MimoAsrGgmlExecutor {
                     reason: error.to_string(),
                 }
             })?;
-        // The OpenASR pipeline delivers 16kHz mono to every executor, but
-        // MiMo's audio tokenizer (and its baked mel filterbank/window) is
-        // trained at 24kHz -- resample up before the mel front-end, matching
-        // the reference `preprocess_input`'s own resample-to-tokenizer-rate.
-        let input_rate = request.prepared_audio.sample_rate_hz;
-        let target_rate = mel_plan.sample_rate_hz as u32;
-        let resampled = resample_mono(samples, input_rate, target_rate).ok_or(
-            MimoAsrExecutorError::MelFrontendFailed {
-                reason: format!("failed to resample {input_rate}Hz -> {target_rate}Hz"),
-            },
-        )?;
-        let mel_features =
-            mimo_mel_features_from_samples(&resampled, &mel_plan).map_err(|error| {
-                MimoAsrExecutorError::MelFrontendFailed {
-                    reason: error.to_string(),
-                }
-            })?;
 
         let runtime_source = &preflight.runtime_source;
-        let mut encoder_runtime = MimoAudiotokEncoderRuntime::new(
-            runtime_source,
-            audiotok_metadata.clone(),
-            request.resolved_runtime.backend(),
-        )
-        .map_err(|error| MimoAsrExecutorError::EncoderFailed {
-            reason: error.to_string(),
-        })?;
-        let encoder_output = encoder_runtime.encode(&mel_features).map_err(|error| {
-            MimoAsrExecutorError::EncoderFailed {
-                reason: error.to_string(),
-            }
-        })?;
+        let encoder_runtime =
+            MimoAudiotokEncoderRuntime::new(runtime_source, audiotok_metadata.clone(), backend)
+                .map_err(|error| MimoAsrExecutorError::EncoderFailed {
+                    reason: error.to_string(),
+                })?;
 
         let codebooks =
             load_mimo_rvq_codebooks_from_reader(&reader, &audiotok_metadata).map_err(|error| {
@@ -281,26 +317,6 @@ impl MimoAsrGgmlExecutor {
                     reason: error.to_string(),
                 }
             })?;
-        let mut codes =
-            encode_rvq_codes(&codebooks, &encoder_output.rows, encoder_output.frame_count)
-                .map_err(|error| MimoAsrExecutorError::RvqFailed {
-                    reason: error.to_string(),
-                })?;
-
-        // Truncate to the nearest group_size multiple (drop up to
-        // group_size-1 trailing 25Hz frames = well under 200ms of audio) --
-        // the reference asserts exact divisibility rather than padding.
-        let group_size = inlocal_metadata.group_size;
-        let usable_frames = (codes.len() / group_size) * group_size;
-        codes.truncate(usable_frames);
-        if usable_frames == 0 {
-            return Err(MimoAsrExecutorError::RvqFailed {
-                reason: format!(
-                    "audio too short: {} RVQ frames produced, need at least {group_size}",
-                    codes.len()
-                ),
-            });
-        }
 
         // `mimo.speech.vocab_size` (LLM-side embedding table sizes) is each
         // RVQ codebook's size +1 (a trailing zeroemb padding row); `mimo.speech.
@@ -315,7 +331,7 @@ impl MimoAsrGgmlExecutor {
             .map(|size| size + 1)
             .collect();
         let zeroemb_idx: Vec<u32> = audiotok_metadata.codebook_sizes.clone();
-        let tables = load_speech_embedding_tables_from_reader(
+        let speech_embedding_tables = load_speech_embedding_tables_from_reader(
             &reader,
             inlocal_metadata.d_model,
             &speech_vocab_sizes,
@@ -324,38 +340,203 @@ impl MimoAsrGgmlExecutor {
         .map_err(|error| MimoAsrExecutorError::InputLocalFailed {
             reason: error.to_string(),
         })?;
-        let summed = sum_speech_embeddings(&tables, &codes);
 
-        let mut inlocal_runtime = MimoInputLocalRuntime::new(
-            runtime_source,
+        let inlocal_runtime = MimoInputLocalRuntime::new(runtime_source, inlocal_metadata, backend)
+            .map_err(|error| MimoAsrExecutorError::InputLocalFailed {
+                reason: error.to_string(),
+            })?;
+
+        let decoder =
+            MimoLlmDecoderRuntime::new(runtime_source, llm_metadata, backend).map_err(|error| {
+                MimoAsrExecutorError::DecoderFailed {
+                    reason: error.to_string(),
+                }
+            })?;
+
+        Ok(Self {
+            encoder_runtime,
+            inlocal_runtime,
+            decoder,
+            tokenizer,
+            codebooks,
+            speech_embedding_tables,
+            mel_plan,
+            llm_metadata,
             inlocal_metadata,
-            request.resolved_runtime.backend(),
+        })
+    }
+}
+
+impl MimoAsrGgmlExecutor {
+    fn execute_inner(
+        &self,
+        request: &GgmlAsrExecutionRequest,
+    ) -> Result<GgmlAsrExecutionResult, MimoAsrExecutorError> {
+        let expected_adapter = crate::arch::MIMO_ASR_GGML_ADAPTER_ID;
+        if request.selected_family.adapter_id != expected_adapter {
+            return Err(MimoAsrExecutorError::AdapterMismatch {
+                expected: expected_adapter,
+                found: request.selected_family.adapter_id.to_string(),
+            });
+        }
+        let preflight = request
+            .resolve_runtime_source_preflight()
+            .map_err(|error| MimoAsrExecutorError::RuntimePreflightFailed {
+                reason: error.to_string(),
+            })?;
+
+        let samples = &request.prepared_audio.samples_f32;
+        let audio_duration_seconds =
+            samples.len() as f32 / request.prepared_audio.sample_rate_hz.max(1) as f32;
+        if audio_duration_seconds > MIMO_ASR_MAX_INPUT_SECONDS {
+            return Err(MimoAsrExecutorError::AudioTooLong {
+                seconds: audio_duration_seconds,
+                limit: MIMO_ASR_MAX_INPUT_SECONDS,
+            });
+        }
+
+        // Take the resident prepared runtime out of this thread's cache (or
+        // build it once on a cold miss). Sampled before the take and reused for
+        // the store-back below: if the idle-unload reaper bumps the generation
+        // while this decode is in flight, the runtime goes back tagged with the
+        // pre-unload generation and the *next* take discards it, so an unload is
+        // never lost to an overlapping decode (mirrors `firered_llm`).
+        let backend = request.resolved_runtime.backend();
+        let cache_key: MimoAsrPreparedRuntimeCacheKey = (
+            PackContentKey::for_runtime_source(&preflight.runtime_source),
+            backend,
+        );
+        let unload_generation = current_unload_generation();
+        let mut prepared = match take_cached_prepared_runtime(&cache_key, unload_generation) {
+            Some(prepared) => prepared,
+            None => MimoAsrPreparedRuntime::build(&preflight, backend)?,
+        };
+
+        let result = self.transcribe_with_prepared(&mut prepared, request, samples);
+
+        // Return the resident runtime to the cache for the next chunk /
+        // execute() regardless of decode outcome (the session-scoped buffer
+        // release below already discarded any state a partial compute poisoned;
+        // uploaded weights and the arena/graph handles remain valid).
+        prepared.decoder.release_session_scoped_buffers();
+        store_cached_prepared_runtime(cache_key, unload_generation, prepared);
+
+        let result = result?;
+        let text = strip_mimo_language_tags(&result.text);
+        let transcription = Transcription {
+            truncated_decodes: Vec::new(),
+            unnamed_speakers: Vec::new(),
+            segments: vec![Segment {
+                start: 0.0,
+                end: audio_duration_seconds.max(0.0),
+                text: text.clone(),
+                speaker: None,
+                speaker_label: None,
+                speaker_person_id: None,
+                speaker_snapshot_label: None,
+                words: Vec::new(),
+            }],
+            text,
+            longform: None,
+            language: None,
+        };
+        Ok(GgmlAsrExecutionResult {
+            transcription,
+            carry_context: None,
+            // No intra-decode timestamps -- the single segment spans the whole
+            // buffer -- so the cut point has no honest second to name. See
+            // `DecodeTruncation::transcript_covers_up_to_seconds`.
+            decode_truncation: result.stop_reason.into_decode_truncation(None),
+        })
+    }
+
+    /// The per-request path: everything that depends on the audio input, run
+    /// against an already-built resident [`MimoAsrPreparedRuntime`]. Nothing
+    /// here reads the pack or constructs a graph runtime -- it only feeds this
+    /// utterance's samples through the resident encoder / input-local / decoder
+    /// graphs and returns the greedy decode result. Fields are borrowed
+    /// disjointly (`&mut` encoder, then `&mut` input-local, then `&mut` decoder
+    /// alongside `&` tokenizer) so the resident runtime is reused in place.
+    fn transcribe_with_prepared(
+        &self,
+        prepared: &mut MimoAsrPreparedRuntime,
+        request: &GgmlAsrExecutionRequest,
+        samples: &[f32],
+    ) -> Result<Seq2SeqGreedyDecodeResult, MimoAsrExecutorError> {
+        // The OpenASR pipeline delivers 16kHz mono to every executor, but
+        // MiMo's audio tokenizer (and its baked mel filterbank/window) is
+        // trained at 24kHz -- resample up before the mel front-end, matching
+        // the reference `preprocess_input`'s own resample-to-tokenizer-rate.
+        let input_rate = request.prepared_audio.sample_rate_hz;
+        let target_rate = prepared.mel_plan.sample_rate_hz as u32;
+        let resampled = resample_mono(samples, input_rate, target_rate).ok_or(
+            MimoAsrExecutorError::MelFrontendFailed {
+                reason: format!("failed to resample {input_rate}Hz -> {target_rate}Hz"),
+            },
+        )?;
+        let mel_features =
+            mimo_mel_features_from_samples(&resampled, &prepared.mel_plan).map_err(|error| {
+                MimoAsrExecutorError::MelFrontendFailed {
+                    reason: error.to_string(),
+                }
+            })?;
+
+        let encoder_output = prepared
+            .encoder_runtime
+            .encode(&mel_features)
+            .map_err(|error| MimoAsrExecutorError::EncoderFailed {
+                reason: error.to_string(),
+            })?;
+
+        let mut codes = encode_rvq_codes(
+            &prepared.codebooks,
+            &encoder_output.rows,
+            encoder_output.frame_count,
         )
-        .map_err(|error| MimoAsrExecutorError::InputLocalFailed {
+        .map_err(|error| MimoAsrExecutorError::RvqFailed {
             reason: error.to_string(),
         })?;
-        let speech_rows = inlocal_runtime
-            .run(&summed, usable_frames, llm_metadata.d_model)
+
+        // Truncate to the nearest group_size multiple (drop up to
+        // group_size-1 trailing 25Hz frames = well under 200ms of audio) --
+        // the reference asserts exact divisibility rather than padding.
+        let group_size = prepared.inlocal_metadata.group_size;
+        let usable_frames = (codes.len() / group_size) * group_size;
+        codes.truncate(usable_frames);
+        if usable_frames == 0 {
+            return Err(MimoAsrExecutorError::RvqFailed {
+                reason: format!(
+                    "audio too short: {} RVQ frames produced, need at least {group_size}",
+                    codes.len()
+                ),
+            });
+        }
+
+        let summed = sum_speech_embeddings(&prepared.speech_embedding_tables, &codes);
+
+        let llm_d_model = prepared.llm_metadata.d_model;
+        let speech_rows = prepared
+            .inlocal_runtime
+            .run(&summed, usable_frames, llm_d_model)
             .map_err(|error| MimoAsrExecutorError::InputLocalFailed {
                 reason: error.to_string(),
             })?;
         let audio_group_count = usable_frames / group_size;
 
+        // Disjoint field borrows: `&mut decoder` for the decode graph and
+        // `&tokenizer` for prompt/text decoding are distinct fields of the
+        // same resident runtime, so both are live at once without conflict.
+        let tokenizer = &prepared.tokenizer;
+        let llm_metadata = prepared.llm_metadata;
+        let decoder = &mut prepared.decoder;
+
         let decode_prompt =
-            build_mimo_asr_decode_prompt(&tokenizer, audio_group_count).map_err(|error| {
+            build_mimo_asr_decode_prompt(tokenizer, audio_group_count).map_err(|error| {
                 MimoAsrExecutorError::DecodePromptFailed {
                     reason: error.to_string(),
                 }
             })?;
 
-        let mut decoder = MimoLlmDecoderRuntime::new(
-            runtime_source,
-            llm_metadata,
-            request.resolved_runtime.backend(),
-        )
-        .map_err(|error| MimoAsrExecutorError::DecoderFailed {
-            reason: error.to_string(),
-        })?;
         let mut token_rows =
             Vec::with_capacity(decode_prompt.token_ids.len() * llm_metadata.d_model);
         for &token_id in &decode_prompt.token_ids {
@@ -385,7 +566,7 @@ impl MimoAsrGgmlExecutor {
                 .saturating_add(MIMO_ASR_MAX_GENERATED_TOKENS),
         );
         let mut step_executor = MimoAsrGreedyStepExecutor {
-            decoder: &mut decoder,
+            decoder,
             layer_kv_caches,
             prompt_embeddings: Some(prompt_embeddings),
             cache_prompt_tokens: 0,
@@ -397,7 +578,7 @@ impl MimoAsrGgmlExecutor {
             vocab_size: llm_metadata.vocab_size,
             max_generated_tokens: MIMO_ASR_MAX_GENERATED_TOKENS,
         };
-        let result = run_builtin_seq2seq_decode_policy(
+        run_builtin_seq2seq_decode_policy(
             MIMO_ASR_DECODE_POLICY_ID,
             &config,
             &NoPhraseBiasTokenSource,
@@ -417,33 +598,6 @@ impl MimoAsrGgmlExecutor {
         )
         .map_err(|error| MimoAsrExecutorError::GreedyDecodeFailed {
             reason: error.to_string(),
-        })?;
-
-        let text = strip_mimo_language_tags(&result.text);
-        let transcription = Transcription {
-            truncated_decodes: Vec::new(),
-            unnamed_speakers: Vec::new(),
-            segments: vec![Segment {
-                start: 0.0,
-                end: audio_duration_seconds.max(0.0),
-                text: text.clone(),
-                speaker: None,
-                speaker_label: None,
-                speaker_person_id: None,
-                speaker_snapshot_label: None,
-                words: Vec::new(),
-            }],
-            text,
-            longform: None,
-            language: None,
-        };
-        Ok(GgmlAsrExecutionResult {
-            transcription,
-            carry_context: None,
-            // No intra-decode timestamps -- the single segment spans the whole
-            // buffer -- so the cut point has no honest second to name. See
-            // `DecodeTruncation::transcript_covers_up_to_seconds`.
-            decode_truncation: result.stop_reason.into_decode_truncation(None),
         })
     }
 }
@@ -706,5 +860,32 @@ mod tests {
             elapsed.as_secs_f32() / audio_duration_seconds.max(0.001)
         );
         assert_eq!(text, GOLDEN_EN_ZH_MIXED_TEXT);
+    }
+
+    /// Resident prepared-runtime cache regression: `execute()` twice in a row on
+    /// the same thread (same pack + backend) must hit the thread-local
+    /// `MIMO_ASR_PREPARED_BY_KEY` cache on the second call and still produce a
+    /// transcript byte-identical to the first call (a cold cache-miss build) and
+    /// to the dedicated single-call golden above -- the resident encoder /
+    /// input-local / decoder carry no per-request state across calls that could
+    /// leak into a later transcript. This is the mimo mirror of firered-llm's
+    /// `resident_decoder_cache_reuse_across_consecutive_calls_stays_byte_identical`.
+    /// Run with `OPENASR_GGML_BACKEND=cpu` for the deterministic reference decode.
+    #[test]
+    #[ignore = "requires the private ~9.6GB dev-only mimo-v2.5-asr-q8_0.oasr pack; \
+                OPENASR_GGML_BACKEND=cpu recommended (see the single-call goldens)"]
+    fn resident_prepared_runtime_reuse_across_consecutive_calls_stays_byte_identical() {
+        let Some((first_text, _, _)) = transcribe_with_dev_pack(jfk_wav_path()) else {
+            return;
+        };
+        let Some((second_text, _, _)) = transcribe_with_dev_pack(jfk_wav_path()) else {
+            return;
+        };
+        assert_eq!(first_text, GOLDEN_JFK_TEXT);
+        assert_eq!(
+            second_text, GOLDEN_JFK_TEXT,
+            "second execute() (a resident prepared-runtime cache hit) must match the first \
+             (cache-miss/build) call byte-for-byte"
+        );
     }
 }

--- a/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
+++ b/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
@@ -167,6 +167,16 @@ impl MimoLlmDecoderRuntime {
             .collect()
     }
 
+    /// Releases the CPU per-token grow-to-fit step buffer before this decoder
+    /// goes back into the cross-request resident cache, so it stays scoped to
+    /// one utterance instead of living on indefinitely with the cached
+    /// decoder. A no-op on Metal/GPU or when no CPU step ever ran. Mirrors
+    /// `firered_llm::llm_transformer::FireRedLlmDecoderRuntime::
+    /// release_session_scoped_buffers` (both drive the same shared executor).
+    pub(crate) fn release_session_scoped_buffers(&mut self) {
+        self.whole_decoder.release_session_scoped_buffers();
+    }
+
     pub(crate) fn gather_token_embedding(
         &self,
         token_id: u32,

--- a/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
+++ b/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
@@ -91,6 +91,15 @@ pub(crate) struct MimoLlmDecoderRuntime {
     metadata: MimoLlmMetadata,
 }
 
+/// Prefill output for the shared greedy driver's step 0: the host logits row
+/// for the first generated token, or (on the fused Metal/GPU lane) a device
+/// argmax hint with no host row. Mirrors
+/// `moss_transcribe_diarize::llm_decoder::MossTdPrefillOutput`.
+pub(crate) struct MimoLlmPrefillOutput {
+    pub(crate) logits: Vec<f32>,
+    pub(crate) greedy_token_hint: Option<u32>,
+}
+
 impl MimoLlmDecoderRuntime {
     pub(crate) fn new(
         runtime_source: &crate::GgmlRuntimeSource,
@@ -102,17 +111,6 @@ impl MimoLlmDecoderRuntime {
                 reason: error.to_string(),
             })?;
         let projections = load_layer_projections(&reader, &metadata)?;
-        let whole_decoder =
-            Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_rms_norm_epsilon_and_fused_logits_head(
-                &projections,
-                Some(runtime_source),
-                metadata.rms_norm_epsilon,
-                None,
-                backend,
-            )
-            .map_err(|error| MimoLlmDecoderError::GraphFailed {
-                reason: error.to_string(),
-            })?;
         let logits_head = load_llm_logits_head_from_reader_with_tensor_names(
             &reader,
             runtime_source,
@@ -126,6 +124,24 @@ impl MimoLlmDecoderRuntime {
         .map_err(|error| MimoLlmDecoderError::LogitsHeadFailed {
             reason: error.to_string(),
         })?;
+        // Keep the output projection in the same static arena as the resident
+        // decoder graph so Metal/GPU decode can return a device-side top-1
+        // token per step instead of building a separate full-vocab logits
+        // graph and reading the whole row back to the host -- mirrors
+        // `moss_transcribe_diarize::llm_decoder`'s identical wiring (mimo's
+        // registered policy has no suppression or phrase bias, so the shared
+        // driver can always honor the hint).
+        let whole_decoder =
+            Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_rms_norm_epsilon_and_fused_logits_head(
+                &projections,
+                Some(runtime_source),
+                metadata.rms_norm_epsilon,
+                logits_head.fused_top1_spec(),
+                backend,
+            )
+            .map_err(|error| MimoLlmDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?;
         let token_embedding = load_token_embedding_table_from_reader_with_tensor_name(
             &reader,
             TOKEN_EMBD_WEIGHT,
@@ -192,7 +208,7 @@ impl MimoLlmDecoderRuntime {
         prompt_embeddings: &Qwen3AsrPromptEmbeddings,
         layer_kv_caches: &mut [Qwen3AsrLayerKvCacheState],
         control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
-    ) -> Result<Vec<f32>, MimoLlmDecoderError> {
+    ) -> Result<MimoLlmPrefillOutput, MimoLlmDecoderError> {
         let token_count = prompt_embeddings.token_count;
         if let Some(final_hidden) = self
             .whole_decoder
@@ -207,12 +223,28 @@ impl MimoLlmDecoderRuntime {
                 reason: error.to_string(),
             })?
         {
-            return self
+            if let Some(token_id) = self
+                .whole_decoder
+                .fused_logits_top1_from_hidden(&final_hidden)
+                .map_err(|error| MimoLlmDecoderError::GraphFailed {
+                    reason: error.to_string(),
+                })?
+            {
+                return Ok(MimoLlmPrefillOutput {
+                    logits: Vec::new(),
+                    greedy_token_hint: Some(token_id),
+                });
+            }
+            let logits = self
                 .logits_head
                 .compute_logits_for_last_hidden(&final_hidden)
                 .map_err(|error| MimoLlmDecoderError::LogitsHeadFailed {
                     reason: error.to_string(),
-                });
+                })?;
+            return Ok(MimoLlmPrefillOutput {
+                logits,
+                greedy_token_hint: None,
+            });
         }
         let step = self
             .whole_decoder
@@ -225,11 +257,16 @@ impl MimoLlmDecoderRuntime {
                 reason: error.to_string(),
             })?;
         let final_hidden = self.write_prefill_outputs(0, token_count, &step, layer_kv_caches)?;
-        self.logits_head
+        let logits = self
+            .logits_head
             .compute_logits_for_last_hidden(&final_hidden)
             .map_err(|error| MimoLlmDecoderError::LogitsHeadFailed {
                 reason: error.to_string(),
-            })
+            })?;
+        Ok(MimoLlmPrefillOutput {
+            logits,
+            greedy_token_hint: None,
+        })
     }
 
     pub(crate) fn decode_step(
@@ -266,6 +303,42 @@ impl MimoLlmDecoderRuntime {
             .map_err(|error| MimoLlmDecoderError::LogitsHeadFailed {
                 reason: error.to_string(),
             })
+    }
+
+    /// On the resident Metal/GPU reuse graph, return the decoder's device-side
+    /// argmax directly. mimo-asr's registered policy has no suppression or
+    /// phrase bias, so the shared greedy driver can safely consume this as a
+    /// validated `greedy_token_hint`; CPU and any non-reuse backend fall back
+    /// to the full host logits path above. Mirrors
+    /// `moss_transcribe_diarize::llm_decoder::decode_step_reused_top1`.
+    pub(crate) fn decode_step_reused_top1(
+        &mut self,
+        token_id: u32,
+        cache_position: usize,
+        layer_kv_caches: &[Qwen3AsrLayerKvCacheState],
+    ) -> Result<Option<u32>, MimoLlmDecoderError> {
+        if !self.whole_decoder.supports_graph_reuse() || !self.whole_decoder.supports_fused_top1() {
+            return Ok(None);
+        }
+        let max_positions = layer_kv_caches
+            .first()
+            .map(Qwen3AsrLayerKvCacheState::max_positions)
+            .ok_or_else(|| MimoLlmDecoderError::KvCacheFailed {
+                reason: "mimo-asr backbone has no layer KV caches".to_string(),
+            })?;
+        let hidden = self.gather_token_embedding(token_id)?;
+        let step = self
+            .whole_decoder
+            .run_step_reused_batched_top1(
+                &hidden,
+                &[cache_position],
+                self.metadata.rope_theta,
+                max_positions,
+            )
+            .map_err(|error| MimoLlmDecoderError::GraphFailed {
+                reason: error.to_string(),
+            })?;
+        Ok(Some(step.token_id))
     }
 
     fn write_prefill_outputs(

--- a/crates/openasr-core/src/models/mimo_asr/mod.rs
+++ b/crates/openasr-core/src/models/mimo_asr/mod.rs
@@ -13,6 +13,7 @@
 //! decode-policy registration, and the dedicated executor.
 
 mod audio_tokenizer_graph;
+pub(crate) mod capacity;
 mod decode_prompt;
 pub(crate) mod executor;
 mod input_local_graph;

--- a/crates/openasr-core/src/models/qwen/audio_encoder.rs
+++ b/crates/openasr-core/src/models/qwen/audio_encoder.rs
@@ -719,6 +719,23 @@ fn conv_out_len(input: usize) -> usize {
     (input + 2 * QWEN3_AUDIO_CONV_PADDING - QWEN3_AUDIO_CONV_KERNEL) / QWEN3_AUDIO_CONV_STRIDE + 1
 }
 
+/// Post-encoder audio tokens this family splices into the decoder prompt for
+/// `mel_frames` input mel frames -- the exact row count
+/// `pack_mel_into_chunked_layout` produces (`num_chunks * chunk_output_frames`),
+/// exposed so `capacity` counts the same prompt audio tokens the decode path
+/// actually builds rather than a drifting approximation. Each
+/// `QWEN3_AUDIO_CHUNK_FRAMES`-frame chunk (a partial tail chunk is padded to a
+/// full one) passes through the three stride-2 conv stems, so it contributes
+/// `conv_out_len^3(chunk_frames)` rows; zero frames emit zero tokens.
+pub(crate) fn qwen3_audio_token_count_for_mel_frames(mel_frames: usize) -> usize {
+    if mel_frames == 0 {
+        return 0;
+    }
+    let num_chunks = mel_frames.div_ceil(QWEN3_AUDIO_CHUNK_FRAMES);
+    let chunk_output_frames = conv_out_len(conv_out_len(conv_out_len(QWEN3_AUDIO_CHUNK_FRAMES)));
+    num_chunks.saturating_mul(chunk_output_frames)
+}
+
 fn build_audio_positional_embedding(
     d_model: usize,
     positions: usize,

--- a/crates/openasr-core/src/models/qwen/capacity.rs
+++ b/crates/openasr-core/src/models/qwen/capacity.rs
@@ -1,0 +1,224 @@
+//! qwen3-asr capacity derivation: the family's decoder KV geometry and the
+//! decoder positions a single decode of a given audio span needs, assembled
+//! from PACK METADATA (`Qwen3AsrExecutionMetadata`) plus family constants, so
+//! the shared host-memory admission check
+//! ([`crate::capacity::evaluate_host_memory_admission`]) can refuse a request
+//! that plainly cannot fit BEFORE the ggml graph build turns the shortfall
+//! into an opaque `ggml cpu graph backend buffer allocation failed` (issue
+//! #159's root cause on CPU). It is the qwen3 analogue of
+//! [`crate::models::moss_transcribe_diarize::capacity`].
+//!
+//! Reuses, never re-derives:
+//! - KV geometry comes straight off the parsed pack (`llm_layers` /
+//!   `llm_kv_heads` / `llm_head_dim` are required metadata keys).
+//! - The prompt's audio-token count is
+//!   [`super::audio_encoder::qwen3_audio_token_count_for_mel_frames`], the
+//!   exact row count the decode path splices into the prompt.
+//! - The generation budget reuses the same `QWEN3_DECODE_*` constants and the
+//!   `llm_max_positions` context clamp the runtime's
+//!   `qwen3_generated_token_budget` / `required_max_positions_for_job` apply,
+//!   so admission argues from the same position ceiling the real decode does.
+
+use crate::capacity::KvGeometry;
+use crate::models::decode_token_history::context_window_budget;
+
+use super::audio_encoder::qwen3_audio_token_count_for_mel_frames;
+use super::ggml_executor::{
+    QWEN3_DECODE_MIN_GENERATED_TOKENS, QWEN3_DECODE_TOKEN_BUDGET_MARGIN,
+    QWEN3_DECODE_TOKENS_PER_AUDIO_SECOND,
+};
+use super::runtime_contract::Qwen3AsrExecutionMetadata;
+
+/// The audio a single qwen3 decode is estimated to fold in, for admission.
+/// qwen3-asr is [`crate::arch::OpenAsrLongformSliceShape::SharedWindow`]: a
+/// recording longer than this is sliced by the shared slicer and each slice is
+/// its own decode, so no single decode's KV cache ever spans more than one
+/// window's audio. Clamping the admission estimate here (the analogue of
+/// moss's `integral_seconds` clamp) is what keeps a multi-hour recording from
+/// being judged -- and falsely rejected -- as if it decoded whole. The shared
+/// slicer's generic safety chunk is the honest, backend-independent single-
+/// slice bound; a user who forces a larger `longform.chunk_seconds` only makes
+/// admission MORE permissive (an under-estimate resolves to "allow", per
+/// `crate::capacity`'s fail-open invariant), never falsely rejecting.
+pub(crate) const QWEN3_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS: f32 =
+    crate::arch::DEFAULT_ENCODER_SAFE_CHUNK_SECONDS;
+
+/// Fixed ChatML wrapper tokens around the audio span (`<|im_start|>system ...
+/// <|audio_start|>` prefix + `<|audio_end|> ... <|im_start|>assistant` suffix,
+/// see `super::decode_prompt::build_qwen3_decode_prompt`). A small conservative
+/// figure: it is dwarfed by the audio-token term at any real duration, and the
+/// whole required-positions estimate is bounded by `llm_max_positions`, so its
+/// exact value cannot swing an admission decision.
+const QWEN3_ADMISSION_FIXED_PROMPT_TOKENS: usize = 32;
+
+/// The decoder KV geometry the loaded pack advertises.
+pub(crate) fn qwen3_kv_geometry(metadata: &Qwen3AsrExecutionMetadata) -> KvGeometry {
+    KvGeometry {
+        n_layers: metadata.llm_layers,
+        kv_heads: metadata.llm_kv_heads,
+        head_dim: metadata.llm_head_dim,
+    }
+}
+
+/// Desired generation budget (before the context clamp) for `audio_seconds` of
+/// audio: the family's per-second token allowance plus a fixed margin, floored
+/// at the short-audio minimum. The seconds-based twin of the sample-count
+/// arithmetic in `super::ggml_executor::qwen3_generated_token_budget`; both
+/// read the same `QWEN3_DECODE_*` constants and
+/// `qwen3_admission_desired_generation_matches_runtime_budget` pins them equal
+/// on whole-second inputs so the two never drift.
+fn qwen3_desired_generated_tokens_for_seconds(audio_seconds: f32) -> usize {
+    let audio_rate_budget =
+        (audio_seconds.max(0.0) * QWEN3_DECODE_TOKENS_PER_AUDIO_SECOND as f32).ceil() as usize;
+    audio_rate_budget
+        .saturating_add(QWEN3_DECODE_TOKEN_BUDGET_MARGIN)
+        .max(QWEN3_DECODE_MIN_GENERATED_TOKENS)
+}
+
+/// Decoder positions a single decode of `audio_duration_seconds` requires, the
+/// admission figure `evaluate_host_memory_admission` charges KV bytes against.
+/// The audio is clamped to [`QWEN3_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS`]
+/// (one slice's worth), the prompt is the fixed wrapper plus the exact spliced
+/// audio-token count, the generation budget is the family's measured demand
+/// clamped to the remaining context, and the whole figure is capped at
+/// `llm_max_positions` -- the same ceiling the runtime allocates against.
+pub(crate) fn qwen3_admission_required_positions(
+    metadata: &Qwen3AsrExecutionMetadata,
+    audio_duration_seconds: f32,
+) -> usize {
+    let admission_seconds =
+        audio_duration_seconds.clamp(0.0, QWEN3_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS);
+    let sample_rate = metadata.sample_rate_hz.max(1) as f32;
+    let hop = metadata.hop_length.max(1) as f32;
+    let mel_frames = (admission_seconds * sample_rate / hop) as usize;
+    let audio_tokens = qwen3_audio_token_count_for_mel_frames(mel_frames);
+    let prompt_tokens = QWEN3_ADMISSION_FIXED_PROMPT_TOKENS.saturating_add(audio_tokens);
+    let desired_generation = qwen3_desired_generated_tokens_for_seconds(admission_seconds);
+    // Same context clamp the runtime applies: generation may only use what the
+    // decoder positions past the prompt leave; a prompt that already fills the
+    // context leaves nothing to generate (the runtime fails that request
+    // closed separately -- admission just stops charging past the ceiling).
+    let generation = context_window_budget(metadata.llm_max_positions, prompt_tokens)
+        .map(|remaining| desired_generation.min(remaining))
+        .unwrap_or(0);
+    prompt_tokens
+        .saturating_add(generation)
+        .min(metadata.llm_max_positions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capacity::{KvGeometry, kv_bytes_per_position};
+    use crate::nn::decoder::LlmKvCacheSpec;
+
+    /// Real-checkpoint-shaped metadata (the 1.7B config: 28-layer GQA decoder,
+    /// 8 KV heads, head_dim 128, 40960-position context, 16kHz/160-hop mel).
+    fn reference_metadata() -> Qwen3AsrExecutionMetadata {
+        Qwen3AsrExecutionMetadata {
+            sample_rate_hz: 16_000,
+            n_mels: 128,
+            n_fft: 400,
+            win_length: 400,
+            hop_length: 160,
+            audio_layers: 18,
+            audio_d_model: 896,
+            audio_heads: 14,
+            llm_layers: 28,
+            llm_d_model: 1024,
+            llm_heads: 16,
+            llm_kv_heads: 8,
+            llm_head_dim: 128,
+            vocab_size: 151_936,
+            llm_max_positions: 40_960,
+            audio_start_token_id: 11,
+            audio_end_token_id: 12,
+            audio_pad_token_id: 13,
+            eos_token_id: 14,
+            pad_token_id: 15,
+        }
+    }
+
+    #[test]
+    fn kv_geometry_reads_the_llm_decoder_metadata() {
+        let geometry = qwen3_kv_geometry(&reference_metadata());
+        assert_eq!(
+            geometry,
+            KvGeometry {
+                n_layers: 28,
+                kv_heads: 8,
+                head_dim: 128,
+            }
+        );
+        // The geometry feeds the shared KV byte model without error (the same
+        // 448-row/position shape the runtime_contract capacity anchor pins).
+        let default = kv_bytes_per_position(&geometry, LlmKvCacheSpec::DEFAULT).expect("default");
+        assert_eq!(default.total(), 448 * 768);
+    }
+
+    #[test]
+    fn required_positions_is_clamped_to_the_single_decode_window() {
+        let metadata = reference_metadata();
+        // 30s and 3600s clamp to the same single-decode window, so a multi-hour
+        // recording is never judged as one giant decode (the false-reject the
+        // clamp exists to prevent).
+        let at_window = qwen3_admission_required_positions(
+            &metadata,
+            QWEN3_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS,
+        );
+        let at_hour = qwen3_admission_required_positions(&metadata, 3600.0);
+        assert_eq!(at_window, at_hour);
+        // A short clip needs strictly fewer positions than a full window.
+        let short = qwen3_admission_required_positions(&metadata, 5.0);
+        assert!(short < at_window, "short={short} window={at_window}");
+        // Every estimate stays within the pack's advertised context ceiling.
+        assert!(at_window <= metadata.llm_max_positions);
+    }
+
+    #[test]
+    fn required_positions_counts_audio_tokens_and_generation() {
+        let metadata = reference_metadata();
+        // 30s at 16kHz/160-hop = 3000 mel frames -> ceil(3000/100)=30 chunks *
+        // conv_out_len^3(100)=13 = 390 audio tokens; prompt = 32 + 390 = 422.
+        // Desired generation = ceil(30*12)+32 = 392 (> the 128 floor).
+        // required = 422 + 392 = 814, well under the 40960 ceiling.
+        let positions = qwen3_admission_required_positions(&metadata, 30.0);
+        assert_eq!(positions, 814);
+    }
+
+    #[test]
+    fn required_positions_is_capped_at_llm_max_positions() {
+        // A pack with a tiny context ceiling: the prompt alone overruns it, so
+        // admission charges exactly the ceiling and never more (saturating, not
+        // wrapping into a small "fits" number).
+        let mut metadata = reference_metadata();
+        metadata.llm_max_positions = 64;
+        let positions = qwen3_admission_required_positions(&metadata, 30.0);
+        assert_eq!(positions, 64);
+    }
+
+    #[test]
+    fn qwen3_admission_desired_generation_matches_runtime_budget() {
+        // The seconds-based generation budget equals the runtime's sample-count
+        // arithmetic (`prepared_audio.len() * 12 / sample_rate`, ceil) on a
+        // whole-second input -- the shared-constant contract that keeps the
+        // admission estimate from drifting off the real decode budget.
+        for seconds in [1usize, 3, 10, 30] {
+            let sample_rate = 16_000usize;
+            let samples = seconds * sample_rate;
+            let runtime_audio_rate = samples
+                .checked_mul(QWEN3_DECODE_TOKENS_PER_AUDIO_SECOND)
+                .and_then(|value| value.checked_add(sample_rate - 1))
+                .and_then(|value| value.checked_div(sample_rate))
+                .expect("no overflow");
+            let runtime_desired = runtime_audio_rate
+                .saturating_add(QWEN3_DECODE_TOKEN_BUDGET_MARGIN)
+                .max(QWEN3_DECODE_MIN_GENERATED_TOKENS);
+            let admission_desired = qwen3_desired_generated_tokens_for_seconds(seconds as f32);
+            assert_eq!(
+                admission_desired, runtime_desired,
+                "generation budget drifted at {seconds}s"
+            );
+        }
+    }
+}

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -575,9 +575,17 @@ impl Qwen3AsrGgmlExecutor {
                 decoder
             }
             None => {
+                // The fused spec is `None` for packs whose output weight is not
+                // directly loadable in the `[hidden, vocab]` layout; the decoder
+                // then reports `supports_fused_top1() == false` and every step
+                // stays on the host logits path -- fail-closed, never a wrong
+                // token. LoRA never targets the lm-head stage (see
+                // `new_with_lora`'s doc comment), so the fused head is safe to
+                // keep alongside an active adapter.
                 let decoder = Qwen3AsrLlmWholeDecoderGraphExecutor::new_with_lora(
                     &layer_attention_projections,
                     Some(runtime_source),
+                    logits_head.fused_top1_spec(),
                     adapter.as_deref(),
                     backend,
                 )
@@ -622,6 +630,13 @@ impl Qwen3AsrGgmlExecutor {
             whole_decoder,
             cache_prompt_tokens: 1,
             consumed_prefill_step: false,
+            fused_top1_hint_allowed: qwen_fused_top1_hint_allowed(
+                request.request_options.word_timestamps,
+                request
+                    .request_options
+                    .word_timestamps_forced_for_diarization,
+                request.request_options.phrase_bias.is_some(),
+            ),
             control: Arc::clone(&request.execution_context.control),
         };
         let decode_text_token_ids = |token_ids: &[u32]| {
@@ -1016,6 +1031,46 @@ impl LayerCountResolver for Qwen3AsrLayerCountResolver {
     }
 }
 
+/// Whether this request may take the fused device-side top-1 (hint-only) lane.
+///
+/// Hint-only steps report `probability: 0.0` and never materialize a host
+/// logit row, so they are only taken when nothing about the request consumes
+/// that row:
+///
+/// - USER-REQUESTED `word_timestamps` feeds `generated_probabilities` into
+///   the emitted per-word confidences, so a zeroed probability would change
+///   the output. The CLI transcribe path, however, force-enables
+///   `word_timestamps` for EVERY non-whisper family purely to obtain word
+///   anchors for cue segmentation / diarization turn-splitting and then
+///   strips the words from the result (`word_timestamps_forced_for_diarization`
+///   marks exactly that case). Word anchor TIMES are index-positional
+///   (`seq2seq_word_timestamps_from_generated_tokens` never reads
+///   probabilities for timing) and the cue splitter emits `confidence: None`,
+///   so on the forced-and-stripped lane the probabilities are invisible to
+///   the output and the fused lane stays byte-identical.
+/// - A phrase-bias request makes the shared driver require the full row to
+///   apply biases (a hint-only step would fail closed on `EmptyStepLogits`).
+///
+/// Both gates are decided per request; the fused head stays resident in the
+/// whole-decoder arena either way so a cached decoder serves both kinds of
+/// request.
+fn qwen_fused_top1_hint_allowed(
+    word_timestamps: bool,
+    word_timestamps_forced_for_diarization: bool,
+    has_phrase_bias: bool,
+) -> bool {
+    (!word_timestamps || word_timestamps_forced_for_diarization) && !has_phrase_bias
+}
+
+/// Prefill output for the shared greedy driver's step 0: the host logits row
+/// for the first generated token, or (on the fused Metal/GPU lane) a device
+/// argmax hint with no host row -- mirrors
+/// `moss_transcribe_diarize::llm_decoder::MossTdPrefillOutput`.
+struct Qwen3AsrPrefillStepOutput {
+    logits: Vec<f32>,
+    greedy_token_hint: Option<u32>,
+}
+
 struct Qwen3AsrPrefillOnlyGreedyStepExecutor {
     metadata: Qwen3AsrExecutionMetadata,
     prefill_input: super::llm_prefill::Qwen3AsrLlmPrefillInput,
@@ -1025,6 +1080,9 @@ struct Qwen3AsrPrefillOnlyGreedyStepExecutor {
     whole_decoder: Qwen3AsrLlmWholeDecoderGraphExecutor,
     cache_prompt_tokens: usize,
     consumed_prefill_step: bool,
+    /// See [`qwen_fused_top1_hint_allowed`]. `true` only for requests that
+    /// never consume a host logit row (no word timestamps, no phrase bias).
+    fused_top1_hint_allowed: bool,
     /// Explicit cancel/pause/resume control for this decode -- never a
     /// thread-local. See [`crate::RequestExecutionContext`].
     control: Arc<crate::api::backend::TranscriptionControl>,
@@ -1043,7 +1101,7 @@ impl Seq2SeqGreedyDecodeStepExecutor for Qwen3AsrPrefillOnlyGreedyStepExecutor {
             // Preserve typed cancel from the prefill chunk loop so the shared
             // greedy driver (and dispatch_error_to_backend) see Canceled, not a
             // generic DecoderStepFailed.
-            let logits = self.prefill_prompt_and_compute_last_logits().map_err(|error| {
+            let prefill = self.prefill_prompt_and_compute_last_logits().map_err(|error| {
                 match error {
                     Qwen3AsrGreedyDecodeError::Canceled => {
                         crate::models::seq2seq_greedy_decode::Seq2SeqGreedyDecodeError::Canceled
@@ -1055,8 +1113,8 @@ impl Seq2SeqGreedyDecodeStepExecutor for Qwen3AsrPrefillOnlyGreedyStepExecutor {
             })?;
             self.consumed_prefill_step = true;
             return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
-                logits,
-                greedy_token_hint: None,
+                logits: prefill.logits,
+                greedy_token_hint: prefill.greedy_token_hint,
             });
         }
 
@@ -1077,6 +1135,19 @@ impl Seq2SeqGreedyDecodeStepExecutor for Qwen3AsrPrefillOnlyGreedyStepExecutor {
                     reason: "qwen3-asr decode cache position underflowed".to_string(),
                 }
             })?;
+        if let Some(token_id) = self
+            .decode_step_reused_top1(input.generated_tokens, cache_position)
+            .map_err(|error| {
+                crate::models::seq2seq_greedy_decode::Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                    reason: error.to_string(),
+                }
+            })?
+        {
+            return Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+                logits: Vec::new(),
+                greedy_token_hint: Some(token_id),
+            });
+        }
         let mut hidden = self
             .gather_last_generated_token_hidden(input.generated_tokens)
             .map_err(|error| {
@@ -1130,9 +1201,44 @@ fn map_prefill_graph_error(error: GgmlCpuGraphError) -> Qwen3AsrGreedyDecodeErro
 }
 
 impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
+    /// On the resident Metal/GPU reuse graph, return the decoder's device-side
+    /// argmax for the next token directly (zero host logits materialization,
+    /// zero full-vocab readback), or `None` to stay on the host logits path --
+    /// mirrors `moss_transcribe_diarize::llm_decoder::decode_step_reused_top1`.
+    /// Gated on [`Self::fused_top1_hint_allowed`] because qwen (unlike moss)
+    /// serves requests that consume the host row (word timestamps, phrase
+    /// bias); those keep the byte-identical host path.
+    fn decode_step_reused_top1(
+        &mut self,
+        generated_tokens: &[u32],
+        cache_position: usize,
+    ) -> Result<Option<u32>, Qwen3AsrGreedyDecodeError> {
+        if !self.fused_top1_hint_allowed
+            || !self.whole_decoder.supports_graph_reuse()
+            || !self.whole_decoder.supports_fused_top1()
+        {
+            return Ok(None);
+        }
+        let max_positions = self
+            .layer_kv_caches
+            .first()
+            .map(Qwen3AsrLayerKvCacheState::max_positions)
+            .ok_or_else(|| Qwen3AsrGreedyDecodeError::DecoderStepFailed {
+                reason: "qwen3-asr decoder has no layer KV caches".to_string(),
+            })?;
+        let hidden = self.gather_last_generated_token_hidden(generated_tokens)?;
+        let step = self
+            .whole_decoder
+            .run_step_reused_batched_top1(&hidden, &[cache_position], 1_000_000.0, max_positions)
+            .map_err(|error| Qwen3AsrGreedyDecodeError::DecoderStepFailed {
+                reason: error.to_string(),
+            })?;
+        Ok(Some(step.token_id))
+    }
+
     fn prefill_prompt_and_compute_last_logits(
         &mut self,
-    ) -> Result<Vec<f32>, Qwen3AsrGreedyDecodeError> {
+    ) -> Result<Qwen3AsrPrefillStepOutput, Qwen3AsrGreedyDecodeError> {
         let profile_started_at = qwen_decode_profile_start();
         let token_count = self.prefill_input.token_count;
         if token_count == 0 {
@@ -1169,6 +1275,23 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
         {
             self.cache_prompt_tokens = token_count;
             qwen_decode_profile_log_opt("prefill_prompt_resident_bulk", resident_started_at);
+            // Fused device argmax for the first generated token too (mirrors
+            // moss's prefill): only when this request never needs the host
+            // row, same gate as the per-token decode steps.
+            if self.fused_top1_hint_allowed
+                && let Some(token_id) = self
+                    .whole_decoder
+                    .fused_logits_top1_from_hidden(&final_hidden)
+                    .map_err(|error| Qwen3AsrGreedyDecodeError::DecoderStepFailed {
+                        reason: error.to_string(),
+                    })?
+            {
+                qwen_decode_profile_log_opt("prefill_prompt_total", profile_started_at);
+                return Ok(Qwen3AsrPrefillStepOutput {
+                    logits: Vec::new(),
+                    greedy_token_hint: Some(token_id),
+                });
+            }
             let result = self
                 .logits_head
                 .compute_logits_for_last_hidden(&final_hidden)
@@ -1176,7 +1299,10 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
                     reason: error.to_string(),
                 });
             qwen_decode_profile_log_opt("prefill_prompt_total", profile_started_at);
-            return result;
+            return result.map(|logits| Qwen3AsrPrefillStepOutput {
+                logits,
+                greedy_token_hint: None,
+            });
         }
         let Some(chunk_size) = self
             .whole_decoder
@@ -1188,11 +1314,17 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor {
             // over the historical serial launch storm.
             let result = self.prefill_prompt_bulk_host_and_compute_last_logits();
             qwen_decode_profile_log_opt("prefill_prompt_total", profile_started_at);
-            return result;
+            return result.map(|logits| Qwen3AsrPrefillStepOutput {
+                logits,
+                greedy_token_hint: None,
+            });
         };
         let result = self.prefill_prompt_chunked_and_compute_last_logits(chunk_size);
         qwen_decode_profile_log_opt("prefill_prompt_total", profile_started_at);
-        result
+        result.map(|logits| Qwen3AsrPrefillStepOutput {
+            logits,
+            greedy_token_hint: None,
+        })
     }
 
     fn prefill_prompt_bulk_host_and_compute_last_logits(
@@ -1600,6 +1732,30 @@ mod tests {
 
     fn qwen_metadata() -> BTreeMap<String, String> {
         qwen_metadata_with_llm_layers(2)
+    }
+
+    /// The fused hint-only lane must never serve a request that consumes the
+    /// host logit row: USER-REQUESTED word timestamps feed per-token
+    /// probabilities into the emitted word confidences, and phrase bias needs
+    /// the full row for the driver to apply biases (a hint-only step would
+    /// fail closed). Word timestamps that were only force-enabled for cue
+    /// segmentation / diarization anchors (and are stripped from the result)
+    /// never surface a probability, so that lane stays fused-eligible --
+    /// otherwise the standard CLI transcribe path (which always forces them
+    /// for non-whisper families) would never take the fused lane at all.
+    #[test]
+    fn fused_top1_hint_gate_rejects_row_consuming_requests() {
+        // Plain request: fused allowed.
+        assert!(qwen_fused_top1_hint_allowed(false, false, false));
+        // Forced-and-stripped word anchors (the standard CLI transcribe
+        // shape): probabilities are invisible, fused stays allowed.
+        assert!(qwen_fused_top1_hint_allowed(true, true, false));
+        // User-requested word timestamps: confidences are emitted, host row
+        // required.
+        assert!(!qwen_fused_top1_hint_allowed(true, false, false));
+        // Phrase bias always requires the host row.
+        assert!(!qwen_fused_top1_hint_allowed(false, false, true));
+        assert!(!qwen_fused_top1_hint_allowed(true, true, true));
     }
 
     fn add_audio_layer_shapes(spec: TinyGgufFixtureSpec, layer_idx: usize) -> TinyGgufFixtureSpec {

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -145,9 +145,9 @@ fn encode_qwen_audio_embeddings_cached(
 
 const QWEN3_EXECUTOR_ID: &str = "qwen3-asr-ggml-executor-v1";
 const QWEN3_STREAMING_EXECUTOR_ID: &str = "qwen3-asr-ggml-snapshot-streaming-executor-v1";
-const QWEN3_DECODE_MIN_GENERATED_TOKENS: usize = 128;
-const QWEN3_DECODE_TOKENS_PER_AUDIO_SECOND: usize = 12;
-const QWEN3_DECODE_TOKEN_BUDGET_MARGIN: usize = 32;
+pub(crate) const QWEN3_DECODE_MIN_GENERATED_TOKENS: usize = 128;
+pub(crate) const QWEN3_DECODE_TOKENS_PER_AUDIO_SECOND: usize = 12;
+pub(crate) const QWEN3_DECODE_TOKEN_BUDGET_MARGIN: usize = 32;
 const QWEN3_DECODE_PROFILE_ENV: &str = "OPENASR_QWEN_DECODE_PROFILE";
 
 fn qwen_decode_profile_enabled() -> bool {

--- a/crates/openasr-core/src/models/qwen/graph_config.rs
+++ b/crates/openasr-core/src/models/qwen/graph_config.rs
@@ -6,18 +6,18 @@ use crate::models::graph_runtime_config::{
     has_explicit_thread_override,
 };
 
-/// qwen is NOT gated (`AutoGpuPolicy::AllBackends`, see `arch::mod`) as of
-/// this audit. The measured 1.71x Metal slowdown at qwen's recommended 1.7B
-/// @ q8_0 config looks like a fixed `size x quant` platform trade-off rather
-/// than a qwen-specific code bug -- mimo/firered-llm share this exact decode
-/// driver (fused logits head, on-device argmax, persistent reused decode
-/// graph, scheduler-off) and measure clearly *faster* on Metal at their 8B @
-/// q4_k config -- but that read is not yet confirmed by a dedicated
-/// follow-up investigation, so it is deliberately left un-gated rather than
-/// baking an unconfirmed platform verdict into the default. If a follow-up
-/// study confirms the trade-off (or finds an actual fix), flipping qwen to
-/// `AutoGpuPolicy::ExceptMetal` here and in its `arch::mod` descriptor is a
-/// one-line change (the `AutoGpuPolicy` gate machinery already exists, see
+/// qwen is NOT gated (`AutoGpuPolicy::AllBackends`, see `arch::mod`), and
+/// that is the *measured-correct* default: a 2026-07 re-measurement across
+/// the full `size x quant` matrix (0.6b/1.7b x q4_k/q8_0/fp16, M1, warm
+/// compute medians) has Metal *faster* than CPU everywhere -- 1.7x-2.4x,
+/// e.g. 1.7b @ q8_0 RTF 0.327 (CPU) vs 0.180 (Metal) on an 11s clip and
+/// 0.387 vs 0.159 on a 69s clip. An early 2026-07-04 measurement of the same
+/// 1.7b @ q8_0 config had Metal 1.71x *slower*; that slowdown was an
+/// artifact of the pre-rework decode path and no longer reproduces after the
+/// decode changes (persistent reused decode graph, resident KV arena,
+/// batched resident prefill seeding). Do not re-gate Metal off that stale
+/// number. Should a future platform regression appear, the `AutoGpuPolicy`
+/// gate machinery already exists (see
 /// `xasr_zipformer::graph_config::encoder_gpu_enabled` for the pattern).
 pub(crate) fn qwen_runtime_graph_config(backend: GgmlCpuGraphBackend) -> GgmlCpuGraphConfig {
     configure_model_runtime_graph_config_from_env(

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -1072,9 +1072,12 @@ fn allocate_decode_layer_tensors(
             reason: "decode layer q/kv head ratio mismatch",
         });
     }
-    // Bias forces the split (non-fused) QKV path (see `nn::decoder::LlmLayerWeights`'
-    // doc comment) -- never build a fused-QKV synthetic tensor when bias is present.
-    let allow_fused_qkv = !has_qkv_bias;
+    // QKV bias no longer forces the split path: the fused `[q|k|v]` matmul
+    // produces the same per-projection columns, and the bias is added on the
+    // (ggml-contiguous) per-projection view/copy downstream in `nn::decoder`
+    // -- identical arithmetic to the split path, so Qwen2-shaped packs (bias,
+    // e.g. funasr/mimo) get the single-matmul decode speedup too.
+    let allow_fused_qkv = true;
 
     let attn_norm = arena.new_tensor_2d_f32(d_model, 1, "qwen_llm_decode_attn_norm_weight")?;
     let q_norm = has_qk_norm

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -1526,10 +1526,19 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
     }
 
     /// Like [`new`] but with an optional LoRA adapter injected into the decoder
-    /// graph.  Uses [`DEFAULT_RMS_NORM_EPSILON`] and no fused logits head.
+    /// graph.  Uses [`DEFAULT_RMS_NORM_EPSILON`].
+    ///
+    /// The fused logits head stays correct alongside an active adapter: LoRA
+    /// slots only ever attach to the per-layer projections
+    /// (`allocate_layer_lora_slots` -- q/k/v/o and the FFN gate/up/down), never
+    /// to the output-norm/lm-head stage, and the host
+    /// [`super::logits_head::Qwen3AsrLlmLogitsHead`] the spec is derived from
+    /// is likewise loaded from the base pack only -- both selection paths see
+    /// the identical head weights whether or not an adapter is active.
     pub(crate) fn new_with_lora(
         projections: &[Qwen3AsrLlmLayerAttentionProjection],
         runtime_source: Option<&GgmlRuntimeSource>,
+        fused_logits_head: Option<Qwen3AsrLlmFusedLogitsHeadSpec<'_>>,
         adapter: Option<&QwenLoraAdapter>,
         backend: GgmlCpuGraphBackend,
     ) -> Result<Self, GgmlCpuGraphError> {
@@ -1537,7 +1546,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             projections,
             runtime_source,
             DEFAULT_RMS_NORM_EPSILON,
-            None,
+            fused_logits_head,
             adapter,
             backend,
         )
@@ -5339,6 +5348,117 @@ mod tests {
         let token_id = validate_fused_top1_token_id(reversed_top1[0], spec.vocab_size)
             .expect("top1 should map to a valid token");
         assert_eq!(token_id, 1);
+    }
+
+    /// Pin the correctness contract every fused-top1 family (moss, and now
+    /// qwen/mimo/firered-llm) rides: the device-graph argmax must select the
+    /// exact token a host full-vocab logits row would (RMSNorm -> norm-weight
+    /// mul -> [d_model x vocab] projection -> first-max argmax), across many
+    /// deterministic pseudo-random hidden rows. The host reference below is
+    /// computed independently in-test, mirroring
+    /// `logits_head::Qwen3AsrLlmLogitsHead`'s `VocabHidden` fallback math.
+    #[test]
+    fn fused_logits_top1_matches_host_logits_argmax_over_many_hiddens() {
+        const D_MODEL: usize = 8;
+        const VOCAB: usize = 17;
+        fn deterministic_f32_vec(seed: u64, len: usize) -> Vec<f32> {
+            let mut state = seed ^ 0x9E37_79B9_7F4A_7C15;
+            let mut out = Vec::with_capacity(len);
+            for _ in 0..len {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                let unit = ((state >> 40) as u32 & 0x00FF_FFFF) as f32 / 16_777_216.0;
+                out.push(unit * 2.0 - 1.0);
+            }
+            out
+        }
+        let output_weight_values = deterministic_f32_vec(0xF0_5ED0, D_MODEL * VOCAB);
+        let output_norm_weight = deterministic_f32_vec(0x00BA_D001, D_MODEL);
+        let output_weight_bytes = output_weight_values
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect::<Vec<_>>();
+        let config = GgmlCpuGraphConfig::default();
+        let mut runner =
+            GgmlCpuGraphRunner::new(config).expect("cpu graph runner should initialize");
+        let mut arena = runner
+            .start_static_tensor_arena(config.context_bytes)
+            .expect("static arena should allocate");
+        let dims = Qwen3AsrLlmDecodeDims {
+            d_model: D_MODEL,
+            q_width: D_MODEL,
+            k_width: D_MODEL,
+            v_width: D_MODEL,
+            head_dim: D_MODEL,
+            q_heads: 1,
+            kv_heads: 1,
+        };
+        let spec = Qwen3AsrLlmFusedLogitsHeadSpec {
+            d_model: D_MODEL,
+            vocab_size: VOCAB,
+            rms_norm_epsilon: DEFAULT_RMS_NORM_EPSILON,
+            output_norm_weight: &output_norm_weight,
+            output_weight_tensor_name: "synthetic.output.weight",
+            output_weight_ggml_type: GGML_TYPE_F32,
+            output_weight_dims: &[D_MODEL, VOCAB],
+            output_weight_bytes: &output_weight_bytes,
+        };
+        let handles = allocate_fused_logits_head_tensors(&mut arena, None, dims, &spec)
+            .expect("fused logits handles should allocate");
+        upload_fused_logits_head_weights(&mut arena, &handles, &spec)
+            .expect("fused logits weights should upload");
+
+        for case in 0..32u64 {
+            let hidden = deterministic_f32_vec(0x41D_0000 + case, D_MODEL);
+
+            // Independent host reference: RMSNorm + norm-weight mul +
+            // [d_model, vocab] matvec + first-max argmax.
+            let mut sum_squares = 0.0_f32;
+            for value in &hidden {
+                sum_squares += value * value;
+            }
+            let inv_rms = (sum_squares / D_MODEL as f32 + DEFAULT_RMS_NORM_EPSILON)
+                .sqrt()
+                .recip();
+            let mut host_best_token = 0usize;
+            let mut host_best_logit = f32::NEG_INFINITY;
+            for vocab_index in 0..VOCAB {
+                let row = &output_weight_values[vocab_index * D_MODEL..(vocab_index + 1) * D_MODEL];
+                let mut logit = 0.0_f32;
+                for hidden_index in 0..D_MODEL {
+                    logit += hidden[hidden_index]
+                        * inv_rms
+                        * output_norm_weight[hidden_index]
+                        * row[hidden_index];
+                }
+                if logit > host_best_logit {
+                    host_best_logit = logit;
+                    host_best_token = vocab_index;
+                }
+            }
+
+            let mut graph = runner.start_graph();
+            let state = graph
+                .new_tensor_2d_f32(D_MODEL, 1, "synthetic_state")
+                .expect("state tensor should allocate");
+            graph.set_input(state).expect("state should be input");
+            let top1 = build_fused_logits_top1(&arena, &handles, &mut graph, state, 1)
+                .expect("fused top1 should build");
+            graph.set_output(top1).expect("top1 should be output");
+            graph
+                .set_f32_slice(state, &hidden, "synthetic_state")
+                .expect("state should upload");
+            let reversed_top1 = graph
+                .compute_output_i32(top1, 1)
+                .expect("fused top1 should compute");
+            let fused_token = validate_fused_top1_token_id(reversed_top1[0], VOCAB)
+                .expect("top1 should map to a valid token");
+            assert_eq!(
+                fused_token as usize, host_best_token,
+                "fused device argmax diverged from host full-vocab argmax for case {case}"
+            );
+        }
     }
 
     #[test]

--- a/crates/openasr-core/src/models/qwen/mod.rs
+++ b/crates/openasr-core/src/models/qwen/mod.rs
@@ -1,5 +1,6 @@
 mod audio_encoder;
 mod batched_decode;
+pub(crate) mod capacity;
 mod decode_prompt;
 mod forced_aligner_align_text;
 mod forced_aligner_import;

--- a/crates/openasr-core/src/models/qwen/token_embedding.rs
+++ b/crates/openasr-core/src/models/qwen/token_embedding.rs
@@ -3,11 +3,14 @@ use std::path::Path;
 
 use thiserror::Error;
 
-use crate::ggml_runtime::{GgufTensorDataReadError, GgufTensorDataReader};
+use crate::ggml_runtime::{
+    GgufTensorDataReadError, GgufTensorDataReader, dequantize_ggml_row_to_f32, ggml_row_size_bytes,
+};
 use crate::nn::half::f16_bits_to_f32;
 
 use super::runtime_contract::Qwen3AsrExecutionMetadata;
 use super::tensor_names::TOKEN_EMBD_WEIGHT as TOKEN_EMBEDDING_TENSOR_NAME;
+const GGML_TYPE_F32: i32 = 0;
 const GGML_TYPE_F16: i32 = 1;
 
 #[derive(Debug, Clone)]
@@ -24,6 +27,16 @@ enum TokenEmbeddingStorage {
     // Layouts use raw F16 bits to avoid eager full-table f32 materialization.
     F16Token(Vec<u16>),
     F16Hidden(Vec<u16>),
+    // Quantized, token-major ([d_model, vocab], so each ggml row is one token's
+    // embedding). The raw quantized bytes are kept and a gathered token's single
+    // row is dequantized on demand, so a large quantized vocab table is never
+    // materialized as a full f32 buffer (the dominant load-time RSS + latency
+    // cost the F16 layouts already avoid).
+    QuantizedToken {
+        data: Vec<u8>,
+        ggml_type: i32,
+        row_size: usize,
+    },
 }
 
 impl Qwen3AsrTokenEmbeddingTable {
@@ -65,6 +78,29 @@ impl Qwen3AsrTokenEmbeddingTable {
                             .and_then(|base| base.checked_add(token_index))
                             .ok_or(Qwen3AsrTokenEmbeddingError::GatherOverflow)?;
                         out.push(f16_bits_to_f32(values[src]));
+                    }
+                }
+                TokenEmbeddingStorage::QuantizedToken {
+                    data,
+                    ggml_type,
+                    row_size,
+                } => {
+                    let start = token_index
+                        .checked_mul(*row_size)
+                        .ok_or(Qwen3AsrTokenEmbeddingError::GatherOverflow)?;
+                    let end = start
+                        .checked_add(*row_size)
+                        .ok_or(Qwen3AsrTokenEmbeddingError::GatherOverflow)?;
+                    let row_bytes = data
+                        .get(start..end)
+                        .ok_or(Qwen3AsrTokenEmbeddingError::GatherOverflow)?;
+                    let row_start = out.len();
+                    dequantize_ggml_row_to_f32(*ggml_type, row_bytes, self.d_model, &mut out)
+                        .map_err(|error| Qwen3AsrTokenEmbeddingError::TensorReadFailed {
+                            reason: error.to_string(),
+                        })?;
+                    if out[row_start..].iter().any(|value| !value.is_finite()) {
+                        return Err(Qwen3AsrTokenEmbeddingError::NonFiniteValues);
                     }
                 }
             }
@@ -151,7 +187,8 @@ pub(crate) fn load_token_embedding_table_from_reader_with_tensor_name(
         });
     }
 
-    let storage = if tensor.ggml_type == GGML_TYPE_F16 {
+    let ggml_type = tensor.ggml_type;
+    let storage = if ggml_type == GGML_TYPE_F16 {
         let values = reader
             .host_tensor_f16_bits_copy_by_name(tensor_name, &dims)
             .map_err(map_tensor_read_error)?;
@@ -159,6 +196,35 @@ pub(crate) fn load_token_embedding_table_from_reader_with_tensor_name(
             TokenEmbeddingStorage::F16Token(values)
         } else {
             TokenEmbeddingStorage::F16Hidden(values)
+        }
+    } else if ggml_type != GGML_TYPE_F32 && output_major_vocab_layout {
+        // Token-major quantized table: each ggml row (ne0 == d_model) is one
+        // token, so keep the compact quantized bytes and dequantize a single
+        // row per gathered token instead of blowing the whole vocab table up to
+        // f32 at load. Non-token-major quantized layouts (rare) fall through to
+        // the f32 path below, which handles the transpose.
+        let row_size = ggml_row_size_bytes(ggml_type, d_model)
+            .ok_or(Qwen3AsrTokenEmbeddingError::GatherOverflow)?;
+        let expected_len = row_size
+            .checked_mul(vocab_size)
+            .ok_or(Qwen3AsrTokenEmbeddingError::GatherOverflow)?;
+        let data = reader
+            .host_tensor_bytes_copy_by_name(tensor_name)
+            .map_err(map_tensor_read_error)?;
+        if data.len() != expected_len {
+            return Err(Qwen3AsrTokenEmbeddingError::InvalidTensorShape {
+                tensor_name,
+                shape: render_shape(&dims),
+                reason: format!(
+                    "quantized token-embedding payload is {} bytes, expected {expected_len}",
+                    data.len()
+                ),
+            });
+        }
+        TokenEmbeddingStorage::QuantizedToken {
+            data,
+            ggml_type,
+            row_size,
         }
     } else {
         let values = reader
@@ -357,6 +423,49 @@ mod tests {
             .map(f16_bits_to_f32)
             .collect();
         assert_eq!(rows, expected);
+    }
+
+    #[test]
+    fn token_embedding_quantized_token_major_gather_matches_full_dequant() {
+        use crate::ggml_runtime::{GgmlKvElementType, dequantize_q8_0_rows};
+
+        // q8_0 block size is 32, so d_model must be a multiple of 32.
+        let d_model = 64usize;
+        let vocab_size = 5usize;
+        let mut values = Vec::with_capacity(d_model * vocab_size);
+        for token in 0..vocab_size {
+            for hidden in 0..d_model {
+                values.push(((token * 7 + hidden) as f32) * 0.013 - 0.4);
+            }
+        }
+        let data = GgmlKvElementType::Q8_0
+            .quantize_rows_from_f32(&values, d_model, vocab_size)
+            .expect("quantize q8_0 token rows");
+        let row_size = data.len() / vocab_size;
+        let reference =
+            dequantize_q8_0_rows(&data, d_model, vocab_size).expect("reference dequant");
+
+        let table = Qwen3AsrTokenEmbeddingTable {
+            d_model,
+            vocab_size,
+            storage: TokenEmbeddingStorage::QuantizedToken {
+                data,
+                ggml_type: 8, // GGML_TYPE_Q8_0
+                row_size,
+            },
+        };
+
+        let order = [3usize, 0, 4];
+        let token_ids: Vec<u32> = order.iter().map(|&t| t as u32).collect();
+        let gathered = table.gather_rows(&token_ids).expect("gather");
+        assert_eq!(gathered.len(), order.len() * d_model);
+        // Per-row lazy dequant must be byte-identical to dequantizing the whole
+        // table up front (same ggml `to_float` trait), just without the f32 blow-up.
+        for (out_idx, &token) in order.iter().enumerate() {
+            let gathered_row = &gathered[out_idx * d_model..(out_idx + 1) * d_model];
+            let reference_row = &reference[token * d_model..(token + 1) * d_model];
+            assert_eq!(gathered_row, reference_row, "token {token} row must match");
+        }
     }
 
     #[test]

--- a/crates/openasr-core/src/models/resident_runtime_audit.rs
+++ b/crates/openasr-core/src/models/resident_runtime_audit.rs
@@ -1,0 +1,300 @@
+//! Model-agnostic integration gates for two runtime-cost invariants that used
+//! to be enforced only by prose in `docs/MODEL_ONBOARDING.md` plus a human's
+//! eyes on the published model card -- which is exactly how families slipped
+//! through rebuilding their whole runtime per request (mimo-asr) or (in earlier
+//! incidents) dequantizing weights to host f32.
+//!
+//! These are **source-tree audits** (tests only; nothing here ships in a
+//! release binary), the same lever `family_integration_audit`'s test-only
+//! checks use to lock an SSOT list against the on-disk tree. They read the
+//! repository source under `CARGO_MANIFEST_DIR`, so they run in CI with no
+//! model packs and no inference, and they fail closed the moment a NEW family's
+//! source is added without meeting the invariant -- catching the next family at
+//! integration time instead of after publishing.
+//!
+//! - **K1 (keep quantized):** [`k1_host_f32_loader_sites_match_inventory`] locks
+//!   the set of source files that materialize a tensor to a host `Vec<f32>`
+//!   (via the reader's `host_tensor_f32_copy*` helpers) against the committed
+//!   inventory `docs/model-audits/host_f32_loader_sites.txt`. A new host-f32
+//!   loader site turns CI red until it is added to the inventory -- which is the
+//!   point of human review: the reviewer certifies it loads only tensors that
+//!   legitimately stay f32/f16 (norms, biases, conv kernels, get_rows
+//!   embeddings, positional tables), NOT a rank-2 `mul_mat` weight, which must
+//!   bind natively (`weight_tensor_payload_by_name` + `new_matmul_weight_2d_typed`;
+//!   see `dolphin::executor::insert_pool_tensor` classifying per tensor). This
+//!   is the structural complement to the pack-header quant floor
+//!   (`pack_quant_audit`) and the model card's RAM-ordering self-check.
+//!
+//! - **K2 (resident reuse):** [`k2_every_ggml_executor_family_is_classified`]
+//!   and [`k2_resident_families_reference_a_resident_cache`] require every
+//!   dedicated ggml-executor family (a `models/<family>/executor.rs` or
+//!   `ggml_executor.rs`) to be classified in [`GGML_EXECUTOR_FAMILY_GATES`] and,
+//!   unless explicitly exempt, to reference a resident runtime-cache primitive
+//!   in its own module (so a per-request `Runtime::new()` rebuild has somewhere
+//!   to be cached). A new family's executor file added without a table entry
+//!   fails the completeness lock; classified as resident without a cache
+//!   primitive fails the structural check. The byte-identity of a cache HIT vs a
+//!   fresh build is proved per family by that family's own dev-pack e2e test
+//!   (e.g. mimo-asr's / firered-llm's
+//!   `resident_*_cache_reuse_across_consecutive_calls_stays_byte_identical`),
+//!   which this static gate backstops.
+
+#![cfg(test)]
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// The committed K1 inventory (see the file's own header for the contract).
+const HOST_F32_LOADER_SITES_INVENTORY: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/model-audits/host_f32_loader_sites.txt"
+));
+
+/// Reader helpers that materialize a tensor into a host `Vec<f32>`. Any source
+/// file calling one of these is a "host-f32 loader site" for K1.
+const HOST_F32_LOADER_CALLS: &[&str] = &[
+    "host_tensor_f32_copy_dequantized_by_name",
+    "host_tensor_f32_copy_by_name",
+    "host_tensor_f32_copy_by_id",
+];
+
+/// Source-token signatures of a resident runtime-cache primitive. A family that
+/// reuses a prepared runtime across requests references at least one of these
+/// (a thread-local generation-tagged cache, the shared prepared-runtime cache,
+/// or a content-id-keyed process weights pool such as dolphin's). This is the
+/// K2 "there is somewhere the per-request runtime is kept resident" signal.
+const RESIDENT_CACHE_PRIMITIVES: &[&str] = &[
+    "thread_local!",
+    "take_generation_tagged",
+    "with_thread_local_cached_mut_by_key",
+    "PreparedRuntimeCache",
+    "take_cached_",
+    "store_cached_",
+    "DolphinRuntimeWeights",
+    "weights_pool",
+    "runtime_prepared_registry",
+    "UnloadGenerationGated",
+    "BoundedRuntimeCache",
+];
+
+/// Classification of one dedicated ggml-executor family for the K2 gate.
+#[derive(Debug, Clone, Copy)]
+enum ResidentClassification {
+    /// The family reuses a resident runtime across requests; the structural
+    /// check asserts it references a [`RESIDENT_CACHE_PRIMITIVES`] token.
+    Resident,
+    /// The family legitimately does not keep a resident runtime. The reason is
+    /// recorded and must be non-empty; no family currently needs this, but the
+    /// slot exists so a genuinely one-shot family can be admitted with review
+    /// rather than by silently weakening the gate.
+    #[allow(dead_code)]
+    Exempt(&'static str),
+}
+
+/// Every dedicated ggml-executor family and its K2 classification. The key is
+/// the `models/<family>/` directory name. [`k2_every_ggml_executor_family_is_classified`]
+/// locks this set against the on-disk executor files, so a newly onboarded
+/// family (e.g. a future granite / funasr executor merged on another branch)
+/// cannot land without an explicit entry here.
+const GGML_EXECUTOR_FAMILY_GATES: &[(&str, ResidentClassification)] = &[
+    ("cohere", ResidentClassification::Resident),
+    ("dolphin", ResidentClassification::Resident),
+    ("firered_aed", ResidentClassification::Resident),
+    ("firered_llm", ResidentClassification::Resident),
+    ("mimo_asr", ResidentClassification::Resident),
+    ("moonshine", ResidentClassification::Resident),
+    ("moss_transcribe_diarize", ResidentClassification::Resident),
+    ("parakeet_ctc", ResidentClassification::Resident),
+    ("parakeet_tdt", ResidentClassification::Resident),
+    ("qwen", ResidentClassification::Resident),
+    ("sensevoice", ResidentClassification::Resident),
+    ("wav2vec2_ctc", ResidentClassification::Resident),
+    ("whisper", ResidentClassification::Resident),
+    ("xasr_zipformer", ResidentClassification::Resident),
+];
+
+/// The dedicated-executor file names that mark a `models/<family>/` directory
+/// as a ggml-executor family.
+const GGML_EXECUTOR_FILE_NAMES: &[&str] = &["executor.rs", "ggml_executor.rs"];
+
+fn models_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/models")
+}
+
+/// Recursively collects every `.rs` file under `dir`.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|error| panic!("read_dir {}: {error}", dir.display()));
+    for entry in entries {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Parses the inventory file into a set of `models/`-relative paths, ignoring
+/// blank lines and `#` comments.
+fn parse_inventory(inventory: &str) -> BTreeSet<String> {
+    inventory
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Path of `file` relative to the `models/` directory, using `/` separators.
+fn models_relative(models_dir: &Path, file: &Path) -> String {
+    file.strip_prefix(models_dir)
+        .expect("file under models dir")
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// K1: the on-disk set of host-f32 loader sites must equal the committed
+/// inventory. A new file that materializes a tensor to host f32 (the load-time
+/// dequant pitfall for a bulk weight) turns this red until reviewed and added.
+#[test]
+fn k1_host_f32_loader_sites_match_inventory() {
+    let models_dir = models_dir();
+    let mut rs_files = Vec::new();
+    collect_rs_files(&models_dir, &mut rs_files);
+
+    let mut on_disk = BTreeSet::new();
+    for file in &rs_files {
+        let relative = models_relative(&models_dir, file);
+        // This audit module names the loader helpers in string constants; it is
+        // not itself a loader site.
+        if relative == "resident_runtime_audit.rs" {
+            continue;
+        }
+        let source = std::fs::read_to_string(file)
+            .unwrap_or_else(|error| panic!("read {}: {error}", file.display()));
+        if HOST_F32_LOADER_CALLS
+            .iter()
+            .any(|call| source.contains(call))
+        {
+            on_disk.insert(relative);
+        }
+    }
+
+    let inventory = parse_inventory(HOST_F32_LOADER_SITES_INVENTORY);
+
+    let unlisted: Vec<_> = on_disk.difference(&inventory).cloned().collect();
+    let stale: Vec<_> = inventory.difference(&on_disk).cloned().collect();
+
+    assert!(
+        unlisted.is_empty(),
+        "K1 keep-quantized gate: these source files materialize a tensor to host \
+         f32 but are NOT in docs/model-audits/host_f32_loader_sites.txt. Add each \
+         after certifying it loads only sanctioned f32/f16 tensors (norms, biases, \
+         conv kernels, get_rows embeddings, positional tables) -- NEVER a rank-2 \
+         mul_mat weight (bind those natively; see MODEL_ONBOARDING.md): {unlisted:?}"
+    );
+    assert!(
+        stale.is_empty(),
+        "K1 keep-quantized gate: these inventory entries no longer call a host-f32 \
+         loader; remove the stale lines from docs/model-audits/host_f32_loader_sites.txt: \
+         {stale:?}"
+    );
+}
+
+/// Discovers the `models/<family>/` directories that carry a dedicated ggml
+/// executor file.
+fn on_disk_ggml_executor_families(models_dir: &Path) -> BTreeSet<String> {
+    let mut families = BTreeSet::new();
+    let entries = std::fs::read_dir(models_dir).expect("read models dir");
+    for entry in entries {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let has_executor = GGML_EXECUTOR_FILE_NAMES
+            .iter()
+            .any(|name| path.join(name).is_file());
+        if has_executor {
+            families.insert(
+                path.file_name()
+                    .expect("family dir name")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+    }
+    families
+}
+
+/// K2 completeness lock: the classified family set must equal the on-disk set
+/// of dedicated ggml-executor families. A new executor file with no entry (or a
+/// removed family with a stale entry) fails here, forcing a conscious
+/// classification at integration time.
+#[test]
+fn k2_every_ggml_executor_family_is_classified() {
+    let models_dir = models_dir();
+    let on_disk = on_disk_ggml_executor_families(&models_dir);
+    let classified: BTreeSet<String> = GGML_EXECUTOR_FAMILY_GATES
+        .iter()
+        .map(|(family, _)| family.to_string())
+        .collect();
+
+    let unclassified: Vec<_> = on_disk.difference(&classified).cloned().collect();
+    let stale: Vec<_> = classified.difference(&on_disk).cloned().collect();
+
+    assert!(
+        unclassified.is_empty(),
+        "K2 resident-runtime gate: these families have a dedicated ggml executor but \
+         no entry in GGML_EXECUTOR_FAMILY_GATES. Add each as Resident (and wire a \
+         resident runtime cache so it does not rebuild per request) or Exempt with a \
+         reason: {unclassified:?}"
+    );
+    assert!(
+        stale.is_empty(),
+        "K2 resident-runtime gate: these classified families no longer have a \
+         dedicated ggml executor on disk; remove the stale entries: {stale:?}"
+    );
+}
+
+/// K2 structural check: every family classified `Resident` must reference a
+/// resident runtime-cache primitive somewhere in its module directory, so the
+/// per-request runtime it builds is actually kept resident and reused. `Exempt`
+/// families must carry a non-empty reason.
+#[test]
+fn k2_resident_families_reference_a_resident_cache() {
+    let models_dir = models_dir();
+    for (family, classification) in GGML_EXECUTOR_FAMILY_GATES {
+        match classification {
+            ResidentClassification::Exempt(reason) => {
+                assert!(
+                    !reason.trim().is_empty(),
+                    "K2 resident-runtime gate: family '{family}' is Exempt but its reason is empty"
+                );
+            }
+            ResidentClassification::Resident => {
+                let family_dir = models_dir.join(family);
+                let mut rs_files = Vec::new();
+                collect_rs_files(&family_dir, &mut rs_files);
+                let references_cache = rs_files.iter().any(|file| {
+                    let source = std::fs::read_to_string(file).unwrap_or_default();
+                    RESIDENT_CACHE_PRIMITIVES
+                        .iter()
+                        .any(|primitive| source.contains(primitive))
+                });
+                assert!(
+                    references_cache,
+                    "K2 resident-runtime gate: family '{family}' is classified Resident but no \
+                     file under models/{family}/ references a resident runtime-cache primitive \
+                     ({RESIDENT_CACHE_PRIMITIVES:?}). Either wire a resident cache (the runtime \
+                     is otherwise rebuilt on every request -- see firered_llm / mimo_asr) or \
+                     reclassify it Exempt with a reason."
+                );
+            }
+        }
+    }
+}

--- a/crates/openasr-core/src/models/xasr_zipformer/runtime.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/runtime.rs
@@ -51,6 +51,32 @@ pub(super) struct XasrZipformerPreparedRuntime {
     joiner: XasrJoiner,
 }
 
+/// Result of decoding a single streaming hop via
+/// [`XasrZipformerPreparedRuntime::decode_next_chunk`].
+pub(super) struct HopDecodeOutcome {
+    /// Non-blank tokens the greedy step appended to `state.emitted` for this
+    /// hop.
+    pub new_tokens: usize,
+    /// False once the loop's break conditions are met and no hop was decoded;
+    /// callers stop iterating when this is false.
+    pub processed: bool,
+    /// This hop's greedy decode time, so the multi-hop
+    /// [`XasrZipformerPreparedRuntime::decode_available_chunks`] caller can keep
+    /// logging the same aggregate `greedy` profile line it did before the loop
+    /// body was split into this single-step entry point.
+    greedy_elapsed: Duration,
+}
+
+impl HopDecodeOutcome {
+    fn skipped() -> Self {
+        Self {
+            new_tokens: 0,
+            processed: false,
+            greedy_elapsed: Duration::ZERO,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct XasrChunkedDecodeState {
     feature_cursor: usize,
@@ -360,105 +386,19 @@ impl XasrZipformerPreparedRuntime {
         features: &XasrFbankFeatures,
         final_flush: bool,
     ) -> Result<usize, String> {
-        let chunk_hop = self.metadata.decode_chunk_len;
-        let chunk_input_frames = chunk_hop
-            .checked_add(XASR_ZIPFORMER_STREAMING_WARMUP_FRAMES)
-            .ok_or_else(|| "xasr chunk frame count overflows".to_string())?;
         let mut new_tokens = 0usize;
         let mut greedy_elapsed = Duration::ZERO;
         let mut processed_chunks = 0usize;
 
         loop {
-            if state.feature_cursor >= features.n_frames {
+            let outcome = self.decode_next_chunk(state, features, final_flush)?;
+            if !outcome.processed {
                 break;
-            }
-            let remaining = features.n_frames - state.feature_cursor;
-            if !state.first_chunk && remaining <= XASR_ZIPFORMER_STREAMING_WARMUP_FRAMES {
-                break;
-            }
-            if !final_flush {
-                let end_frame = state
-                    .feature_cursor
-                    .checked_add(chunk_input_frames)
-                    .ok_or_else(|| "xasr chunk end frame overflows".to_string())?;
-                if end_frame > features.n_frames {
-                    break;
-                }
-            }
-
-            let real_chunk_frames = if final_flush {
-                remaining.min(chunk_input_frames)
-            } else {
-                chunk_input_frames
-            };
-            let input = XasrEncoderFeatureInput::new(
-                chunk_input_frames,
-                features.n_mels,
-                feature_chunk_rows(
-                    features,
-                    state.feature_cursor,
-                    real_chunk_frames,
-                    chunk_input_frames,
-                )?,
-            )
-            .map_err(|e| e.to_string())?;
-            let chunk_profile = xasr_profile_start();
-            let chunk = self
-                .encoder
-                .encode_streaming_chunk_from_features(&input, state.encoder_state.as_ref())
-                .map_err(|e| e.to_string())?;
-            xasr_profile_log(
-                "encoder_chunk",
-                chunk_profile,
-                format_args!(
-                    "chunk={} cursor={} real_frames={} padded_frames={} output_frames={}",
-                    state.chunk_index,
-                    state.feature_cursor,
-                    real_chunk_frames,
-                    chunk_input_frames,
-                    chunk.output.frames
-                ),
-            );
-
-            // The chunk's emissions index encoder frames from the offset the
-            // stream had before this chunk's output was appended.
-            let chunk_frame_offset = state.encoder_frames;
-            state.encoder_frames = state
-                .encoder_frames
-                .checked_add(chunk.output.frames)
-                .ok_or_else(|| "xasr encoder frame count overflows".to_string())?;
-            let greedy_profile = xasr_profile_start();
-            let emitted = greedy_decode_frames_incremental(
-                &chunk.output.rows,
-                chunk.output.frames,
-                self.metadata.encoder_output_dim(),
-                &self.decoder,
-                &self.joiner,
-                self.metadata.blank_id,
-                DEFAULT_MAX_SYMBOLS_PER_FRAME,
-                &mut state.context,
-                &mut state.emitted,
-                &mut state.emitted_frames,
-                &mut state.emitted_probabilities,
-                chunk_frame_offset,
-            )?;
-            if let Some(started_at) = greedy_profile {
-                greedy_elapsed += started_at.elapsed();
             }
             new_tokens = new_tokens
-                .checked_add(emitted)
+                .checked_add(outcome.new_tokens)
                 .ok_or_else(|| "xasr emitted token count overflows".to_string())?;
-            state.encoder_state = Some(chunk.state);
-            let advance = chunk_hop.min(remaining);
-            state.feature_cursor = state
-                .feature_cursor
-                .checked_add(advance)
-                .ok_or_else(|| "xasr chunk cursor overflows".to_string())?;
-            state.first_chunk = false;
-            state.chunk_index = state
-                .chunk_index
-                .checked_add(1)
-                .ok_or_else(|| "xasr chunk index overflows".to_string())?;
+            greedy_elapsed += outcome.greedy_elapsed;
             processed_chunks = processed_chunks
                 .checked_add(1)
                 .ok_or_else(|| "xasr processed chunk count overflows".to_string())?;
@@ -472,6 +412,122 @@ impl XasrZipformerPreparedRuntime {
             );
         }
         Ok(new_tokens)
+    }
+
+    /// Decodes exactly one streaming hop from `features` at the current
+    /// `state.feature_cursor`, mirroring a single iteration of the loop
+    /// [`Self::decode_available_chunks`] runs. Returns `processed = false` (a
+    /// no-op that advances nothing) when the same break conditions that end
+    /// that loop are met, so a caller can drive hops one at a time and inspect
+    /// each hop's emissions between steps. That single-step control is what the
+    /// final-flush early exit in `XasrIncrementalDecoder::finish` needs to stop
+    /// padding once the model has settled, without duplicating the chunk
+    /// geometry or the encoder/greedy plumbing. `decode_available_chunks` stays
+    /// the batch / steady-state entry point and preserves its exact semantics by
+    /// looping over this method.
+    pub(super) fn decode_next_chunk(
+        &mut self,
+        state: &mut XasrChunkedDecodeState,
+        features: &XasrFbankFeatures,
+        final_flush: bool,
+    ) -> Result<HopDecodeOutcome, String> {
+        let chunk_hop = self.metadata.decode_chunk_len;
+        let chunk_input_frames = chunk_hop
+            .checked_add(XASR_ZIPFORMER_STREAMING_WARMUP_FRAMES)
+            .ok_or_else(|| "xasr chunk frame count overflows".to_string())?;
+
+        if state.feature_cursor >= features.n_frames {
+            return Ok(HopDecodeOutcome::skipped());
+        }
+        let remaining = features.n_frames - state.feature_cursor;
+        if !state.first_chunk && remaining <= XASR_ZIPFORMER_STREAMING_WARMUP_FRAMES {
+            return Ok(HopDecodeOutcome::skipped());
+        }
+        if !final_flush {
+            let end_frame = state
+                .feature_cursor
+                .checked_add(chunk_input_frames)
+                .ok_or_else(|| "xasr chunk end frame overflows".to_string())?;
+            if end_frame > features.n_frames {
+                return Ok(HopDecodeOutcome::skipped());
+            }
+        }
+
+        let real_chunk_frames = if final_flush {
+            remaining.min(chunk_input_frames)
+        } else {
+            chunk_input_frames
+        };
+        let input = XasrEncoderFeatureInput::new(
+            chunk_input_frames,
+            features.n_mels,
+            feature_chunk_rows(
+                features,
+                state.feature_cursor,
+                real_chunk_frames,
+                chunk_input_frames,
+            )?,
+        )
+        .map_err(|e| e.to_string())?;
+        let chunk_profile = xasr_profile_start();
+        let chunk = self
+            .encoder
+            .encode_streaming_chunk_from_features(&input, state.encoder_state.as_ref())
+            .map_err(|e| e.to_string())?;
+        xasr_profile_log(
+            "encoder_chunk",
+            chunk_profile,
+            format_args!(
+                "chunk={} cursor={} real_frames={} padded_frames={} output_frames={}",
+                state.chunk_index,
+                state.feature_cursor,
+                real_chunk_frames,
+                chunk_input_frames,
+                chunk.output.frames
+            ),
+        );
+
+        // The chunk's emissions index encoder frames from the offset the
+        // stream had before this chunk's output was appended.
+        let chunk_frame_offset = state.encoder_frames;
+        state.encoder_frames = state
+            .encoder_frames
+            .checked_add(chunk.output.frames)
+            .ok_or_else(|| "xasr encoder frame count overflows".to_string())?;
+        let greedy_profile = xasr_profile_start();
+        let emitted = greedy_decode_frames_incremental(
+            &chunk.output.rows,
+            chunk.output.frames,
+            self.metadata.encoder_output_dim(),
+            &self.decoder,
+            &self.joiner,
+            self.metadata.blank_id,
+            DEFAULT_MAX_SYMBOLS_PER_FRAME,
+            &mut state.context,
+            &mut state.emitted,
+            &mut state.emitted_frames,
+            &mut state.emitted_probabilities,
+            chunk_frame_offset,
+        )?;
+        let greedy_elapsed =
+            greedy_profile.map_or(Duration::ZERO, |started_at| started_at.elapsed());
+        state.encoder_state = Some(chunk.state);
+        let advance = chunk_hop.min(remaining);
+        state.feature_cursor = state
+            .feature_cursor
+            .checked_add(advance)
+            .ok_or_else(|| "xasr chunk cursor overflows".to_string())?;
+        state.first_chunk = false;
+        state.chunk_index = state
+            .chunk_index
+            .checked_add(1)
+            .ok_or_else(|| "xasr chunk index overflows".to_string())?;
+
+        Ok(HopDecodeOutcome {
+            new_tokens: emitted,
+            processed: true,
+            greedy_elapsed,
+        })
     }
 
     pub(super) fn decode_text(&self, token_ids: &[u32]) -> Result<String, String> {

--- a/crates/openasr-core/src/models/xasr_zipformer/streaming_decoder.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/streaming_decoder.rs
@@ -174,6 +174,50 @@ impl XasrIncrementalDecoder {
         self.detokenizer.rebase_preserving_boundary_context();
         debug_assert_eq!(self.decoded_tokens, self.decode_state.emitted_history_len());
     }
+
+    /// Adaptive early-exit predicate for the final-flush pad loop in
+    /// [`IncrementalAudioDecoder::finish`]: true once the model has settled on
+    /// the end of the utterance. The `#[cfg(test)]` escape hatch forces the loop
+    /// to run every pad hop so a golden test can byte-compare "early exit"
+    /// against "pad the full 0.8 s" on the same decoder.
+    fn finish_endpoint_reached(&self, new_tokens_this_hop: usize) -> bool {
+        #[cfg(test)]
+        if FORCE_FULL_FLUSH.with(std::cell::Cell::get) {
+            return false;
+        }
+        xasr_finish_endpoint_reached(new_tokens_this_hop, self.detokenizer.text())
+    }
+}
+
+/// The tail text already ends a sentence: its last visible character is one of
+/// the terminal punctuation marks the streaming zipformer emits only after
+/// seeing trailing silence. Matches the batch golden's punctuation set in this
+/// file.
+fn xasr_tail_is_sentence_terminal(tail_text: &str) -> bool {
+    tail_text
+        .trim_end()
+        .ends_with(['.', '?', '!', '\u{3002}', '\u{ff1f}', '\u{ff01}'])
+}
+
+/// Whether the final-flush pad loop can safely stop after this hop. BOTH
+/// conditions are required: the tail must already carry sentence-terminal
+/// punctuation (the sole reason the flush pads with silence at all) AND this
+/// hop must have produced no new non-blank token (the padded frames
+/// greedy-decoded to all blanks, i.e. the model answered the silence with
+/// blanks). Only then are the remaining pad hops -- more of the same trailing
+/// silence -- safe to skip. Requiring terminal punctuation keeps early exit
+/// from ever dropping it; requiring a zero-emission hop keeps it from cutting
+/// off a word the model is still emitting.
+fn xasr_finish_endpoint_reached(new_tokens_this_hop: usize, tail_text: &str) -> bool {
+    new_tokens_this_hop == 0 && xasr_tail_is_sentence_terminal(tail_text)
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only override: when set, [`XasrIncrementalDecoder::finish_endpoint_reached`]
+    /// never fires, so `finish` pads the full 0.8 s and decodes every hop --
+    /// the byte-for-byte baseline the early-exit golden compares against.
+    static FORCE_FULL_FLUSH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 impl IncrementalAudioDecoder for XasrIncrementalDecoder {
@@ -192,17 +236,57 @@ impl IncrementalAudioDecoder for XasrIncrementalDecoder {
         let _thread_override = install_request_inference_threads_override(
             self.request.request_options.inference_threads,
         );
-        // Final flush: append the tail padding so the model sees the trailing
-        // silence it needs to emit end-of-sentence tokens (terminal
-        // punctuation). Mirrors the batch path in `PooledRuntime::transcribe`;
-        // the session driver guarantees finish() runs at most once.
-        if !self.audio.is_empty() {
-            self.audio.extend(std::iter::repeat_n(
-                0.0f32,
-                XASR_FINAL_FLUSH_TAIL_PAD_SAMPLES,
-            ));
+        if self.audio.is_empty() {
+            return self.process_available_chunks(true);
         }
-        self.process_available_chunks(true)
+        // Final flush: append the tail padding so the model sees the trailing
+        // silence it needs to emit the last sentence's terminal punctuation
+        // (mirrors the batch path in `PooledRuntime::transcribe`). Appending the
+        // whole 0.8 s up front -- rather than growing it hop by hop -- keeps
+        // every fbank row byte-identical to a full-pad flush, so the adaptive
+        // early exit below can only ever skip trailing hops, never change the
+        // rows the retained hops decode. The session driver guarantees finish()
+        // runs at most once.
+        self.audio.extend(std::iter::repeat_n(
+            0.0f32,
+            XASR_FINAL_FLUSH_TAIL_PAD_SAMPLES,
+        ));
+        let total_samples = self.dropped_samples + self.audio.len();
+        let target_total_frames = total_frame_count_for_samples(total_samples);
+        if target_total_frames == 0 {
+            return Ok(String::new());
+        }
+        self.extend_feature_rows(target_total_frames)?;
+
+        // Decode the flush hops one at a time and stop as soon as the model has
+        // settled on the end of the utterance: the tail already carries terminal
+        // punctuation AND this hop produced no new non-blank token (the padded
+        // frames greedy-decoded to all blanks). The real audio's last word is
+        // never at risk -- it lives in the hops before any padding and is always
+        // decoded. The 0.8 s pad stays the hard upper bound: if the heuristic
+        // never fires (e.g. a clause that ends without terminal punctuation)
+        // every hop runs, exactly like the pad-all-then-flush path, so this can
+        // only skip work, never change a retained hop's output.
+        let executor_id = self.executor_id;
+        let adapter_id = self.adapter_id;
+        let mut delta = String::new();
+        loop {
+            let outcome = self
+                .runtime
+                .decode_next_chunk(&mut self.decode_state, &self.features, true)
+                .map_err(|error| {
+                    GgmlAsrExecutionError::executor_failed(executor_id, adapter_id, error)
+                })?;
+            if !outcome.processed {
+                break;
+            }
+            delta.push_str(&self.text_delta()?);
+            if self.finish_endpoint_reached(outcome.new_tokens) {
+                break;
+            }
+        }
+        self.drain_consumed_prefix();
+        Ok(delta)
     }
 
     fn reset(&mut self) {
@@ -258,6 +342,43 @@ mod tests {
     use super::*;
     use crate::ggml_runtime::{GgufTensorDataReader, read_gguf_metadata};
     use crate::models::xasr_zipformer::executor::transcribe_xasr_zipformer_pcm;
+
+    #[test]
+    fn endpoint_requires_both_terminal_punctuation_and_a_silent_hop() {
+        // Fires: terminal punctuation is present and the hop added nothing.
+        assert!(xasr_finish_endpoint_reached(0, "hello world."));
+        assert!(xasr_finish_endpoint_reached(0, "hello world.  "));
+        assert!(xasr_finish_endpoint_reached(0, "\u{4f60}\u{597d}\u{3002}"));
+        // Negative: the hop was silent but the tail is not sentence-final, so
+        // the model may still owe the closing punctuation -- keep padding.
+        assert!(!xasr_finish_endpoint_reached(0, "hello world"));
+        assert!(!xasr_finish_endpoint_reached(0, "hello,"));
+        assert!(!xasr_finish_endpoint_reached(0, ""));
+        // Negative: punctuation is there but the hop still emitted a token, so
+        // the model has not settled -- never cut off an in-flight emission.
+        assert!(!xasr_finish_endpoint_reached(1, "hello world."));
+        assert!(!xasr_finish_endpoint_reached(3, "hello world."));
+    }
+
+    #[test]
+    fn tail_terminal_check_matches_the_batch_golden_punctuation_set() {
+        for terminal in ['.', '?', '!', '\u{3002}', '\u{ff1f}', '\u{ff01}'] {
+            assert!(
+                xasr_tail_is_sentence_terminal(&format!("done{terminal}")),
+                "'{terminal}' must count as sentence-terminal"
+            );
+            // Trailing whitespace must not hide the terminal mark.
+            assert!(xasr_tail_is_sentence_terminal(&format!(
+                "done{terminal} \t"
+            )));
+        }
+        for non_terminal in [',', ';', ':', '\u{ff0c}', '-'] {
+            assert!(
+                !xasr_tail_is_sentence_terminal(&format!("clause{non_terminal}")),
+                "'{non_terminal}' must not count as sentence-terminal"
+            );
+        }
+    }
 
     #[test]
     #[ignore = "host-local: requires the X-ASR q8_0 pack under tmp/xasr-test/out"]
@@ -430,6 +551,76 @@ mod tests {
             decoder.dropped_frames,
             decoder.features.n_frames
         );
+    }
+
+    #[test]
+    #[ignore = "host-local: requires the X-ASR q8_0 pack under tmp/xasr-test/out"]
+    fn early_exit_finish_matches_full_pad_finish_byte_for_byte() {
+        let pack = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tmp/xasr-test/out/xasr-zh-en-onnx-q8_0.oasr");
+        if !pack.exists() {
+            eprintln!("skipping: xasr q8_0 pack absent at {}", pack.display());
+            return;
+        }
+        let runtime_source =
+            crate::validate_ggml_runtime_source_path(&pack).expect("runtime source");
+        let resolved_runtime = crate::ggml_runtime::ResolvedFamilyRuntimeInput::resolve(
+            Some(crate::ggml_runtime::RequestBackendPreference::CpuOnly),
+            crate::arch::family_auto_gpu_policy_for_model_architecture(
+                crate::XASR_ZIPFORMER_GGML_ARCHITECTURE_ID,
+            ),
+        );
+        let mut request = xasr_streaming_request();
+        request.runtime_source_path = pack.clone();
+        request.resolved_runtime = resolved_runtime;
+
+        // Streams `wav` in small chunks then flushes, returning the final-flush
+        // delta. With `force_full` the endpoint heuristic is disabled, so
+        // finish pads the full 0.8 s and decodes every hop -- the baseline the
+        // early-exit path must reproduce byte-for-byte.
+        let finish_delta = |wav: &str, force_full: bool| -> String {
+            let samples = crate::api::audio_io::load_wav_16khz_mono_f32_v0(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("../../fixtures")
+                    .join(wav)
+                    .canonicalize()
+                    .expect("fixture wav path must exist"),
+                "xasr early-exit parity test",
+                "xasr early-exit parity test",
+            )
+            .expect("sample wav should load");
+            let runtime = super::super::runtime::checkout_prepared_runtime(
+                &runtime_source,
+                resolved_runtime.backend(),
+            )
+            .expect("streaming runtime");
+            let mut decoder = XasrIncrementalDecoder::new(
+                &request,
+                crate::arch::XASR_ZIPFORMER_STREAMING_EXECUTOR_COMPONENT_ID,
+                crate::XASR_ZIPFORMER_GGML_ADAPTER_ID,
+                runtime,
+            );
+            for chunk in samples.chunks(320) {
+                decoder.accept_samples(chunk).expect("stream chunk");
+            }
+            FORCE_FULL_FLUSH.with(|f| f.set(force_full));
+            let delta = decoder.finish().expect("stream finish");
+            FORCE_FULL_FLUSH.with(|f| f.set(false));
+            delta
+        };
+
+        // en, zh-en mixed, and a short zh clip: representative of the punctuation
+        // the adaptive early exit keys off. Any divergence means the heuristic
+        // dropped or added a token relative to padding the full 0.8 s.
+        for wav in ["jfk.wav", "en_zh_mixed.wav", "zh_sample.wav"] {
+            let early = finish_delta(wav, false);
+            let full = finish_delta(wav, true);
+            eprintln!("xasr early-exit vs full-pad {wav}: early_finish={early:?}");
+            assert_eq!(
+                early, full,
+                "early-exit finish must byte-match full-pad finish for {wav}"
+            );
+        }
     }
 
     fn xasr_streaming_request() -> GgmlAsrStreamingSessionRequest {

--- a/crates/openasr-core/src/nn/decoder.rs
+++ b/crates/openasr-core/src/nn/decoder.rs
@@ -1180,14 +1180,14 @@ pub(crate) struct LlmLoraSlot<'a> {
 /// LLM family applies QK-norm (Qwen3 does; Qwen2 does not) -- `None` skips the
 /// RMS-norm step entirely rather than normalizing against a substitute weight.
 /// `q_bias`/`k_bias`/`v_bias` are `Option` for the mirror-image reason (Qwen2
-/// has per-projection attention biases; Qwen3 does not). A bias is only ever
-/// applied against the SPLIT-path (non-fused) q/k/v projection output, so a
-/// consumer that wants bias support must also leave `qkv_weight` `None`
-/// (matching the LoRA convention above) -- this keeps every bias-add operating
-/// on a contiguous `mul_mat` output, never a strided fused-QKV view. Consumers
-/// that leave `q_norm_weight`/`k_norm_weight` `Some` and every bias `None`
-/// (Qwen3's shape) produce a byte-identical graph to the pre-parameterization
-/// code path.
+/// has per-projection attention biases; Qwen3 does not). Bias is compatible with
+/// EITHER path: the fused `[q|k|v]` slice a bias adds onto is a single-token
+/// `view_2d` (ne1 == 1, so ggml-contiguous) on the decode step and an explicit
+/// `cont` copy on prefill, so every bias-add still operates on ggml-contiguous
+/// data, never a strided view -- byte-identical to adding the bias on the split
+/// `mul_mat` output. Consumers that leave `q_norm_weight`/`k_norm_weight` `Some`
+/// and every bias `None` (Qwen3's shape) produce a byte-identical graph to the
+/// pre-parameterization code path.
 #[derive(Clone, Copy)]
 pub(crate) struct LlmLayerWeights<'a> {
     pub attn_norm_weight: GgmlCpuTensor<'a>,
@@ -1689,16 +1689,6 @@ where
         RMS_NORM_STEPS,
         map_err,
     )?;
-    let any_qkv_bias =
-        weights.q_bias.is_some() || weights.k_bias.is_some() || weights.v_bias.is_some();
-    if any_qkv_bias && weights.qkv_weight.is_some() {
-        return Err(map_err(
-            "llm_qkv_bias_requires_split_path",
-            GgmlCpuGraphError::UnsupportedInputs {
-                reason: "qkv bias requires the split (non-fused) QKV projection path",
-            },
-        ));
-    }
     let (q, k, v) = build_projected_qkv(
         graph,
         normed,
@@ -3371,6 +3361,9 @@ mod tests {
         use_native_gqa: bool,
         use_flash_attention: bool,
         use_fused_qkv: bool,
+        /// Attach per-projection q/k/v attention biases (Qwen2 shape). Exercises
+        /// the bias-add against both the fused-QKV slice and the split output.
+        use_bias: bool,
     }
 
     /// Single-layer GQA (q_heads=2, kv_heads=1) stack runner used to pin the
@@ -3448,6 +3441,27 @@ mod tests {
         let ffn = graph
             .new_tensor_2d_f32(D_MODEL, D_MODEL, "ffn")
             .expect("ffn weight");
+        let (q_bias, k_bias, v_bias) = if options.use_bias {
+            (
+                Some(
+                    graph
+                        .new_tensor_2d_f32(Q_WIDTH, 1, "q_bias")
+                        .expect("q bias"),
+                ),
+                Some(
+                    graph
+                        .new_tensor_2d_f32(KV_WIDTH, 1, "k_bias")
+                        .expect("k bias"),
+                ),
+                Some(
+                    graph
+                        .new_tensor_2d_f32(KV_WIDTH, 1, "v_bias")
+                        .expect("v bias"),
+                ),
+            )
+        } else {
+            (None, None, None)
+        };
         let mut inputs = vec![
             state,
             row_indices_tensor,
@@ -3463,6 +3477,9 @@ mod tests {
         ];
         if let Some(qkv) = qkv {
             inputs.push(qkv);
+        }
+        for bias in [q_bias, k_bias, v_bias].into_iter().flatten() {
+            inputs.push(bias);
         }
         for input in inputs {
             graph
@@ -3506,9 +3523,9 @@ mod tests {
                 q_weight: q,
                 k_weight: k,
                 v_weight: v,
-                q_bias: None,
-                k_bias: None,
-                v_bias: None,
+                q_bias,
+                k_bias,
+                v_bias,
                 q_norm_weight: Some(head_norm),
                 k_norm_weight: Some(head_norm),
                 output_weight: output,
@@ -3580,6 +3597,21 @@ mod tests {
         graph
             .set_f32_slice(v, &v_weight, "v")
             .expect("v weight upload");
+        if let Some(q_bias) = q_bias {
+            graph
+                .set_f32_slice(q_bias, &weight(Q_WIDTH, 0.6), "q_bias")
+                .expect("q bias upload");
+        }
+        if let Some(k_bias) = k_bias {
+            graph
+                .set_f32_slice(k_bias, &weight(KV_WIDTH, 0.7), "k_bias")
+                .expect("k bias upload");
+        }
+        if let Some(v_bias) = v_bias {
+            graph
+                .set_f32_slice(v_bias, &weight(KV_WIDTH, 0.8), "v_bias")
+                .expect("v bias upload");
+        }
         graph
             .set_f32_slice(output, &weight(D_MODEL * Q_WIDTH, 0.4), "output")
             .expect("output weight upload");
@@ -3618,6 +3650,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         let expanded = compute_gqa_llm_state(
@@ -3630,6 +3663,7 @@ mod tests {
                 use_native_gqa: false,
                 use_flash_attention: true,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         assert_f32_slices_close(&expanded, &native, 1.0e-4);
@@ -3647,6 +3681,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         let expanded = compute_gqa_llm_state(
@@ -3659,6 +3694,7 @@ mod tests {
                 use_native_gqa: false,
                 use_flash_attention: true,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         assert_f32_slices_close(&expanded, &native, 1.0e-4);
@@ -3679,6 +3715,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         let naive = compute_gqa_llm_state(
@@ -3691,6 +3728,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: false,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         assert_f32_slices_close(&naive, &flash, 1.0e-4);
@@ -3706,6 +3744,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         let naive = compute_gqa_llm_state(
@@ -3718,6 +3757,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: false,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         assert_f32_slices_close(&naive, &flash, 1.0e-4);
@@ -3738,6 +3778,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         let fused = compute_gqa_llm_state(
@@ -3750,6 +3791,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 use_fused_qkv: true,
+                use_bias: false,
             },
         );
         assert_f32_slices_close(&fused, &split, 1.0e-4);
@@ -3766,6 +3808,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 use_fused_qkv: false,
+                use_bias: false,
             },
         );
         let fused = compute_gqa_llm_state(
@@ -3778,6 +3821,77 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 use_fused_qkv: true,
+                use_bias: false,
+            },
+        );
+        assert_f32_slices_close(&fused, &split, 1.0e-4);
+    }
+
+    #[test]
+    fn llm_decoder_stack_fused_qkv_with_bias_matches_split_projection() {
+        // Qwen2-shaped packs (funasr/mimo) carry per-projection q/k/v biases.
+        // The fused [q|k|v] matmul followed by a bias-add on each contiguous
+        // slice must match the split-path projection + bias exactly, so bias no
+        // longer forces the slower split path.
+        //
+        // Decode shape (single token): the fused slices are single-row views
+        // (ne1 == 1, ggml-contiguous), the bias-add sensitive case.
+        let state = [0.25, -0.75, 0.5, 1.25];
+        let split = compute_gqa_llm_state(
+            1,
+            1,
+            &state,
+            &[0],
+            &[0],
+            GqaStackOptions {
+                use_native_gqa: true,
+                use_flash_attention: true,
+                use_fused_qkv: false,
+                use_bias: true,
+            },
+        );
+        let fused = compute_gqa_llm_state(
+            1,
+            1,
+            &state,
+            &[0],
+            &[0],
+            GqaStackOptions {
+                use_native_gqa: true,
+                use_flash_attention: true,
+                use_fused_qkv: true,
+                use_bias: true,
+            },
+        );
+        assert_f32_slices_close(&fused, &split, 1.0e-4);
+
+        // Prefill shape (multiple tokens): the fused slices are `cont`-copied
+        // before the bias-add.
+        let state = [0.25, -0.75, 0.5, 1.25, 1.0, 0.125, -0.5, 0.75];
+        let split = compute_gqa_llm_state(
+            2,
+            1,
+            &state,
+            &[0, 1],
+            &[0, 1],
+            GqaStackOptions {
+                use_native_gqa: true,
+                use_flash_attention: true,
+                use_fused_qkv: false,
+                use_bias: true,
+            },
+        );
+        let fused = compute_gqa_llm_state(
+            2,
+            1,
+            &state,
+            &[0, 1],
+            &[0, 1],
+            GqaStackOptions {
+                use_native_gqa: true,
+                use_flash_attention: true,
+                use_fused_qkv: true,
+                use_bias: true,
             },
         );
         assert_f32_slices_close(&fused, &split, 1.0e-4);

--- a/crates/openasr-core/tests/concurrent_slice_pipeline_equivalence.rs
+++ b/crates/openasr-core/tests/concurrent_slice_pipeline_equivalence.rs
@@ -1,6 +1,8 @@
 //! Real-pack end-to-end equivalence for the concurrent long-audio slice
 //! pipeline (P1): decoding the SAME recording with the pipeline width forced to
-//! 1 (serial) and to 4 (concurrent) must produce a byte-identical transcript.
+//! 1 (serial), forced to 4 (concurrent), and left to the carry-gated default
+//! (env unset; concurrent for this carry-disabled run) must produce a
+//! byte-identical transcript.
 //!
 //! Isolating the concurrency variable: the production serial path threads a
 //! cross-slice prompt carry between slices, while the concurrent path is
@@ -93,9 +95,15 @@ fn carry_light_multi_slice_options() -> LongFormOptions {
     }
 }
 
-fn transcribe_with_width(pack: &Path, audio: &Path, width: usize) -> String {
+/// `width` `Some(n)` pins `OPENASR_SLICE_PIPELINE_WIDTH=n`; `None` leaves the
+/// variable unset so the run exercises the carry-gated default (this is a
+/// carry-disabled run, so the default takes the concurrent pipeline).
+fn transcribe_with_width(pack: &Path, audio: &Path, width: Option<usize>) -> String {
     let _lock = PIPELINE_WIDTH_ENV_LOCK.lock().expect("pipeline width lock");
-    unsafe { std::env::set_var(SLICE_PIPELINE_WIDTH_ENV, width.to_string()) };
+    match width {
+        Some(width) => unsafe { std::env::set_var(SLICE_PIPELINE_WIDTH_ENV, width.to_string()) },
+        None => unsafe { std::env::remove_var(SLICE_PIPELINE_WIDTH_ENV) },
+    }
     let result = openasr_core::NativeBackend.transcribe(
         TranscriptionRequest::new(audio, MODEL_ID)
             .with_model_pack_path(Some(pack.to_path_buf()))
@@ -105,32 +113,43 @@ fn transcribe_with_width(pack: &Path, audio: &Path, width: usize) -> String {
     unsafe { std::env::remove_var(SLICE_PIPELINE_WIDTH_ENV) };
     result
         .unwrap_or_else(|error| {
-            panic!("real native transcription failed at width {width}: {error}")
+            panic!("real native transcription failed at width {width:?}: {error}")
         })
         .text
 }
 
 #[test]
 #[ignore = "real-pack P1 pipeline: needs moonshine-tiny q8_0 installed (~/.openasr) or \
-            OPENASR_SLICE_PIPELINE_REAL_PACK; runs the real ggml decode twice on \
+            OPENASR_SLICE_PIPELINE_REAL_PACK; runs the real ggml decode three times on \
             fixtures/longform_en_zh.wav"]
 fn concurrent_width_matches_serial_width_byte_for_byte() {
     let pack = resolve_real_pack();
     let audio = longform_audio();
 
     // Width 1: serial path, carry disabled -> carry-light serial reference.
-    let serial = transcribe_with_width(&pack, &audio, 1);
+    let serial = transcribe_with_width(&pack, &audio, Some(1));
     assert!(
         !serial.trim().is_empty(),
         "the ~69s recording must produce a non-empty transcript"
     );
 
     // Width 4: concurrent carry-light path over the SAME plan.
-    let concurrent = transcribe_with_width(&pack, &audio, 4);
+    let concurrent = transcribe_with_width(&pack, &audio, Some(4));
 
     assert_eq!(
         serial, concurrent,
         "concurrent (width=4) and serial (width=1) carry-light transcripts must be \
          byte-identical; the only difference between the runs is concurrency"
+    );
+
+    // Env unset: the shipping default for this carry-disabled run, which takes
+    // the concurrent pipeline via the carry-gated default width. Its transcript
+    // must still match the serial reference byte for byte.
+    let default_run = transcribe_with_width(&pack, &audio, None);
+
+    assert_eq!(
+        serial, default_run,
+        "the carry-gated default (env unset, carry-disabled run -> concurrent) must \
+         stay byte-identical to the explicit serial run"
     );
 }

--- a/crates/openasr-core/tests/concurrent_slice_pipeline_equivalence.rs
+++ b/crates/openasr-core/tests/concurrent_slice_pipeline_equivalence.rs
@@ -1,0 +1,136 @@
+//! Real-pack end-to-end equivalence for the concurrent long-audio slice
+//! pipeline (P1): decoding the SAME recording with the pipeline width forced to
+//! 1 (serial) and to 4 (concurrent) must produce a byte-identical transcript.
+//!
+//! Isolating the concurrency variable: the production serial path threads a
+//! cross-slice prompt carry between slices, while the concurrent path is
+//! carry-light (it drops that carry). Comparing "serial + carry" against
+//! "concurrent + no carry" would confound concurrency with the carry
+//! difference. This test therefore disables prompt carry on BOTH runs (via
+//! request-level [`LongFormOptions::carry_prompt_across_slices`] = false), so
+//! the ONLY thing that differs between the width-1 and width-4 runs is
+//! concurrency. Byte-identical output is then evidence that concurrent ggml
+//! decoding does not change the transcript.
+//!
+//! Backend: CPU (deterministic greedy decode) so a run-to-run diff cannot come
+//! from GPU nondeterminism. Model: the real moonshine-tiny q8_0 pack -- a
+//! `SharedWindow` family, so a ~69s recording genuinely slices into several
+//! chunks and the width-4 path engages.
+//!
+//! Loud-fail prerequisites (never a silent skip; `#[ignore]` is the opt-in):
+//! - moonshine-tiny q8_0 pack at `~/.openasr/models/moonshine-tiny/q8_0/...`
+//!   or pointed to by `OPENASR_SLICE_PIPELINE_REAL_PACK`;
+//! - `fixtures/longform_en_zh.wav` checked in (a ~69s recording).
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use openasr_core::{
+    ExecutionTarget, LongFormMode, LongFormOptions, TranscriptionBackend, TranscriptionRequest,
+};
+
+/// The pipeline width is read from a process-global env var, so the two runs
+/// must not race each other or any other test mutating it.
+static PIPELINE_WIDTH_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const MODEL_ID: &str = "moonshine-tiny";
+const REAL_PACK_ENV: &str = "OPENASR_SLICE_PIPELINE_REAL_PACK";
+const PACK_HOME_RELATIVE_PATH: &str =
+    ".openasr/models/moonshine-tiny/q8_0/moonshine-tiny-q8_0.oasr";
+const SLICE_PIPELINE_WIDTH_ENV: &str = "OPENASR_SLICE_PIPELINE_WIDTH";
+
+fn resolve_real_pack() -> PathBuf {
+    if let Some(value) = std::env::var_os(REAL_PACK_ENV) {
+        let path = PathBuf::from(value);
+        assert!(
+            path.is_file(),
+            "{REAL_PACK_ENV} must point to an existing moonshine .oasr pack: {}",
+            path.display()
+        );
+        return path;
+    }
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            panic!(
+                "slice-pipeline real-pack prerequisites missing: neither HOME nor {REAL_PACK_ENV} \
+             is set; #[ignore] is the opt-in, so this test must not silently skip"
+            )
+        });
+    let path = home.join(PACK_HOME_RELATIVE_PATH);
+    assert!(
+        path.is_file(),
+        "slice-pipeline real-pack prerequisites missing; install moonshine-tiny q8_0 (searched \
+         {}) or set {REAL_PACK_ENV}",
+        path.display()
+    );
+    path
+}
+
+fn longform_audio() -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("openasr-core lives under crates/openasr-core")
+        .join("fixtures/longform_en_zh.wav");
+    assert!(
+        path.is_file(),
+        "longform_en_zh.wav fixture missing at {}",
+        path.display()
+    );
+    path
+}
+
+/// Carry-light long-form options that force several fixed 10s slices, so both
+/// the serial and the concurrent run see the SAME multi-slice plan with NO
+/// cross-slice prompt carry.
+fn carry_light_multi_slice_options() -> LongFormOptions {
+    LongFormOptions {
+        mode: LongFormMode::Fixed,
+        chunk_seconds: 10.0,
+        carry_prompt_across_slices: false,
+        ..LongFormOptions::default()
+    }
+}
+
+fn transcribe_with_width(pack: &Path, audio: &Path, width: usize) -> String {
+    let _lock = PIPELINE_WIDTH_ENV_LOCK.lock().expect("pipeline width lock");
+    unsafe { std::env::set_var(SLICE_PIPELINE_WIDTH_ENV, width.to_string()) };
+    let result = openasr_core::NativeBackend.transcribe(
+        TranscriptionRequest::new(audio, MODEL_ID)
+            .with_model_pack_path(Some(pack.to_path_buf()))
+            .with_execution_target(Some(ExecutionTarget::Cpu))
+            .with_longform(Some(carry_light_multi_slice_options())),
+    );
+    unsafe { std::env::remove_var(SLICE_PIPELINE_WIDTH_ENV) };
+    result
+        .unwrap_or_else(|error| {
+            panic!("real native transcription failed at width {width}: {error}")
+        })
+        .text
+}
+
+#[test]
+#[ignore = "real-pack P1 pipeline: needs moonshine-tiny q8_0 installed (~/.openasr) or \
+            OPENASR_SLICE_PIPELINE_REAL_PACK; runs the real ggml decode twice on \
+            fixtures/longform_en_zh.wav"]
+fn concurrent_width_matches_serial_width_byte_for_byte() {
+    let pack = resolve_real_pack();
+    let audio = longform_audio();
+
+    // Width 1: serial path, carry disabled -> carry-light serial reference.
+    let serial = transcribe_with_width(&pack, &audio, 1);
+    assert!(
+        !serial.trim().is_empty(),
+        "the ~69s recording must produce a non-empty transcript"
+    );
+
+    // Width 4: concurrent carry-light path over the SAME plan.
+    let concurrent = transcribe_with_width(&pack, &audio, 4);
+
+    assert_eq!(
+        serial, concurrent,
+        "concurrent (width=4) and serial (width=1) carry-light transcripts must be \
+         byte-identical; the only difference between the runs is concurrency"
+    );
+}

--- a/docs/MODEL_ONBOARDING.md
+++ b/docs/MODEL_ONBOARDING.md
@@ -219,6 +219,70 @@ RTF per quant) and read down the columns:
 When RAM is flat *and* RTF is flat across quants, treat it as a keep-quantized
 regression and audit the weights loader, not the pack.
 
+### CI gate (K1) — enforced at integration, not after publishing
+
+The RAM-ordering self-check above is a *post-publish* human read of the model
+card. It is now backstopped by a **hard CI gate** that fails at integration time,
+before any pack is built:
+
+- `models::resident_runtime_audit::k1_host_f32_loader_sites_match_inventory` locks
+  the set of source files that materialize a tensor to a host `Vec<f32>` (the
+  reader's `host_tensor_f32_copy*` helpers) against the committed inventory
+  `docs/model-audits/host_f32_loader_sites.txt`. **Adding a new host-f32 loader
+  site turns CI red** until the file is listed there.
+- Listing a file is a reviewed certification that it loads **only** the sanctioned
+  f32/f16 tensors above (norms, biases, conv kernels, `get_rows` embeddings,
+  positional/rotary tables, CMVN vectors). **Loading a rank-2 `mul_mat` weight to
+  host f32 is forbidden** — bind it natively through the seam
+  (`weight_tensor_payload_by_name` + `new_matmul_weight_2d_typed`; see
+  `dolphin::executor::insert_pool_tensor`, which classifies each tensor). So the
+  load-time-dequant pitfall now shows up as a red gate a reviewer must clear, not
+  as a flat model-card column someone has to notice.
+
+This complements the pack-header quant floor (`models::pack_quant_audit`, which
+fails closed on a sub-Q8 encoder), which checks the *pack*; K1 checks the *loader*.
+
+## Runtime contract: keep the prepared runtime resident
+
+**Hard requirement.** A family's executor MUST NOT rebuild its heavy graph
+runtime (encoder / decoder / adapter graphs, device-uploaded weights, embedding
+and logits tables) **on every request**. Build it once per `(pack content id,
+backend)` and keep it **resident**, reusing it across requests; only the
+per-request, audio-dependent work (frontend, encode, prompt, decode) runs each
+call. A per-request `Runtime::new()` on the hot path re-pays the full
+weight-upload + graph-construction cost (seconds for an 8B-class decoder) to
+re-derive state that never changes between requests against the same pack — this
+is what mimo-asr did before its `MimoAsrPreparedRuntime` cache, and what granite
+did before it was caught.
+
+**The seam** (keep the built runtime alive; take it out, use it, put it back):
+
+- Cache the prepared runtime in a thread-local generation-tagged map keyed by
+  `(PackContentKey, backend)` (`models::thread_local_runtime_cache`:
+  `take_generation_tagged` / store), the shared `PreparedRuntimeCache`, or a
+  content-id-keyed process weights pool (dolphin). Tag entries with
+  `current_unload_generation()` so the central idle-unload clock can evict the
+  resident runtime under memory pressure.
+- **Reference families:** `firered_llm` (resident decoder), `mimo_asr` (whole
+  resident encoder + input-local + decoder pipeline), `dolphin` (process weights
+  pool). All AED / autoregressive families and all encoder families already do
+  this.
+
+### CI gate (K2) — every ggml-executor family is checked
+
+- `models::resident_runtime_audit::k2_every_ggml_executor_family_is_classified`
+  locks the set of `models/<family>/{executor,ggml_executor}.rs` files against the
+  `GGML_EXECUTOR_FAMILY_GATES` table. **A new family's executor added without a
+  table entry turns CI red**, so a new AED family (e.g. a future granite / funasr
+  executor) cannot land unclassified.
+- `k2_resident_families_reference_a_resident_cache` then requires every family
+  classified `Resident` to reference a resident-cache primitive in its own module.
+  A one-shot family that genuinely should rebuild per request must be explicitly
+  `Exempt("<reason>")` — reviewed, not silent.
+- Per-family byte-identity of a **cache hit vs a fresh build** is proved by that
+  family's own dev-pack e2e test (`resident_*_cache_reuse_across_consecutive_calls_stays_byte_identical`),
+  which the static K2 gate backstops.
+
 ## Honest gap list — what still blocks true zero-code onboarding
 
 1. **Step-executor construction is irreducibly per-family** and is not closeable

--- a/docs/model-audits/host_f32_loader_sites.txt
+++ b/docs/model-audits/host_f32_loader_sites.txt
@@ -1,0 +1,52 @@
+# Host-f32 weight-loader site inventory (keep-quantized gate K1 SSOT)
+#
+# Every source file under crates/openasr-core/src/models/ that calls one of the
+# reader's host-f32 materialization helpers -- host_tensor_f32_copy_dequantized_by_name,
+# host_tensor_f32_copy_by_name, host_tensor_f32_copy_by_id -- MUST be listed here
+# (path relative to crates/openasr-core/src/models/). The K1 gate
+# (models::resident_runtime_audit) locks the on-disk set of such files against
+# this inventory: adding a NEW host-f32 loader site (a new file that materializes
+# any tensor to a host Vec<f32>) fails the gate until the site is added here.
+#
+# Adding a line is a certification, reviewed at that point, that the site loads
+# ONLY tensors that legitimately stay f32/f16 per the keep-quantized runtime
+# contract in docs/MODEL_ONBOARDING.md ("What stays f32/f16"): 1-D norm/bias
+# vectors, convolution kernels, get_rows token/decoder embeddings, positional /
+# rotary tables, CMVN vectors, and small classifier/adaptor heads. It MUST NOT be
+# used to load a rank-2 `mul_mat` weight matrix to f32 -- those bind natively via
+# weight_tensor_payload_by_name + new_matmul_weight_2d_typed (reference: qwen
+# llm_transformer/logits_head; dolphin executor's insert_pool_tensor classifies
+# per tensor). A host-f32 bulk weight is the load-time-dequant pitfall the
+# contract forbids: it flattens RAM/RTF across quants.
+#
+# Lines are sorted; one path per line; '#' comments and blank lines ignored.
+
+cohere/frontend.rs
+cohere/weights.rs
+diarize_pack_import.rs
+dolphin/executor.rs
+fastconformer/weights.rs
+firered_aed/encoder_graph.rs
+firered_aed/executor.rs
+firered_llm/adapter_graph.rs
+firered_llm/executor.rs
+firered_punc/weights.rs
+mimo_asr/audio_tokenizer_graph.rs
+mimo_asr/input_local_graph.rs
+mimo_asr/mel_frontend.rs
+mimo_asr/rvq.rs
+moonshine/weights.rs
+moss_transcribe_diarize/adaptor_graph.rs
+moss_transcribe_diarize/encoder_graph.rs
+moss_transcribe_diarize/package_import.rs
+qwen/audio_encoder.rs
+qwen/frontend.rs
+qwen/llm_transformer.rs
+qwen/logits_head.rs
+qwen/token_embedding.rs
+sensevoice/encoder_weights.rs
+wav2vec2_ctc/encoder_weights.rs
+whisper/ggml_decoder_weights.rs
+whisper/ggml_encoder_weights.rs
+xasr_zipformer/encoder_graph.rs
+xasr_zipformer/weights.rs


### PR DESCRIPTION
## Summary

Integrate the 0.1.27 engine batch onto main: cross-family performance
optimizations, host-memory admission for more model families, the concurrent
long-audio slice pipeline defaulting on carry state, the XASR final-flush
latency fix, qwen decode/load optimization, the mimo resident runtime cache,
and keep-quantized/resident onboarding CI gates.

## Why

Consolidate the individually-tested batch ahead of the 0.1.27 engine release.
Bundles the dictation-path latency fix and the perf/infrastructure work into a
single merge. No version bump here; the release bump lands separately.

## Changes

- perf: dolphin prepared-graph cache + n-best rescore fusion; firered-aed
  incremental decode graph reuse; device-side fused top1 for qwen/mimo-asr/firered-llm.
- feat: host-memory admission extended to firered/mimo/cohere + diarize embedder.
- feat: default slice-pipeline width gated on longform carry state.
- perf(xasr): adaptive early exit for final-flush tail padding.
- perf(qwen): fuse biased QKV and lazy-dequant quantized token embeddings.
- feat(core): mimo resident prepared-runtime cache + keep-quantized/resident
  onboarding gates (K1/K2) + MODEL_ONBOARDING docs.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (3349 passed, 0 failed, 152 skipped)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check` (not run in this batch)

Also: `cargo test -p openasr-core golden_diff` (4 passed, 14 ignored for absent private packs); bundled catalog signature (1 passed).

## Manual smoke checks

n/a -- engine-internal changes covered by the workspace tests and golden diff.

## Docs updated

- [x] `MODEL_ONBOARDING.md` updated with the keep-quantized/resident CI-gate requirements.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No new model families here: `granite_speech` and `funasr_nano` are
  intentionally excluded; they land with their own release once optimized and published.
- No version bump; the 0.1.27 release bump is a separate step.

## Artifact confirmation

- [x] No model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] No vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] No unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy.
- [x] I understand every line of this change and own its maintenance.
- AI usage disclosure: YES -- implementation was AI-assisted across the batch; validated by the full local gate suite above.
