### PR TITLE
fix(ci): checkout Dockerfiles from workflow ref, not release tag

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -117,8 +117,12 @@ jobs:
       - name: Checkout for version metadata
         uses: actions/checkout@v7
         with:
-          # Prefer an explicit ref, then the release tag, then the default ref.
-          ref: ${{ inputs.ref || inputs.tag || github.ref }}
+          # Dockerfiles and scripts come from the workflow tree (or an
+          # explicit inputs.ref). Never default to the release tag here:
+          # tags cut before Dockerfile.release existed would make the build
+          # jobs fail with "no such file". Version/tag inputs alone select
+          # which GitHub Release assets to download.
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Plan
         id: plan
@@ -149,11 +153,19 @@ jobs:
             tag="v${version}"
           fi
 
+          # Release-assemble Dockerfiles (Dockerfile.release / Dockerfile.cuda.release)
+          # live on the workflow commit / default branch. The release tag only
+          # names which GitHub Release assets to download -- checking out the
+          # tag itself fails for any release cut before those Dockerfiles
+          # existed (open Dockerfile.release: no such file).
           checkout_ref="${INPUT_REF}"
           if [ -z "${checkout_ref}" ]; then
-            checkout_ref="${tag}"
+            checkout_ref="${GITHUB_SHA}"
           fi
 
+          # Prefer the release-tag commit for the image sha-* label when the
+          # resolve job checked out that tag (binary provenance). Fall back to
+          # the workflow commit otherwise.
           short_sha="$(git rev-parse --short HEAD)"
 
           variants="$(printf '%s' "${INPUT_VARIANTS:-all}" | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
## Summary

Default `docker-release.yml` build context to the workflow commit instead of the release tag, so publishing images for an already-cut release (e.g. v0.1.27) still finds `Dockerfile.release` / `Dockerfile.cuda.release`.

## Why

The first Hub publish for 0.1.27 failed because `checkout_ref` defaulted to `v0.1.27`, which predates the release-assemble Dockerfiles. The tag only names which GitHub Release assets to download; the Dockerfiles live on main / the workflow SHA.

## Tests run

- [x] Inspect failed run `30748576595` (missing Dockerfile on tag checkout)
- [x] Confirm run `30748715666` with `ref=main` builds CUDA successfully
- [ ] Live re-run after merge if CPU leg of the manual publish needs a clean re-dispatch

## Docs updated

- [x] No docs change required (workflow comment only)

## Artifact confirmation

- [x] No weights, secrets, or binaries committed