### PR TITLE
ci(release): run container steps with bash

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -194,6 +194,9 @@ jobs:
       attestations: write
     env:
       OPENASR_GGML_NATIVE: "0"
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
﻿## Summary
- force Bash for run steps in the containerized Linux core-release job

## Why
GitHub container jobs default to `/bin/sh`. The release binary built and passed its smoke checks, but the archive step uses `set -o pipefail`, which POSIX `sh` rejected before packaging began.

## Validation
- `python .github/ci/check-linux-build-env.py`
- `git diff --check`
- release run 32237477553: build and smoke passed; packaging reproduced the shell mismatch

Disclosure: developed with assistance from OpenAI Codex.
