### PR TITLE
perf(metal): select validated Apple Silicon routes

### DIFF
--- a/crates/openasr-cli/src/bench_suite_cli.rs
+++ b/crates/openasr-cli/src/bench_suite_cli.rs
@@ -147,8 +147,8 @@ pub(crate) fn bench_suite(
 /// the pack is absent and the entry is `optional` (host lacks this pack).
 /// The bench passes select the backend via OPENASR_GGML_BACKEND. Map it to an
 /// explicit per-request execution target so families whose Auto default
-/// differs from the env-global (xasr stays CPU on Auto) actually run what the
-/// pass label claims — a metal pass must never silently record CPU numbers.
+/// excludes Metal on Apple Silicon actually run what the pass label claims --
+/// a metal pass must never silently record CPU numbers.
 fn bench_execution_target() -> Option<ExecutionTarget> {
     let raw = std::env::var("OPENASR_GGML_BACKEND").ok()?;
     let value = raw.trim();

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -4817,17 +4817,16 @@ mod tests {
     }
 
     #[test]
-    fn family_auto_gpu_policy_lookup_matches_dolphin_and_xasr_gates() {
+    fn family_auto_gpu_policy_lookup_matches_measured_metal_gates() {
         use crate::ggml_runtime::AutoGpuPolicy;
 
         // Regression pin: dolphin lets Auto pick any GPU-class backend
         // (it flipped from CPU-pinned once its encoder weight-placement fix
-        // let Metal truly offload and beat CPU end-to-end). xasr-zipformer is
-        // `ExceptMetal`: Auto still prefers the generic GPU lane but falls
-        // back to CPU on Apple Silicon Metal specifically per the platform
-        // performance audit. qwen measured a similar Metal slowdown but is
-        // deliberately left `AllBackends` pending a dedicated follow-up (see
-        // `models::qwen::graph_config`).
+        // let Metal truly offload and beat CPU end-to-end). xasr-zipformer and
+        // moonshine are `ExceptMetal`: Auto still prefers the generic GPU lane
+        // but falls back to CPU on Apple Silicon Metal for their dispatch-bound
+        // graph shapes. Qwen stays explicitly `AllBackends`; a family-specific
+        // platform gate must not spread to a neighboring architecture.
         assert_eq!(
             crate::arch::family_auto_gpu_policy_for_model_architecture(
                 crate::arch::XASR_ZIPFORMER_GGML_ARCHITECTURE_ID
@@ -4839,6 +4838,12 @@ mod tests {
                 crate::arch::DOLPHIN_GGML_ARCHITECTURE_ID
             ),
             AutoGpuPolicy::AllBackends
+        );
+        assert_eq!(
+            crate::arch::family_auto_gpu_policy_for_model_architecture(
+                crate::arch::MOONSHINE_GGML_ARCHITECTURE_ID
+            ),
+            AutoGpuPolicy::ExceptMetal
         );
         assert_eq!(
             crate::arch::family_auto_gpu_policy_for_model_architecture(
@@ -4890,9 +4895,8 @@ mod tests {
         // "cpu" regardless of what the generic resolver would pick.
         assert_eq!(label_for(AutoGpuPolicy::Never), "cpu");
 
-        // Auto, family gate enabled (`AllBackends` shape, every builtin
-        // family but the three `ExceptMetal` ones): reports exactly what the
-        // generic resolver picks -- unchanged behavior.
+        // Auto, family gate enabled (`AllBackends` shape): reports exactly
+        // what the generic resolver picks -- unchanged behavior.
         let generic_auto_label = match GgmlCpuGraphConfig::runtime_default().backend {
             GgmlCpuGraphBackend::Cpu => "cpu",
             GgmlCpuGraphBackend::Metal => "metal",

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -2275,7 +2275,12 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
         },
         optimization_contract: OpenAsrOptimizationContract {
             prefer_cpu_decoder_for_multichunk_metal: false,
-            auto_gpu_policy: AutoGpuPolicy::AllBackends,
+            // The reusable incremental decoder closed Moonshine's earlier
+            // per-step graph rebuild, but the small Apple Silicon graph remains
+            // dispatch-bound. Keep explicit Metal available as a lower-resident-
+            // memory trade-off, while Auto chooses CPU on Apple Silicon and
+            // still permits the generic CUDA/HIP/Vulkan accelerated lane.
+            auto_gpu_policy: AutoGpuPolicy::ExceptMetal,
             encoder_attention_span: OpenAsrEncoderAttentionSpan::GlobalQuadratic {
                 max_safe_chunk_seconds: DEFAULT_ENCODER_SAFE_CHUNK_SECONDS,
             },
@@ -3542,22 +3547,13 @@ mod tests {
     /// Pins `auto_gpu_policy` per builtin architecture. Most builtins let
     /// Auto pick any GPU-class backend automatically when available
     /// (`AllBackends`), matching how `resolve_runtime_backend` behaves
-    /// generically. xasr-zipformer alone is `ExceptMetal` -- Auto still
+    /// generically. xasr-zipformer and moonshine are `ExceptMetal` -- Auto still
     /// prefers the generic GPU lane (CUDA/HIP/Vulkan) but falls back to CPU
-    /// on Apple Silicon Metal specifically, per a platform-specific
-    /// performance audit that found its streaming chunk graph dispatch-bound
-    /// and net-slower on Metal (an explicit `--backend metal` request is
-    /// unaffected). Two other families measured a similar Metal slowdown but
-    /// are deliberately NOT gated this round: qwen (the slowdown looks like a
-    /// fixed size x quant platform trade-off, not a qwen-specific bug --
-    /// mimo/firered-llm share qwen's exact decode driver and measure faster
-    /// on Metal at their 8B @ q4_k config -- but that read awaits a dedicated
-    /// follow-up before it's baked into the default; see
-    /// `models::qwen::graph_config`) and moonshine (this audit found and
-    /// applied an actual architectural fix -- decoder scheduler-off to
-    /// activate the reusable incremental decode graph, see
-    /// `models::moonshine::graph_config` -- rather than gating around the
-    /// problem). See the field doc and each family's own executor/
+    /// on Apple Silicon Metal specifically because their current graph shapes
+    /// are dispatch-bound there (an explicit `--backend metal` request is
+    /// unaffected). Qwen remains explicitly `AllBackends`; this table must not
+    /// broaden one family's platform gate to neighboring architectures.
+    /// See the field doc and each family's own executor/
     /// `graph_config` doc comment for detail. A silent flip of this table
     /// would silently deny Auto users a GPU their hardware supports (or
     /// silently regress them onto a Metal path known to be slower), for any
@@ -3587,7 +3583,7 @@ mod tests {
                 XASR_ZIPFORMER_GGML_ARCHITECTURE_ID,
                 AutoGpuPolicy::ExceptMetal,
             ),
-            (MOONSHINE_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
+            (MOONSHINE_GGML_ARCHITECTURE_ID, AutoGpuPolicy::ExceptMetal),
             (DOLPHIN_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
             (SENSEVOICE_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
             (FIRERED_AED_GGML_ARCHITECTURE_ID, AutoGpuPolicy::AllBackends),
@@ -3640,38 +3636,45 @@ mod tests {
             ResolvedFamilyRuntimeInput,
         };
 
-        let model_architecture = XASR_ZIPFORMER_GGML_ARCHITECTURE_ID;
-        let policy = family_auto_gpu_policy_for_model_architecture(model_architecture);
-        assert_eq!(policy, AutoGpuPolicy::ExceptMetal);
+        for model_architecture in [
+            XASR_ZIPFORMER_GGML_ARCHITECTURE_ID,
+            MOONSHINE_GGML_ARCHITECTURE_ID,
+        ] {
+            let policy = family_auto_gpu_policy_for_model_architecture(model_architecture);
+            assert_eq!(policy, AutoGpuPolicy::ExceptMetal);
 
-        // Auto: gated to CPU only if the generic resolver would have picked
-        // Metal specifically. `resolve` is a pure function here -- no
-        // thread-local install/read round-trip.
-        let resolved = GgmlCpuGraphConfig::runtime_default().backend;
-        let gated = ResolvedFamilyRuntimeInput::resolve(None, policy).backend();
-        if matches!(resolved, GgmlCpuGraphBackend::Metal) {
-            assert_eq!(gated, GgmlCpuGraphBackend::Cpu);
-        } else {
-            assert_eq!(gated, resolved);
-        }
-        assert_ne!(gated, GgmlCpuGraphBackend::Metal);
+            // Auto: gated to CPU only if the generic resolver would have picked
+            // Metal specifically. `resolve` is a pure function here -- no
+            // thread-local install/read round-trip.
+            let resolved = GgmlCpuGraphConfig::runtime_default().backend;
+            let gated = ResolvedFamilyRuntimeInput::resolve(None, policy).backend();
+            if matches!(resolved, GgmlCpuGraphBackend::Metal) {
+                assert_eq!(gated, GgmlCpuGraphBackend::Cpu);
+            } else {
+                assert_eq!(gated, resolved);
+            }
+            assert_ne!(gated, GgmlCpuGraphBackend::Metal);
 
-        // An explicit accelerated request always wins, even on Metal: the
-        // gate only ever pins Auto, so an explicit preference must still
-        // resolve to a GPU-class backend regardless of `policy`.
-        let accelerated = ResolvedFamilyRuntimeInput::resolve(
-            Some(RequestBackendPreference::Accelerated),
-            policy,
-        )
-        .backend();
-        assert!(accelerated.is_gpu_class());
+            // An explicit accelerated request always wins, even on Metal: the
+            // gate only ever pins Auto, so an explicit preference must still
+            // resolve to a GPU-class backend regardless of `policy`.
+            let accelerated = ResolvedFamilyRuntimeInput::resolve(
+                Some(RequestBackendPreference::Accelerated),
+                policy,
+            )
+            .backend();
+            assert!(accelerated.is_gpu_class());
 
-        // An explicit CPU-only request always wins too.
-        assert_eq!(
-            ResolvedFamilyRuntimeInput::resolve(Some(RequestBackendPreference::CpuOnly), policy)
+            // An explicit CPU-only request always wins too.
+            assert_eq!(
+                ResolvedFamilyRuntimeInput::resolve(
+                    Some(RequestBackendPreference::CpuOnly),
+                    policy,
+                )
                 .backend(),
-            GgmlCpuGraphBackend::Cpu
-        );
+                GgmlCpuGraphBackend::Cpu
+            );
+        }
     }
 
     /// Pins `encoder_attention_span` per builtin architecture -- the single

--- a/crates/openasr-core/src/models/aux_pack_registry.rs
+++ b/crates/openasr-core/src/models/aux_pack_registry.rs
@@ -89,6 +89,21 @@ const AUX_CPU_AND_FULL_DEVICE_EXECUTION: ExecutionCapabilities = ExecutionCapabi
         AcceleratedPlacementCapabilities::FULL_DEVICE,
     );
 
+const AUX_CPU_AND_NON_METAL_FULL_DEVICE_EXECUTION: ExecutionCapabilities =
+    ExecutionCapabilities::new(true)
+        .with_provider(
+            ExecutionProvider::Cuda,
+            AcceleratedPlacementCapabilities::FULL_DEVICE,
+        )
+        .with_provider(
+            ExecutionProvider::Hip,
+            AcceleratedPlacementCapabilities::FULL_DEVICE,
+        )
+        .with_provider(
+            ExecutionProvider::Vulkan,
+            AcceleratedPlacementCapabilities::FULL_DEVICE,
+        );
+
 /// Which pull-time error prefix a matched aux family reports, preserving the
 /// exact wording `api::backend::native`'s tests assert on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -310,13 +325,15 @@ const AUX_PACK_DESCRIPTORS: &[AuxPackDescriptor] = &[
         architecture_id: crate::models::qwen::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
         catalog_family_id: "qwen3-forced-aligner",
         kind: AuxPackKind::ForcedAlignment,
+        // Timestamp classification contains near-tied bins whose backend-level
+        // floating-point differences are amplified by the reference LIS repair.
+        // Metal does not currently satisfy this runtime's timestamp parity
+        // contract. Treat that as a provider capability boundary, rather than
+        // an Auto preference, while preserving the existing CUDA/HIP/Vulkan
+        // capability declarations.
         execution_policy: AuxiliaryExecutionPolicy::RequestScoped {
-            capabilities: AUX_CPU_AND_FULL_DEVICE_EXECUTION,
-            // The runtime has no partial-offload topology. Metal is fast and
-            // remains available explicitly, but current Q8_0/FP16 parity
-            // evidence has rare boundary deviations above the model's 80 ms
-            // resolution. Auto therefore keeps the quality-safe CPU path.
-            auto_gpu_policy: AutoGpuPolicy::ExceptMetal,
+            capabilities: AUX_CPU_AND_NON_METAL_FULL_DEVICE_EXECUTION,
+            auto_gpu_policy: AutoGpuPolicy::AllBackends,
         },
         ownership: AuxiliaryRuntimeOwnership::InvocationTransient,
         quantization_classification:
@@ -443,7 +460,7 @@ mod tests {
     }
 
     #[test]
-    fn forced_aligner_auto_avoids_metal_without_disabling_other_accelerators() {
+    fn forced_aligner_omits_unvalidated_metal_without_disabling_other_accelerators() {
         let policy = auxiliary_execution_policy(
             crate::models::qwen::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
         );
@@ -454,19 +471,26 @@ mod tests {
         else {
             panic!("forced aligner must remain request-scoped");
         };
-        assert_eq!(auto_gpu_policy, AutoGpuPolicy::ExceptMetal);
+        assert_eq!(auto_gpu_policy, AutoGpuPolicy::AllBackends);
         assert!(capabilities.supports_cpu());
-        assert!(capabilities.supports(
+        assert!(!capabilities.supports(
             ExecutionProvider::Metal,
             crate::device::execution_policy::ExecutionPlacement::FullDevice,
         ));
-        assert!(
-            !capabilities.supports(
-                ExecutionProvider::Metal,
+        for provider in [
+            ExecutionProvider::Cuda,
+            ExecutionProvider::Hip,
+            ExecutionProvider::Vulkan,
+        ] {
+            assert!(capabilities.supports(
+                provider,
+                crate::device::execution_policy::ExecutionPlacement::FullDevice,
+            ));
+            assert!(!capabilities.supports(
+                provider,
                 crate::device::execution_policy::ExecutionPlacement::Hybrid,
-            ),
-            "forced aligner has no partial-offload topology"
-        );
+            ));
+        }
     }
 
     #[test]

--- a/crates/openasr-core/src/models/moonshine/graph_config.rs
+++ b/crates/openasr-core/src/models/moonshine/graph_config.rs
@@ -60,7 +60,9 @@ pub(crate) fn moonshine_encoder_graph_config(backend: GgmlCpuGraphBackend) -> Gg
 /// now gets the same persistent reused graph qwen's decoder already uses.
 /// This is a pure backend/scheduling choice: output must stay byte-identical
 /// (verified via the moonshine golden test), since it does not change which
-/// arithmetic runs, only whether the graph is rebuilt per token.
+/// arithmetic runs, only whether the graph is rebuilt per token. This remains
+/// the explicit-Metal path; the architecture's measured Auto policy chooses
+/// CPU on Apple Silicon because the small end-to-end graph is dispatch-bound.
 pub(crate) fn moonshine_decoder_graph_config(
     backend: GgmlCpuGraphBackend,
     prefer_cpu_backend: bool,

--- a/tooling/model-family-inventory.v1.json
+++ b/tooling/model-family-inventory.v1.json
@@ -1014,7 +1014,7 @@
       },
       "optimization": {
         "prefer_cpu_decoder_for_multichunk_metal": false,
-        "auto_gpu_policy": "all-backends",
+        "auto_gpu_policy": "except-metal",
         "encoder_attention_span": "global-quadratic",
         "encoder_attention_max_safe_chunk_seconds": 30.0
       },


### PR DESCRIPTION
## Summary

- pin the merged Metal residency, fused-binary, and normalization fixes from `openasr-ggml` PR #10
- keep explicit Metal support for Moonshine while making Auto prefer CPU on Apple Silicon
- remove the unvalidated Metal capability from Qwen3 ForcedAligner while preserving CPU, CUDA, HIP, and Vulkan routes
- regenerate the model-family inventory and update policy regression coverage

## Why

Metal was not uniformly the fastest or quality-valid route across the published model matrix. Moonshine was consistently faster on CPU in the reference Apple Silicon measurements, while ForcedAligner Metal output exceeded the repository timestamp parity contract. At the backend layer, residency teardown and operator edge cases also needed fixes at their shared Metal ownership boundary.

The resulting policy is fail-closed: Auto selects only validated routes, explicit Moonshine Metal remains available, and ForcedAligner no longer advertises a Metal route that does not meet its quality contract.

## Validation

- independent final architecture and correctness review: PASS
- `openasr-ggml` PR #10: all required checks passed
- Metal backend operator suite: 12,984/12,984 passed
- workspace nextest: 4,154/4,154 passed, 192 skipped
- Moonshine family conformance: 3,504/3,504 passed, 178 skipped
- publish-model Python suite: 268/268 passed
- 14 published ASR families: CPU/Metal transcript hashes matched for every pair
- long-duration auxiliary gates passed for Segmentation3, DiariZen CPU/Metal, FireRedVAD, ReDimNet2, and ForcedAligner CPU
- installed model production preflight: 9/9 passed
- format, clippy, doctest, generated inventory, catalog consistency, and diff hygiene checks passed

The performance policy is scoped to the measured hardware and published packs; it does not claim universal optimality across future Apple chips.
