### PR TITLE
perf(diarizen): cut persistent graph buffer 63x with liveness allocation

### DIFF
--- a/crates/openasr-core/src/diarize/segment/diarizen/config.rs
+++ b/crates/openasr-core/src/diarize/segment/diarizen/config.rs
@@ -209,7 +209,7 @@ pub(super) fn output_frames(samples: usize) -> usize {
         .iter()
         .zip(CONV_STRIDES)
         .try_fold(samples, |frames, (&kernel, stride)| {
-            (frames >= kernel).then_some((frames - kernel) / stride + 1)
+            (frames >= kernel).then(|| (frames - kernel) / stride + 1)
         })
         .unwrap_or(0)
 }

--- a/crates/openasr-core/src/diarize/segment/diarizen/runtime.rs
+++ b/crates/openasr-core/src/diarize/segment/diarizen/runtime.rs
@@ -30,6 +30,7 @@ use super::{DiariZenSegmenterError, DiariZenWindowOutput, postprocess_logits};
 
 const GRAPH_SIZE: usize = 1 << 16;
 const STATIC_GRAPH_SIZE: usize = 1 << 10;
+const FEATURE_TILE_FRAMES: usize = 256;
 const LAYER_NORM_EPSILON: f32 = 1.0e-5;
 const BATCH_NORM_EPSILON: f32 = 1.0e-5;
 
@@ -334,6 +335,13 @@ impl DiariZenRuntime {
     }
 
     #[cfg(test)]
+    pub(super) fn prepared_graph_allocation_bytes(&self) -> Option<u64> {
+        self.graph
+            .as_ref()
+            .and_then(|graph| graph.session.prepared_allocation_bytes())
+    }
+
+    #[cfg(test)]
     pub(super) fn infer_trace(
         &mut self,
         samples: &[f32],
@@ -601,36 +609,10 @@ fn build_graph(
         .map_err(graph_error("allocate_pcm"))?;
     let mut traces = Vec::new();
 
-    let mut state = graph
+    let normalized_pcm = graph
         .norm(pcm, LAYER_NORM_EPSILON)
         .map_err(graph_error("wavlm_waveform_norm"))?;
-    let mut current_frames = samples;
-    for layer in 0..CONV_CHANNELS.len() {
-        let kernel = weight(
-            weights,
-            &format!("wavlm_model.feature_extractor.conv_layers.{layer}.conv.weight"),
-        )?;
-        state = graph
-            .conv_1d(kernel, state, CONV_STRIDES[layer], 0, 1)
-            .map_err(graph_error("wavlm_feature_conv"))?;
-        current_frames = (current_frames - CONV_KERNELS[layer]) / CONV_STRIDES[layer] + 1;
-        state = feature_layer_norm(
-            graph,
-            state,
-            weight(
-                weights,
-                &format!("wavlm_model.feature_extractor.conv_layers.{layer}.layer_norm.weight"),
-            )?,
-            weight(
-                weights,
-                &format!("wavlm_model.feature_extractor.conv_layers.{layer}.layer_norm.bias"),
-            )?,
-        )?;
-        state = graph
-            .gelu_erf(state)
-            .map_err(graph_error("wavlm_feature_gelu"))?;
-    }
-    debug_assert_eq!(current_frames, frames);
+    let mut state = wavlm_feature_extractor_tiled(graph, weights, normalized_pcm, samples, frames)?;
     state = graph
         .transpose(state)
         .and_then(|value| graph.cont(value))
@@ -845,6 +827,91 @@ fn affine_layer_norm<'a>(
         },
         DiariZenSegmenterError::graph,
     )
