### PR TITLE
fix(server): preserve boot warmup failure diagnostics

### DIFF
--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -1272,9 +1272,11 @@ fn native_offline_request_to_transcription_request(
 }
 
 fn native_backend_error_to_asr(error: BackendError) -> NativeAsrError {
-    NativeAsrError::SessionFailed {
-        message: error.to_string(),
-    }
+    let message = match error {
+        BackendError::NativeFailClosed { reason } => reason,
+        error => error.to_string(),
+    };
+    NativeAsrError::SessionFailed { message }
 }
 
 pub fn validate_local_native_model_pack_path(
@@ -1564,6 +1566,20 @@ mod tests {
         sync::Barrier,
         sync::atomic::{AtomicUsize, Ordering},
     };
+
+    #[test]
+    fn native_backend_error_mapping_does_not_nest_the_fail_closed_envelope() {
+        let error = native_backend_error_to_asr(BackendError::NativeFailClosed {
+            reason: "first causal failure".to_string(),
+        });
+
+        assert_eq!(
+            error,
+            NativeAsrError::SessionFailed {
+                message: "first causal failure".to_string(),
+            }
+        );
+    }
 
     #[test]
     fn native_content_cache_singleflights_concurrent_cold_misses() {

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -1023,9 +1023,10 @@ pub(crate) fn warm_up_native_streaming_session_once(
 /// in the background, right after `serve_with_launch_options` finishes
 /// binding the listener -- so the very first real dictation session does not
 /// pay the cold model-pack-load cost (observed 1.7-2.1s) before its first
-/// partial. Fire-and-forget: never blocks bind/serve/health, and any failure
-/// here (bad pack, no adapter, ...) is swallowed silently -- a real request
-/// still fails closed with a proper error through the normal request path.
+/// partial. Fire-and-forget: never blocks bind/serve/health, and a failure here
+/// (bad pack, no adapter, ...) is reported as a one-line diagnostic without
+/// changing daemon readiness -- a real request still fails closed through the
+/// normal request path.
 /// Derives its `hardware_target`/`inference_threads` from the user's saved
 /// preferences the same way a real WS attach without an explicit per-session
 /// override does (see `realtime_execution_target_preference` /
@@ -1122,7 +1123,18 @@ pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime
         session_config,
     ) {
         Ok(session) => session,
-        Err(_) => return,
+        Err(error) => {
+            openasr_core::stage_timing::log_event(
+                "realtime_warmup",
+                format_args!(
+                    "stage=session_start_failed model_pack_path={} hardware_target={} error={}",
+                    model_pack.root.display(),
+                    hardware_target,
+                    single_line_log_value(&error.to_string()),
+                ),
+            );
+            return;
+        }
     };
     let key = NativeStreamingWorkerKey::with_route(
         model_pack.root.clone(),
@@ -1130,7 +1142,23 @@ pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime
         resolved_route.as_ref(),
         inference_threads,
     );
-    attach_and_run_boot_warmup(key, session, Some(model_session_permit)).await;
+    let diagnostic_key = key.clone();
+    if let Err(error) = attach_and_run_boot_warmup(key, session, Some(model_session_permit)).await {
+        openasr_core::stage_timing::log_event(
+            "realtime_warmup",
+            format_args!(
+                "stage=failed model_pack_path={} hardware_target={} execution_route_key={} error={}",
+                diagnostic_key.model_pack_path.display(),
+                diagnostic_key.hardware_target,
+                diagnostic_key.execution_route_key,
+                single_line_log_value(&error),
+            ),
+        );
+    }
+}
+
+pub(crate) fn single_line_log_value(value: &str) -> String {
+    value.replace('\r', "\\r").replace('\n', "\\n")
 }
 
 /// The generic (session-agnostic) half of the boot warm-up: attach `session`
@@ -1145,28 +1173,45 @@ pub(crate) async fn attach_and_run_boot_warmup(
     key: NativeStreamingWorkerKey,
     session: Box<dyn NativeAsrSession>,
     model_session_permit: Option<ModelSessionPermit>,
-) {
-    let Ok(mut worker) =
-        NativeStreamingDecodeWorker::attach_admitted(key, session, model_session_permit).await
-    else {
-        return;
-    };
+) -> Result<(), String> {
+    let mut worker =
+        NativeStreamingDecodeWorker::attach_admitted(key, session, model_session_permit)
+            .await
+            .map_err(|error| format!("worker attach failed: {error}"))?;
     let envelope = NativeStreamingCommandEnvelope {
         kind: NativeStreamingCommandKind::Warm,
         command: NativeStreamingCommand::Warm,
     };
-    if worker.commands.send(envelope).await.is_ok() {
-        // Wait for the Warm outcome so this session -- and the worker-key
-        // acquisition it holds -- does not release before warm-up actually
-        // finishes; otherwise a concurrent real attach would not meaningfully
-        // "queue behind" this one.
-        let _ = worker.outcomes.recv().await;
-    }
+    let result = match worker.commands.send(envelope).await {
+        Ok(()) => {
+            // Wait for the Warm outcome so this session -- and the worker-key
+            // acquisition it holds -- does not release before warm-up actually
+            // finishes; otherwise a concurrent real attach would not meaningfully
+            // "queue behind" this one.
+            match worker.outcomes.recv().await {
+                Some(NativeStreamingOutcome::Events {
+                    kind: NativeStreamingCommandKind::Warm,
+                    ..
+                }) => Ok(()),
+                Some(NativeStreamingOutcome::Error {
+                    kind: NativeStreamingCommandKind::Warm,
+                    message,
+                }) => Err(message),
+                Some(outcome) => Err(format!(
+                    "worker returned unexpected {:?} outcome for boot warm-up",
+                    outcome.kind()
+                )),
+                None => Err("worker stopped before returning the boot warm-up outcome".to_string()),
+            }
+        }
+        Err(_) => Err("worker stopped before accepting the boot warm-up command".to_string()),
+    };
     // No Finish/Cancel is sent, so the worker thread cancels this session on
     // its behalf (see `run_native_streaming_session_on_worker`) and loops
     // straight back to accept the next real Attach -- the thread-local warm
     // state this call just primed stays resident for it.
     worker.join();
+    result
 }
 
 pub(crate) fn finish_native_streaming_session_in_worker(

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -2575,7 +2575,8 @@ async fn boot_native_warmup_runs_in_background_without_blocking_a_concurrent_tas
 
     warmup_handle
         .await
-        .expect("boot warmup task must not panic");
+        .expect("boot warmup task must not panic")
+        .expect("boot warmup must succeed");
     assert_eq!(
         warm_calls.load(Ordering::Acquire),
         1,
@@ -2661,7 +2662,8 @@ async fn health_answers_immediately_while_boot_warmup_is_artificially_slow() {
 
     warmup_handle
         .await
-        .expect("boot warmup task must not panic");
+        .expect("boot warmup task must not panic")
+        .expect("boot warmup must succeed");
     assert_eq!(warm_calls.load(Ordering::Acquire), 1);
 }
 
@@ -2686,7 +2688,9 @@ async fn boot_native_warmup_leaves_the_worker_thread_warm_for_the_next_real_atta
         warm_sleep: Duration::from_millis(50),
         warm_calls: Arc::clone(&warm_calls),
     });
-    attach_and_run_boot_warmup(key.clone(), boot_session, None).await;
+    attach_and_run_boot_warmup(key.clone(), boot_session, None)
+        .await
+        .expect("boot warmup must succeed");
     assert_eq!(warm_calls.load(Ordering::Acquire), 1);
 
     let (event_sender, _event_receiver) = mpsc::channel(8);
@@ -2720,6 +2724,31 @@ async fn boot_native_warmup_leaves_the_worker_thread_warm_for_the_next_real_atta
          worker thread -- warm_up() must not run a second time"
     );
     real_session.finish("client_closed", true).await.unwrap();
