### PR TITLE
fix(qwen): restore policy-guarded forced aligner q4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Qwen3 Forced Aligner import and runtime validation now accept the reserved
+  policy-guarded `q4_k` tier. Boundary-sensitive audio, token-embedding, and
+  timestamp-head matrices remain Q8_0; legacy all-Q4, Q3, and mislabeled mixed
+  packs fail closed. The downloadable catalog continues to recommend Q8_0 until
+  a separately authorized catalog release enables the new tier.
 - Core: built-in model families now share the runtime admission, resource
   ownership, request-progress, and importer/tokenizer building blocks while
   retaining their family-specific graph and decode behavior.

--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -722,9 +722,9 @@ pub(crate) enum ModelPackCommand {
         #[arg(long)]
         json: bool,
     },
-    /// Audit a pack's tensor quantization against the current policy: the
-    /// audio-encoder Q8_0 floor (unconditional) plus, when `--quant` names the
-    /// tier the pack claims, the declared-tier ceiling. Reads only the GGUF
+    /// Audit a pack's tensor quantization against the current policy: every
+    /// family-specific semantic precision floor plus, when `--quant` names
+    /// the tier the pack claims, the declared-tier ceiling. Reads only the GGUF
     /// header, so it also works on published, remotely-hosted packs via an
     /// HTTP `Range` prefix fetch -- no source weights, no download, no
     /// inference.
