### PR TITLE
fix(release): bind provider matrix evidence

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -35,6 +35,14 @@ on:
         description: "Reuse immutable build artifacts from this completed release-core run and execute only aggregation/upload/completeness"
         required: false
         default: ""
+      supplemental_source_run_id:
+        description: "Optional completed single-target run whose immutable artifacts supplement source_run_id during recovery"
+        required: false
+        default: ""
+      promote_cuda_targets:
+        description: "Comma-separated experimental CUDA targets to promote during a recovery (for example 120)"
+        required: false
+        default: ""
       cuda_gpu_targets:
         description: "Optional CUDA arch list for a diagnostic workflow_dispatch build (empty = release defaults)"
         required: false
@@ -1200,24 +1208,39 @@ jobs:
         with:
           path: staging
           merge-multiple: true
-      - name: Download archives from source run
+      - name: Download archives from source runs
         if: inputs.source_run_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SUPPLEMENTAL_SOURCE_RUN_ID: ${{ inputs.supplemental_source_run_id || '' }}
         run: |
           set -euo pipefail
           [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
             echo "source_run_id must be a positive Actions run id" >&2
             exit 1
           }
-          status="$(gh run view "$SOURCE_RUN_ID" --repo "${{ github.repository }}" --json status --jq .status)"
-          [ "$status" = "completed" ] || {
-            echo "source run $SOURCE_RUN_ID is not completed" >&2
-            exit 1
-          }
           mkdir -p staging
-          gh run download "$SOURCE_RUN_ID" --repo "${{ github.repository }}" --dir staging
+          run_ids=("$SOURCE_RUN_ID")
+          if [ -n "$SUPPLEMENTAL_SOURCE_RUN_ID" ]; then
+            [[ "$SUPPLEMENTAL_SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+              echo "supplemental_source_run_id must be a positive Actions run id" >&2
+              exit 1
+            }
+            [ "$SUPPLEMENTAL_SOURCE_RUN_ID" != "$SOURCE_RUN_ID" ] || {
+              echo "supplemental_source_run_id must differ from source_run_id" >&2
+              exit 1
+            }
+            run_ids+=("$SUPPLEMENTAL_SOURCE_RUN_ID")
+          fi
+          for run_id in "${run_ids[@]}"; do
+            status="$(gh run view "$run_id" --repo "${{ github.repository }}" --json status --jq .status)"
+            [ "$status" = "completed" ] || {
+              echo "source run $run_id is not completed" >&2
+              exit 1
+            }
+            gh run download "$run_id" --repo "${{ github.repository }}" --dir "staging/$run_id"
+          done
       - name: Generate SHA256SUMS
         run: |
           set -euo pipefail
@@ -1229,15 +1252,34 @@ jobs:
 
       - name: Compile ABI-scoped backend catalog candidate
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.only_target == ''
+        env:
+          PROMOTE_CUDA_TARGETS: ${{ inputs.promote_cuda_targets || '' }}
         run: |
           set -euo pipefail
           mapfile -t cuda_targets < <(python3 - <<'PY'
           import json
+          import os
           from pathlib import Path
 
           matrix = json.loads(Path("tooling/release-manifest/release_binaries_matrix.json").read_text())
+          promoted = {
+              target.removeprefix("sm_")
+              for token in os.environ.get("PROMOTE_CUDA_TARGETS", "").replace(",", " ").split()
+              if (target := token.strip())
+          }
+          known = {
+              str(row["cuda_gpu_target"])
+              for row in matrix
+              if row.get("provider") == "cuda"
+          }
+          unknown = promoted - known
+          if unknown:
+              raise SystemExit(f"unknown promoted CUDA target(s): {sorted(unknown)}")
           for row in matrix:
-              if row.get("provider") == "cuda" and not row.get("experimental", False):
+              if row.get("provider") == "cuda" and (
+                  not row.get("experimental", False)
+                  or str(row["cuda_gpu_target"]) in promoted
+              ):
                   print(row["cuda_gpu_target"])
           PY
           )
@@ -1251,8 +1293,8 @@ jobs:
                   print(row["hip_gpu_target"])
           PY
           )
-          if [ "${#cuda_targets[@]}" -ne 5 ] || [ "${#hip_targets[@]}" -ne 14 ]; then
-            echo "release matrix must define exactly 5 required CUDA SM and 14 required HIP gfx targets" >&2
+          if [ "${#cuda_targets[@]}" -lt 5 ] || [ "${#hip_targets[@]}" -ne 14 ]; then
+            echo "release matrix must define at least 5 required CUDA SM and exactly 14 required HIP gfx targets" >&2
             exit 1
           fi
           cuda_entries=()
@@ -1477,6 +1519,8 @@ jobs:
         # listed: they may fail without failing the run, so requiring their
         # asset here would defeat the escape hatch. Promote such a leg (drop
         # `experimental`, add its asset:ext here) once it proves green.
+        env:
+          PROMOTE_CUDA_TARGETS: ${{ inputs.promote_cuda_targets || '' }}
         run: |
           set -euo pipefail
           tag="${RELEASE_TAG}"
@@ -1507,18 +1551,67 @@ jobs:
             echo "openasr-${version}-${target}.${ext}" >> "$expected_file"
           done
           echo "openasr-${version}-xcframework.zip.sha256" >> "$expected_file"