+}
+
+#[tokio::test]
+async fn boot_native_warmup_preserves_the_first_failure_message() {
+    let key = test_native_streaming_worker_key("boot-warmup-failure-diagnostic");
+    let session = Box::new(WarmFailingNativeSession {
+        inner: TestServerNativeSession::new("boot-warmup-failure-diagnostic"),
+    });
+
+    let error = attach_and_run_boot_warmup(key, session, None)
+        .await
+        .expect_err("the warm-up fixture must fail");
+
+    assert!(
+        error.contains("simulated warm-up allocation failure"),
+        "the boot task must preserve the worker's first causal error: {error}"
+    );
+}
+
+#[test]
+fn boot_native_warmup_log_value_stays_on_one_line_without_losing_boundaries() {
+    assert_eq!(
+        single_line_log_value("first\r\nsecond\nthird"),
+        "first\\r\\nsecond\\nthird"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Preserve and log the first causal failure from the asynchronous native streaming boot warmup without changing daemon readiness or request-time fail-closed behavior.

## Why

Boot warmup intentionally runs in the background, but its session-start, worker-attach, command-send, and warm outcome failures were silently discarded. A later real request therefore exposed only a secondary symptom, making backend and memory failures much harder to diagnose. Native fail-closed errors were also wrapped in a duplicate fail-closed envelope.

## Changes

- return the boot warmup outcome from the session-agnostic worker helper
- preserve worker error messages for attach, send, unexpected outcome, and early worker shutdown failures
- emit one-line startup diagnostics with the model pack, hardware target, route key, and first causal error
- unwrap the existing native fail-closed reason instead of nesting a duplicate envelope
- keep warmup fire-and-forget so server bind, readiness, and health remain unaffected

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core -p openasr-server --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core native_backend_error_mapping_does_not_nest_the_fail_closed_envelope -- --nocapture` (1 passed)
- [x] `cargo test -p openasr-server boot_native_warmup -- --nocapture` (5 passed)

## Manual smoke checks

No real model pack was used. Tests cover successful background warmup, worker reuse, occupied-capacity handling, first-error preservation, and single-line log sanitization.

## Model-family changes (when applicable)

- [x] No model-family contract, execution policy, or catalog entry changed.
- [x] No quality or performance claim is made.

## Docs updated

- [x] No user-facing documentation change is required for this diagnostic behavior.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR does not make warmup blocking, retry failed model execution, relax request-time errors, or change backend selection.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in `AGENTS.md`.
- [x] I understand every line of this change and own its maintenance.
- AI usage disclosure: AI tools assisted with implementation and verification; the maintainer reviewed and owns the change.