+}
+
+pub(super) fn feature_input_samples(output_frames: usize) -> Option<usize> {
+    CONV_KERNELS.iter().zip(CONV_STRIDES).rev().try_fold(
+        output_frames,
+        |samples, (&kernel, stride)| {
+            samples
+                .checked_sub(1)
+                .and_then(|value| value.checked_mul(stride))
+                .and_then(|value| value.checked_add(kernel))
+        },
+    )
+}
+
+fn wavlm_feature_extractor_tiled<'a>(
+    graph: &GgmlCpuGraphBuilder<'a>,
+    weights: &GgmlLoadedWeightContext,
+    normalized_pcm: GgmlCpuTensor<'a>,
+    samples: usize,
+    frames: usize,
+) -> Result<GgmlCpuTensor<'a>, DiariZenSegmenterError> {
+    let total_stride = CONV_STRIDES.iter().product::<usize>();
+    let mut output = None;
+    for first_frame in (0..frames).step_by(FEATURE_TILE_FRAMES) {
+        let tile_frames = FEATURE_TILE_FRAMES.min(frames - first_frame);
+        let tile_samples = feature_input_samples(tile_frames).ok_or_else(|| {
+            DiariZenSegmenterError::Capacity(
+                "DiariZen feature-tile sample count overflowed".to_string(),
+            )
+        })?;
+        let sample_offset = first_frame.checked_mul(total_stride).ok_or_else(|| {
+            DiariZenSegmenterError::Capacity("DiariZen feature-tile offset overflowed".to_string())
+        })?;
+        let tile_end = sample_offset.checked_add(tile_samples).ok_or_else(|| {
+            DiariZenSegmenterError::Capacity("DiariZen feature-tile end overflowed".to_string())
+        })?;
+        if tile_end > samples {
+            return Err(DiariZenSegmenterError::Capacity(format!(
+                "DiariZen feature tile [{sample_offset}, {tile_end}) exceeds {samples} samples"
+            )));
+        }
+        let mut state = graph
+            .view_1d(
+                normalized_pcm,
+                tile_samples,
+                sample_offset * std::mem::size_of::<f32>(),
+            )
+            .map_err(graph_error("wavlm_feature_tile"))?;
+        let mut current_frames = tile_samples;
+        for layer in 0..CONV_CHANNELS.len() {
+            let kernel = weight(
+                weights,
+                &format!("wavlm_model.feature_extractor.conv_layers.{layer}.conv.weight"),
+            )?;
+            state = graph
+                .conv_1d(kernel, state, CONV_STRIDES[layer], 0, 1)
+                .map_err(graph_error("wavlm_feature_conv"))?;
+            current_frames = (current_frames - CONV_KERNELS[layer]) / CONV_STRIDES[layer] + 1;
+            state = feature_layer_norm(
+                graph,
+                state,
+                weight(
+                    weights,
+                    &format!("wavlm_model.feature_extractor.conv_layers.{layer}.layer_norm.weight"),
+                )?,
+                weight(
+                    weights,
+                    &format!("wavlm_model.feature_extractor.conv_layers.{layer}.layer_norm.bias"),
+                )?,
+            )?;
+            state = graph
+                .gelu_erf(state)
+                .map_err(graph_error("wavlm_feature_gelu"))?;
+        }
+        debug_assert_eq!(current_frames, tile_frames);
+        output = Some(match output {
+            None => state,
+            Some(previous) => graph
+                .concat(previous, state, 0)
+                .map_err(graph_error("wavlm_feature_tile_concat"))?,
+        });
+    }
+    output.ok_or_else(|| {
+        DiariZenSegmenterError::Capacity("DiariZen feature extractor produced no tiles".to_string())
+    })
 }
 
 fn feature_layer_norm<'a>(
@@ -1157,16 +1224,14 @@ fn wavlm_relative_mask<'a>(
         .and_then(|value| graph.sub(value, gate_a))
         .and_then(|value| graph.add(value, arena.graph_tensor(static_handles.two)))
         .map_err(graph_error("wavlm_gate_factor"))?;
-    let gated = graph
-        .mul(arena.graph_tensor(static_handles.relative_bias), factor)
-        .map_err(graph_error("wavlm_gate_relative_bias"))?;
-
+    let relative_bias = arena.graph_tensor(static_handles.relative_bias);
     let plane_bytes = frames * frames * std::mem::size_of::<f32>();
