### PR TITLE
docs(docker): expand Hub usage and correct release FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,21 +90,32 @@ Drop-in compatible with OpenAI SDKs (`base_url="http://127.0.0.1:8080/v1"`). Off
 
 ### Docker
 
-Published images track each core release on Docker Hub (binary + model-registry
-metadata only; pull models at runtime into a volume mounted at `/data`):
+Published images track each core release on
+[Docker Hub](https://hub.docker.com/r/quintinshaw/openasr) (binary +
+model-registry metadata only; pull models at runtime into a volume mounted at
+`/data`). The HTTP server never auto-downloads a pack — install one first:
 
 ```bash
 docker pull quintinshaw/openasr:latest
-docker run --rm -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:latest
+docker run --rm -d --name openasr \
+  -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:latest
+docker exec openasr openasr pull whisper-small --yes
 
-# NVIDIA GPU (requires NVIDIA Container Toolkit)
+# NVIDIA GPU (requires NVIDIA Container Toolkit; sm_75 / Turing+)
 docker pull quintinshaw/openasr:cuda-latest
-docker run --rm --gpus all -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:cuda-latest
+docker run --rm -d --name openasr-cuda --gpus all \
+  -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:cuda-latest
 ```
 
-CPU images are multi-arch (`linux/amd64`, `linux/arm64`). CUDA images are
-`linux/amd64` only (Turing / sm_75 and newer). For local source builds see
-`Dockerfile` / `Dockerfile.cuda` and `compose.yaml`.
+| Tag | Platforms | Notes |
+| --- | --- | --- |
+| `latest`, `<version>`, `sha-<short>` | `linux/amd64`, `linux/arm64` | CPU |
+| `cuda-latest`, `cuda-<version>`, `cuda-sha-<short>` | `linux/amd64` | CUDA 13.2 runtime; fail-closed if no GPU is visible |
+
+Vulkan, ROCm, and musl builds ship as GitHub Release archives only (not as
+images). Local source builds: `Dockerfile` / `Dockerfile.cuda` and
+`compose.yaml`. Longer guide (tags, compose, networking):
+[openasr.org/docs/docker](https://openasr.org/docs/docker/).
 
 ### Building from source
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,18 +90,32 @@ curl http://127.0.0.1:8080/v1/audio/transcriptions \
 
 ### Docker
 
-每个 core release 会同步发布到 Docker Hub(仅二进制 + model-registry 元数据;模型权重在运行时拉取到挂载在 `/data` 的卷):
+每个 core release 会同步发布到
+[Docker Hub](https://hub.docker.com/r/quintinshaw/openasr)(仅二进制 +
+model-registry 元数据;模型权重在运行时拉取到挂载在 `/data` 的卷)。HTTP 服务
+**不会**自动下载模型——先显式安装:
 
 ```bash
 docker pull quintinshaw/openasr:latest
-docker run --rm -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:latest
+docker run --rm -d --name openasr \
+  -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:latest
+docker exec openasr openasr pull whisper-small --yes
 
-# NVIDIA GPU(需要 NVIDIA Container Toolkit)
+# NVIDIA GPU(需要 NVIDIA Container Toolkit; sm_75 / Turing 及以上)
 docker pull quintinshaw/openasr:cuda-latest
-docker run --rm --gpus all -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:cuda-latest
+docker run --rm -d --name openasr-cuda --gpus all \
+  -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:cuda-latest
 ```
 
-CPU 镜像为 multi-arch(`linux/amd64`、`linux/arm64`)。CUDA 镜像仅 `linux/amd64`(Turing / sm_75 及以上)。本地源码构建见 `Dockerfile` / `Dockerfile.cuda` 与 `compose.yaml`。
+| 标签 | 平台 | 说明 |
+| --- | --- | --- |
+| `latest`、`<version>`、`sha-<short>` | `linux/amd64`、`linux/arm64` | CPU |
+| `cuda-latest`、`cuda-<version>`、`cuda-sha-<short>` | `linux/amd64` | CUDA 13.2 runtime;看不到 GPU 时失败即停 |
+
+Vulkan / ROCm / musl 变体只以 GitHub Release 压缩包形式提供(不做镜像)。本地
+源码构建见 `Dockerfile` / `Dockerfile.cuda` 与 `compose.yaml`。更完整的标签、
+组网与 compose 说明:
+[openasr.org/docs/docker](https://openasr.org/docs/docker/)。
 
 ### 从源码构建
 

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -19,9 +19,13 @@ contributors -- crate relationships, the audio-to-transcript pipeline, and the
 | [Catalog Forward Compatibility and Client Resilience](CATALOG_COMPATIBILITY.md) | What a running build must do with a catalog from a different epoch: fail-closed boundary (signature/epoch rollback/schema-major/required fields) vs. must-tolerate degradation (unknown language codes, unknown kind/license_class/capability role -> hide the entry, not the catalog); the epoch floor's narrower boot-local-candidate exception; the verify-then-persist + cache/embedded fallback chain; the `catalog_degraded` status surface (`doctor`, `/health`); and the 2026-07-16 cache-pollution incident this hardens against. |
 | [Known Limitations](KNOWN_LIMITATIONS.md) | Current user-visible limits: no public binary release yet, `.oasr`-only native packs, gated streaming/diarization (declared/capability packs only), generic accelerator selection, and internal-only benchmarks. |
 | [FAQ](FAQ.md) | Current-behavior questions: what OpenASR is, which families run, which backends are active, and the conservative offline transcription lane. |
-| [Releasing](../RELEASING.md) | The commit-driven release process: the single workspace version, `scripts/bump-version.sh`, and the version-triggered `Release core` workflow. |
+| [Releasing](../RELEASING.md) | The commit-driven release process: the single workspace version, `scripts/bump-version.sh`, the version-triggered `Release core` workflow, and the post-release Docker Hub image push (`docker-release.yml`). |
 | [Agent Integration](AGENT_INTEGRATION.md) | How a coding agent uses OpenASR: the `skills/openasr` Skill (CLI path) and the local OpenAI-compatible HTTP API, including `openasr apikey` for opt-in loopback authentication. |
 | [Default Model Resolution](default-model-resolution.md) | The single-authority `default_selection` resolver (fail-closed, `config.json` + `default.json` pointer, three-state result) that the server, CLI, and any future shell must all read/write through -- no second resolver, no fabricated defaults. |
+
+User-facing Docker install/run guide (tags, GPU, volumes, pull-before-serve):
+[openasr.org/docs/docker](https://openasr.org/docs/docker/). The short form lives
+in the root [README](../README.md#docker).
 
 ## Format contracts (`docs/format/`)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -145,9 +145,24 @@ Model packs are distributed separately under their own upstream licenses. See
 
 ## Are official installers/releases available?
 
-Not yet. Public binary-release readiness (signed, checksummed release artifacts
-and package-manager channels) remains deferred. Build from source meanwhile — see
-the README and CONTRIBUTING.
+Yes for the open-core CLI and local server. Each core release publishes
+checksummed archives on
+[GitHub Releases](https://github.com/QuintinShaw/openasr/releases) (macOS,
+Linux, Windows, plus CUDA/ROCm/Vulkan/musl variants where applicable) and
+matching runtime images on
+[Docker Hub](https://hub.docker.com/r/quintinshaw/openasr) (`latest` /
+`<version>` for CPU multi-arch, `cuda-latest` / `cuda-<version>` for CUDA
+amd64). The separate macOS/Windows desktop apps ship from
+[openasr.org/download](https://openasr.org/download/).
+
+## Is there an official Docker image?
+
+Yes. `quintinshaw/openasr` on Docker Hub. Images contain the release binary and
+model-registry metadata only — mount a volume at `/data`, then
+`docker exec … openasr pull <model> --yes` before calling the HTTP API. The
+server never auto-pulls. CUDA tags require the NVIDIA Container Toolkit and
+refuse to start if no GPU is visible. Longer guide:
+[openasr.org/docs/docker](https://openasr.org/docs/docker/).
 
 ## Is ffmpeg required?
 


### PR DESCRIPTION
## Summary

Document the published Docker Hub images (`quintinshaw/openasr`) in the README and FAQ, and point operators at the longer website guide.

## Why

Core releases now assemble CPU multi-arch and CUDA images on Docker Hub. The README still described only the source-build compose path, and the FAQ still claimed there were no official installers.

## Changes

- Expand the README / README.zh-CN Docker section: pull-before-serve, tag matrix, Vulkan/ROCm/musl not imaged, link to https://openasr.org/docs/docker/
- FAQ: correct the installers answer; add "Is there an official Docker image?"
- DOCS_INDEX: note docker-release.yml and the website Docker guide

## Tests run

- [x] Docs-only change (no Rust gates)
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

- Cross-checked tag names against live Hub manifests for 0.1.27 (`latest`, `cuda-latest`, version and sha tags).

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not add Vulkan/ROCm/musl Docker images.
- Does not change docker-release.yml behavior.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — drafting and editing assistance; human-owned content and review.