### PR TITLE
fix(core): restore release platform compatibility

### DIFF
--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -17,10 +17,10 @@ use crate::arch::{
 };
 use crate::device::{
     execution_policy::{
-        ExecutionCandidate, ExecutionCandidateFailure, ExecutionIntent, ExecutionPlacement,
-        ExecutionPlan, ExecutionPolicyError,
+        AcceleratedDeviceConstraint, ExecutionCandidate, ExecutionCandidateFailure,
+        ExecutionIntent, ExecutionPlacement, ExecutionPlan, ExecutionPolicyError,
     },
-    execution_route::enumerate_compute_devices_from_ggml,
+    execution_route::{ExecutionProvider, enumerate_compute_devices_from_ggml},
 };
 use crate::ggml_runtime::{GgmlCpuGraphBackend, GgmlCpuGraphConfig, RequestBackendPreference};
 #[cfg(test)]
@@ -86,6 +86,57 @@ const DEFAULT_NATIVE_LONGFORM_AUTO_TRIGGER_SECONDS: f32 = 30.0;
 /// both gets whichever is tighter.
 const CONSERVATIVE_SEQ2SEQ_LONGFORM_MAX_CHUNK_SECONDS: f32 = DEFAULT_ENCODER_CHUNK_SECONDS;
 const COHERE_LONGFORM_OVERLAP_SECONDS: f32 = 0.0;
+
+fn execution_intent_from_backend_env(raw: Option<&str>) -> Option<ExecutionIntent> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    if value.eq_ignore_ascii_case("cpu") {
+        return Some(ExecutionIntent::CpuOnly);
+    }
+    if value.eq_ignore_ascii_case("gpu") {
+        return Some(ExecutionIntent::AcceleratedOnly);
+    }
+    let provider = if value.eq_ignore_ascii_case("metal") {
+        ExecutionProvider::Metal
+    } else if value.eq_ignore_ascii_case("cuda") {
+        ExecutionProvider::Cuda
+    } else if value.eq_ignore_ascii_case("hip") || value.eq_ignore_ascii_case("rocm") {
+        ExecutionProvider::Hip
+    } else if value.eq_ignore_ascii_case("vulkan") {
+        ExecutionProvider::Vulkan
+    } else {
+        return None;
+    };
+    Some(ExecutionIntent::ConstrainedAcceleratedOnly(
+        AcceleratedDeviceConstraint::Provider(provider),
+    ))
+}
+
+/// Resolve the process-wide developer/backend override into the same typed
+/// request intent consumed by the unified execution policy. The environment
+/// is read exactly once at the native boundary; every main and auxiliary
+/// stage then receives a clone of this immutable value.
+fn request_execution_intent(target: Option<crate::ExecutionTarget>) -> ExecutionIntent {
+    let backend_env = std::env::var(GgmlCpuGraphConfig::BACKEND_ENV).ok();
+    request_execution_intent_with_backend_env(target, backend_env.as_deref())
+}
+
+fn request_execution_intent_with_backend_env(
+    target: Option<crate::ExecutionTarget>,
+    backend_env: Option<&str>,
+) -> ExecutionIntent {
+    match target.unwrap_or_default() {
+        crate::ExecutionTarget::Cpu => ExecutionIntent::CpuOnly,
+        crate::ExecutionTarget::Accelerated => {
+            match execution_intent_from_backend_env(backend_env) {
+                Some(intent @ ExecutionIntent::ConstrainedAcceleratedOnly(_)) => intent,
+                _ => ExecutionIntent::AcceleratedOnly,
+            }
+        }
+        crate::ExecutionTarget::Auto => {
+            execution_intent_from_backend_env(backend_env).unwrap_or(ExecutionIntent::Auto)
+        }
+    }
+}
 // Phase-aware progress for the in-flight native file transcription, keyed by
 // transcription id in a bounded per-request registry. The server's native
 // path has no concurrency gate (each request's native transcription runs on
