### PR TITLE
fix(ggml): harden scheduler plan memory lifecycle

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -30,6 +30,10 @@ on:
         description: "Build only this matrix.target key (empty = all legs; for validating a single platform without the full matrix)"
         required: false
         default: ""
+      cuda_gpu_targets:
+        description: "Optional CUDA arch list for a diagnostic workflow_dispatch build (empty = release defaults)"
+        required: false
+        default: ""
   workflow_call:
     inputs:
       ref:
@@ -71,6 +75,10 @@ jobs:
     # users tune locally via --features native or OPENASR_GGML_NATIVE=1.
     env:
       OPENASR_GGML_NATIVE: "0"
+      # A maintainer may narrow a manual diagnostic build to the exact GPU
+      # under test. Tag/workflow_call releases leave this empty and retain the
+      # portable build.rs defaults.
+      OPENASR_CUDA_GPU_TARGETS: ${{ inputs.cuda_gpu_targets || '' }}
       # AMD HIP SDK "PRO Edition" silent-installer release train, matched to
       # llama.cpp's current Windows HIP release job.
       HIPSDK_INSTALLER_VERSION: 26.Q1

--- a/crates/openasr-core/src/ggml_runtime/backend_memory.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend_memory.rs
@@ -370,6 +370,31 @@ pub(crate) struct SchedulerMemoryPlan<'scheduler> {
     _scheduler: PhantomData<&'scheduler mut c_void>,
 }
 
+#[derive(Debug, Error)]
+#[error("{source} (scheduler native allocation may_have_mutated={may_have_mutated})")]
+pub(crate) struct SchedulerMemoryPlanCommitError {
+    source: BackendMemoryAbiError,
+    may_have_mutated: bool,
+}
+
+impl SchedulerMemoryPlanCommitError {
+    pub(crate) fn requires_quarantine(&self) -> bool {
+        if self.may_have_mutated {
+            return true;
+        }
+        match &self.source {
+            BackendMemoryAbiError::Status { status, .. } => {
+                *status != ffi::GGML_STATUS_FAILED && *status != ffi::GGML_STATUS_ALLOC_FAILED
+            }
+            _ => true,
+        }
+    }
+
+    pub(crate) fn into_source(self) -> BackendMemoryAbiError {
+        self.source
+    }
+}
+
 impl<'scheduler> SchedulerMemoryPlan<'scheduler> {
     /// `scheduler`, `graph`, and every tensor reachable from `graph` must stay
     /// live and immutable until this plan is committed or dropped.
@@ -440,10 +465,22 @@ impl<'scheduler> SchedulerMemoryPlan<'scheduler> {
         Ok(batches)
     }
 
-    pub(crate) fn commit(mut self) -> Result<(), BackendMemoryAbiError> {
-        status("scheduler_plan/commit", unsafe {
-            ffi::ggml_backend_sched_memory_plan_commit_v1(self.raw)
-        })?;
+    pub(crate) fn commit(mut self) -> Result<(), SchedulerMemoryPlanCommitError> {
+        let mut flags = 0_u32;
+        if let Err(source) = status("scheduler_plan/commit", unsafe {
+            ffi::ggml_backend_sched_memory_plan_commit_v2(self.raw, &mut flags)
+        }) {
+            let known_mutation =
+                flags & ffi::GGML_BACKEND_SCHED_MEMORY_PLAN_COMMIT_MAY_HAVE_MUTATED != 0;
+            let unknown_flags =
+                flags & !ffi::GGML_BACKEND_SCHED_MEMORY_PLAN_COMMIT_MAY_HAVE_MUTATED;
+            return Err(SchedulerMemoryPlanCommitError {
+                source,
+                // Unknown future flags are conservative: only an exact zero
+                // proves that native scheduler allocation did not change.
+                may_have_mutated: known_mutation || unknown_flags != 0,
+            });
+        }
         unsafe { ffi::ggml_backend_sched_memory_plan_free_v1(self.raw) };
         self.raw = ptr::null_mut();
         Ok(())
@@ -470,5 +507,23 @@ mod tests {
         assert_eq!(mem::size_of::<ffi::GgmlBackendMemoryQuoteV1>(), 48);
         assert_eq!(mem::size_of::<ffi::GgmlBackendMemoryStatsV1>(), 152);
         assert_eq!(mem::size_of::<ffi::GgmlBackendMemoryApiV1>(), 64);
+    }
+
+    #[test]
+    fn scheduler_commit_quarantines_only_unrecoverable_failures() {
+        let error = |status, may_have_mutated| SchedulerMemoryPlanCommitError {
+            source: BackendMemoryAbiError::Status {
+                operation: "scheduler_plan/commit",
+                status,
+            },
+            may_have_mutated,
+        };
+
+        assert!(!error(ffi::GGML_STATUS_FAILED, false).requires_quarantine());
+        assert!(!error(ffi::GGML_STATUS_ALLOC_FAILED, false).requires_quarantine());
+        assert!(error(ffi::GGML_STATUS_FAILED, true).requires_quarantine());
+        assert!(error(ffi::GGML_STATUS_DEVICE_LOST, false).requires_quarantine());
+        assert!(error(ffi::GGML_STATUS_BACKEND_POISONED, false).requires_quarantine());
+        assert!(error(i32::MAX, false).requires_quarantine());
     }
 }

--- a/crates/openasr-core/src/ggml_runtime/backend_memory_admission.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend_memory_admission.rs
@@ -255,6 +255,46 @@ pub(crate) struct NativeMemoryAllocationTransaction {
     reservation: DeviceMemoryReservationBatch,
 }
 
+#[derive(Debug)]
+pub(crate) enum NativeOwnerAttachedCommitFailure<E> {
+    Reclaimable(E),
+    Quarantine(E),
+}
+
+impl<E> NativeOwnerAttachedCommitFailure<E> {
+    pub(crate) fn reclaimable(source: E) -> Self {
+        Self::Reclaimable(source)
+    }
+
+    pub(crate) fn quarantine(source: E) -> Self {
+        Self::Quarantine(source)
+    }
+
+    fn requires_quarantine(&self) -> bool {
+        matches!(self, Self::Quarantine(_))
+    }
+
+    fn into_source(self) -> E {
+        match self {
+            Self::Reclaimable(source) | Self::Quarantine(source) => source,
+        }
+    }
+}
+
+fn owner_attached_native_commit_error<E>(
+    reservation: &mut DeviceMemoryReservationBatch,
+    failure: NativeOwnerAttachedCommitFailure<E>,
+) -> NativeOwnerAttachedMemoryError<E> {
+    let quarantined = failure.requires_quarantine();
+    if quarantined {
+        reservation.quarantine();
+    }
+    NativeOwnerAttachedMemoryError::NativeCommit {
+        source: failure.into_source(),
+        quarantined,
+    }
+}
+
 impl NativeMemoryAllocationTransaction {
     pub(crate) fn groups(&self) -> &[NativeQuotedBackendGroup] {
         &self.groups
@@ -431,18 +471,18 @@ impl NativeMemoryAllocationTransaction {
     /// the owner must release its native allocation before dropping the
     /// lease.
     ///
-    /// Unlike [`Self::commit_engine_owned_with`], a failed native commit or
-    /// post-commit reconciliation cannot locally destroy the allocation: the
-    /// enclosing owner may already have grown an internal high-water arena.
-    /// Therefore every failure after `native_commit` begins quarantines the
-    /// broker reservation. The caller must additionally poison or destroy the
-    /// enclosing native owner before it can be used again.
+    /// Unlike [`Self::commit_engine_owned_with`], a failure after native state
+    /// may have changed cannot locally destroy the allocation: the enclosing
+    /// owner may already have grown an internal high-water arena. The callback
+    /// must therefore classify its failure precisely. Pre-mutation validation
+    /// failures refund normally; potentially-mutating failures quarantine the
+    /// broker reservation and require poisoning or destroying the owner.
     pub(crate) fn commit_owner_attached_with<E, F>(
         mut self,
         native_commit: F,
     ) -> Result<NativeOwnerAttachedMemoryLease, NativeOwnerAttachedMemoryError<E>>
     where
-        F: FnOnce() -> Result<(), E>,
+        F: FnOnce() -> Result<(), NativeOwnerAttachedCommitFailure<E>>,
     {
         self.require_request_class(NativeRequestClass::EngineOwned)
             .map_err(NativeOwnerAttachedMemoryError::RequestKinds)?;
@@ -460,9 +500,11 @@ impl NativeMemoryAllocationTransaction {
             }
         }
 
-        if let Err(source) = native_commit() {
-            self.reservation.quarantine();
-            return Err(NativeOwnerAttachedMemoryError::NativeCommit { source });
+        if let Err(failure) = native_commit() {
+            return Err(owner_attached_native_commit_error(
+                &mut self.reservation,
+                failure,
+            ));
         }
 
         let groups = &self.groups;
@@ -888,6 +930,7 @@ pub(crate) enum NativeOwnerAttachedMemoryError<E> {
     },
     NativeCommit {
         source: E,
+        quarantined: bool,
     },
     PostAllocationStats {
         source: NativeMemoryAdmissionError,
@@ -909,9 +952,12 @@ impl<E: fmt::Display> fmt::Display for NativeOwnerAttachedMemoryError<E> {
                 formatter,
                 "native quote-token validation failed for owner group '{group_id}' (quarantined={quarantined}): {source}"
             ),
-            Self::NativeCommit { source } => write!(
+            Self::NativeCommit {
+                source,
+                quarantined,
+            } => write!(
                 formatter,
-                "native owner-attached allocation commit failed and was quarantined: {source}"
+                "native owner-attached allocation commit failed (quarantined={quarantined}): {source}"
             ),
             Self::PostAllocationStats { source } => write!(
                 formatter,
@@ -1646,6 +1692,48 @@ mod tests {
         PhysicalDeviceKey::new(value).unwrap()
     }
 
+    fn dedicated_request(
+        domain: MemoryDomainKey,
+        bytes: u64,
+        resource_id: &str,
+    ) -> DomainReservationRequest {
+        DomainReservationRequest {
+            domain,
+            snapshot: DeviceMemorySnapshot {
+                free_bytes: 8 * GIB,
+                total_bytes: 8 * GIB,
+                confidence: MemoryObservationConfidence::DeviceSnapshot,
+            },
+            peak_bytes: bytes,
+            retained_bytes: bytes,
+            requires_reconciliation: false,
+            resource_id: resource_id.to_owned(),
+            cohort_id: None,
+        }
+    }
+
+    fn owner_attached_dedicated_reservation(
+        physical_device: &str,
+        resource_id: &str,
+    ) -> (
+        Arc<DeviceMemoryBrokerSet>,
+        MemoryDomainKey,
+        DeviceMemoryReservationBatch,
+    ) {
+        let broker = Arc::new(DeviceMemoryBrokerSet::new(DeviceMemoryPolicy {
+            maximum_owned_basis_points: 10_000,
+            minimum_headroom_bytes: 0,
+        }));
+        let domain = MemoryDomainKey::DedicatedDevice {
+            physical_device: identity(physical_device),
+            heap_index: 0,
+        };
+        let reservation = broker
+            .try_reserve_batch(vec![dedicated_request(domain.clone(), GIB, resource_id)])
+            .unwrap();
+        (broker, domain, reservation)
+    }
+
     fn domain(kind: u32, heap_index: u32, uuid: [u8; 16]) -> ffi::GgmlBackendMemoryDomainIdV1 {
         ffi::GgmlBackendMemoryDomainIdV1 {
             physical_device_uuid: uuid,
@@ -2331,5 +2419,66 @@ mod tests {
             minimum_headroom_bytes: 256 * 1024 * 1024,
         });
         assert!(plan.require_opaque_driver_headroom(&protected).is_ok());
+    }
+
+    #[test]
+    fn owner_attached_failure_before_native_mutation_refunds_dedicated_domain() {
+        let (broker, dedicated, mut reservation) = owner_attached_dedicated_reservation(
+            "uuid:55555555555555555555555555555555",
+            "scheduler-validation",
+        );
+
+        let error = owner_attached_native_commit_error(
+            &mut reservation,
+            NativeOwnerAttachedCommitFailure::Reclaimable("stale graph"),
+        );
+        assert!(matches!(
+            error,
+            NativeOwnerAttachedMemoryError::NativeCommit {
+                source: "stale graph",
+                quarantined: false,
+            }
+        ));
+        drop(reservation);
+
+        let usage = broker.usage(&dedicated);
+        assert_eq!(usage.pending_bytes, 0);
+        assert_eq!(usage.unreclaimable_bytes, 0);
+        assert!(!usage.quarantined);
+        assert!(
+            broker
+                .try_reserve_batch(vec![dedicated_request(dedicated, GIB, "scheduler-retry")])
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn owner_attached_failure_after_possible_native_mutation_quarantines_dedicated_domain() {
+        let (broker, dedicated, mut reservation) = owner_attached_dedicated_reservation(
+            "uuid:66666666666666666666666666666666",
+            "scheduler-mutation",
+        );
+
+        let error = owner_attached_native_commit_error(
+            &mut reservation,
+            NativeOwnerAttachedCommitFailure::Quarantine("allocation changed"),
+        );
+        assert!(matches!(
+            error,
+            NativeOwnerAttachedMemoryError::NativeCommit {
+                source: "allocation changed",
+                quarantined: true,
+            }
+        ));
+        drop(reservation);
+
+        let usage = broker.usage(&dedicated);
+        assert_eq!(usage.pending_bytes, 0);
+        assert_eq!(usage.unreclaimable_bytes, GIB);
+        assert!(usage.quarantined);
+        assert!(matches!(
+            broker.try_reserve_batch(vec![dedicated_request(dedicated, 1, "scheduler-blocked")]),
+            Err(MemoryPlanningError::DeviceQuarantined { .. })
+        ));
     }
 }

--- a/crates/openasr-core/src/ggml_runtime/backend_memory_admission.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend_memory_admission.rs
@@ -774,6 +774,10 @@ impl NativeOwnerAttachedMemoryLease {
 }
 
 impl NativeBackendPrivateMemoryLease {
+    pub(crate) fn shares_reservation_with(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.inner, &other.inner)
+    }
+
     pub(crate) fn is_pending(&self) -> bool {
         let inner = self.inner.borrow();
         !inner.committed && !inner.quarantined && inner.transaction.is_some()

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -25,8 +25,8 @@ use super::backend_memory::{BackendMemoryAbi, BackendMemoryAbiError, SchedulerMe
 use super::backend_memory_admission::{
     NativeBackendPrivateMemoryError, NativeBackendPrivateMemoryLease, NativeMemoryAdmissionError,
     NativeMemoryAdmissionPlan, NativeMemoryAllocation, NativeMemoryAllocationError,
-    NativeMemoryClaimSemantics, NativeOwnerAttachedMemoryError, NativeOwnerAttachedMemoryLease,
-    NativeQuotedBackendGroup, NativeRequestClass,
+    NativeMemoryClaimSemantics, NativeOwnerAttachedCommitFailure, NativeOwnerAttachedMemoryError,
+    NativeOwnerAttachedMemoryLease, NativeQuotedBackendGroup, NativeRequestClass,
 };
 use super::ffi;
 use super::{
@@ -4535,8 +4535,13 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         else {
             #[cfg(test)]
             {
-                return plan.commit().map_err(|source| {
-                    self.scheduler_plan_error("scheduler-plan/test-direct-commit", source, true)
+                return plan.commit().map_err(|error| {
+                    let requires_quarantine = error.requires_quarantine();
+                    self.scheduler_plan_error(
+                        "scheduler-plan/test-direct-commit",
+                        error.into_source(),
+                        requires_quarantine,
+                    )
                 });
             }
             #[cfg(not(test))]
@@ -4674,7 +4679,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         // Exact CPU private reserve changes the backend generation. Refresh the
         // engine quote token after that mutation, but prove its new byte shape
         // still fits the already-admitted engine child before native commit.
-        let mut engine_native_started = false;
+        let mut engine_commit_requires_quarantine = false;
         let engine_commit = if let Some(transaction) = engine_transaction {
             let fresh_transaction = NativeMemoryAdmissionPlan::from_groups(quote_scheduler_groups(
                 "scheduler-engine-refresh",
@@ -4683,8 +4688,21 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             .and_then(|fresh| transaction.rebind_fresh_plan(fresh));
             match fresh_transaction {
                 Ok(transaction) => match transaction.commit_owner_attached_with(|| {
-                    engine_native_started = true;
-                    plan.commit()
+                    match plan.commit() {
+                        Ok(()) => {
+                            engine_commit_requires_quarantine = true;
+                            Ok(())
+                        }
+                        Err(error) => {
+                            engine_commit_requires_quarantine = error.requires_quarantine();
+                            let source = error.into_source();
+                            if engine_commit_requires_quarantine {
+                                Err(NativeOwnerAttachedCommitFailure::quarantine(source))
+                            } else {
+                                Err(NativeOwnerAttachedCommitFailure::reclaimable(source))
+                            }
+                        }
+                    }
                 }) {
                     Ok(lease) => {
                         memory_owner
@@ -4694,8 +4712,11 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                             .push(lease);
                         Ok(())
                     }
-                    Err(NativeOwnerAttachedMemoryError::NativeCommit { source }) => {
-                        Err(self.scheduler_plan_error("scheduler-plan/commit", source, true))
+                    Err(NativeOwnerAttachedMemoryError::NativeCommit {
+                        source,
+                        quarantined,
+                    }) => {
+                        Err(self.scheduler_plan_error("scheduler-plan/commit", source, quarantined))
                     }
                     Err(NativeOwnerAttachedMemoryError::PostAllocationStats { source }) => {
                         self.poison_scheduler_after_allocation_commit();
@@ -4725,20 +4746,33 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 Err(source) => Err(memory_admission_error("scheduler-engine/refresh", source)),
             }
         } else {
-            plan.commit()
-                .map_err(|source| self.scheduler_plan_error("scheduler-plan/commit", source, true))
+            match plan.commit() {
+                Ok(()) => {
+                    engine_commit_requires_quarantine = true;
+                    Ok(())
+                }
+                Err(error) => {
+                    engine_commit_requires_quarantine = error.requires_quarantine();
+                    Err(self.scheduler_plan_error(
+                        "scheduler-plan/commit",
+                        error.into_source(),
+                        engine_commit_requires_quarantine,
+                    ))
+                }
+            }
         };
 
         if let Err(error) = engine_commit {
             // A provisional provider has not computed yet, but its gate must not
             // remain pinned in a cached backend after scheduler commit fails.
-            // Before native scheduler mutation, live private evidence can close
-            // it. Once mutation starts, quarantine both ownership children:
-            // their deltas can no longer be separated safely.
+            // After a recoverable pre-mutation failure, live private evidence
+            // can close the gate. If native allocation may have changed or the
+            // device is terminal, quarantine both ownership children: their
+            // deltas can no longer be separated safely.
             if let Some(lease) = &private_lease
                 && lease.is_pending()
             {
-                if engine_native_started {
+                if engine_commit_requires_quarantine {
                     // The enclosing scheduler may retain a partial arena and
                     // its engine child is already quarantined. Do not relabel
                     // that sibling growth as private or refund the private gate.
@@ -4767,9 +4801,9 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         &mut self,
         operation: &'static str,
         source: BackendMemoryAbiError,
-        commit_started: bool,
+        requires_poison: bool,
     ) -> GgmlCpuGraphError {
-        if commit_started {
+        if requires_poison {
             self.poison_scheduler_after_allocation_commit();
         }
         match source {

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -1458,42 +1458,11 @@ impl GgmlCpuGraphRunner {
             scheduler_cpu_fallback = Some(cpu);
         }
         let scheduler = if config.use_scheduler {
-            let mut backends = Vec::new();
-            let mut backend_private_leases = BTreeMap::new();
-            if matches!(
+            Some(build_graph_scheduler(
                 config.backend,
-                GgmlCpuGraphBackend::Metal | GgmlCpuGraphBackend::Gpu
-            ) {
-                backends.push(backend.raw.as_ptr());
-                backend_private_leases.insert(
-                    backend.raw.as_ptr() as usize,
-                    Rc::clone(&backend.private_memory_leases),
-                );
-            }
-            for accel in &scheduler_accel_backends {
-                backends.push(accel.raw.as_ptr());
-                backend_private_leases.insert(
-                    accel.raw.as_ptr() as usize,
-                    Rc::clone(&accel.private_memory_leases),
-                );
-            }
-            if matches!(config.backend, GgmlCpuGraphBackend::Cpu) {
-                backends.push(backend.raw.as_ptr());
-                backend_private_leases.insert(
-                    backend.raw.as_ptr() as usize,
-                    Rc::clone(&backend.private_memory_leases),
-                );
-            }
-            if let Some(cpu) = scheduler_cpu_fallback.as_ref() {
-                backends.push(cpu.raw.as_ptr());
-                backend_private_leases.insert(
-                    cpu.raw.as_ptr() as usize,
-                    Rc::clone(&cpu.private_memory_leases),
-                );
-            }
-            Some(GgmlBackendSchedulerGuard::new(
-                &mut backends,
-                backend_private_leases,
+                &backend,
+                &scheduler_accel_backends,
+                scheduler_cpu_fallback.as_ref(),
                 config.graph_size,
             )?)
         } else {
@@ -1682,6 +1651,69 @@ impl GgmlCpuGraphRunner {
     /// process-resident allocation instead.
     pub(crate) fn release_cpu_step_buffer_pool(&mut self) {
         self.cpu_step_buffer_pool = GgmlCpuStepBufferPool::new();
+    }
+
+    /// Releases a completed transient stage's scheduler-owned graph buffers
+    /// while keeping its backend handles, loaded weight buffers, and runner
+    /// metadata resident.
+    ///
+    /// This is deliberately stronger than `ggml_backend_sched_reset`, which
+    /// only clears graph bookkeeping and retains the gallocr high-water
+    /// buffers. Phase-separated cached runtimes (for example an audio encoder
+    /// followed by a large decoder) use this after terminal output readback so
+    /// the next phase is quoted against physical memory that the prior phase
+    /// no longer needs. Callers MUST NOT invoke it while a persistent graph
+    /// session built from this runner is alive: rebuilding the scheduler would
+    /// invalidate that session's native scheduler pointer.
+    pub(crate) fn release_transient_scheduler_working_set(
+        &mut self,
+    ) -> Result<(), GgmlCpuGraphError> {
+        let Some(current) = self.scheduler.as_ref() else {
+            return Ok(());
+        };
+        if current
+            .memory_owner
+            .poisoned
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return Err(GgmlCpuGraphError::BackendSchedulerPoisoned);
+        }
+
+        // Construct the empty replacement first. If native scheduler creation
+        // fails, the current runtime remains intact and reusable.
+        let replacement = build_graph_scheduler(
+            self.backend_kind,
+            &self.backend,
+            &self._scheduler_accel_backends,
+            self._scheduler_cpu_fallback.as_ref(),
+            self.graph_size,
+        )?;
+        let released_owner = current.memory_owner.clone();
+        let released_private_leases = released_owner.private_leases();
+        let previous = self
+            .scheduler
+            .replace(replacement)
+            .expect("scheduler presence was checked above");
+
+        // Native buffers disappear before their owner-attached broker leases.
+        // CUDA may return freed buffers to its backend pool, so trim each
+        // participating backend only after gallocr destruction. The trim ABI
+        // synchronizes first and releases only reclaimable backend cache.
+        drop(previous);
+        for raw in released_owner.backend_private_leases.keys().copied() {
+            let backend = raw as ffi::GgmlBackendRaw;
+            let abi = unsafe { BackendMemoryAbi::from_backend(backend) }
+                .map_err(|source| memory_admission_error("scheduler-release/abi", source.into()))?;
+            abi.trim(0).map_err(|source| {
+                memory_admission_error("scheduler-release/trim", source.into())
+            })?;
+        }
+
+        // Only leases created by the retired scheduler are detached. Other
+        // live runners sharing a cached backend keep their own conservative
+        // high-water accounting.
+        released_owner.detach_private_leases(&released_private_leases);
+        Ok(())
     }
 
     pub(crate) fn start_static_tensor_arena(
@@ -4650,6 +4682,10 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             for owner in &private_owners {
                 owner.borrow_mut().push(lease.clone());
             }
+            memory_owner
+                .scheduler_private_leases
+                .borrow_mut()
+                .push(lease.clone());
             if provisional {
                 // Preserve any private growth performed by the transactional
                 // hook before the scheduler sibling changes the same device
@@ -6364,6 +6400,7 @@ type GgmlBackendPrivateLeaseOwner = Rc<RefCell<Vec<NativeBackendPrivateMemoryLea
 #[derive(Clone)]
 struct GgmlSchedulerMemoryOwner {
     backend_private_leases: BTreeMap<usize, GgmlBackendPrivateLeaseOwner>,
+    scheduler_private_leases: Rc<RefCell<Vec<NativeBackendPrivateMemoryLease>>>,
     scheduler_leases: Arc<Mutex<Vec<NativeOwnerAttachedMemoryLease>>>,
     poisoned: Arc<AtomicBool>,
 }
@@ -6381,6 +6418,27 @@ impl GgmlSchedulerMemoryOwner {
             }
         }
         Ok(())
+    }
+
+    fn private_leases(&self) -> Vec<NativeBackendPrivateMemoryLease> {
+        self.scheduler_private_leases.borrow().clone()
+    }
+
+    fn detach_private_leases(&self, released: &[NativeBackendPrivateMemoryLease]) {
+        for owner in self.backend_private_leases.values() {
+            owner.borrow_mut().retain(|candidate| {
+                !released
+                    .iter()
+                    .any(|lease| candidate.shares_reservation_with(lease))
+            });
+        }
+        self.scheduler_private_leases
+            .borrow_mut()
+            .retain(|candidate| {
+                !released
+                    .iter()
+                    .any(|lease| candidate.shares_reservation_with(lease))
+            });
     }
 }
 
@@ -7419,6 +7477,7 @@ impl GgmlBackendSchedulerGuard {
                 raw,
                 memory_owner: GgmlSchedulerMemoryOwner {
                     backend_private_leases,
+                    scheduler_private_leases: Rc::new(RefCell::new(Vec::new())),
                     scheduler_leases: Arc::new(Mutex::new(Vec::new())),
                     poisoned: Arc::new(AtomicBool::new(false)),
                 },
@@ -7428,6 +7487,49 @@ impl GgmlBackendSchedulerGuard {
                 GgmlCpuGraphError::BackendSchedulerInitFailed
             })
     }
+}
+
+fn build_graph_scheduler(
+    backend_kind: GgmlCpuGraphBackend,
+    backend: &GgmlBackendGuard,
+    scheduler_accel_backends: &[GgmlBackendGuard],
+    scheduler_cpu_fallback: Option<&GgmlBackendGuard>,
+    graph_size: usize,
+) -> Result<GgmlBackendSchedulerGuard, GgmlCpuGraphError> {
+    let mut backends = Vec::new();
+    let mut backend_private_leases = BTreeMap::new();
+    if matches!(
+        backend_kind,
+        GgmlCpuGraphBackend::Metal | GgmlCpuGraphBackend::Gpu
+    ) {
+        backends.push(backend.raw.as_ptr());
+        backend_private_leases.insert(
+            backend.raw.as_ptr() as usize,
+            Rc::clone(&backend.private_memory_leases),
+        );
+    }
+    for accel in scheduler_accel_backends {
+        backends.push(accel.raw.as_ptr());
+        backend_private_leases.insert(
+            accel.raw.as_ptr() as usize,
+            Rc::clone(&accel.private_memory_leases),
+        );
+    }
+    if matches!(backend_kind, GgmlCpuGraphBackend::Cpu) {
+        backends.push(backend.raw.as_ptr());
+        backend_private_leases.insert(
+            backend.raw.as_ptr() as usize,
+            Rc::clone(&backend.private_memory_leases),
+        );
+    }
+    if let Some(cpu) = scheduler_cpu_fallback {
+        backends.push(cpu.raw.as_ptr());
+        backend_private_leases.insert(
+            cpu.raw.as_ptr() as usize,
+            Rc::clone(&cpu.private_memory_leases),
+        );
+    }
+    GgmlBackendSchedulerGuard::new(&mut backends, backend_private_leases, graph_size)
 }
 
 impl Drop for GgmlBackendSchedulerGuard {
@@ -10227,6 +10329,110 @@ mod tests {
         assert_eq!(released.pending_bytes, baseline.pending_bytes);
         assert_eq!(released.committed_bytes, baseline.committed_bytes);
         assert_eq!(released.exclusive_pending, baseline.exclusive_pending);
+    }
+
+    fn assert_transient_scheduler_release_drops_owner_and_rebuilds_runner(
+        backend: GgmlCpuGraphBackend,
+    ) {
+        let services = crate::models::native_execution_services::test_native_execution_services();
+        let broker = std::sync::Arc::clone(services.memory_broker());
+        let _scope =
+            crate::models::native_execution_services::install_native_execution_services(&services);
+
+        let mut config = GgmlCpuGraphConfig::conservative_default();
+        config.backend = backend;
+        config.use_scheduler = true;
+        let mut runner =
+            GgmlCpuGraphRunner::new(config).expect("scheduler cpu graph runner should initialize");
+        let mut arena = runner
+            .start_static_tensor_arena(GgmlCpuGraphConfig::default().context_bytes)
+            .expect("static tensor arena should initialize");
+        let weight = arena
+            .new_tensor_2d_f16(2, 2, "resident_weight")
+            .expect("resident weight should allocate");
+        arena
+            .set_f16_bits_slice(weight, &[0x3c00, 0x0000, 0x0000, 0x3c00], "resident_weight")
+            .expect("resident weight should upload");
+        let retired_scheduler_leases = std::sync::Arc::downgrade(
+            &runner
+                .scheduler
+                .as_ref()
+                .expect("scheduler was requested")
+                .memory_owner
+                .scheduler_leases,
+        );
+        let mut graph = runner.start_graph();
+        let input = graph
+            .new_tensor_2d_f32(2, 1, "input")
+            .expect("input should allocate");
+        graph.set_input(input).expect("input should be marked");
+        let output = graph
+            .mul_mat(arena.graph_tensor(weight), input)
+            .expect("resident weight should be usable");
+        graph.set_output(output).expect("output should be marked");
+        graph
+            .prepare_outputs_for_upload(&[output])
+            .expect("scheduler should allocate first graph");
+        graph
+            .set_f32_slice(input, &[2.0, 3.0], "input")
+            .expect("input should upload");
+        let values = graph
+            .compute_output_f32(output, 2)
+            .expect("first scheduler graph should compute");
+        assert_eq!(values, vec![2.0, 3.0]);
+        drop(graph);
+        assert!(retired_scheduler_leases.upgrade().is_some());
+
+        runner
+            .release_transient_scheduler_working_set()
+            .expect("completed transient graph working set should release");
+        assert!(
+            retired_scheduler_leases.upgrade().is_none(),
+            "retired scheduler leases must drop with the native gallocr"
+        );
+        let released =
+            broker.usage(&crate::device::execution_memory::MemoryDomainKey::SystemMemory);
+        assert_eq!(released.pending_bytes, 0);
+        assert!(!released.exclusive_pending);
+
+        let mut graph = runner.start_graph();
+        let input = graph
+            .new_tensor_2d_f32(2, 1, "input_after_release")
+            .expect("second input should allocate");
+        graph
+            .set_input(input)
+            .expect("second input should be marked");
+        let output = graph
+            .mul_mat(arena.graph_tensor(weight), input)
+            .expect("resident weight must survive scheduler release");
+        graph
+            .set_output(output)
+            .expect("second output should be marked");
+        graph
+            .prepare_outputs_for_upload(&[output])
+            .expect("rebuilt scheduler should allocate graph");
+        graph
+            .set_f32_slice(input, &[4.0, 5.0], "input_after_release")
+            .expect("second input should upload");
+        let values = graph
+            .compute_output_f32(output, 2)
+            .expect("rebuilt scheduler should remain reusable");
+        assert_eq!(values, vec![4.0, 5.0]);
+    }
+
+    #[test]
+    fn transient_scheduler_release_drops_owner_and_rebuilds_runner() {
+        assert_transient_scheduler_release_drops_owner_and_rebuilds_runner(
+            GgmlCpuGraphBackend::Cpu,
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn metal_transient_scheduler_release_drops_owner_and_rebuilds_runner() {
+        assert_transient_scheduler_release_drops_owner_and_rebuilds_runner(
+            GgmlCpuGraphBackend::Metal,
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -1664,9 +1664,23 @@ impl GgmlCpuGraphRunner {
     /// the next phase is quoted against physical memory that the prior phase
     /// no longer needs. Callers MUST NOT invoke it while a persistent graph
     /// session built from this runner is alive: rebuilding the scheduler would
-    /// invalidate that session's native scheduler pointer.
+    /// invalidate that session's native scheduler pointer. If native trim
+    /// fails, the replacement scheduler retains the retired private leases so
+    /// accounting stays conservative and a later release can retry safely.
     pub(crate) fn release_transient_scheduler_working_set(
         &mut self,
+    ) -> Result<(), GgmlCpuGraphError> {
+        self.release_transient_scheduler_working_set_with(|backend| {
+            let abi = unsafe { BackendMemoryAbi::from_backend(backend) }
+                .map_err(|source| memory_admission_error("scheduler-release/abi", source.into()))?;
+            abi.trim(0)
+                .map_err(|source| memory_admission_error("scheduler-release/trim", source.into()))
+        })
+    }
+
+    fn release_transient_scheduler_working_set_with(
+        &mut self,
+        mut trim_backend: impl FnMut(ffi::GgmlBackendRaw) -> Result<(), GgmlCpuGraphError>,
     ) -> Result<(), GgmlCpuGraphError> {
         let Some(current) = self.scheduler.as_ref() else {
             return Ok(());
@@ -1702,11 +1716,19 @@ impl GgmlCpuGraphRunner {
         drop(previous);
         for raw in released_owner.backend_private_leases.keys().copied() {
             let backend = raw as ffi::GgmlBackendRaw;
-            let abi = unsafe { BackendMemoryAbi::from_backend(backend) }
-                .map_err(|source| memory_admission_error("scheduler-release/abi", source.into()))?;
-            abi.trim(0).map_err(|source| {
-                memory_admission_error("scheduler-release/trim", source.into())
-            })?;
+            if let Err(source) = trim_backend(backend) {
+                // A failed trim does not prove that backend-private cached
+                // bytes disappeared, so refunding here would under-account
+                // physical memory. Transfer the retired scheduler's lease
+                // tracking to the empty replacement instead: the next stage
+                // release retries trim and can then detach both generations.
+                self.scheduler
+                    .as_ref()
+                    .expect("replacement scheduler was installed above")
+                    .memory_owner
+                    .retain_private_leases_for_retry(&released_private_leases);
+                return Err(source);
+            }
         }
 
         // Only leases created by the retired scheduler are detached. Other
@@ -6440,6 +6462,18 @@ impl GgmlSchedulerMemoryOwner {
                     .any(|lease| candidate.shares_reservation_with(lease))
             });
     }
+
+    fn retain_private_leases_for_retry(&self, retained: &[NativeBackendPrivateMemoryLease]) {
+        let mut tracked = self.scheduler_private_leases.borrow_mut();
+        for lease in retained {
+            if !tracked
+                .iter()
+                .any(|candidate| candidate.shares_reservation_with(lease))
+            {
+                tracked.push(lease.clone());
+            }
+        }
+    }
 }
 
 /// GPU-class backends are expensive to initialize (device enumeration + driver
@@ -10425,6 +10459,82 @@ mod tests {
         assert_transient_scheduler_release_drops_owner_and_rebuilds_runner(
             GgmlCpuGraphBackend::Cpu,
         );
+    }
+
+    #[test]
+    fn transient_scheduler_release_retains_private_leases_until_trim_can_retry() {
+        let services = crate::models::native_execution_services::test_native_execution_services();
+        let broker = std::sync::Arc::clone(services.memory_broker());
+        let _scope =
+            crate::models::native_execution_services::install_native_execution_services(&services);
+        let mut config = GgmlCpuGraphConfig::conservative_default();
+        config.use_scheduler = true;
+        let mut runner =
+            GgmlCpuGraphRunner::new(config).expect("scheduler cpu graph runner should initialize");
+        let output = runner
+            .compute_add_f32(&[1.0, 2.0], &[3.0, 4.0])
+            .expect("scheduler graph should allocate and compute");
+        assert_eq!(output, vec![4.0, 6.0]);
+
+        let retired = runner
+            .scheduler
+            .as_ref()
+            .expect("scheduler was requested")
+            .memory_owner
+            .private_leases();
+        assert!(
+            !retired.is_empty(),
+            "scheduler allocation should retain backend-private accounting"
+        );
+        let usage_before_failure =
+            broker.usage(&crate::device::execution_memory::MemoryDomainKey::SystemMemory);
+        let error = runner
+            .release_transient_scheduler_working_set_with(|_| {
+                Err(GgmlCpuGraphError::BackendSchedulerPoisoned)
+            })
+            .expect_err("injected trim failure must fail the release");
+        assert!(matches!(error, GgmlCpuGraphError::BackendSchedulerPoisoned));
+
+        let retained = runner
+            .scheduler
+            .as_ref()
+            .expect("failed release installs an empty replacement")
+            .memory_owner
+            .private_leases();
+        assert_eq!(retained.len(), retired.len());
+        assert!(retired.iter().all(|lease| {
+            retained
+                .iter()
+                .any(|candidate| candidate.shares_reservation_with(lease))
+        }));
+        assert_eq!(
+            broker.usage(&crate::device::execution_memory::MemoryDomainKey::SystemMemory),
+            usage_before_failure,
+            "a failed trim must not refund bytes that may still be physically cached"
+        );
+
+        runner
+            .release_transient_scheduler_working_set()
+            .expect("a later successful trim should release retained accounting");
+        assert!(
+            runner
+                .scheduler
+                .as_ref()
+                .expect("successful release keeps an empty scheduler")
+                .memory_owner
+                .private_leases()
+                .is_empty(),
+            "retained private leases must detach after the retry succeeds"
+        );
+        let released =
+            broker.usage(&crate::device::execution_memory::MemoryDomainKey::SystemMemory);
+        assert_eq!(released.pending_bytes, 0);
+        assert!(!released.exclusive_pending);
+        assert!(!released.quarantined);
+        let output = runner
+            .compute_add_f32(&[5.0, 6.0], &[7.0, 8.0])
+            .expect("runner should remain reusable after trim retry");
+        assert_eq!(output, vec![12.0, 14.0]);
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -112,6 +112,7 @@ pub(crate) const GGML_STATUS_ABORTED: c_int = 1;
 pub(crate) const GGML_STATUS_EXECUTION_FAILED: c_int = 2;
 pub(crate) const GGML_STATUS_DEVICE_LOST: c_int = 3;
 pub(crate) const GGML_STATUS_BACKEND_POISONED: c_int = 4;
+pub(crate) const GGML_BACKEND_SCHED_MEMORY_PLAN_COMMIT_MAY_HAVE_MUTATED: u32 = 1 << 0;
 pub(crate) const GGML_BACKEND_GRAPH_CANCEL_DISABLED: c_int = 0;
 pub(crate) const GGML_BACKEND_GRAPH_CANCEL_NATIVE: c_int = 1;
 pub(crate) const GGML_BACKEND_GRAPH_CANCEL_SEGMENTED: c_int = 2;
@@ -443,8 +444,9 @@ unsafe extern "C" {
         index: u32,
         out_item: *mut GgmlBackendMemoryRequestV1,
     ) -> bool;
-    pub(crate) fn ggml_backend_sched_memory_plan_commit_v1(
+    pub(crate) fn ggml_backend_sched_memory_plan_commit_v2(
         plan: GgmlBackendSchedMemoryPlanRaw,
+        out_flags: *mut u32,
     ) -> c_int;
     pub(crate) fn ggml_backend_sched_memory_plan_free_v1(plan: GgmlBackendSchedMemoryPlanRaw);
     pub(crate) fn ggml_backend_sched_graph_compute(

--- a/crates/openasr-core/src/models/cohere/encoder_graph.rs
+++ b/crates/openasr-core/src/models/cohere/encoder_graph.rs
@@ -1006,6 +1006,17 @@ impl CohereTranscribeEncoderGraphRuntime {
             rows,
         })
     }
+
+    pub(crate) fn release_transient_compute_memory(
+        &mut self,
+    ) -> Result<(), CohereTranscribeEncoderError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(|source| CohereTranscribeEncoderError::GraphBuildFailed {
+                step: "release_transient_scheduler_working_set",
+                source,
+            })
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/openasr-core/src/models/cohere/ggml_executor.rs
+++ b/crates/openasr-core/src/models/cohere/ggml_executor.rs
@@ -619,7 +619,15 @@ impl CohereTranscribeGgmlExecutor {
                 reason: error.to_string(),
             })?;
         actor
-            .call_mut(move |state| state.runtime.encode(&features))
+            .call_mut(move |state| {
+                let encode_result = state.runtime.encode(&features);
+                let release_result = state.runtime.release_transient_compute_memory();
+                match (encode_result, release_result) {
+                    (Ok(output), Ok(())) => Ok(output),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                }
+            })
             .map_err(|error| CohereTranscribeEncoderError::GraphExecutionFailed {
                 reason: error.to_string(),
             })?

--- a/crates/openasr-core/src/models/dolphin/encoder_graph.rs
+++ b/crates/openasr-core/src/models/dolphin/encoder_graph.rs
@@ -1607,6 +1607,12 @@ impl DolphinEncoderRuntime {
             encoder_out,
         })
     }
+
+    pub(crate) fn release_transient_compute_memory(&mut self) -> Result<(), DolphinEncoderError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(ggml_err("release_transient_scheduler_working_set"))
+    }
 }
 
 /// One-shot convenience wrapper over [`DolphinEncoderRuntime`] for callers

--- a/crates/openasr-core/src/models/dolphin/executor.rs
+++ b/crates/openasr-core/src/models/dolphin/executor.rs
@@ -593,7 +593,8 @@ pub(crate) fn run_dolphin_pipeline(
     // the pre-runtime per-call behavior. Production transcription only ever
     // reads `encoder.encoder_out` below; `after_subsample`/per-block taps
     // exist solely for `#[cfg(test)]` parity, so they stay off here (P6).
-    let encoder = if prepared.encoder.supports_input_frames(features.n_frames) {
+    let used_prepared_encoder = prepared.encoder.supports_input_frames(features.n_frames);
+    let encoder_result = if used_prepared_encoder {
         prepared
             .encoder
             .encode(&features.data, features.n_frames, false)
@@ -608,8 +609,18 @@ pub(crate) fn run_dolphin_pipeline(
             backend,
             false,
         )
-    }
-    .map_err(|error| format!("dolphin encoder graph failed: {error}"))?;
+    };
+    let release_result = if used_prepared_encoder {
+        prepared.encoder.release_transient_compute_memory()
+    } else {
+        Ok(())
+    };
+    let encoder = match (encoder_result, release_result) {
+        (Ok(output), Ok(())) => output,
+        (Err(error), _) | (Ok(_), Err(error)) => {
+            return Err(format!("dolphin encoder graph failed: {error}"));
+        }
+    };
 
     // Hotword deep-biasing (native `context_module.*` fusion). Upstream's
     // `decode()` computes `ctc_logprobs` from the *unbiased* encoder output

--- a/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/encoder_graph.rs
@@ -171,6 +171,12 @@ impl FireRedEncoderGraphRuntime {
             n_frames,
         )
     }
+
+    pub(crate) fn release_transient_compute_memory(&mut self) -> Result<(), FireRedEncoderError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(|source| map_err("release_transient_scheduler_working_set", source))
+    }
 }
 
 /// Post-subsampling encoder time-frame count the 2x Conv2d(k3,s2) stem

--- a/crates/openasr-core/src/models/firered_aed/executor.rs
+++ b/crates/openasr-core/src/models/firered_aed/executor.rs
@@ -322,7 +322,15 @@ impl FireRedAedGgmlExecutor {
     ) -> Result<FireRedEncoderOutput, FireRedAedExecutorError> {
         let runtime = self.checkout_encoder_runtime(preflight, metadata, backend)?;
         runtime
-            .call_mut(move |runtime| runtime.encode(&cmvn_features, n_frames))
+            .call_mut(move |runtime| {
+                let encode_result = runtime.encode(&cmvn_features, n_frames);
+                let release_result = runtime.release_transient_compute_memory();
+                match (encode_result, release_result) {
+                    (Ok(output), Ok(())) => Ok(output),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                }
+            })
             .map_err(|error| Self::map_actor_error("encoder", error))?
             .map_err(|error| FireRedAedExecutorError::EncoderFailed {
                 reason: error.to_string(),

--- a/crates/openasr-core/src/models/firered_llm/executor.rs
+++ b/crates/openasr-core/src/models/firered_llm/executor.rs
@@ -487,6 +487,7 @@ impl FireRedLlmGgmlExecutor {
             .map_err(|error| FireRedLlmExecutorError::EncoderFailed {
                 reason: error.to_string(),
             })?;
+        drop(encoder_runtime);
 
         let adapter_profile_started_at = std::time::Instant::now();
         let mut adapter_runtime = FireRedLlmAdapterGraphRuntime::new_from_preflight(
@@ -507,6 +508,7 @@ impl FireRedLlmGgmlExecutor {
             .map_err(|error| FireRedLlmExecutorError::AdapterGraphFailed {
                 reason: error.to_string(),
             })?;
+        drop(adapter_runtime);
         // Opt-in perf diagnostic, same gate/shape as the decoder_backend line
         // below (mirrors the qwen `OPENASR_HYMT2_PROFILE` precedent): the
         // adapter stage regressed to 2868ms/18.4% of `execute` on the naive

--- a/crates/openasr-core/src/models/funasr_nano/adapter_graph.rs
+++ b/crates/openasr-core/src/models/funasr_nano/adapter_graph.rs
@@ -307,4 +307,12 @@ impl FunasrNanoAdapterGraph {
         }
         Ok((rows, frame_count))
     }
+
+    pub(crate) fn release_transient_compute_memory(
+        &mut self,
+    ) -> Result<(), FunasrNanoAdapterError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(|source| map_err("release_transient_scheduler_working_set", source))
+    }
 }

--- a/crates/openasr-core/src/models/funasr_nano/encoder_graph.rs
+++ b/crates/openasr-core/src/models/funasr_nano/encoder_graph.rs
@@ -495,6 +495,17 @@ impl FunasrNanoEncoderGraph {
             rows,
         })
     }
+
+    pub(crate) fn release_transient_compute_memory(
+        &mut self,
+    ) -> Result<(), FunasrNanoEncoderError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(|source| FunasrNanoEncoderError::GraphBuildFailed {
+                step: "release_transient_scheduler_working_set",
+                source,
+            })
+    }
 }
 
 fn alloc_layer(

--- a/crates/openasr-core/src/models/funasr_nano/executor.rs
+++ b/crates/openasr-core/src/models/funasr_nano/executor.rs
@@ -361,28 +361,34 @@ impl FunasrNanoGgmlExecutor {
         )?;
         actor
             .call_mut(move |state| {
-                let encoder_output = state
-                    .runtime
-                    .encoder
-                    .encode(
-                        &encoder_input.data,
-                        encoder_input.n_frames,
-                        encoder_input.feature_dim,
-                    )
-                    .map_err(|error| FunasrNanoExecutorError::EncoderFailed {
-                        reason: error.to_string(),
-                    })?;
-                let (adapter_rows, adapter_frames) = state
-                    .runtime
-                    .adapter
-                    .run(
-                        &encoder_output.rows,
-                        encoder_output.frame_count,
-                        encoder_output.d_model,
-                    )
-                    .map_err(|error| FunasrNanoExecutorError::AdapterFailed {
-                        reason: error.to_string(),
-                    })?;
+                let encode_result = state.runtime.encoder.encode(
+                    &encoder_input.data,
+                    encoder_input.n_frames,
+                    encoder_input.feature_dim,
+                );
+                let encoder_release = state.runtime.encoder.release_transient_compute_memory();
+                let encoder_output = match (encode_result, encoder_release) {
+                    (Ok(output), Ok(())) => output,
+                    (Err(error), _) | (Ok(_), Err(error)) => {
+                        return Err(FunasrNanoExecutorError::EncoderFailed {
+                            reason: error.to_string(),
+                        });
+                    }
+                };
+                let adapter_result = state.runtime.adapter.run(
+                    &encoder_output.rows,
+                    encoder_output.frame_count,
+                    encoder_output.d_model,
+                );
+                let adapter_release = state.runtime.adapter.release_transient_compute_memory();
+                let (adapter_rows, adapter_frames) = match (adapter_result, adapter_release) {
+                    (Ok(output), Ok(())) => output,
+                    (Err(error), _) | (Ok(_), Err(error)) => {
+                        return Err(FunasrNanoExecutorError::AdapterFailed {
+                            reason: error.to_string(),
+                        });
+                    }
+                };
                 let audio_token_count =
                     funasr_nano_audio_token_count(encoder_output.frame_count).min(adapter_frames);
                 if audio_token_count == 0 {

--- a/crates/openasr-core/src/models/granite_speech/encoder_graph.rs
+++ b/crates/openasr-core/src/models/granite_speech/encoder_graph.rs
@@ -285,6 +285,14 @@ impl GraniteSpeechEncoderRuntime {
             capture_mid_tap,
         )
     }
+
+    pub(crate) fn release_transient_compute_memory(
+        &mut self,
+    ) -> Result<(), GraniteSpeechEncoderError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(ggml_err("release_transient_scheduler_working_set"))
+    }
 }
 
 /// Weight source for the encoder graph: dequantized f32 tensors keyed by their

--- a/crates/openasr-core/src/models/granite_speech/executor.rs
+++ b/crates/openasr-core/src/models/granite_speech/executor.rs
@@ -595,22 +595,33 @@ impl GraniteSpeechGgmlExecutor {
             .call_mut(move |state| {
                 let prepared = &mut state.runtime;
                 let decode_result = (|| {
-                    let encoder_output = prepared
-                        .encoder
-                        .encode(&prepared.encoder_config, &features, frames, false)
-                        .map_err(|error| GraniteSpeechGgmlExecutorError::EncoderFailed {
-                            reason: error.to_string(),
-                        })?;
-                    let projector_output = prepared
-                        .projector
-                        .project(
-                            &prepared.projector_config,
-                            &encoder_output.encoder_out,
-                            encoder_output.frames,
-                        )
-                        .map_err(|error| GraniteSpeechGgmlExecutorError::ProjectorFailed {
-                            reason: error.to_string(),
-                        })?;
+                    let encoder_result =
+                        prepared
+                            .encoder
+                            .encode(&prepared.encoder_config, &features, frames, false);
+                    let encoder_release = prepared.encoder.release_transient_compute_memory();
+                    let encoder_output = match (encoder_result, encoder_release) {
+                        (Ok(output), Ok(())) => output,
+                        (Err(error), _) | (Ok(_), Err(error)) => {
+                            return Err(GraniteSpeechGgmlExecutorError::EncoderFailed {
+                                reason: error.to_string(),
+                            });
+                        }
+                    };
+                    let projector_result = prepared.projector.project(
+                        &prepared.projector_config,
+                        &encoder_output.encoder_out,
+                        encoder_output.frames,
+                    );
+                    let projector_release = prepared.projector.release_transient_compute_memory();
+                    let projector_output = match (projector_result, projector_release) {
+                        (Ok(output), Ok(())) => output,
+                        (Err(error), _) | (Ok(_), Err(error)) => {
+                            return Err(GraniteSpeechGgmlExecutorError::ProjectorFailed {
+                                reason: error.to_string(),
+                            });
+                        }
+                    };
                     let (prompt_token_ids, prompt_embeddings) = build_audio_prompt_embeddings(
                         &prepared.decoder_config,
                         &prepared.embed_table,

--- a/crates/openasr-core/src/models/granite_speech/qformer.rs
+++ b/crates/openasr-core/src/models/granite_speech/qformer.rs
@@ -199,6 +199,14 @@ impl GraniteSpeechProjectorRuntime {
             build_loaded_projector_weights(&self.loaded, &self.query_arena, self.query, config)?;
         run_projector_graph(&mut self.runner, config, &weights, encoder_out, frames)
     }
+
+    pub(crate) fn release_transient_compute_memory(
+        &mut self,
+    ) -> Result<(), GraniteSpeechProjectorError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(ggml_err("release_transient_scheduler_working_set"))
+    }
 }
 
 pub(crate) trait GraniteSpeechProjectorWeightProvider {

--- a/crates/openasr-core/src/models/mimo_asr/audio_tokenizer_graph.rs
+++ b/crates/openasr-core/src/models/mimo_asr/audio_tokenizer_graph.rs
@@ -656,6 +656,14 @@ impl MimoAudiotokEncoderRuntime {
             rows,
         })
     }
+
+    pub(crate) fn release_transient_compute_memory(
+        &mut self,
+    ) -> Result<(), MimoAudiotokEncoderError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(|source| build_err("release_transient_scheduler_working_set", source))
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/openasr-core/src/models/mimo_asr/executor.rs
+++ b/crates/openasr-core/src/models/mimo_asr/executor.rs
@@ -765,12 +765,18 @@ impl MimoAsrGgmlExecutor {
         let summed = sum_speech_embeddings(&prepared.speech_embedding_tables, &codes);
 
         let llm_d_model = prepared.llm_metadata.d_model;
-        let speech_rows = prepared
+        let inlocal_result = prepared
             .inlocal_runtime
-            .run(&summed, usable_frames, llm_d_model)
-            .map_err(|error| MimoAsrExecutorError::InputLocalFailed {
-                reason: error.to_string(),
-            })?;
+            .run(&summed, usable_frames, llm_d_model);
+        let inlocal_release = prepared.inlocal_runtime.release_transient_compute_memory();
+        let speech_rows = match (inlocal_result, inlocal_release) {
+            (Ok(output), Ok(())) => output,
+            (Err(error), _) | (Ok(_), Err(error)) => {
+                return Err(MimoAsrExecutorError::InputLocalFailed {
+                    reason: error.to_string(),
+                });
+            }
+        };
         let audio_group_count = usable_frames / group_size;
 
         // Disjoint field borrows: `&mut decoder` for the decode graph and

--- a/crates/openasr-core/src/models/mimo_asr/executor.rs
+++ b/crates/openasr-core/src/models/mimo_asr/executor.rs
@@ -727,12 +727,16 @@ impl MimoAsrGgmlExecutor {
                 }
             })?;
 
-        let encoder_output = prepared
-            .encoder_runtime
-            .encode(&mel_features)
-            .map_err(|error| MimoAsrExecutorError::EncoderFailed {
-                reason: error.to_string(),
-            })?;
+        let encode_result = prepared.encoder_runtime.encode(&mel_features);
+        let release_result = prepared.encoder_runtime.release_transient_compute_memory();
+        let encoder_output = match (encode_result, release_result) {
+            (Ok(output), Ok(())) => output,
+            (Err(error), _) | (Ok(_), Err(error)) => {
+                return Err(MimoAsrExecutorError::EncoderFailed {
+                    reason: error.to_string(),
+                });
+            }
+        };
 
         let mut codes = encode_rvq_codes(
             &prepared.codebooks,

--- a/crates/openasr-core/src/models/mimo_asr/input_local_graph.rs
+++ b/crates/openasr-core/src/models/mimo_asr/input_local_graph.rs
@@ -539,6 +539,12 @@ impl MimoInputLocalRuntime {
             }
         })
     }
+
+    pub(crate) fn release_transient_compute_memory(&mut self) -> Result<(), MimoInputLocalError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(|source| build_err("release_transient_scheduler_working_set", source))
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/openasr-core/src/models/moonshine/encoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/encoder_graph.rs
@@ -560,6 +560,12 @@ impl MoonshineEncoderGraphRuntime {
             rows,
         })
     }
+
+    pub(crate) fn release_transient_compute_memory(&mut self) -> Result<(), MoonshineEncoderError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(build_err("release_transient_scheduler_working_set"))
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/openasr-core/src/models/moonshine/ggml_executor.rs
+++ b/crates/openasr-core/src/models/moonshine/ggml_executor.rs
@@ -459,7 +459,15 @@ impl MoonshineGgmlExecutor {
     ) -> Result<MoonshineEncoderOutput, MoonshineGgmlExecutorError> {
         let runtime = self.checkout_encoder_runtime(preflight, prepared, adapter, backend)?;
         runtime
-            .call_mut(move |state| state.runtime.encode(&features))
+            .call_mut(move |state| {
+                let encode_result = state.runtime.encode(&features);
+                let release_result = state.runtime.release_transient_compute_memory();
+                match (encode_result, release_result) {
+                    (Ok(output), Ok(())) => Ok(output),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                }
+            })
             .map_err(|error| Self::map_actor_error("encoder", error))?
             .map_err(|error| MoonshineGgmlExecutorError::EncoderFailed {
                 reason: error.to_string(),

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/encoder_graph.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/encoder_graph.rs
@@ -585,6 +585,17 @@ impl MossEncoderRuntime {
             })?;
         Ok(values)
     }
+
+    /// Drops the completed encoder phase's scheduler/gallocr working set
+    /// without unloading its mmap-backed weights or backend. MOSS keeps this
+    /// runtime in an actor cache, but its decoder is a separate, much larger
+    /// phase and must not be quoted while the encoder's transient high-water
+    /// buffers remain resident.
+    pub(crate) fn release_transient_compute_memory(&mut self) -> Result<(), MossEncoderError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(|source| map_graph_error("release_transient_scheduler_working_set", source))
+    }
 }
 
 /// Test-only twin of [`MossEncoderRuntime::encode`] for the CPU-vs-Metal

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -562,34 +562,48 @@ fn encode_moss_td_chunks_with_cached_runtime(
     let samples = samples.to_vec();
     actor
         .call_mut(move |state| {
-            let mut concatenated_rows: Vec<f32> = Vec::new();
-            let mut total_frames = 0usize;
-            for chunk in samples.chunks(CHUNK_SAMPLES) {
-                let mel = whisper_log_mel_spectrogram_16khz_mono_v0(
-                    chunk,
-                    encoder_config.n_mels,
-                    MEL_TARGET_FRAMES,
-                )
-                .map_err(|error| MossTdExecutorError::FrontendFailed {
-                    reason: error.to_string(),
-                })?;
-                let encoder_out = state
-                    .runtime
-                    .encode(encoder_config, mel.data(), MEL_TARGET_FRAMES)
-                    .map_err(|error| MossTdExecutorError::EncoderFailed {
+            let encode_result = (|| {
+                let mut concatenated_rows: Vec<f32> = Vec::new();
+                let mut total_frames = 0usize;
+                for chunk in samples.chunks(CHUNK_SAMPLES) {
+                    let mel = whisper_log_mel_spectrogram_16khz_mono_v0(
+                        chunk,
+                        encoder_config.n_mels,
+                        MEL_TARGET_FRAMES,
+                    )
+                    .map_err(|error| MossTdExecutorError::FrontendFailed {
                         reason: error.to_string(),
                     })?;
-                let token_length = moss_td_chunk_token_length(chunk.len(), token_stride);
-                let keep_frames = moss_td_chunk_keep_frames(
-                    token_length,
-                    merge_size,
-                    encoder_config.max_source_positions,
-                );
-                let keep_values = keep_frames * encoder_config.d_model;
-                concatenated_rows.extend_from_slice(&encoder_out[..keep_values]);
-                total_frames += keep_frames;
+                    let encoder_out = state
+                        .runtime
+                        .encode(encoder_config, mel.data(), MEL_TARGET_FRAMES)
+                        .map_err(|error| MossTdExecutorError::EncoderFailed {
+                            reason: error.to_string(),
+                        })?;
+                    let token_length = moss_td_chunk_token_length(chunk.len(), token_stride);
+                    let keep_frames = moss_td_chunk_keep_frames(
+                        token_length,
+                        merge_size,
+                        encoder_config.max_source_positions,
+                    );
+                    let keep_values = keep_frames * encoder_config.d_model;
+                    concatenated_rows.extend_from_slice(&encoder_out[..keep_values]);
+                    total_frames += keep_frames;
+                }
+                Ok((concatenated_rows, total_frames))
+            })();
+            let release_result =
+                state
+                    .runtime
+                    .release_transient_compute_memory()
+                    .map_err(|error| MossTdExecutorError::EncoderFailed {
+                        reason: error.to_string(),
+                    });
+            match (encode_result, release_result) {
+                (Ok(output), Ok(())) => Ok(output),
+                (Err(error), _) => Err(error),
+                (Ok(_), Err(error)) => Err(error),
             }
-            Ok((concatenated_rows, total_frames))
         })
         .map_err(|error| MossTdExecutorError::RuntimeOwnershipFailed {
             stage: "encoder",

--- a/crates/openasr-core/src/models/qwen/audio_encoder.rs
+++ b/crates/openasr-core/src/models/qwen/audio_encoder.rs
@@ -341,6 +341,17 @@ impl Qwen3AsrAudioEncoderRuntime {
             profile_started,
         )
     }
+
+    pub(crate) fn release_transient_compute_memory(
+        &mut self,
+    ) -> Result<(), Qwen3AsrAudioEncoderError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(|source| Qwen3AsrAudioEncoderError::GraphBuildFailed {
+                step: "release_transient_scheduler_working_set",
+                source,
+            })
+    }
 }
 
 fn encode_qwen3_audio_embeddings_with_graph<'a>(

--- a/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
@@ -441,6 +441,10 @@ pub(crate) fn align_forced(
             &mel_features,
         )
         .map_err(Qwen3ForcedAlignerRuntimeError::AudioEncoderFailed)?;
+    audio_runtime
+        .release_transient_compute_memory()
+        .map_err(Qwen3ForcedAlignerRuntimeError::AudioEncoderFailed)?;
+    drop(audio_runtime);
 
     let (decode_prompt, timestamp_positions) = build_forced_aligner_decode_prompt(
         &assets.metadata,

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -323,11 +323,17 @@ impl Qwen3AsrGgmlExecutor {
                     .ok_or_else(|| Qwen3AsrAudioEncoderError::GraphExecutionFailed {
                         reason: "audio actor received a non-qwen prepared runtime".to_string(),
                     })?;
-                state.runtime.encode(
+                let encode_result = state.runtime.encode(
                     &prepared_runtime.audio_encoder_weights,
                     prepared_runtime.metadata,
                     &mel_features,
-                )
+                );
+                let release_result = state.runtime.release_transient_compute_memory();
+                match (encode_result, release_result) {
+                    (Ok(output), Ok(())) => Ok(output),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                }
             })
             .map_err(|error| Self::map_actor_error("audio-encoder", error))?
             .map_err(map_audio_encoder_error)

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -380,6 +380,18 @@ struct WhisperEncoderPersistentStaticSession {
     encoder_hidden_size: usize,
 }
 
+impl WhisperEncoderPersistentStaticSession {
+    fn release_transient_compute_memory(&mut self) -> Result<(), WhisperGgmlExecutorError> {
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(
+                |error| WhisperGgmlExecutorError::EncoderGraphExecutionFailed {
+                    reason: format!("could not release transient encoder working set: {error}"),
+                },
+            )
+    }
+}
+
 struct WhisperDecoderPersistentStaticSession {
     runner: GgmlCpuGraphRunner,
     cache: WhisperDecoderPersistentWeightCache,
@@ -3459,6 +3471,11 @@ fn run_whisper_encoder_actor(
                     state.runner.as_ref(),
                 )
             });
+            let release_result = if allow_persistent_session_reuse {
+                session.release_transient_compute_memory()
+            } else {
+                Ok(())
+            };
             if !allow_persistent_session_reuse {
                 // Short-form requests do not promise cross-request graph
                 // reuse. Drop the session while still on its owner thread;
@@ -3466,7 +3483,11 @@ fn run_whisper_encoder_actor(
                 // and prepared-runtime reuse.
                 state.session = None;
             }
-            result
+            match (result, release_result) {
+                (Ok(output), Ok(())) => Ok(output),
+                (Err(error), _) => Err(error),
+                (Ok(_), Err(error)) => Err(error),
+            }
         })
         .map_err(|error| map_whisper_actor_error("encoder", error))?
 }


### PR DESCRIPTION
## Summary

Make scheduler memory-plan commits distinguish recoverable validation failures from native allocation mutations, and release transient scheduler working sets at model stage boundaries.

## Why

Scheduler graph splitting legitimately rewrites graph inputs before allocation planning. The previous fingerprint was frozen too early, so a valid mixed-backend graph could fail commit with `GGML_STATUS_FAILED`. The owner-attached admission path then treated every commit error as a terminal device failure, permanently quarantining an otherwise healthy dedicated GPU domain. Multi-stage model executors could also retain scheduler high-water allocations after a completed stage, reducing the memory available to later stages.

## Changes

- update the vendored backend contract to freeze fingerprints after scheduler splitting and report whether a failed commit may have mutated native allocation state
- refund recoverable pre-mutation failures while preserving quarantine and scheduler poisoning for failures after possible native mutation or terminal backend states
- centralize transient scheduler working-set release and call it at safe stage boundaries across affected model families
- keep persistent decoder sessions resident where their lifecycle requires it
- allow targeted CUDA diagnostic binary builds without changing normal release behavior
- add shared regression coverage for recoverable and unrecoverable commit classification, dedicated-domain reuse, plan cleanup, and stage release behavior

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (4025 passed, 177 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] `cargo test -p openasr-core golden_diff -- --nocapture` (4 passed, 14 ignored because private packs were unavailable)
- [x] vendored ggml CTest suite (25/25 passed)

## Manual smoke checks

No fresh Windows CUDA end-to-end model run was performed for this PR. The shared contract and lifecycle regressions are covered locally and in CI; Windows CUDA model validation remains a separate product acceptance step.

## Model-family changes (when applicable)

- [x] No family contract, catalog entry, or onboarding scope changed; existing executors only adopt the shared scheduler release boundary.
- [x] No real-weight quality or performance claim is made.

## Docs updated

- [x] No user-facing documentation change is required for this internal failure-classification and memory-lifecycle fix.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR does not change model topology, decoding policy, quantization, catalog metadata, or backend selection. Unsupported Metal flash-attention shapes are handled in a separate focused change.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in `AGENTS.md`.
- [x] I understand every line of this change and own its maintenance.
- AI usage disclosure: AI tools assisted with implementation and verification; the maintainer reviewed and owns the change.