### PR TITLE
fix(core): harden Windows native cache and streaming recovery

### DIFF
--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -449,10 +449,10 @@ pub(crate) enum Command {
         /// Optional exact or best-effort microphone device name.
         #[arg(long)]
         device: Option<String>,
-        /// Simulate live streaming from a local audio file (WAV/MP3/MP4/M4A/WEBM/FLAC/OGG).
+        /// Replay a local audio file through the live pipeline (WAV/MP3/MP4/M4A/WEBM/FLAC/OGG).
         ///
-        /// When set, OpenASR feeds fixed-duration frames from this file into the live pipeline
-        /// instead of capturing from microphone.
+        /// Near-real-time pacing means one hour of audio takes roughly one hour of wall-clock time.
+        /// OpenASR feeds fixed-duration frames from this file instead of capturing from microphone.
         #[arg(long)]
         input_file: Option<PathBuf>,
         /// Model id from the registry.

--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -584,6 +584,9 @@ pub(crate) enum Command {
         /// Local `.oasr` runtime pack file for native backend transcription.
         #[arg(long)]
         model_pack: Option<PathBuf>,
+        /// Start without binding a model, even if a configured default is installed.
+        #[arg(long, conflicts_with_all = ["model", "model_pack"])]
+        no_model: bool,
         /// Maximum admitted native sessions for one resolved model. `1` keeps
         /// offline decoding serial; eligible direct-GPU families batch admitted
         /// jobs internally up to width 8, while larger values continue in

--- a/crates/openasr-cli/src/live.rs
+++ b/crates/openasr-cli/src/live.rs
@@ -385,13 +385,22 @@ fn run_live_from_input_file(
         input_file.display(),
         options.frame_duration_ms
     );
-    let mut transcription_worker =
-        LiveTranscriptionWorker::spawn(native_execution_services, backend, model_pack_path);
+    // A stored file can safely slow its producer while the bounded worker queue
+    // drains (including a cold model load). Capture sources cannot: they keep
+    // the fail-fast policy in `LiveTranscriptionWorker::spawn`.
+    let mut transcription_worker = LiveTranscriptionWorker::spawn_with_queue_policy(
+        native_execution_services,
+        backend,
+        model_pack_path,
+        LiveTranscriptionQueuePolicy::WaitForCapacity,
+    );
     let samples = prepare_input_file_samples_pcm16_mono_16khz(input_file, options)?;
     let frame_sample_count = RealtimeAudioFormat::pcm16_mono_16khz()
         .sample_count_for_duration_ms(options.frame_duration_ms)?;
+    let replay_started_at = Instant::now();
     let mut start_ms = 0_u64;
     for (frame_seq, chunk) in samples.chunks(frame_sample_count).enumerate() {
+        pace_live_input_file_frame(replay_started_at, start_ms);
         let frame = RealtimeAudioFrame::new(
             frame_seq as u64,
             start_ms,
@@ -409,6 +418,17 @@ fn run_live_from_input_file(
         }
     }
     pipeline.shutdown(start_ms, &mut transcription_worker, true)
+}
+
+fn pace_live_input_file_frame(replay_started_at: Instant, frame_start_ms: u64) {
+    let delay = live_input_file_replay_delay(replay_started_at.elapsed(), frame_start_ms);
+    if !delay.is_zero() {
+        thread::sleep(delay);
+    }
+}
+
+fn live_input_file_replay_delay(elapsed: Duration, frame_start_ms: u64) -> Duration {
+    Duration::from_millis(frame_start_ms).saturating_sub(elapsed)
 }
 
 fn prepare_input_file_samples_pcm16_mono_16khz(
@@ -1134,11 +1154,45 @@ enum LiveTranscriptionResult {
     Error(anyhow::Error),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveTranscriptionQueuePolicy {
+    FailFast,
+    WaitForCapacity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveTranscriptionQueueSendError {
+    Full,
+    Disconnected,
+}
+
+impl LiveTranscriptionQueuePolicy {
+    fn send<T>(
+        self,
+        sender: &SyncSender<T>,
+        value: T,
+    ) -> std::result::Result<(), LiveTranscriptionQueueSendError> {
+        match self {
+            Self::FailFast => match sender.try_send(value) {
+                Ok(()) => Ok(()),
+                Err(TrySendError::Full(_)) => Err(LiveTranscriptionQueueSendError::Full),
+                Err(TrySendError::Disconnected(_)) => {
+                    Err(LiveTranscriptionQueueSendError::Disconnected)
+                }
+            },
+            Self::WaitForCapacity => sender
+                .send(value)
+                .map_err(|_| LiveTranscriptionQueueSendError::Disconnected),
+        }
+    }
+}
+
 struct LiveTranscriptionWorker {
     jobs: Option<SyncSender<LiveTranscriptionJob>>,
     results: Receiver<LiveTranscriptionResult>,
     handle: Option<JoinHandle<()>>,
     pending_jobs: usize,
+    queue_policy: LiveTranscriptionQueuePolicy,
 }
 
 impl LiveTranscriptionWorker {
@@ -1146,6 +1200,20 @@ impl LiveTranscriptionWorker {
         native_execution_services: Arc<openasr_core::NativeExecutionServices>,
         backend: BackendKind,
         model_pack_path: Option<PathBuf>,
+    ) -> Self {
+        Self::spawn_with_queue_policy(
+            native_execution_services,
+            backend,
+            model_pack_path,
+            LiveTranscriptionQueuePolicy::FailFast,
+        )
+    }
+
+    fn spawn_with_queue_policy(
+        native_execution_services: Arc<openasr_core::NativeExecutionServices>,
+        backend: BackendKind,
+        model_pack_path: Option<PathBuf>,
+        queue_policy: LiveTranscriptionQueuePolicy,
     ) -> Self {
         let (job_sender, job_receiver) =
             mpsc::sync_channel::<LiveTranscriptionJob>(LIVE_TRANSCRIPTION_QUEUE_CAPACITY);
@@ -1198,6 +1266,7 @@ impl LiveTranscriptionWorker {
             results: result_receiver,
             handle: Some(handle),
             pending_jobs: 0,
+            queue_policy,
         }
     }
 
@@ -1206,17 +1275,17 @@ impl LiveTranscriptionWorker {
             .jobs
             .as_ref()
             .context("Live transcription worker is not running")?;
-        match sender.try_send(job) {
+        match self.queue_policy.send(sender, job) {
             Ok(()) => {
                 self.pending_jobs += 1;
                 Ok(())
             }
-            Err(TrySendError::Full(_)) => {
+            Err(LiveTranscriptionQueueSendError::Full) => {
                 bail!(
                     "Live transcription worker queue is full; stopped instead of buffering unbounded utterances."
                 )
             }
-            Err(TrySendError::Disconnected(_)) => {
+            Err(LiveTranscriptionQueueSendError::Disconnected) => {
                 bail!("Live transcription worker stopped before accepting the utterance.")
             }
         }
@@ -2741,6 +2810,54 @@ mod tests {
                 .to_string()
                 .contains("--max-utterances")
         );
+    }
+
+    #[test]
+    fn input_file_replay_delay_never_runs_ahead_of_audio_time() {
+        assert_eq!(
+            live_input_file_replay_delay(Duration::from_millis(125), 200),
+            Duration::from_millis(75)
+        );
+        assert_eq!(
+            live_input_file_replay_delay(Duration::from_millis(225), 200),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn input_file_queue_waits_for_bounded_capacity_while_capture_fails_fast() {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        sender.send(1).unwrap();
+        assert_eq!(
+            LiveTranscriptionQueuePolicy::FailFast.send(&sender, 2),
+            Err(LiveTranscriptionQueueSendError::Full)
+        );
+
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (result_sender, result_receiver) = mpsc::channel();
+        let waiting_sender = sender.clone();
+        let handle = thread::spawn(move || {
+            started_sender.send(()).unwrap();
+            let result = LiveTranscriptionQueuePolicy::WaitForCapacity.send(&waiting_sender, 3);
+            result_sender.send(result).unwrap();
+        });
+        started_receiver.recv().unwrap();
+        assert!(
+            result_receiver
+                .recv_timeout(Duration::from_millis(50))
+                .is_err(),
+            "file replay must wait instead of rejecting work from a full bounded queue"
+        );
+
+        assert_eq!(receiver.recv().unwrap(), 1);
+        assert_eq!(
+            result_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap(),
+            Ok(())
+        );
+        assert_eq!(receiver.recv().unwrap(), 3);
+        handle.join().unwrap();
     }
 
     #[test]

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -479,6 +479,7 @@ async fn run() -> Result<()> {
             backend,
             ffmpeg_bin,
             model_pack,
+            no_model,
             max_native_sessions_per_model,
             parent_pid,
         } => {
@@ -492,6 +493,7 @@ async fn run() -> Result<()> {
                 backend,
                 RuntimePathOverrides { ffmpeg_bin },
                 model_pack.as_deref(),
+                no_model,
                 max_native_sessions_per_model,
                 ServeSecurityOptions {
                     tls_self_signed,
@@ -1654,6 +1656,7 @@ mod tests {
             Some("qwen3-asr-0.6b"),
             BackendKind::Native,
             None,
+            false,
             &OpenAsrConfig::default(),
         )
         .expect("serve must resolve a model source even with zero packs installed");
@@ -1675,6 +1678,7 @@ mod tests {
             None,
             BackendKind::Native,
             Some(&missing_pack),
+            false,
             &OpenAsrConfig::default(),
         )
         .unwrap_err()
@@ -1933,15 +1937,11 @@ mod tests {
 
     /// Desktop-sidecar contract: the desktop sidecar spawns
     /// this binary as `openasr serve --backend native --parent-pid <pid> ...`.
-    /// Both
-    /// flags are `hide = true` in `cli_args.rs` because they are launch-detail
-    /// only, never meant for interactive use -- but "hidden from `--help`" must
-    /// never come to mean "safe to rename or remove". This test locks the two
-    /// flags' presence and shape (long names, hyphenated `--parent-pid`, an
-    /// accepted `native`/`mock` value for `--backend`, a `u32` for
-    /// `--parent-pid`) so a future "clean up hidden flags" pass fails CI here
-    /// instead of silently breaking every desktop build's ability to launch and
-    /// supervise its sidecar.
+    /// `--backend` and `--parent-pid` are hidden launch details, while
+    /// `--no-model` is the explicit fail-closed recovery mode used when the
+    /// desktop cannot launch its configured pack. This test locks all three
+    /// flags' presence and shape so a future CLI cleanup fails CI here instead
+    /// of silently breaking the desktop sidecar contract.
     #[test]
     fn serve_accepts_desktop_sidecar_contract_flags() {
         let cli = Cli::try_parse_from([
@@ -1951,11 +1951,15 @@ mod tests {
             "native",
             "--parent-pid",
             "4321",
+            "--no-model",
         ])
-        .expect("serve must keep accepting --backend and --parent-pid for the desktop sidecar");
+        .expect(
+            "serve must keep accepting --backend, --parent-pid, and --no-model for the desktop sidecar",
+        );
 
         let Command::Serve {
             backend,
+            no_model,
             max_native_sessions_per_model,
             parent_pid,
             ..
@@ -1965,8 +1969,33 @@ mod tests {
         };
 
         assert_eq!(backend, Some(BackendKind::Native));
+        assert!(no_model);
         assert_eq!(max_native_sessions_per_model.get(), 1);
         assert_eq!(parent_pid, Some(4321));
+    }
+
+    #[test]
+    fn serve_no_model_conflicts_with_explicit_model_sources() {
+        assert!(
+            Cli::try_parse_from([
+                "openasr",
+                "serve",
+                "--no-model",
+                "--model",
+                "moonshine-tiny",
+            ])
+            .is_err()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "openasr",
+                "serve",
+                "--no-model",
+                "--model-pack",
+                "moonshine.oasr",
+            ])
+            .is_err()
+        );
     }
 
     #[test]
@@ -1988,6 +2017,7 @@ mod tests {
 
         let Command::Serve {
             backend,
+            no_model,
             max_native_sessions_per_model,
             parent_pid,
             ..
@@ -1997,6 +2027,7 @@ mod tests {
         };
 
         assert_eq!(backend, None);
+        assert!(!no_model);
         assert_eq!(max_native_sessions_per_model.get(), 1);
         assert_eq!(parent_pid, None);
     }

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -483,13 +483,28 @@ pub(super) fn prepare_backend_run(
 /// `--model-pack` escape hatch still fails closed if the path does not
 /// validate; only the "nothing installed yet" case degrades to no model bound,
 /// which `openasr-server` reports via `/health` and fails closed on a
-/// transcription request instead.
+/// transcription request instead. Explicit `--no-model` skips persisted
+/// default resolution entirely so a supervisor can preserve that unbound
+/// recovery state even when the rejected pack is still installed on disk.
 pub(super) fn resolve_serve_model_source(
     model: Option<&str>,
     backend_kind: BackendKind,
     model_pack: Option<&Path>,
+    no_model: bool,
     config: &OpenAsrConfig,
 ) -> Result<ResolvedModelSource> {
+    if no_model {
+        if model.is_some() || model_pack.is_some() {
+            bail!("--no-model cannot be combined with --model or --model-pack");
+        }
+        if backend_kind != BackendKind::Native {
+            bail!("--no-model is only supported with the native backend");
+        }
+        return Ok(ResolvedModelSource {
+            model_id: NATIVE_RUNTIME_MODEL_ID_AUTO.to_string(),
+            model_pack_path: None,
+        });
+    }
     if backend_kind != BackendKind::Native {
         return resolve_model_source_for_backend("serve", model, backend_kind, model_pack, config);
     }
@@ -543,6 +558,7 @@ pub(super) async fn serve(
     backend_kind: Option<BackendKind>,
     runtime_paths: RuntimePathOverrides,
     model_pack: Option<&Path>,
+    no_model: bool,
     max_native_sessions_per_model: std::num::NonZeroUsize,
     security: ServeSecurityOptions,
 ) -> Result<()> {
@@ -554,7 +570,7 @@ pub(super) async fn serve(
     let config_document = openasr_core::load_config_document(&home)?;
     let config = &config_document.config;
     let backend = resolve_backend(backend_kind, config)?;
-    let model_source = resolve_serve_model_source(model, backend, model_pack, config)?;
+    let model_source = resolve_serve_model_source(model, backend, model_pack, no_model, config)?;
     if backend == BackendKind::Native
         && let Some(model_pack_path) = model_source.model_pack_path.as_deref()
     {
@@ -588,6 +604,10 @@ pub(super) async fn serve(
                 local_model_id
             );
         }
+    } else if backend == BackendKind::Native && no_model {
+        eprintln!(
+            "openasr-server: --no-model requested; starting with no model bound. Transcription requests will fail closed until the server is restarted with a model."
+        );
     } else if backend == BackendKind::Native {
         eprintln!(
             "openasr-server: no installed native model pack found; starting with no model bound. Install one (openasr pull <model-id>) or install via the desktop model market; transcription requests will fail closed until then."
@@ -1562,7 +1582,7 @@ mod tests {
     }
 
     #[test]
-    fn serve_auto_binds_default_from_content_addressed_ref() {
+    fn serve_auto_binds_default_from_content_addressed_ref_unless_no_model_is_explicit() {
         use sha2::Digest as _;
 
         with_env_lock(|| {
@@ -1610,8 +1630,14 @@ mod tests {
             std::fs::write(reference, serde_json::to_vec(&pack).unwrap()).unwrap();
 
             let resolved =
-                resolve_serve_model_source(None, BackendKind::Native, None, &config).unwrap();
+                resolve_serve_model_source(None, BackendKind::Native, None, false, &config)
+                    .unwrap();
             assert_eq!(resolved.model_pack_path, Some(object));
+
+            let explicitly_unbound =
+                resolve_serve_model_source(None, BackendKind::Native, None, true, &config).unwrap();
+            assert_eq!(explicitly_unbound.model_pack_path, None);
+            assert_eq!(explicitly_unbound.model_id, NATIVE_RUNTIME_MODEL_ID_AUTO);
         });
     }
 

--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -1216,6 +1216,14 @@ fn serve_native_accepts_quant_pinned_model_ref_for_bare_local_runtime_source() {
 // that boundary.
 #[allow(clippy::zombie_processes)]
 fn spawn_serve_and_wait_until_listening(home: &Path) -> (std::process::Child, String) {
+    spawn_serve_with_extra_args_and_wait_until_listening(home, &[])
+}
+
+#[allow(clippy::zombie_processes)]
+fn spawn_serve_with_extra_args_and_wait_until_listening(
+    home: &Path,
+    extra_args: &[&str],
+) -> (std::process::Child, String) {
     // `--addr 127.0.0.1:0` asks the OS for an ephemeral port; `serve` reports
     // back the listener's actual bound address (not the `:0` it was given
     // verbatim), so the real port is parsed straight from that banner line
@@ -1229,6 +1237,7 @@ fn spawn_serve_and_wait_until_listening(home: &Path) -> (std::process::Child, St
         .env_remove("OPENASR_ASSUME_YES")
         .env_remove("OPENASR_OFFLINE")
         .args(["serve", "--backend", "native", "--addr", "127.0.0.1:0"])
+        .args(extra_args)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
     let mut child = command.spawn().expect("spawn openasr serve");
@@ -1269,6 +1278,52 @@ fn spawn_serve_and_wait_until_listening(home: &Path) -> (std::process::Child, St
     }
 }
 
+fn install_default_moonshine_pack(home: &Path) {
+    let source = home.join("fixture-source.oasr");
+    write_moonshine_oasr_v1_fixture(&source, "moonshine-tiny");
+    let bytes = std::fs::read(&source).expect("read installed-pack fixture");
+    std::fs::remove_file(&source).expect("remove source after populating object store");
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let object = home
+        .join("models/objects/sha256")
+        .join(&sha256)
+        .join("content");
+    std::fs::create_dir_all(object.parent().expect("object parent")).expect("create object store");
+    std::fs::write(&object, &bytes).expect("write installed-pack object");
+
+    let reference = home.join("models/refs/moonshine-tiny/q8_0.json");
+    std::fs::create_dir_all(reference.parent().expect("reference parent"))
+        .expect("create model reference directory");
+    let pack = openasr_core::InstalledPack {
+        model_id: "moonshine-tiny".to_string(),
+        display_name: "Moonshine Tiny".to_string(),
+        quant: "q8_0".to_string(),
+        suffix: "q8".to_string(),
+        pull: "moonshine-tiny:q8".to_string(),
+        filename: "moonshine-tiny-q8_0.oasr".to_string(),
+        path: object,
+        url: "https://example.invalid/moonshine-tiny-q8_0.oasr".to_string(),
+        hf_revision: "test".to_string(),
+        sha256,
+        size_bytes: bytes.len() as u64,
+        installed_at_unix_seconds: 1,
+        source: None,
+    };
+    std::fs::write(
+        reference,
+        serde_json::to_vec(&pack).expect("serialize installed pack"),
+    )
+    .expect("write model reference");
+    openasr_core::save_config(
+        home,
+        &openasr_core::OpenAsrConfig {
+            default_model: Some("moonshine-tiny".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("persist installed default model");
+}
+
 fn raw_http_request(addr: &str, request: &[u8]) -> String {
     use std::io::{Read, Write};
     let stream = std::net::TcpStream::connect(addr).expect("connect to daemon");
@@ -1303,6 +1358,45 @@ fn serve_native_without_installed_model_starts_and_answers_health() {
     assert!(
         response.contains("\"model_installed\":false"),
         "expected /health to honestly report no model installed, got: {response}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn serve_no_model_keeps_an_installed_default_unbound_in_health() {
+    let temp = tempfile::tempdir().unwrap();
+    install_default_moonshine_pack(temp.path());
+    let installed = openasr_core::list_installed_packs(temp.path())
+        .expect("the fixture must be recognized as installed before the daemon starts");
+    assert_eq!(installed.len(), 1);
+    assert_eq!(installed[0].pull, "moonshine-tiny:q8");
+    assert_eq!(
+        openasr_core::load_config(temp.path())
+            .expect("load fixture config")
+            .default_model
+            .as_deref(),
+        Some("moonshine-tiny")
+    );
+    let (mut child, addr) =
+        spawn_serve_with_extra_args_and_wait_until_listening(temp.path(), &["--no-model"]);
+
+    let response = raw_http_request(
+        &addr,
+        format!("GET /health HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n").as_bytes(),
+    );
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "expected a healthy 200 response, got: {response}"
+    );
+    assert!(
+        response.contains("\"model_installed\":false"),
+        "--no-model must hide even an installed default from the serving runtime: {response}"
+    );
+    assert!(
+        response.contains("\"model_resident\":false"),
+        "--no-model must not make an installed default resident: {response}"
     );
 
     let _ = child.kill();

--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -297,6 +297,17 @@ fn help_does_not_list_removed_legacy_backends() {
 }
 
 #[test]
+fn live_input_file_help_documents_near_real_time_pacing() {
+    openasr()
+        .args(["live", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Near-real-time pacing"))
+        .stdout(predicate::str::contains("one hour of audio takes roughly"))
+        .stdout(predicate::str::contains("one hour of wall-clock time"));
+}
+
+#[test]
 fn serve_help_documents_local_default_and_remote_security() {
     openasr()
         .args(["serve", "--help"])

--- a/crates/openasr-core/Cargo.toml
+++ b/crates/openasr-core/Cargo.toml
@@ -83,6 +83,10 @@ ts-rs = { version = "12.0.1", features = ["no-serde-warnings"], optional = true 
 # Locate the MSVC `cl` toolchain (path + vcvars env) so build.rs can pin it for
 # non-HIP Windows ggml builds instead of the ROCm clang that Ninja picks off PATH.
 cc = "1"
+# Fingerprint every build-relevant vendored ggml input before reusing the private
+# CMake tree. This is also a normal dependency above, so it adds no new package to
+# the workspace lockfile.
+sha2.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal.workspace = true

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -184,7 +184,10 @@ fn main() {
         } else {
             msvc_tool.as_ref().map(|tool| cmake_path(tool.path()))
         };
-        let mut tool_expectations = Vec::new();
+        // CMake embeds the absolute source directory in its cache and refuses to
+        // reuse that tree from a new immutable staging path, even when the native
+        // contents have the same fingerprint.
+        let mut tool_expectations = vec![("CMAKE_HOME_DIRECTORY", cmake_path(&source_dir))];
         if let Some(compiler) = expected_compiler {
             tool_expectations.push(("CMAKE_C_COMPILER", compiler.clone()));
             tool_expectations.push(("CMAKE_CXX_COMPILER", compiler));

--- a/crates/openasr-core/build.rs
+++ b/crates/openasr-core/build.rs
@@ -134,8 +134,24 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
     let build_dir = out_dir.join("openasr-ggml-build");
     let lib_dir = build_dir.join("lib");
-    fs::create_dir_all(&build_dir).expect("create openasr-ggml build dir");
-    fs::create_dir_all(&lib_dir).expect("create openasr-ggml lib dir");
+    let source_fingerprint = windows_cmake_cache::build_relevant_fingerprint(&source_dir)
+        .unwrap_or_else(|error| {
+            panic!(
+                "fingerprint build-relevant openasr-ggml inputs under {}: {error}",
+                source_dir.display()
+            )
+        });
+    let source_fingerprint_stamp = build_dir.join(windows_cmake_cache::SOURCE_FINGERPRINT_STAMP);
+    let stored_source_fingerprint = fs::read_to_string(&source_fingerprint_stamp).ok();
+    // A restored Cargo target directory can contain CMake objects newer than a
+    // freshly checked-out native source tree. In that state CMake's timestamp-
+    // based incremental build can accept old objects even though Cargo reran this
+    // build script. Treat source contents as part of the cache contract and force
+    // a fresh private CMake tree whenever that identity changes or is absent.
+    let mut reset_native_build_dir = windows_cmake_cache::source_fingerprint_requires_reset(
+        stored_source_fingerprint.as_deref(),
+        &source_fingerprint,
+    );
 
     let hip_path = feat_hip.then(hip_toolkit_path).flatten();
     let cuda_path = feat_cuda.then(cuda_toolkit_path).flatten();
@@ -200,18 +216,21 @@ fn main() {
             ("GGML_HIP", on_off(feat_hip)),
             ("GGML_SYCL", on_off(feat_sycl)),
         ];
-        let cache = build_dir.join("CMakeCache.txt");
-        if let Ok(text) = fs::read_to_string(&cache)
-            && !windows_cmake_cache::cache_matches_contract(
-                &text,
-                &tool_expectations,
-                &scalar_expectations,
-            )
-        {
-            fs::remove_dir_all(&build_dir).expect("reset incompatible openasr-ggml build dir");
-            fs::create_dir_all(&lib_dir).expect("recreate openasr-ggml lib dir");
+        if !reset_native_build_dir {
+            let cache = build_dir.join("CMakeCache.txt");
+            reset_native_build_dir = fs::read_to_string(&cache).map_or(true, |text| {
+                !windows_cmake_cache::cache_matches_contract(
+                    &text,
+                    &tool_expectations,
+                    &scalar_expectations,
+                )
+            });
         }
     }
+    if reset_native_build_dir && build_dir.exists() {
+        fs::remove_dir_all(&build_dir).expect("reset incompatible openasr-ggml build dir");
+    }
+    fs::create_dir_all(&lib_dir).expect("create openasr-ggml lib dir");
     let windows_hip_shim = if feat_hip && is_windows {
         Some(prepare_windows_hip_sdk_shim(
             &target,
@@ -636,6 +655,14 @@ fn main() {
         }
     }
     run(&mut build);
+    fs::write(&source_fingerprint_stamp, format!("{source_fingerprint}\n")).unwrap_or_else(
+        |error| {
+            panic!(
+                "write openasr-ggml source fingerprint stamp {}: {error}",
+                source_fingerprint_stamp.display()
+            )
+        },
+    );
 
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
     if is_windows {
@@ -808,82 +835,17 @@ fn main() {
     println!("cargo:rerun-if-env-changed=MACOSX_DEPLOYMENT_TARGET");
     println!("cargo:rerun-if-env-changed=OPENASR_GGML_BUILD_JOBS");
     println!("cargo:rerun-if-env-changed=ROCM_PATH");
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("CMakeLists.txt").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("src/CMakeLists.txt").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("include/ggml.h").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("include/ggml-backend.h").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("include/ggml-cpu.h").display()
-    );
-    // These sources define the backend-wide submission/completion and native
-    // cancellation contract. Missing them from Cargo's dependency set can
-    // silently reuse a stale native archive after an incremental edit, making
-    // backend tests exercise different code from the worktree. BLAS is watched
-    // as a directory because CMake may enable it from platform defaults rather
-    // than a Cargo feature.
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("src/ggml-backend.cpp").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("src/ggml-backend-impl.h").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("src/ggml-blas").display()
-    );
-    // The GGML_BACKEND_DL loader shim is OpenASR-authored and decides how plugin
-    // DLLs (and their co-located satellite runtime DLLs) are opened on each OS, so
-    // edits to it must trigger a ggml rebuild. It was previously untracked, so
-    // changing the loader silently kept the stale compiled shim.
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("src/ggml-backend-dl.cpp").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("src/ggml-backend-dl.h").display()
-    );
-    // Watch the linked GPU backend's source tree so editing a backend kernel
-    // actually triggers a rebuild. HIP is built from the ggml-cuda sources
-    // (hipified), so it watches both. Gated by feature to avoid spurious
-    // rebuilds on the CPU/Metal-only build.
-    if feat_hip || feat_cuda {
+    // Cargo recursively watches directory inputs. Use the same complete roots
+    // as the source fingerprint above instead of a hand-maintained list of
+    // selected native files; adding an operation to a previously unlisted .c,
+    // header, shader, or CMake module must always rerun this build script.
+    for relative in windows_cmake_cache::BUILD_RELEVANT_DIRECTORIES
+        .iter()
+        .chain(windows_cmake_cache::BUILD_RELEVANT_FILES)
+    {
         println!(
             "cargo:rerun-if-changed={}",
-            source_dir.join("src/ggml-cuda").display()
-        );
-    }
-    if feat_hip {
-        println!(
-            "cargo:rerun-if-changed={}",
-            source_dir.join("src/ggml-hip").display()
-        );
-    }
-    if feat_vulkan {
-        println!(
-            "cargo:rerun-if-changed={}",
-            source_dir.join("src/ggml-vulkan").display()
-        );
-    }
-    if feat_sycl {
-        println!(
-            "cargo:rerun-if-changed={}",
-            source_dir.join("src/ggml-sycl").display()
+            source_dir.join(relative).display()
         );
     }
     println!("cargo:rerun-if-env-changed=OPENASR_HIP_GPU_TARGETS");
@@ -939,60 +901,6 @@ fn main() {
             "disabled".to_string()
         }
     );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("include/gguf.h").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("src/gguf.cpp").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir
-            .join("src/ggml-metal/ggml-metal-device.cpp")
-            .display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir
-            .join("src/ggml-metal/ggml-metal-device.m")
-            .display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir
-            .join("src/ggml-metal/ggml-metal-device.h")
-            .display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir
-            .join("src/ggml-metal/ggml-metal-context.m")
-            .display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir
-            .join("src/ggml-metal/ggml-metal-ops.cpp")
-            .display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir
-            .join("src/ggml-metal/ggml-metal-impl.h")
-            .display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_dir.join("src/ggml-metal/ggml-metal.metal").display()
-    );
-    if is_macos {
-        println!(
-            "cargo:rerun-if-changed={}",
-            source_dir.join("include/ggml-metal.h").display()
-        );
-    }
 }
 
 fn cmake_flag(name: &str, enabled: bool) -> String {

--- a/crates/openasr-core/src/windows_cmake_cache.rs
+++ b/crates/openasr-core/src/windows_cmake_cache.rs
@@ -262,6 +262,14 @@ mod tests {
         )
     }
 
+    fn cache_with_source(source_dir: &Path, compiler: &str, shared: &str, cuda: &str) -> String {
+        format!(
+            "CMAKE_HOME_DIRECTORY:INTERNAL={}\n{}",
+            source_dir.display(),
+            cache(compiler, shared, cuda)
+        )
+    }
+
     #[test]
     fn equivalent_windows_compiler_spelling_matches() {
         let actual = cache(
@@ -331,6 +339,47 @@ mod tests {
             ("CMAKE_C_COMPILER", "clang-cl".to_owned()),
             ("CMAKE_CXX_COMPILER", "clang-cl.exe".to_owned()),
         ];
+
+        assert!(cache_matches_contract(&actual, &tools, &scalar_contract()));
+    }
+
+    #[test]
+    fn identical_native_contents_at_different_source_path_require_fresh_configure() {
+        let first = tempdir().expect("create first source fixture");
+        let second = tempdir().expect("create second source fixture");
+        native_fixture(first.path(), false);
+        native_fixture(second.path(), false);
+        assert_eq!(
+            build_relevant_fingerprint(first.path()).expect("fingerprint first source"),
+            build_relevant_fingerprint(second.path()).expect("fingerprint second source")
+        );
+
+        let compiler = "D:/Toolchain/VS/VC/Tools/MSVC/14.44/bin/HostX64/x64/cl.exe";
+        let tools = vec![
+            ("CMAKE_HOME_DIRECTORY", second.path().display().to_string()),
+            ("CMAKE_C_COMPILER", compiler.to_owned()),
+            ("CMAKE_CXX_COMPILER", compiler.to_owned()),
+        ];
+        let actual = cache_with_source(first.path(), compiler, "OFF", "ON");
+
+        assert!(!cache_matches_contract(&actual, &tools, &scalar_contract()));
+    }
+
+    #[test]
+    fn same_source_path_keeps_compatible_cache() {
+        let source_dir = Path::new(r"D:\Staging\openasr-ggml");
+        let compiler = "D:/Toolchain/VS/VC/Tools/MSVC/14.44/bin/HostX64/x64/cl.exe";
+        let tools = vec![
+            ("CMAKE_HOME_DIRECTORY", source_dir.display().to_string()),
+            ("CMAKE_C_COMPILER", compiler.to_owned()),
+            ("CMAKE_CXX_COMPILER", compiler.to_owned()),
+        ];
+        let actual = cache_with_source(
+            Path::new(r"\\?\d:\STAGING\openasr-ggml\"),
+            compiler,
+            "OFF",
+            "ON",
+        );
 
         assert!(cache_matches_contract(&actual, &tools, &scalar_contract()));
     }

--- a/crates/openasr-core/src/windows_cmake_cache.rs
+++ b/crates/openasr-core/src/windows_cmake_cache.rs
@@ -1,9 +1,137 @@
-//! Pure validation for the Windows ggml CMake cache contract.
+//! Native ggml source fingerprinting and Windows CMake cache validation.
 //!
 //! `build.rs` includes this file directly because a build script cannot depend
 //! on the crate it configures. The library also compiles it under `cfg(test)` so
 //! the regression tests run under `cargo nextest`; tests declared only inside a
 //! build script are never collected.
+
+use std::{
+    fs::{self, File},
+    io::{self, Read},
+    path::{Path, PathBuf},
+};
+
+use sha2::{Digest, Sha256};
+
+/// Directories CMake can compile or include for the production ggml library.
+///
+/// Cargo recursively watches directory paths emitted through
+/// `rerun-if-changed`, and the fingerprint walks the same roots. Keep this list
+/// as the single source of truth so a newly added native source cannot be
+/// omitted from one invalidation mechanism while appearing in the other.
+pub(crate) const BUILD_RELEVANT_DIRECTORIES: &[&str] = &["cmake", "include", "src"];
+
+/// Build-relevant files at the vendored ggml root, outside the directories
+/// above. Tests/examples are disabled by `build.rs`, so their trees are not
+/// native inputs and intentionally do not invalidate the expensive CMake build.
+pub(crate) const BUILD_RELEVANT_FILES: &[&str] = &["CMakeLists.txt", "ggml.pc.in"];
+
+pub(crate) const SOURCE_FINGERPRINT_STAMP: &str = "openasr-native-inputs.sha256";
+
+/// Hash every build-relevant native input by normalized relative path and
+/// contents. The result is independent of checkout location, directory
+/// enumeration order, file mtimes, and git metadata.
+pub(crate) fn build_relevant_fingerprint(source_dir: &Path) -> io::Result<String> {
+    let mut files = Vec::new();
+    for relative in BUILD_RELEVANT_DIRECTORIES {
+        collect_regular_files(source_dir, Path::new(relative), &mut files)?;
+    }
+    for relative in BUILD_RELEVANT_FILES {
+        let relative = PathBuf::from(relative);
+        ensure_regular_file(&source_dir.join(&relative))?;
+        files.push(relative);
+    }
+
+    files.sort_by_key(|path| normalized_relative_path(path));
+
+    let mut digest = Sha256::new();
+    digest.update(b"openasr-native-inputs-v1\0");
+    let mut buffer = [0_u8; 64 * 1024];
+    for relative in files {
+        let normalized = normalized_relative_path(&relative);
+        hash_framed_bytes(&mut digest, normalized.as_bytes());
+
+        let mut file = File::open(source_dir.join(&relative))?;
+        let mut file_digest = Sha256::new();
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            file_digest.update(&buffer[..read]);
+        }
+        digest.update(file_digest.finalize());
+    }
+
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+/// A missing or different stamp means the private CMake tree cannot be reused.
+/// Trimming accepts the newline written by `build.rs` without weakening the
+/// exact fingerprint comparison.
+pub(crate) fn source_fingerprint_requires_reset(
+    stored_fingerprint: Option<&str>,
+    expected_fingerprint: &str,
+) -> bool {
+    stored_fingerprint.is_none_or(|stored| stored.trim() != expected_fingerprint)
+}
+
+fn collect_regular_files(
+    source_dir: &Path,
+    relative_dir: &Path,
+    files: &mut Vec<PathBuf>,
+) -> io::Result<()> {
+    let directory = source_dir.join(relative_dir);
+    if !directory.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("native input directory is missing: {}", directory.display()),
+        ));
+    }
+
+    for entry in fs::read_dir(&directory)? {
+        let entry = entry?;
+        let relative = relative_dir.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_regular_files(source_dir, &relative, files)?;
+        } else if file_type.is_file() {
+            files.push(relative);
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "native input must be a regular file or directory: {}",
+                    entry.path().display()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_regular_file(path: &Path) -> io::Result<()> {
+    if path.is_file() {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("native input file is missing: {}", path.display()),
+        ))
+    }
+}
+
+fn normalized_relative_path(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn hash_framed_bytes(digest: &mut Sha256, bytes: &[u8]) {
+    digest.update((bytes.len() as u64).to_le_bytes());
+    digest.update(bytes);
+}
 
 pub(crate) fn cache_matches_contract(
     cache: &str,
@@ -74,7 +202,41 @@ fn normalize_scalar(raw: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::cache_matches_contract;
+    use std::{fs, path::Path};
+
+    use tempfile::tempdir;
+
+    use super::{
+        SOURCE_FINGERPRINT_STAMP, build_relevant_fingerprint, cache_matches_contract,
+        source_fingerprint_requires_reset,
+    };
+
+    fn write(root: &Path, relative: &str, contents: &str) {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().expect("fixture path has a parent"))
+            .expect("create fixture directory");
+        fs::write(path, contents).expect("write fixture file");
+    }
+
+    fn native_fixture(root: &Path, reverse_creation_order: bool) {
+        let files = [
+            ("CMakeLists.txt", "add_subdirectory(src)\n"),
+            ("ggml.pc.in", "prefix=@CMAKE_INSTALL_PREFIX@\n"),
+            ("cmake/common.cmake", "set(GGML_VERSION 1)\n"),
+            ("include/ggml.h", "void ggml_old(void);\n"),
+            ("src/CMakeLists.txt", "add_library(ggml ggml.c)\n"),
+            ("src/ggml.c", "void ggml_old(void) {}\n"),
+        ];
+        if reverse_creation_order {
+            for (relative, contents) in files.iter().rev() {
+                write(root, relative, contents);
+            }
+        } else {
+            for (relative, contents) in files {
+                write(root, relative, contents);
+            }
+        }
+    }
 
     fn scalar_contract() -> Vec<(&'static str, String)> {
         vec![
@@ -171,5 +333,75 @@ mod tests {
         ];
 
         assert!(cache_matches_contract(&actual, &tools, &scalar_contract()));
+    }
+
+    #[test]
+    fn fingerprint_changes_for_native_content_addition_and_deletion() {
+        let fixture = tempdir().expect("create fixture tempdir");
+        native_fixture(fixture.path(), false);
+        let baseline = build_relevant_fingerprint(fixture.path()).expect("fingerprint baseline");
+
+        write(
+            fixture.path(),
+            "src/ggml.c",
+            "void ggml_old(void) {}\nvoid ggml_new(void) {}\n",
+        );
+        let modified = build_relevant_fingerprint(fixture.path()).expect("fingerprint modified");
+        assert_ne!(baseline, modified);
+
+        write(
+            fixture.path(),
+            "src/new-op.c",
+            "void ggml_new_op(void) {}\n",
+        );
+        let added = build_relevant_fingerprint(fixture.path()).expect("fingerprint added");
+        assert_ne!(modified, added);
+
+        fs::remove_file(fixture.path().join("include/ggml.h")).expect("remove native header");
+        let deleted = build_relevant_fingerprint(fixture.path()).expect("fingerprint deleted");
+        assert_ne!(added, deleted);
+    }
+
+    #[test]
+    fn fingerprint_is_stable_across_creation_and_enumeration_order() {
+        let forward = tempdir().expect("create forward fixture");
+        let reverse = tempdir().expect("create reverse fixture");
+        native_fixture(forward.path(), false);
+        native_fixture(reverse.path(), true);
+
+        assert_eq!(
+            build_relevant_fingerprint(forward.path()).expect("fingerprint forward"),
+            build_relevant_fingerprint(reverse.path()).expect("fingerprint reverse")
+        );
+    }
+
+    #[test]
+    fn documentation_outside_build_roots_does_not_change_fingerprint() {
+        let fixture = tempdir().expect("create fixture tempdir");
+        native_fixture(fixture.path(), false);
+        let before = build_relevant_fingerprint(fixture.path()).expect("fingerprint before docs");
+
+        write(
+            fixture.path(),
+            "docs/benchmark-notes.md",
+            "not a native build input\n",
+        );
+
+        assert_eq!(
+            before,
+            build_relevant_fingerprint(fixture.path()).expect("fingerprint after docs")
+        );
+    }
+
+    #[test]
+    fn missing_or_mismatched_source_fingerprint_requires_cache_reset() {
+        assert_eq!(SOURCE_FINGERPRINT_STAMP, "openasr-native-inputs.sha256");
+        let expected = "0123456789abcdef";
+        assert!(source_fingerprint_requires_reset(None, expected));
+        assert!(source_fingerprint_requires_reset(Some("old"), expected));
+        assert!(!source_fingerprint_requires_reset(
+            Some("0123456789abcdef\n"),
+            expected
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- invalidate stale Windows native GGML build state when build-relevant sources or the CMake source checkout changes
- add an explicit `serve --no-model` contract for launching the daemon without resolving an installed default model
- pace `live --input-file` against the audio timeline and apply bounded backpressure only to finite file replay

## Why

A restored Cargo target directory could retain native CMake outputs from an older GGML revision. Rust code would rebuild against the current headers while stale DLLs remained reusable, creating an ABI mismatch at runtime.

Desktop recovery also needs an explicit way to keep the daemon unbound after rejecting an installed default model. Omitting the model argument was ambiguous because the CLI independently resolved the persisted default.

File-backed live input previously produced frames as fast as the CPU could decode them. Slow inference could fill the bounded worker queue before the first result returned, causing a queue-full failure that does not represent a real-time capture overload.

## Changes

- fingerprint build-relevant GGML source inputs and reset the private native build directory when the fingerprint or cache contract changes
- include normalized `CMAKE_HOME_DIRECTORY` in the Windows cache contract so staging-path changes force reconfiguration
- expose `--no-model`, make it mutually exclusive with explicit model sources, and short-circuit default-model resolution
- pace finite file replay in near real time and wait for bounded queue capacity while leaving microphone and system-audio capture fail-fast
- add unit, parser-contract, daemon health, CLI help, and file-replay regression coverage

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

## Manual smoke checks

- verified `serve --no-model` keeps an installed persisted default unbound and reports both model health fields as false
- replayed a real WAV through `live --input-file`; all four final segments completed without a queue-full error
- verified the CLI help documents that one hour of file input takes roughly one hour of wall-clock time

## Model-family changes (when applicable)

Not applicable. This PR does not add or modify a model family, catalog entry, or public model artifact.

## Docs updated

- [x] CLI help documents near-real-time file replay and its wall-clock cost.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- microphone and system-audio capture retain their existing fail-fast queue policy
- the first build without a native cache stamp intentionally rebuilds GGML
- this PR does not bump the workspace version, create a tag, or publish a release

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [ ] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md].
- [ ] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - AI assistance was used for implementation, testing, and review.