### PR TITLE
fix(release): normalize CUDA entry names

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1257,7 +1257,7 @@ jobs:
           fi
           cuda_entries=()
           for target in "${cuda_targets[@]}"; do
-            entry="dist/backend-pack-cuda-${target}.json"
+            entry="dist/backend-pack-cuda-sm_${target}.json"
             [ -f "$entry" ] || { echo "missing required CUDA entry: $entry" >&2; exit 1; }
             cuda_entries+=("$entry")
           done

--- a/tooling/release-manifest/windows_backend_release_contract_test.py
+++ b/tooling/release-manifest/windows_backend_release_contract_test.py
@@ -219,8 +219,18 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
         ]
         self.assertEqual(len(required_cuda), 5)
         self.assertEqual(len(required_hip), 14)
+        self.assertEqual(
+            [f'backend-pack-cuda-sm_{row["cuda_gpu_target"]}.json' for row in required_cuda],
+            [
+                "backend-pack-cuda-sm_75.json",
+                "backend-pack-cuda-sm_80.json",
+                "backend-pack-cuda-sm_86.json",
+                "backend-pack-cuda-sm_89.json",
+                "backend-pack-cuda-sm_90.json",
+            ],
+        )
         self.assertIn('not row.get("experimental", False)', self.workflow)
-        self.assertIn('entry="dist/backend-pack-cuda-${target}.json"', self.workflow)
+        self.assertIn('entry="dist/backend-pack-cuda-sm_${target}.json"', self.workflow)
         self.assertIn('entry="dist/backend-pack-hip-${target}.json"', self.workflow)
 
     def test_full_matrix_has_exactly_one_vendor_owner_per_optional_vendor(self) -> None:


### PR DESCRIPTION
## Summary

Normalizes CUDA matrix target names to the `backend-pack-cuda-sm_<target>.json` release-asset convention during artifact recovery.

## Why

The release matrix stores CUDA architecture values as `75`, `80`, `86`, `89`, and `90`, while target-scoped metadata files use the canonical `sm_` prefix. Recovery correctly downloaded every artifact but looked for `backend-pack-cuda-75.json` instead of `backend-pack-cuda-sm_75.json`.

## Changes

- add the canonical `sm_` prefix when resolving required CUDA metadata files
- add a matrix-driven test that locks all five expected CUDA metadata filenames

## Tests run

- [x] `actionlint .github/workflows/release-binaries.yml`
- [x] `python -m unittest discover -s tooling/release-manifest -p '*_test.py'` (95 passed)
- [x] `git diff --check`
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` (CI Rust lint)
- [x] `cargo nextest run --workspace` and `cargo test --workspace --doc` (CI Rust test)
- [x] `cargo deny check` (CI dependency policy)

## Manual smoke checks

The previous recovery run proved artifact reuse and download behavior; it failed at the exact filename lookup corrected here, before catalog generation or attestation.

## Model-family changes (when applicable)

- [ ] Not applicable; no model-family code changed.

## Docs updated

- [x] No user-facing documentation change is required.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR only corrects release metadata lookup. It does not rebuild binaries, change runtime behavior, edit the live catalog, or publish v0.1.34.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in `AGENTS.md`.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES