### PR TITLE
fix(vulkan): use typed provider in XASR smoke

### DIFF
--- a/crates/openasr-core/src/models/xasr_zipformer/encoder_graph.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/encoder_graph.rs
@@ -6839,9 +6839,12 @@ mod tests {
         config.graph_size = 2_048;
         let mut runner = GgmlCpuGraphRunner::new(config)
             .expect("accelerated (Vulkan) ggml backend should initialize on the smoke runner");
-        assert_eq!(
-            ExecutionProvider::from_backend_name(&runner.backend_label()),
-            ExecutionProvider::Vulkan,
+        // `GgmlCpuGraphRunner::new` has already attested the Exact request
+        // against the initialized device's typed provider.  Check the shared
+        // runtime capability here; `backend_label()` is a composite diagnostic
+        // string (`Gpu:Vulkan`) and must never be parsed as a raw backend name.
+        assert!(
+            runner.backend_capabilities().is_vulkan(),
             "smoke test must execute on the exact Vulkan route"
         );
 


### PR DESCRIPTION
## Summary
- keep Exact Vulkan attestation fail-closed in the shared runner
- stop reparsing the composite diagnostic label `Gpu:Vulkan` as a raw backend name
- validate the smoke through the runner's typed Vulkan capability

## Root cause
The scheduled lavapipe smoke constructed and attested the Exact Vulkan runner successfully, then parsed `runner.backend_label()`. That API intentionally returns a composite diagnostic string (`Gpu:Vulkan`), so `ExecutionProvider::from_backend_name` correctly returned `Unknown`.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p openasr-core --features vulkan --lib -- -D warnings`
- `cargo test -p openasr-core --features vulkan --lib --no-run`
- RTX 3060: `xasr_attention_weighted_values_vulkan_head_offset_smoke` PASS with `ggml-vulkan.dll`
- main lavapipe run 32177930946 reproduced the pre-fix failure twice; hotfix CI is the Linux lavapipe confirmation

Disclosure: developed with assistance from OpenAI Codex.