+    let factor_head_bytes = frames * std::mem::size_of::<f32>();
     let mut selected = None;
     for &head in REMAINING_HEADS[layer] {
         let plane = graph
             .view_3d(
-                gated,
+                relative_bias,
                 frames,
                 frames,
                 1,
@@ -1176,6 +1241,21 @@ fn wavlm_relative_mask<'a>(
             )
             .and_then(|value| graph.cont(value))
             .map_err(graph_error("wavlm_select_relative_head"))?;
+        let head_factor = graph
+            .view_3d(
+                factor,
+                1,
+                frames,
+                1,
+                std::mem::size_of::<f32>(),
+                factor_head_bytes,
+                head * factor_head_bytes,
+            )
+            .and_then(|value| graph.cont(value))
+            .map_err(graph_error("wavlm_select_relative_factor_head"))?;
+        let plane = graph
+            .mul(plane, head_factor)
+            .map_err(graph_error("wavlm_gate_relative_head"))?;
         selected = Some(match selected {
             None => plane,
             Some(previous) => graph

--- a/crates/openasr-core/src/diarize/segment/diarizen/tests.rs
+++ b/crates/openasr-core/src/diarize/segment/diarizen/tests.rs
@@ -10,6 +10,18 @@ fn external_path(env: &str) -> PathBuf {
         .unwrap_or_else(|| panic!("{env} must point at the external DiariZen parity fixture"))
 }
 
+fn benchmark_backend() -> crate::ggml_runtime::GgmlCpuGraphBackend {
+    match std::env::var("OPENASR_DIARIZEN_BENCH_BACKEND")
+        .unwrap_or_else(|_| "cpu".to_string())
+        .as_str()
+    {
+        "cpu" => crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+        "metal" => crate::ggml_runtime::GgmlCpuGraphBackend::Metal,
+        "gpu" => crate::ggml_runtime::GgmlCpuGraphBackend::Gpu,
+        backend => panic!("unsupported OPENASR_DIARIZEN_BENCH_BACKEND '{backend}'"),
+    }
+}
+
 fn npy_bytes(npz: &std::path::Path, name: &str) -> Vec<u8> {
     let file = std::fs::File::open(npz).expect("open external npz fixture");
     let mut archive = zip::ZipArchive::new(file).expect("parse external npz fixture");
@@ -124,6 +136,22 @@ fn median_filter_uses_scipy_reflect_edges() {
             .collect::<Vec<_>>(),
         vec![1, 1, 1, 0, 0, 0, 0]
     );
+}
+
+#[test]
+fn feature_tiles_use_the_minimal_exact_receptive_field() {
+    for expected_frames in [1, 2, 31, 64, 128, 799] {
+        let samples = runtime::feature_input_samples(expected_frames)
+            .expect("valid output frame count has an inverse receptive field");
+        assert_eq!(config::output_frames(samples), expected_frames);
+        if samples > 0 {
+            assert_eq!(
+                config::output_frames(samples - 1),
+                expected_frames - 1,
+                "one fewer source sample must not manufacture the last feature frame"
+            );
+        }
+    }
 }
 
 #[test]
@@ -261,17 +289,18 @@ fn native_graph_matches_external_pytorch_golden() {
 fn native_fp16_exact_window_benchmark() {
     let pack = external_path("OPENASR_DIARIZEN_PACK");
     let samples = synthetic_exact_window();
-    let mut runtime = DiariZenRuntime::new(
-        &pack,
-        samples.len(),
-        false,
-        Some(crate::ggml_runtime::GgmlCpuGraphBackend::Cpu),
-    )
-    .expect("construct production runtime");
+    let mut runtime = DiariZenRuntime::new(&pack, samples.len(), false, Some(benchmark_backend()))
+        .expect("construct production runtime");
+    let allocation_bytes = runtime
+        .prepared_graph_allocation_bytes()
+        .expect("direct benchmark backend uses the liveness-aware graph allocator");
+    assert!(
+        allocation_bytes <= 96 * 1024 * 1024,
+        "the fixed 16-second production graph must stay below the audited 96 MiB ceiling; got {allocation_bytes} bytes"
+    );
 
     let warmup = runtime.infer(&samples).expect("warmup inference");
     assert_eq!(warmup.logits.len(), warmup.frame_count * POWERSET_CLASSES);
-
     let mut seconds = Vec::with_capacity(5);
     let mut checksum = 0.0_f64;
     for _ in 0..5 {
@@ -285,7 +314,7 @@ fn native_fp16_exact_window_benchmark() {
     let median_seconds = seconds[seconds.len() / 2];
     let audio_seconds = super::config::WINDOW_SAMPLES as f64 / super::config::SAMPLE_RATE_HZ as f64;
     eprintln!(
-        "DIARIZEN_NATIVE_BENCH median_seconds={median_seconds:.6} rtf={:.6} runs={seconds:?} checksum={checksum:.6}",
+        "DIARIZEN_NATIVE_BENCH median_seconds={median_seconds:.6} rtf={:.6} graph_allocation_bytes={allocation_bytes} runs={seconds:?} checksum={checksum:.6}",
         median_seconds / audio_seconds
     );
     assert!(median_seconds.is_finite() && median_seconds > 0.0);
@@ -297,13 +326,8 @@ fn native_fp16_exact_window_benchmark() {
 fn native_fp16_sixty_second_window_throughput_benchmark() {
     let pack = external_path("OPENASR_DIARIZEN_PACK");
     let samples = synthetic_exact_window();
-    let mut runtime = DiariZenRuntime::new(
-        &pack,
-        samples.len(),
-        false,
-        Some(crate::ggml_runtime::GgmlCpuGraphBackend::Cpu),
-    )
-    .expect("construct production runtime");
+    let mut runtime = DiariZenRuntime::new(&pack, samples.len(), false, Some(benchmark_backend()))
+        .expect("construct production runtime");
     runtime.infer(&samples).expect("warmup inference");
 
     // Match pyannote Inference.slide: all complete 16 s windows at the pinned

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -5329,13 +5329,24 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
     }
 
     fn allocate_direct_graph(&mut self, graph: NonNull<c_void>) -> Result<(), GgmlCpuGraphError> {
+        self.allocate_direct_graph_with(graph, GgmlGraphAllocatorGuard::allocate)
+    }
+
+    fn allocate_direct_graph_with(
+        &mut self,
+        graph: NonNull<c_void>,
+        allocate: impl FnOnce(
+            NonNull<c_void>,
+            NonNull<c_void>,
+        ) -> Result<GgmlGraphAllocatorGuard, GgmlCpuGraphError>,
+    ) -> Result<(), GgmlCpuGraphError> {
         self.ensure_not_poisoned()?;
         if self.frozen {
             return Ok(());
         }
-        self.frozen = true;
-        let allocator = GgmlGraphAllocatorGuard::allocate(graph, self.backend)?;
+        let allocator = allocate(graph, self.backend)?;
         self.graph_allocator = Some(allocator);
+        self.frozen = true;
         Ok(())
     }
 
@@ -8082,7 +8093,8 @@ mod tests {
         GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuGraphThreadingWorkload, GgmlRopeExtParams,
         GpuProbeCache, GpuProbeOutcome, GpuProbeState, METAL_FLASH_ATTN_EXT_SUPPORTED_HEAD_DIMS,
         flash_attn_ext_head_dim_supported_on_backend, gpu_probe_failed_log_message,
-        gpu_probe_log_message, runtime_gpu_is_available, validate_graph_cancel_capability,
+        gpu_probe_log_message, memory_admission_failure, runtime_gpu_is_available,
+        validate_graph_cancel_capability,
     };
 
     #[test]
@@ -9900,6 +9912,55 @@ mod tests {
     }
 
     #[test]
+    fn failed_direct_graph_allocation_leaves_builder_retryable() {
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default())
+            .expect("cpu graph runner should initialize");
+        let mut session = runner
+            .start_persistent_graph_session(GgmlCpuGraphConfig::metadata_context_bytes(4096))
+            .expect("persistent session should open");
+        let (input, output) = {
+            let graph = session.builder();
+            let input = graph.new_tensor_1d_f32(4, "input").expect("input tensor");
+            graph.set_input(input).expect("input flag");
+            let output = graph.mul(input, input).expect("square graph");
+            graph.set_output(output).expect("output flag");
+            let forward = graph
+                .build_forward_graph(&[output])
+                .expect("forward graph should build");
+            let error = graph
+                .allocate_direct_graph_with(forward, |_forward, _backend| {
+                    Err(memory_admission_failure(
+                        "direct-gallocr/test-injected",
+                        "injected allocation failure",
+                    ))
+                })
+                .expect_err("injected allocation must fail");
+            assert!(matches!(error, GgmlCpuGraphError::MemoryAdmission { .. }));
+            assert!(
+                !graph.frozen,
+                "a failed allocation must not freeze the builder"
+            );
+            assert!(graph.graph_allocator.is_none());
+            assert!(graph.prepared_graph.is_none());
+            (input, output)
+        };
+
+        let graph = session.builder();
+        graph
+            .prepare_outputs_for_upload(&[output])
+            .expect("the same builder must remain retryable after allocation failure");
+        graph
+            .set_f32_slice(input, &[1.0, 2.0, 3.0, 4.0], "input")
+            .expect("input upload");
+        assert_eq!(
+            graph
+                .compute_output_f32(output, 4)
+                .expect("retried graph should compute"),
+            vec![1.0, 4.0, 9.0, 16.0]
+        );
+    }
+
+    #[test]
     fn persistent_graph_session_reuses_built_graph_for_i32_output() {
         let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
             .expect("cpu graph runner should initialize");
@@ -10097,34 +10158,41 @@ mod tests {
         let broker = std::sync::Arc::clone(services.memory_broker());
         let _scope =
             crate::models::native_execution_services::install_native_execution_services(&services);
-
-        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default())
-            .expect("direct cpu graph runner should initialize");
-        let mut session = runner
-            .start_persistent_graph_session(1024 * 1024)
-            .expect("persistent session should open");
-        let graph = session.builder();
-        let input = graph.new_tensor_1d_f32(4, "input").expect("input tensor");
-        graph.set_input(input).expect("input flag");
-        let output = graph.mul(input, input).expect("square graph");
-        graph.set_output(output).expect("output flag");
-        graph
-            .prepare_outputs_for_upload(&[output])
-            .expect("direct graph allocation should be admitted atomically");
-        graph
-            .set_f32_slice(input, &[1.0, 2.0, 3.0, 4.0], "input")
-            .expect("input upload");
-        assert_eq!(
+        let domain = crate::device::execution_memory::MemoryDomainKey::SystemMemory;
+        let baseline = broker.usage(&domain);
+        {
+            let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default())
+                .expect("direct cpu graph runner should initialize");
+            let mut session = runner
+                .start_persistent_graph_session(1024 * 1024)
+                .expect("persistent session should open");
+            let graph = session.builder();
+            let input = graph.new_tensor_1d_f32(4, "input").expect("input tensor");
+            graph.set_input(input).expect("input flag");
+            let output = graph.mul(input, input).expect("square graph");
+            graph.set_output(output).expect("output flag");
             graph
-                .compute_output_f32(output, 4)
-                .expect("direct graph should compute"),
-            vec![1.0, 4.0, 9.0, 16.0]
-        );
+                .prepare_outputs_for_upload(&[output])
+                .expect("direct graph allocation should be admitted atomically");
+            graph
+                .set_f32_slice(input, &[1.0, 2.0, 3.0, 4.0], "input")
+                .expect("input upload");
+            assert_eq!(
+                graph
+                    .compute_output_f32(output, 4)
+                    .expect("direct graph should compute"),
+                vec![1.0, 4.0, 9.0, 16.0]
+            );
 
-        let usage = broker.usage(&crate::device::execution_memory::MemoryDomainKey::SystemMemory);
-        assert_eq!(usage.pending_bytes, 0);
-        assert!(!usage.exclusive_pending);
-        assert!(usage.committed_bytes > 0);
+            let usage = broker.usage(&domain);
+            assert_eq!(usage.pending_bytes, 0);
+            assert!(!usage.exclusive_pending);
+            assert!(usage.committed_bytes > baseline.committed_bytes);
+        }
+        let released = broker.usage(&domain);
+        assert_eq!(released.pending_bytes, baseline.pending_bytes);
+        assert_eq!(released.committed_bytes, baseline.committed_bytes);
+        assert_eq!(released.exclusive_pending, baseline.exclusive_pending);
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -1352,6 +1352,7 @@ pub(crate) struct GgmlCpuGraphBuilder<'a> {
     backend_private_memory_owner: GgmlBackendPrivateLeaseOwner,
     graph_size: usize,
     buffer: Option<GgmlBackendBufferGuard>,
+    graph_allocator: Option<GgmlGraphAllocatorGuard>,
     /// `Some` only for plain `start_graph()` builders on the CPU backend with
     /// no scheduler -- the per-token rebuild path this pool targets. `None`
     /// for persistent-graph-session builders (which already allocate once and
@@ -1403,6 +1404,14 @@ impl GgmlPersistentGraphSession {
 
     pub(crate) fn mark_poisoned_after_failed_compute(&mut self) {
         self.builder.mark_poisoned_after_failed_compute();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn prepared_allocation_bytes(&self) -> Option<u64> {
+        self.builder
+            .graph_allocator
+            .as_ref()
+            .map(GgmlGraphAllocatorGuard::requested_bytes)
     }
 }
 
@@ -1650,6 +1659,7 @@ impl GgmlCpuGraphRunner {
             backend_private_memory_owner: Rc::clone(&self.backend.private_memory_leases),
             graph_size: self.graph_size,
             buffer: None,
+            graph_allocator: None,
             step_buffer_pool,
             frozen: false,
             prepared_graph: None,
@@ -1715,9 +1725,10 @@ impl GgmlCpuGraphRunner {
             backend_private_memory_owner: Rc::clone(&self.backend.private_memory_leases),
             graph_size: self.graph_size,
             buffer: None,
-            // A persistent session already allocates its buffer once (via
-            // `ensure_backend_buffer`) and keeps it for the session's whole
-            // lifetime, so it does not need the step pool's grow-to-fit reuse.
+            graph_allocator: None,
+            // A persistent session allocates its graph once and keeps that
+            // allocation for the session's whole lifetime, so it does not
+            // need the step pool's grow-to-fit reuse.
             step_buffer_pool: None,
             frozen: false,
             prepared_graph: None,
@@ -4428,8 +4439,13 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         let graph = self.build_forward_graph(outputs)?;
         if self.scheduler.is_some() {
             self.allocate_scheduler_graph(graph)?;
-        } else {
+        } else if self.step_buffer_pool.is_some() {
+            // Preserve the CPU per-step grow-to-fit pool. A one-shot gallocr
+            // would save bytes for this graph but would also allocate and free
+            // a backend buffer on every decoder step.
             self.ensure_backend_buffer()?;
+        } else {
+            self.allocate_direct_graph(graph)?;
         }
         self.prepared_graph = Some(graph);
         Ok(())
@@ -5309,6 +5325,17 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         }
         let buffer = GgmlBackendBufferGuard::allocate(self.context, self.backend)?;
         self.buffer = Some(buffer);
+        Ok(())
+    }
+
+    fn allocate_direct_graph(&mut self, graph: NonNull<c_void>) -> Result<(), GgmlCpuGraphError> {
+        self.ensure_not_poisoned()?;
+        if self.frozen {
+            return Ok(());
+        }
+        self.frozen = true;
+        let allocator = GgmlGraphAllocatorGuard::allocate(graph, self.backend)?;
+        self.graph_allocator = Some(allocator);
         Ok(())
     }
 
@@ -7371,6 +7398,230 @@ struct GgmlRawBackendBufferGuard {
 impl Drop for GgmlRawBackendBufferGuard {
     fn drop(&mut self) {
         unsafe { ffi::ggml_backend_buffer_free(self.raw.as_ptr()) };
+    }
+}
+
+struct GgmlRawGraphAllocatorGuard {
+    raw: NonNull<c_void>,
+}
+
+impl GgmlRawGraphAllocatorGuard {
+    fn new(buft: NonNull<c_void>) -> Result<Self, GgmlCpuGraphError> {
+        NonNull::new(unsafe { ffi::ggml_gallocr_new(buft.as_ptr()) })
+            .map(|raw| Self { raw })
+            .ok_or_else(|| {
+                memory_admission_failure("direct-gallocr/create", "ggml_gallocr_new returned null")
+            })
+    }
+
+    fn measure(
+        &self,
+        graph: NonNull<c_void>,
+    ) -> Result<Vec<(NonNull<c_void>, u64, u64)>, GgmlCpuGraphError> {
+        if !unsafe {
+            ffi::ggml_gallocr_measure_n_v1(
+                self.raw.as_ptr(),
+                graph.as_ptr(),
+                ptr::null(),
+                ptr::null(),
+            )
+        } {
+            return Err(memory_admission_failure(
+                "direct-gallocr/measure",
+                "ggml_gallocr_measure_n_v1 failed",
+            ));
+        }
+        let count = unsafe { ffi::ggml_gallocr_measure_get_chunk_count_v1(self.raw.as_ptr()) };
+        let mut chunks = Vec::with_capacity(count as usize);
+        for index in 0..count {
+            let mut buft = ptr::null_mut();
+            let mut requested_bytes = 0_u64;
+            let mut currently_allocated_bytes = 0_u64;
+            if !unsafe {
+                ffi::ggml_gallocr_measure_get_chunk_v1(
+                    self.raw.as_ptr(),
+                    index,
+                    &mut buft,
+                    &mut requested_bytes,
+                    &mut currently_allocated_bytes,
+                )
+            } {
+                return Err(memory_admission_failure(
+                    "direct-gallocr/describe",
+                    format!("ggml_gallocr_measure_get_chunk_v1 failed for chunk {index}"),
+                ));
+            }
+            let buft = NonNull::new(buft).ok_or_else(|| {
+                memory_admission_failure(
+                    "direct-gallocr/describe",
+                    format!("chunk {index} returned a null buffer type"),
+                )
+            })?;
+            chunks.push((buft, requested_bytes, currently_allocated_bytes));
+        }
+        Ok(chunks)
+    }
+
+    fn commit_and_bind(&self, graph: NonNull<c_void>) -> Result<(), GgmlCpuGraphError> {
+        if !unsafe { ffi::ggml_gallocr_measure_commit_v1(self.raw.as_ptr()) } {
+            return Err(memory_admission_failure(
+                "direct-gallocr/commit",
+                "ggml_gallocr_measure_commit_v1 failed",
+            ));
+        }
+        if !unsafe { ffi::ggml_gallocr_alloc_graph(self.raw.as_ptr(), graph.as_ptr()) } {
+            return Err(memory_admission_failure(
+                "direct-gallocr/bind",
+                "ggml_gallocr_alloc_graph failed",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for GgmlRawGraphAllocatorGuard {
+    fn drop(&mut self) {
+        unsafe { ffi::ggml_gallocr_free(self.raw.as_ptr()) };
+    }
+}
+
+enum GgmlGraphAllocatorOwnership {
+    #[cfg(test)]
+    Direct { _owner: GgmlRawGraphAllocatorGuard },
+    Admitted {
+        _owner: NativeMemoryAllocation<GgmlRawGraphAllocatorGuard>,
+    },
+}
+
+struct GgmlGraphAllocatorGuard {
+    _ownership: GgmlGraphAllocatorOwnership,
+    #[cfg(test)]
+    requested_bytes: u64,
+}
+
+impl GgmlGraphAllocatorGuard {
+    fn allocate(
+        graph: NonNull<c_void>,
+        backend: NonNull<c_void>,
+    ) -> Result<Self, GgmlCpuGraphError> {
+        ensure_backend_device_present(backend)?;
+        let buft =
+            NonNull::new(unsafe { ffi::ggml_backend_get_default_buffer_type(backend.as_ptr()) })
+                .ok_or_else(|| {
+                    memory_admission_failure(
+                        "direct-gallocr/describe",
+                        "backend returned no default buffer type",
+                    )
+                })?;
+        let allocator = GgmlRawGraphAllocatorGuard::new(buft)?;
+        let chunks = allocator.measure(graph)?;
+        #[cfg(test)]
+        let requested_bytes = chunks.iter().try_fold(0_u64, |total, (_, requested, _)| {
+            total.checked_add(*requested).ok_or_else(|| {
+                memory_admission_failure(
+                    "direct-gallocr/describe",
+                    "graph allocation byte count overflowed u64",
+                )
+            })
+        })?;
+
+        let Some(broker) =
+            crate::models::native_execution_services::current_native_execution_memory_broker()
+        else {
+            #[cfg(test)]
+            {
+                allocator.commit_and_bind(graph)?;
+                return Ok(Self {
+                    _ownership: GgmlGraphAllocatorOwnership::Direct { _owner: allocator },
+                    requested_bytes,
+                });
+            }
+            #[cfg(not(test))]
+            {
+                return Err(memory_admission_failure(
+                    "direct-gallocr/broker",
+                    "process-wide native execution memory broker is not installed",
+                ));
+            }
+        };
+
+        let semantics = NativeMemoryClaimSemantics {
+            resource_id: "direct-graph-gallocr".to_owned(),
+            lifetime: AllocationLifetime::SessionResident,
+            phases: PhaseSet::ALL,
+        };
+        let mut request_semantics = BTreeMap::new();
+        let mut requests = Vec::with_capacity(chunks.len());
+        for (index, (buft, requested_bytes, currently_allocated_bytes)) in
+            chunks.into_iter().enumerate()
+        {
+            let request_id = u64::try_from(index + 1).map_err(|_| {
+                memory_admission_failure(
+                    "direct-gallocr/describe",
+                    "graph allocation chunk count exceeds u64",
+                )
+            })?;
+            requests.push(ffi::GgmlBackendMemoryRequestV1 {
+                kind: ffi::GGML_BACKEND_MEMORY_REQUEST_BUFFER,
+                usage: ffi::GGML_BACKEND_BUFFER_USAGE_COMPUTE as u32,
+                request_id,
+                backend: backend.as_ptr(),
+                buft: buft.as_ptr(),
+                graph: graph.as_ptr(),
+                requested_bytes,
+                currently_allocated_bytes,
+                ..Default::default()
+            });
+            request_semantics.insert(
+                request_id,
+                NativeMemoryClaimSemantics {
+                    resource_id: format!("direct-graph-gallocr-chunk-{index}"),
+                    ..semantics.clone()
+                },
+            );
+        }
+        let abi = unsafe { BackendMemoryAbi::from_backend(backend.as_ptr()) }
+            .map_err(|source| memory_admission_error("direct-gallocr/describe", source.into()))?;
+        let group = NativeQuotedBackendGroup::quote(
+            "direct-gallocr",
+            backend_memory_identity(backend)?,
+            abi,
+            requests,
+            request_semantics,
+            semantics,
+        )
+        .map_err(|source| memory_admission_error("direct-gallocr/quote", source))?;
+        let transaction = NativeMemoryAdmissionPlan::from_groups(vec![group])
+            .and_then(|plan| {
+                plan.try_reserve(
+                    &broker,
+                    crate::models::native_execution_services::current_memory_reservation_cohort_id(
+                    ),
+                )
+            })
+            .map_err(|source| memory_admission_error("direct-gallocr/reserve", source))?;
+        let allocation = transaction
+            .commit_engine_owned_with(|| {
+                allocator.commit_and_bind(graph)?;
+                Ok::<_, GgmlCpuGraphError>(allocator)
+            })
+            .map_err(|error| match error {
+                NativeMemoryAllocationError::NativeCommit { source } => source,
+                NativeMemoryAllocationError::PostAllocationStats { source } => {
+                    memory_admission_error("direct-gallocr/reconcile", source)
+                }
+                other => memory_admission_failure("direct-gallocr/commit", other.to_string()),
+            })?;
+        Ok(Self {
+            _ownership: GgmlGraphAllocatorOwnership::Admitted { _owner: allocation },
+            #[cfg(test)]
+            requested_bytes,
+        })
+    }
+
+    #[cfg(test)]
+    fn requested_bytes(&self) -> u64 {
+        self.requested_bytes
     }
 }
 
@@ -9597,6 +9848,58 @@ mod tests {
     }
 
     #[test]
+    fn persistent_direct_graph_reuses_intermediate_storage_by_lifetime() {
+        const ELEMENTS: usize = 4096;
+        const ADDITIONS: usize = 64;
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default())
+            .expect("cpu graph runner should initialize");
+        let mut session = runner
+            .start_persistent_graph_session(GgmlCpuGraphConfig::metadata_context_bytes(4096))
+            .expect("persistent session should open");
+        let (input, increment, output) = {
+            let graph = session.builder();
+            let input = graph
+                .new_tensor_1d_f32(ELEMENTS, "input")
+                .expect("input tensor");
+            let increment = graph
+                .new_tensor_1d_f32(ELEMENTS, "increment")
+                .expect("increment tensor");
+            graph.set_input(input).expect("input flag");
+            graph.set_input(increment).expect("increment flag");
+            let mut output = input;
+            for _ in 0..ADDITIONS {
+                output = graph.add(output, increment).expect("add node");
+            }
+            graph.set_output(output).expect("output flag");
+            graph
+                .prepare_outputs_for_upload(&[output])
+                .expect("liveness-aware graph allocation");
+            (input, increment, output)
+        };
+
+        let allocated = session
+            .prepared_allocation_bytes()
+            .expect("direct persistent graph owns a graph allocator");
+        let naive = (ADDITIONS + 2) * ELEMENTS * std::mem::size_of::<f32>();
+        assert!(
+            allocated < (naive / 2) as u64,
+            "liveness allocation {allocated} should be far below declaration-order sum {naive}"
+        );
+
+        let graph = session.builder();
+        graph
+            .set_f32_slice(input, &vec![0.0; ELEMENTS], "input")
+            .expect("input upload");
+        graph
+            .set_f32_slice(increment, &vec![1.0; ELEMENTS], "increment")
+            .expect("increment upload");
+        let values = graph
+            .compute_output_f32(output, ELEMENTS)
+            .expect("compute reused graph");
+        assert!(values.iter().all(|value| *value == ADDITIONS as f32));
+    }
+
+    #[test]
     fn persistent_graph_session_reuses_built_graph_for_i32_output() {
         let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
             .expect("cpu graph runner should initialize");
@@ -9786,6 +10089,42 @@ mod tests {
         let usage = broker.usage(&crate::device::execution_memory::MemoryDomainKey::SystemMemory);
         assert_eq!(usage.pending_bytes, 0);
         assert!(!usage.exclusive_pending);
+    }
+
+    #[test]
+    fn direct_persistent_graph_with_injected_broker_clears_candidate_pending_state() {
+        let services = crate::models::native_execution_services::test_native_execution_services();
+        let broker = std::sync::Arc::clone(services.memory_broker());
+        let _scope =
+            crate::models::native_execution_services::install_native_execution_services(&services);
+
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default())
+            .expect("direct cpu graph runner should initialize");
+        let mut session = runner
+            .start_persistent_graph_session(1024 * 1024)
+            .expect("persistent session should open");
+        let graph = session.builder();
+        let input = graph.new_tensor_1d_f32(4, "input").expect("input tensor");
+        graph.set_input(input).expect("input flag");
+        let output = graph.mul(input, input).expect("square graph");
+        graph.set_output(output).expect("output flag");
+        graph
+            .prepare_outputs_for_upload(&[output])
+            .expect("direct graph allocation should be admitted atomically");
+        graph
+            .set_f32_slice(input, &[1.0, 2.0, 3.0, 4.0], "input")
+            .expect("input upload");
+        assert_eq!(
+            graph
+                .compute_output_f32(output, 4)
+                .expect("direct graph should compute"),
+            vec![1.0, 4.0, 9.0, 16.0]
+        );
+
+        let usage = broker.usage(&crate::device::execution_memory::MemoryDomainKey::SystemMemory);
+        assert_eq!(usage.pending_bytes, 0);
+        assert!(!usage.exclusive_pending);
+        assert!(usage.committed_bytes > 0);
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -6,6 +6,7 @@ pub(crate) type GgmlBackendBufferRaw = *mut c_void;
 pub(crate) type GgmlBackendBufferTypeRaw = *mut c_void;
 pub(crate) type GgmlBackendSchedRaw = *mut c_void;
 pub(crate) type GgmlBackendSchedMemoryPlanRaw = *mut c_void;
+pub(crate) type GgmlGallocrRaw = *mut c_void;
 pub(crate) type GgmlBackendRegRaw = *mut c_void;
 pub(crate) type GgmlContextRaw = *mut c_void;
 pub(crate) type GgmlTensorRaw = *mut c_void;
@@ -493,6 +494,24 @@ unsafe extern "C" {
         size: usize,
     ) -> GgmlBackendBufferRaw;
     pub(crate) fn ggml_backend_buffer_get_size(buffer: GgmlBackendBufferRaw) -> usize;
+    pub(crate) fn ggml_gallocr_new(buft: GgmlBackendBufferTypeRaw) -> GgmlGallocrRaw;
+    pub(crate) fn ggml_gallocr_free(galloc: GgmlGallocrRaw);
+    pub(crate) fn ggml_gallocr_measure_n_v1(
+        galloc: GgmlGallocrRaw,
+        graph: GgmlCgraphRaw,
+        node_buffer_ids: *const c_int,
+        leaf_buffer_ids: *const c_int,
+    ) -> bool;
+    pub(crate) fn ggml_gallocr_measure_get_chunk_count_v1(galloc: GgmlGallocrRaw) -> u32;
+    pub(crate) fn ggml_gallocr_measure_get_chunk_v1(
+        galloc: GgmlGallocrRaw,
+        index: u32,
+        buft: *mut GgmlBackendBufferTypeRaw,
+        requested_bytes: *mut u64,
+        currently_allocated_bytes: *mut u64,
+    ) -> bool;
+    pub(crate) fn ggml_gallocr_measure_commit_v1(galloc: GgmlGallocrRaw) -> bool;
+    pub(crate) fn ggml_gallocr_alloc_graph(galloc: GgmlGallocrRaw, graph: GgmlCgraphRaw) -> bool;
     // Tensor allocator (ggml-alloc.h): binds tensors into an already-allocated
     // buffer -- the primitive `ggml_backend_alloc_ctx_tensors` itself uses,
     // exposed here to bind the CPU step pool's *reused* buffer without


### PR DESCRIPTION
## Summary

Reduce DiariZen's persistent direct-graph allocation from 5,846,073,344 bytes to 92,728,832 bytes by allocating intermediates according to tensor lifetimes and bounding feature-extractor activations with exact receptive-field tiling.

## Why

The direct graph previously kept declaration-ordered intermediate tensors resident for the full graph lifetime. A single fixed 16-second DiariZen window therefore requested about 5.85 GB before inference, which could fail admission on otherwise supported Macs.

The allocation represented graph workspace, not audio size. The runtime should reuse non-overlapping intermediate storage while preserving the model's official window, step, weights, and numerical path.

## Changes

- Measure persistent direct graphs with ggml gallocr before memory admission, then reserve and bind the measured liveness allocation through the native memory broker.
- Tile the convolutional feature extractor at its exact 400-sample receptive field and 320-sample stride, with the minimal 80-sample overlap between adjacent tiles.
- Keep failed direct-graph allocations retryable and release broker accounting when the session is dropped.
- Add regression tests for lifetime reuse, exact tile geometry, failed-allocation retry, and broker cleanup.

The relative-position bias staging remains full-sized; attention computation selects only the remaining heads before multiplication.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (3,944 passed, 177 skipped)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Focused regression tests:

- `persistent_direct_graph_reuses_intermediate_storage_by_lifetime`
- `feature_tiles_use_the_minimal_exact_receptive_field`
- `failed_direct_graph_allocation_leaves_builder_retryable`
- `direct_persistent_graph_with_injected_broker_clears_candidate_pending_state`

## Manual smoke checks

- Native Metal 16-second exact-window benchmark: 92,728,832-byte graph allocation (88.4 MiB), below the 96 MiB regression gate; median 0.708 seconds versus 0.772 seconds before this change.
- Locked six-file diarization acceptance: 7.949026% DER versus 7.949084% before this change.
- A 57-second two-speaker end-to-end transcription completed in 72.65 seconds versus 88.65 seconds before this change, with byte-identical transcript JSON.

## Model-family changes (when applicable)

Not a new model family or release candidate. This PR changes the existing DiariZen native runtime only.

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any staged/public-ready work completes Model Onboarding Step 5 without hand-editing generated catalog/registry truth.
- [x] Real-weight quality/performance claims have artifact-backed evidence; otherwise they are explicitly listed as unverified.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed. No user-facing documentation change is required for this internal runtime optimization.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Keep the official 16-second window and 1.6-second step unchanged.
- Keep the FP16 model and numerical execution path unchanged.
- Do not add a model downgrade, shorter-window mode, or silent fallback.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in `AGENTS.md`.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - AI assisted implementation and verification; the maintainer reviewed the change and owns its maintenance.
