### PR TITLE
feat(core): wire host-memory admission for funasr-nano and granite-speech

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -2902,6 +2902,70 @@ fn firered_aed_native_capacity_admission_facts(
     })
 }
 
+/// This request's decoder KV admission facts for `funasr-nano`, assembled from
+/// the loaded pack's Qwen3 decoder metadata
+/// (`crate::models::funasr_nano::capacity`). Audio-token count walks the same
+/// fbank + LFR + low-frame-rate truncation arithmetic the executor uses;
+/// generation backstop and single-decode window reuse the executor's own
+/// constants. The KV element-type policy is resolved from the SAME
+/// `resolve_qwen_family_production_kv_cache_policy(backend, head_dim)` the
+/// real decoder allocates against (`Qwen3AsrLlmWholeDecoderGraphExecutor`
+/// construction). `None` (unparseable funasr-nano metadata) leaves the
+/// request admission-unchecked (fail open).
+fn funasr_nano_native_capacity_admission_facts(
+    metadata: &crate::ggml_runtime::GgufMetadata,
+    audio_duration_seconds: f32,
+    backend: crate::ggml_runtime::GgmlCpuGraphBackend,
+) -> Option<NativeKvAdmissionFacts> {
+    let decoder =
+        crate::models::funasr_nano::runtime_contract::parse_funasr_nano_decoder_metadata(metadata)
+            .ok()?;
+    let geometry = crate::models::funasr_nano::capacity::funasr_nano_kv_geometry(&decoder);
+    let required_positions =
+        crate::models::funasr_nano::capacity::funasr_nano_admission_required_positions(
+            audio_duration_seconds,
+        );
+    let spec = crate::models::qwen::resolve_qwen_family_production_kv_cache_policy(
+        backend,
+        geometry.head_dim,
+    )
+    .to_spec();
+    Some(NativeKvAdmissionFacts {
+        geometry,
+        spec,
+        required_positions,
+        fixed_decode_state_bytes: 0,
+    })
+}
+
+/// This request's decoder KV admission facts for `granite-speech`, assembled
+/// from the loaded pack's decoder metadata
+/// (`crate::models::granite_speech::capacity`). Audio-token rate and fixed
+/// prompt overhead reuse the family's capacity module (the same geometry the
+/// max-input-seconds derivation uses); generation headroom is the executor's
+/// `GRANITE_SPEECH_MAX_GENERATED_TOKENS`. Spec is
+/// `GRANITE_SPEECH_ADMISSION_KV_SPEC` (two f16 halves = the single f32 copy
+/// the runtime keeps -- see that constant's doc; NOT the qwen-family
+/// resolver, granite does not share the qwen decoder path). `None`
+/// (unparseable granite-speech metadata) leaves the request
+/// admission-unchecked (fail open).
+fn granite_speech_native_capacity_admission_facts(
+    metadata: &crate::ggml_runtime::GgufMetadata,
+    audio_duration_seconds: f32,
+) -> Option<NativeKvAdmissionFacts> {
+    let decoder =
+        crate::models::granite_speech::runtime_contract::parse_decoder_metadata(metadata).ok()?;
+    Some(NativeKvAdmissionFacts {
+        geometry: crate::models::granite_speech::capacity::granite_speech_kv_geometry(&decoder),
+        spec: crate::models::granite_speech::capacity::GRANITE_SPEECH_ADMISSION_KV_SPEC,
+        required_positions:
+            crate::models::granite_speech::capacity::granite_speech_admission_required_positions(
+                audio_duration_seconds,
+            ),
+        fixed_decode_state_bytes: 0,
+    })
+}
+
 /// The per-family KV admission facts deriver for `model_architecture`, or
 /// `None` when this architecture has no wired deriver (fail open -- left
 /// admission-unchecked, exactly as before this check existed). Each wired arm
