### PR TITLE
fix(ci): restore public hf release gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Subtitles: transcription results now keep readable paragraphs separate from
+  short subtitle cues. JSON responses expose `subtitle_cues` and
+  `timeline_quality`; SRT/VTT render the cue view. The server also provides
+  `POST /v1/audio/precise-timeline` to refine an existing transcript against
+  its source audio when the Qwen3 Forced Aligner capability pack is installed.
+- CLI: `openasr bench-receipt short-audio` writes a machine-readable receipt
+  for a measured short-audio run, binding the report to the selected pack,
+  source audio, runtime settings, and recorded measurements.
 - Voice ID: local file transcription now has one model-independent speaker
   pipeline. `moss-transcribe-diarize` keeps its in-decoder speaker turns; every
   other ASR family uses the shared FireRed Stream-VAD + speaker-segmenter +
@@ -36,6 +44,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Core: built-in model families now share the runtime admission, resource
+  ownership, request-progress, and importer/tokenizer building blocks while
+  retaining their family-specific graph and decode behavior.
+- Core: scheduler-backed graph stages release their completed transient working
+  sets before the next stage is admitted. DiariZen persistent graphs and
+  Qwen3 Forced Aligner prefill also use bounded-liveness allocation paths.
 - Voice ID: ReDimNet2-B6 now embeds independent speech windows through the
   ordered batch seam, reuses content-keyed resident runtimes, and freezes one
   exact pack snapshot for the entire request. Parallel work preserves input
@@ -61,6 +75,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- `ggml`: unsupported Metal flash-attention head widths now select the existing
+  non-flash attention path before graph construction instead of failing the
+  request.
+- Server: native boot warm-up preserves the first causal failure in its startup
+  diagnostic instead of wrapping it in later generic errors.
+- Core: MOSS decoder admission derives its actor memory quote from the prepared
+  decoder plan, keeping the preflight estimate aligned with the graph it will
+  execute.
 - Voice ID: external diarization now treats the recording-wide speaker timeline
   as the shared source of truth for both transcript attribution and enrolled
   identity matching. Coarse ASR segments that cross speaker changes are split

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -5,10 +5,11 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
 
 ## Current limitations
 