-          for sm in 75 80 86 89 90; do
-            echo "openasr-${version}-windows-x86_64-cuda-sm_${sm}-plugin.dll" >> "$expected_file"
-            echo "backend-pack-cuda-sm_${sm}.json" >> "$expected_file"
-          done
-          for gfx in gfx1030 gfx1031 gfx1032 gfx1035 gfx1100 gfx1101 gfx1102 gfx1103 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201; do
-            echo "openasr-${version}-windows-x86_64-rocm-${gfx}-plugin.dll" >> "$expected_file"
-            echo "backend-pack-hip-${gfx}.json" >> "$expected_file"
-          done
+          pack_names="$(mktemp)"
+          python3 - "$pack_names" <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          matrix = json.loads(Path("tooling/release-manifest/release_binaries_matrix.json").read_text())
+          promoted = {
+              token.strip().removeprefix("sm_")
+              for token in os.environ.get("PROMOTE_CUDA_TARGETS", "").replace(",", " ").split()
+              if token.strip()
+          }
+          known = {
+              str(row["cuda_gpu_target"])
+              for row in matrix
+              if row.get("provider") == "cuda"
+          }
+          unknown = promoted - known
+          if unknown:
+              raise SystemExit(f"unknown promoted CUDA target(s): {sorted(unknown)}")
+          names = []
+          for row in matrix:
+              provider = row.get("provider")
+              if provider == "cuda" and (
+                  not row.get("experimental", False)
+                  or str(row["cuda_gpu_target"]) in promoted
+              ):
+                  names.append(f"backend-pack-cuda-sm_{row['cuda_gpu_target']}.json")
+              elif provider == "hip" and not row.get("experimental", False):
+                  names.append(f"backend-pack-hip-{row['hip_gpu_target']}.json")
+          Path(sys.argv[1]).write_text("\n".join(names) + "\n", encoding="utf-8")
+          PY
+          pack_dir="$(mktemp -d)"
+          while IFS= read -r pack_name; do
+            [ -n "$pack_name" ] || continue
+            echo "$pack_name" >> "$expected_file"
+            gh release download "$tag" --repo "${{ github.repository }}" \
+              -p "$pack_name" -D "$pack_dir"
+          done < "$pack_names"
+          python3 - "$pack_dir" >> "$expected_file" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          root = Path(sys.argv[1])
+          for entry_path in sorted(root.glob("backend-pack-*.json")):
+              entry = json.loads(entry_path.read_text(encoding="utf-8"))
+              files = entry.get("files")
+              if not isinstance(files, list) or not files:
+                  raise SystemExit(f"{entry_path.name} has no files")
+              for file in files:
+                  name = file.get("filename") if isinstance(file, dict) else None
+                  if not isinstance(name, str) or not name or Path(name).name != name:
+                      raise SystemExit(f"{entry_path.name} has unsafe filename {name!r}")
+                  print(name)
+          PY
           echo "backend-plugin-hints.json" >> "$expected_file"
           echo "catalog.backends.candidate.json" >> "$expected_file"
           echo "SHA256SUMS" >> "$expected_file"
-          sort -o "$expected_file" "$expected_file"
+          sort -u -o "$expected_file" "$expected_file"
 
           actual_file="$(mktemp)"
           gh release view "$tag" --repo "${{ github.repository }}" --json assets \
@@ -1537,15 +1630,4 @@ jobs:
           fi
           echo "release ${tag} has all $(wc -l < "$expected_file" | tr -d ' ') expected assets."
 
-          # Optional-plugin vendor runtime archives are named
-          # openasr-vendor-<layer>-<sha12>.zip, content-addressed by their own
-          # sha256, so (unlike every asset above) the exact filename cannot be
-          # hardcoded into TARGETS. Every complete target-plugin set must also
-          # ship the shared runtime referenced by its backend-pack metadata.
-          for vendor_key in cuda-runtime rocm-runtime; do
-            if ! grep -Eq "^openasr-vendor-${vendor_key}-[0-9a-f]{12,}\.zip\$" "$actual_file"; then
-              echo "::error::release ${tag} is missing an openasr-vendor-${vendor_key}-<sha12>.zip vendor archive asset"
-              exit 1
-            fi
-          done
-          echo "release ${tag} also has both expected vendor_layers archives (cuda-runtime, rocm-runtime)."
+          echo "release ${tag} has every plugin and content-addressed vendor archive declared by its required backend packs."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -114,16 +114,18 @@ production-signed catalog. Core 0.1.34 and later publish no legacy whole-engine
 Windows sidecars and no per-release `backends-manifest.json`. A draft is not
 made public until the signed catalog distribution plane is complete:
 
-1. Attach one `backend-hardware-evidence-*.json` receipt for every target that
-   is intended to become runtime-selectable. A receipt is accepted only when it
-   matches the exact release entry, plugin digest, ABI fingerprint, binary,
-   model and workload; proves at least five fresh processes; and records
-   FullDevice execution with no CPU fallback. Building a target is not hardware
-   evidence.
+1. Attach `backend-hardware-evidence-*.json` receipts for every provider that is
+   intended to become runtime-selectable. Schema v1 approves only the exact
+   tested target. Schema v2 may approve an explicit provider target matrix from
+   one representative target, but it binds the tested plugin digest plus the
+   complete target list and artifact fingerprint of every approved entry. Both
+   schemas require at least five fresh processes, FullDevice execution, and no
+   CPU fallback. Building a target is not hardware evidence, and a matrix receipt
+   is an explicit compatibility policy rather than a claim that every GPU ran.
 2. Run `scripts/prepare-windows-backend-catalog-release.sh vX.Y.Z` locally with
