### PR TITLE
perf(qwen): bound forced-aligner prefill memory

### DIFF
--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -4494,6 +4494,25 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         &mut self,
         outputs: &[GgmlCpuTensor<'a>],
     ) -> Result<(), GgmlCpuGraphError> {
+        self.prepare_outputs_for_upload_with_cpu_step_reuse(outputs, true)
+    }
+
+    /// Prepare a one-shot graph through the scheduler/direct liveness
+    /// allocator even on plain CPU. This deliberately bypasses the CPU
+    /// grow-to-fit step pool, whose declaration-sized arena is appropriate for
+    /// repeated one-token decode but wasteful for a single wide prefill.
+    pub(crate) fn prepare_one_shot_outputs_for_upload(
+        &mut self,
+        outputs: &[GgmlCpuTensor<'a>],
+    ) -> Result<(), GgmlCpuGraphError> {
+        self.prepare_outputs_for_upload_with_cpu_step_reuse(outputs, false)
+    }
+
+    fn prepare_outputs_for_upload_with_cpu_step_reuse(
+        &mut self,
+        outputs: &[GgmlCpuTensor<'a>],
+        reuse_cpu_step_buffer: bool,
+    ) -> Result<(), GgmlCpuGraphError> {
         self.ensure_not_poisoned()?;
         if self.prepared_graph.is_some() {
             return Ok(());
@@ -4501,7 +4520,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         let graph = self.build_forward_graph(outputs)?;
         if self.scheduler.is_some() {
             self.allocate_scheduler_graph(graph)?;
-        } else if self.step_buffer_pool.is_some() {
+        } else if reuse_cpu_step_buffer && self.step_buffer_pool.is_some() {
             // Preserve the CPU per-step grow-to-fit pool. A one-shot gallocr
             // would save bytes for this graph but would also allocate and free
             // a backend buffer on every decoder step.
@@ -4531,6 +4550,15 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         }
         self.prepared_graph = Some(graph);
         Ok(())
+    }
+
+    /// Bytes reserved by the direct graph liveness allocator after
+    /// [`Self::prepare_outputs_for_upload`]. Scheduler-backed graphs own their
+    /// allocation plan separately and therefore return `None` here.
+    pub(crate) fn prepared_direct_graph_allocation_bytes(&self) -> Option<u64> {
+        self.graph_allocator
+            .as_ref()
+            .map(GgmlGraphAllocatorGuard::requested_bytes)
     }
 
     /// Rebind this prepared persistent graph after another graph temporarily
@@ -7684,7 +7712,6 @@ enum GgmlGraphAllocatorOwnership {
 
 struct GgmlGraphAllocatorGuard {
     _ownership: GgmlGraphAllocatorOwnership,
-    #[cfg(test)]
     requested_bytes: u64,
 }
 
@@ -7704,7 +7731,6 @@ impl GgmlGraphAllocatorGuard {
                 })?;
         let allocator = GgmlRawGraphAllocatorGuard::new(buft)?;
         let chunks = allocator.measure(graph)?;
-        #[cfg(test)]
         let requested_bytes = chunks.iter().try_fold(0_u64, |total, (_, requested, _)| {
             total.checked_add(*requested).ok_or_else(|| {
                 memory_admission_failure(
@@ -7803,12 +7829,10 @@ impl GgmlGraphAllocatorGuard {
             })?;
         Ok(Self {
             _ownership: GgmlGraphAllocatorOwnership::Admitted { _owner: allocation },
-            #[cfg(test)]
             requested_bytes,
         })
     }
 
-    #[cfg(test)]
     fn requested_bytes(&self) -> u64 {
         self.requested_bytes
     }
@@ -9969,6 +9993,42 @@ mod tests {
                 .expect("step after release should still compute");
             assert_eq!(output, vec![5.0, 6.0]);
             assert!(runner.cpu_step_buffer_pool.capacity_bytes > 0);
+        }
+
+        #[test]
+        fn one_shot_prepare_bypasses_the_cpu_step_pool_for_liveness_allocation() {
+            const ELEMENTS: usize = 4096;
+            const ADDITIONS: usize = 32;
+            let mut runner = cpu_no_scheduler_runner();
+            {
+                let mut graph = runner.start_graph();
+                let input = graph
+                    .new_tensor_1d_f32(ELEMENTS, "one_shot_input")
+                    .expect("input");
+                let increment = graph
+                    .new_tensor_1d_f32(ELEMENTS, "one_shot_increment")
+                    .expect("increment");
+                graph.set_input(input).expect("input flag");
+                graph.set_input(increment).expect("increment flag");
+                let mut output = input;
+                for _ in 0..ADDITIONS {
+                    output = graph.add(output, increment).expect("add node");
+                }
+                graph.set_output(output).expect("output flag");
+                graph
+                    .prepare_one_shot_outputs_for_upload(&[output])
+                    .expect("one-shot liveness prepare");
+                assert!(graph.graph_allocator.is_some());
+                assert!(graph.buffer.is_none());
+                let naive = (ADDITIONS + 2) * ELEMENTS * std::mem::size_of::<f32>();
+                assert!(
+                    graph
+                        .prepared_direct_graph_allocation_bytes()
+                        .is_some_and(|bytes| bytes < (naive / 2) as u64),
+                    "one-shot graph should recycle the addition chain"
+                );
+            }
+            assert_eq!(runner.cpu_step_buffer_pool.capacity_bytes, 0);
         }
 
         #[test]

--- a/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
@@ -441,10 +441,14 @@ pub(crate) fn align_forced(
             &mel_features,
         )
         .map_err(Qwen3ForcedAlignerRuntimeError::AudioEncoderFailed)?;
+    // The encoder graph and mel input are not needed by the LLM stage. Release
+    // and drop them before constructing its much larger graph so the two
+    // stages do not overlap in the request's peak working set.
     audio_runtime
         .release_transient_compute_memory()
         .map_err(Qwen3ForcedAlignerRuntimeError::AudioEncoderFailed)?;
     drop(audio_runtime);
+    drop(mel_features);
 
     let (decode_prompt, timestamp_positions) = build_forced_aligner_decode_prompt(
         &assets.metadata,
@@ -464,6 +468,7 @@ pub(crate) fn align_forced(
         &audio_embeddings.rows,
     )?;
     let prefill_input = build_qwen3_llm_prefill_input(prompt_embeddings)?;
+    drop(audio_embeddings);
 
     let mut whole_decoder = Qwen3AsrLlmWholeDecoderGraphExecutor::new_from_plan_with_preflight(
         &assets.decoder_plan,
@@ -475,7 +480,7 @@ pub(crate) fn align_forced(
     })?;
     let mut logits_runtime = assets.logits_head.new_runtime(backend)?;
     let prefill_output = whole_decoder
-        .run_prefill(
+        .run_stateless_prefill(
             &prefill_input.token_major_embeddings,
             prefill_input.token_count,
             FORCED_ALIGNER_ROPE_THETA,

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -17,7 +17,7 @@ use crate::GgmlRuntimeSource;
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor, GgmlKvElementType,
     GgmlRopeExtParams, GgmlStaticTensor, GgmlStaticTensorArena, GgufTensorDataReadError,
-    GgufTensorDataReader, env_toggle_with_raw,
+    GgufTensorDataReader, env_toggle_with_raw, env_var_truthy,
 };
 
 use super::graph_config::qwen_decoder_graph_config;
@@ -46,6 +46,7 @@ const QWEN3_LLM_WHOLE_DECODE_GRAPH_CONTEXT_BYTES: usize = 768 * 1024 * 1024;
 // Correctness escape hatch for backend kernels with divergent native GQA
 // behavior; keep it unless every backend's GQA path is verified.
 const QWEN3_LLM_NATIVE_GQA_ENV: &str = "OPENASR_QWEN_LLM_NATIVE_GQA";
+const QWEN3_LLM_PREFILL_ALLOCATION_PROFILE_ENV: &str = "OPENASR_QWEN_PREFILL_ALLOCATION_PROFILE";
 const QWEN3_LLM_CPU_SAFE_PREFILL_QUERY_TOKENS: usize = 8;
 /// Conservative single-query width kept for backends that have not been
 /// validated for multi-query host-cache prefill (legacy default). Discrete
@@ -1045,6 +1046,7 @@ fn qwen_llm_stack_config(
     n_seq: usize,
     use_flash_attention: bool,
     kv_cache_spec: LlmKvCacheSpec,
+    materialize_kv_outputs: bool,
 ) -> LlmDecoderStackConfig {
     LlmDecoderStackConfig {
         d_model: dims.d_model,
@@ -1067,6 +1069,7 @@ fn qwen_llm_stack_config(
         use_native_gqa: use_native_gqa || n_seq > 1,
         use_flash_attention,
         kv_cache_spec,
+        materialize_kv_outputs,
     }
 }
 
@@ -2798,6 +2801,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 1,
                 true,
                 self.kv_cache_spec,
+                true,
             ),
             LlmDecoderStackInputs {
                 state: hidden_tensor,
@@ -3023,6 +3027,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 1,
                 true,
                 self.kv_cache_spec,
+                true,
             ),
             LlmDecoderStackInputs {
                 state: hidden_tensor,
@@ -3149,6 +3154,32 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         )
     }
 
+    /// Run a complete prompt as one causal forward pass without materializing
+    /// the per-layer K/V tensors for a later autoregressive decode.
+    ///
+    /// This is the exact execution contract needed by non-autoregressive
+    /// consumers such as Qwen3-ForcedAligner: they consume the final hidden
+    /// state once and never seed a decode cache. Keeping every layer's K/V as a
+    /// graph output extends all of those tensors' lifetimes to the end of the
+    /// graph and defeats the liveness allocator for no mathematical benefit.
+    pub(crate) fn run_stateless_prefill(
+        &mut self,
+        token_major_hidden: &[f32],
+        token_count: usize,
+        rope_theta: f32,
+    ) -> Result<Qwen3AsrLlmWholeStepOutput, GgmlCpuGraphError> {
+        self.run_prefill_with_batched_history(
+            token_major_hidden,
+            token_count,
+            1,
+            0,
+            token_count,
+            &[&[]],
+            rope_theta,
+            false,
+        )
+    }
+
     pub(crate) fn run_prefill_chunk(
         &mut self,
         token_major_hidden: &[f32],
@@ -3186,6 +3217,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             total_token_count,
             layer_caches_by_sequence,
             rope_theta,
+            true,
         )
     }
 
@@ -3441,6 +3473,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                     n_seq,
                     use_flash_attention,
                     self.kv_cache_spec,
+                    true,
                 ),
                 LlmDecoderStackInputs {
                     state: hidden_tensor,
@@ -3547,6 +3580,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             total_token_count,
             &layer_caches_by_sequence,
             rope_theta,
+            true,
         )
     }
 
@@ -3559,6 +3593,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         total_token_count: usize,
         layer_caches_by_sequence: &[&[Qwen3AsrLayerKvCacheState]],
         rope_theta: f32,
+        materialize_layer_kv: bool,
     ) -> Result<Qwen3AsrLlmWholeStepOutput, GgmlCpuGraphError> {
         let dims = self.dims;
         if token_count == 0 {
@@ -3671,6 +3706,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 n_seq,
                 use_flash_attention,
                 self.kv_cache_spec,
+                materialize_layer_kv,
             ),
             LlmDecoderStackInputs {
                 state: hidden_tensor,
@@ -3689,6 +3725,40 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         let kv_inputs = stack.kv_inputs;
         let kv_outputs = stack.kv_outputs;
         graph.set_output(state)?;
+
+        let mut requested: Vec<(GgmlCpuTensor, usize)> =
+            Vec::with_capacity(1 + usize::from(materialize_layer_kv) * 2 * self.layers.len());
+        requested.push((state, expected_hidden));
+        let layer_kv_width = dims.k_width.checked_mul(output_tokens).ok_or(
+            GgmlCpuGraphError::UnsupportedInputs {
+                reason: "whole-decoder prefill KV output width overflow",
+            },
+        )?;
+        if materialize_layer_kv {
+            for (k, v) in &kv_outputs {
+                requested.push((*k, layer_kv_width));
+                requested.push((*v, layer_kv_width));
+            }
+        }
+        let requested_tensors = requested
+            .iter()
+            .map(|(tensor, _)| *tensor)
+            .collect::<Vec<_>>();
+        // Preparing before the first input upload is essential. Uploading into
+        // an unprepared direct graph falls back to allocating every declared
+        // intermediate in the ggml context; preparing first lets gallocr bind
+        // one liveness-planned buffer instead.
+        if materialize_layer_kv {
+            graph.prepare_outputs_for_upload(&requested_tensors)?;
+        } else {
+            graph.prepare_one_shot_outputs_for_upload(&requested_tensors)?;
+        }
+        if env_var_truthy(QWEN3_LLM_PREFILL_ALLOCATION_PROFILE_ENV) {
+            eprintln!(
+                "openasr-qwen-prefill-allocation token_count={token_count} materialize_layer_kv={materialize_layer_kv} direct_graph_bytes={:?}",
+                graph.prepared_direct_graph_allocation_bytes()
+            );
+        }
 
         graph.set_f32_slice(
             hidden_tensor,
@@ -3803,28 +3873,22 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             }
         }
 
-        let mut requested: Vec<(GgmlCpuTensor, usize)> =
-            Vec::with_capacity(1 + 2 * self.layers.len());
-        requested.push((state, expected_hidden));
-        let layer_kv_width = dims.k_width.checked_mul(output_tokens).ok_or(
-            GgmlCpuGraphError::UnsupportedInputs {
-                reason: "whole-decoder prefill KV output width overflow",
-            },
-        )?;
-        for (k, v) in &kv_outputs {
-            requested.push((*k, layer_kv_width));
-            requested.push((*v, layer_kv_width));
-        }
         let build_micros = build_started_at.elapsed().as_micros();
         let compute_started_at = std::time::Instant::now();
         let mut outputs = graph.compute_outputs_f32(&requested)?;
         let compute_micros = compute_started_at.elapsed().as_micros();
         let hidden_out = outputs.remove(0);
-        let mut layer_kv = Vec::with_capacity(self.layers.len());
-        for _ in 0..self.layers.len() {
-            let k = outputs.remove(0);
-            let v = outputs.remove(0);
-            layer_kv.push((k, v));
+        let mut layer_kv = Vec::with_capacity(if materialize_layer_kv {
+            self.layers.len()
+        } else {
+            0
+        });
+        if materialize_layer_kv {
+            for _ in 0..self.layers.len() {
+                let k = outputs.remove(0);
+                let v = outputs.remove(0);
+                layer_kv.push((k, v));
+            }
         }
         Ok(Qwen3AsrLlmWholeStepOutput {
             hidden: hidden_out,
@@ -3938,6 +4002,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                     n_seq,
                     true,
                     self.kv_cache_spec,
+                    true,
                 ),
                 LlmDecoderStackInputs {
                     state: hidden_tensor,
@@ -4253,6 +4318,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 n_seq,
                 true,
                 self.kv_cache_spec,
+                true,
             ),
             LlmDecoderStackInputs {
                 state: hidden_tensor,
@@ -6741,6 +6807,39 @@ mod tests {
             "peak staging {} must fit within one layer payload {one_layer_payload}",
             executor.materialization_peak_staging_bytes
         );
+    }
+
+    #[test]
+    fn stateless_prefill_matches_full_hidden_without_materializing_kv() {
+        let (_temp, source, metadata) = metadata_only_decoder_fixture(false);
+        let reader = GgufTensorDataReader::from_runtime_source(&source).expect("reader");
+        let projections = load_qwen3_llm_attention_projections_from_reader(&reader, metadata)
+            .expect("synthetic projections");
+        let hidden = deterministic_prefill_hidden(metadata.llm_d_model, 7);
+
+        let mut full = Qwen3AsrLlmWholeDecoderGraphExecutor::new(
+            &projections,
+            Some(&source),
+            GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("full prefill executor");
+        let full = full
+            .run_prefill(&hidden, 7, 1_000_000.0)
+            .expect("full prefill");
+
+        let mut stateless = Qwen3AsrLlmWholeDecoderGraphExecutor::new(
+            &projections,
+            Some(&source),
+            GgmlCpuGraphBackend::Cpu,
+        )
+        .expect("stateless prefill executor");
+        let stateless = stateless
+            .run_stateless_prefill(&hidden, 7, 1_000_000.0)
+            .expect("stateless prefill");
+
+        assert_eq!(stateless.hidden, full.hidden);
+        assert!(stateless.layer_kv.is_empty());
+        assert_eq!(full.layer_kv.len(), metadata.llm_layers);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/qwen/logits_head.rs
+++ b/crates/openasr-core/src/models/qwen/logits_head.rs
@@ -656,6 +656,7 @@ impl Qwen3AsrLlmLogitsHeadGraphExecutor {
         let normed = graph.mul(normed, self.arena.graph_tensor(self.output_norm_weight))?;
         let logits = graph.mul_mat(self.arena.graph_tensor(self.output_weight), normed)?;
         graph.set_output(logits)?;
+        graph.prepare_outputs_for_upload(&[logits])?;
         graph.set_f32_slice(hidden_tensor, hidden, "qwen_llm_logits_hidden")?;
         graph.compute_output_f32(logits, self.vocab_size)
     }
@@ -686,6 +687,7 @@ impl Qwen3AsrLlmLogitsHeadGraphExecutor {
             self.arena.graph_tensor(self.argmax_reverse_indices),
         )?;
         graph.set_output(top1)?;
+        graph.prepare_outputs_for_upload(&[top1])?;
         graph.set_f32_slice(hidden_tensor, hidden, "qwen_llm_logits_hidden")?;
         let token_ids = graph.compute_output_i32(top1, 1)?;
         let reversed_token_id =

--- a/crates/openasr-core/src/nn/decoder.rs
+++ b/crates/openasr-core/src/nn/decoder.rs
@@ -1324,6 +1324,11 @@ pub(crate) struct LlmDecoderStackConfig {
     pub use_flash_attention: bool,
     /// Host/resident KV element types for this stack composition.
     pub kv_cache_spec: LlmKvCacheSpec,
+    /// Keep each layer's projected K/V alive as a graph output so a caller can
+    /// read it back into an autoregressive host cache. Stateless consumers
+    /// leave this false: attention still consumes the exact same K/V values in
+    /// graph, but their storage can be recycled after the layer finishes.
+    pub materialize_kv_outputs: bool,
 }
 
 /// Per-step inputs for one composition of an LLM decoder layer stack.
@@ -2164,12 +2169,14 @@ where
             map_err,
         )?;
         state = layer_out.output;
-        graph
-            .set_output(layer_out.projected_k)
-            .map_err(|source| map_err("llm_decoder_stack_projected_k", source))?;
-        graph
-            .set_output(layer_out.projected_v)
-            .map_err(|source| map_err("llm_decoder_stack_projected_v", source))?;
+        if config.materialize_kv_outputs {
+            graph
+                .set_output(layer_out.projected_k)
+                .map_err(|source| map_err("llm_decoder_stack_projected_k", source))?;
+            graph
+                .set_output(layer_out.projected_v)
+                .map_err(|source| map_err("llm_decoder_stack_projected_v", source))?;
+        }
         kv_inputs.push((key_history, value_history));
         kv_outputs.push((layer_out.projected_k, layer_out.projected_v));
     }
@@ -2906,6 +2913,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 kv_cache_spec: LlmKvCacheSpec::DEFAULT,
+                materialize_kv_outputs: true,
             },
             LlmDecoderStackInputs {
                 state,
@@ -2972,6 +2980,7 @@ mod tests {
                 use_native_gqa: false,
                 use_flash_attention: true,
                 kv_cache_spec: LlmKvCacheSpec::DEFAULT,
+                materialize_kv_outputs: true,
             },
             LlmDecoderStackInputs {
                 state,
@@ -3141,6 +3150,7 @@ mod tests {
                 use_native_gqa: true,
                 use_flash_attention: true,
                 kv_cache_spec: LlmKvCacheSpec::DEFAULT,
+                materialize_kv_outputs: true,
             },
             LlmDecoderStackInputs {
                 state,
@@ -3564,6 +3574,7 @@ mod tests {
                 use_native_gqa: options.use_native_gqa,
                 use_flash_attention: options.use_flash_attention,
                 kv_cache_spec: LlmKvCacheSpec::DEFAULT,
+                materialize_kv_outputs: true,
             },
             LlmDecoderStackInputs {
                 state,


### PR DESCRIPTION
## Summary

Bound Qwen3 Forced Aligner prefill memory by using a stateless decoder path and liveness-based one-shot graph allocation.

## Why

Forced alignment consumes the final hidden states once and never continues autoregressive decoding. The previous path nevertheless retained every decoder layer's K/V tensors as graph outputs and uploaded inputs before the graph allocation plan was prepared. A 752-token alignment prompt could therefore request a multi-gigabyte declaration-sized graph buffer and fail on otherwise supported machines.

## Changes

- add a stateless prefill contract that preserves the final hidden output without materializing or reading back layer K/V caches;
- prepare prefill and logits graphs before uploading inputs so scheduler/direct liveness allocation is used;
- add a one-shot direct allocator path for CPU execution without the reusable decode step pool;
- release audio-encoder transient memory before constructing the LLM graph;
- add hidden-output parity and allocation-lifetime regression tests.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (4030 passed, 177 skipped)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

- Ran the full local FunASR Nano + Voice ID + Forced Aligner path on a 59.856-second AAC recording.
- With the scheduler disabled to exercise the direct allocator, the two alignment prompts reserved 77,756,800 B and 69,586,528 B instead of the previous 3,413,606,400 B request.
- The run completed without swap or an allocation error and preserved the transcript, speaker sequence, and subtitle text.

## Scope / non-goals

- No model weights, quantization, context length, alignment protocol, fallback policy, or public catalog metadata changes.
- No Desktop UI changes.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in `AGENTS.md`.
- [x] I understand every line of this change and own its maintenance.
- AI usage disclosure: YES - implementation assistance was used; the maintainer reviewed the diff and validated it with unit, workspace, and real-audio tests.