-- OpenASR is Apache-2.0 open core, but there is no public binary release yet: no
-  published binaries/installers/checksums, and no package-manager channels. Build
-  from source meanwhile. Public model-pack distribution is limited to catalog
-  entries explicitly marked `public:true`.
+- OpenASR publishes binary archives and SHA-256 checksums for macOS, Linux, and
+  Windows on [GitHub Releases](https://github.com/QuintinShaw/openasr/releases).
+  There are no package-manager channels yet; building from source remains
+  supported. Public model-pack distribution is limited to catalog entries
+  explicitly marked `public:true`.
 - The only executable backends are the default `native` and the opt-in `mock`
   stub. Native transcription runs offline from `.oasr` runtime packs -- a pinned
   `--model-pack`, an installed pack, or one the CLI installs on first use through

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,8 +4,10 @@ This file is the source of truth for OpenASR sequencing. Implemented status is
 the [Implemented baseline](#implemented-baseline) section below.
 
 OpenASR is licensed under Apache-2.0 and maintained as the public open core.
-Public binary-release readiness (signed/checksummed release artifacts and
-package-manager channels) is still deferred; build from source meanwhile.
+Versioned binary archives and SHA-256 checksums are published through
+[GitHub Releases](https://github.com/QuintinShaw/openasr/releases).
+Package-manager channels remain deferred; building from source remains
+supported.
 
 ## Implemented baseline
 
@@ -77,8 +79,8 @@ These were prior roadmap goals and are now shipped on the native runtime path:
 
 ## Deferred
 
-- Public binary-release readiness (signed/checksummed release artifacts, package channels).
-- Production distribution channels.
+- Package-manager integrations and additional production distribution channels
+  beyond GitHub Releases and Docker Hub.
 - Public true-streaming release guarantees, official streaming-enabled pack
   publication, and broad multilingual feature claims.
 

--- a/tooling/public-hf-e2e/installed_pack_path.py
+++ b/tooling/public-hf-e2e/installed_pack_path.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate the installed pack path reported by ``openasr pull``."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+
+
+def validate_installed_pack_path(home_arg: str, pack_arg: str, sha256: str) -> None:
+    if SHA256_RE.fullmatch(sha256) is None:
+        raise ValueError(f"installed pack has an invalid sha256: {sha256}")
+
+    home = Path(home_arg).resolve(strict=True)
+    pack = Path(pack_arg).resolve(strict=True)
+    if not pack.is_file():
+        raise ValueError(f"installed pack is not a file: {pack}")
+
+    try:
+        relative_pack = pack.relative_to(home)
+    except ValueError as error:
+        raise ValueError(f"installed pack is outside OPENASR_HOME: {pack}") from error
+
+    # Legacy model-store layouts name the installed file itself with the
+    # package extension. The current store names immutable objects by their
+    # digest and keeps the GGUF payload in a file named ``content``. Accept the
+    # latter only at its exact canonical location, with the directory digest
+    # matching the bytes the caller just hashed.
+    if pack.suffix == ".oasr":
+        return
+
+    expected_parts = ("models", "objects", "sha256", sha256, "content")
+    if relative_pack.parts != expected_parts:
+        raise ValueError(
+            "installed pack is neither a .oasr file nor the canonical "
+            f"content-addressed object for sha256 {sha256}: {pack}"
+        )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print(
+            "usage: installed_pack_path.py OPENASR_HOME PACK_PATH SHA256",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        validate_installed_pack_path(argv[1], argv[2], argv[3])
+    except (OSError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tooling/public-hf-e2e/run.sh
+++ b/tooling/public-hf-e2e/run.sh
@@ -361,6 +361,7 @@ run_openasr() {
     -u HUGGINGFACE_HUB_TOKEN \
     -u HUGGING_FACE_HUB_TOKEN \
     OPENASR_HOME="${openasr_home}" \
+    OPENASR_MODELS_DIR="${openasr_home}/models" \
     OPENASR_GGML_BACKEND="${ggml_backend}" \
     "${openasr_bin}" "$@"
 }
@@ -378,19 +379,8 @@ pack_file="$(basename "${pack_path}")"
 pack_sha256="$(shasum -a 256 "${pack_path}" | awk '{ print $1 }')"
 pack_size_bytes="$(wc -c < "${pack_path}" | tr -d '[:space:]')"
 
-python3 - "${openasr_home}" "${pack_path}" <<'PY'
-import sys
-from pathlib import Path
-
-home = Path(sys.argv[1]).resolve()
-pack = Path(sys.argv[2]).resolve()
-try:
-    pack.relative_to(home)
-except ValueError:
-    raise SystemExit(f"installed pack is outside OPENASR_HOME: {pack}")
-if pack.suffix != ".oasr":
-    raise SystemExit(f"installed pack is not a .oasr file: {pack}")
-PY
+python3 "${script_dir}/installed_pack_path.py" \
+  "${openasr_home}" "${pack_path}" "${pack_sha256}"
 
 echo "Transcribing with installed pack..."
 run_openasr transcribe "${audio}" \

--- a/tooling/public-hf-e2e/test_public_hf_e2e.py
+++ b/tooling/public-hf-e2e/test_public_hf_e2e.py
@@ -8,7 +8,10 @@ CI can keep the helper safe without doing network I/O.
 
 from __future__ import annotations
 
+import hashlib
+import importlib.util
 import json
+import os
 import subprocess
 import tempfile
 import unittest
@@ -17,12 +20,26 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RUN_SH = REPO_ROOT / "tooling" / "public-hf-e2e" / "run.sh"
+PACK_PATH_HELPER = REPO_ROOT / "tooling" / "public-hf-e2e" / "installed_pack_path.py"
+
+PACK_PATH_SPEC = importlib.util.spec_from_file_location(
+    "installed_pack_path", PACK_PATH_HELPER
+)
+assert PACK_PATH_SPEC is not None and PACK_PATH_SPEC.loader is not None
+installed_pack_path = importlib.util.module_from_spec(PACK_PATH_SPEC)
+PACK_PATH_SPEC.loader.exec_module(installed_pack_path)
 
 
-def run_helper(*args: str) -> subprocess.CompletedProcess[str]:
+def run_helper(
+    *args: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    command_env = os.environ.copy()
+    if env is not None:
+        command_env.update(env)
     return subprocess.run(
         [str(RUN_SH), *args],
         cwd=REPO_ROOT,
+        env=command_env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -31,6 +48,147 @@ def run_helper(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 class PublicHfE2ETests(unittest.TestCase):
+    def test_installed_pack_path_accepts_legacy_oasr_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            home = Path(temp)
+            pack = home / "models" / "legacy" / "pack.oasr"
+            pack.parent.mkdir(parents=True)
+            pack.write_bytes(b"legacy pack")
+            digest = hashlib.sha256(pack.read_bytes()).hexdigest()
+
+            installed_pack_path.validate_installed_pack_path(
+                str(home), str(pack), digest
+            )
+
+    def test_installed_pack_path_accepts_content_addressed_object(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            home = Path(temp)
+            payload = b"content addressed pack"
+            digest = hashlib.sha256(payload).hexdigest()
+            pack = home / "models" / "objects" / "sha256" / digest / "content"
+            pack.parent.mkdir(parents=True)
+            pack.write_bytes(payload)
+
+            installed_pack_path.validate_installed_pack_path(
+                str(home), str(pack), digest
+            )
+
+    def test_installed_pack_path_rejects_content_object_with_wrong_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            home = Path(temp)
+            payload = b"content addressed pack"
+            digest = hashlib.sha256(payload).hexdigest()
+            wrong_digest = hashlib.sha256(b"other pack").hexdigest()
+            pack = home / "models" / "objects" / "sha256" / wrong_digest / "content"
+            pack.parent.mkdir(parents=True)
+            pack.write_bytes(payload)
+
+            with self.assertRaisesRegex(ValueError, "canonical content-addressed"):
+                installed_pack_path.validate_installed_pack_path(
+                    str(home), str(pack), digest
+                )
+
+    def test_installed_pack_path_rejects_content_file_outside_canonical_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            home = Path(temp)
+            payload = b"content addressed pack"
+            digest = hashlib.sha256(payload).hexdigest()
+            pack = home / "models" / "objects" / "sha256" / "content"
+            pack.parent.mkdir(parents=True)
+            pack.write_bytes(payload)
+
+            with self.assertRaisesRegex(ValueError, "canonical content-addressed"):
+                installed_pack_path.validate_installed_pack_path(
+                    str(home), str(pack), digest
+                )
+
+    def test_installed_pack_path_rejects_file_outside_home(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            home = root / "home"
+            home.mkdir()
+            pack = root / "outside.oasr"
+            pack.write_bytes(b"outside")
+            digest = hashlib.sha256(pack.read_bytes()).hexdigest()
+
+            with self.assertRaisesRegex(ValueError, "outside OPENASR_HOME"):
+                installed_pack_path.validate_installed_pack_path(
+                    str(home), str(pack), digest
+                )
+
+    def test_installed_pack_path_rejects_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            home = root / "home"
+            home.mkdir()
+            payload = b"outside content addressed pack"
+            digest = hashlib.sha256(payload).hexdigest()
+            outside = root / "outside-content"
+            outside.write_bytes(payload)
+            pack = home / "models" / "objects" / "sha256" / digest / "content"
+            pack.parent.mkdir(parents=True)
+            pack.symlink_to(outside)
+
+            with self.assertRaisesRegex(ValueError, "outside OPENASR_HOME"):
+                installed_pack_path.validate_installed_pack_path(
+                    str(home), str(pack), digest
+                )
+
+    def test_runner_ignores_inherited_models_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            workdir = root / "work"
+            inherited_models = root / "host-models"
+            capture = root / "models-dir.txt"
+            fake_openasr = root / "openasr"
+            fake_openasr.write_text(
+                """#!/usr/bin/env python3
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+models_dir = Path(os.environ["OPENASR_MODELS_DIR"])
+Path(os.environ["FAKE_OPENASR_ENV_CAPTURE"]).write_text(
+    str(models_dir), encoding="utf-8"
+)
+if sys.argv[1] == "pull":
+    payload = b"fake public pack"
+    digest = hashlib.sha256(payload).hexdigest()
+    pack = models_dir / "objects" / "sha256" / digest / "content"
+    pack.parent.mkdir(parents=True, exist_ok=True)
+    pack.write_bytes(payload)
+    print(f"installed\\tfake\\tq8\\t{pack}")
+elif sys.argv[1] == "transcribe":
+    output = Path(sys.argv[sys.argv.index("--output") + 1])
+    output.write_text("And so my fellow Americans ask not", encoding="utf-8")
+else:
+    raise SystemExit(f"unexpected command: {sys.argv[1]}")
+""",
+                encoding="utf-8",
+            )
+            fake_openasr.chmod(0o755)
+
+            result = run_helper(
+                "--bin",
+                str(fake_openasr),
+                "--workdir",
+                str(workdir),
+                "--catalog-url",
+                "model-registry/catalog.json",
+                env={
+                    "OPENASR_MODELS_DIR": str(inherited_models),
+                    "FAKE_OPENASR_ENV_CAPTURE": str(capture),
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                Path(capture.read_text(encoding="utf-8")),
+                workdir / "openasr-home" / "models",
+            )
+            self.assertFalse(inherited_models.exists())
+
     def test_dry_run_summary_is_redacted_and_structured(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             summary_json = Path(temp) / "nested" / "summary.json"


### PR DESCRIPTION
## Summary

Restore the strict public-HF pull-to-transcribe release gate after the model store moved installed packs to content-addressed objects, and prepare accurate 0.1.31 release notes.

## Why

The latest scheduled public-HF E2E successfully downloaded and verified Moonshine, then failed because the evidence helper required the installed path to end in .oasr. The current store correctly returns models/objects/sha256/<digest>/content. The helper also inherited OPENASR_MODELS_DIR, which could escape its isolated test home.

## Changes

- accept only legacy .oasr files or the exact canonical content-addressed object path whose directory digest matches the downloaded bytes
- pin OPENASR_MODELS_DIR to the E2E work directory
- reject paths outside OPENASR_HOME, malformed layouts, digest mismatches, and symlink escapes
- add no-network helper tests and an environment-isolation fake-CLI integration test
- update Unreleased notes and correct the stale public-binary limitation

## Tests run

- [ ] cargo fmt --check
- [ ] cargo clippy --all-targets -- -D warnings
- [ ] cargo nextest run --workspace
- [ ] cargo test --workspace --doc
- [ ] cargo deny check
- [x] python3 -m unittest discover -s tooling/public-hf-e2e -p test_*.py (13 passed)
- [x] bash -n tooling/public-hf-e2e/run.sh
- [x] python3 -m py_compile for both Python helpers
- [x] cargo build -p openasr-cli --release
- [x] strict anonymous public-HF Moonshine q8 pull and native CPU transcription
- [x] Gitleaks v8.30.1 full-history scan: 5,339 commits; 23 reviewed non-secret identifiers/cache keys; 0 untriaged findings after baseline

## Manual smoke checks

The strict public-HF flow downloaded and verified the canonical Moonshine q8 pack (34,360,896 bytes), accepted its content-addressed store path, and transcribed the JFK fixture to the expected 106-character text.

## Model-family changes (when applicable)

Not applicable. No model runtime, graph, quantization, catalog, or family descriptor changed.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR does not bump the workspace version, create v0.1.31, tag, publish release assets, or claim real HIP hardware acceptance.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside crates/openasr-core/third_party/openasr-ggml.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and own its maintenance.
- AI usage disclosure: YES - implementation support and verification; the maintainer reviewed and owns the change.