-   the production catalog signing seed. It downloads and hashes all 5 CUDA and
-   11 HIP build artifacts, but merges only the exact target entries approved by
-   those receipts. It then bumps the catalog epoch and signs the full/public
+   the production catalog signing seed. It downloads and hashes all 6 CUDA and
+   14 HIP build artifacts, but merges only the target entries approved by those
+   receipts. It then bumps the catalog epoch and signs the full/public
    catalogs. Review, commit, and push those catalog files.
 3. Wait for `deploy-catalog.yml` to prove the signed public bytes are live.
 4. Run `scripts/finalize-core-release.sh vX.Y.Z`. It requires the live signed

--- a/scripts/finalize-core-release.sh
+++ b/scripts/finalize-core-release.sh
@@ -34,15 +34,15 @@ backend_entries=("$workdir"/backend-pack-*.json)
 hardware_evidence=("$workdir"/backend-hardware-evidence-*.json)
 cuda_entries=("$workdir"/backend-pack-cuda-sm_*.json)
 hip_entries=("$workdir"/backend-pack-hip-gfx*.json)
-if [ "${#cuda_entries[@]}" -ne 5 ] || [ "${#hip_entries[@]}" -ne 14 ] || [ "${#backend_entries[@]}" -ne 19 ]; then
-  fail "release ${tag} must contain exactly 5 CUDA SM and 14 HIP gfx backend-pack metadata files"
+if [ "${#cuda_entries[@]}" -ne 6 ] || [ "${#hip_entries[@]}" -ne 14 ] || [ "${#backend_entries[@]}" -ne 20 ]; then
+  fail "release ${tag} must contain exactly 6 CUDA SM and 14 HIP gfx backend-pack metadata files"
 fi
 all_backend_entry_args=()
 for entry in "${backend_entries[@]}"; do
   all_backend_entry_args+=(--entry "$entry")
 done
 [ "${#hardware_evidence[@]}" -gt 0 ] \
-  || fail "release ${tag} has no exact real-hardware backend evidence"
+  || fail "release ${tag} has no real-hardware backend evidence"
 hardware_evidence_args=()
 for evidence in "${hardware_evidence[@]}"; do
   hardware_evidence_args+=(--evidence "$evidence")
@@ -52,7 +52,7 @@ python3 tooling/release-manifest/backend_hardware_evidence.py \
   > "$workdir/hardware-approved-entries.txt"
 mapfile -t approved_entries < "$workdir/hardware-approved-entries.txt"
 [ "${#approved_entries[@]}" -gt 0 ] \
-  || fail "release ${tag} has no backend entry approved by exact hardware evidence"
+  || fail "release ${tag} has no backend entry approved by hardware evidence"
 backend_entry_args=()
 for entry in "${approved_entries[@]}"; do
   backend_entry_args+=(--entry "$entry")

--- a/scripts/prepare-windows-backend-catalog-release.sh
+++ b/scripts/prepare-windows-backend-catalog-release.sh
@@ -70,15 +70,15 @@ backend_entries=("$workdir"/backend-pack-*.json)
 hardware_evidence=("$workdir"/backend-hardware-evidence-*.json)
 cuda_entries=("$workdir"/backend-pack-cuda-sm_*.json)
 hip_entries=("$workdir"/backend-pack-hip-gfx*.json)
-if [ "${#cuda_entries[@]}" -ne 5 ] || [ "${#hip_entries[@]}" -ne 14 ] || [ "${#backend_entries[@]}" -ne 19 ]; then
-  fail "release ${tag} must contain exactly 5 CUDA SM and 14 HIP gfx backend-pack metadata files"
+if [ "${#cuda_entries[@]}" -ne 6 ] || [ "${#hip_entries[@]}" -ne 14 ] || [ "${#backend_entries[@]}" -ne 20 ]; then
+  fail "release ${tag} must contain exactly 6 CUDA SM and 14 HIP gfx backend-pack metadata files"
 fi
 all_backend_entry_args=()
 for entry in "${backend_entries[@]}"; do
   all_backend_entry_args+=(--entry "$entry")
 done
 [ "${#hardware_evidence[@]}" -gt 0 ] \
-  || fail "release ${tag} has no exact real-hardware backend evidence; build artifacts alone are not publishable catalog claims"
+  || fail "release ${tag} has no real-hardware backend evidence; build artifacts alone are not publishable catalog claims"
 hardware_evidence_args=()
 for evidence in "${hardware_evidence[@]}"; do
   hardware_evidence_args+=(--evidence "$evidence")
@@ -88,7 +88,7 @@ python3 tooling/release-manifest/backend_hardware_evidence.py \
   > "$workdir/hardware-approved-entries.txt"
 mapfile -t approved_entries < "$workdir/hardware-approved-entries.txt"
 [ "${#approved_entries[@]}" -gt 0 ] \
