### PR TITLE
ci(linux): prebuild routine job dependencies

### DIFF
--- a/.github/ci/check-linux-build-env.py
+++ b/.github/ci/check-linux-build-env.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LOCK = ROOT / ".github/ci/linux-build-env.lock"
+IMAGE_PATTERN = re.compile(
+    r"ghcr\.io/quintinshaw/openasr-ci-linux@sha256:[0-9a-f]{64}"
+)
+CONSUMERS = {
+    ".github/workflows/ci.yml": 2,
+    ".github/workflows/family-regression.yml": 1,
+    ".github/workflows/public-hf-e2e.yml": 1,
+    ".github/workflows/serve-batch-parity.yml": 1,
+}
+
+
+def main() -> None:
+    expected = LOCK.read_text(encoding="utf-8").strip()
+    if IMAGE_PATTERN.fullmatch(expected) is None:
+        raise SystemExit(f"invalid Linux CI image lock: {expected!r}")
+
+    failures: list[str] = []
+    for relative, expected_count in CONSUMERS.items():
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        references = IMAGE_PATTERN.findall(text)
+        if references != [expected] * expected_count:
+            failures.append(
+                f"{relative}: expected {expected_count} reference(s) to {expected}, "
+                f"found {references}"
+            )
+        if "apt-get" in text:
+            failures.append(f"{relative}: routine consumer must not run apt-get")
+
+    if failures:
+        raise SystemExit("\n".join(failures))
+    print(f"Linux CI image consumers match {expected}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/ci/linux-build-env.lock
+++ b/.github/ci/linux-build-env.lock
@@ -1,1 +1,1 @@
-ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
+ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc

--- a/.github/ci/linux-build-env.lock
+++ b/.github/ci/linux-build-env.lock
@@ -1,0 +1,1 @@
+ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0

--- a/.github/ci/linux-build-env/Dockerfile
+++ b/.github/ci/linux-build-env/Dockerfile
@@ -36,7 +36,14 @@ RUN success=0; \
     test "${success}" -eq 1; \
     rm -rf /var/lib/apt/lists/*
 
+RUN groupadd --gid 1001 openasr-ci \
+    && useradd --uid 1001 --gid 1001 --home-dir /github/home \
+      --create-home --shell /bin/bash openasr-ci
+
 COPY --chmod=0755 verify.sh /usr/local/bin/openasr-ci-verify
+
+USER 1001:1001
+
 RUN openasr-ci-verify
 
 LABEL org.opencontainers.image.source="https://github.com/QuintinShaw/openasr" \

--- a/.github/ci/linux-build-env/Dockerfile
+++ b/.github/ci/linux-build-env/Dockerfile
@@ -36,7 +36,9 @@ RUN success=0; \
     test "${success}" -eq 1; \
     rm -rf /var/lib/apt/lists/*
 
+COPY --chmod=0755 verify.sh /usr/local/bin/openasr-ci-verify
+RUN openasr-ci-verify
+
 LABEL org.opencontainers.image.source="https://github.com/QuintinShaw/openasr" \
       org.opencontainers.image.description="Pinned Linux build environment for OpenASR CI" \
       org.opencontainers.image.licenses="Apache-2.0"
-

--- a/.github/ci/linux-build-env/Dockerfile
+++ b/.github/ci/linux-build-env/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:24.04@sha256:d78ab76437b1afc5f01e223d6bf0172763f404bb166441328845adbef44518cb
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Keep the routine Linux CI jobs independent of Ubuntu mirror availability.
+# This networked install runs only when the image contract changes; consumers
+# pin the resulting immutable GHCR digest and perform no apt work themselves.
+RUN success=0; \
+    for attempt in 1 2 3; do \
+      if apt-get update -o Acquire::Retries=5 \
+        && apt-get install -y --no-install-recommends \
+          build-essential \
+          ca-certificates \
+          cmake \
+          curl \
+          file \
+          git \
+          jq \
+          libasound2-dev \
+          ninja-build \
+          pkg-config \
+          python3 \
+          python3-numpy \
+          python3-pip \
+          unzip \
+          xz-utils \
+          zstd; then \
+        success=1; \
+        break; \
+      fi; \
+      echo "apt attempt ${attempt}/3 failed" >&2; \
+      sleep $((attempt * 10)); \
+    done; \
+    test "${success}" -eq 1; \
+    rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.source="https://github.com/QuintinShaw/openasr" \
+      org.opencontainers.image.description="Pinned Linux build environment for OpenASR CI" \
+      org.opencontainers.image.licenses="Apache-2.0"
+

--- a/.github/ci/linux-build-env/README.md
+++ b/.github/ci/linux-build-env/README.md
@@ -1,0 +1,15 @@
+# Linux CI build environment
+
+This image removes networked `apt-get` work from routine Linux CI jobs. It is
+not a product or release image.
+
+- The base image is pinned by digest.
+- Every source revision is published under its commit SHA.
+- Consumer workflows pin the verified GHCR digest, never a mutable tag.
+- The publish workflow verifies C/C++, CMake, ALSA, and Python/NumPy before a
+  digest is eligible for consumers.
+
+To change the dependency contract, update the Dockerfile in the same pull
+request. After the image workflow succeeds, copy its immutable digest into the
+consumer workflow declarations and let their ordinary tests validate the new
+environment.

--- a/.github/ci/linux-build-env/README.md
+++ b/.github/ci/linux-build-env/README.md
@@ -8,6 +8,8 @@ not a product or release image.
 - Consumer workflows pin the verified GHCR digest, never a mutable tag.
 - The publish workflow verifies C/C++, CMake, ALSA, and Python/NumPy before a
   digest is eligible for consumers.
+- Each consumer runs the image-owned `openasr-ci-verify` contract and marks the
+  mounted checkout as a Git safe directory before invoking repository scripts.
 
 To change the dependency contract, update the Dockerfile in the same pull
 request. After the image workflow succeeds, copy its immutable digest into the

--- a/.github/ci/linux-build-env/README.md
+++ b/.github/ci/linux-build-env/README.md
@@ -13,5 +13,6 @@ not a product or release image.
 
 To change the dependency contract, update the Dockerfile in the same pull
 request. After the image workflow succeeds, copy its immutable digest into the
-consumer workflow declarations and let their ordinary tests validate the new
-environment.
+consumer workflow declarations and `.github/ci/linux-build-env.lock`, then let
+their ordinary tests validate the new environment. The lint job rejects partial
+digest updates and any reintroduced `apt-get` in routine consumers.

--- a/.github/ci/linux-build-env/README.md
+++ b/.github/ci/linux-build-env/README.md
@@ -8,6 +8,8 @@ not a product or release image.
 - Consumer workflows pin the verified GHCR digest, never a mutable tag.
 - The publish workflow verifies C/C++, CMake, ALSA, and Python/NumPy before a
   digest is eligible for consumers.
+- The default user is a fixed non-root CI account so Unix permission tests keep
+  the same semantics as GitHub-hosted runner jobs.
 - Each consumer runs the image-owned `openasr-ci-verify` contract and marks the
   mounted checkout as a Git safe directory before invoking repository scripts.
 

--- a/.github/ci/linux-build-env/verify.sh
+++ b/.github/ci/linux-build-env/verify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmake --version
+cc --version
+pkg-config --exists alsa
+python3 -c 'import numpy; print(numpy.__version__)'

--- a/.github/ci/linux-build-env/verify.sh
+++ b/.github/ci/linux-build-env/verify.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "OpenASR routine CI must run as a non-root user" >&2
+  exit 1
+fi
+
 cmake --version
 cc --version
 pkg-config --exists alsa

--- a/.github/workflows/ci-linux-build-env.yml
+++ b/.github/workflows/ci-linux-build-env.yml
@@ -1,0 +1,67 @@
+name: CI Linux build environment
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/ci/linux-build-env/**"
+      - ".github/workflows/ci-linux-build-env.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ci-linux-build-env-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build, publish, and verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish immutable image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .github/ci/linux-build-env
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/quintinshaw/openasr-ci-linux:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify published image contract
+        env:
+          IMAGE: ghcr.io/quintinshaw/openasr-ci-linux@${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker run --rm "$IMAGE" bash -euc '
+            cmake --version
+            cc --version
+            pkg-config --exists alsa
+            python3 -c "import numpy; print(numpy.__version__)"
+          '
+
+      - name: Record immutable consumer reference
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "### Linux CI build environment"
+            echo
+            echo '```text'
+            echo "ghcr.io/quintinshaw/openasr-ci-linux@${DIGEST}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-linux-build-env.yml
+++ b/.github/workflows/ci-linux-build-env.yml
@@ -45,14 +45,7 @@ jobs:
       - name: Verify published image contract
         env:
           IMAGE: ghcr.io/quintinshaw/openasr-ci-linux@${{ steps.build.outputs.digest }}
-        run: |
-          set -euo pipefail
-          docker run --rm "$IMAGE" bash -euc '
-            cmake --version
-            cc --version
-            pkg-config --exists alsa
-            python3 -c "import numpy; print(numpy.__version__)"
-          '
+        run: docker run --rm "$IMAGE" openasr-ci-verify
 
       - name: Record immutable consumer reference
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ permissions:
   contents: read
   packages: read
 
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -32,28 +36,16 @@ jobs:
   lint:
     name: Rust lint (fmt, clippy, catalog, python)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - name: Install build dependencies
-        timeout-minutes: 5
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          set -eu
-          ok=0
-          for attempt in 1 2 3; do
-            if sudo apt-get update -o Acquire::Retries=3 \
-              && sudo apt-get install -y -o DPkg::Lock::Timeout=60 cmake libasound2-dev; then
-              ok=1
-              break
-            fi
-            echo "apt-get attempt ${attempt}/3 failed" >&2
-            sleep $((attempt * 10))
-          done
-          test "$ok" -eq 1
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
@@ -69,8 +61,8 @@ jobs:
         run: python3 tooling/publish-model/scripts/check_catalog_consistency.py
       - name: GPU weight placement gate
         run: scripts/gpu-weight-placement-gate.sh
-      - name: Install python test dependencies
-        run: python3 -m pip install --user numpy
+      - name: Verify preinstalled Python test dependencies
+        run: python3 -c 'import numpy; print(numpy.__version__)'
       - name: Public source hygiene gate
         run: python3 tooling/check_public_source_hygiene.py
       - name: Python helper gates
@@ -91,28 +83,16 @@ jobs:
     # GitHub-hosted: runs for pushes and every PR, including forks (the repo is
     # public, so hosted-runner minutes are free and unlimited).
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - name: Install build dependencies
-        timeout-minutes: 5
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          set -eu
-          ok=0
-          for attempt in 1 2 3; do
-            if sudo apt-get update -o Acquire::Retries=3 \
-              && sudo apt-get install -y -o DPkg::Lock::Timeout=60 cmake libasound2-dev; then
-              ok=1
-              break
-            fi
-            echo "apt-get attempt ${attempt}/3 failed" >&2
-            sleep $((attempt * 10))
-          done
-          test "$ok" -eq 1
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     name: Rust lint (fmt, clippy, catalog, python)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -94,7 +94,7 @@ jobs:
     # public, so hosted-runner minutes are free and unlimited).
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     name: Rust lint (fmt, clippy, catalog, python)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -54,6 +54,8 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           openasr-ci-verify
+      - name: Linux build environment drift gate
+        run: python3 .github/ci/check-linux-build-env.py
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
@@ -92,7 +94,7 @@ jobs:
     # public, so hosted-runner minutes are free and unlimited).
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+      - name: Prepare pinned Linux build environment
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          openasr-ci-verify
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
@@ -97,6 +101,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+      - name: Prepare pinned Linux build environment
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          openasr-ci-verify
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt

--- a/.github/workflows/family-regression.yml
+++ b/.github/workflows/family-regression.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build CLI (ubuntu-latest)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/family-regression.yml
+++ b/.github/workflows/family-regression.yml
@@ -19,32 +19,39 @@ concurrency:
   group: family-regression-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  packages: read
+
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-cli:
-    name: Build CLI (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        # macos pinned (not macos-latest, which migrates to macOS 26 from
-        # 2026-06-15): the regression net's environment must not drift
-        # under the alias.
-        os: [ubuntu-latest, macos-15]
-    runs-on: ${{ matrix.os }}
+  build-cli-linux:
+    name: Build CLI (ubuntu-latest)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - name: Install build dependencies
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y cmake libasound2-dev
+      - name: Prepare pinned Linux build environment
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          openasr-ci-verify
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: family-regression-${{ matrix.os }}
+          shared-key: family-regression-ubuntu-latest
       - name: Build openasr CLI
         # The binary is shared with the case jobs via an artifact, and
         # GitHub's x86 runner fleet mixes CPU generations, so host-tuned ggml
@@ -55,13 +62,35 @@ jobs:
         run: cargo build --release -p openasr-cli
       - uses: actions/upload-artifact@v7
         with:
-          name: openasr-cli-${{ matrix.os }}
+          name: openasr-cli-ubuntu-latest
+          path: target/release/openasr
+          retention-days: 3
+
+  build-cli-macos:
+    name: Build CLI (macos-15)
+    runs-on: macos-15
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: family-regression-macos-15
+      - name: Build openasr CLI
+        env:
+          OPENASR_GGML_NATIVE: "0"
+        run: cargo build --release -p openasr-cli
+      - uses: actions/upload-artifact@v7
+        with:
+          name: openasr-cli-macos-15
           path: target/release/openasr
           retention-days: 3
 
   family:
     name: ${{ matrix.case.name }} (${{ matrix.os }})
-    needs: build-cli
+    needs: [build-cli-linux, build-cli-macos]
     strategy:
       # A single family failure must stay readable and must not cancel the
       # rest of the net.

--- a/.github/workflows/family-regression.yml
+++ b/.github/workflows/family-regression.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build CLI (ubuntu-latest)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/public-hf-e2e.yml
+++ b/.github/workflows/public-hf-e2e.yml
@@ -27,6 +27,10 @@ concurrency:
   group: public-hf-e2e-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -34,13 +38,16 @@ jobs:
   public-hf-e2e:
     name: Pull public pack and transcribe
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake libasound2-dev
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: Run public-HF E2E

--- a/.github/workflows/public-hf-e2e.yml
+++ b/.github/workflows/public-hf-e2e.yml
@@ -43,7 +43,7 @@ jobs:
     name: Pull public pack and transcribe
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/public-hf-e2e.yml
+++ b/.github/workflows/public-hf-e2e.yml
@@ -52,6 +52,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+      - name: Prepare pinned Linux build environment
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          openasr-ci-verify
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: Run public-HF E2E

--- a/.github/workflows/public-hf-e2e.yml
+++ b/.github/workflows/public-hf-e2e.yml
@@ -31,6 +31,10 @@ permissions:
   contents: read
   packages: read
 
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/public-hf-e2e.yml
+++ b/.github/workflows/public-hf-e2e.yml
@@ -43,7 +43,7 @@ jobs:
     name: Pull public pack and transcribe
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/serve-batch-parity.yml
+++ b/.github/workflows/serve-batch-parity.yml
@@ -25,6 +25,10 @@ permissions:
   contents: read
   packages: read
 
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_TERM_COLOR: always
   # Public moonshine-tiny q8_0 pack pinned to its immutable HF revision so the

--- a/.github/workflows/serve-batch-parity.yml
+++ b/.github/workflows/serve-batch-parity.yml
@@ -50,6 +50,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Prepare pinned Linux build environment
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          openasr-ci-verify
+
       - uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/serve-batch-parity.yml
+++ b/.github/workflows/serve-batch-parity.yml
@@ -41,7 +41,7 @@ jobs:
     name: moonshine CPU real-pack parity
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/serve-batch-parity.yml
+++ b/.github/workflows/serve-batch-parity.yml
@@ -21,6 +21,10 @@ concurrency:
   group: serve-batch-parity-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   CARGO_TERM_COLOR: always
   # Public moonshine-tiny q8_0 pack pinned to its immutable HF revision so the
@@ -32,13 +36,15 @@ jobs:
   cpu-real-pack-parity:
     name: moonshine CPU real-pack parity
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake
 
       - uses: dtolnay/rust-toolchain@1.95.0
 

--- a/.github/workflows/serve-batch-parity.yml
+++ b/.github/workflows/serve-batch-parity.yml
@@ -41,7 +41,7 @@ jobs:
     name: moonshine CPU real-pack parity
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:de3fd9f5a7d0b7ddce162ff9efda410a5b0c05252a63e29223d4b6d3728fb6d4
+      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:4b479dd9ac4e1618cd693cbf3ec8fba762c6984beadfb5dff8ac105287da12d0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- publish a minimal Linux build environment to GHCR from a digest-pinned Ubuntu base
- verify C/C++, CMake, ALSA, and NumPy before a produced image can be consumed
- pin routine Linux CI jobs to the immutable verified image digest
- remove per-job `apt-get update` from CI, real-pack parity, and public-HF E2E

## Why
GitHub-hosted Ubuntu mirror requests repeatedly exhausted the five-minute dependency-install timeout before any repository code ran. Retrying entire jobs eventually passed, but left main red and made merge/release evidence nondeterministic.

The networked package install now occurs only when the image contract changes. Routine jobs authenticate to GHCR with their read-only repository token and pull a fixed digest; no mutable tag controls execution.

## Validation
- image build/publish/contract verification: run 32229423885
- workflow YAML parse: PASS
- `git diff --check`: PASS
- PR CI validates the containerized lint, workspace test, and real-pack jobs
- public-HF E2E will be dispatched explicitly on this branch

Disclosure: developed with assistance from OpenAI Codex.