### PR TITLE
ci(docker): publish CPU and CUDA images to Docker Hub on core release

### DIFF
--- a/.github/workflows/docker-cuda-release.yml
+++ b/.github/workflows/docker-cuda-release.yml
@@ -1,36 +1,31 @@
 name: Docker CUDA release
 
-# Manual-only: builds Dockerfile.cuda (the NVIDIA GPU image; see that file for
-# why it compiles from source instead of assembling the released
-# linux-x86_64-cuda binary) and, when explicitly asked to, pushes it to GHCR.
-#
-# GitHub-hosted runners have no GPU, so this validates "compiles + links +
-# packages" only -- exactly like the `linux-x86_64-cuda` leg in
-# release-binaries.yml, which already compiles the same `cuda` feature
-# successfully on a GPU-less hosted runner today (nvcc device-code
-# compilation does not require a physical GPU, only a matching driver at
-# *run* time). Real GPU execution is validated on real hardware, e.g. via
-# `docker compose --profile gpu up openasr-cuda` on a machine with an NVIDIA
-# card and the NVIDIA Container Toolkit installed -- see compose.yaml and
-# scripts/docker-cuda-entrypoint.sh for the fail-closed GPU-visibility gate
-# that guards against a silent CPU fallback there.
-#
-# Dispatch manually from the Actions tab or `gh workflow run docker-cuda-release.yml`.
+# Convenience wrapper around docker-release.yml for CUDA-only builds.
+# Prefer `docker-release.yml` (variants=all|cpu|cuda) for new manual runs.
+# Pushes go to Docker Hub (`quintinshaw/openasr:cuda-*`), not GHCR.
 
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "OpenASR version without the leading v (empty = read Cargo.toml at ref)"
+        required: false
+        default: ""
+      tag:
+        description: "Release tag (empty = v<version>)"
+        required: false
+        default: ""
       ref:
-        description: "Git ref (branch, tag, or SHA) to build; empty = default branch"
+        description: "Git ref to checkout for Dockerfiles/scripts (empty = tag or default branch)"
         required: false
         default: ""
       push:
-        description: "Push the built image to ghcr.io (false = build-only dry run, no registry writes)"
+        description: "Push the built image to Docker Hub (false = build-only dry run)"
         required: false
         default: false
         type: boolean
       mark_latest:
-        description: "Also tag/push cuda-latest (only meaningful when push is true; use for a real release ref, not an arbitrary dev branch)"
+        description: "Also tag/push cuda-latest (only meaningful when push is true)"
         required: false
         default: false
         type: boolean
@@ -42,88 +37,16 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  build-and-push:
-    name: Build (and optionally push) the CUDA image
-    # Only the canonical repo may push to its GHCR namespace; forks can still
-    # dispatch this for a build-only dry run since `packages: write` is not
-    # granted below unless this check passes.
+  docker:
+    name: Build CUDA image via docker-release
     if: github.repository_owner == 'QuintinShaw'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.ref }}
