### PR TITLE
fix(ci): drop granite workstation paths and shrink sparse admission fixture

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -4696,8 +4696,10 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let oversized = dir.path().join("oversized.oasr");
         let file = std::fs::File::create(&oversized).expect("create sparse pack");
-        // 1 PiB sparse: larger than any host's RAM + swap, no disk cost.
-        file.set_len(1 << 50).expect("sparse set_len");
+        // 1 TiB sparse: larger than any host's RAM + swap, no disk cost.
+        // Stay under common Linux CI/FS sparse-file caps (1 PiB trips
+        // FileTooLarge on some runners).
+        file.set_len(1 << 40).expect("sparse set_len");
         drop(file);
         let modest = dir.path().join("modest.oasr");
         std::fs::write(&modest, vec![0u8; 4096]).expect("write modest pack");

--- a/crates/openasr-core/src/models/granite_speech/decode_executor.rs
+++ b/crates/openasr-core/src/models/granite_speech/decode_executor.rs
@@ -295,9 +295,26 @@ mod tests {
         Seq2SeqGreedyDecodeConfig, run_seq2seq_greedy_decode_loop_with_adapter_v0,
     };
 
-    const SOURCE_ROOT: &str =
-        "/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/granite-speech-4.1-2b-src";
-    const GOLDEN_ROOT: &str = "/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/golden";
+    const SOURCE_ROOT_ENV: &str = "OPENASR_GRANITE_SPEECH_SOURCE_ROOT";
+    const GOLDEN_ROOT_ENV: &str = "OPENASR_GRANITE_SPEECH_GOLDEN_ROOT";
+    const SAMPLES_ROOT_ENV: &str = "OPENASR_GRANITE_SPEECH_SAMPLES_ROOT";
+
+    fn source_root() -> Option<PathBuf> {
+        let path = PathBuf::from(std::env::var_os(SOURCE_ROOT_ENV)?);
+        path.join("model.safetensors.index.json")
+            .exists()
+            .then_some(path)
+    }
+
+    fn golden_root() -> Option<PathBuf> {
+        let path = PathBuf::from(std::env::var_os(GOLDEN_ROOT_ENV)?);
+        path.is_dir().then_some(path)
+    }
+
+    fn sample_wav(name: &str) -> Option<PathBuf> {
+        let path = PathBuf::from(std::env::var_os(SAMPLES_ROOT_ENV)?).join(name);
+        path.is_file().then_some(path)
+    }
 
     fn load_safetensors_prefixed(dir: &Path, prefix: &str) -> HashMap<String, Vec<f32>> {
         let index_path = dir.join("model.safetensors.index.json");
@@ -367,12 +384,14 @@ mod tests {
     #[test]
     #[ignore = "requires local 4.6GB granite-speech-4.1-2b weights + golden fixtures under tmp/ (not committed)"]
     fn granite_speech_greedy_decode_matches_hf_reference() {
-        let source_root = PathBuf::from(SOURCE_ROOT);
-        if !source_root.join("model.safetensors.index.json").exists() {
-            eprintln!("skip: {SOURCE_ROOT} not present");
+        let Some(source_root) = source_root() else {
+            eprintln!("skip: set {SOURCE_ROOT_ENV} to a local granite-speech source tree");
             return;
-        }
-        let golden_root = PathBuf::from(GOLDEN_ROOT);
+        };
+        let Some(golden_root) = golden_root() else {
+            eprintln!("skip: set {GOLDEN_ROOT_ENV} to a local granite-speech golden dir");
+            return;
+        };
 
         let weights = load_safetensors_prefixed(&source_root, "language_model.");
         let config = GraniteSpeechDecoderConfig::granite_speech_4_1_2b();
@@ -573,14 +592,14 @@ mod tests {
     #[test]
     #[ignore = "requires local 4.6GB granite-speech-4.1-2b weights under tmp/ (not committed)"]
     fn granite_speech_end_to_end_transcribes_en_short() {
-        let source_root = PathBuf::from(SOURCE_ROOT);
-        if !source_root.join("model.safetensors.index.json").exists() {
-            eprintln!("skip: {SOURCE_ROOT} not present");
+        let Some(source_root) = source_root() else {
+            eprintln!("skip: set {SOURCE_ROOT_ENV} to a local granite-speech source tree");
             return;
-        }
-        let wav_path = PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/samples/en_short.wav",
-        );
+        };
+        let Some(wav_path) = sample_wav("en_short.wav") else {
+            eprintln!("skip: set {SAMPLES_ROOT_ENV} to a local granite-speech samples dir");
+            return;
+        };
         let text = transcribe_wav(
             &source_root,
             &wav_path,
@@ -601,14 +620,14 @@ mod tests {
     #[test]
     #[ignore = "requires local 4.6GB granite-speech-4.1-2b weights under tmp/ (not committed)"]
     fn granite_speech_end_to_end_transcribes_ja_short() {
-        let source_root = PathBuf::from(SOURCE_ROOT);
-        if !source_root.join("model.safetensors.index.json").exists() {
-            eprintln!("skip: {SOURCE_ROOT} not present");
+        let Some(source_root) = source_root() else {
+            eprintln!("skip: set {SOURCE_ROOT_ENV} to a local granite-speech source tree");
             return;
-        }
-        let wav_path = PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/samples/ja_short.wav",
-        );
+        };
+        let Some(wav_path) = sample_wav("ja_short.wav") else {
+            eprintln!("skip: set {SAMPLES_ROOT_ENV} to a local granite-speech samples dir");
+            return;
+        };
         let text = transcribe_wav(
             &source_root,
             &wav_path,
@@ -631,14 +650,14 @@ mod tests {
     #[test]
     #[ignore = "requires local 4.6GB granite-speech-4.1-2b weights under tmp/ (not committed)"]
     fn granite_speech_keyword_list_biasing_corrects_name() {
-        let source_root = PathBuf::from(SOURCE_ROOT);
-        if !source_root.join("model.safetensors.index.json").exists() {
-            eprintln!("skip: {SOURCE_ROOT} not present");
+        let Some(source_root) = source_root() else {
+            eprintln!("skip: set {SOURCE_ROOT_ENV} to a local granite-speech source tree");
             return;
-        }
-        let wav_path = PathBuf::from(
-            "/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/samples/kwb_test.wav",
-        );
+        };
+        let Some(wav_path) = sample_wav("kwb_test.wav") else {
+            eprintln!("skip: set {SAMPLES_ROOT_ENV} to a local granite-speech samples dir");
+            return;
+        };
 
         let without_kwb = transcribe_wav(
             &source_root,

--- a/crates/openasr-core/src/models/granite_speech/package_import.rs
+++ b/crates/openasr-core/src/models/granite_speech/package_import.rs
@@ -618,11 +618,10 @@ mod tests {
     use super::*;
     use crate::ggml_runtime::GgufTensorDataReader;
 
-    const SOURCE_ROOT: &str =
-        "/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/granite-speech-4.1-2b-src";
+    const SOURCE_ROOT_ENV: &str = "OPENASR_GRANITE_SPEECH_SOURCE_ROOT";
 
     fn source_root() -> Option<PathBuf> {
-        let path = PathBuf::from(SOURCE_ROOT);
+        let path = PathBuf::from(std::env::var_os(SOURCE_ROOT_ENV)?);
         path.join(SOURCE_INDEX_JSON).exists().then_some(path)
     }
 
@@ -636,7 +635,7 @@ mod tests {
     #[ignore = "requires local 4.6GB granite-speech-4.1-2b weights under tmp/ (not committed)"]
     fn granite_speech_converter_round_trips_sampled_tensors() {
         let Some(source_root) = source_root() else {
-            eprintln!("skip: {SOURCE_ROOT} not present");
+            eprintln!("skip: set {SOURCE_ROOT_ENV} to a local granite-speech source tree");
             return;
         };
         let output_root = std::env::temp_dir().join("granite_speech_converter_test.oasr");

--- a/crates/openasr-core/src/models/granite_speech/parity.rs
+++ b/crates/openasr-core/src/models/granite_speech/parity.rs
@@ -19,16 +19,25 @@ use super::encoder_graph::{GraniteSpeechEncoderConfig, encode};
 use super::frontend::GraniteSpeechMelFrontend;
 use super::qformer::{GraniteSpeechProjectorConfig, project};
 
-const WEIGHTS_ROOT: &str =
-    "/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/granite-speech-4.1-2b-src";
-const GOLDEN_ROOT: &str = "/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/golden";
+const SOURCE_ROOT_ENV: &str = "OPENASR_GRANITE_SPEECH_SOURCE_ROOT";
+const GOLDEN_ROOT_ENV: &str = "OPENASR_GRANITE_SPEECH_GOLDEN_ROOT";
+const SAMPLES_ROOT_ENV: &str = "OPENASR_GRANITE_SPEECH_SAMPLES_ROOT";
 
-fn weights_root() -> PathBuf {
-    PathBuf::from(WEIGHTS_ROOT)
+fn weights_root() -> Option<PathBuf> {
+    let path = PathBuf::from(std::env::var_os(SOURCE_ROOT_ENV)?);
+    path.join("model.safetensors.index.json")
+        .exists()
+        .then_some(path)
 }
 
-fn golden_root() -> PathBuf {
-    PathBuf::from(GOLDEN_ROOT)
+fn golden_root() -> Option<PathBuf> {
+    let path = PathBuf::from(std::env::var_os(GOLDEN_ROOT_ENV)?);
+    path.is_dir().then_some(path)
+}
+
+fn sample_wav(name: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(std::env::var_os(SAMPLES_ROOT_ENV)?).join(name);
+    path.is_file().then_some(path)
 }
 
 fn bf16_to_f32(bits: u16) -> f32 {
@@ -146,12 +155,14 @@ fn relative_max_diff(actual: &[f32], expected: &[f32]) -> f32 {
 #[test]
 #[ignore = "requires local 4.6GB granite-speech-4.1-2b weights + golden fixtures under tmp/ (not committed)"]
 fn granite_speech_encoder_parity() {
-    let weights_dir = weights_root();
-    if !weights_dir.join("model.safetensors.index.json").exists() {
-        eprintln!("skip: {weights_dir:?} not present");
+    let Some(weights_dir) = weights_root() else {
+        eprintln!("skip: set {SOURCE_ROOT_ENV} to a local granite-speech source tree");
         return;
-    }
-    let golden = golden_root();
+    };
+    let Some(golden) = golden_root() else {
+        eprintln!("skip: set {GOLDEN_ROOT_ENV} to a local granite-speech golden dir");
+        return;
+    };
 
     let weights = load_safetensors_prefixed(&weights_dir, "encoder.");
     let (in_shape, features) = load_npy_f32(&golden.join("en_short_input_features.npy"));
@@ -210,12 +221,14 @@ fn granite_speech_encoder_parity() {
 #[test]
 #[ignore = "requires local 4.6GB granite-speech-4.1-2b weights + golden fixtures under tmp/ (not committed)"]
 fn granite_speech_projector_parity() {
-    let weights_dir = weights_root();
-    if !weights_dir.join("model.safetensors.index.json").exists() {
-        eprintln!("skip: {weights_dir:?} not present");
+    let Some(weights_dir) = weights_root() else {
+        eprintln!("skip: set {SOURCE_ROOT_ENV} to a local granite-speech source tree");
         return;
-    }
-    let golden = golden_root();
+    };
+    let Some(golden) = golden_root() else {
+        eprintln!("skip: set {GOLDEN_ROOT_ENV} to a local granite-speech golden dir");
+        return;
+    };
 
     let encoder_weights = load_safetensors_prefixed(&weights_dir, "encoder.");
     let projector_weights = load_safetensors_prefixed(&weights_dir, "projector.");
@@ -309,12 +322,14 @@ fn top_k_indices(values: &[f32], k: usize) -> Vec<usize> {
 #[test]
 #[ignore = "requires local 4.6GB granite-speech-4.1-2b weights + golden fixtures under tmp/ (not committed)"]
 fn granite_speech_decoder_prefill_parity() {
-    let weights_dir = weights_root();
-    if !weights_dir.join("model.safetensors.index.json").exists() {
-        eprintln!("skip: {weights_dir:?} not present");
+    let Some(weights_dir) = weights_root() else {
+        eprintln!("skip: set {SOURCE_ROOT_ENV} to a local granite-speech source tree");
         return;
-    }
-    let golden = golden_root();
+    };
+    let Some(golden) = golden_root() else {
+        eprintln!("skip: set {GOLDEN_ROOT_ENV} to a local granite-speech golden dir");
+        return;
+    };
 
     let weights = load_safetensors_prefixed(&weights_dir, "language_model.");
     let (ids_shape, ids_i64) = load_npy_i64(&golden.join("decoder_input_ids.npy"));
@@ -418,12 +433,17 @@ fn load_wav_pcm16_mono_f32(path: &Path) -> Vec<f32> {
 
 #[test]
 fn granite_speech_frontend_parity() {
-    let golden = golden_root();
-    let sample_path =
-        PathBuf::from("/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/samples/en_short.wav");
+    let Some(golden) = golden_root() else {
+        eprintln!("skip: set {GOLDEN_ROOT_ENV} to a local granite-speech golden dir");
+        return;
+    };
+    let Some(sample_path) = sample_wav("en_short.wav") else {
+        eprintln!("skip: set {SAMPLES_ROOT_ENV} to a local granite-speech samples dir");
+        return;
+    };
     let golden_path = golden.join("en_short_input_features.npy");
-    if !sample_path.exists() || !golden_path.exists() {
-        eprintln!("skip: {sample_path:?} or {golden_path:?} not present");
+    if !golden_path.exists() {
+        eprintln!("skip: {golden_path:?} not present");
         return;
     }
 

--- a/crates/openasr-core/src/models/granite_speech/tokenizer.rs
+++ b/crates/openasr-core/src/models/granite_speech/tokenizer.rs
@@ -221,17 +221,20 @@ impl GraniteSpeechTokenizer {
 mod tests {
     use super::*;
 
-    const SOURCE_ROOT: &str =
-        "/Volumes/QuintinDocument/openasr-dev/tmp/granite-work/granite-speech-4.1-2b-src";
+    const SOURCE_ROOT_ENV: &str = "OPENASR_GRANITE_SPEECH_SOURCE_ROOT";
+
+    fn source_root() -> Option<std::path::PathBuf> {
+        let path = std::path::PathBuf::from(std::env::var_os(SOURCE_ROOT_ENV)?);
+        path.join("vocab.json").exists().then_some(path)
+    }
 
     #[test]
     #[ignore = "requires local granite-speech-4.1-2b tokenizer files under tmp/ (not committed)"]
     fn granite_speech_tokenizer_round_trips_plain_text() {
-        let root = std::path::PathBuf::from(SOURCE_ROOT);
-        if !root.join("vocab.json").exists() {
-            eprintln!("skip: {SOURCE_ROOT} not present");
+        let Some(root) = source_root() else {
+            eprintln!("skip: set {SOURCE_ROOT_ENV} to a local granite-speech source tree");
             return;
-        }
+        };
         let tokenizer = GraniteSpeechTokenizer::from_source_files(&root).expect("load tokenizer");
         let text = "The quick brown fox jumps over the lazy dog.";
         let ids = tokenizer.encode_prompt_text(text).expect("encode");


### PR DESCRIPTION
## Summary

Unblock main CI after the granite-speech merge: remove absolute workstation paths from local-only granite harnesses, and shrink the host-memory admission sparse fixture so Linux runners can create it.

## Why

Main went red on two independent gates after #264 / #265:

1. Public source hygiene rejects `/Volumes/` in tracked source. Several granite-speech `#[ignore]` harnesses still hard-coded local workstation paths.
2. `enforce_native_host_memory_admission_rejects_each_new_family_on_an_oversized_pack` used a 1 PiB sparse `set_len`, which some Linux CI filesystems reject with `FileTooLarge`.

## Changes

- Gate granite-speech local harness roots behind `OPENASR_GRANITE_SPEECH_SOURCE_ROOT` / `_GOLDEN_ROOT` / `_SAMPLES_ROOT` (same pattern as the converter test already used for source).
- Shrink the oversized sparse admission fixture from 1 PiB to 1 TiB (still far above any host budget, portable on Linux CI).

## Tests run

- [x] `python3 tooling/check_public_source_hygiene.py`
- [x] `cargo test -p openasr-core --lib api::backend::native::native_transcribe::tests::enforce_native_host_memory_admission_rejects_each_new_family_on_an_oversized_pack -- --exact`
- [x] granite_speech test modules list/compile cleanly
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

n/a -- CI unblock only; ignored local harnesses still skip without the env vars set.

## Docs updated

- [x] No docs overclaim current capabilities.
- [ ] README or docs updated, if behavior or limitations changed. (n/a)

## Scope / non-goals

- No model / runtime behavior change.
- Does not publish packs or bump versions.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES -- drafting and mechanical rewrite of path constants; human-owned review and merge decision.