### PR TITLE
fix(release): verify neutral rescue bundle

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1012,6 +1012,15 @@ jobs:
           if ("${{ matrix.distribution }}" -ne "plugin" -and "${{ matrix.provider }}" -ne "cuda" -and "${{ matrix.provider }}" -ne "hip" -and "${{ matrix.rust_target }}" -eq "") {
             & "$env:DIST_DIR\${{ matrix.binary_name }}" --version
             if ($LASTEXITCODE -ne 0) { exit 1 }
+            $doctor = & "$env:DIST_DIR\${{ matrix.binary_name }}" doctor 2>&1 | Out-String
+            Write-Host $doctor
+            if ($LASTEXITCODE -ne 0) { exit 1 }
+            if ($doctor -notmatch "bundled CPU/Vulkan modules: verified") {
+              throw "staged neutral host did not verify its post-signing CPU/Vulkan bundle"
+            }
+            if ($doctor -match "ggml: best backend unavailable" -or $doctor -match "CPU backend unavailable") {
+              throw "staged neutral host could not initialize its bundled CPU rescue backend"
+            }
           }
           if ("${{ matrix.distribution }}" -ne "plugin") {
             Compress-Archive -Path "$env:DIST_DIR" -DestinationPath "dist\$env:ARCHIVE_NAME.${{ matrix.archive_ext }}" -Force

--- a/tooling/release-manifest/backend_catalog.py
+++ b/tooling/release-manifest/backend_catalog.py
@@ -110,6 +110,19 @@ def bundle_contract_sha256(host_abi_fingerprint: str, files: list[dict[str, Any]
     return digest.hexdigest()
 
 
+def provider_bundle_contract_sha256(
+    host_abi_fingerprint: str, files: list[dict[str, Any]], provider: str
+) -> str:
+    """Bind the common host DLLs plus exactly one bundled provider rail."""
+
+    selected = [
+        entry
+        for entry in files
+        if entry["provider"] == "host" or entry["provider"] == provider
+    ]
+    return bundle_contract_sha256(host_abi_fingerprint, selected)
+
+
 def compile_bundled_manifest(
     directory: Path,
     host_abi_path: Path,
@@ -177,9 +190,15 @@ def compile_bundled_manifest(
         )
 
     result = {
-        "schema_version": 2,
+        "schema_version": 3,
         "host_abi_fingerprint": fingerprint,
         "bundle_contract_sha256": bundle_contract_sha256(fingerprint, files),
+        "cpu_contract_sha256": provider_bundle_contract_sha256(
+            fingerprint, files, "cpu"
+        ),
+        "vulkan_contract_sha256": provider_bundle_contract_sha256(
+            fingerprint, files, "vulkan"
+        ),
         "files": files,
     }
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/tooling/release-manifest/backend_catalog_test.py
+++ b/tooling/release-manifest/backend_catalog_test.py
@@ -442,8 +442,23 @@ class BackendCatalogTest(unittest.TestCase):
             result = json.loads(out.read_text(encoding="utf-8"))
 
             self.assertEqual(result["host_abi_fingerprint"], fingerprint)
-            self.assertEqual(result["schema_version"], 2)
+            self.assertEqual(result["schema_version"], 3)
             self.assertEqual(len(result["bundle_contract_sha256"]), 64)
+            self.assertEqual(
+                result["cpu_contract_sha256"],
+                backend_catalog.provider_bundle_contract_sha256(
+                    fingerprint, result["files"], "cpu"
+                ),
+            )
+            self.assertEqual(
+                result["vulkan_contract_sha256"],
+                backend_catalog.provider_bundle_contract_sha256(
+                    fingerprint, result["files"], "vulkan"
+                ),
+            )
+            self.assertNotEqual(
+                result["cpu_contract_sha256"], result["vulkan_contract_sha256"]
+            )
             self.assertEqual(
                 {entry["provider"] for entry in result["files"]},
                 {"host", "cpu", "vulkan", "dependency"},


### PR DESCRIPTION
## Summary

Fix the post-signing Windows neutral-host bundle manifest and add an executable release smoke gate for the bundled CPU/Vulkan rescue rail.

## Why

The release workflow regenerated `openasr-backend-bundle-v1.json` with the obsolete schema v2 shape after Authenticode signing. The current runtime requires schema v3 plus provider-scoped CPU and Vulkan contract hashes, so the resulting v0.1.34 Draft neutral archive passed structural CI but failed closed at runtime with `missing field cpu_contract_sha256`.

## Changes

- Emit the schema v3 bundle manifest from the shared release compiler.
- Derive CPU and Vulkan provider contracts with the same canonical algorithm as the Rust build script.
- Lock both provider contracts in the Python unit tests.
- Run `openasr doctor` from the signed staged distribution and fail release packaging unless the CPU/Vulkan bundle verifies and the CPU rescue backend initializes.

## Tests run

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`
- [x] `python -m unittest discover -s tooling/release-manifest -p '*_test.py'` (98 passed)
- [x] `python -m py_compile tooling/release-manifest/backend_catalog.py`
- [x] `git diff --check`

## Manual smoke checks

- Recompiled the manifest against the final signed v0.1.34 Draft neutral archive.
- Confirmed `openasr doctor` changed from fail-closed `missing field cpu_contract_sha256` to `bundled CPU/Vulkan modules: verified`.
- Confirmed the same staged archive initializes CPU and Vulkan devices after regeneration.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any staged/public-ready work completes Model Onboarding Step 5 without hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence; otherwise they are explicitly listed as unverified.

Not applicable: no model-family behavior changes.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

No user-facing behavior or documentation contract changes.

## Scope / non-goals

- Does not publish v0.1.34 or modify the live catalog.
- Does not change backend selection, plugin ABI, or hardware target coverage.
- The existing v0.1.34 Draft remains non-publishable until rebuilt from this fix and hardware evidence is rebound to the rebuilt bytes.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