-  || fail "release ${tag} has no backend entry approved by exact hardware evidence"
+  || fail "release ${tag} has no backend entry approved by hardware evidence"
 backend_entry_args=()
 for entry in "${approved_entries[@]}"; do
   backend_entry_args+=(--entry "$entry")

--- a/tooling/release-manifest/README.md
+++ b/tooling/release-manifest/README.md
@@ -183,13 +183,15 @@ maintainer machine; none of the signing steps runs in CI.
    above and `RELEASING.md`). This step is REQUIRED and not optional: the
    release is not signed until this script prints `SIGNED-AND-VERIFIED` and
    exits 0.
-2. **Attach exact hardware evidence** -- add one
-   `backend-hardware-evidence-*.json` release asset for every target intended
-   for activation. Each receipt binds the release entry, plugin digest, ABI
-   fingerprint, binary, model and workload; requires at least five fresh
-   processes; and proves FullDevice execution without CPU fallback. The 5 CUDA
-   and 11 HIP build matrix is artifact coverage, not a hardware-validation
-   claim.
+2. **Attach hardware evidence** -- add `backend-hardware-evidence-*.json`
+   release assets for each provider intended for activation. Schema v1 approves
+   one exact tested target. Schema v2 may approve an explicit provider matrix
+   from one representative target only when the receipt binds the tested plugin
+   plus the sorted target set and every target-scoped artifact fingerprint.
+   Both require at least five fresh processes and prove FullDevice execution
+   without CPU fallback. The 6 CUDA and 14 HIP build matrix is artifact coverage;
+   a schema v2 matrix receipt records an explicit compatibility policy and does
+   not claim that every target ran on hardware.
 3. **Prepare and deploy the signed backend catalog** -- run
    `scripts/prepare-windows-backend-catalog-release.sh v<version>` with the same
    local production signing seed, review and commit its five catalog/epoch
@@ -200,7 +202,7 @@ maintainer machine; none of the signing steps runs in CI.
    activation source.
 4. **Finalize the draft** -- run `scripts/finalize-core-release.sh v<version>`.
    It verifies the published manifest signature and requires the live signed