-          submodules: recursive
-
-      - name: Resolve workspace version
-        id: version
-        run: |
-          set -euo pipefail
-          version="$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
-          if [ -z "${version}" ]; then
-            echo "could not read workspace version from Cargo.toml" >&2
-            exit 1
-          fi
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        if: inputs.push
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute image tags
-        id: tags
-        run: |
-          set -euo pipefail
-          image="${REGISTRY}/${IMAGE_NAME}"
-          # Lowercase (GHCR requires lowercase repository paths); github.repository
-          # is already QuintinShaw/openasr (mixed case owner), so normalize.
-          image="$(printf '%s' "${image}" | tr '[:upper:]' '[:lower:]')"
-          short_sha="$(git rev-parse --short HEAD)"
-          tags="${image}:cuda-${{ steps.version.outputs.version }},${image}:cuda-sha-${short_sha}"
-          if [ "${{ inputs.mark_latest }}" = "true" ]; then
-            tags="${tags},${image}:cuda-latest"
-          fi
-          echo "tags=${tags}" >> "${GITHUB_OUTPUT}"
-
-      # linux/amd64 only: matches release-binaries.yml's Linux CUDA leg
-      # (x86_64-only -- there is no aarch64 desktop/server NVIDIA CUDA leg
-      # there either; Jetson uses a separate l4t base image, out of scope).
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.cuda
-          platforms: linux/amd64
-          push: ${{ inputs.push }}
-          tags: ${{ steps.tags.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Summary
-        run: |
-          {
-            echo "### Docker CUDA image"
-            echo
-            if [ "${{ inputs.push }}" = "true" ]; then
-              echo "Pushed: \`${{ steps.tags.outputs.tags }}\`"
-            else
-              echo "Build-only dry run (push=false) -- no registry writes. Tags that would have been pushed:"
-              echo "\`${{ steps.tags.outputs.tags }}\`"
-            fi
-          } >> "${GITHUB_STEP_SUMMARY}"
+    uses: ./.github/workflows/docker-release.yml
+    with:
+      version: ${{ inputs.version }}
+      tag: ${{ inputs.tag }}
+      ref: ${{ inputs.ref }}
+      push: ${{ inputs.push }}
+      mark_latest: ${{ inputs.mark_latest }}
+      variants: cuda
+    secrets: inherit

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,349 @@
+name: Docker release
+
+# Build (and optionally push) CPU + CUDA runtime images to Docker Hub from
+# published GitHub Release assets. Release-core calls this after the full
+# binary matrix lands so the images match the just-published CLI; a failed
+# Docker job does not delete or roll back the GitHub Release.
+#
+# Images (Docker Hub namespace `quintinshaw`, repository `openasr`):
+#   CPU  (linux/amd64 + linux/arm64):
+#     quintinshaw/openasr:<version>
+#     quintinshaw/openasr:latest          (only when mark_latest=true)
+#     quintinshaw/openasr:sha-<short>
+#   CUDA (linux/amd64 only):
+#     quintinshaw/openasr:cuda-<version>
+#     quintinshaw/openasr:cuda-latest     (only when mark_latest=true)
+#     quintinshaw/openasr:cuda-sha-<short>
+#
+# Secrets: DOCKER_PAT (Docker Hub access token for user `quintinshaw`). When
+# push=true but the secret is missing, the job prints a ::notice:: and skips
+# the push (same optional-infra pattern as HOMEBREW_TAP_TOKEN) so a missing
+# registry credential cannot turn a successful core release into a mystery
+# failure. workflow_dispatch defaults to push=false for dry-run builds.
+#
+# Manual:
+#   gh workflow run docker-release.yml \
+#     -f version=0.1.28 -f push=false -f mark_latest=false -f variants=all
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "OpenASR version without the leading v (e.g. 0.1.28); empty = Cargo.toml"
+        required: false
+        type: string
+        default: ""
+      tag:
+        description: "Release tag (e.g. v0.1.28); empty = v<version>"
+        required: false
+        type: string
+        default: ""
+      push:
+        description: "Push images to Docker Hub"
+        required: false
+        type: boolean
+        default: true
+      mark_latest:
+        description: "Also move latest / cuda-latest"
+        required: false
+        type: boolean
+        default: true
+      variants:
+        description: "cpu | cuda | all"
+        required: false
+        type: string
+        default: "all"
+      ref:
+        description: "Git ref to checkout for Dockerfiles/scripts (empty = tag)"
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "OpenASR version without the leading v (empty = read Cargo.toml at ref)"
+        required: false
+        default: ""
+      tag:
+        description: "Release tag (empty = v<version>)"
+        required: false
+        default: ""
+      ref:
+        description: "Git ref to checkout for Dockerfiles/scripts (empty = tag or default branch)"
+        required: false
+        default: ""
+      push:
+        description: "Push images to Docker Hub (false = build-only dry run)"
+        required: false
+        default: false
+        type: boolean
+      mark_latest:
+        description: "Also move latest / cuda-latest (only meaningful when push is true)"
+        required: false
+        default: false
+        type: boolean
+      variants:
+        description: "cpu | cuda | all"
+        required: false
+        default: "all"
+
+concurrency:
+  group: docker-release-${{ inputs.tag || inputs.version || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DOCKERHUB_NAMESPACE: quintinshaw
+  DOCKERHUB_IMAGE: openasr
+  DOCKERHUB_USERNAME: quintinshaw
+
+jobs:
+  resolve:
+    name: Resolve version and push plan
+    if: github.repository_owner == 'QuintinShaw'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.plan.outputs.version }}
+      tag: ${{ steps.plan.outputs.tag }}
+      checkout_ref: ${{ steps.plan.outputs.checkout_ref }}
+      short_sha: ${{ steps.plan.outputs.short_sha }}
+      do_push: ${{ steps.plan.outputs.do_push }}
+      mark_latest: ${{ steps.plan.outputs.mark_latest }}
+      build_cpu: ${{ steps.plan.outputs.build_cpu }}
+      build_cuda: ${{ steps.plan.outputs.build_cuda }}
+    steps:
+      - name: Checkout for version metadata
+        uses: actions/checkout@v7
+        with:
+          # Prefer an explicit ref, then the release tag, then the default ref.
+          ref: ${{ inputs.ref || inputs.tag || github.ref }}
+
+      - name: Plan
+        id: plan
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_PUSH: ${{ inputs.push }}
+          INPUT_MARK_LATEST: ${{ inputs.mark_latest }}
+          INPUT_VARIANTS: ${{ inputs.variants }}
+          # Deliberately expanded in env (not shell) so a missing secret stays
+          # empty rather than printing a literal secrets reference.
+          DOCKER_PAT: ${{ secrets.DOCKER_PAT }}
+        run: |
+          set -euo pipefail
+
+          version="${INPUT_VERSION}"
+          if [ -z "${version}" ]; then
+            version="$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+          fi
+          if [ -z "${version}" ]; then
+            echo "could not resolve OPENASR version" >&2
+            exit 1
+          fi
+
+          tag="${INPUT_TAG}"
+          if [ -z "${tag}" ]; then
+            tag="v${version}"
+          fi
+
+          checkout_ref="${INPUT_REF}"
+          if [ -z "${checkout_ref}" ]; then
+            checkout_ref="${tag}"
+          fi
+
+          short_sha="$(git rev-parse --short HEAD)"
+
+          variants="$(printf '%s' "${INPUT_VARIANTS:-all}" | tr '[:upper:]' '[:lower:]')"
+          case "${variants}" in
+            cpu|cuda|all) ;;
+            *)
+              echo "variants must be cpu, cuda, or all (got: ${INPUT_VARIANTS})" >&2
+              exit 1
+              ;;
+          esac
+          build_cpu=false
+          build_cuda=false
+          if [ "${variants}" = "cpu" ] || [ "${variants}" = "all" ]; then
+            build_cpu=true
+          fi
+          if [ "${variants}" = "cuda" ] || [ "${variants}" = "all" ]; then
+            build_cuda=true
+          fi
+
+          want_push=false
+          if [ "${INPUT_PUSH}" = "true" ]; then
+            want_push=true
+          fi
+          do_push=false
+          if [ "${want_push}" = "true" ]; then
+            if [ -n "${DOCKER_PAT}" ]; then
+              do_push=true
+            else
+              echo "::notice::DOCKER_PAT secret not set -- building images without pushing to Docker Hub. Add a Docker Hub access token for user quintinshaw as the DOCKER_PAT repository secret to enable pushes."
+            fi
+          fi
+
+          mark_latest=false
+          if [ "${INPUT_MARK_LATEST}" = "true" ]; then
+            mark_latest=true
+          fi
+
+          {
+            echo "version=${version}"
+            echo "tag=${tag}"
+            echo "checkout_ref=${checkout_ref}"
+            echo "short_sha=${short_sha}"
+            echo "do_push=${do_push}"
+            echo "mark_latest=${mark_latest}"
+            echo "build_cpu=${build_cpu}"
+            echo "build_cuda=${build_cuda}"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "### Docker release plan"
+            echo
+            echo "- version: \`${version}\`"
+            echo "- tag: \`${tag}\`"
+            echo "- checkout_ref: \`${checkout_ref}\`"
+            echo "- short_sha: \`${short_sha}\`"
+            echo "- variants: \`${variants}\`"
+            echo "- push: \`${do_push}\` (requested=${want_push})"
+            echo "- mark_latest: \`${mark_latest}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  cpu:
+    name: CPU image (amd64 + arm64)
+    needs: resolve
+    if: needs.resolve.outputs.build_cpu == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: needs.resolve.outputs.do_push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          set -euo pipefail
+          image="${DOCKERHUB_NAMESPACE}/${DOCKERHUB_IMAGE}"
+          version="${{ needs.resolve.outputs.version }}"
+          short_sha="${{ needs.resolve.outputs.short_sha }}"
+          tags="${image}:${version},${image}:sha-${short_sha}"
+          if [ "${{ needs.resolve.outputs.mark_latest }}" = "true" ]; then
+            tags="${tags},${image}:latest"
+          fi
+          echo "tags=${tags}" >> "${GITHUB_OUTPUT}"
+          echo "tags=${tags}"
+
+      - name: Build and push CPU image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.release
+          platforms: linux/amd64,linux/arm64
+          # Multi-arch cannot `load` into the local docker driver. When not
+          # pushing, export type=cacheonly so the dry-run still compiles every
+          # platform layer without needing a registry.
+          push: ${{ needs.resolve.outputs.do_push == 'true' }}
+          outputs: ${{ needs.resolve.outputs.do_push == 'true' && 'type=registry' || 'type=cacheonly' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            OPENASR_VERSION=${{ needs.resolve.outputs.version }}
+            OPENASR_REPO=${{ github.repository }}
+          # Release-assemble downloads the published asset; GHA cache does not
+          # help the fetch stage and would only cache the thin runtime layer.
+          provenance: false
+
+      - name: Summary
+        run: |
+          {
+            echo "### CPU image"
+            echo
+            if [ "${{ needs.resolve.outputs.do_push }}" = "true" ]; then
+              echo "Pushed: \`${{ steps.tags.outputs.tags }}\`"
+            else
+              echo "Build-only (no Docker Hub push). Tags prepared:"
+              echo "\`${{ steps.tags.outputs.tags }}\`"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  cuda:
+    name: CUDA image (amd64)
+    needs: resolve
+    if: needs.resolve.outputs.build_cuda == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: needs.resolve.outputs.do_push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          set -euo pipefail
+          image="${DOCKERHUB_NAMESPACE}/${DOCKERHUB_IMAGE}"
+          version="${{ needs.resolve.outputs.version }}"
+          short_sha="${{ needs.resolve.outputs.short_sha }}"
+          tags="${image}:cuda-${version},${image}:cuda-sha-${short_sha}"
+          if [ "${{ needs.resolve.outputs.mark_latest }}" = "true" ]; then
+            tags="${tags},${image}:cuda-latest"
+          fi
+          echo "tags=${tags}" >> "${GITHUB_OUTPUT}"
+          echo "tags=${tags}"
+
+      - name: Build and push CUDA image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.cuda.release
+          platforms: linux/amd64
+          push: ${{ needs.resolve.outputs.do_push == 'true' }}
+          outputs: ${{ needs.resolve.outputs.do_push == 'true' && 'type=registry' || 'type=cacheonly' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            OPENASR_VERSION=${{ needs.resolve.outputs.version }}
+            OPENASR_REPO=${{ github.repository }}
+          provenance: false
+
+      - name: Summary
+        run: |
+          {
+            echo "### CUDA image"
+            echo
+            if [ "${{ needs.resolve.outputs.do_push }}" = "true" ]; then
+              echo "Pushed: \`${{ steps.tags.outputs.tags }}\`"
+            else
+              echo "Build-only (no Docker Hub push). Tags prepared:"
+              echo "\`${{ steps.tags.outputs.tags }}\`"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -296,6 +296,26 @@ jobs:
 
           gh release edit "$tag" --notes-file new-body.md
 
+  docker-images:
+    name: Publish Docker Hub images
+    # Needs the full asset matrix so Dockerfile.release / Dockerfile.cuda.release
+    # can download the just-published linux-x86_64, linux-arm64, and
+    # linux-x86_64-cuda archives (+ SHA256SUMS). A red Docker job fails this
+    # workflow leg only -- it must never delete or roll back the GitHub Release
+    # the earlier jobs already published.
+    needs: [resolve, release, binaries]
+    if: needs.resolve.outputs.should_release == 'true' && success()
+    permissions:
+      contents: read
+    uses: ./.github/workflows/docker-release.yml
+    with:
+      version: ${{ needs.resolve.outputs.version }}
+      tag: ${{ needs.resolve.outputs.tag }}
+      push: true
+      mark_latest: true
+      variants: all
+    secrets: inherit
+
   update-homebrew-tap:
     name: Update Homebrew tap formula
     # Needs the full asset matrix (binaries), not just the core build job's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,12 +70,19 @@ cargo run -p openasr-cli -- doctor
 
 ## Optional Docker smoke
 
+Source-build image (what `docker-smoke.yml` exercises; good for local tree changes):
+
 ```bash
 docker build -t openasr:local .
-docker run --rm -d --name openasr-docker-smoke -p 18080:8080 openasr:local
+docker run --rm -d --name openasr-docker-smoke -p 18080:8080 openasr:local serve --addr 0.0.0.0:8080 --backend mock
 curl -fsS http://127.0.0.1:18080/health
 docker rm -f openasr-docker-smoke
 ```
+
+Published release images live on Docker Hub (`quintinshaw/openasr`,
+`quintinshaw/openasr:cuda-*`) and are assembled from GitHub Release assets by
+`.github/workflows/docker-release.yml` via `Dockerfile.release` /
+`Dockerfile.cuda.release`. See [RELEASING.md](RELEASING.md#docker-hub-images).
 
 ## Formatting and linting
 

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,17 +1,16 @@
-# CUDA-enabled image for NVIDIA GPUs (Turing/sm_75 and up -- RTX 20xx, GTX
-# 16xx, T4, and newer Ampere/Ada/Hopper cards).
+# CUDA-enabled *source-build* image for local NVIDIA GPU development
+# (Turing/sm_75 and up -- RTX 20xx, GTX 16xx, T4, and newer Ampere/Ada/Hopper).
 #
-# Why compile from source here instead of assembling the released
-# `openasr-<version>-linux-x86_64-cuda.tar.gz` binary (release-binaries.yml
-# does publish one): that release binary is compiled against
-# `openasr-core/build.rs`'s current default CUDA arch list, which does not
-# include sm_75 on `main` today, so it silently drops Turing cards ("no
-# kernel image available" at runtime) -- exactly the failure this image
-# exists to fix. Building in-image with an explicit OPENASR_CUDA_GPU_TARGETS
-# below decouples this image from that default and guarantees Turing support
-# regardless of upstream's current state. Once a released binary is built
-# with sm_75 included, switching this Dockerfile to "download + unpack the
-# release asset" becomes a valid, lighter-weight alternative -- revisit then.
+# Published images on Docker Hub are assembled from the released
+# `openasr-<version>-linux-x86_64-cuda.tar.gz` asset via Dockerfile.cuda.release
+# (see .github/workflows/docker-release.yml). That path is preferred for
+# releases because crates/openasr-core's default CUDA arch list already
+# includes sm_75 (see crates/openasr-core/src/cuda_targets.rs), so the
+# published binary matches this image's Turing floor without a second compile.
+#
+# Keep this Dockerfile for:
+#   - `docker compose --profile gpu` / unreleased tree testing
+#   - validating a CUDA build when no release asset exists yet
 #
 # CUDA toolkit version (13.2.0) and base OS (Ubuntu 22.04) match the
 # `linux-x86_64-cuda` leg in .github/workflows/release-binaries.yml so the

--- a/Dockerfile.cuda.release
+++ b/Dockerfile.cuda.release
@@ -1,0 +1,101 @@
+# Assemble a CUDA runtime image from a published GitHub Release asset.
+#
+# The released `openasr-<version>-linux-x86_64-cuda.tar.gz` binary is built
+# with crates/openasr-core's default CUDA arch list (sm_75 through sm_90 --
+# Turing and newer; see crates/openasr-core/src/cuda_targets.rs). That is the
+# same floor this image needs, so release-assemble is preferred over compiling
+# from source: faster CI, and bit-identical to the published CUDA CLI.
+#
+# Local GPU development that needs an unreleased tree still uses the
+# source-build Dockerfile.cuda (compose.yaml --profile gpu).
+#
+# linux/amd64 only (matches the release-binaries.yml CUDA leg).
+#
+# Build:
+#   docker build -f Dockerfile.cuda.release \
+#     --build-arg OPENASR_VERSION=0.1.28 \
+#     -t quintinshaw/openasr:cuda-0.1.28 .
+
+ARG OPENASR_VERSION
+ARG OPENASR_REPO=QuintinShaw/openasr
+# Keep in lockstep with the linux-x86_64-cuda leg in
+# .github/workflows/release-binaries.yml and the source-build Dockerfile.cuda.
+ARG CUDA_VERSION=13.2.0
+ARG UBUNTU_CODENAME=ubuntu22.04
+
+FROM debian:trixie-slim AS fetch
+
+ARG OPENASR_VERSION
+ARG OPENASR_REPO
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -euo pipefail \
+    && if [ -z "${OPENASR_VERSION:-}" ]; then \
+         echo "OPENASR_VERSION build-arg is required" >&2; exit 1; \
+       fi \
+    && tag="v${OPENASR_VERSION}" \
+    && archive="openasr-${OPENASR_VERSION}-linux-x86_64-cuda.tar.gz" \
+    && base="https://github.com/${OPENASR_REPO}/releases/download/${tag}" \
+    && curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS" \
+    && curl -fsSL -o "/tmp/${archive}" "${base}/${archive}" \
+    && expected="$(grep -E "  ${archive}\$" /tmp/SHA256SUMS | awk '{print $1}')" \
+    && if [ -z "${expected}" ]; then \
+         echo "no SHA256SUMS entry for ${archive}" >&2; exit 1; \
+       fi \
+    && echo "${expected}  /tmp/${archive}" | sha256sum -c - \
+    && mkdir -p /out \
+    && tar -xzf "/tmp/${archive}" -C /out --strip-components=1 \
+    && test -x /out/openasr \
+    && test -d /out/model-registry
+
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-${UBUNTU_CODENAME} AS runtime
+
+# The "runtime" nvidia/cuda tag already ships libcudart/libcublas/etc (the
+# CUDA redistributable math libraries); it does not ship libcuda.so (the
+# driver), which the NVIDIA Container Toolkit mounts in from the host at
+# `docker run --gpus ...` time. libasound2/libgomp1 match the CPU image
+# (ALSA + OpenMP runtime deps of the openasr binary).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libasound2 libgomp1 ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 10001 openasr \
+    && mkdir -p /app /data \
+    && chown -R openasr:openasr /app /data
+
+WORKDIR /app
+# Prefer the release binary only. CUDA redistributable libs come from the
+# nvidia/cuda runtime base (same CUDA_VERSION the release leg builds against).
+COPY --from=fetch /out/openasr /usr/local/bin/openasr
+COPY --from=fetch /out/model-registry ./model-registry
+COPY scripts/docker-cuda-entrypoint.sh /usr/local/bin/docker-cuda-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-cuda-entrypoint.sh
+
+ENV OPENASR_HOME=/data
+# See the CPU Dockerfile for why this opt-in is safe: binding 0.0.0.0 inside
+# the container is the standard Docker exposure pattern (the operator
+# controls exposure via port-publish/orchestration); the server stays
+# fail-closed against non-loopback plaintext unless this is set. Front it
+# with TLS (or a TLS-terminating proxy) for untrusted networks.
+ENV OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1
+
+# NVIDIA Container Toolkit contract: request GPU capability + full visibility
+# by default (overridable by the operator via `--gpus`/`NVIDIA_VISIBLE_DEVICES`).
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+EXPOSE 8080
+
+USER openasr
+
+# Fail-closed GPU gate: refuses to start (and to keep passing its healthcheck)
+# if the container cannot see a real GPU device, instead of silently falling
+# back to CPU. See scripts/docker-cuda-entrypoint.sh.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+    CMD /usr/local/bin/docker-cuda-entrypoint.sh --gpu-check-only || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-cuda-entrypoint.sh"]
+CMD ["serve", "--addr", "0.0.0.0:8080"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,76 @@
+# Assemble a CPU runtime image from a published GitHub Release asset.
+#
+# Used by .github/workflows/docker-release.yml so a core release does not
+# recompile the CLI inside Docker: the binary, model-registry metadata, and
+# checksums already shipped on the release are the source of truth. Local
+# development and CI smoke still use the source-build Dockerfile.
+#
+# Build (single arch example):
+#   docker build -f Dockerfile.release \
+#     --build-arg OPENASR_VERSION=0.1.28 \
+#     -t quintinshaw/openasr:0.1.28 .
+#
+# Multi-arch (amd64 + arm64) is handled by buildx in CI.
+
+ARG OPENASR_VERSION
+ARG OPENASR_REPO=QuintinShaw/openasr
+
+FROM debian:trixie-slim AS fetch
+
+ARG OPENASR_VERSION
+ARG OPENASR_REPO
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -euo pipefail \
+    && if [ -z "${OPENASR_VERSION:-}" ]; then \
+         echo "OPENASR_VERSION build-arg is required" >&2; exit 1; \
+       fi \
+    && case "${TARGETARCH}" in \
+         amd64) asset_arch="linux-x86_64" ;; \
+         arm64) asset_arch="linux-arm64" ;; \
+         *) echo "unsupported TARGETARCH=${TARGETARCH} (want amd64 or arm64)" >&2; exit 1 ;; \
+       esac \
+    && tag="v${OPENASR_VERSION}" \
+    && archive="openasr-${OPENASR_VERSION}-${asset_arch}.tar.gz" \
+    && base="https://github.com/${OPENASR_REPO}/releases/download/${tag}" \
+    && curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS" \
+    && curl -fsSL -o "/tmp/${archive}" "${base}/${archive}" \
+    && expected="$(grep -E "  ${archive}\$" /tmp/SHA256SUMS | awk '{print $1}')" \
+    && if [ -z "${expected}" ]; then \
+         echo "no SHA256SUMS entry for ${archive}" >&2; exit 1; \
+       fi \
+    && echo "${expected}  /tmp/${archive}" | sha256sum -c - \
+    && mkdir -p /out \
+    && tar -xzf "/tmp/${archive}" -C /out --strip-components=1 \
+    && test -x /out/openasr \
+    && test -d /out/model-registry
+
+FROM debian:trixie-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libasound2t64 libgomp1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 10001 openasr \
+    && mkdir -p /app /data \
+    && chown -R openasr:openasr /app /data
+
+WORKDIR /app
+COPY --from=fetch /out/openasr /usr/local/bin/openasr
+COPY --from=fetch /out/model-registry ./model-registry
+
+ENV OPENASR_HOME=/data
+# Binding 0.0.0.0 inside the container is the standard Docker pattern (exposure is
+# controlled by the operator's port-publish / orchestration). The server is
+# fail-closed against non-loopback plaintext by default; this image opts in
+# explicitly. Front it with TLS (or a TLS-terminating proxy) for untrusted networks.
+ENV OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1
+
+EXPOSE 8080
+
+USER openasr
+ENTRYPOINT ["openasr"]
+CMD ["serve", "--addr", "0.0.0.0:8080"]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ curl http://127.0.0.1:8080/v1/audio/transcriptions \
 
 Drop-in compatible with OpenAI SDKs (`base_url="http://127.0.0.1:8080/v1"`). Offline native requests are serial by default. Operators can set `--max-native-sessions-per-model N`; `N` is both the admission limit and, for eligible direct-GPU Cohere, Moonshine, Qwen, and Whisper jobs, the source for an internal batch width capped at 8. CPU, scheduler, adapter, realtime, FireRed-AED, and FireRed2 paths remain serial; translations follow the offline policy. See [Agent Integration](docs/AGENT_INTEGRATION.md) for API key setup and agent workflows.
 
+### Docker
+
+Published images track each core release on Docker Hub (binary + model-registry
+metadata only; pull models at runtime into a volume mounted at `/data`):
+
+```bash
+docker pull quintinshaw/openasr:latest
+docker run --rm -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:latest
+
+# NVIDIA GPU (requires NVIDIA Container Toolkit)
+docker pull quintinshaw/openasr:cuda-latest
+docker run --rm --gpus all -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:cuda-latest
+```
+
+CPU images are multi-arch (`linux/amd64`, `linux/arm64`). CUDA images are
+`linux/amd64` only (Turing / sm_75 and newer). For local source builds see
+`Dockerfile` / `Dockerfile.cuda` and `compose.yaml`.
+
 ### Building from source
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,6 +88,21 @@ curl http://127.0.0.1:8080/v1/audio/transcriptions \
 
 与 OpenAI SDK 直接兼容(`base_url="http://127.0.0.1:8080/v1"`)。API Key 和 Agent 集成见 [Agent Integration](docs/AGENT_INTEGRATION.md)。
 
+### Docker
+
+每个 core release 会同步发布到 Docker Hub(仅二进制 + model-registry 元数据;模型权重在运行时拉取到挂载在 `/data` 的卷):
+
+```bash
+docker pull quintinshaw/openasr:latest
+docker run --rm -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:latest
+
+# NVIDIA GPU(需要 NVIDIA Container Toolkit)
+docker pull quintinshaw/openasr:cuda-latest
+docker run --rm --gpus all -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:cuda-latest
+```
+
+CPU 镜像为 multi-arch(`linux/amd64`、`linux/arm64`)。CUDA 镜像仅 `linux/amd64`(Turing / sm_75 及以上)。本地源码构建见 `Dockerfile` / `Dockerfile.cuda` 与 `compose.yaml`。
+
 ### 从源码构建
 
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -203,3 +203,49 @@ set, the job prints a `::notice::` and skips -- the release itself still
 succeeds and stays green; the tap formula just does not get bumped for that
 release (bump it manually by re-running the `update-homebrew-tap` job, or by
 hand, once the secret exists).
+
+## Docker Hub images
+
+`release-core.yml`'s `docker-images` job runs after the full binary matrix
+(`binaries`) and builds runtime images from the just-published Linux release
+assets (no second cargo build inside Docker):
+
+- CPU multi-arch (`linux/amd64` + `linux/arm64`) from
+  `openasr-<version>-linux-x86_64.tar.gz` / `linux-arm64.tar.gz` via
+  `Dockerfile.release`
+- CUDA (`linux/amd64` only) from `openasr-<version>-linux-x86_64-cuda.tar.gz`
+  via `Dockerfile.cuda.release`
+
+Images push to Docker Hub under the `quintinshaw` namespace:
+
+```text
+quintinshaw/openasr:<version>
+quintinshaw/openasr:latest
+quintinshaw/openasr:sha-<short>
+quintinshaw/openasr:cuda-<version>
+quintinshaw/openasr:cuda-latest
+quintinshaw/openasr:cuda-sha-<short>
+```
+
+`latest` / `cuda-latest` move only on a successful formal release
+(`mark_latest: true`). Images ship the CLI binary plus bundled
+`model-registry` metadata only -- never model weights. Data lives under
+`OPENASR_HOME=/data`.
+
+This needs a `DOCKER_PAT` repository secret: a Docker Hub access token for
+user `quintinshaw` with permission to push `quintinshaw/openasr`. If the
+secret is not set, the job prints a `::notice::` and builds without pushing
+-- the GitHub Release itself still succeeds; only the Hub publish is skipped.
+A red Docker job fails that leg of the workflow only and does not delete or
+roll back the already-published Release.
+
+Manual dry-run / re-publish against an existing tag:
+
+```bash
+gh workflow run docker-release.yml \
+  -f version=X.Y.Z -f tag=vX.Y.Z -f push=false -f mark_latest=false -f variants=all
+```
+
+Local source-build Dockerfiles (`Dockerfile`, `Dockerfile.cuda`) remain for
+development and `docker-smoke.yml`; they are not the release path.
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,7 @@
 services:
+  # Local source-build services. Published images are on Docker Hub:
+  #   docker pull quintinshaw/openasr:latest
+  #   docker pull quintinshaw/openasr:cuda-latest
   openasr:
     build:
       context: .


### PR DESCRIPTION
## Summary

Publish CPU and CUDA runtime images to Docker Hub automatically after a successful core release, assembled from the just-published Linux release assets instead of recompiling inside CI.

## Why

Core releases already ship verified Linux binaries (`linux-x86_64`, `linux-arm64`, `linux-x86_64-cuda`). Operators need matching container images on Docker Hub without a second full compile, without GHCR, and without blocking or rolling back the GitHub Release if the image job fails.

## Changes

- Add `Dockerfile.release` (CPU multi-arch) and `Dockerfile.cuda.release` (CUDA amd64) that download release tarballs, verify `SHA256SUMS`, and install binary + `model-registry` only
- Add `.github/workflows/docker-release.yml` (`workflow_call` + `workflow_dispatch`) pushing to `quintinshaw/openasr` with `DOCKER_PAT`
- Hook `release-core.yml` `docker-images` job after `binaries` (`push=true`, `mark_latest=true`, `secrets: inherit`)
- Turn `docker-cuda-release.yml` into a CUDA-only convenience wrapper around the new workflow
- Keep source-build `Dockerfile` / `Dockerfile.cuda` for local dev and `docker-smoke.yml`
- Document Hub pull/run examples in README / README.zh-CN, RELEASING, CONTRIBUTING, compose.yaml

## Tests run

- [x] `actionlint` on the touched workflows (only pre-existing shellcheck info in `release-core.yml`)
- [x] PyYAML parse of `docker-release.yml`, `docker-cuda-release.yml`, `release-core.yml`
- [x] Confirmed release asset layout + sha256 for `v0.1.27` `linux-arm64` (`openasr` binary + `model-registry/`)
- [x] Confirmed default CUDA arch list includes sm_75 (`crates/openasr-core/src/cuda_targets.rs`)
- [x] `rg` self-check: no `ghcr.io` / `packages: write` on the new release path; `DOCKER_PAT` referenced; `release-core` hooks `docker-images`
- [ ] `cargo fmt --check` (docs/CI only)
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`
- [ ] Live multi-arch push (not run; needs explicit publish authorization)

## Manual smoke checks

```bash
# Dry-run against an existing tag (no Hub push)
gh workflow run docker-release.yml \
  -f version=0.1.27 -f tag=v0.1.27 -f push=false -f mark_latest=false -f variants=all

# After merge + next core release, or manual push=true:
docker pull quintinshaw/openasr:latest
docker pull quintinshaw/openasr:cuda-latest
```

Local Docker daemon was not running in this environment, so image build was not executed here.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not push to GHCR
- Does not bake model weights into images
- Does not replace local source-build Dockerfiles used by compose/smoke
- Does not perform a live Docker Hub push in this PR

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - drafting assistance for workflow/Dockerfile text; human-owned review and submit.