@@ -1185,6 +1185,7 @@ pub(crate) enum ImportQwen3AsrQuantization {
 pub(crate) enum ImportQwenForcedAlignerQuantization {
     Fp16,
     Q8_0,
+    Q4_K,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -1715,7 +1715,7 @@ mod tests {
     }
 
     #[test]
-    fn forced_aligner_import_cli_accepts_q8_and_rejects_q4() {
+    fn forced_aligner_import_cli_accepts_q8_and_policy_guarded_q4_k() {
         let base = [
             "openasr",
             "model-pack",
@@ -1744,9 +1744,42 @@ mod tests {
         };
         assert_eq!(quantization, ImportQwenForcedAlignerQuantization::Q8_0);
 
-        let error = Cli::try_parse_from(base.into_iter().chain(["q4-k"]))
-            .expect_err("q4_k must not be exposed for forced-aligner imports");
-        assert!(error.to_string().contains("invalid value 'q4-k'"));
+        let cli = Cli::try_parse_from(base.into_iter().chain(["q4-k"]))
+            .expect("the policy-guarded q4_k tier must parse");
+        let Command::ModelPack {
+            command: ModelPackCommand::Import { command },
+        } = cli.command
+        else {
+            panic!("expected forced-aligner import command");
+        };
+        let ImportCommand::QwenForcedAligner { quantization, .. } = *command else {
+            panic!("expected forced-aligner import command");
+        };
+        assert_eq!(quantization, ImportQwenForcedAlignerQuantization::Q4_K);
+
+        let error = Cli::try_parse_from(base.into_iter().chain(["q4-k-m"]))
+            .expect_err("q4_k_m must not become a second forced-aligner product identity");
+        assert!(error.to_string().contains("invalid value 'q4-k-m'"));
+    }
+
+    #[test]
+    fn audit_quant_cli_accepts_the_policy_guarded_q4_k_tier() {
+        let cli = Cli::try_parse_from([
+            "openasr",
+            "model-pack",
+            "audit-quant",
+            "forced-aligner-q4_k.oasr",
+            "--quant",
+            "q4-k",
+        ])
+        .expect("q4-k must be an auditable declared tier");
+        let Command::ModelPack {
+            command: ModelPackCommand::AuditQuant { quant, .. },
+        } = cli.command
+        else {
+            panic!("expected audit-quant command");
+        };
+        assert_eq!(quant, Some(AuditQuantTier::Q4_K));
     }
 
     #[test]

--- a/crates/openasr-cli/src/model_pack_cli.rs
+++ b/crates/openasr-cli/src/model_pack_cli.rs
@@ -944,11 +944,17 @@ fn import_qwen_forced_aligner_local_command(
     license_source: &str,
     quantization: ImportQwenForcedAlignerQuantization,
 ) -> Result<()> {
+    let package_variant = match quantization {
+        ImportQwenForcedAlignerQuantization::Q4_K => {
+            Some(package_variant.unwrap_or("q4_k").to_string())
+        }
+        _ => package_variant.map(ToOwned::to_owned),
+    };
     let request = Qwen3ForcedAlignerLocalSourceImportRequest {
         source_root: source_root.to_path_buf(),
         output_root: output_root.to_path_buf(),
         package_id: package_id.to_string(),
-        package_variant: package_variant.map(ToOwned::to_owned),
+        package_variant,
         source_name: source_name.to_string(),
         source_revision: source_revision.to_string(),
         license_name: license_name.to_string(),
@@ -959,6 +965,9 @@ fn import_qwen_forced_aligner_local_command(
             }
             ImportQwenForcedAlignerQuantization::Q8_0 => {
                 openasr_core::Qwen3AsrRuntimeQuantizationMode::Q8_0
+            }
+            ImportQwenForcedAlignerQuantization::Q4_K => {
+                openasr_core::Qwen3AsrRuntimeQuantizationMode::Q4_K
             }
         },
     };
@@ -1550,6 +1559,15 @@ mod tests {
                 None => unsafe { std::env::remove_var(self.name) },
             }
         }
+    }
+
+    #[test]
+    fn pack_filename_tier_recognizes_q4_k_suffix() {
+        use openasr_core::models::pack_quant::PackQuant;
+        assert_eq!(
+            pack_tier_from_pack_filename(Path::new("forced-aligner-q4_k.oasr")),
+            Some(PackQuant::Q4_K)
+        );
     }
 
     #[test]

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -1047,7 +1047,7 @@ pub(super) fn ensure_cli_word_timestamps_pack_installed(
         std::env::var_os("OPENASR_FORCED_ALIGNER_PACK").filter(|value| !value.is_empty())
     {
         bail!(
-            "OPENASR_FORCED_ALIGNER_PACK points to a missing or incompatible forced-alignment pack: {}\nReplace it with a qwen3-forced-aligner-0.6b Q8_0 pack, or unset OPENASR_FORCED_ALIGNER_PACK and run: openasr pull qwen3-forced-aligner-0.6b:q8_0",
+            "OPENASR_FORCED_ALIGNER_PACK points to a missing or incompatible forced-alignment pack: {}\nReplace it with a current qwen3-forced-aligner-0.6b pack, or unset OPENASR_FORCED_ALIGNER_PACK and run: openasr pull qwen3-forced-aligner-0.6b",
             Path::new(&path).display()
         );
     }
@@ -1055,7 +1055,7 @@ pub(super) fn ensure_cli_word_timestamps_pack_installed(
     if consent.offline {
         return Err(crate::consent::CliExit::new(
             crate::consent::ExitCode::ModelNotInstalled,
-            "The Qwen3 forced-alignment capability pack is missing or incompatible with the current Q8_0 contract, and OpenASR is offline.\nRun: openasr pull qwen3-forced-aligner-0.6b:q8_0",
+            "The Qwen3 forced-alignment capability pack is missing or incompatible with the current precision contract, and OpenASR is offline.\nRun: openasr pull qwen3-forced-aligner-0.6b",
         )
         .into());
     }
@@ -2015,11 +2015,12 @@ mod tests {
             .expect("offline capability failure must preserve the stable CLI exit contract");
         assert_eq!(exit.code, crate::consent::ExitCode::ModelNotInstalled);
         assert!(exit.message.contains("OpenASR is offline"));
-        assert!(exit.message.contains("qwen3-forced-aligner-0.6b:q8_0"));
+        assert!(exit.message.contains("qwen3-forced-aligner-0.6b"));
+        assert!(!exit.message.contains(":q8_0"));
     }
 
     #[test]
-    fn invalid_forced_aligner_override_fails_with_q8_replacement_instructions() {
+    fn invalid_forced_aligner_override_points_to_the_catalog_default() {
         let _guard = env_lock();
         let temp = tempfile::tempdir().unwrap();
         let _home = EnvVarRestore::set_os("OPENASR_HOME", temp.path());
@@ -2043,15 +2044,15 @@ mod tests {
             error.contains(&invalid_pack.display().to_string()),
             "{error}"
         );
-        assert!(error.contains("Q8_0"), "{error}");
         assert!(
             error.contains("unset OPENASR_FORCED_ALIGNER_PACK"),
             "{error}"
         );
         assert!(
-            error.contains("openasr pull qwen3-forced-aligner-0.6b:q8_0"),
+            error.contains("openasr pull qwen3-forced-aligner-0.6b"),
             "{error}"
         );
+        assert!(!error.contains(":q8_0"), "{error}");
     }
 
     #[test]

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -3970,7 +3970,7 @@ mod tests {
     /// pack is claimed by the aux table (never ASR selection) yet still
     /// rejected.
     #[test]
-    fn pull_contract_validation_enforces_forced_aligner_q8_floor_and_metadata() {
+    fn pull_contract_validation_enforces_forced_aligner_mixed_floor_and_metadata() {
         let temp = tempfile::tempdir().unwrap();
 
         let mut complete_metadata = std::collections::BTreeMap::new();
@@ -3981,6 +3981,10 @@ mod tests {
         complete_metadata.insert(
             "openasr.package.version".to_string(),
             crate::ggml_runtime::GgufWriteValue::String("1".to_string()),
+        );
+        complete_metadata.insert(
+            "openasr.model.id".to_string(),
+            crate::ggml_runtime::GgufWriteValue::String("qwen3-forced-aligner-0.6b".to_string()),
         );
         for key in [
             "qwen3_forced_aligner.audio.sample_rate_hz",
@@ -4032,7 +4036,7 @@ mod tests {
 
         let q4_values = vec![0.0f32; 256 * 256];
         let q4_tensors = [crate::ggml_runtime::GgufWriteTensor {
-            name: "blk.0.attn_q.weight".to_string(),
+            name: "audio.blk.0.attn_q.weight".to_string(),
             dims: vec![256, 256],
             tensor_type: crate::ggml_runtime::GgufWriteTensorType::Q4_K,
             data: crate::ggml_runtime::quantize_f32_to_ggml_tensor_data(
@@ -4045,7 +4049,7 @@ mod tests {
         let q4_path = temp.path().join("forced-aligner-q4.oasr");
         crate::ggml_runtime::write_gguf_file_v0(&q4_path, &complete_metadata, &q4_tensors).unwrap();
         let q4_error = verify_native_runtime_model_pack_path(&q4_path)
-            .expect_err("a Q4 forced-aligner matrix must fail the public pack verifier");
+            .expect_err("a Q4 forced-aligner audio matrix must fail the public pack verifier");
         assert!(q4_error.contains("Q8_0"), "got: {q4_error}");
 
         crate::test_process_env::with_test_process_env(

--- a/crates/openasr-core/src/models/aux_pack_registry.rs
+++ b/crates/openasr-core/src/models/aux_pack_registry.rs
@@ -213,7 +213,10 @@ fn validate_forced_aligner(
 ) -> Result<(), String> {
     crate::models::qwen::validate_forced_aligner_runtime_pack_contract(metadata)
         .and_then(|()| {
-            crate::models::qwen::validate_forced_aligner_quantization_contract(tensor_index)
+            crate::models::qwen::validate_forced_aligner_quantization_contract(
+                metadata,
+                tensor_index,
+            )
         })
         .map_err(|error| error.to_string())
 }
@@ -302,12 +305,15 @@ const AUX_PACK_DESCRIPTORS: &[AuxPackDescriptor] = &[
         architecture_id: crate::models::qwen::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
         catalog_family_id: "qwen3-forced-aligner",
         kind: AuxPackKind::ForcedAlignment,
-        // Every published pack satisfies the runtime's semantic Q8 floor.
-        // Metal retains its validated precise FullDevice graph. CUDA and
-        // Vulkan share a Hybrid topology that runs the audio encoder without
-        // flash attention on the selected GPU while retaining numerically
-        // sensitive decoder/logits state on CPU. HIP remains fail-closed until
-        // the same timestamp and performance gates have passed there.
+        // Every published pack satisfies the runtime's semantic mixed-precision
+        // floor: precision-sensitive matrices stay Q8_0 or higher while the
+        // policy-guarded q4_k tier may quantize eligible decoder matrices.
+        // Metal retains its validated precise FullDevice graph. CUDA and Vulkan
+        // share a Hybrid topology that runs the audio encoder without flash
+        // attention on the selected GPU while retaining numerically sensitive
+        // decoder/logits state on CPU. HIP remains fail-closed until the same
+        // timestamp and performance gates have passed there. Auto stays off
+        // Metal because its near-tie timestamp drift still exceeds the envelope.
         execution_policy: AuxiliaryExecutionPolicy::RequestScoped {
             capabilities: AUX_CPU_METAL_FULL_DEVICE_CUDA_VULKAN_HYBRID_EXECUTION,
             auto_gpu_policy: AutoGpuPolicy::ExceptMetal,
@@ -701,7 +707,7 @@ mod tests {
 
     /// A complete, minimal set of `qwen3_forced_aligner.*` + tokenizer keys --
     /// mirrors exactly what a real published pack carries (verified against
-    /// the rebuilt `qwen3-forced-aligner-0.6b-q8_0.oasr` pack's GGUF header:
+    /// the rebuilt `qwen3-forced-aligner-0.6b` packs' shared GGUF header:
     /// no `openasr.audio.frontend` / `openasr.decode.policy`, only these).
     fn valid_forced_aligner_metadata() -> GgufMetadata {
         use crate::ggml_runtime::GgufMetadataValue;
@@ -711,6 +717,10 @@ mod tests {
             GgufMetadataValue::String(
                 crate::models::qwen::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID.to_string(),
             ),
+        );
+        values.insert(
+            "openasr.model.id".to_string(),
+            GgufMetadataValue::String("qwen3-forced-aligner-0.6b".to_string()),
         );
         for key in [
             "qwen3_forced_aligner.audio.sample_rate_hz",
@@ -768,10 +778,11 @@ mod tests {
     }
 
     #[test]
-    fn forced_aligner_pack_rejects_sub_q8_decoder_weights_on_every_route() {
+    fn forced_aligner_pack_accepts_policy_guarded_q4_k_and_rejects_q3_decoder_weights() {
         let metadata = valid_forced_aligner_metadata();
         let q8 = crate::models::pack_quant_audit::GGML_TYPE_Q8_0 as i32;
         let q4 = crate::models::pack_quant_audit::GGML_TYPE_Q4_K as i32;
+        let q3 = crate::models::pack_quant_audit::GGML_TYPE_Q3_K as i32;
         let (_, q8_result) = validate_aux_runtime_pack_contract(
             Path::new("/nonexistent"),
             &metadata,
@@ -780,14 +791,30 @@ mod tests {
         .expect("forced-aligner architecture must be claimed");
         q8_result.expect("Q8 decoder weight must satisfy the pack contract");
 
+        let mut q4_values = metadata.values().clone();
+        q4_values.insert(
+            "openasr.model.id".to_string(),
+            crate::ggml_runtime::GgufMetadataValue::String(
+                "qwen3-forced-aligner-0.6b:q4_k".to_string(),
+            ),
+        );
+        let q4_metadata = GgufMetadata::from_values_for_test(q4_values);
         let (_, q4_result) = validate_aux_runtime_pack_contract(
             Path::new("/nonexistent"),
-            &metadata,
+            &q4_metadata,
             &forced_aligner_tensor_index(q4),
         )
         .expect("forced-aligner architecture must be claimed");
-        let error = q4_result.expect_err("Q4 decoder weight must fail closed");
-        assert!(error.contains("require Q8_0 or higher"), "got: {error}");
+        q4_result.expect("Q4_K decoder weight must satisfy the q4_k contract");
+
+        let (_, q3_result) = validate_aux_runtime_pack_contract(
+            Path::new("/nonexistent"),
+            &q4_metadata,
+            &forced_aligner_tensor_index(q3),
+        )
+        .expect("forced-aligner architecture must be claimed");
+        let error = q3_result.expect_err("Q3 decoder weight must fail closed");
+        assert!(error.contains("require q4_k"), "got: {error}");
     }
 
     /// Negative direction: a forced-aligner pack missing a required

--- a/crates/openasr-core/src/models/pack_quant_audit.rs
+++ b/crates/openasr-core/src/models/pack_quant_audit.rs
@@ -758,7 +758,7 @@ mod tests {
     }
 
     #[test]
-    fn forced_aligner_matrix_below_q8_fails_the_same_floor() {
+    fn forced_aligner_q4_k_keeps_only_sensitive_matrices_at_q8() {
         let view = view_with(
             Some(crate::models::qwen::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID),
             vec![
@@ -769,10 +769,9 @@ mod tests {
         );
         let report = audit_quant_floor(&view, Some(PackQuant::Q4_K)).expect("auditable");
         assert_eq!(report.block_quant_tensors, 3);
-        assert_eq!(report.q8_floor_block_quant_tensors, 3);
-        assert_eq!(report.violations.len(), 2);
+        assert_eq!(report.q8_floor_block_quant_tensors, 2);
+        assert_eq!(report.violations.len(), 1);
         assert_eq!(report.violations[0].tensor, "output.weight");
-        assert_eq!(report.violations[1].tensor, "blk.0.ffn_gate.weight");
         assert!(
             report
                 .violations
@@ -782,7 +781,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_index_uses_the_same_forced_aligner_q8_floor() {
+    fn runtime_index_uses_the_same_forced_aligner_mixed_floor() {
         let architecture = crate::models::qwen::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID;
         let compliant = runtime_index(&[
             ("output.weight", GGML_TYPE_Q8_0 as i32),
@@ -807,11 +806,7 @@ mod tests {
                 .iter()
                 .map(|violation| violation.tensor.as_str())
                 .collect::<Vec<_>>(),
-            [
-                "output.weight",
-                "token_embd.weight",
-                "blk.0.ffn_gate.weight"
-            ]
+            ["output.weight", "token_embd.weight"]
         );
     }
 

--- a/crates/openasr-core/src/models/pack_requant.rs
+++ b/crates/openasr-core/src/models/pack_requant.rs
@@ -580,17 +580,13 @@ mod tests {
     }
 
     #[test]
-    fn semantic_q8_floor_preserves_every_forced_aligner_matrix() {
+    fn semantic_q8_floor_preserves_forced_aligner_sensitive_matrices() {
         let contract = TensorQuantizationContract::SemanticRolesV1 {
             model_architecture: crate::models::qwen::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
             classify: crate::models::qwen::forced_aligner_tensor_role,
             quantized_axis: crate::models::pack_quant::QuantizedAxis::First,
         };
-        for tensor in [
-            "output.weight",
-            "token_embd.weight",
-            "blk.0.ffn_gate.weight",
-        ] {
+        for tensor in ["output.weight", "token_embd.weight"] {
             assert!(
                 preserve_q8_floor_source_tensor(
                     contract,
@@ -608,9 +604,17 @@ mod tests {
                 Err(PackRequantError::SourceBelowQ8Floor { .. })
             ));
         }
+        assert!(
+            !preserve_q8_floor_source_tensor(
+                contract,
+                "blk.0.ffn_gate.weight",
+                GgufWriteTensorType::Q8_0.ggml_type(),
+            )
+            .expect("decoder blocks do not carry the Q8 floor")
+        );
         assert_eq!(
             contract.target_write_type("blk.0.ffn_gate.weight", &[256, 256], PackQuant::Q4_K,),
-            Some(GgufWriteTensorType::Q8_0)
+            Some(GgufWriteTensorType::Q4_K)
         );
     }
 

--- a/crates/openasr-core/src/models/qwen/forced_aligner_import.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_import.rs
@@ -221,11 +221,16 @@ pub fn convert_local_qwen_forced_aligner_source_to_runtime_pack(
 }
 
 /// Forced alignment takes discrete argmax decisions over 80 ms timestamp bins.
-/// Sub-Q8 perturbations anywhere in the audio/text forward pass can move a word
-/// boundary by many bins, so every quantizable matrix carries the Q8_0 floor.
+/// The audio encoder, token embedding, and timestamp head keep the Q8_0 floor;
+/// only the text decoder blocks may use Q4_K in the public `q4_k` tier. The
+/// tier name follows OpenASR's unified quant naming; the per-tensor precision
+/// policy, rather than the label alone, is the authoritative contract.
 /// Rank, alignment, bias/norm, and F32 eligibility remain owned by the shared
 /// Qwen writer; this classifier only states the model-level precision contract.
-pub(crate) fn forced_aligner_tensor_role(_name: &str) -> TensorRole {
+pub(crate) fn forced_aligner_tensor_role(name: &str) -> TensorRole {
+    if name.starts_with("blk.") && name.ends_with(".weight") {
+        return TensorRole::TextDecoderMatrix;
+    }
     TensorRole::PrecisionCriticalMatrix
 }
 
@@ -451,14 +456,25 @@ fn discover_safetensor_files(
 fn validate_request(
     request: &Qwen3ForcedAlignerLocalSourceImportRequest,
 ) -> Result<(), LocalSourceImportError> {
-    if matches!(
-        request.quantization,
-        Qwen3AsrRuntimeQuantizationMode::Q3_K | Qwen3AsrRuntimeQuantizationMode::Q4_K
-    ) {
+    if request.quantization == Qwen3AsrRuntimeQuantizationMode::Q3_K {
         return Err(validate_error(format!(
-            "Qwen3-ForcedAligner requires fp16 or q8_0 output; {} can cause multi-bin word-boundary drift",
+            "Qwen3-ForcedAligner requires fp16, q8_0, or policy-guarded q4_k output; {} can cause multi-bin word-boundary drift",
             request.quantization.label()
         )));
+    }
+    if request.quantization == Qwen3AsrRuntimeQuantizationMode::Q4_K
+        && request.package_variant.as_deref() != Some("q4_k")
+    {
+        return Err(validate_error(
+            "Qwen3-ForcedAligner Q4_K output must use package_variant 'q4_k'; this is the unified public tier name while the audio encoder, token embedding, and timestamp head remain Q8_0",
+        ));
+    }
+    if request.quantization != Qwen3AsrRuntimeQuantizationMode::Q4_K
+        && request.package_variant.as_deref() == Some("q4_k")
+    {
+        return Err(validate_error(
+            "Qwen3-ForcedAligner package_variant 'q4_k' requires Q4_K output",
+        ));
     }
     if request.package_id.trim().is_empty() {
         return Err(validate_error(
@@ -496,7 +512,39 @@ mod tests {
     use std::collections::BTreeSet;
 
     #[test]
-    fn every_forced_aligner_matrix_carries_the_q8_floor() {
+    #[ignore = "host-local: builds the policy-guarded q4_k forced-aligner pack from the pinned source checkpoint"]
+    fn build_forced_aligner_q4_k_pack() {
+        let source_root = crate::testing::external_test_fixture_path(
+            "OPENASR_FORCED_ALIGNER_EXPERIMENT_SOURCE",
+            "Qwen3 forced-aligner source checkpoint",
+        )
+        .expect("OPENASR_FORCED_ALIGNER_EXPERIMENT_SOURCE");
+        let output_root = std::env::var_os("OPENASR_FORCED_ALIGNER_EXPERIMENT_OUTPUT")
+            .map(PathBuf::from)
+            .expect("OPENASR_FORCED_ALIGNER_EXPERIMENT_OUTPUT");
+        let request = Qwen3ForcedAlignerLocalSourceImportRequest {
+            source_root,
+            output_root,
+            package_id: "qwen3-forced-aligner-0.6b".to_string(),
+            package_variant: Some("q4_k".to_string()),
+            source_name: "Qwen/Qwen3-ForcedAligner-0.6B".to_string(),
+            source_revision: "c7cbfc2048c462b0d63a45797104fc9db3ad62b7".to_string(),
+            license_name: "Apache-2.0".to_string(),
+            license_source: "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B/blob/c7cbfc2048c462b0d63a45797104fc9db3ad62b7/LICENSE".to_string(),
+            quantization: Qwen3AsrRuntimeQuantizationMode::Q4_K,
+        };
+        let result = convert_local_qwen_forced_aligner_source_to_runtime_pack(&request)
+            .expect("build forced-aligner q4_k pack");
+        eprintln!(
+            "FORCED_ALIGNER_Q4_K_BUILD output={} model_id={} tensors={}",
+            result.output_path.display(),
+            result.model_id,
+            result.tensor_count,
+        );
+    }
+
+    #[test]
+    fn forced_aligner_q4_k_keeps_sensitive_matrices_at_q8() {
         let contract = crate::models::pack_quant::TensorQuantizationContract::SemanticRolesV1 {
             model_architecture: QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
             classify: forced_aligner_tensor_role,
@@ -524,30 +572,40 @@ mod tests {
                 &[1024, 1024],
                 crate::models::pack_quant::PackQuant::Q4_K,
             ),
-            Some(crate::ggml_runtime::GgufWriteTensorType::Q8_0),
+            Some(crate::ggml_runtime::GgufWriteTensorType::Q4_K),
         );
     }
 
     #[test]
-    fn importer_rejects_q3_and_q4_before_reading_source_files() {
-        for quantization in [
-            Qwen3AsrRuntimeQuantizationMode::Q3_K,
-            Qwen3AsrRuntimeQuantizationMode::Q4_K,
-        ] {
-            let request = Qwen3ForcedAlignerLocalSourceImportRequest {
-                source_root: PathBuf::from("/nonexistent/forced-aligner-source"),
-                output_root: PathBuf::from("/nonexistent/forced-aligner.oasr"),
-                package_id: "qwen3-forced-aligner-0.6b".to_string(),
-                package_variant: None,
-                source_name: "Qwen/Qwen3-ForcedAligner-0.6B".to_string(),
-                source_revision: "test".to_string(),
-                license_name: "Apache-2.0".to_string(),
-                license_source: "https://example.invalid/license".to_string(),
-                quantization,
-            };
-            let error = validate_request(&request).expect_err("sub-Q8 import must fail closed");
-            assert!(error.to_string().contains("requires fp16 or q8_0"));
-        }
+    fn importer_accepts_only_policy_guarded_q4_k() {
+        let mut request = Qwen3ForcedAlignerLocalSourceImportRequest {
+            source_root: PathBuf::from("/nonexistent/forced-aligner-source"),
+            output_root: PathBuf::from("/nonexistent/forced-aligner.oasr"),
+            package_id: "qwen3-forced-aligner-0.6b".to_string(),
+            package_variant: None,
+            source_name: "Qwen/Qwen3-ForcedAligner-0.6B".to_string(),
+            source_revision: "test".to_string(),
+            license_name: "Apache-2.0".to_string(),
+            license_source: "https://example.invalid/license".to_string(),
+            quantization: Qwen3AsrRuntimeQuantizationMode::Q3_K,
+        };
+        let error = validate_request(&request).expect_err("q3_k import must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("fp16, q8_0, or policy-guarded q4_k")
+        );
+
+        request.quantization = Qwen3AsrRuntimeQuantizationMode::Q4_K;
+        let error = validate_request(&request).expect_err("unlabeled q4_k must fail closed");
+        assert!(error.to_string().contains("package_variant 'q4_k'"));
+
+        request.package_variant = Some("q4_k".to_string());
+        validate_request(&request).expect("policy-guarded q4_k must be accepted");
+
+        request.quantization = Qwen3AsrRuntimeQuantizationMode::Q8_0;
+        let error = validate_request(&request).expect_err("Q8 must not claim q4_k");
+        assert!(error.to_string().contains("requires Q4_K output"));
     }
 
     /// Stage 1 gate: convert the real downloaded Qwen3-ForcedAligner-0.6B

--- a/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
+++ b/crates/openasr-core/src/models/qwen/forced_aligner_runtime.rs
@@ -59,6 +59,7 @@ use crate::models::mapped_token_embedding::{MappedTokenEmbeddingError, MappedTok
 /// byte-for-byte (see `forced_aligner_import.rs`), so it uses the same value.
 const FORCED_ALIGNER_ROPE_THETA: f32 = 1_000_000.0;
 const DEFAULT_RMS_NORM_EPSILON: f32 = 1.0e-6;
+const OPENASR_MODEL_ID_KEY: &str = "openasr.model.id";
 /// Upper bound for one timestamp-classification graph. At the current 5k
 /// vocabulary this keeps each f32 logits matrix at or below 1.25 MiB while
 /// still amortizing graph construction and GPU submission across many words.
@@ -783,8 +784,14 @@ pub(crate) struct Qwen3ForcedAlignerSession {
 }
 
 pub(crate) fn validate_forced_aligner_quantization_contract(
+    metadata: &GgufMetadata,
     tensor_index: &crate::ggml_runtime::GgufTensorIndex,
 ) -> Result<(), Qwen3ForcedAlignerRuntimeError> {
+    let model_id = metadata.get_string(OPENASR_MODEL_ID_KEY).ok_or(
+        Qwen3ForcedAlignerRuntimeError::MissingMetadata {
+            key: OPENASR_MODEL_ID_KEY,
+        },
+    )?;
     let violations = runtime_tensor_index_q8_floor_violations(
         super::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
         tensor_index,
@@ -797,10 +804,118 @@ pub(crate) fn validate_forced_aligner_quantization_contract(
         return Err(Qwen3ForcedAlignerRuntimeError::InvalidMetadata {
             key: "<quantization floor>",
             reason: format!(
-                "forced-aligner packs require Q8_0 or higher for every quantizable matrix; pack has {} violation(s), first tensor '{}' is {}",
+                "forced-aligner packs require Q8_0 or higher for the audio encoder, token embedding, and timestamp head; pack has {} violation(s), first tensor '{}' is {}",
                 violations.len(),
                 first.tensor,
                 crate::models::pack_quant_audit::ggml_type_name(first.ggml_type),
+            ),
+        });
+    }
+    let declared_variant = model_id.rsplit_once(':').map(|(_, variant)| variant);
+    if matches!(
+        declared_variant,
+        Some("q3")
+            | Some("q3_k")
+            | Some("q3k")
+            | Some("q4")
+            | Some("q4k")
+            | Some("q4_k_m")
+            | Some("q4km")
+    ) {
+        return Err(Qwen3ForcedAlignerRuntimeError::InvalidMetadata {
+            key: OPENASR_MODEL_ID_KEY,
+            reason: format!(
+                "forced-aligner pack '{model_id}' uses a disallowed low-precision variant; the only supported Q4 product identity is ':q4_k'",
+            ),
+        });
+    }
+    let q4_k_contract = crate::models::pack_quant::TensorQuantizationContract::SemanticRolesV1 {
+        model_architecture: super::QWEN3_FORCED_ALIGNER_GGML_ARCHITECTURE_ID,
+        classify: super::forced_aligner_tensor_role,
+        quantized_axis: crate::models::pack_quant::QuantizedAxis::First,
+    };
+    let mut expected_q4_decoder_matrices = 0usize;
+    for tensor in tensor_index.tensors() {
+        if tensor.dims.len() != 2
+            || super::forced_aligner_tensor_role(&tensor.name)
+                != crate::models::pack_quant::TensorRole::TextDecoderMatrix
+        {
+            continue;
+        }
+        let ggml_type = u32::try_from(tensor.ggml_type).unwrap_or(u32::MAX);
+        if !matches!(
+            ggml_type,
+            crate::models::pack_quant_audit::GGML_TYPE_F32
+                | crate::models::pack_quant_audit::GGML_TYPE_F16
+                | crate::models::pack_quant_audit::GGML_TYPE_Q8_0
+                | crate::models::pack_quant_audit::GGML_TYPE_Q4_K
+        ) {
+            return Err(Qwen3ForcedAlignerRuntimeError::InvalidMetadata {
+                key: "<quantization floor>",
+                reason: format!(
+                    "forced-aligner q4_k decoder matrices require q4_k, q8_0, f16, or f32; tensor '{}' is {}",
+                    tensor.name,
+                    crate::models::pack_quant_audit::ggml_type_name(ggml_type),
+                ),
+            });
+        }
+        if declared_variant == Some("q4_k") {
+            let expected = q4_k_contract.target_write_type(
+                &tensor.name,
+                &tensor.dims,
+                crate::models::pack_quant::PackQuant::Q4_K,
+            );
+            let expected_ggml_type = match expected {
+                Some(crate::ggml_runtime::GgufWriteTensorType::Q4_K) => {
+                    expected_q4_decoder_matrices += 1;
+                    Some(crate::models::pack_quant_audit::GGML_TYPE_Q4_K)
+                }
+                Some(crate::ggml_runtime::GgufWriteTensorType::Q8_0) => {
+                    Some(crate::models::pack_quant_audit::GGML_TYPE_Q8_0)
+                }
+                Some(crate::ggml_runtime::GgufWriteTensorType::F16) => {
+                    Some(crate::models::pack_quant_audit::GGML_TYPE_F16)
+                }
+                Some(crate::ggml_runtime::GgufWriteTensorType::F32) => {
+                    Some(crate::models::pack_quant_audit::GGML_TYPE_F32)
+                }
+                Some(_) | None => None,
+            };
+            if let Some(expected_ggml_type) = expected_ggml_type
+                && ggml_type != expected_ggml_type
+            {
+                return Err(Qwen3ForcedAlignerRuntimeError::InvalidMetadata {
+                    key: "<quantization floor>",
+                    reason: format!(
+                        "forced-aligner q4_k tensor '{}' must match the importer policy type {}, got {}",
+                        tensor.name,
+                        crate::models::pack_quant_audit::ggml_type_name(expected_ggml_type),
+                        crate::models::pack_quant_audit::ggml_type_name(ggml_type),
+                    ),
+                });
+            }
+        }
+    }
+    let has_q4_decoder_matrix = tensor_index.tensors().iter().any(|tensor| {
+        tensor.dims.len() == 2
+            && super::forced_aligner_tensor_role(&tensor.name)
+                == crate::models::pack_quant::TensorRole::TextDecoderMatrix
+            && u32::try_from(tensor.ggml_type).ok()
+                == Some(crate::models::pack_quant_audit::GGML_TYPE_Q4_K)
+    });
+    if has_q4_decoder_matrix && declared_variant != Some("q4_k") {
+        return Err(Qwen3ForcedAlignerRuntimeError::InvalidMetadata {
+            key: OPENASR_MODEL_ID_KEY,
+            reason: format!(
+                "forced-aligner packs containing Q4_K decoder matrices must declare the public ':q4_k' variant; got '{model_id}'",
+            ),
+        });
+    }
+    if declared_variant == Some("q4_k") && expected_q4_decoder_matrices == 0 {
+        return Err(Qwen3ForcedAlignerRuntimeError::InvalidMetadata {
+            key: OPENASR_MODEL_ID_KEY,
+            reason: format!(
+                "forced-aligner pack '{model_id}' claims q4_k but contains no importer-eligible Q4_K decoder matrix",
             ),
         });
     }
@@ -1039,55 +1154,134 @@ mod tests {
         token_embedding_type: i32,
         decoder_type: i32,
     ) -> crate::ggml_runtime::GgufTensorIndex {
+        quant_floor_index_with_decoders(output_type, token_embedding_type, &[decoder_type])
+    }
+
+    fn quant_floor_index_with_decoders(
+        output_type: i32,
+        token_embedding_type: i32,
+        decoder_types: &[i32],
+    ) -> crate::ggml_runtime::GgufTensorIndex {
+        let mut tensors = vec![
+            crate::ggml_runtime::GgufTensorMetadata {
+                name: "output.weight".to_string(),
+                dims: vec![1024, 5000],
+                ggml_type: output_type,
+                type_name: "synthetic".to_string(),
+                size_bytes: 0,
+                offset_bytes: 0,
+            },
+            crate::ggml_runtime::GgufTensorMetadata {
+                name: "token_embd.weight".to_string(),
+                dims: vec![1024, 152_064],
+                ggml_type: token_embedding_type,
+                type_name: "synthetic".to_string(),
+                size_bytes: 0,
+                offset_bytes: 0,
+            },
+        ];
+        tensors.extend(decoder_types.iter().enumerate().map(|(index, ggml_type)| {
+            crate::ggml_runtime::GgufTensorMetadata {
+                name: format!("blk.{index}.ffn_gate.weight"),
+                dims: vec![1024, 3072],
+                ggml_type: *ggml_type,
+                type_name: "synthetic".to_string(),
+                size_bytes: 0,
+                offset_bytes: 0,
+            }
+        }));
         crate::ggml_runtime::GgufTensorIndex::from_snapshot(
             crate::ggml_runtime::GgufTensorIndexSnapshot {
                 path: "/nonexistent/forced-aligner-policy.oasr".into(),
                 data_section_offset_bytes: 0,
-                tensors: vec![
-                    crate::ggml_runtime::GgufTensorMetadata {
-                        name: "output.weight".to_string(),
-                        dims: vec![1024, 5000],
-                        ggml_type: output_type,
-                        type_name: "synthetic".to_string(),
-                        size_bytes: 0,
-                        offset_bytes: 0,
-                    },
-                    crate::ggml_runtime::GgufTensorMetadata {
-                        name: "token_embd.weight".to_string(),
-                        dims: vec![1024, 152_064],
-                        ggml_type: token_embedding_type,
-                        type_name: "synthetic".to_string(),
-                        size_bytes: 0,
-                        offset_bytes: 0,
-                    },
-                    crate::ggml_runtime::GgufTensorMetadata {
-                        name: "blk.0.ffn_gate.weight".to_string(),
-                        dims: vec![1024, 3072],
-                        ggml_type: decoder_type,
-                        type_name: "synthetic".to_string(),
-                        size_bytes: 0,
-                        offset_bytes: 0,
-                    },
-                ],
+                tensors,
             },
         )
         .expect("valid synthetic tensor index")
     }
 
+    fn quant_floor_metadata(model_id: &str) -> GgufMetadata {
+        let mut values = std::collections::BTreeMap::new();
+        values.insert(
+            OPENASR_MODEL_ID_KEY.to_string(),
+            crate::ggml_runtime::GgufMetadataValue::String(model_id.to_string()),
+        );
+        GgufMetadata::from_values_for_test(values)
+    }
+
     #[test]
-    fn forced_aligner_pack_contract_requires_q8_for_every_matrix() {
+    fn forced_aligner_pack_contract_accepts_policy_guarded_q4_k_or_higher() {
         let q8 = crate::models::pack_quant_audit::GGML_TYPE_Q8_0 as i32;
         let q4 = crate::models::pack_quant_audit::GGML_TYPE_Q4_K as i32;
-        validate_forced_aligner_quantization_contract(&quant_floor_index(q8, q8, q8))
-            .expect("current Q8 contract must remain eligible on every backend");
+        let q3 = crate::models::pack_quant_audit::GGML_TYPE_Q3_K as i32;
+        let q8_metadata = quant_floor_metadata("qwen3-forced-aligner-0.6b");
+        let q4_metadata = quant_floor_metadata("qwen3-forced-aligner-0.6b:q4_k");
+        validate_forced_aligner_quantization_contract(&q8_metadata, &quant_floor_index(q8, q8, q8))
+            .expect("Q8 contract must remain eligible on every backend");
+        validate_forced_aligner_quantization_contract(&q4_metadata, &quant_floor_index(q8, q8, q4))
+            .expect("policy-guarded q4_k decoder weights must remain eligible on every backend");
         assert!(
-            validate_forced_aligner_quantization_contract(&quant_floor_index(q4, q8, q8)).is_err()
+            validate_forced_aligner_quantization_contract(
+                &q4_metadata,
+                &quant_floor_index(q4, q8, q8),
+            )
+            .is_err()
         );
         assert!(
-            validate_forced_aligner_quantization_contract(&quant_floor_index(q8, q4, q8)).is_err()
+            validate_forced_aligner_quantization_contract(
+                &q4_metadata,
+                &quant_floor_index(q8, q4, q8),
+            )
+            .is_err()
         );
         assert!(
-            validate_forced_aligner_quantization_contract(&quant_floor_index(q8, q8, q4)).is_err()
+            validate_forced_aligner_quantization_contract(
+                &q4_metadata,
+                &quant_floor_index(q8, q8, q3),
+            )
+            .is_err()
+        );
+        assert!(
+            validate_forced_aligner_quantization_contract(
+                &q8_metadata,
+                &quant_floor_index(q8, q8, q4),
+            )
+            .is_err(),
+            "a mixed pack must not omit the q4_k identity"
+        );
+        assert!(
+            validate_forced_aligner_quantization_contract(
+                &q4_metadata,
+                &quant_floor_index(q8, q8, q8),
+            )
+            .is_err(),
+            "an all-Q8 pack must not masquerade as q4_k"
+        );
+        assert!(
+            validate_forced_aligner_quantization_contract(
+                &q4_metadata,
+                &quant_floor_index_with_decoders(q8, q8, &[q4, q8]),
+            )
+            .is_err(),
+            "one Q4 decoy must not let an otherwise-Q8 decoder masquerade as q4_k"
+        );
+        let misleading_q3 = quant_floor_metadata("qwen3-forced-aligner-0.6b:q3_k");
+        assert!(
+            validate_forced_aligner_quantization_contract(
+                &misleading_q3,
+                &quant_floor_index(q8, q8, q8),
+            )
+            .is_err(),
+            "an all-Q8 pack must not carry a Q3 label"
+        );
+        let legacy_q4m = quant_floor_metadata("qwen3-forced-aligner-0.6b:q4_k_m");
+        assert!(
+            validate_forced_aligner_quantization_contract(
+                &legacy_q4m,
+                &quant_floor_index(q8, q8, q4),
+            )
+            .is_err(),
+            "the unpublished q4_k_m experiment name must not become a second public identity"
         );
     }
 
@@ -1340,6 +1534,66 @@ mod tests {
             max_ms <= 320.0,
             "CPU/Metal maximum timestamp drift {max_ms:.3}ms exceeds four 80ms model bins"
         );
+    }
+
+    #[test]
+    #[ignore = "host-local: compares policy-guarded q4_k against the released q8_0 pack on CPU and Metal"]
+    fn forced_aligner_q4_k_matches_q8_0_within_one_bin() {
+        let q4_pack = crate::testing::external_test_fixture_path(
+            "OPENASR_FORCED_ALIGNER_Q4_K_PACK",
+            "Qwen3 forced-aligner q4_k pack",
+        )
+        .expect("OPENASR_FORCED_ALIGNER_Q4_K_PACK");
+        let q8_pack = crate::testing::external_test_fixture_path(
+            "OPENASR_FORCED_ALIGNER_Q8_PACK",
+            "released Qwen3 forced-aligner q8_0 pack",
+        )
+        .expect("OPENASR_FORCED_ALIGNER_Q8_PACK");
+        let audio = crate::testing::external_test_fixture_path(
+            "OPENASR_AUX_BENCH_AUDIO",
+            "private auxiliary-model benchmark audio",
+        )
+        .expect("OPENASR_AUX_BENCH_AUDIO");
+        let text_path = crate::testing::external_test_fixture_path(
+            "OPENASR_AUX_BENCH_TEXT",
+            "private auxiliary-model benchmark transcript",
+        )
+        .expect("OPENASR_AUX_BENCH_TEXT");
+        let text = std::fs::read_to_string(text_path).expect("read parity transcript");
+        let language =
+            std::env::var("OPENASR_AUX_BENCH_LANGUAGE").unwrap_or_else(|_| "Chinese".to_string());
+        let samples = crate::api::audio_io::load_wav_16khz_mono_f32_v0(
+            &audio,
+            "forced-aligner quant-tier parity",
+            "forced-aligner quant-tier parity",
+        )
+        .expect("load parity audio");
+        let pcm = crate::PcmBuffer::from_vec(samples);
+        for backend in [
+            crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+            crate::ggml_runtime::GgmlCpuGraphBackend::Metal,
+        ] {
+            let run = |pack: &std::path::Path| {
+                Qwen3ForcedAlignerSession::load(pack, backend)
+                    .expect("load aligner")
+                    .align(pcm.full_slice(), text.trim(), &language)
+                    .expect("align parity audio")
+            };
+            let q8 = run(&q8_pack);
+            let q4 = run(&q4_pack);
+            let (median_ms, p95_ms, max_ms) = forced_aligner_timestamp_drift_stats(&q8, &q4);
+            eprintln!(
+                "FORCED_ALIGNER_QUANT_PARITY backend={backend:?} items={} endpoints={} median_ms={median_ms:.3} p95_ms={p95_ms:.3} max_ms={max_ms:.3}",
+                q8.len(),
+                q8.len() * 2,
+            );
+            assert_eq!(median_ms, 0.0, "q4_k/q8_0 median drift");
+            assert_eq!(p95_ms, 0.0, "q4_k/q8_0 p95 drift");
+            assert!(
+                max_ms <= 80.001,
+                "q4_k/q8_0 maximum drift {max_ms:.3}ms exceeds one model bin"
+            );
+        }
     }
 
     fn forced_aligner_timestamp_drift_stats(


### PR DESCRIPTION
## Summary

Add a fail-closed, policy-guarded Qwen3 Forced Aligner `q4_k` import and runtime contract while keeping the current signed catalog and installed-pack preference on Q8_0.

## Why

The previous all-Q4 experiment quantized precision-sensitive tensors too aggressively and could shift word boundaries by more than one timestamp bin. Removing Q4 avoided the unsafe artifact, but the runtime still needs a trustworthy way to build and validate a future smaller tier.

This change defines one reserved `q4_k` product identity: audio encoder matrices, token embeddings, and the timestamp head remain Q8_0, while only eligible text-decoder matrices use Q4_K. The importer and runtime replay that policy tensor by tensor, so legacy all-Q4 packs and mislabeled mixed packs fail closed.

## Changes

- add guarded Q4_K import and quant-audit support;
- validate the forced-aligner precision policy from model identity and tensor index at pull-time and runtime;
- reject Q3, legacy Q4 aliases, all-Q8 packs mislabeled as Q4, and decoy-Q4 packs;
- retain the existing Metal full-device and CUDA/Vulkan hybrid execution topology from main;
- keep the downloadable catalog and preferred installed quantization on Q8_0;
- update CLI guidance and changelog notes for the staged runtime capability.

## Tests run on the rebased head

- [x] `cargo fmt --check`
- [x] `tooling/publish-model/scripts/regenerate_all.sh --check`
- [x] `python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'` (265 tests)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (4,250 passed, 214 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`
- [x] Targeted Q4 contract, catalog-preference, and execution-topology tests (6 passed)

## Artifact qualification already completed

- The canonical policy-guarded Q4_K candidate was built from the pinned source revision.
- CPU and Metal timestamp checks covered 205 items / 410 endpoints.
- Q4_K versus Q8_0 parity stayed within one 80 ms model bin.
- FP16, Q8_0, and Q4_K artifacts remain staged at immutable Hugging Face revision `3a82628cf7036c2ad0128f2d35bd1cced09b3100`.

These artifacts are not made discoverable by this PR.

## Scope / non-goals

This PR does not:

- change release authoring metadata or the signed catalog;
- make Q4_K the default download;
- bump the core version or release core 0.1.32;
- deploy catalog outputs;
- commit model weights, large binaries, signing material, or private audio.

The current signed catalog continues to publish and recommend Q8_0. Enabling Q4_K in the catalog requires a separately authorized release and catalog PR after the compatible core version is published.

## Model-family checklist

- [x] Existing Qwen Forced Aligner family; no new model family.
- [x] Runtime/import trust boundary is fail-closed and covered by tests.
- [x] Existing Q8_0 and FP16 behavior remains supported.
- [x] No generated catalog or signature output is included.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in `AGENTS.md`.
- [x] I understand every line of this change and own its maintenance.
- AI usage disclosure: YES - AI assisted implementation and validation; the maintainer reviewed and owns the changes.
