### PR TITLE
fix(runtime): unify cooperative cancellation

### DIFF
--- a/.github/workflows/hip-compile.yml
+++ b/.github/workflows/hip-compile.yml
@@ -76,6 +76,21 @@ jobs:
           $env:OPENASR_GGML_NATIVE = "${{ inputs.ggml_native }}"
           cargo test -p openasr-core capabilities --lib --features hip
 
+      - name: Test HIP native cancellation contract
+        shell: pwsh
+        run: |
+          $env:OPENASR_HIP_GPU_TARGETS = "${{ inputs.gpu_targets }}"
+          $env:OPENASR_GGML_NATIVE = "${{ inputs.ggml_native }}"
+          cargo test -p openasr-core --features hip --lib `
+            ggml_runtime::cpu_graph::tests::gpu_compute_scoped_cancel_reports_native_mode_and_reuses_backend `
+            -- --exact --nocapture
+          cargo test -p openasr-core --features hip --lib `
+            ggml_runtime::cpu_graph::tests::gpu_native_cancel_stops_during_graph_submission_and_reuses_backend `
+            -- --exact --nocapture
+          cargo test -p openasr-core --features hip --lib `
+            ggml_runtime::cpu_graph::tests::gpu_native_cancel_false_preserves_direct_and_scheduler_graphs `
+            -- --exact --nocapture
+
       - name: Smoke HIP doctor output
         shell: pwsh
         run: |

--- a/.github/workflows/vulkan-lavapipe-smoke.yml
+++ b/.github/workflows/vulkan-lavapipe-smoke.yml
@@ -83,6 +83,20 @@ jobs:
       - name: Build openasr-core test binary (vulkan feature)
         run: cargo test -p openasr-core --features vulkan --lib --no-run
 
+      - name: Run Vulkan native cancellation contract tests
+        env:
+          GGML_VK_VISIBLE_DEVICES: "0"
+        run: |
+          cargo test -p openasr-core --features vulkan --lib \
+            ggml_runtime::cpu_graph::tests::gpu_compute_scoped_cancel_reports_native_mode_and_reuses_backend \
+            -- --exact --nocapture
+          cargo test -p openasr-core --features vulkan --lib \
+            ggml_runtime::cpu_graph::tests::gpu_native_cancel_stops_during_graph_submission_and_reuses_backend \
+            -- --exact --nocapture
+          cargo test -p openasr-core --features vulkan --lib \
+            ggml_runtime::cpu_graph::tests::gpu_native_cancel_false_preserves_direct_and_scheduler_graphs \
+            -- --exact --nocapture
+
       - name: Run the Vulkan lavapipe attention-offset smoke test
         env:
           RUST_BACKTRACE: "1"

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -773,6 +773,24 @@ fn main() {
         "cargo:rerun-if-changed={}",
         source_dir.join("include/ggml-cpu.h").display()
     );