@@ -1185,7 +1236,7 @@ fn run_native_transcription_fallible(
     // re-reads process defaults after the main ASR dispatch completes.
     let request_execution_intent = execution_intent
         .clone()
-        .unwrap_or_else(|| ExecutionIntent::from(request.execution_target.unwrap_or_default()));
+        .unwrap_or_else(|| request_execution_intent(request.execution_target));
     // Coarse per-request stage timing: "inference" spans model resolution +
     // audio prep (see the `audio_prep` stage logged inside `_impl` around the
     // WAV load) + decode/longform-assembly, i.e. the whole
@@ -1610,8 +1661,8 @@ fn run_native_transcription_impl(
     )?;
     let emits_punctuation =
         emits_punctuation_for_model_architecture(selected_family.model_architecture);
-    let request_execution_intent = execution_intent
-        .unwrap_or_else(|| ExecutionIntent::from(request.execution_target.unwrap_or_default()));
+    let request_execution_intent =
+        execution_intent.unwrap_or_else(|| request_execution_intent(request.execution_target));
     let execution_plan = resolve_native_execution_plan(
         execution_services.as_ref(),
         &selected_family,
@@ -3816,6 +3867,76 @@ fn quant_tag_for_log(requested_model_id: &str, runtime_pack_path: &Path) -> Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn native_request_auto_honors_backend_environment_as_typed_intent() {
+        assert_eq!(
+            request_execution_intent_with_backend_env(None, Some("cpu")),
+            ExecutionIntent::CpuOnly
+        );
+        assert_eq!(
+            request_execution_intent_with_backend_env(
+                Some(crate::ExecutionTarget::Auto),
+                Some("metal")
+            ),
+            ExecutionIntent::ConstrainedAcceleratedOnly(AcceleratedDeviceConstraint::Provider(
+                ExecutionProvider::Metal
+            ))
+        );
+        assert_eq!(
+            request_execution_intent_with_backend_env(None, Some("rocm")),
+            ExecutionIntent::ConstrainedAcceleratedOnly(AcceleratedDeviceConstraint::Provider(
+                ExecutionProvider::Hip
+            ))
+        );
+        assert_eq!(
+            request_execution_intent_with_backend_env(None, Some("gpu")),
+            ExecutionIntent::AcceleratedOnly
+        );
+    }
+
+    #[test]
+    fn native_request_explicit_target_preserves_product_constraint() {
+        assert_eq!(
+            request_execution_intent_with_backend_env(
+                Some(crate::ExecutionTarget::Cpu),
+                Some("cuda")
+            ),
+            ExecutionIntent::CpuOnly
+        );
+        assert_eq!(
+            request_execution_intent_with_backend_env(
+                Some(crate::ExecutionTarget::Accelerated),
+                Some("cpu")
+            ),
+            ExecutionIntent::AcceleratedOnly
+        );
+        assert_eq!(
+            request_execution_intent_with_backend_env(
+                Some(crate::ExecutionTarget::Accelerated),
+                Some("vulkan")
+            ),
+            ExecutionIntent::ConstrainedAcceleratedOnly(AcceleratedDeviceConstraint::Provider(
+                ExecutionProvider::Vulkan
+            ))
+        );
+    }
+
+    #[test]
+    fn native_request_unknown_or_missing_backend_environment_keeps_auto() {
+        assert_eq!(
+            request_execution_intent_with_backend_env(None, None),
+            ExecutionIntent::Auto
+        );
+        assert_eq!(
+            request_execution_intent_with_backend_env(None, Some("")),
+            ExecutionIntent::Auto
+        );
+        assert_eq!(
+            request_execution_intent_with_backend_env(None, Some("not-a-backend")),
+            ExecutionIntent::Auto
+        );
+    }
 
     #[test]
     fn canceled_longform_planning_maps_to_typed_backend_cancel() {

--- a/crates/openasr-core/src/ggml_runtime/runtime_source.rs
+++ b/crates/openasr-core/src/ggml_runtime/runtime_source.rs
@@ -10,7 +10,12 @@ use std::{
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 #[cfg(windows)]
-use std::os::windows::fs::MetadataExt;
+use std::os::windows::io::AsRawHandle;
+
+#[cfg(windows)]
+use windows_sys::Win32::Storage::FileSystem::{
+    BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+};
 
 use memmap2::Mmap;
 use serde::{Deserialize, Serialize};
@@ -53,12 +58,31 @@ impl StrongFileIdentity {
     /// `None` when any needed metadata field cannot be read (including a
     /// pre-1970 mtime, which cannot be represented here) -- callers must fail
     /// closed rather than trust a partial identity.
-    pub(crate) fn of(metadata: &std::fs::Metadata) -> Option<Self> {
+    pub(crate) fn of_file(file: &File, metadata: &std::fs::Metadata) -> Option<Self> {
         #[cfg(not(any(unix, windows)))]
         {
-            let _ = metadata;
+            let _ = (file, metadata);
             return None;
         }
+        #[cfg(unix)]
+        let _ = file;
+        #[cfg(windows)]
+        let handle_identity = {
+            let mut information = BY_HANDLE_FILE_INFORMATION::default();
+            // SAFETY: `file` owns a live Windows file handle for the duration
+            // of this call, and `information` points to writable storage of
+            // the exact structure required by GetFileInformationByHandle.
+            let succeeded =
+                unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut information) };
+            if succeeded == 0 {
+                return None;
+            }
+            (
+                information.dwVolumeSerialNumber,
+                (u64::from(information.nFileIndexHigh) << 32)
+                    | u64::from(information.nFileIndexLow),
+            )
+        };
         let modified = metadata.modified().ok()?;
         let since_epoch = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
         Some(Self {
@@ -67,9 +91,9 @@ impl StrongFileIdentity {
             #[cfg(unix)]
             ino: metadata.ino(),
             #[cfg(windows)]
-            volume_serial_number: metadata.volume_serial_number()?,
+            volume_serial_number: handle_identity.0,
             #[cfg(windows)]
-            file_index: metadata.file_index()?,
+            file_index: handle_identity.1,
             len: metadata.len(),
             mtime_secs: since_epoch.as_secs(),
             mtime_nanos: since_epoch.subsec_nanos(),
@@ -341,7 +365,7 @@ impl GgmlRuntimeSource {
     fn trusted_object_content_id(&self, models_root: &Path) -> Option<String> {
         let canonical_path = fs::canonicalize(&self.path).ok()?;
         let canonical_models_root = fs::canonicalize(models_root).ok()?;
-        let current_identity = StrongFileIdentity::of(&fs::metadata(&canonical_path).ok()?)?;
+        let current_identity = self.current_strong_file_identity()?;
         if current_identity != self.stat_identity {
             return None;
         }
@@ -395,7 +419,7 @@ impl GgmlRuntimeSource {
         let file = file
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        StrongFileIdentity::of(&file.metadata().ok()?)
+        StrongFileIdentity::of_file(&file, &file.metadata().ok()?)
     }
 
     /// Return the exact engine-requested host-memory peak for making an
@@ -676,7 +700,7 @@ pub fn validate_ggml_runtime_source_path(
             path: path.to_path_buf(),
         });
     }
-    let stat_identity = StrongFileIdentity::of(&fd_metadata).ok_or_else(|| {
+    let stat_identity = StrongFileIdentity::of_file(&file, &fd_metadata).ok_or_else(|| {
         GgmlRuntimeSourcePathError::UnsupportedFileIdentity {
             path: path.to_path_buf(),
         }

--- a/crates/openasr-core/src/models/runtime_cache_coordinator.rs
+++ b/crates/openasr-core/src/models/runtime_cache_coordinator.rs
@@ -71,7 +71,10 @@ pub fn is_cacheable_pack_content_id(pack_content_id: &str) -> bool {
 /// already exists costs no read of its bytes.
 pub(crate) fn pack_content_id_for_path_before_replace(path: &Path, models_root: &Path) -> String {
     let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    let Ok(metadata) = std::fs::metadata(&canonical) else {
+    let Ok(mut file) = std::fs::File::open(&canonical) else {
+        return unreadable_content_id(&canonical);
+    };
+    let Ok(metadata) = file.metadata() else {
         return unreadable_content_id(&canonical);
     };
     // `models_root` is canonicalized the same way `path` just was: on
@@ -83,14 +86,10 @@ pub(crate) fn pack_content_id_for_path_before_replace(path: &Path, models_root: 
     // without weakening it.
     let canonical_root =
         std::fs::canonicalize(models_root).unwrap_or_else(|_| models_root.to_path_buf());
-    // The seal here comes from a path stat, not an open descriptor --
-    // `trusted_object_digest`'s contract prefers fd-derived metadata. This
-    // call site may keep the weaker form because its verdict only ever
-    // decides a cache eviction: a stat/open race can at worst evict too
-    // little or too much, never key a runtime build by the wrong content.
-    // A new caller that feeds a runtime build must not copy this shape --
-    // open the file first and take the seal from its fd, as
-    // `GgmlRuntimeSource` does.
+    // Read the seal and identity from the same open file that the cold path
+    // hashes. Besides being required for stable Windows file identity, this
+    // prevents a path replacement between stat and open from warming the
+    // shared identity memo with a digest for a different generation.
     if let Some(digest) = crate::content_store::trusted_object_digest(
         &canonical,
         metadata.permissions().readonly(),
@@ -98,10 +97,10 @@ pub(crate) fn pack_content_id_for_path_before_replace(path: &Path, models_root: 
     ) {
         return content_id_from_sha256_hex(digest);
     }
-    let Some(identity) = StrongFileIdentity::of(&metadata) else {
+    let Some(identity) = StrongFileIdentity::of_file(&file, &metadata) else {
         return unreadable_content_id(&canonical);
     };
-    resolve_content_id(&canonical, identity, || sha256_hex_file(&canonical).ok())
+    resolve_content_id(&canonical, identity, || sha256_hex_reader(&mut file).ok())
 }
 
 /// Content-addressed prepared/process-pool cache key: pack content id alone.
@@ -145,15 +144,19 @@ impl PackContentKey {
 /// the seal gate declines (sealed objects answer from their path digest and
 /// never get here). `GgmlRuntimeSource::content_id` never calls this: it
 /// hashes the mapping it already holds open instead.
+#[cfg(test)]
 fn sha256_hex_file(path: &Path) -> std::io::Result<String> {
-    use sha2::{Digest, Sha256};
-    use std::io::Read;
-
     let mut file = std::fs::File::open(path)?;
+    sha256_hex_reader(&mut file)
+}
+
+fn sha256_hex_reader(reader: &mut impl std::io::Read) -> std::io::Result<String> {
+    use sha2::{Digest, Sha256};
+
     let mut hasher = Sha256::new();
     let mut buffer = vec![0_u8; 1024 * 1024];
     loop {
-        let read = file.read(&mut buffer)?;
+        let read = reader.read(&mut buffer)?;
         if read == 0 {
             break;
         }


### PR DESCRIPTION
## Summary

- use stable Win32 handle metadata for strong runtime-file identity
- preserve the existing `OPENASR_GGML_BACKEND` override at the unified request execution-policy boundary
- hash pre-replace content from the same open file used for identity

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p openasr-core --all-targets -- -D warnings`
- `cargo nextest run --workspace` (3720 passed)
- `cargo test --workspace --doc`
- `cargo test -p openasr-core golden_diff -- --nocapture`

AI usage disclosure: YES — implementation and validation assistance.