@@ -2911,11 +2975,12 @@ fn firered_aed_native_capacity_admission_facts(
 /// family geometry.
 ///
 /// Wired today: every `Derived`-capacity family (moss-transcribe-diarize,
-/// qwen3-asr, firered-llm, mimo-asr, cohere-transcribe) plus firered-aed
-/// (whose fixed-ceiling decoder arenas are large enough to matter even
-/// though its audio bound lives elsewhere). Families that keep no
-/// per-request decoder KV state worth charging (CTC/transducer shapes, the
-/// small `BoundedElsewhere` decoders) stay unchecked.
+/// qwen3-asr, firered-llm, mimo-asr, cohere-transcribe, funasr-nano,
+/// granite-speech) plus firered-aed (whose fixed-ceiling decoder arenas are
+/// large enough to matter even though its audio bound lives elsewhere).
+/// Families that keep no per-request decoder KV state worth charging
+/// (CTC/transducer shapes, the small `BoundedElsewhere` decoders) stay
+/// unchecked.
 fn native_capacity_admission_facts(
     model_architecture: &str,
     metadata: &crate::ggml_runtime::GgufMetadata,
@@ -2934,6 +2999,10 @@ fn native_capacity_admission_facts(
         cohere_native_capacity_admission_facts(metadata)
     } else if model_architecture == crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID {
         firered_aed_native_capacity_admission_facts(metadata)
+    } else if model_architecture == crate::arch::FUNASR_NANO_GGML_ARCHITECTURE_ID {
+        funasr_nano_native_capacity_admission_facts(metadata, audio_duration_seconds, backend)
+    } else if model_architecture == crate::arch::GRANITE_SPEECH_GGML_ARCHITECTURE_ID {
+        granite_speech_native_capacity_admission_facts(metadata, audio_duration_seconds)
     } else {
         None
     }
@@ -4685,6 +4754,150 @@ mod tests {
         );
     }
 
+    /// Synthetic GGUF metadata carrying the real Fun-ASR-Nano-2512
+    /// checkpoint's Qwen3-0.6B decoder facts (the same values
+    /// `funasr_nano::runtime_contract`'s `full_metadata` fixture parses).
+    /// Only the decoder keys are required: the admission deriver only parses
+    /// the LLM decoder subset.
+    fn funasr_nano_shipped_pack_metadata_for_test() -> crate::ggml_runtime::GgufMetadata {
+        use crate::ggml_runtime::GgufMetadataValue as V;
+        use crate::models::funasr_nano::runtime_contract::*;
+
+        let mut values = std::collections::BTreeMap::new();
+        for (key, value) in [
+            (LLM_N_LAYERS_KEY, 28u64),
+            (LLM_D_MODEL_KEY, 1024),
+            (LLM_N_HEADS_KEY, 16),
+            (LLM_N_KV_HEADS_KEY, 8),
+            (LLM_HEAD_DIM_KEY, 128),
+            (LLM_FFN_DIM_KEY, 3072),
+            (LLM_VOCAB_SIZE_KEY, 151_936),
+            (LLM_MAX_POSITIONS_KEY, 40_960),
+            (LLM_CHATML_IM_START_TOKEN_ID_KEY, 151_644),
+            (LLM_CHATML_IM_END_TOKEN_ID_KEY, 151_645),
+            (LLM_ENDOFTEXT_TOKEN_ID_KEY, 151_643),
+        ] {
+            values.insert(key.to_string(), V::U64(value));
+        }
+        crate::ggml_runtime::GgufMetadata::from_values_for_test(values)
+    }
+
+    /// Synthetic GGUF metadata carrying the real granite-speech-4.1-2b
+    /// checkpoint's decoder facts (the same values
+    /// `GraniteSpeechDecoderConfig::granite_speech_4_1_2b` pins and
+    /// `package_import` writes). Integer keys as u32; the four scaling
+    /// scalars + rms/rope as stringified floats (the pack's real encoding).
+    fn granite_speech_shipped_pack_metadata_for_test() -> crate::ggml_runtime::GgufMetadata {
+        use crate::ggml_runtime::GgufMetadataValue as V;
+
+        let mut values = std::collections::BTreeMap::new();
+        for (key, value) in [
+            ("granite_speech.decoder.hidden_size", 2048u32),
+            ("granite_speech.decoder.num_hidden_layers", 40),
+            ("granite_speech.decoder.num_attention_heads", 16),
+            ("granite_speech.decoder.num_key_value_heads", 4),
+            ("granite_speech.decoder.head_dim", 128),
+            ("granite_speech.decoder.intermediate_size", 4096),
+            ("granite_speech.decoder.vocab_size", 100_353),
+        ] {
+            values.insert(key.to_string(), V::U32(value));
+        }
+        for (key, value) in [
+            ("granite_speech.decoder.rms_norm_eps", "0.00001"),
+            ("granite_speech.decoder.rope_theta", "10000"),
+            ("granite_speech.decoder.attention_multiplier", "0.0078125"),
+            ("granite_speech.decoder.embedding_multiplier", "12"),
+            ("granite_speech.decoder.residual_multiplier", "0.22"),
+            ("granite_speech.decoder.logits_scaling", "8"),
+        ] {
+            values.insert(key.to_string(), V::String(value.to_string()));
+        }
+        crate::ggml_runtime::GgufMetadata::from_values_for_test(values)
+    }
+
+    /// funasr-nano is now wired: geometry off the pack's Qwen3 decoder keys,
+    /// spec from the same resolver the real decoder allocates against (Q8_0
+    /// on CPU at head_dim 128), positions cross-checked against the family
+    /// deriver, and the single-decode clamp holding for a multi-hour file.
+    #[test]
+    fn funasr_nano_capacity_admission_facts_derive_from_pack_metadata() {
+        let metadata = funasr_nano_shipped_pack_metadata_for_test();
+        let facts = native_capacity_admission_facts(
+            crate::arch::FUNASR_NANO_GGML_ARCHITECTURE_ID,
+            &metadata,
+            40.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("funasr-nano-shaped metadata must derive admission facts");
+        assert_eq!(
+            facts.geometry,
+            crate::capacity::KvGeometry {
+                n_layers: 28,
+                kv_heads: 8,
+                head_dim: 128,
+            }
+        );
+        assert_eq!(facts.spec, crate::nn::decoder::LlmKvCacheSpec::Q8_0);
+        assert_eq!(facts.fixed_decode_state_bytes, 0);
+        assert_eq!(
+            facts.required_positions,
+            crate::models::funasr_nano::capacity::funasr_nano_admission_required_positions(40.0)
+        );
+        // A multi-hour recording clamps to the 40s single-decode window.
+        let at_hour = native_capacity_admission_facts(
+            crate::arch::FUNASR_NANO_GGML_ARCHITECTURE_ID,
+            &metadata,
+            3600.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("facts");
+        assert_eq!(at_hour, facts);
+    }
+
+    /// granite-speech is now wired: geometry off the pack's decoder keys,
+    /// spec is the family's single-f32-copy admission stand-in (not the
+    /// qwen-family resolver), positions cross-checked against the family
+    /// deriver, and the SharedWindow clamp holding for a multi-hour file.
+    #[test]
+    fn granite_speech_capacity_admission_facts_derive_from_pack_metadata() {
+        let metadata = granite_speech_shipped_pack_metadata_for_test();
+        let facts = native_capacity_admission_facts(
+            crate::arch::GRANITE_SPEECH_GGML_ARCHITECTURE_ID,
+            &metadata,
+            30.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("granite-speech-shaped metadata must derive admission facts");
+        assert_eq!(
+            facts.geometry,
+            crate::capacity::KvGeometry {
+                n_layers: 40,
+                kv_heads: 4,
+                head_dim: 128,
+            }
+        );
+        assert_eq!(
+            facts.spec,
+            crate::models::granite_speech::capacity::GRANITE_SPEECH_ADMISSION_KV_SPEC
+        );
+        assert_eq!(facts.fixed_decode_state_bytes, 0);
+        assert_eq!(
+            facts.required_positions,
+            crate::models::granite_speech::capacity::granite_speech_admission_required_positions(
+                30.0
+            )
+        );
+        // A multi-hour recording clamps to the SharedWindow single-decode window.
+        let at_hour = native_capacity_admission_facts(
+            crate::arch::GRANITE_SPEECH_GGML_ARCHITECTURE_ID,
+            &metadata,
+            3600.0,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("facts");
+        assert_eq!(at_hour, facts);
+    }
+
     /// The gap this round closes for every newly wired family: a pack whose
     /// on-disk bytes plainly exceed any host budget is refused with the
     /// typed, actionable `NativeInsufficientHostMemory` error BEFORE the
@@ -4704,7 +4917,7 @@ mod tests {
         let modest = dir.path().join("modest.oasr");
         std::fs::write(&modest, vec![0u8; 4096]).expect("write modest pack");
 
-        let cases: [(&str, crate::ggml_runtime::GgufMetadata); 4] = [
+        let cases: [(&str, crate::ggml_runtime::GgufMetadata); 6] = [
             (
                 crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID,
                 firered_llm_shipped_pack_metadata_for_test(),
@@ -4721,6 +4934,14 @@ mod tests {
                 crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID,
                 firered_aed_shipped_pack_metadata_for_test(),
             ),
+            (
+                crate::arch::FUNASR_NANO_GGML_ARCHITECTURE_ID,
+                funasr_nano_shipped_pack_metadata_for_test(),
+            ),
+            (
+                crate::arch::GRANITE_SPEECH_GGML_ARCHITECTURE_ID,
+                granite_speech_shipped_pack_metadata_for_test(),
+            ),
         ];
         for (architecture, metadata) in &cases {
             let error = enforce_native_host_memory_admission(
@@ -4731,7 +4952,7 @@ mod tests {
                 crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
                 0,
             )
-            .expect_err("a 1 PiB pack cannot fit any host");
+            .expect_err("a 1 TiB pack cannot fit any host");
             match error {
                 BackendError::NativeInsufficientHostMemory { reason } => {
                     assert!(

--- a/crates/openasr-core/src/models/funasr_nano/capacity.rs
+++ b/crates/openasr-core/src/models/funasr_nano/capacity.rs
@@ -1,0 +1,177 @@
+//! funasr-nano capacity derivation: the family's Qwen3 decoder KV geometry
+//! and the decoder positions a single decode of a given audio span needs,
+//! assembled from PACK METADATA (`FunasrNanoDecoderMetadata`) plus the same
+//! frontend / audio-token / generation constants the executor uses, so the
+//! shared host-memory admission check
+//! ([`crate::capacity::evaluate_host_memory_admission`]) can refuse a request
+//! that plainly cannot fit BEFORE the ggml graph build turns the shortfall
+//! into an opaque allocation failure. The funasr-nano analogue of
+//! [`crate::models::firered_llm::capacity`] / [`crate::models::qwen::capacity`].
+//!
+//! Reuses, never re-derives:
+//! - KV geometry comes straight off the parsed pack (`funasr.llm.*` are
+//!   required metadata keys).
+//! - The audio-token count walks the exact runtime pipeline arithmetic:
+//!   snip-edges kaldi fbank framing (SenseVoice `WavFrontend` constants the
+//!   executor reuses -- 16 kHz / 25 ms / 10 ms), FunASR LFR stacking
+//!   (`LFR_N = 6`), and the official low-frame-rate truncation
+//!   ([`super::decode_prompt::funasr_nano_audio_token_count`], the same
+//!   function the real decode path calls).
+//! - The generation budget and the single-decode window reuse the executor's
+//!   own constants ([`super::executor::FUNASR_NANO_MAX_GENERATED_TOKENS`],
+//!   [`super::executor::FUNASR_NANO_MAX_INPUT_SECONDS`]), so admission
+//!   charges the same `prompt + generation` KV capacity
+//!   `FunasrNanoDecoderRuntime::new_kv_caches` actually allocates.
+
+use crate::capacity::KvGeometry;
+use crate::models::sensevoice::frontend::{LFR_N, SAMPLE_RATE_HZ};
+
+use super::decode_prompt::funasr_nano_audio_token_count;
+use super::executor::{FUNASR_NANO_MAX_GENERATED_TOKENS, FUNASR_NANO_MAX_INPUT_SECONDS};
+use super::runtime_contract::FunasrNanoDecoderMetadata;
+
+/// Kaldi fbank frame length / shift the SenseVoice `WavFrontend` pins
+/// (25 ms / 10 ms @ 16 kHz) -- the same constants
+/// `crate::models::sensevoice::frontend`'s frontend config carries. Kept local
+/// (rather than reaching into the private frontend config) so the admission
+/// arithmetic stays a pure function of publicly named family facts.
+const FBANK_FRAME_LENGTH_SAMPLES: usize = 400;
+const FBANK_FRAME_SHIFT_SAMPLES: usize = 160;
+
+/// The audio a single funasr-nano decode is estimated to fold in, for
+/// admission. The executor fails closed above this upstream hard cap
+/// (`FUNASR_NANO_MAX_INPUT_SECONDS`, ~40s OOD-repeat bound), and longer
+/// recordings reach it only as longform slices each at or under this bound --
+/// so no single decode's KV cache ever spans more audio. Clamping here is the
+/// funasr-nano analogue of firered-llm's
+/// `FIRERED_LLM_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS` clamp: a multi-hour
+/// recording is judged by what one decode actually needs, never falsely
+/// rejected as if it decoded whole.
+pub(crate) const FUNASR_NANO_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS: f32 =
+    FUNASR_NANO_MAX_INPUT_SECONDS;
+
+/// Fixed ChatML wrapper tokens around the audio span
+/// (`<|im_start|>system ... <|im_start|>user\n语音转写：` prefix +
+/// `<|im_end|>\n<|im_start|>assistant\n` suffix, see
+/// `super::decode_prompt::build_funasr_nano_decode_prompt`). A small
+/// conservative figure, dwarfed by the audio-token term at any real duration;
+/// its exact value cannot swing an admission decision.
+const FUNASR_NANO_ADMISSION_FIXED_PROMPT_TOKENS: usize = 32;
+
+/// The decoder KV geometry the loaded pack advertises.
+pub(crate) fn funasr_nano_kv_geometry(decoder: &FunasrNanoDecoderMetadata) -> KvGeometry {
+    KvGeometry {
+        n_layers: decoder.n_layers,
+        kv_heads: decoder.n_kv_heads,
+        head_dim: decoder.head_dim,
+    }
+}
+
+/// Decoder positions a single decode of `audio_duration_seconds` requires --
+/// the admission figure `evaluate_host_memory_admission` charges KV bytes
+/// against. Mirrors the runtime's own KV-capacity sizing
+/// (`decode_prompt.token_ids.len() + FUNASR_NANO_MAX_GENERATED_TOKENS` in
+/// `super::executor`): fixed wrapper + one audio token per kept adaptor
+/// output frame + the full runaway-generation backstop, with the audio
+/// clamped to the family's single-decode window.
+pub(crate) fn funasr_nano_admission_required_positions(audio_duration_seconds: f32) -> usize {
+    let admission_seconds =
+        audio_duration_seconds.clamp(0.0, FUNASR_NANO_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS);
+    let samples = (admission_seconds * SAMPLE_RATE_HZ as f32) as usize;
+    // snip_edges fbank framing: 1 + (len - frame_length) / frame_shift.
+    let mel_frames = samples
+        .checked_sub(FBANK_FRAME_LENGTH_SAMPLES)
+        .map(|tail| 1 + tail / FBANK_FRAME_SHIFT_SAMPLES)
+        .unwrap_or(0);
+    // FunASR LFR stacking: ceil(mel_frames / LFR_N), matching
+    // `sensevoice::frontend::apply_lfr`'s output-frame count (computed from
+    // the original, pre-padding frame count).
+    let lfr_frames = if mel_frames == 0 {
+        0
+    } else {
+        mel_frames.div_ceil(LFR_N)
+    };
+    // Official low-frame-rate truncation -- the same function the executor
+    // calls after the adaptor. A degenerate frame count resolves to a tiny
+    // positive audio-token count (the formula bottoms at 1); an under-estimate
+    // resolves to "allow" per `crate::capacity`'s fail-open invariant.
+    let audio_tokens = funasr_nano_audio_token_count(lfr_frames);
+    FUNASR_NANO_ADMISSION_FIXED_PROMPT_TOKENS
+        .saturating_add(audio_tokens)
+        .saturating_add(FUNASR_NANO_MAX_GENERATED_TOKENS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capacity::kv_bytes_per_position;
+    use crate::nn::decoder::LlmKvCacheSpec;
+
+    /// Real-checkpoint-shaped metadata (Qwen3-0.6B decoder: 28 layers, GQA
+    /// with 8 KV heads, head_dim 128, 40960-position context -- the same
+    /// values `runtime_contract`'s `full_metadata` fixture parses).
+    fn reference_decoder() -> FunasrNanoDecoderMetadata {
+        FunasrNanoDecoderMetadata {
+            n_layers: 28,
+            d_model: 1024,
+            n_heads: 16,
+            n_kv_heads: 8,
+            head_dim: 128,
+            ffn_dim: 3072,
+            vocab_size: 151_936,
+            max_positions: 40_960,
+            chatml_im_start_token_id: 151_644,
+            chatml_im_end_token_id: 151_645,
+            endoftext_token_id: 151_643,
+        }
+    }
+
+    #[test]
+    fn kv_geometry_reads_the_llm_decoder_metadata() {
+        let geometry = funasr_nano_kv_geometry(&reference_decoder());
+        assert_eq!(
+            geometry,
+            KvGeometry {
+                n_layers: 28,
+                kv_heads: 8,
+                head_dim: 128,
+            }
+        );
+        // Feeds the shared KV byte model without error (448 rows/position,
+        // the same shape the qwen3 / moss capacity anchors pin).
+        let default = kv_bytes_per_position(&geometry, LlmKvCacheSpec::DEFAULT).expect("default");
+        assert_eq!(default.total(), 448 * 768);
+    }
+
+    #[test]
+    fn required_positions_is_clamped_to_the_single_decode_window() {
+        // 40s and 3600s clamp to the same single-decode window: the executor
+        // hard-caps a single decode at 40s and longform slices the rest, so a
+        // multi-hour recording is never judged as one giant decode.
+        let at_window = funasr_nano_admission_required_positions(
+            FUNASR_NANO_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS,
+        );
+        let at_hour = funasr_nano_admission_required_positions(3600.0);
+        assert_eq!(at_window, at_hour);
+        // A short clip needs strictly fewer positions than a full window.
+        let short = funasr_nano_admission_required_positions(5.0);
+        assert!(short < at_window, "short={short} window={at_window}");
+        // Sanity: well under the pack's 40960 context ceiling at any window.
+        assert!(at_window < reference_decoder().max_positions);
+    }
+
+    #[test]
+    fn required_positions_walks_the_runtime_pipeline_arithmetic() {
+        // 40s at 16kHz snip-edges fbank: 1 + (640000-400)/160 = 3998 mel
+        // frames -> LFR ceil(3998/6) = 667 lfr frames ->
+        // funasr_nano_audio_token_count(667):
+        //   conv(t) = 1 + (t - 3 + 2) / 2
+        //   conv(667) = 1 + 666/2 = 334
+        //   conv(334) = 1 + 333/2 = 167
+        //   n_aud = (167 - 1) / 2 + 1 = 84
+        // required = 32 fixed + 84 audio + 512 generation backstop = 628.
+        let positions = funasr_nano_admission_required_positions(40.0);
+        assert_eq!(positions, 628);
+        assert_eq!(funasr_nano_audio_token_count(667), 84);
+    }
+}

--- a/crates/openasr-core/src/models/funasr_nano/executor.rs
+++ b/crates/openasr-core/src/models/funasr_nano/executor.rs
@@ -66,10 +66,13 @@ const FUNASR_NANO_STREAMING_EXECUTOR_ID: &str = "funasr-nano-ggml-snapshot-strea
 /// it). The executor fails closed rather than silently running an OOD
 /// multi-minute prefill; longer audio is the shared longform slicing
 /// orchestrator's job (see the `ConservativeSeq2SeqV1` longform profile).
-const FUNASR_NANO_MAX_INPUT_SECONDS: f32 = 40.0;
+/// Also the single-decode clamp host-memory admission reads
+/// ([`super::capacity::FUNASR_NANO_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS`]).
+pub(crate) const FUNASR_NANO_MAX_INPUT_SECONDS: f32 = 40.0;
 /// Fail-closed backstop against a non-terminating decode -- greedy decode stops
-/// at `<|im_end|>` well before this in practice.
-const FUNASR_NANO_MAX_GENERATED_TOKENS: usize = 512;
+/// at `<|im_end|>` well before this in practice. Admission charges the same
+/// figure (`super::capacity::funasr_nano_admission_required_positions`).
+pub(crate) const FUNASR_NANO_MAX_GENERATED_TOKENS: usize = 512;
 
 type FunasrNanoRuntimeCacheKey = (PackContentKey, GgmlCpuGraphBackend);
 

--- a/crates/openasr-core/src/models/funasr_nano/mod.rs
+++ b/crates/openasr-core/src/models/funasr_nano/mod.rs
@@ -16,6 +16,7 @@
 //! to the model catalog is a later step.
 
 pub(crate) mod adapter_graph;
+pub(crate) mod capacity;
 pub(crate) mod decode_prompt;
 pub(crate) mod encoder_graph;
 pub(crate) mod executor;

--- a/crates/openasr-core/src/models/granite_speech/capacity.rs
+++ b/crates/openasr-core/src/models/granite_speech/capacity.rs
@@ -1,9 +1,10 @@
-//! granite-speech capacity derivation: the single-decode max audio length is
-//! computed from the decoder's trained context window, the fixed prompt text
+//! granite-speech capacity derivation: two related surfaces.
+//!
+//! # 1. Single-decode max audio length
+//!
+//! Computed from the decoder's trained context window, the fixed prompt text
 //! overhead, the generation backstop, and the Q-Former audio-token rate --
 //! never a margin-note magic number.
-//!
-//! # Formula
 //!
 //! ```text
 //! audio_token_budget = decoder_max_positions
@@ -17,8 +18,6 @@
 //! (16_000 / (160 * 2 * 5) = 10 tok/s -- one projector token per 100ms, the
 //! same rate `encoder_graph.rs`'s long-audio note documents).
 //!
-//! # What this bound protects
-//!
 //! The executor rejects a single buffer longer than
 //! [`GRANITE_SPEECH_MAX_INPUT_SECONDS`] with a typed `AudioTooLong` error
 //! (fail-closed, no silent truncation). Longer recordings are the shared
@@ -28,13 +27,54 @@
 //! against a direct over-limit buffer, the slicer keeps ordinary longform
 //! work inside a comfortable window.
 //!
-//! Production reads the derived constant below. The pure derivation helpers
-//! stay unit-tested so a future pack-carried `max_position_embeddings` key
-//! can replace the architecture constant without silent drift.
+//! # 2. Host-memory admission (decoder KV)
+//!
+//! [`granite_speech_kv_geometry`] / [`granite_speech_admission_required_positions`]
+//! / [`GRANITE_SPEECH_ADMISSION_KV_SPEC`] feed the shared host-memory admission
+//! check ([`crate::capacity::evaluate_host_memory_admission`]) so a pack whose
+//! weights + decode KV plainly cannot fit is refused BEFORE the ggml graph
+//! build turns the shortfall into an opaque allocation failure.
+//!
+//! Reuses, never re-derives:
+//! - KV geometry comes straight off the parsed pack
+//!   (`granite_speech.decoder.{num_hidden_layers,num_key_value_heads,head_dim}`).
+//! - Audio-token rate is [`granite_speech_audio_tokens_per_second`] (the same
+//!   frontend geometry product the max-input-seconds derivation uses).
+//! - Fixed prompt overhead is [`GRANITE_SPEECH_FIXED_PROMPT_TOKENS`]; generation
+//!   headroom is [`super::executor::GRANITE_SPEECH_MAX_GENERATED_TOKENS`] (the
+//!   same figure `decode_session`'s resident-KV arena headroom reserves).
+//! - The single-decode admission window is the shared longform safety chunk
+//!   ([`crate::arch::DEFAULT_ENCODER_SAFE_CHUNK_SECONDS`]): granite is
+//!   `SharedWindow`, so no single decode's KV cache ever spans more audio than
+//!   one slice. Clamping here keeps a multi-hour recording from being judged
+//!   (and falsely rejected) as if it decoded whole. A user who forces a larger
+//!   `longform.chunk_seconds` only makes admission MORE permissive (an under-
+//!   estimate resolves to "allow", per `crate::capacity`'s fail-open
+//!   invariant), never falsely rejecting.
+//!
+//! KV element-type truth source: the runtime keeps a SINGLE f32 copy of the
+//! decode KV -- host growing history on CPU (`decode_session`'s `k_history` /
+//! `v_history`), device-resident f32 arena on Metal
+//! (`GRANITE_RESIDENT_KV_SPEC` in `decode_session.rs`). The shared position
+//! model charges host + resident halves, so
+//! [`GRANITE_SPEECH_ADMISSION_KV_SPEC`] models that single f32 copy as two f16
+//! halves whose `.total()` equals one f32 (the same cohere / firered-aed
+//! modeling stand-in). Hard-coding `LlmKvCacheSpec::DEFAULT` (f32 host + f16
+//! resident) would overstate by 1.5x in the false-reject direction admission
+//! forbids.
+//!
+//! Production reads the derived max-input-seconds constant below. The pure
+//! derivation helpers stay unit-tested so a future pack-carried
+//! `max_position_embeddings` key can replace the architecture constant
+//! without silent drift.
 #![cfg_attr(not(test), allow(dead_code))]
 
-use crate::capacity::{FrontendGeometry, audio_tokens_per_second};
+use crate::capacity::{FrontendGeometry, KvGeometry, audio_tokens_per_second};
+use crate::ggml_runtime::GgmlKvElementType;
+use crate::nn::decoder::LlmKvCacheSpec;
 
+use super::decoder_graph::GraniteSpeechDecoderConfig;
+use super::executor::GRANITE_SPEECH_MAX_GENERATED_TOKENS;
 use super::frontend::{HOP_LENGTH, SAMPLE_RATE_HZ};
 use super::qformer::GraniteSpeechProjectorConfig;
 
@@ -113,12 +153,72 @@ pub(crate) fn derive_max_input_seconds(
 /// to [`derive_max_input_seconds`] so the arithmetic cannot drift silently.
 pub(crate) const GRANITE_SPEECH_MAX_INPUT_SECONDS: f32 = 382.0;
 
+/// The audio a single granite-speech decode is estimated to fold in, for
+/// host-memory admission. granite-speech is
+/// [`crate::arch::OpenAsrLongformSliceShape::SharedWindow`]: a recording
+/// longer than the shared longform safety chunk is sliced, and each slice is
+/// its own decode, so no single decode's KV cache ever spans more than one
+/// window's audio. Clamping the admission estimate here (the analogue of
+/// qwen3's `QWEN3_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS` clamp) is what
+/// keeps a multi-hour recording from being judged -- and falsely rejected --
+/// as if it decoded whole. The executor's own 382s decoder-context ceiling
+/// is a separate fail-closed bound on a direct over-limit buffer; ordinary
+/// longform work never approaches it.
+pub(crate) const GRANITE_SPEECH_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS: f32 =
+    crate::arch::DEFAULT_ENCODER_SAFE_CHUNK_SECONDS;
+
+/// Two f16 copies = 4 B/value total: byte-for-byte the single f32 copy the
+/// runtime actually keeps (host growing history on CPU; device-resident f32
+/// arena on Metal -- see the module doc). Only
+/// [`crate::capacity::KvBytesPerPosition::total`] is consumed by admission,
+/// so the host/resident split is a modeling stand-in, not a claim that both
+/// copies exist at once.
+pub(crate) const GRANITE_SPEECH_ADMISSION_KV_SPEC: LlmKvCacheSpec = LlmKvCacheSpec {
+    host: GgmlKvElementType::F16,
+    resident: GgmlKvElementType::F16,
+};
+
+/// The decoder KV geometry the loaded pack advertises.
+pub(crate) fn granite_speech_kv_geometry(decoder: &GraniteSpeechDecoderConfig) -> KvGeometry {
+    KvGeometry {
+        n_layers: decoder.num_layers,
+        kv_heads: decoder.num_kv_heads,
+        head_dim: decoder.head_dim,
+    }
+}
+
+/// Decoder positions a single decode of `audio_duration_seconds` requires --
+/// the admission figure `evaluate_host_memory_admission` charges KV bytes
+/// against. Mirrors the runtime's own KV-capacity sizing
+/// (`prompt_tokens + GRANITE_SPEECH_MAX_GENERATED_TOKENS` /
+/// `GRANITE_RESIDENT_DECODE_HEADROOM` in `decode_session`): fixed prompt
+/// overhead + projected audio tokens at the frontend rate + the full
+/// generation backstop, with the audio clamped to the SharedWindow single-
+/// decode window.
+pub(crate) fn granite_speech_admission_required_positions(audio_duration_seconds: f32) -> usize {
+    let admission_seconds =
+        audio_duration_seconds.clamp(0.0, GRANITE_SPEECH_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS);
+    let rate = granite_speech_audio_tokens_per_second();
+    // Ceil so a fractional token still reserves a full position (matches the
+    // Q-Former's partial-window pad behaviour at the frame boundary). A non-
+    // positive rate fails closed to zero audio tokens -- an under-estimate
+    // resolves to "allow" per `crate::capacity`'s fail-open invariant.
+    let audio_tokens = if rate.is_finite() && rate > 0.0 {
+        (admission_seconds * rate).ceil() as usize
+    } else {
+        0
+    };
+    GRANITE_SPEECH_FIXED_PROMPT_TOKENS
+        .saturating_add(audio_tokens)
+        .saturating_add(GRANITE_SPEECH_MAX_GENERATED_TOKENS)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::super::executor::GRANITE_SPEECH_MAX_GENERATED_TOKENS;
     use super::*;
     use crate::capacity::{
-        AudioFrontendCapacityBasis, audio_tokens_per_second, frontend_capacity_basis,
+        AudioFrontendCapacityBasis, KvGeometry, audio_tokens_per_second, frontend_capacity_basis,
+        kv_bytes_per_position,
     };
 
     #[test]
@@ -205,5 +305,40 @@ mod tests {
             GraniteSpeechProjectorConfig::granite_speech_4_1_2b().window_size,
             15
         );
+    }
+
+    #[test]
+    fn kv_geometry_reads_the_llm_decoder_metadata() {
+        let geometry =
+            granite_speech_kv_geometry(&GraniteSpeechDecoderConfig::granite_speech_4_1_2b());
+        assert_eq!(
+            geometry,
+            KvGeometry {
+                n_layers: 40,
+                kv_heads: 4,
+                head_dim: 128,
+            }
+        );
+        // Two f16 halves = one f32 copy: 40 layers * 2 (K+V) * 4 kv-heads *
+        // 128 * 4 B = 163_840 B/position.
+        let per_pos =
+            kv_bytes_per_position(&geometry, GRANITE_SPEECH_ADMISSION_KV_SPEC).expect("spec");
+        assert_eq!(per_pos.total(), 40 * 2 * 4 * 128 * 4);
+    }
+
+    #[test]
+    fn required_positions_is_clamped_to_the_shared_window() {
+        // 30s and 3600s clamp to the same SharedWindow single-decode window.
+        let at_window = granite_speech_admission_required_positions(
+            GRANITE_SPEECH_ADMISSION_SINGLE_DECODE_WINDOW_SECONDS,
+        );
+        let at_hour = granite_speech_admission_required_positions(3600.0);
+        assert_eq!(at_window, at_hour);
+        let short = granite_speech_admission_required_positions(5.0);
+        assert!(short < at_window, "short={short} window={at_window}");
+        // Explicit arithmetic pin at the SharedWindow: 19 fixed + ceil(30*10)
+        // audio + 256 generation = 19 + 300 + 256 = 575.
+        assert_eq!(at_window, 575);
+        assert_eq!(granite_speech_admission_required_positions(30.0), 575);
     }
 }


### PR DESCRIPTION
## Summary

Extend `enforce_native_host_memory_admission` to funasr-nano and granite-speech so oversized packs fail closed before graph build on tiny hosts, matching the moss/qwen3/firered/mimo/cohere path already on main.

## Why

Host-memory admission already covers several Derived families. funasr-nano and granite-speech still failed open because their decoder KV geometry was not wired into the shared gate. Both families now have honest pack-derived capacity numbers, so the remaining gap is just dispatch.

## Changes

- New `funasr_nano/capacity.rs`: pack geometry from `funasr.llm`, Qwen-family KV policy, 40s clamp.
- Expand `granite_speech/capacity.rs`: decoder metadata + Q-Former rate, single-f32-copy KV spec, SharedWindow 30s clamp.
- Wire both into `native_transcribe` admission derivers/dispatch with unit coverage.

## Tests run

- [x] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run -E 'test(capacity)|test(enforce_native_host_memory)'` (81 passed, including the 4 new `enforce_native_host_memory_*` cases)
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

None required; pure admission math + dispatch wiring.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- CTC / BoundedElsewhere families stay fail-open (no invented geometry).
- Does not change desktop pin or release train.
- Does not close #159 (issue hygiene is separate).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — drafting and mechanical wiring assisted; human owns design, review, and maintenance.