-   catalog target set to equal the exact hardware-approved subset before it can
+   catalog target set to equal the hardware-approved subset before it can
    publish the draft.
 5. **Sync to dl.openasr.org** -- see "dl.openasr.org sync" above
    (`b2_sync.py sync --version <version>`, uploading the Windows sidecar

--- a/tooling/release-manifest/backend_hardware_evidence.py
+++ b/tooling/release-manifest/backend_hardware_evidence.py
@@ -1,23 +1,50 @@
 #!/usr/bin/env python3
-"""Gate live Windows GPU catalog entries on exact real-hardware evidence.
+"""Gate live Windows GPU catalog entries on real-hardware evidence.
 
 Release CI may build every supported target, but build provenance is not a
-correctness claim. This tool selects only entry bytes that have a matching
-fresh-process hardware receipt. The production catalog signer and release
-finalizer both invoke it, so an untested HIP/CUDA target can remain an inert
-draft-release asset without becoming runtime-selectable.
+correctness claim. Schema v1 receipts approve only the exact target that ran.
+Schema v2 receipts may explicitly approve a provider matrix from one
+representative target, but only when they bind the complete selected target
+set and every target-scoped artifact fingerprint in that matrix. The
+production catalog signer and release finalizer both invoke this tool.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from backend_catalog import artifact_fingerprint
 
 
 class EvidenceError(ValueError):
     pass
+
+
+@dataclass(frozen=True)
+class EntryIdentity:
+    path: Path
+    provider: str
+    target: str
+    backend_id: str
+    artifact_fingerprint: str
+    plugin_sha256: str
+    version: str
+
+    @property
+    def tuple(self) -> tuple[str, ...]:
+        return (
+            self.provider,
+            self.target,
+            self.backend_id,
+            self.artifact_fingerprint,
+            self.plugin_sha256,
+            self.version,
+        )
 
 
 def _read(path: Path) -> dict[str, Any]:
@@ -35,7 +62,7 @@ def _lower_hex(value: object, length: int, field: str) -> str:
     return value
 
 
-def _entry_identity(path: Path) -> tuple[dict[str, Any], tuple[str, ...]]:
+def _entry_identity(path: Path) -> tuple[dict[str, Any], EntryIdentity]:
     entry = _read(path)
     provider = entry.get("vendor")
     targets = entry.get("targets")
@@ -48,20 +75,27 @@ def _entry_identity(path: Path) -> tuple[dict[str, Any], tuple[str, ...]]:
     plugin_files = [file for file in entry.get("files", []) if file.get("role") == "plugin"]
     if len(plugin_files) != 1:
         raise EvidenceError(f"{path} must declare exactly one plugin file")
-    return entry, (
-        str(provider),
-        target,
-        str(entry.get("id", "")),
-        _lower_hex(entry.get("artifact_fingerprint"), 64, "artifact_fingerprint"),
-        _lower_hex(plugin_files[0].get("sha256"), 64, "plugin_sha256"),
-        str(entry.get("version", "")),
+    try:
+        fingerprint = artifact_fingerprint(entry)
+    except (TypeError, ValueError) as error:
+        raise EvidenceError(f"{path} has no computable artifact fingerprint: {error}") from error
+    return entry, EntryIdentity(
+        path=path,
+        provider=str(provider),
+        target=target,
+        backend_id=str(entry.get("id", "")),
+        artifact_fingerprint=_lower_hex(
+            fingerprint, 64, "computed artifact_fingerprint"
+        ),
+        plugin_sha256=_lower_hex(plugin_files[0].get("sha256"), 64, "plugin_sha256"),
+        version=str(entry.get("version", "")),
     )
 
 
-def _evidence_identity(path: Path) -> tuple[str, ...]:
+def _common_evidence_identity(path: Path) -> tuple[dict[str, Any], tuple[str, ...]]:
     evidence = _read(path)
-    if evidence.get("schema_version") != 1 or evidence.get("result") != "pass":
-        raise EvidenceError(f"{path} is not a passing backend hardware evidence v1 receipt")
+    if evidence.get("schema_version") not in {1, 2} or evidence.get("result") != "pass":
+        raise EvidenceError(f"{path} is not a passing backend hardware evidence receipt")
     if evidence.get("placement") != "full_device" or evidence.get("cpu_fallback") is not False:
         raise EvidenceError(f"{path} does not prove fail-closed FullDevice execution")
     runs = evidence.get("fresh_process_runs")
@@ -76,7 +110,7 @@ def _evidence_identity(path: Path) -> tuple[str, ...]:
     prefix = "sm_" if provider == "cuda" else "gfx"
     if not isinstance(target, str) or not target.startswith(prefix):
         raise EvidenceError(f"{path} has an invalid device target")
-    return (
+    return evidence, (
         str(provider),
         target,
         str(evidence.get("backend_id", "")),
@@ -86,26 +120,99 @@ def _evidence_identity(path: Path) -> tuple[str, ...]:
     )
 
 
+def provider_matrix_sha256(entries: list[EntryIdentity]) -> str:
+    payload = [
+        {
+            "artifact_fingerprint": entry.artifact_fingerprint,
+            "backend_id": entry.backend_id,
+            "plugin_sha256": entry.plugin_sha256,
+            "provider": entry.provider,
+            "release_version": entry.version,
+            "target": entry.target,
+        }
+        for entry in sorted(entries, key=lambda item: (item.provider, item.version, item.target))
+    ]
+    encoded = json.dumps(
+        payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def approved_entry_paths(entry_paths: list[Path], evidence_paths: list[Path]) -> list[Path]:
-    entries: dict[tuple[str, ...], Path] = {}
+    entries: dict[tuple[str, ...], EntryIdentity] = {}
+    all_entries: list[EntryIdentity] = []
     for path in entry_paths:
         _, identity = _entry_identity(path)
-        if identity in entries:
-            raise EvidenceError(f"duplicate backend entry identity: {identity}")
-        entries[identity] = path
-    approved: list[Path] = []
-    seen: set[tuple[str, ...]] = set()
+        if identity.tuple in entries:
+            raise EvidenceError(f"duplicate backend entry identity: {identity.tuple}")
+        entries[identity.tuple] = identity
+        all_entries.append(identity)
+
+    approved: dict[Path, Path] = {}
+    seen_evidence: set[tuple[object, ...]] = set()
     for evidence_path in evidence_paths:
-        identity = _evidence_identity(evidence_path)
-        if identity in seen:
-            raise EvidenceError(f"duplicate hardware evidence identity: {identity}")
-        seen.add(identity)
-        entry_path = entries.get(identity)
-        if entry_path is None:
+        evidence, identity_tuple = _common_evidence_identity(evidence_path)
+        tested_entry = entries.get(identity_tuple)
+        if tested_entry is None:
             raise EvidenceError(
-                f"{evidence_path} does not match any exact release backend entry"
+                f"{evidence_path} does not match any exact tested release backend entry"
             )
-        approved.append(entry_path)
+        schema_version = int(evidence["schema_version"])
+        evidence_key = (schema_version, *identity_tuple)
+        if evidence_key in seen_evidence:
+            raise EvidenceError(f"duplicate hardware evidence identity: {evidence_key}")
+        seen_evidence.add(evidence_key)
+
+        selected = [tested_entry]
+        if schema_version == 2:
+            if evidence.get("scope") != "provider_matrix":
+                raise EvidenceError(
+                    f"{evidence_path} schema v2 must declare scope=provider_matrix"
+                )
+            targets = evidence.get("approved_targets")
+            if (
+                not isinstance(targets, list)
+                or not targets
+                or any(not isinstance(target, str) for target in targets)
+                or targets != sorted(set(targets))
+            ):
+                raise EvidenceError(
+                    f"{evidence_path} approved_targets must be a sorted unique non-empty array"
+                )
+            if tested_entry.target not in targets:
+                raise EvidenceError(
+                    f"{evidence_path} does not include its tested target in approved_targets"
+                )
+            provider_entries = [
+                entry
+                for entry in all_entries
+                if entry.provider == tested_entry.provider
+                and entry.version == tested_entry.version
+            ]
+            release_targets = sorted(entry.target for entry in provider_entries)
+            if targets != release_targets:
+                raise EvidenceError(
+                    f"{evidence_path} approved_targets do not equal the complete provider release matrix"
+                )
+            selected = provider_entries
+            expected_matrix = provider_matrix_sha256(selected)
+            actual_matrix = _lower_hex(
+                evidence.get("provider_matrix_sha256"),
+                64,
+                "provider_matrix_sha256",
+            )
+            if actual_matrix != expected_matrix:
+                raise EvidenceError(
+                    f"{evidence_path} does not bind the selected provider matrix"
+                )
+
+        for entry in selected:
+            previous = approved.get(entry.path)
+            if previous is not None:
+                raise EvidenceError(
+                    f"{entry.path} is approved by both {previous} and {evidence_path}"
+                )
+            approved[entry.path] = evidence_path
     return sorted(approved)
 
 

--- a/tooling/release-manifest/backend_hardware_evidence_test.py
+++ b/tooling/release-manifest/backend_hardware_evidence_test.py
@@ -21,50 +21,128 @@ class BackendHardwareEvidenceTests(unittest.TestCase):
         path.write_text(json.dumps(value), encoding="utf-8")
         return path
 
-    def entry(self, target: str = "sm_86", plugin_sha: str = "b" * 64) -> Path:
+    def entry(
+        self,
+        target: str = "sm_86",
+        plugin_sha: str = "b" * 64,
+        provider: str = "cuda",
+    ) -> Path:
         return self.write(
-            "entry.json",
+            f"entry-{provider}-{target}.json",
             {
-                "id": "cuda-sm86",
-                "vendor": "cuda",
+                "id": f"{provider}-{target}",
+                "vendor": provider,
                 "version": "1.2.3",
                 "targets": [target],
-                "artifact_fingerprint": "a" * 64,
-                "files": [{"role": "plugin", "sha256": plugin_sha}],
+                "min_driver_api": "12.0.0" if provider == "cuda" else "7.2.0",
+                "host_abi": {"fingerprint": "9" * 64},
+                "files": [
+                    {
+                        "role": "plugin",
+                        "filename": f"{provider}-{target}.dll",
+                        "sha256": plugin_sha,
+                        "size_bytes": 123,
+                    }
+                ],
             },
         )
 
-    def evidence(self, plugin_sha: str = "b" * 64, runs: int = 5) -> Path:
-        return self.write(
-            "evidence.json",
-            {
-                "schema_version": 1,
-                "result": "pass",
-                "provider": "cuda",
-                "device_target": "sm_86",
-                "backend_id": "cuda-sm86",
-                "release_version": "1.2.3",
-                "artifact_fingerprint": "a" * 64,
-                "plugin_sha256": plugin_sha,
-                "binary_sha256": "c" * 64,
-                "workload_sha256": "d" * 64,
-                "model_pack_sha256": "e" * 64,
-                "evidence_sha256": "f" * 64,
-                "fresh_process_runs": runs,
-                "placement": "full_device",
-                "cpu_fallback": False,
-            },
-        )
+    def evidence(
+        self,
+        entry: Path,
+        *,
+        plugin_sha: str | None = None,
+        runs: int = 5,
+        schema_version: int = 1,
+        matrix_entries: list[Path] | None = None,
+    ) -> Path:
+        _, identity = gate._entry_identity(entry)
+        value: dict[str, object] = {
+            "schema_version": schema_version,
+            "result": "pass",
+            "provider": identity.provider,
+            "device_target": identity.target,
+            "backend_id": identity.backend_id,
+            "release_version": identity.version,
+            "artifact_fingerprint": identity.artifact_fingerprint,
+            "plugin_sha256": plugin_sha or identity.plugin_sha256,
+            "binary_sha256": "c" * 64,
+            "workload_sha256": "d" * 64,
+            "model_pack_sha256": "e" * 64,
+            "evidence_sha256": "f" * 64,
+            "fresh_process_runs": runs,
+            "placement": "full_device",
+            "cpu_fallback": False,
+        }
+        if schema_version == 2:
+            identities = [gate._entry_identity(path)[1] for path in matrix_entries or [entry]]
+            value.update(
+                {
+                    "scope": "provider_matrix",
+                    "approved_targets": sorted(item.target for item in identities),
+                    "provider_matrix_sha256": gate.provider_matrix_sha256(identities),
+                }
+            )
+        return self.write(f"evidence-v{schema_version}.json", value)
 
     def test_exact_receipt_approves_only_its_entry(self) -> None:
+        tested = self.entry()
+        other = self.entry(target="sm_89", plugin_sha="8" * 64)
+        self.assertEqual(
+            gate.approved_entry_paths([tested, other], [self.evidence(tested)]),
+            [tested],
+        )
+
+    def test_raw_pack_artifact_fingerprint_is_computed(self) -> None:
         entry = self.entry()
-        self.assertEqual(gate.approved_entry_paths([entry], [self.evidence()]), [entry])
+        raw = json.loads(entry.read_text(encoding="utf-8"))
+        self.assertNotIn("artifact_fingerprint", raw)
+        _, identity = gate._entry_identity(entry)
+        self.assertEqual(len(identity.artifact_fingerprint), 64)
+
+    def test_provider_matrix_receipt_approves_bound_targets(self) -> None:
+        tested = self.entry()
+        other = self.entry(target="sm_89", plugin_sha="8" * 64)
+        hip = self.entry(target="gfx1200", plugin_sha="7" * 64, provider="hip")
+        evidence = self.evidence(
+            tested,
+            schema_version=2,
+            matrix_entries=[tested, other],
+        )
+        self.assertEqual(
+            gate.approved_entry_paths([tested, other, hip], [evidence]),
+            sorted([tested, other]),
+        )
+
+    def test_provider_matrix_rejects_changed_or_missing_target(self) -> None:
+        tested = self.entry()
+        other = self.entry(target="sm_89", plugin_sha="8" * 64)
+        evidence = self.evidence(
+            tested,
+            schema_version=2,
+            matrix_entries=[tested, other],
+        )
+        changed = self.entry(target="sm_89", plugin_sha="7" * 64)
+        with self.assertRaises(gate.EvidenceError):
+            gate.approved_entry_paths([tested, changed], [evidence])
+        with self.assertRaises(gate.EvidenceError):
+            gate.approved_entry_paths([tested], [evidence])
+        partial = self.evidence(
+            tested,
+            schema_version=2,
+            matrix_entries=[tested],
+        )
+        with self.assertRaises(gate.EvidenceError):
+            gate.approved_entry_paths([tested, other], [partial])
 
     def test_different_bytes_or_insufficient_runs_are_rejected(self) -> None:
+        entry = self.entry()
         with self.assertRaises(gate.EvidenceError):
-            gate.approved_entry_paths([self.entry()], [self.evidence(plugin_sha="9" * 64)])
+            gate.approved_entry_paths(
+                [entry], [self.evidence(entry, plugin_sha="9" * 64)]
+            )
         with self.assertRaises(gate.EvidenceError):
-            gate.approved_entry_paths([self.entry()], [self.evidence(runs=4)])
+            gate.approved_entry_paths([entry], [self.evidence(entry, runs=4)])
 
     def test_live_catalog_must_equal_approved_subset(self) -> None:
         entry = self.entry()
@@ -73,7 +151,11 @@ class BackendHardwareEvidenceTests(unittest.TestCase):
             gate.verify_catalog_policy(catalog, "1.2.3", [entry])
         catalog = self.write(
             "catalog.json",
-            {"backends": [{"id": "cuda-sm86", "vendor": "cuda", "version": "1.2.3"}]},
+            {
+                "backends": [
+                    {"id": "cuda-sm_86", "vendor": "cuda", "version": "1.2.3"}
+                ]
+            },
         )
         gate.verify_catalog_policy(catalog, "1.2.3", [entry])
 

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -30,7 +30,7 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
     def test_finalizer_never_publishes_before_all_cuda_and_hip_target_entries(self) -> None:
         finalize = (ROOT / "scripts/finalize-core-release.sh").read_text(encoding="utf-8")
         self.assertIn("backend-pack-*.json", finalize)
-        self.assertIn('"${#cuda_entries[@]}" -ne 5', finalize)
+        self.assertIn('"${#cuda_entries[@]}" -ne 6', finalize)
         self.assertIn('"${#hip_entries[@]}" -ne 14', finalize)
         self.assertLess(finalize.index("verify-catalog"), finalize.index("--draft=false"))
 

--- a/tooling/release-manifest/release_binaries_matrix.json
+++ b/tooling/release-manifest/release_binaries_matrix.json
@@ -122,8 +122,7 @@
     "cuda_gpu_target": "120",
     "cuda_toolkit": "12.8.1",
     "min_driver_api": "12.8.0",
-    "vendor_owner": false,
-    "experimental": true,
+    "vendor_owner": true,
     "timeout": 180
   },
   {

--- a/tooling/release-manifest/windows_backend_release_contract_test.py
+++ b/tooling/release-manifest/windows_backend_release_contract_test.py
@@ -100,8 +100,8 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
             "--require-single-target",
             "--out dist/catalog.backends.candidate.json",
             "--out dist/backend-plugin-hints.json",
-            'echo "backend-pack-cuda-sm_${sm}.json"',
-            'echo "backend-pack-hip-${gfx}.json"',
+            'names.append(f"backend-pack-cuda-sm_{row[\'cuda_gpu_target\']}.json")',
+            'names.append(f"backend-pack-hip-{row[\'hip_gpu_target\']}.json")',
             'echo "backend-plugin-hints.json"',
             'echo "catalog.backends.candidate.json"',
             "staging/catalog.backends.candidate.json",
@@ -155,7 +155,8 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
         )
         self.assertEqual(sm120.get("cuda_toolkit"), "12.8.1")
         self.assertEqual(sm120.get("min_driver_api"), "12.8.0")
-        self.assertTrue(sm120.get("experimental"))
+        self.assertIsNot(sm120.get("experimental"), True)
+        self.assertTrue(sm120.get("vendor_owner"))
 
     def test_dynamic_matrix_is_selected_before_build_jobs_instantiate(self) -> None:
         self.assertIn("\n  select-matrix:\n", self.workflow)
@@ -200,7 +201,9 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
 
     def test_failed_aggregation_can_reuse_completed_build_artifacts(self) -> None:
         self.assertIn("source_run_id:", self.workflow)
-        self.assertIn("gh run download \"$SOURCE_RUN_ID\"", self.workflow)
+        self.assertIn("supplemental_source_run_id:", self.workflow)
+        self.assertIn("promote_cuda_targets:", self.workflow)
+        self.assertIn('gh run download "$run_id"', self.workflow)
         self.assertIn("inputs.source_run_id == ''", self.workflow)
         self.assertIn("inputs.source_run_id != ''", self.workflow)
         self.assertIn("Upload recovered assets to release", self.workflow)
@@ -219,7 +222,7 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
             for row in self.matrix
             if row.get("provider") == "hip" and not row.get("experimental", False)
         ]
-        self.assertEqual(len(required_cuda), 5)
+        self.assertEqual(len(required_cuda), 6)
         self.assertEqual(len(required_hip), 14)
         self.assertEqual(
             [f'backend-pack-cuda-sm_{row["cuda_gpu_target"]}.json' for row in required_cuda],
@@ -229,13 +232,14 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
                 "backend-pack-cuda-sm_86.json",
                 "backend-pack-cuda-sm_89.json",
                 "backend-pack-cuda-sm_90.json",
+                "backend-pack-cuda-sm_120.json",
             ],
         )
         self.assertIn('not row.get("experimental", False)', self.workflow)
         self.assertIn('entry="dist/backend-pack-cuda-sm_${target}.json"', self.workflow)
         self.assertIn('entry="dist/backend-pack-hip-${target}.json"', self.workflow)
 
-    def test_full_matrix_has_exactly_one_vendor_owner_per_optional_vendor(self) -> None:
+    def test_full_matrix_has_one_vendor_owner_per_distinct_runtime(self) -> None:
         cuda_owners = [
             row["target"]
             for row in self.matrix
@@ -246,7 +250,13 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
             for row in self.matrix
             if row.get("provider") == "hip" and row.get("vendor_owner") is True
         ]
-        self.assertEqual(cuda_owners, ["x86_64-pc-windows-msvc-cuda-sm_75-plugin"])
+        self.assertEqual(
+            cuda_owners,
+            [
+                "x86_64-pc-windows-msvc-cuda-sm_75-plugin",
+                "x86_64-pc-windows-msvc-cuda-sm_120-plugin",
+            ],
+        )
         self.assertEqual(hip_owners, ["x86_64-pc-windows-msvc-hip-gfx1030-plugin"])
 
     def test_diagnostic_only_target_temporarily_owns_vendor_assets(self) -> None:


### PR DESCRIPTION
## Summary

Makes representative hardware validation an explicit, byte-bound release policy for a provider target matrix and completes the CUDA sm_120 release component contract.

## Why

The hardware gate read an `artifact_fingerprint` field that raw backend-pack metadata does not contain, so valid evidence could never approve a release entry. The v0.1.34 Draft also contained the sm_120 plugin and metadata without the separately content-addressed CUDA 12.8 runtime archive referenced by that metadata.

## Changes

- compute release artifact fingerprints from raw backend-pack metadata with the same catalog algorithm used by runtime installation
- retain schema v1 exact-target receipts and add schema v2 provider-matrix receipts
- bind matrix receipts to the representative tested plugin, complete sorted target set, and every approved target's artifact fingerprint and plugin digest
- promote sm_120 as the sixth required CUDA plugin and give its distinct CUDA 12.8 runtime an independent vendor owner
- let immutable-artifact recovery merge one completed full run with one completed single-target supplemental run
- derive release completeness from required backend-pack file declarations, including every content-addressed vendor archive
- update release documentation and target-count contracts for 6 CUDA and 14 HIP targets

## Tests run

- [ ] `cargo fmt --check` (not applicable; no Rust source changed)
- [ ] `cargo clippy --all-targets -- -D warnings` (not applicable; no Rust source changed)
- [ ] `cargo nextest run --workspace` (not applicable; no Rust source changed)
- [ ] `cargo test --workspace --doc` (not applicable; no Rust source changed)
- [ ] `cargo deny check` (not applicable; no dependency changed)
- [x] `actionlint .github/workflows/release-binaries.yml`
- [x] `python -m unittest discover -s tooling/release-manifest -p '*_test.py'` (98 passed)
- [x] Python compile checks for the changed release tools and tests
- [x] `bash -n scripts/prepare-windows-backend-catalog-release.sh scripts/finalize-core-release.sh`
- [x] `git diff --check`

## Manual smoke checks

- downloaded all 6 CUDA and 14 HIP v0.1.34 Draft backend-pack metadata files
- computed both provider matrix digests from the real release entries
- verified a schema v2 representative receipt fixture approves exactly 6 CUDA and 14 HIP entries
- verified representative v0.1.34 release metadata and the xcframework checksum sidecar against GitHub build provenance

## Model-family changes (when applicable)

- [x] Not applicable; no model-family code changed.

## Docs updated

- [x] Release documentation now distinguishes exact-target evidence from representative provider-matrix policy.
- [x] No docs claim that untested target hardware was directly exercised.

## Scope / non-goals

This PR does not fabricate hardware receipts, sign or deploy the production catalog, publish v0.1.34, or change runtime inference behavior. A provider matrix still requires a real five-process FullDevice/no-CPU-fallback receipt from one representative final release plugin.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in `AGENTS.md`.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES