### PR TITLE
fix(ggml): fall back from unsupported Metal flash attention

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -3531,6 +3531,14 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         self.backend_kind == GgmlCpuGraphBackend::Cpu
     }
 
+    /// Reports whether `flash_attn_ext` can execute the requested head width
+    /// on this graph's backend. High-level attention builders use this before
+    /// choosing flash-specific tensor layouts so unsupported Metal widths can
+    /// take their existing naive attention path instead of failing at build.
+    pub(crate) fn supports_flash_attn_ext_head_dim(&self, head_dim: usize) -> bool {
+        flash_attn_ext_head_dim_supported_on_backend(self.backend_kind, head_dim)
+    }
+
     pub(crate) fn gelu(
         &self,
         input: GgmlCpuTensor<'a>,

--- a/crates/openasr-core/src/models/whisper/ggml_decoder_graph.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_decoder_graph.rs
@@ -4757,7 +4757,8 @@ fn apply_decoder_self_attention<'a>(
     };
 
     let scale = 1.0f32 / (head_dim as f32).sqrt();
-    let use_self_flash_attention = use_flash_attention && use_self_kv;
+    let use_self_flash_attention =
+        use_flash_attention && use_self_kv && graph.supports_flash_attn_ext_head_dim(head_dim);
     let output_columns = token_count.checked_mul(n_seq).ok_or_else(|| {
         WhisperDecoderGraphExecutionError::InvalidInput {
             reason: "decoder self-attention output shape overflows usize".to_string(),
@@ -5074,7 +5075,10 @@ fn apply_decoder_cross_attention<'a>(
             reason: "decoder cross-attention output shape overflows usize".to_string(),
         }
     })?;
-    let context = if use_flash_attention && !collect_attention_probs {
+    let use_cross_flash_attention = use_flash_attention
+        && !collect_attention_probs
+        && graph.supports_flash_attn_ext_head_dim(head_dim);
+    let context = if use_cross_flash_attention {
         let q = reshape_projected_hidden_sequence_to_heads_view_with_n_seq(
             graph,
             q,

--- a/crates/openasr-core/src/models/whisper/ggml_encoder_graph.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_encoder_graph.rs
@@ -701,7 +701,9 @@ pub(crate) fn execute_whisper_encoder_graph_ggml_v0(
         )?;
 
         let attention_scale = 1.0f32 / (head_dim as f32).sqrt();
-        let attn_context = if config.use_flash_attention {
+        let use_flash_attention =
+            config.use_flash_attention && graph.supports_flash_attn_ext_head_dim(head_dim);
+        let attn_context = if use_flash_attention {
             match graph.flash_attn_ext(k, q, v, None, attention_scale, 0.0, 0.0) {
                 Ok(flash) => flash,
                 Err(error) => {

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -1319,7 +1319,9 @@ fn run_encoder_graph_with_runner(
 
         let head_dim = plan.output_hidden_size / execution.encoder_attention_heads;
         let attention_scale = 1.0f32 / (head_dim as f32).sqrt();
-        let attn_context = if whisper_encoder_flash_attention_enabled() {
+        let use_flash_attention = whisper_encoder_flash_attention_enabled()
+            && graph.supports_flash_attn_ext_head_dim(head_dim);
+        let attn_context = if use_flash_attention {
             let use_strided_views = graph_config.backend.is_gpu_class();
             let q = reshape_encoder_projection_to_heads_for_flash(
                 &mut graph,

--- a/crates/openasr-core/src/nn/decoder.rs
+++ b/crates/openasr-core/src/nn/decoder.rs
@@ -1908,7 +1908,9 @@ where
         map_err,
     )?;
     let scale = (head_dim as f32).sqrt().recip();
-    let attended = if config.use_flash_attention {
+    let use_flash_attention =
+        config.use_flash_attention && graph.supports_flash_attn_ext_head_dim(head_dim);
+    let attended = if use_flash_attention {
         graph
             .flash_attn_ext(q_flash, k_full, v_full, kv.attention_mask, scale, 0.0, 0.0)
             .map_err(|source| map_err("llm_flash_attn", source))?

--- a/crates/openasr-core/src/nn/encoder.rs
+++ b/crates/openasr-core/src/nn/encoder.rs
@@ -680,7 +680,9 @@ where
     // `reshape_encoder_projection_to_heads_for_flash` GPU/CPU split in
     // `models/whisper/ggml_executor.rs`. The naive path (and flash on CPU)
     // keeps the original `cont`'d heads unchanged.
-    let use_strided_views = config.use_flash_attention && graph.backend_kind().is_gpu_class();
+    let use_flash_attention =
+        config.use_flash_attention && graph.supports_flash_attn_ext_head_dim(config.head_dim);
+    let use_strided_views = use_flash_attention && graph.backend_kind().is_gpu_class();
     let heads_contiguous = !use_strided_views;
     let q = reshape_projection_to_attention_heads(
         graph,
@@ -722,7 +724,7 @@ where
         map_err,
     )?;
     let scale = 1.0 / (config.head_dim as f32).sqrt();
-    let context = if config.use_flash_attention {
+    let context = if use_flash_attention {
         // `flash_attn_ext` requires an F16 contiguous mask (unlike
         // `soft_max_ext`, which also accepts f32); cast the caller's additive
         // f32 padding mask once per layer. See `nn/decoder.rs`'s shared


### PR DESCRIPTION
## Summary

Select the existing naive attention path before graph construction when Metal does not support the requested `flash_attn_ext` head width.

## Why

The shared ggml runtime already rejects Metal flash-attention head dimensions outside the backend kernel whitelist. Higher-level encoder, decoder, and Whisper graph builders still selected flash-specific layouts solely from their feature flag, so an unsupported width failed graph construction instead of using the available naive attention implementation.

## Changes

- expose the backend-aware flash-attention head-width predicate on the graph builder
- gate shared encoder and decoder flash layouts before constructing them
- apply the same capability check to Whisper encoder, self-attention, and cross-attention paths
- preserve flash attention for supported Metal widths and for non-Metal backends

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core flash_attn_ext_ -- --nocapture` (4 passed)
- [x] `cargo nextest run --workspace` on the exact combined source tree (4025 passed, 177 skipped)
- [x] `cargo test --workspace --doc` on the exact combined source tree

## Manual smoke checks

No real model pack was used for this focused PR. The Metal backend predicate and fail-closed direct call are covered on Apple M1; model-level transcript validation remains a separate acceptance step.

## Model-family changes (when applicable)

- [x] No family contract, registry, catalog, or onboarding scope changed.
- [x] No quality or performance claim is made.

## Docs updated

- [x] No user-facing documentation change is required.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR does not expand Metal kernel support or change attention math. It only routes unsupported Metal shapes to the existing naive implementation.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in `AGENTS.md`.
- [x] I understand every line of this change and own its maintenance.
- AI usage disclosure: AI tools assisted with implementation and verification; the maintainer reviewed and owns the change.