### PR TITLE
fix(core): derive MOSS actor quote from prepared plan

### DIFF
--- a/crates/openasr-core/src/models/family_source_gates.rs
+++ b/crates/openasr-core/src/models/family_source_gates.rs
@@ -80,6 +80,7 @@ pub(super) struct ProductionSyntax {
     provider_name_parses: BTreeSet<String>,
     block_stack_none: bool,
     creates_request_output_pack: bool,
+    borrowed_field_calls: BTreeSet<(String, String, String)>,
 }
 
 impl ProductionSyntax {
@@ -100,6 +101,14 @@ impl ProductionSyntax {
 
     pub(super) fn has_unsafe_impl_for(&self, trait_name: &str) -> bool {
         self.unsafe_impl_traits.contains(trait_name)
+    }
+
+    fn calls_with_borrowed_field(&self, function: &str, receiver: &str, field: &str) -> bool {
+        self.borrowed_field_calls.contains(&(
+            function.to_string(),
+            receiver.to_string(),
+            field.to_string(),
+        ))
     }
 
     fn parses_provider_names(&self) -> bool {
@@ -157,6 +166,28 @@ impl<'ast> Visit<'ast> for ProductionSyntax {
             && let Some(last) = function.path.segments.last()
         {
             self.calls.insert(last.ident.to_string());
+            for argument in &node.args {
+                let Expr::Reference(reference) = argument else {
+                    continue;
+                };
+                let Expr::Field(field) = reference.expr.as_ref() else {
+                    continue;
+                };
+                let Expr::Path(receiver) = field.base.as_ref() else {
+                    continue;
+                };
+                let Some(receiver) = receiver.path.get_ident() else {
+                    continue;
+                };
+                let Member::Named(field) = &field.member else {
+                    continue;
+                };
+                self.borrowed_field_calls.insert((
+                    last.ident.to_string(),
+                    receiver.to_string(),
+                    field.to_string(),
+                ));
+            }
             if last.ident == "create"
                 && function
                     .path
@@ -641,10 +672,26 @@ fn qwen_shaped_family_constructors_keep_the_bound_plan_tail_compile_chain() {
         );
     }
     let moss_compile = "moss_transcribe_diarize/llm_decoder.rs";
+    let moss_compile_syntax = ProductionSyntax::collect(&root.join(moss_compile));
     assert!(
-        ProductionSyntax::collect(&root.join(moss_compile))
+        moss_compile_syntax
             .calls_or_invokes_method("compile_qwen_whole_decoder_graph_from_prepared_plan"),
         "{moss_compile} must materialize the prepared decoder through the shared compile seam"
+    );
+    assert!(
+        moss_compile_syntax.references_identifier("QwenWholeDecoderPlan")
+            && moss_compile_syntax.calls_or_invokes_method("layer_count"),
+        "{moss_compile} must derive actor graph-handle quotes from the prepared decoder plan"
+    );
+
+    let moss_actor = "moss_transcribe_diarize/executor.rs";
+    assert!(
+        ProductionSyntax::collect(&root.join(moss_actor)).calls_with_borrowed_field(
+            "quoted_resident_system_memory_bytes",
+            "prepared",
+            "decoder_plan",
+        ),
+        "{moss_actor} must pass the prepared decoder plan into the actor memory quote"
     );
 }
 

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -860,7 +860,7 @@ impl MossTdGgmlExecutor {
             key,
             move || {
                 let retained = MossTdDecoderRuntime::quoted_resident_system_memory_bytes(
-                    prepared.decoder_metadata.n_layers,
+                    &prepared.decoder_plan,
                 )
                 .map_err(|reason| MossTdExecutorError::RuntimeOwnershipFailed {
                     stage: "decoder",

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -69,8 +69,16 @@ pub(crate) struct MossTdPrefillOutput {
 }
 
 impl MossTdDecoderRuntime {
-    pub(crate) fn quoted_resident_system_memory_bytes(layer_count: usize) -> Result<u64, String> {
-        Qwen3AsrLlmWholeDecoderGraphExecutor::quoted_retained_system_memory_bytes(layer_count)
+    /// Quote the actor-local graph handles from the already-prepared plan.
+    ///
+    /// Accepting the plan instead of a raw layer count keeps runtime admission
+    /// on the same source of truth as materialization.
+    pub(crate) fn quoted_resident_system_memory_bytes(
+        plan: &QwenWholeDecoderPlan,
+    ) -> Result<u64, String> {
+        Qwen3AsrLlmWholeDecoderGraphExecutor::quoted_retained_system_memory_bytes(
+            plan.layer_count(),
+        )
     }
 
     pub(crate) fn resident_system_memory_bytes(&self) -> Result<u64, String> {


### PR DESCRIPTION
## Summary

- derive the MOSS actor graph-handle memory quote from the prepared Qwen decoder plan
- add a source-shape regression gate that prevents the executor from reintroducing raw decoder geometry

## Why

Decoder admission, planning, tail loading, and compilation already consume one bound Qwen contract, but the MOSS actor quote still accepted a raw layer count. Passing the prepared plan closes that final duplicate source of truth.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo nextest run --workspace` (4,122 passed)
- `cargo test --workspace --doc`
- `cargo xtask family conformance` (3,476 passed)
- `cargo xtask verify-installed-packs --require-store` (12/12 passed)
- focused Qwen source gates, Metal device reuse, Qwen prefill parity, requant, and real-pack gates

AI assistance: Used for implementation and verification.