### PR TITLE
test(core): synchronize single-flight concurrency test

### DIFF
--- a/crates/openasr-core/src/models/admitted_exclusive_object_pool.rs
+++ b/crates/openasr-core/src/models/admitted_exclusive_object_pool.rs
@@ -670,6 +670,7 @@ mod tests {
         let first_builds = Arc::clone(&builds);
         let first_active = Arc::clone(&active_builders);
         let first_maximum = Arc::clone(&maximum_active_builders);
+        let (first_builder_entered_tx, first_builder_entered_rx) = mpsc::channel();
         let first = thread::spawn(move || {
             first_pool
                 .checkout_or_try_build(
@@ -679,6 +680,9 @@ mod tests {
                         first_builds.fetch_add(1, Ordering::SeqCst);
                         let active = first_active.fetch_add(1, Ordering::SeqCst) + 1;
                         first_maximum.fetch_max(active, Ordering::SeqCst);
+                        first_builder_entered_tx
+                            .send(())
+                            .expect("report first builder entry");
                         thread::sleep(Duration::from_millis(30));
                         first_active.fetch_sub(1, Ordering::SeqCst);
                         Ok(owner(1, 32))
@@ -687,7 +691,9 @@ mod tests {
                 )
                 .expect("first checkout")
         });
-        thread::sleep(Duration::from_millis(5));
+        first_builder_entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("first builder should enter before the second checkout starts");
         let second_pool = pool.clone();
         let second_builds = Arc::clone(&builds);
         let second_active = Arc::clone(&active_builders);


### PR DESCRIPTION
## What

Replace the timing assumption in the single-flight concurrency test with an explicit channel signal from the first builder.

## Why

Under a heavily loaded runner, the second thread could start first and make the test observe one build instead of two even though the pool behavior was correct.

## Validation

- cargo fmt --check
- focused test repeated 100 times
- git diff --check

AI usage disclosure: YES — AI assistance was used for implementation and verification; the maintainer reviewed and owns the change.