+    // These sources define the backend-wide submission/completion and native
+    // cancellation contract. Missing them from Cargo's dependency set can
+    // silently reuse a stale native archive after an incremental edit, making
+    // backend tests exercise different code from the worktree. BLAS is watched
+    // as a directory because CMake may enable it from platform defaults rather
+    // than a Cargo feature.
+    println!(
+        "cargo:rerun-if-changed={}",
+        source_dir.join("src/ggml-backend.cpp").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        source_dir.join("src/ggml-backend-impl.h").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        source_dir.join("src/ggml-blas").display()
+    );
     // The GGML_BACKEND_DL loader shim is OpenASR-authored and decides how plugin
     // DLLs (and their co-located satellite runtime DLLs) are opened on each OS, so
     // edits to it must trigger a ggml rebuild. It was previously untracked, so

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -857,11 +857,18 @@ fn run_concurrent_slice_pipeline(pipeline: ConcurrentSlicePipeline) -> Result<()
             for _ in 0..worker_count {
                 let result_tx = result_tx.clone();
                 scope.spawn(move || {
-                    // Arm this worker thread's ggml abort callback so a cancel
-                    // that arrives mid-graph aborts this worker's compute too;
-                    // between-step cancel is already covered by the shared
-                    // greedy driver's per-token poll of the job-carried control.
-                    let _abort_guard = execution_context.control.arm_for_native_decode();
+                    // Arm this worker thread's ggml abort callback when the
+                    // request has a cancel source, so a mid-graph cancel aborts
+                    // this worker too. Between-step cancel is already covered
+                    // by the shared greedy driver's per-token control poll.
+                    let _abort_guard = execution_context
+                        .control
+                        .arm_for_native_decode_if_cancellable();
+                    // Per-worker fallback tracker (property 4): the GPU-allocation
+                    // streak is meaningful only within one worker's own sequence
+                    // of slices, and sharing it across threads would be a data
+                    // race.
+                    let mut tracker = GpuAllocationFallbackTracker::default();
                     loop {
                         if stop_ref.load(Ordering::Relaxed) {
                             break;
@@ -1161,12 +1168,14 @@ fn run_native_transcription_fallible(
     // below: `publish_align_progress` after that call still needs this
     // request's transcription id.
     let execution_context = Arc::clone(&request.execution_context);
-    // The synchronous core entry owns every auxiliary and decoder graph run,
-    // so it also owns publication of this request's ggml abort flag. Server
-    // callers may already have armed the same control outside spawn_blocking;
-    // the guard is intentionally nestable and restores that outer publication.
-    // Direct core/CLI callers now receive the identical mid-graph cancel path.
-    let _abort_callback_guard = execution_context.control.arm_for_native_decode();
+    // Own graph-level cancellation at the shared native-core boundary. Every
+    // caller that supplies a cancellable context now publishes the request's
+    // flag for synchronous graph compute on this thread; detached contexts
+    // remain callback-free. Concurrent longform workers install the same flag
+    // separately because TLS does not cross thread boundaries.
+    let _abort_callback_guard = execution_context
+        .control
+        .arm_for_native_decode_if_cancellable();
     if execution_context.is_canceled() {
         return Err(BackendError::TranscriptionCanceled);
     }

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -26,9 +26,9 @@ use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig, RequestBacken
 #[cfg(test)]
 use crate::longform::plan_longform_slices;
 use crate::longform::{
-    AudioSliceKind, LongFormMode, LongFormSlicePlanningError, LongFormVadProvider,
-    SegmentMergePolicy, SegmentTimeDomain, SliceTranscript, TranscriptAssembler,
-    plan_longform_slices_with_materialization_gate,
+    AudioSliceKind, LongFormMode, LongFormSliceError, LongFormSlicePlanningError,
+    LongFormVadProvider, SegmentMergePolicy, SegmentTimeDomain, SliceTranscript,
+    TranscriptAssembler, plan_longform_slices_with_materialization_gate,
 };
 use crate::models::decode_policy_component_registry::{
     BuiltinDecodePolicyLongformProfile, BuiltinDecodePolicyLongformPromptCarryMode,
@@ -765,7 +765,7 @@ struct ConcurrentSlicePipeline<'a> {
 /// serial path except where a family's decode genuinely depended on the carried
 /// prompt.
 ///
-/// The six correctness properties the concurrent path must preserve:
+/// The five correctness properties the concurrent path must preserve:
 /// 1. Ordered assembly: workers finish out of order, results are routed back by
 ///    slice position and integrated strictly in slice order.
 /// 2. Cancel / pause: each worker gates on the shared control at every slice
@@ -774,11 +774,9 @@ struct ConcurrentSlicePipeline<'a> {
 ///    polls cancel per token via the job-carried control.
 /// 3. Progress: `DecodeProgress` accumulates atomically and the registry clamps
 ///    every report upward, so concurrent completions never move the bar back.
-/// 4. GPU-fallback tracker: each worker owns its own tracker, so one worker's
-///    fallback streak cannot corrupt another's backend choice.
-/// 5. Memory: `width` is already capacity-gated by the caller
+/// 4. Memory: `width` is already capacity-gated by the caller
 ///    (`effective_slice_pipeline_width`).
-/// 6. Errors / truncation: a worker's error and truncated-slice facts are routed
+/// 5. Errors / truncation: a worker's error and truncated-slice facts are routed
 ///    back and integrated in order; the first (lowest-index) error fails the run
 ///    closed, exactly like the serial `?`.
 fn run_concurrent_slice_pipeline(pipeline: ConcurrentSlicePipeline) -> Result<(), BackendError> {
@@ -864,11 +862,6 @@ fn run_concurrent_slice_pipeline(pipeline: ConcurrentSlicePipeline) -> Result<()
                     let _abort_guard = execution_context
                         .control
                         .arm_for_native_decode_if_cancellable();
-                    // Per-worker fallback tracker (property 4): the GPU-allocation
-                    // streak is meaningful only within one worker's own sequence
-                    // of slices, and sharing it across threads would be a data
-                    // race.
-                    let mut tracker = GpuAllocationFallbackTracker::default();
                     loop {
                         if stop_ref.load(Ordering::Relaxed) {
                             break;
@@ -1886,6 +1879,7 @@ fn run_native_transcription_impl(
                     16_000,
                     &longform_options,
                     Some(vad_provider.as_ref()),
+                    &|| execution_context.is_canceled(),
                     |packed_samples| {
                         // Packing a VAD timeline creates a second, recording-sized
                         // PCM buffer. Reject a known-impossible allocation before
@@ -1909,12 +1903,7 @@ fn run_native_transcription_impl(
                         Ok(())
                     },
                 )
-                .map_err(|error| match error {
-                    LongFormSlicePlanningError::Planning(error) => BackendError::NativeFailClosed {
-                        reason: format!("could not build longform slice plan: {error}"),
-                    },
-                    LongFormSlicePlanningError::PackedAudioAdmission(error) => error,
-                })?;
+                .map_err(longform_planning_error_to_backend)?;
                 Ok((plan, vad_engine_label))
             },
         )
@@ -2420,6 +2409,20 @@ fn run_native_transcription_impl(
         prepared_audio,
         emits_punctuation,
     })
+}
+
+fn longform_planning_error_to_backend(
+    error: LongFormSlicePlanningError<BackendError>,
+) -> BackendError {
+    match error {
+        LongFormSlicePlanningError::Planning(LongFormSliceError::Canceled) => {
+            BackendError::TranscriptionCanceled
+        }
+        LongFormSlicePlanningError::Planning(error) => BackendError::NativeFailClosed {
+            reason: format!("could not build longform slice plan: {error}"),
+        },
+        LongFormSlicePlanningError::PackedAudioAdmission(error) => error,
+    }
 }
 
 /// Render one truncated slice for the `core.native.decode.truncated`
@@ -3813,6 +3816,29 @@ fn quant_tag_for_log(requested_model_id: &str, runtime_pack_path: &Path) -> Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canceled_longform_planning_maps_to_typed_backend_cancel() {
+        let error = longform_planning_error_to_backend(LongFormSlicePlanningError::Planning(
+            LongFormSliceError::Canceled,
+        ));
+        assert!(matches!(error, BackendError::TranscriptionCanceled));
+    }
+
+    #[test]
+    fn auxiliary_execution_policy_preserves_typed_longform_cancel() {
+        let services = native_execution_services_for_test();
+        let plan = resolve_fixed_cpu_execution_plan(services.as_ref()).expect("CPU plan");
+        let error =
+            run_auxiliary_stage_with_policy(services.as_ref(), &plan, "longform-vad", |_| {
+                Err::<(), BackendError>(BackendError::TranscriptionCanceled)
+            })
+            .expect_err("canceled long-form VAD must fail the auxiliary stage");
+        assert!(matches!(
+            required_auxiliary_stage_error(error),
+            BackendError::TranscriptionCanceled
+        ));
+    }
 
     #[test]
     fn native_boundary_rejects_voice_id_before_any_realtime_model_load() {

--- a/crates/openasr-core/src/api/backend/request_execution_context.rs
+++ b/crates/openasr-core/src/api/backend/request_execution_context.rs
@@ -71,8 +71,8 @@ impl RequestExecutionContext {
     /// single-shot transcribe, a public request builder's pre-opt-in
     /// default, an internal test) but still need a concrete, well-formed
     /// context to satisfy the required-field contract -- this is not a "no
-    /// context" escape hatch, it is a real, valid context whose control
-    /// simply has no other holder.
+    /// context" escape hatch, it is a real, valid context whose control is
+    /// explicitly detached so native graph execution stays callback-free.
     ///
     /// `reason` must name, in the caller's own words, *why* this particular
     /// call site has no cancel surface -- never a placeholder like `"n/a"`.
@@ -121,7 +121,7 @@ impl RequestExecutionContext {
         let _ = reason;
         Self {
             request_id: None,
-            control: Arc::new(TranscriptionControl::new()),
+            control: Arc::new(TranscriptionControl::detached()),
         }
     }
 
@@ -140,12 +140,14 @@ mod tests {
         let context = RequestExecutionContext::uncancellable("test fixture");
         assert!(context.request_id.is_none());
         assert!(!context.is_canceled());
+        assert!(!context.control.has_cancel_source());
     }
 
     #[test]
     fn new_context_carries_the_given_id_and_control() {
         let control = Arc::new(TranscriptionControl::new());
         let context = RequestExecutionContext::new(Some("job-1".to_string()), Arc::clone(&control));
+        assert!(context.control.has_cancel_source());
         assert_eq!(context.request_id.as_deref(), Some("job-1"));
         control.request_cancel();
         assert!(context.is_canceled());

--- a/crates/openasr-core/src/api/backend/transcription_control.rs
+++ b/crates/openasr-core/src/api/backend/transcription_control.rs
@@ -61,20 +61,38 @@ pub struct TranscriptionControl {
     /// compute-scoped callback `data` pointer published by
     /// [`Self::arm_for_native_decode`]. Pause never touches this bit.
     cancel_flag: Arc<AtomicBool>,
+    // False only for RequestExecutionContext::uncancellable. Keeping that
+    // path explicit avoids installing an always-false backend callback (and
+    // its polling cost) when no external owner can ever request cancellation.
+    has_cancel_source: bool,
 }
 
 impl TranscriptionControl {
     pub fn new() -> Self {
+        Self::with_cancel_source(true)
+    }
+
+    pub(crate) fn detached() -> Self {
+        Self::with_cancel_source(false)
+    }
+
+    fn with_cancel_source(has_cancel_source: bool) -> Self {
         Self {
             state: Mutex::new(ControlState::default()),
             resumed_or_canceled: Condvar::new(),
             cancel_flag: Arc::new(AtomicBool::new(false)),
+            has_cancel_source,
         }
     }
 
-    /// Request cancellation at the next cooperative checkpoint (slice boundary,
-    /// token step, native CPU node, or segmented GPU graph view). Idempotent.
-    /// Wakes a paused worker so it observes the cancel instead of staying blocked.
+    pub(crate) fn has_cancel_source(&self) -> bool {
+        self.has_cancel_source
+    }
+
+    /// Request cancellation at the next cooperative checkpoint (slice
+    /// boundary, token step, native backend checkpoint, or segmented fallback
+    /// graph view). Idempotent. Wakes a paused worker so it observes the cancel
+    /// instead of staying blocked.
     pub fn request_cancel(&self) {
         // Atomic first so a concurrent ggml abort_callback poll observes cancel
         // even if it races the mutex write below.
@@ -208,12 +226,11 @@ impl TranscriptionControl {
     /// crate's types) can observe a mid-compute cancel. Pause is never
     /// written to that atomic -- the abort trampoline only recognizes cancel.
     ///
-    /// Call once at the top of a synchronous native decode this control is
-    /// tracking (e.g. the server's `spawn_blocking` closure) -- not from a
-    /// serve-batch owner thread that services many jobs in a loop, which has
-    /// no single "this thread's decode" to publish for the whole loop and
-    /// instead relies on the job-carried context at each safe boundary
-    /// between graph calls.
+    /// Call once at the shared core boundary of a synchronous native decode,
+    /// and once per worker when that decode fans out across threads. Do not
+    /// install it around a serve-batch owner loop that services many jobs: the
+    /// loop has no single request flag to publish and instead relies on each
+    /// job-carried context at safe boundaries between graph calls.
     pub fn arm_for_native_decode(self: &Arc<Self>) -> GgmlAbortCallbackGuard {
         let published_flag = self.cancel_flag();
         let previous_job_cancel = arm_thread_job_cancel_flag(Some(Arc::clone(&published_flag)));
@@ -221,6 +238,15 @@ impl TranscriptionControl {
             previous_job_cancel,
             published_flag,
         }
+    }
+
+    /// Install graph-level cancellation only when this control has an external
+    /// cancel source. Detached CLI/test contexts retain callback-free compute.
+    pub(crate) fn arm_for_native_decode_if_cancellable(
+        self: &Arc<Self>,
+    ) -> Option<GgmlAbortCallbackGuard> {
+        self.has_cancel_source()
+            .then(|| self.arm_for_native_decode())
     }
 }
 
@@ -340,12 +366,13 @@ mod tests {
 
     #[test]
     fn no_control_path_leaves_job_cancel_idle() {
-        // Bit-identical CLI path: without `arm_for_native_decode`, no abort
-        // callback data is published and callback-free compute uses the
-        // original backend API.
+        // A detached native request keeps the callback-free graph path even
+        // when it enters the shared transcription boundary.
         assert!(thread_job_cancel_flag_data().is_null());
         assert!(!thread_job_cancel_requested());
-        let orphan = TranscriptionControl::new();
+        let orphan = Arc::new(TranscriptionControl::detached());
+        let guard = orphan.arm_for_native_decode_if_cancellable();
+        assert!(guard.is_none());
         orphan.request_cancel();
         assert!(orphan.is_canceled());
         assert!(

--- a/crates/openasr-core/src/diarize/vad/firered_stream/provider.rs
+++ b/crates/openasr-core/src/diarize/vad/firered_stream/provider.rs
@@ -8,7 +8,8 @@ use super::model::{FRAME_SHIFT_MS, FireRedStreamVadModel};
 use super::streaming::FireRedStreamingVad;
 use super::weights::FireRedStreamVadWeightsError;
 use crate::longform::{
-    LongFormOptions, LongFormVadProvider, LongFormVadProviderKind, LongFormVadSlice,
+    LongFormOptions, LongFormVadProvider, LongFormVadProviderError, LongFormVadProviderKind,
+    LongFormVadSlice,
 };
 
 #[derive(Debug, Error)]
@@ -101,6 +102,28 @@ impl LongFormVadProvider for FireRedStreamVadProvider {
     ) -> Result<Vec<LongFormVadSlice>, String> {
         self.compute_speech_slices_cancellable(samples, sample_rate_hz, options, &|| false)
             .map_err(|error| error.to_string())
+    }
+
+    fn compute_speech_slices_cancellable(
+        &self,
+        samples: &[f32],
+        sample_rate_hz: u32,
+        options: &LongFormOptions,
+        canceled: &dyn Fn() -> bool,
+    ) -> Result<Vec<LongFormVadSlice>, LongFormVadProviderError> {
+        FireRedStreamVadProvider::compute_speech_slices_cancellable(
+            self,
+            samples,
+            sample_rate_hz,
+            options,
+            canceled,
+        )
+        .map_err(|error| match error {
+            FireRedStreamVadError::Canceled => LongFormVadProviderError::Canceled,
+            other => LongFormVadProviderError::Failed {
+                reason: other.to_string(),
+            },
+        })
     }
 }
 

--- a/crates/openasr-core/src/diarize/vad/firered_stream/tests.rs
+++ b/crates/openasr-core/src/diarize/vad/firered_stream/tests.rs
@@ -186,6 +186,23 @@ fn provider_cancellable_path_stops_before_frontend_work() {
     ));
 }
 
+#[test]
+fn longform_provider_contract_preserves_typed_cancellation() {
+    use crate::longform::{LongFormVadProvider, LongFormVadProviderError};
+
+    let provider = FireRedStreamVadProvider::shared().expect("shared Stream-VAD provider");
+    let samples = vec![0.0f32; 32_000];
+    let error = LongFormVadProvider::compute_speech_slices_cancellable(
+        &provider,
+        &samples,
+        super::frontend::SAMPLE_RATE_HZ,
+        &crate::LongFormOptions::default(),
+        &|| true,
+    )
+    .expect_err("shared long-form contract must preserve provider cancellation");
+    assert!(matches!(error, LongFormVadProviderError::Canceled));
+}
+
 /// Host-local RTF benchmark over a real 5-minute recording (not part of the
 /// default gate; run explicitly with `--ignored` on a machine that has the
 /// fixture). Prints wall-clock forward-pass time and RTF (`elapsed / audio_s`)

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -8766,15 +8766,16 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn metal_scheduler_cancel_before_submission_reports_no_backend_mechanism() {
+    fn metal_scheduler_cancel_before_backend_entry_reports_no_backend_mechanism() {
         use std::sync::atomic::Ordering;
 
         let probe = AbortAfterPolls {
             polls: std::sync::atomic::AtomicUsize::new(0),
-            // Scheduler allocation, split, and input-transfer boundaries own
-            // the first six polls. This cancellation fires before the split is
-            // submitted, so the actual execution path reports DISABLED/NONE.
-            abort_after: 6,
+            // The public precheck, post-allocation check, split-entry check,
+            // and pre-submit check own the first four polls for this one-split
+            // graph. Abort on that last scheduler-owned boundary so the Metal
+            // backend is never entered and the actual path is DISABLED/NONE.
+            abort_after: 4,
         };
         let (capability, status, output) = compute_add_chain_with_callback(
             GgmlCpuGraphConfig {
@@ -8796,7 +8797,7 @@ mod tests {
         );
         assert_eq!(status, ffi::GGML_STATUS_ABORTED);
         assert_eq!(output, None);
-        assert_eq!(probe.polls.load(Ordering::SeqCst), 6);
+        assert_eq!(probe.polls.load(Ordering::SeqCst), 4);
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -8229,6 +8229,116 @@ mod tests {
         assert_eq!(output, Some(4.0));
     }
 
+    #[cfg(any(feature = "cuda", feature = "hip", feature = "vulkan"))]
+    #[test]
+    fn gpu_compute_scoped_cancel_reports_native_mode_and_reuses_backend() {
+        use std::sync::atomic::Ordering;
+
+        let config = GgmlCpuGraphConfig {
+            backend: GgmlCpuGraphBackend::Gpu,
+            use_scheduler: false,
+            ..GgmlCpuGraphConfig::default()
+        };
+        let cancel_probe = AbortAfterPolls {
+            polls: std::sync::atomic::AtomicUsize::new(0),
+            // The shared precheck owns poll 1. Poll 2 must happen inside the
+            // native backend adapter after its compute-scoped callback has
+            // been installed.
+            abort_after: 2,
+        };
+        let (mode, status, output) = compute_add_chain_with_callback(
+            config,
+            96,
+            Some(abort_after_polls),
+            (&cancel_probe as *const AbortAfterPolls).cast_mut().cast(),
+        );
+        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(status, ffi::GGML_STATUS_ABORTED);
+        assert_eq!(output, None);
+        assert_eq!(cancel_probe.polls.load(Ordering::SeqCst), 2);
+
+        let reuse_probe = AbortAfterPolls {
+            polls: std::sync::atomic::AtomicUsize::new(0),
+            abort_after: usize::MAX,
+        };
+        let (mode, status, output) = compute_add_chain_with_callback(
+            config,
+            96,
+            Some(abort_after_polls),
+            (&reuse_probe as *const AbortAfterPolls).cast_mut().cast(),
+        );
+        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(status, ffi::GGML_STATUS_SUCCESS);
+        assert_eq!(output, Some(96.0));
+    }
+
+    #[cfg(any(feature = "cuda", feature = "hip", feature = "vulkan"))]
+    #[test]
+    fn gpu_native_cancel_stops_during_graph_submission_and_reuses_backend() {
+        use std::sync::atomic::Ordering;
+
+        let config = GgmlCpuGraphConfig {
+            backend: GgmlCpuGraphBackend::Gpu,
+            use_scheduler: false,
+            ..GgmlCpuGraphConfig::default()
+        };
+        let cancel_probe = AbortAfterPolls {
+            polls: std::sync::atomic::AtomicUsize::new(0),
+            // The public precheck and backend-entry checks consume fewer than
+            // eight polls. CUDA/HIP and Vulkan must therefore keep polling at
+            // safe per-node submission boundaries to observe this request.
+            abort_after: 8,
+        };
+        let (mode, status, output) = compute_add_chain_with_callback(
+            config,
+            96,
+            Some(abort_after_polls),
+            (&cancel_probe as *const AbortAfterPolls).cast_mut().cast(),
+        );
+        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(status, ffi::GGML_STATUS_ABORTED);
+        assert_eq!(output, None);
+        assert_eq!(cancel_probe.polls.load(Ordering::SeqCst), 8);
+
+        let reuse_probe = AbortAfterPolls {
+            polls: std::sync::atomic::AtomicUsize::new(0),
+            abort_after: usize::MAX,
+        };
+        let (mode, status, output) = compute_add_chain_with_callback(
+            config,
+            96,
+            Some(abort_after_polls),
+            (&reuse_probe as *const AbortAfterPolls).cast_mut().cast(),
+        );
+        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(status, ffi::GGML_STATUS_SUCCESS);
+        assert_eq!(output, Some(96.0));
+    }
+
+    #[cfg(any(feature = "cuda", feature = "hip", feature = "vulkan"))]
+    #[test]
+    fn gpu_native_cancel_false_preserves_direct_and_scheduler_graphs() {
+        for use_scheduler in [false, true] {
+            let probe = AbortAfterPolls {
+                polls: std::sync::atomic::AtomicUsize::new(0),
+                abort_after: usize::MAX,
+            };
+            let (mode, status, output) = compute_add_chain_with_callback(
+                GgmlCpuGraphConfig {
+                    backend: GgmlCpuGraphBackend::Gpu,
+                    use_scheduler,
+                    ..GgmlCpuGraphConfig::default()
+                },
+                96,
+                Some(abort_after_polls),
+                (&probe as *const AbortAfterPolls).cast_mut().cast(),
+            );
+            assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+            assert_eq!(status, ffi::GGML_STATUS_SUCCESS);
+            assert_eq!(output, Some(96.0));
+        }
+    }
+
     #[test]
     fn native_abort_can_commit_a_side_effect_before_poisoning_the_session() {
         use std::sync::atomic::Ordering;

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -1055,8 +1055,13 @@ pub enum GgmlCpuGraphError {
     BackendSchedulerInitFailed,
     #[error("ggml cpu graph backend scheduler is poisoned after an incomplete allocation commit")]
     BackendSchedulerPoisoned,
-    #[error("ggml backend returned an invalid graph cancellation mode: mode={mode}")]
-    GraphCancellationContractFailed { mode: i32 },
+    #[error(
+        "ggml backend returned an invalid graph cancellation capability: mechanism={mechanism}, observation_granularity={observation_granularity}"
+    )]
+    GraphCancellationContractFailed {
+        mechanism: i32,
+        observation_granularity: i32,
+    },
     #[error("ggml cpu graph backend scheduler graph allocation failed")]
     BackendSchedulerGraphAllocationFailed,
     #[error("ggml cpu graph tensor index out of bounds: index={index}, len={len}")]
@@ -6352,6 +6357,36 @@ unsafe fn read_tensor_bytes(
     unsafe { ffi::ggml_backend_tensor_get(tensor, data, offset, size) }
 }
 
+fn validate_graph_cancel_capability(
+    status: c_int,
+    capability: ffi::GgmlBackendGraphCancelCapability,
+) -> Result<(), GgmlCpuGraphError> {
+    let valid_pair = matches!(
+        (capability.mechanism, capability.observation_granularity),
+        (
+            ffi::GGML_BACKEND_GRAPH_CANCEL_DISABLED,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_NONE
+        ) | (
+            ffi::GGML_BACKEND_GRAPH_CANCEL_SEGMENTED,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+                | ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_GRAPH_COMPLETION
+        ) | (
+            ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+                | ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_GRAPH_COMPLETION
+        )
+    );
+    let disabled_after_success = status == ffi::GGML_STATUS_SUCCESS
+        && capability.mechanism == ffi::GGML_BACKEND_GRAPH_CANCEL_DISABLED;
+    if valid_pair && !disabled_after_success {
+        return Ok(());
+    }
+    Err(GgmlCpuGraphError::GraphCancellationContractFailed {
+        mechanism: capability.mechanism,
+        observation_granularity: capability.observation_granularity,
+    })
+}
+
 /// Compute one graph under the current job's cancel flag. The cloned Arc owns
 /// the callback data for exactly this synchronous FFI call; neither the shared
 /// backend layer nor a cached backend retains the raw pointer after return.
@@ -6379,7 +6414,7 @@ fn compute_graph_with_current_job_cancel(
         });
     };
 
-    let mut mode = ffi::GGML_BACKEND_GRAPH_CANCEL_DISABLED;
+    let mut capability = ffi::GgmlBackendGraphCancelCapability::default();
     let callback = Some(openasr_ggml_abort_trampoline as unsafe extern "C" fn(*mut c_void) -> bool);
     let data = Arc::as_ptr(&flag) as *mut c_void;
     let status = unsafe {
@@ -6389,7 +6424,7 @@ fn compute_graph_with_current_job_cancel(
                 graph.as_ptr(),
                 callback,
                 data,
-                &mut mode,
+                &mut capability,
             )
         } else {
             ffi::ggml_backend_graph_compute_with_abort(
@@ -6397,16 +6432,11 @@ fn compute_graph_with_current_job_cancel(
                 graph.as_ptr(),
                 callback,
                 data,
-                &mut mode,
+                &mut capability,
             )
         }
     };
-    if !matches!(
-        mode,
-        ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE | ffi::GGML_BACKEND_GRAPH_CANCEL_SEGMENTED
-    ) {
-        return Err(GgmlCpuGraphError::GraphCancellationContractFailed { mode });
-    }
+    validate_graph_cancel_capability(status, capability)?;
     Ok(status)
 }
 
@@ -7725,7 +7755,7 @@ mod tests {
         GgmlCpuGraphRunner, GgmlCpuGraphThreadingWorkload, GgmlRopeExtParams, GpuProbeCache,
         GpuProbeOutcome, GpuProbeState, METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS,
         flash_attn_ext_head_dim_supported_on_backend, gpu_probe_failed_log_message,
-        gpu_probe_log_message, runtime_gpu_is_available,
+        gpu_probe_log_message, runtime_gpu_is_available, validate_graph_cancel_capability,
     };
 
     fn softplus_reference(value: f32) -> f32 {
@@ -8124,7 +8154,7 @@ mod tests {
         node_count: usize,
         callback: ffi::GgmlAbortCallback,
         data: *mut std::ffi::c_void,
-    ) -> (i32, i32, Option<f32>) {
+    ) -> (ffi::GgmlBackendGraphCancelCapability, i32, Option<f32>) {
         let mut runner = GgmlCpuGraphRunner::new(config).expect("graph runner");
         let mut builder = runner.start_graph();
         let input = builder.new_tensor_1d_f32(1, "input").expect("input");
@@ -8148,7 +8178,7 @@ mod tests {
         let graph = builder
             .build_forward_graph(&[output])
             .expect("forward graph");
-        let mut mode = ffi::GGML_BACKEND_GRAPH_CANCEL_DISABLED;
+        let mut capability = ffi::GgmlBackendGraphCancelCapability::default();
         let status = unsafe {
             if let Some(scheduler) = builder.scheduler {
                 ffi::ggml_backend_sched_graph_compute_with_abort(
@@ -8156,7 +8186,7 @@ mod tests {
                     graph.as_ptr(),
                     callback,
                     data,
-                    &mut mode,
+                    &mut capability,
                 )
             } else {
                 ffi::ggml_backend_graph_compute_with_abort(
@@ -8164,7 +8194,7 @@ mod tests {
                     graph.as_ptr(),
                     callback,
                     data,
-                    &mut mode,
+                    &mut capability,
                 )
             }
         };
@@ -8182,7 +8212,7 @@ mod tests {
         } else {
             None
         };
-        (mode, status, output)
+        (capability, status, output)
     }
 
     #[test]
@@ -8218,13 +8248,17 @@ mod tests {
             polls: std::sync::atomic::AtomicUsize::new(0),
             abort_after: usize::MAX,
         };
-        let (mode, status, output) = compute_add_chain_with_callback(
+        let (capability, status, output) = compute_add_chain_with_callback(
             GgmlCpuGraphConfig::conservative_default(),
             4,
             Some(abort_after_polls),
             (&probe as *const AbortAfterPolls).cast_mut().cast(),
         );
-        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(capability.mechanism, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(
+            capability.observation_granularity,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+        );
         assert_eq!(status, ffi::GGML_STATUS_SUCCESS);
         assert_eq!(output, Some(4.0));
     }
@@ -8246,13 +8280,17 @@ mod tests {
             // been installed.
             abort_after: 2,
         };
-        let (mode, status, output) = compute_add_chain_with_callback(
+        let (capability, status, output) = compute_add_chain_with_callback(
             config,
             96,
             Some(abort_after_polls),
             (&cancel_probe as *const AbortAfterPolls).cast_mut().cast(),
         );
-        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(capability.mechanism, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(
+            capability.observation_granularity,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+        );
         assert_eq!(status, ffi::GGML_STATUS_ABORTED);
         assert_eq!(output, None);
         assert_eq!(cancel_probe.polls.load(Ordering::SeqCst), 2);
@@ -8261,13 +8299,17 @@ mod tests {
             polls: std::sync::atomic::AtomicUsize::new(0),
             abort_after: usize::MAX,
         };
-        let (mode, status, output) = compute_add_chain_with_callback(
+        let (capability, status, output) = compute_add_chain_with_callback(
             config,
             96,
             Some(abort_after_polls),
             (&reuse_probe as *const AbortAfterPolls).cast_mut().cast(),
         );
-        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(capability.mechanism, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(
+            capability.observation_granularity,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+        );
         assert_eq!(status, ffi::GGML_STATUS_SUCCESS);
         assert_eq!(output, Some(96.0));
     }
@@ -8289,13 +8331,17 @@ mod tests {
             // safe per-node submission boundaries to observe this request.
             abort_after: 8,
         };
-        let (mode, status, output) = compute_add_chain_with_callback(
+        let (capability, status, output) = compute_add_chain_with_callback(
             config,
             96,
             Some(abort_after_polls),
             (&cancel_probe as *const AbortAfterPolls).cast_mut().cast(),
         );
-        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(capability.mechanism, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(
+            capability.observation_granularity,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+        );
         assert_eq!(status, ffi::GGML_STATUS_ABORTED);
         assert_eq!(output, None);
         assert_eq!(cancel_probe.polls.load(Ordering::SeqCst), 8);
@@ -8304,13 +8350,17 @@ mod tests {
             polls: std::sync::atomic::AtomicUsize::new(0),
             abort_after: usize::MAX,
         };
-        let (mode, status, output) = compute_add_chain_with_callback(
+        let (capability, status, output) = compute_add_chain_with_callback(
             config,
             96,
             Some(abort_after_polls),
             (&reuse_probe as *const AbortAfterPolls).cast_mut().cast(),
         );
-        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(capability.mechanism, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(
+            capability.observation_granularity,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+        );
         assert_eq!(status, ffi::GGML_STATUS_SUCCESS);
         assert_eq!(output, Some(96.0));
     }
@@ -8323,7 +8373,7 @@ mod tests {
                 polls: std::sync::atomic::AtomicUsize::new(0),
                 abort_after: usize::MAX,
             };
-            let (mode, status, output) = compute_add_chain_with_callback(
+            let (capability, status, output) = compute_add_chain_with_callback(
                 GgmlCpuGraphConfig {
                     backend: GgmlCpuGraphBackend::Gpu,
                     use_scheduler,
@@ -8333,7 +8383,11 @@ mod tests {
                 Some(abort_after_polls),
                 (&probe as *const AbortAfterPolls).cast_mut().cast(),
             );
-            assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+            assert_eq!(capability.mechanism, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+            assert_eq!(
+                capability.observation_granularity,
+                ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+            );
             assert_eq!(status, ffi::GGML_STATUS_SUCCESS);
             assert_eq!(output, Some(96.0));
         }
@@ -8388,17 +8442,21 @@ mod tests {
             polls: std::sync::atomic::AtomicUsize::new(0),
             abort_after: 2,
         };
-        let mut mode = ffi::GGML_BACKEND_GRAPH_CANCEL_DISABLED;
+        let mut capability = ffi::GgmlBackendGraphCancelCapability::default();
         let status = unsafe {
             ffi::ggml_backend_graph_compute_with_abort(
                 backend.as_ptr(),
                 graph_ptr.as_ptr(),
                 Some(abort_after_polls),
                 (&probe as *const AbortAfterPolls).cast_mut().cast(),
-                &mut mode,
+                &mut capability,
             )
         };
-        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(capability.mechanism, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(
+            capability.observation_granularity,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+        );
         assert_eq!(status, ffi::GGML_STATUS_ABORTED);
         assert_eq!(probe.polls.load(Ordering::SeqCst), 2);
         assert!(matches!(
@@ -8557,14 +8615,65 @@ mod tests {
         let error = session
             .builder()
             .finish_compute_result(Err(GgmlCpuGraphError::GraphCancellationContractFailed {
-                mode: 99,
+                mechanism: 99,
+                observation_granularity: 98,
             }))
             .expect_err("compute helper errors must poison persistent state");
         assert!(matches!(
             error,
-            GgmlCpuGraphError::GraphCancellationContractFailed { mode: 99 }
+            GgmlCpuGraphError::GraphCancellationContractFailed {
+                mechanism: 99,
+                observation_granularity: 98
+            }
         ));
         assert!(session.is_poisoned());
+    }
+
+    #[test]
+    fn cancellation_capability_validation_is_orthogonal_and_path_sensitive() {
+        for capability in [
+            ffi::GgmlBackendGraphCancelCapability {
+                mechanism: ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE,
+                observation_granularity:
+                    ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT,
+            },
+            ffi::GgmlBackendGraphCancelCapability {
+                mechanism: ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE,
+                observation_granularity:
+                    ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_GRAPH_COMPLETION,
+            },
+            ffi::GgmlBackendGraphCancelCapability {
+                mechanism: ffi::GGML_BACKEND_GRAPH_CANCEL_SEGMENTED,
+                observation_granularity:
+                    ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_GRAPH_COMPLETION,
+            },
+        ] {
+            validate_graph_cancel_capability(ffi::GGML_STATUS_SUCCESS, capability)
+                .expect("valid executed path capability");
+        }
+
+        validate_graph_cancel_capability(
+            ffi::GGML_STATUS_ABORTED,
+            ffi::GgmlBackendGraphCancelCapability::default(),
+        )
+        .expect("pre-submission cancellation runs no backend mechanism");
+
+        for capability in [
+            ffi::GgmlBackendGraphCancelCapability::default(),
+            ffi::GgmlBackendGraphCancelCapability {
+                mechanism: ffi::GGML_BACKEND_GRAPH_CANCEL_DISABLED,
+                observation_granularity:
+                    ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_GRAPH_COMPLETION,
+            },
+            ffi::GgmlBackendGraphCancelCapability {
+                mechanism: ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE,
+                observation_granularity: ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_NONE,
+            },
+        ] {
+            assert!(
+                validate_graph_cancel_capability(ffi::GGML_STATUS_SUCCESS, capability).is_err()
+            );
+        }
     }
 
     #[test]
@@ -8635,7 +8744,7 @@ mod tests {
             polls: std::sync::atomic::AtomicUsize::new(0),
             abort_after: 2,
         };
-        let (mode, status, output) = compute_add_chain_with_callback(
+        let (capability, status, output) = compute_add_chain_with_callback(
             GgmlCpuGraphConfig {
                 backend: GgmlCpuGraphBackend::Metal,
                 use_scheduler: false,
@@ -8645,7 +8754,11 @@ mod tests {
             Some(abort_after_polls),
             (&probe as *const AbortAfterPolls).cast_mut().cast(),
         );
-        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(capability.mechanism, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(
+            capability.observation_granularity,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+        );
         assert_eq!(status, ffi::GGML_STATUS_ABORTED);
         assert_eq!(output, None);
         assert_eq!(probe.polls.load(Ordering::SeqCst), 2);
@@ -8653,18 +8766,17 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn metal_scheduler_cancel_at_a_scheduler_boundary_reports_native_capability() {
+    fn metal_scheduler_cancel_before_submission_reports_no_backend_mechanism() {
         use std::sync::atomic::Ordering;
 
         let probe = AbortAfterPolls {
             polls: std::sync::atomic::AtomicUsize::new(0),
             // Scheduler allocation, split, and input-transfer boundaries own
             // the first six polls. This cancellation fires before the split is
-            // submitted; NATIVE still records that every scheduled backend can
-            // enforce the same callback if cancellation arrives during compute.
+            // submitted, so the actual execution path reports DISABLED/NONE.
             abort_after: 6,
         };
-        let (mode, status, output) = compute_add_chain_with_callback(
+        let (capability, status, output) = compute_add_chain_with_callback(
             GgmlCpuGraphConfig {
                 backend: GgmlCpuGraphBackend::Metal,
                 use_scheduler: true,
@@ -8674,7 +8786,14 @@ mod tests {
             Some(abort_after_polls),
             (&probe as *const AbortAfterPolls).cast_mut().cast(),
         );
-        assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+        assert_eq!(
+            capability.mechanism,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_DISABLED
+        );
+        assert_eq!(
+            capability.observation_granularity,
+            ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_NONE
+        );
         assert_eq!(status, ffi::GGML_STATUS_ABORTED);
         assert_eq!(output, None);
         assert_eq!(probe.polls.load(Ordering::SeqCst), 6);
@@ -8688,7 +8807,7 @@ mod tests {
             abort_after: usize::MAX,
         };
         for use_scheduler in [false, true] {
-            let (mode, status, output) = compute_add_chain_with_callback(
+            let (capability, status, output) = compute_add_chain_with_callback(
                 GgmlCpuGraphConfig {
                     backend: GgmlCpuGraphBackend::Metal,
                     use_scheduler,
@@ -8698,7 +8817,11 @@ mod tests {
                 Some(abort_after_polls),
                 (&probe as *const AbortAfterPolls).cast_mut().cast(),
             );
-            assert_eq!(mode, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+            assert_eq!(capability.mechanism, ffi::GGML_BACKEND_GRAPH_CANCEL_NATIVE);
+            assert_eq!(
+                capability.observation_granularity,
+                ffi::GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT
+            );
             assert_eq!(status, ffi::GGML_STATUS_SUCCESS);
             assert_eq!(output, Some(96.0));
         }

--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -387,11 +387,14 @@ unsafe extern "C" {
     pub(crate) fn ggml_backend_buffer_free(buffer: GgmlBackendBufferRaw);
     pub(crate) fn ggml_backend_buffer_is_host(buffer: GgmlBackendBufferRaw) -> bool;
     pub(crate) fn ggml_backend_buffer_set_usage(buffer: GgmlBackendBufferRaw, usage: c_int);
-    pub(crate) fn ggml_backend_graph_compute(
+    // Keep raw graph execution inside ggml_runtime. Model families must use
+    // GgmlCpuGraphRunner so request cancellation and typed terminal-status
+    // mapping cannot be bypassed as new executors are added.
+    pub(super) fn ggml_backend_graph_compute(
         backend: GgmlBackendRaw,
         cgraph: GgmlCgraphRaw,
     ) -> c_int;
-    pub(crate) fn ggml_backend_graph_compute_with_abort(
+    pub(super) fn ggml_backend_graph_compute_with_abort(
         backend: GgmlBackendRaw,
         cgraph: GgmlCgraphRaw,
         abort_callback: GgmlAbortCallback,
@@ -428,7 +431,7 @@ unsafe extern "C" {
         sched: GgmlBackendSchedRaw,
         cgraph: GgmlCgraphRaw,
     ) -> c_int;
-    pub(crate) fn ggml_backend_sched_graph_compute_with_abort(
+    pub(super) fn ggml_backend_sched_graph_compute_with_abort(
         sched: GgmlBackendSchedRaw,
         cgraph: GgmlCgraphRaw,
         abort_callback: GgmlAbortCallback,

--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -114,6 +114,25 @@ pub(crate) const GGML_STATUS_BACKEND_POISONED: c_int = 4;
 pub(crate) const GGML_BACKEND_GRAPH_CANCEL_DISABLED: c_int = 0;
 pub(crate) const GGML_BACKEND_GRAPH_CANCEL_NATIVE: c_int = 1;
 pub(crate) const GGML_BACKEND_GRAPH_CANCEL_SEGMENTED: c_int = 2;
+pub(crate) const GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_NONE: c_int = 0;
+pub(crate) const GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_SUBMISSION_CHECKPOINT: c_int = 1;
+pub(crate) const GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_GRAPH_COMPLETION: c_int = 2;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GgmlBackendGraphCancelCapability {
+    pub mechanism: c_int,
+    pub observation_granularity: c_int,
+}
+
+impl Default for GgmlBackendGraphCancelCapability {
+    fn default() -> Self {
+        Self {
+            mechanism: GGML_BACKEND_GRAPH_CANCEL_DISABLED,
+            observation_granularity: GGML_BACKEND_GRAPH_CANCEL_OBSERVATION_NONE,
+        }
+    }
+}
 pub(crate) const GGML_BACKEND_BUFFER_USAGE_WEIGHTS: c_int = 1;
 pub(crate) const GGML_BACKEND_BUFFER_USAGE_COMPUTE: c_int = 2;
 
@@ -399,7 +418,7 @@ unsafe extern "C" {
         cgraph: GgmlCgraphRaw,
         abort_callback: GgmlAbortCallback,
         abort_callback_data: *mut c_void,
-        cancel_mode: *mut c_int,
+        cancel_capability: *mut GgmlBackendGraphCancelCapability,
     ) -> c_int;
     pub(crate) fn ggml_backend_sched_new(
         backends: *mut GgmlBackendRaw,
@@ -436,7 +455,7 @@ unsafe extern "C" {
         cgraph: GgmlCgraphRaw,
         abort_callback: GgmlAbortCallback,
         abort_callback_data: *mut c_void,
-        cancel_mode: *mut c_int,
+        cancel_capability: *mut GgmlBackendGraphCancelCapability,
     ) -> c_int;
     pub(crate) fn ggml_backend_tensor_set(
         tensor: GgmlTensorRaw,

--- a/crates/openasr-core/src/longform/mod.rs
+++ b/crates/openasr-core/src/longform/mod.rs
@@ -11,8 +11,9 @@ pub use assembler::{
 };
 pub use options::{LongFormMode, LongFormOptions, LongFormOptionsError, LongFormVadOptions};
 pub use slicing::{
-    AudioSlice, AudioSliceKind, LongFormBenchmarkMetadata, LongFormSlicePlan, LongFormSliceStats,
-    LongFormVadProvider, LongFormVadProviderKind, LongFormVadSlice, plan_longform_slices,
+    AudioSlice, AudioSliceKind, LongFormBenchmarkMetadata, LongFormSliceError, LongFormSlicePlan,
+    LongFormSliceStats, LongFormVadProvider, LongFormVadProviderError, LongFormVadProviderKind,
+    LongFormVadSlice, plan_longform_slices,
 };
 pub(crate) use slicing::{
     LongFormSlicePlanningError, plan_longform_slices_with_materialization_gate,

--- a/crates/openasr-core/src/longform/slicing.rs
+++ b/crates/openasr-core/src/longform/slicing.rs
@@ -46,6 +46,14 @@ pub enum LongFormVadProviderKind {
     EnergyLike,
 }
 
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum LongFormVadProviderError {
+    #[error("longform VAD provider was canceled")]
+    Canceled,
+    #[error("{reason}")]
+    Failed { reason: String },
+}
+
 pub trait LongFormVadProvider: Send + Sync {
     fn provider_kind(&self) -> LongFormVadProviderKind {
         LongFormVadProviderKind::Custom
@@ -57,6 +65,32 @@ pub trait LongFormVadProvider: Send + Sync {
         sample_rate_hz: u32,
         options: &LongFormOptions,
     ) -> Result<Vec<LongFormVadSlice>, String>;
+
+    /// Cancellation-aware form used by request-owned long-form planning.
+    ///
+    /// Providers with bounded internal work should override this method and
+    /// poll `canceled` between those work units. The default preserves source
+    /// compatibility for third-party providers while still stopping before or
+    /// immediately after an otherwise indivisible provider call.
+    fn compute_speech_slices_cancellable(
+        &self,
+        samples: &[f32],
+        sample_rate_hz: u32,
+        options: &LongFormOptions,
+        canceled: &dyn Fn() -> bool,
+    ) -> Result<Vec<LongFormVadSlice>, LongFormVadProviderError> {
+        if canceled() {
+            return Err(LongFormVadProviderError::Canceled);
+        }
+        let slices = self
+            .compute_speech_slices(samples, sample_rate_hz, options)
+            .map_err(|reason| LongFormVadProviderError::Failed { reason })?;
+        if canceled() {
+            Err(LongFormVadProviderError::Canceled)
+        } else {
+            Ok(slices)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -103,6 +137,8 @@ struct PackedAudioMaterializationPlan {
 
 #[derive(Debug, Error, Clone, PartialEq)]
 pub enum LongFormSliceError {
+    #[error("longform slice planning was canceled")]
+    Canceled,
     #[error("longform sample_rate_hz must be > 0")]
     InvalidSampleRate,
     #[error("longform options are invalid: {reason}")]
@@ -136,6 +172,7 @@ pub fn plan_longform_slices(
         sample_rate_hz,
         options,
         vad_provider,
+        &|| false,
         |_| Ok::<(), std::convert::Infallible>(()),
     ) {
         Ok(plan) => Ok(plan),
@@ -153,8 +190,10 @@ pub(crate) fn plan_longform_slices_with_materialization_gate<E>(
     sample_rate_hz: u32,
     options: &LongFormOptions,
     vad_provider: Option<&dyn LongFormVadProvider>,
+    canceled: &dyn Fn() -> bool,
     admit_packed_samples: impl FnOnce(usize) -> Result<(), E>,
 ) -> Result<LongFormSlicePlan, LongFormSlicePlanningError<E>> {
+    check_planning_canceled(canceled)?;
     if sample_rate_hz == 0 {
         return Err(LongFormSliceError::InvalidSampleRate.into());
     }
@@ -164,6 +203,7 @@ pub(crate) fn plan_longform_slices_with_materialization_gate<E>(
             reason: error.to_string(),
         })
         .map_err(LongFormSlicePlanningError::Planning)?;
+    check_planning_canceled(canceled)?;
     if samples.is_empty() {
         return Ok(LongFormSlicePlan {
             sample_rate_hz,
@@ -188,9 +228,13 @@ pub(crate) fn plan_longform_slices_with_materialization_gate<E>(
             sample_rate_hz,
             options,
             vad_provider,
+            canceled,
         )?),
-        LongFormMode::Auto => plan_auto_slices(samples, sample_rate_hz, options, vad_provider)?,
+        LongFormMode::Auto => {
+            plan_auto_slices(samples, sample_rate_hz, options, vad_provider, canceled)?
+        }
     };
+    check_planning_canceled(canceled)?;
     // Transparent fallback: for `Auto` this should never fire in practice
     // (`enforce_coverage_dominance` disqualifies any auto-planner candidate
     // that drops audible content whenever a full-coverage alternative
@@ -203,11 +247,18 @@ pub(crate) fn plan_longform_slices_with_materialization_gate<E>(
     // bindings have to track) so a dropped-audio regression is observable in
     // `daemon.log` instead of only showing up as missing transcript text.
     log_dropped_audible_regions(samples, sample_rate_hz, &layout);
+    check_planning_canceled(canceled)?;
     if layout.processed_audio.is_none() {
         if let Some(materialization_plan) = layout.packed_audio_plan.take() {
+            check_planning_canceled(canceled)?;
             admit_packed_samples(materialization_plan.processed_samples)
                 .map_err(LongFormSlicePlanningError::PackedAudioAdmission)?;
-            layout.processed_audio = Some(materialize_packed_audio(samples, &materialization_plan));
+            check_planning_canceled(canceled)?;
+            layout.processed_audio = Some(materialize_packed_audio(
+                samples,
+                &materialization_plan,
+                canceled,
+            )?);
         } else {
             apply_padding(
                 &mut layout.slices,
@@ -234,6 +285,21 @@ pub(crate) fn plan_longform_slices_with_materialization_gate<E>(
     })
 }
 
+fn check_planning_canceled(canceled: &dyn Fn() -> bool) -> Result<(), LongFormSliceError> {
+    if canceled() {
+        Err(LongFormSliceError::Canceled)
+    } else {
+        Ok(())
+    }
+}
+
+fn map_vad_provider_error(error: LongFormVadProviderError) -> LongFormSliceError {
+    match error {
+        LongFormVadProviderError::Canceled => LongFormSliceError::Canceled,
+        LongFormVadProviderError::Failed { reason } => LongFormSliceError::VadFailed { reason },
+    }
+}
+
 fn layout_from_identity_slices(slices: Vec<AudioSlice>) -> LongFormPlanningLayout {
     LongFormPlanningLayout {
         slices,
@@ -248,15 +314,21 @@ fn layout_uses_packed_timeline(layout: &LongFormPlanningLayout) -> bool {
     layout.processed_audio.is_some() || layout.packed_audio_plan.is_some()
 }
 
-fn materialize_packed_audio(samples: &[f32], plan: &PackedAudioMaterializationPlan) -> Vec<f32> {
+fn materialize_packed_audio(
+    samples: &[f32],
+    plan: &PackedAudioMaterializationPlan,
+    canceled: &dyn Fn() -> bool,
+) -> Result<Vec<f32>, LongFormSliceError> {
     let mut processed_audio = Vec::with_capacity(plan.processed_samples);
     for (index, span) in plan.spans.iter().enumerate() {
+        check_planning_canceled(canceled)?;
         if index > 0 {
             processed_audio.resize(processed_audio.len() + plan.seam_samples, 0.0);
         }
         processed_audio.extend_from_slice(&samples[span.start_sample..span.end_sample]);
     }
-    processed_audio
+    check_planning_canceled(canceled)?;
+    Ok(processed_audio)
 }
 
 fn full_slice(total_samples: usize) -> AudioSlice {
@@ -339,7 +411,9 @@ fn plan_auto_slices(
     sample_rate_hz: u32,
     options: &LongFormOptions,
     vad_provider: Option<&dyn LongFormVadProvider>,
+    canceled: &dyn Fn() -> bool,
 ) -> Result<LongFormPlanningLayout, LongFormSliceError> {
+    check_planning_canceled(canceled)?;
     let total_samples = samples.len();
     let chunk_samples = seconds_to_samples(options.chunk_seconds, sample_rate_hz);
     if total_samples <= chunk_samples {
@@ -355,7 +429,9 @@ fn plan_auto_slices(
         sample_rate_hz,
         options,
     ));
-    if let Some(packed_energy_layout) = plan_packed_energy_layout(samples, sample_rate_hz, options)
+    check_planning_canceled(canceled)?;
+    if let Some(packed_energy_layout) =
+        plan_packed_energy_layout(samples, sample_rate_hz, options, canceled)?
     {
         candidates.push(build_auto_plan_candidate(
             AudioSliceKind::Energy,
@@ -366,6 +442,7 @@ fn plan_auto_slices(
             options,
         ));
     }
+    check_planning_canceled(canceled)?;
 
     let fixed_slices = plan_fixed_slices(total_samples, sample_rate_hz, options);
     if !fixed_slices.is_empty() {
@@ -378,13 +455,15 @@ fn plan_auto_slices(
             options,
         ));
     }
+    check_planning_canceled(canceled)?;
 
     if let Some(provider) = vad_provider
         && provider.provider_kind() != LongFormVadProviderKind::EnergyLike
     {
         let vad_spans = provider
-            .compute_speech_slices(samples, sample_rate_hz, options)
-            .map_err(|reason| LongFormSliceError::VadFailed { reason })?;
+            .compute_speech_slices_cancellable(samples, sample_rate_hz, options, canceled)
+            .map_err(map_vad_provider_error)?;
+        check_planning_canceled(canceled)?;
         if let Some(packed_vad_layout) = plan_packed_layout_from_speech_spans(
             samples,
             sample_rate_hz,
@@ -415,6 +494,7 @@ fn plan_auto_slices(
         }
     }
 
+    check_planning_canceled(canceled)?;
     prune_dominated_vad_candidates(&mut candidates);
     let mut selection_provenance =
         enforce_coverage_dominance(&mut candidates, samples, sample_rate_hz);
@@ -437,6 +517,7 @@ fn plan_auto_slices(
     ));
     candidates.sort_by(compare_auto_plan_candidates);
     selection_provenance.extend(auto_selection_provenance(&candidates));
+    check_planning_canceled(canceled)?;
     Ok(candidates
         .into_iter()
         .next()
@@ -459,18 +540,20 @@ fn plan_packed_energy_layout(
     samples: &[f32],
     sample_rate_hz: u32,
     options: &LongFormOptions,
-) -> Option<LongFormPlanningLayout> {
+    canceled: &dyn Fn() -> bool,
+) -> Result<Option<LongFormPlanningLayout>, LongFormSliceError> {
     let provider = EnergyLongFormVadProvider;
     let speech_spans = provider
-        .compute_speech_slices(samples, sample_rate_hz, options)
-        .ok()?;
-    plan_packed_layout_from_speech_spans(
+        .compute_speech_slices_cancellable(samples, sample_rate_hz, options, canceled)
+        .map_err(map_vad_provider_error)?;
+    check_planning_canceled(canceled)?;
+    Ok(plan_packed_layout_from_speech_spans(
         samples,
         sample_rate_hz,
         options,
         AudioSliceKind::Energy,
         speech_spans,
-    )
+    ))
 }
 
 fn plan_packed_layout_from_speech_spans(
@@ -625,7 +708,9 @@ fn plan_vad_slices(
     sample_rate_hz: u32,
     options: &LongFormOptions,
     vad_provider: Option<&dyn LongFormVadProvider>,
+    canceled: &dyn Fn() -> bool,
 ) -> Result<Vec<AudioSlice>, LongFormSliceError> {
+    check_planning_canceled(canceled)?;
     let Some(provider) = vad_provider else {
         if options.fallback_to_energy_when_vad_unavailable {
             return Ok(plan_energy_slices(samples, sample_rate_hz, options));
@@ -633,8 +718,9 @@ fn plan_vad_slices(
         return Err(LongFormSliceError::VadUnavailable);
     };
     let vad_slices = provider
-        .compute_speech_slices(samples, sample_rate_hz, options)
-        .map_err(|reason| LongFormSliceError::VadFailed { reason })?;
+        .compute_speech_slices_cancellable(samples, sample_rate_hz, options, canceled)
+        .map_err(map_vad_provider_error)?;
+    check_planning_canceled(canceled)?;
     if vad_slices.is_empty() {
         if options.fallback_to_energy_when_vad_empty {
             return Ok(plan_energy_slices(samples, sample_rate_hz, options));
@@ -2248,7 +2334,9 @@ mod tests {
         samples.extend(vec![0.0; 16_000 * 12]);
         samples.extend(tone(16_000));
         let options = LongFormOptions::default();
-        let layout = plan_packed_energy_layout(&samples, 16_000, &options).expect("packed");
+        let layout = plan_packed_energy_layout(&samples, 16_000, &options, &|| false)
+            .expect("planning")
+            .expect("packed");
         assert_eq!(layout.slices.len(), 1);
         assert!(layout.processed_audio.is_none());
         assert!(
@@ -2270,7 +2358,11 @@ mod tests {
         samples.extend(vec![0.0; 16_000 * 3]);
         samples.extend(tone(16_000 * 10));
         let options = LongFormOptions::default();
-        assert!(plan_packed_energy_layout(&samples, 16_000, &options).is_some());
+        assert!(
+            plan_packed_energy_layout(&samples, 16_000, &options, &|| false)
+                .expect("planning")
+                .is_some()
+        );
         let plan = plan_longform_slices(&samples, 16_000, &options, None).unwrap();
         assert_eq!(plan.slices.len(), 1);
         assert!(plan.processed_audio.is_none());
@@ -2331,6 +2423,74 @@ mod tests {
         let samples = tone(16_000 * 2);
         let error = plan_longform_slices(&samples, 16_000, &options, None).unwrap_err();
         assert!(matches!(error, LongFormSliceError::VadUnavailable));
+    }
+
+    #[test]
+    fn mid_provider_cancel_stops_planning_before_materialization() {
+        use std::cell::Cell;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        struct CancelFromInsideProvider {
+            canceled: Arc<AtomicBool>,
+            legacy_calls: Arc<AtomicUsize>,
+        }
+
+        impl LongFormVadProvider for CancelFromInsideProvider {
+            fn compute_speech_slices(
+                &self,
+                _samples: &[f32],
+                _sample_rate_hz: u32,
+                _options: &LongFormOptions,
+            ) -> Result<Vec<LongFormVadSlice>, String> {
+                self.legacy_calls.fetch_add(1, Ordering::Relaxed);
+                Ok(Vec::new())
+            }
+
+            fn compute_speech_slices_cancellable(
+                &self,
+                _samples: &[f32],
+                _sample_rate_hz: u32,
+                _options: &LongFormOptions,
+                canceled: &dyn Fn() -> bool,
+            ) -> Result<Vec<LongFormVadSlice>, LongFormVadProviderError> {
+                self.canceled.store(true, Ordering::Release);
+                assert!(
+                    canceled(),
+                    "provider must observe the request cancel source"
+                );
+                Err(LongFormVadProviderError::Canceled)
+            }
+        }
+
+        let canceled = Arc::new(AtomicBool::new(false));
+        let legacy_calls = Arc::new(AtomicUsize::new(0));
+        let provider = CancelFromInsideProvider {
+            canceled: Arc::clone(&canceled),
+            legacy_calls: Arc::clone(&legacy_calls),
+        };
+        let gate_called = Cell::new(false);
+        let options = options_with_mode(LongFormMode::Vad);
+
+        let error = plan_longform_slices_with_materialization_gate(
+            &tone(16_000 * 2),
+            16_000,
+            &options,
+            Some(&provider),
+            &|| canceled.load(Ordering::Acquire),
+            |_| {
+                gate_called.set(true);
+                Ok::<(), ()>(())
+            },
+        )
+        .expect_err("mid-provider cancellation must stop planning");
+
+        assert!(matches!(
+            error,
+            LongFormSlicePlanningError::Planning(LongFormSliceError::Canceled)
+        ));
+        assert_eq!(legacy_calls.load(Ordering::Relaxed), 0);
+        assert!(!gate_called.get());
     }
 
     #[test]
@@ -3529,6 +3689,7 @@ mod tests {
             16_000,
             &options,
             None,
+            &|| false,
             |count| {
                 proposed_samples = Some(count);
                 Err("memory rejected")
@@ -4078,7 +4239,8 @@ mod tests {
         let mut options = options_with_mode(LongFormMode::Auto);
         options.chunk_seconds = 30.0;
 
-        let packed_layout = plan_packed_energy_layout(&samples, 16_000, &options)
+        let packed_layout = plan_packed_energy_layout(&samples, 16_000, &options, &|| false)
+            .expect("planning")
             .expect("energy VAD must produce a packed candidate for this profile");
         let (_, dropped) = candidate_kept_and_dropped_ranges(&packed_layout, samples.len());
         let dropped_seconds: f32 = dropped

--- a/crates/openasr-core/src/longform/vad.rs
+++ b/crates/openasr-core/src/longform/vad.rs
@@ -1,4 +1,7 @@
-use super::{LongFormOptions, LongFormVadProvider, LongFormVadProviderKind, LongFormVadSlice};
+use super::{
+    LongFormOptions, LongFormVadProvider, LongFormVadProviderError, LongFormVadProviderKind,
+    LongFormVadSlice,
+};
 
 const DEFAULT_FRAME_MS: usize = 20;
 
@@ -16,118 +19,152 @@ impl LongFormVadProvider for EnergyLongFormVadProvider {
         sample_rate_hz: u32,
         options: &LongFormOptions,
     ) -> Result<Vec<LongFormVadSlice>, String> {
-        if sample_rate_hz == 0 {
-            return Err("sample_rate_hz must be greater than zero".to_string());
-        }
-        if samples.is_empty() {
-            return Ok(Vec::new());
-        }
-        let frame_samples = ((sample_rate_hz as usize) * DEFAULT_FRAME_MS / 1000).max(1);
-        let frame_rms = compute_frame_rms(samples, frame_samples);
-        if frame_rms.is_empty() {
-            return Ok(Vec::new());
-        }
-        let max_rms = frame_rms.iter().copied().fold(0.0_f32, f32::max);
-        if max_rms <= f32::EPSILON {
-            return Ok(Vec::new());
-        }
-
-        let threshold = options.vad.threshold.clamp(0.0, 1.0);
-        let noise_floor = percentile(&frame_rms, 0.20);
-        let speech_peak = percentile(&frame_rms, 0.95).max(noise_floor);
-        let relative_gate = noise_floor + (speech_peak - noise_floor) * threshold;
-        // The relative gate is anchored to *this clip's own* 95th-percentile peak,
-        // so a loud opening section inflates `speech_peak` and can drag the gate
-        // above quieter speech later in the same recording -- observed in
-        // production to silently drop an entire trailing utterance: a loud
-        // Chinese opener (~-25 dBFS) pushed the gate to -34.2 dBFS, just above a
-        // quieter English tail peaking at -34.6 dBFS, so the tail was never
-        // detected as speech and never reached the decoder (see the long-form
-        // code-switch investigation). Cap the gate at the module's existing
-        // "definitely not silence" floor -- `energy_silence_threshold_db`
-        // (-38 dBFS default), the same line `choose_forced_cut` and
-        // `subdivide_processed_spans_silence_aware` in `slicing.rs` use to pick
-        // a cut point -- rather than a second, independently tuned constant.
-        // On the repro numbers above it is low enough (-38 < -34.6) that the
-        // dropped English tail passes the gate. VAD/energy slicing is a
-        // performance optimization, not a content filter: a frame louder than
-        // the shared silence floor must never be gated out purely because
-        // something else in the clip was louder still.
-        //
-        // This threshold is a *decision* input: it is what this gate elides
-        // by. Nothing that later validates the resulting plan for lost content
-        // may measure against it -- see `longform::audibility` for why that
-        // closed loop is a bug and not a tuning question. The cap above is
-        // also why a recording that is quiet overall gets no protection from
-        // it: the relative term wins, the gate lands just under this
-        // recording's own speech, and real speech is elided. That is the case
-        // the audibility reference exists to catch.
-        let absolute_floor = 10.0_f32.powf(options.energy_silence_threshold_db / 20.0);
-        let gate = relative_gate.min(absolute_floor);
-        let min_speech_frames = duration_ms_to_frames(
-            options.vad.min_speech_duration_ms as usize,
-            DEFAULT_FRAME_MS,
-        );
-        let min_silence_frames = duration_ms_to_frames(
-            options.vad.min_silence_duration_ms as usize,
-            DEFAULT_FRAME_MS,
-        );
-        let mask: Vec<bool> = frame_rms.iter().map(|value| *value >= gate).collect();
-
-        let mut speech_ranges = Vec::new();
-        let mut in_speech = false;
-        let mut speech_start = 0usize;
-        let mut trailing_silence = 0usize;
-        for (frame_idx, active) in mask.iter().copied().enumerate() {
-            if active {
-                if !in_speech {
-                    in_speech = true;
-                    speech_start = frame_idx;
-                }
-                trailing_silence = 0;
-                continue;
-            }
-            if !in_speech {
-                continue;
-            }
-            trailing_silence = trailing_silence.saturating_add(1);
-            if trailing_silence < min_silence_frames {
-                continue;
-            }
-            let speech_end = frame_idx.saturating_add(1).saturating_sub(trailing_silence);
-            push_if_long_enough(
-                &mut speech_ranges,
-                speech_start,
-                speech_end,
-                min_speech_frames,
-            );
-            in_speech = false;
-            trailing_silence = 0;
-        }
-        if in_speech {
-            let speech_end = mask.len().saturating_sub(trailing_silence);
-            push_if_long_enough(
-                &mut speech_ranges,
-                speech_start,
-                speech_end,
-                min_speech_frames,
-            );
-        }
-
-        let mut slices = Vec::with_capacity(speech_ranges.len());
-        for (start_frame, end_frame) in speech_ranges {
-            let start_sample = (start_frame * frame_samples).min(samples.len());
-            let end_sample = (end_frame * frame_samples).min(samples.len());
-            if end_sample <= start_sample {
-                continue;
-            }
-            slices.push(LongFormVadSlice {
-                start_sample,
-                end_sample,
-            });
-        }
-        Ok(slices)
+        compute_speech_slices_impl(samples, sample_rate_hz, options, &|| false)
+            .map_err(|error| error.to_string())
     }
+
+    fn compute_speech_slices_cancellable(
+        &self,
+        samples: &[f32],
+        sample_rate_hz: u32,
+        options: &LongFormOptions,
+        canceled: &dyn Fn() -> bool,
+    ) -> Result<Vec<LongFormVadSlice>, LongFormVadProviderError> {
+        compute_speech_slices_impl(samples, sample_rate_hz, options, canceled)
+    }
+}
+
+fn compute_speech_slices_impl(
+    samples: &[f32],
+    sample_rate_hz: u32,
+    options: &LongFormOptions,
+    canceled: &dyn Fn() -> bool,
+) -> Result<Vec<LongFormVadSlice>, LongFormVadProviderError> {
+    if canceled() {
+        return Err(LongFormVadProviderError::Canceled);
+    }
+    if sample_rate_hz == 0 {
+        return Err(LongFormVadProviderError::Failed {
+            reason: "sample_rate_hz must be greater than zero".to_string(),
+        });
+    }
+    if samples.is_empty() {
+        return Ok(Vec::new());
+    }
+    let frame_samples = ((sample_rate_hz as usize) * DEFAULT_FRAME_MS / 1000).max(1);
+    let frame_rms = compute_frame_rms(samples, frame_samples, canceled)?;
+    if frame_rms.is_empty() {
+        return Ok(Vec::new());
+    }
+    let max_rms = frame_rms.iter().copied().fold(0.0_f32, f32::max);
+    if max_rms <= f32::EPSILON {
+        return Ok(Vec::new());
+    }
+
+    let threshold = options.vad.threshold.clamp(0.0, 1.0);
+    let noise_floor = percentile(&frame_rms, 0.20);
+    let speech_peak = percentile(&frame_rms, 0.95).max(noise_floor);
+    let relative_gate = noise_floor + (speech_peak - noise_floor) * threshold;
+    // The relative gate is anchored to *this clip's own* 95th-percentile peak,
+    // so a loud opening section inflates `speech_peak` and can drag the gate
+    // above quieter speech later in the same recording -- observed in
+    // production to silently drop an entire trailing utterance: a loud
+    // Chinese opener (~-25 dBFS) pushed the gate to -34.2 dBFS, just above a
+    // quieter English tail peaking at -34.6 dBFS, so the tail was never
+    // detected as speech and never reached the decoder (see the long-form
+    // code-switch investigation). Cap the gate at the module's existing
+    // "definitely not silence" floor -- `energy_silence_threshold_db`
+    // (-38 dBFS default), the same line `choose_forced_cut` and
+    // `subdivide_processed_spans_silence_aware` in `slicing.rs` use to pick
+    // a cut point -- rather than a second, independently tuned constant.
+    // On the repro numbers above it is low enough (-38 < -34.6) that the
+    // dropped English tail passes the gate. VAD/energy slicing is a
+    // performance optimization, not a content filter: a frame louder than
+    // the shared silence floor must never be gated out purely because
+    // something else in the clip was louder still.
+    //
+    // This threshold is a *decision* input: it is what this gate elides
+    // by. Nothing that later validates the resulting plan for lost content
+    // may measure against it -- see `longform::audibility` for why that
+    // closed loop is a bug and not a tuning question. The cap above is
+    // also why a recording that is quiet overall gets no protection from
+    // it: the relative term wins, the gate lands just under this
+    // recording's own speech, and real speech is elided. That is the case
+    // the audibility reference exists to catch.
+    let absolute_floor = 10.0_f32.powf(options.energy_silence_threshold_db / 20.0);
+    let gate = relative_gate.min(absolute_floor);
+    let min_speech_frames = duration_ms_to_frames(
+        options.vad.min_speech_duration_ms as usize,
+        DEFAULT_FRAME_MS,
+    );
+    let min_silence_frames = duration_ms_to_frames(
+        options.vad.min_silence_duration_ms as usize,
+        DEFAULT_FRAME_MS,
+    );
+    let mask: Vec<bool> = frame_rms.iter().map(|value| *value >= gate).collect();
+    if canceled() {
+        return Err(LongFormVadProviderError::Canceled);
+    }
+
+    let mut speech_ranges = Vec::new();
+    let mut in_speech = false;
+    let mut speech_start = 0usize;
+    let mut trailing_silence = 0usize;
+    for (frame_idx, active) in mask.iter().copied().enumerate() {
+        if frame_idx.is_multiple_of(1000 / DEFAULT_FRAME_MS) && canceled() {
+            return Err(LongFormVadProviderError::Canceled);
+        }
+        if active {
+            if !in_speech {
+                in_speech = true;
+                speech_start = frame_idx;
+            }
+            trailing_silence = 0;
+            continue;
+        }
+        if !in_speech {
+            continue;
+        }
+        trailing_silence = trailing_silence.saturating_add(1);
+        if trailing_silence < min_silence_frames {
+            continue;
+        }
+        let speech_end = frame_idx.saturating_add(1).saturating_sub(trailing_silence);
+        push_if_long_enough(
+            &mut speech_ranges,
+            speech_start,
+            speech_end,
+            min_speech_frames,
+        );
+        in_speech = false;
+        trailing_silence = 0;
+    }
+    if in_speech {
+        let speech_end = mask.len().saturating_sub(trailing_silence);
+        push_if_long_enough(
+            &mut speech_ranges,
+            speech_start,
+            speech_end,
+            min_speech_frames,
+        );
+    }
+
+    let mut slices = Vec::with_capacity(speech_ranges.len());
+    for (start_frame, end_frame) in speech_ranges {
+        if canceled() {
+            return Err(LongFormVadProviderError::Canceled);
+        }
+        let start_sample = (start_frame * frame_samples).min(samples.len());
+        let end_sample = (end_frame * frame_samples).min(samples.len());
+        if end_sample <= start_sample {
+            continue;
+        }
+        slices.push(LongFormVadSlice {
+            start_sample,
+            end_sample,
+        });
+    }
+    Ok(slices)
 }
 
 fn duration_ms_to_frames(duration_ms: usize, frame_ms: usize) -> usize {
@@ -152,10 +189,18 @@ fn push_if_long_enough(
     target.push((start_frame, end_frame));
 }
 
-fn compute_frame_rms(samples: &[f32], frame_samples: usize) -> Vec<f32> {
+fn compute_frame_rms(
+    samples: &[f32],
+    frame_samples: usize,
+    canceled: &dyn Fn() -> bool,
+) -> Result<Vec<f32>, LongFormVadProviderError> {
     let mut out = Vec::with_capacity(samples.len() / frame_samples + 1);
     let mut start = 0usize;
     while start < samples.len() {
+        if start.is_multiple_of(frame_samples.saturating_mul(1000 / DEFAULT_FRAME_MS)) && canceled()
+        {
+            return Err(LongFormVadProviderError::Canceled);
+        }
         let end = (start + frame_samples).min(samples.len());
         if end <= start {
             break;
@@ -168,7 +213,11 @@ fn compute_frame_rms(samples: &[f32], frame_samples: usize) -> Vec<f32> {
         out.push((sum / (end - start) as f64).sqrt() as f32);
         start = end;
     }
-    out
+    if canceled() {
+        Err(LongFormVadProviderError::Canceled)
+    } else {
+        Ok(out)
+    }
 }
 
 fn percentile(values: &[f32], fraction: f32) -> f32 {
@@ -223,6 +272,27 @@ mod tests {
             .compute_speech_slices(&vec![0.0; 16_000], 16_000, &options)
             .expect("vad");
         assert!(slices.is_empty());
+    }
+
+    #[test]
+    fn cancellable_path_stops_during_frame_scan() {
+        use std::cell::Cell;
+
+        let provider = EnergyLongFormVadProvider;
+        let polls = Cell::new(0usize);
+        let error = provider
+            .compute_speech_slices_cancellable(
+                &vec![0.1; 16_000 * 3],
+                16_000,
+                &LongFormOptions::default(),
+                &|| {
+                    let next = polls.get() + 1;
+                    polls.set(next);
+                    next >= 3
+                },
+            )
+            .expect_err("energy VAD must poll during a multi-second frame scan");
+        assert!(matches!(error, LongFormVadProviderError::Canceled));
     }
 
     /// Reproduces the code-switch long-form bug at unit scale: a loud opener

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -1681,14 +1681,6 @@ pub(crate) async fn transcribe_with_runtime(
                     // the idle_unload reaper never evicts the model runtime cache out
                     // from under it; dropped (any exit path) once the decode returns.
                     let _activity_guard = NativeActivityGuard::enter();
-                    // Publishes the request's cancel atomic as this thread's
-                    // ggml abort-callback data for the whole synchronous
-                    // decode below, so a mid-graph-compute cancel can
-                    // actually abort (not just stop at the next slice/token
-                    // boundary). The control itself already travels
-                    // explicitly via `execution_context` -- this only arms
-                    // the FFI trampoline, which can't see that context.
-                    let _abort_callback_guard = execution_context.control.arm_for_native_decode();
                     let model_pack_path = runtime.model_pack_path.clone().ok_or_else(|| {
                         TranscriptionRuntimeError::Backend(
                         openasr_core::BackendError::NativeModelPackPathRejected {

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -172,19 +172,26 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   code outside the advertised set reports `language: null` rather than a guess.
   SenseVoice also classifies emotion and audio events internally, but those
   tags are intentionally not exposed on the API surface yet.
-- Cooperative cancel of an in-flight offline transcription is layered: long-form
-  slice boundaries (L0), shared seq2seq greedy token / prefill chunk checks (L1),
-  and a compute-scoped ggml abort contract (L2). CPU uses its native per-node
-  callback. Metal and source-enabled CUDA/HIP/Vulkan/SYCL builds use the shared
-  backend fallback: while cancel is armed, a graph is submitted in at most
-  32-node views, synchronized, then polled. A scheduler reports the weakest mode
-  among all of its backends and applies the same contract to every split, with
-  checks around scheduler input transfers as well, so a missing backend-specific
-  proc is never a silent no-op. One already-entered kernel, event wait, or copy
-  remains non-preemptible; the bound is a graph/scheduler checkpoint, not a
-  wall-clock deadline. A failed persistent compute poisons its model/session
-  graph and forces graph/KV rebuild before reuse; cached backend handles and
-  uploaded immutable weights are retained. See
+- Cooperative cancel of an in-flight offline transcription is layered:
+  request-owned long-form planning/VAD checkpoints plus slice boundaries (L0),
+  shared seq2seq greedy token / prefill chunk checks (L1), and a compute-scoped
+  ggml abort contract (L2). The built-in neural and energy VAD providers poll
+  the same typed request control between bounded recording chunks; custom
+  providers that do not override the cancellable method are still checked
+  before and after their indivisible call. CPU, Metal, source-enabled CUDA/HIP,
+  and Vulkan expose native cancellation hooks; other backends use the shared
+  fallback, which submits at most 32-node views and synchronizes between views.
+  The capability also reports whether a newly raised request is observed at a
+  submission checkpoint or only at graph completion (notably a warmed CUDA/HIP
+  graph replay). A scheduler reports the weakest mechanism and coarsest
+  observation boundary among its backends and applies the same contract to every
+  split, with checks around scheduler input transfers as well, so a missing
+  backend-specific proc is never a silent no-op. One already-entered kernel,
+  graph replay, event wait, or copy remains non-preemptible; the bound is an
+  explicitly reported graph/scheduler checkpoint, not a wall-clock deadline. A
+  failed persistent compute poisons its model/session graph and forces graph/KV
+  rebuild before reuse; cached backend handles and uploaded immutable weights
+  are retained. See
   [Graph cancellation contract](design/graph-cancellation.md).
   Pause still only blocks at slice boundaries and never arms graph cancellation.
 

--- a/docs/design/graph-cancellation.md
+++ b/docs/design/graph-cancellation.md
@@ -10,18 +10,21 @@ scheduler-backed runners; model families must not add backend-specific wiring.
 synchronous, compute-scoped calls. They report the mode used through an output
 parameter:
 
-- `NATIVE`: the backend exposes `ggml_backend_set_abort_callback`; today CPU
-  polls between graph nodes.
+- `NATIVE`: the backend exposes `ggml_backend_set_abort_callback` and reports
+  the observation boundary actually used by this compute. CPU polls between
+  graph nodes; Metal gates dispatches; CUDA/HIP and Vulkan stop later
+  submissions. A warmed CUDA/HIP graph replay is still one indivisible launch,
+  so it truthfully reports graph-completion observation.
 - `SEGMENTED`: the backend has no native hook. The shared layer submits graph
   views of at most 32 nodes, synchronizes after every view, and polls before the
   first and after every completed view.
 - `DISABLED`: no callback was supplied. OpenASR does not call the cancellation
   entry point in this case; it uses the original graph-compute API unchanged.
 
-The contract is unified; the mechanism is deliberately not. Forcing CPU through
-`SEGMENTED` would replace its finer per-node native polling with coarser graph
-views and unnecessary synchronization overhead, so CPU remains `NATIVE` while
-backends without an equivalent hook use the shared fallback.
+The contract is unified; the mechanism is deliberately not. Forcing a backend
+with a native hook through `SEGMENTED` would replace its normal submission path
+with coarser graph views and unnecessary synchronization overhead. Backends
+without an equivalent hook use the shared fallback.
 
 The 32-node segment is an explicit latency/throughput compromise. It is half of
 Metal's historical 64-node main submission: reducing it lowers worst-case
@@ -34,9 +37,9 @@ The source-build matrix is:
 | Backend | Mode | Cancellation checkpoint |
 | --- | --- | --- |
 | CPU | `NATIVE` | backend per-node poll |
-| Metal | `SEGMENTED` | synchronized graph views |
-| CUDA / HIP | `SEGMENTED` | synchronized graph views |
-| Vulkan | `SEGMENTED` | synchronized graph views |
+| Metal | `NATIVE` | host-visible abort flag sampled before dispatch |
+| CUDA / HIP | `NATIVE` | submission checkpoints; warmed replay at graph completion |
+| Vulkan | `NATIVE` | per-context submission/timeline completion |
 | SYCL | `SEGMENTED` | synchronized graph views |
 
 Future backends automatically receive `SEGMENTED` behavior unless they expose
@@ -52,12 +55,13 @@ safe across sequential jobs and keeps parallel worker threads isolated.
 The scheduler polls before graph allocation, before and after every
 scheduler-controlled input transfer/wait boundary, before each split compute,
 and inside each backend compute. Its reported mode is `SEGMENTED` if any
-scheduler backend lacks a native hook; otherwise it is `NATIVE`. A backend API
-call already entered by the scheduler (one event wait, synchronization, copy,
-or kernel) is indivisible, so cancellation cannot preempt that call; it is
-observed at the next shared checkpoint. An aborted return is synchronized: no
-submitted transfer or graph work remains in flight and can touch buffers reused
-by a later job.
+scheduler backend lacks a native hook; otherwise it is `NATIVE`. It also reports
+the coarsest observation boundary across the participating backends. A backend
+API call already entered by the scheduler (one graph replay, event wait,
+synchronization, copy, or kernel) is indivisible, so cancellation cannot preempt
+that call; it is observed at the next reported checkpoint. An aborted return is
+synchronized: no submitted transfer or graph work remains in flight and can
+touch buffers reused by a later job.
 
 Cancel unwinds the active request; it does not evict stateless cached backend or
 device handles. Model/session tensor state is different: native and segmented
@@ -84,6 +88,14 @@ paths that support per-request cancellation therefore carry each job's control
 explicitly and remove canceled members at typed prefill-chunk/token boundaries
 (currently Qwen); single-job graph execution uses L2.
 
+Before any long-form graph exists, the shared slice planner carries that same
+request control into VAD. Built-in FireRed Stream-VAD and energy VAD providers
+poll between bounded recording chunks and return a typed planning cancel;
+packed-audio admission and materialization are skipped after cancellation. The
+legacy provider method remains available for callers with no request control,
+while the cancellable trait method gives external providers an override point
+without putting family-specific cancellation code in the native executor.
+
 ## Boundary
 
 OpenASR invokes `ggml_backend_graph_compute` and scheduler graph compute; it
@@ -94,14 +106,18 @@ described above. OpenASR helpers named “graph plan” build ordinary
 
 ## Regression evidence
 
-The ggml fake-backend contract test proves callback-free single submission,
-`false` completion as `32 + 32 + 1`, a deterministic mid-graph flip after the
-first synchronized segment, typed abort, and no pending work on return. A
+The ggml fake-backend contract test proves the shared segmented fallback's
+callback-free single submission, `false` completion as `32 + 32 + 1`, a
+deterministic mid-graph flip after the first synchronized segment, typed abort,
+and no pending work on return. Native backend tests separately cover their
+reported observation boundaries. A
 two-backend scheduler seam also forces an incompatible-buffer copy, flips cancel
 inside that copy, proves the destination split is never submitted, and proves
 the pending copy is drained before return. Rust tests cover callback false/true,
-direct and scheduler paths, parallel-job isolation, real Metal segmented
-cancellation, Metal scheduler cancellation, callback-false completion across
-multiple Metal graph views (direct and scheduler), cached-Metal reuse after a
-canceled job, and persistent-session poison/rebuild including a synthetic
-cancellation-contract error.
+direct and scheduler paths, parallel-job isolation, real Metal native
+cancellation, Metal scheduler cancellation, callback-false completion,
+cached-Metal reuse after a canceled job, and persistent-session poison/rebuild
+including a synthetic cancellation-contract error. Long-form tests additionally
+prove a cancellation
+raised inside a provider remains typed through planning, skips packed-audio
+materialization, and maps to `BackendError::TranscriptionCanceled`.


### PR DESCRIPTION
## Summary

Unify cooperative cancellation across OpenASR's native execution stack, from request-owned long-form planning through direct and scheduler-backed ggml graph execution.

This PR integrates the native backend contract from QuintinShaw/openasr-ggml#7, preserves callback-free execution when cancellation is disabled, and ensures cancellation raised before the first model graph remains a typed `TranscriptionCanceled` result.

## Why

The server already publishes a request cancellation flag, but two gaps remained:

1. GPU requests with cancellation armed could fall back to synchronized 32-node graph views even when the backend had a safe native observation point, adding overhead to requests that were never canceled.
2. Long-form slice planning and neural VAD ran before the model graph and did not receive the request control. A cancellation accepted by the server could therefore wait for recording-wide planning to finish before the request returned.

Cancellation needs to be a shared execution invariant rather than model-family or route-specific wiring. The runtime must also distinguish a native cancellation mechanism from the boundary at which a newly raised flag can actually be observed.

## Changes

- Route the request-owned cancellation control through the shared native execution context instead of arming it in the server route.
- Use the backend's compute-scoped cancellation API for direct and scheduler graph execution.
- Validate and expose both cancellation mechanism and observation granularity.
- Preserve typed abort status, terminal drain, backend reuse, and persistent graph/session poison-and-rebuild semantics.
- Add a cancellable `LongFormVadProvider` contract while retaining a compatibility default for external providers.
- Poll cancellation between bounded chunks in the built-in FireRed Stream-VAD and energy VAD providers.
- Stop before packed-audio admission/materialization after cancellation and map the result to `BackendError::TranscriptionCanceled`.
- Preserve the unified execution memory planner and auxiliary-stage candidate policy introduced on current `main`.
- Add HIP compile and Vulkan software-smoke coverage for the expanded backend ABI.
- Document native, segmented, and graph-completion observation boundaries without promising a wall-clock deadline.

## Tests run

- [x] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

Additional local checks:

- `cargo fmt --all --check`
- `cargo clippy -p openasr-core --all-targets -- -D warnings`
- `cargo test -p openasr-core golden_diff -- --nocapture` (4 passed, 14 ignored)
- workspace nextest: 3717 passed, 176 skipped

## Manual smoke checks

- Apple M1 Metal native cancellation tests covered direct and scheduler execution, callback-false completion, mid-graph cancellation, cached-backend reuse, and poisoned persistent-session rebuild.
- AMD Radeon RX 9060 XT hardware validation covered HIP and Vulkan native modes, cancellation correctness, backend reuse, Vulkan concurrent initialization, and representative encoder/CTC and autoregressive model paths.
- NVIDIA GeForce RTX 3080 hardware validation covered CUDA direct and scheduler execution, callback-free and armed-false performance controls, triggered cancellation, warmed graph replay semantics, output correctness, and backend reuse.
- The RTX 3080 real-model run also exposed the separate pre-graph long-form VAD gap fixed here. The shared typed planning/VAD fix is covered after rebase by unit, Metal, and full-workspace tests; that exact CUDA real-model request has not yet been rerun against this follow-up.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

Updated `docs/KNOWN_LIMITATIONS.md` and `docs/design/graph-cancellation.md` to describe pre-graph planning/VAD checkpoints, native backend mechanisms, scheduler aggregation, and indivisible graph-completion boundaries.

## Scope / non-goals

- This PR provides cooperative cancellation, not hard real-time kernel or graph-replay preemption.
- Pause remains a long-form slice-boundary operation and does not arm graph cancellation.
- Serve-batch keeps per-job cancellation isolation; one member cannot abort a shared graph for healthy siblings.
- QuintinShaw/openasr-ggml#7 is merged, and this PR now pins its final `master` commit `4a93816b`.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [ ] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [ ] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - AI assistance was used for implementation, testing, and documentation.