### PR TITLE
fix(release): retain checksum sidecars

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1222,7 +1222,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          find staging -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dll' -o -name 'backend-pack-*.json' \) -exec cp {} dist/ \;
+          find staging -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dll' -o -name '*.sha256' -o -name 'backend-pack-*.json' \) -exec cp {} dist/ \;
           cd dist
           sha256sum * > SHA256SUMS
           cat SHA256SUMS

--- a/tooling/release-manifest/windows_backend_release_contract_test.py
+++ b/tooling/release-manifest/windows_backend_release_contract_test.py
@@ -205,6 +205,8 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
         self.assertIn("inputs.source_run_id != ''", self.workflow)
         self.assertIn("Upload recovered assets to release", self.workflow)
         self.assertIn("recovery only uploads to an existing draft release", self.workflow)
+        self.assertIn("-name '*.sha256'", self.workflow)
+        self.assertIn("dist/*.sha256", self.workflow)
 
     def test_catalog_candidate_uses_only_release_blocking_plugin_targets(self) -> None:
         required_cuda = [


### PR DESCRIPTION
## Summary

Preserves release checksum sidecar files when a failed aggregation run is recovered from immutable workflow artifacts.

## Why

The recovery path downloaded `openasr-<version>-xcframework.zip.sha256`, but the aggregation copy allowlist omitted `*.sha256`. The archive, backend packs, candidate catalog, aggregate `SHA256SUMS`, provenance, and release upload succeeded, while the final completeness gate correctly rejected the missing checksum sidecar.

## Changes

- include `*.sha256` files in the aggregation copy allowlist
- lock both collection and upload patterns in the release-contract test

## Tests run

- [x] `actionlint .github/workflows/release-binaries.yml`
- [x] `python -m unittest discover -s tooling/release-manifest -p '*_test.py'` (95 passed)
- [x] `git diff --check`
- [x] Repository CI is green.

## Manual smoke checks

Recovery run `32261887507` completed artifact reuse, SHA generation, catalog candidate generation, aggregate provenance, and Draft upload. The final gate identified only the omitted xcframework checksum sidecar corrected here.

## Model-family changes (when applicable)

- [ ] Not applicable; no model-family code changed.

## Docs updated

- [x] No user-facing documentation change is required.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR only preserves an existing release checksum sidecar during aggregation. It does not rebuild binaries, change runtime behavior, edit the live catalog, or publish v0.1.34.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in `AGENTS.md`.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES