### PR TITLE
ci(release): pin Linux GPU images and isolate plugin builds

### DIFF
--- a/.github/actions/setup-cbindgen/action.yml
+++ b/.github/actions/setup-cbindgen/action.yml
@@ -1,0 +1,31 @@
+name: Setup cbindgen
+description: Restore ~/.cargo/bin/cbindgen from cache, otherwise cargo-install it.
+
+runs:
+  using: composite
+  steps:
+    - name: Cache cbindgen
+      id: cache
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/bin/cbindgen
+          ~/.cargo/bin/cbindgen.exe
+        key: cbindgen-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
+
+    - name: Install cbindgen
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v cbindgen >/dev/null 2>&1; then
+          cbindgen --version
+          exit 0
+        fi
+        cargo install cbindgen --locked
+        cbindgen --version
+
+    - name: Verify cached cbindgen
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: cbindgen --version

--- a/.github/ci/check-linux-build-env.py
+++ b/.github/ci/check-linux-build-env.py
@@ -15,10 +15,6 @@ CONSUMERS = {
     ".github/workflows/public-hf-e2e.yml": 1,
     ".github/workflows/release-core.yml": 1,
     ".github/workflows/serve-batch-parity.yml": 1,
-    # release-binaries.yml pins the CPU linux image once (see matrix JSON for
-    # the matching container field). It still apt-gets on arm64/musl/vulkan
-    # host legs and official CUDA/ROCm image extras, so it is not apt-free.
-    ".github/workflows/release-binaries.yml": 1,
 }
 
 APTGET_FORBIDDEN = {

--- a/.github/ci/check-linux-build-env.py
+++ b/.github/ci/check-linux-build-env.py
@@ -31,6 +31,22 @@ APTGET_FORBIDDEN = {
 
 LINUX_CI_MATRIX = ROOT / "tooling/release-manifest/release_binaries_matrix.json"
 LINUX_CI_MATRIX_TARGETS = ("x86_64-unknown-linux-gnu",)
+GPU_LOCKS = (
+    (
+        "x86_64-unknown-linux-gnu-cuda",
+        ROOT / ".github/ci/linux-cuda.lock",
+        re.compile(
+            r"ghcr\.io/quintinshaw/openasr-ci-linux-cuda@sha256:[0-9a-f]{64}"
+        ),
+    ),
+    (
+        "x86_64-unknown-linux-gnu-rocm",
+        ROOT / ".github/ci/linux-rocm.lock",
+        re.compile(
+            r"ghcr\.io/quintinshaw/openasr-ci-linux-rocm@sha256:[0-9a-f]{64}"
+        ),
+    ),
+)
 
 
 def main() -> None:
@@ -69,6 +85,20 @@ def main() -> None:
                 failures.append(
                     f"{LINUX_CI_MATRIX}: {target} container must be {expected}, "
                     f"found {container!r}"
+                )
+        for target, lock_path, pattern in GPU_LOCKS:
+            pinned = lock_path.read_text(encoding="utf-8").strip()
+            if pattern.fullmatch(pinned) is None:
+                failures.append(f"invalid GPU image lock {lock_path}: {pinned!r}")
+                continue
+            row = by_target.get(target)
+            if row is None:
+                failures.append(f"{LINUX_CI_MATRIX}: missing release leg {target}")
+                continue
+            if row.get("container") != pinned:
+                failures.append(
+                    f"{LINUX_CI_MATRIX}: {target} container must be {pinned}, "
+                    f"found {row.get('container')!r}"
                 )
 
     if failures:

--- a/.github/ci/check-linux-build-env.py
+++ b/.github/ci/check-linux-build-env.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from pathlib import Path
+import json
 import re
 
 
@@ -14,7 +15,22 @@ CONSUMERS = {
     ".github/workflows/public-hf-e2e.yml": 1,
     ".github/workflows/release-core.yml": 1,
     ".github/workflows/serve-batch-parity.yml": 1,
+    # release-binaries.yml pins the CPU linux image once (see matrix JSON for
+    # the matching container field). It still apt-gets on arm64/musl/vulkan
+    # host legs and official CUDA/ROCm image extras, so it is not apt-free.
+    ".github/workflows/release-binaries.yml": 1,
 }
+
+APTGET_FORBIDDEN = {
+    ".github/workflows/ci.yml",
+    ".github/workflows/family-regression.yml",
+    ".github/workflows/public-hf-e2e.yml",
+    ".github/workflows/release-core.yml",
+    ".github/workflows/serve-batch-parity.yml",
+}
+
+LINUX_CI_MATRIX = ROOT / "tooling/release-manifest/release_binaries_matrix.json"
+LINUX_CI_MATRIX_TARGETS = ("x86_64-unknown-linux-gnu",)
 
 
 def main() -> None:
@@ -31,8 +47,29 @@ def main() -> None:
                 f"{relative}: expected {expected_count} reference(s) to {expected}, "
                 f"found {references}"
             )
-        if "apt-get" in text:
+        if relative in APTGET_FORBIDDEN and "apt-get" in text:
             failures.append(f"{relative}: routine consumer must not run apt-get")
+
+    matrix = json.loads(LINUX_CI_MATRIX.read_text(encoding="utf-8"))
+    if not isinstance(matrix, list):
+        failures.append(f"{LINUX_CI_MATRIX}: expected a JSON array")
+    else:
+        by_target = {
+            row.get("target"): row
+            for row in matrix
+            if isinstance(row, dict) and isinstance(row.get("target"), str)
+        }
+        for target in LINUX_CI_MATRIX_TARGETS:
+            row = by_target.get(target)
+            if row is None:
+                failures.append(f"{LINUX_CI_MATRIX}: missing release leg {target}")
+                continue
+            container = row.get("container")
+            if container != expected:
+                failures.append(
+                    f"{LINUX_CI_MATRIX}: {target} container must be {expected}, "
+                    f"found {container!r}"
+                )
 
     if failures:
         raise SystemExit("\n".join(failures))

--- a/.github/ci/linux-cuda.lock
+++ b/.github/ci/linux-cuda.lock
@@ -1,0 +1,1 @@
+ghcr.io/quintinshaw/openasr-ci-linux-cuda@sha256:7d3a80aae720b6e726c71f2da726857039abf52e9f32d0f8ae1f68b8a7de3a77

--- a/.github/ci/linux-cuda/Dockerfile
+++ b/.github/ci/linux-cuda/Dockerfile
@@ -1,0 +1,67 @@
+# Linux CUDA CI build environment
+#
+# Wrapper around the official NVIDIA CUDA 13.2.0 devel image. Release consumers
+# in this change still pin that official digest directly; switch them to the
+# published GHCR digest only after this workflow has produced one.
+#
+# Base digest verified 2026-08-20 with `docker buildx imagetools inspect`
+# nvidia/cuda:13.2.0-devel-ubuntu22.04:
+#   index  sha256:46a7128f65491ae6ed6e3a4ef31fc140a4ca77d5dddb68a4350fea9d53a95c5f
+#   amd64  sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3
+
+FROM nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# cmake/ninja/alsa/git are not part of the official CUDA devel contract.
+# rustup is installed so later consumers can skip a cold toolchain fetch; jobs
+# still honor rust-toolchain.toml via rustup override.
+RUN success=0; \
+    for attempt in 1 2 3; do \
+      if apt-get update -o Acquire::Retries=5 \
+        && apt-get install -y --no-install-recommends \
+          build-essential \
+          ca-certificates \
+          cmake \
+          curl \
+          git \
+          libasound2-dev \
+          ninja-build \
+          pkg-config \
+          python3 \
+          python3-pip \
+          unzip \
+          xz-utils \
+          zstd; then \
+        success=1; \
+        break; \
+      fi; \
+      echo "apt attempt ${attempt}/3 failed" >&2; \
+      sleep $((attempt * 10)); \
+    done; \
+    test "${success}" -eq 1; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1001 openasr-ci \
+    && useradd --uid 1001 --gid 1001 --home-dir /github/home \
+      --create-home --shell /bin/bash openasr-ci
+
+ENV CUDA_PATH=/usr/local/cuda \
+    CUDA_HOME=/usr/local/cuda \
+    PATH="/usr/local/cuda/bin:/github/home/.cargo/bin:${PATH}"
+
+COPY --chmod=0755 verify.sh /usr/local/bin/openasr-ci-verify
+
+USER 1001:1001
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain 1.95.0 --profile minimal \
+    && /github/home/.cargo/bin/rustup default 1.95.0
+
+RUN openasr-ci-verify
+
+LABEL org.opencontainers.image.source="https://github.com/QuintinShaw/openasr" \
+      org.opencontainers.image.description="Pinned Linux CUDA 13.2.0 build environment for OpenASR CI" \
+      org.opencontainers.image.licenses="Apache-2.0"

--- a/.github/ci/linux-cuda/README.md
+++ b/.github/ci/linux-cuda/README.md
@@ -1,0 +1,17 @@
+# Linux CUDA CI build environment
+
+Wrapper around the official NVIDIA CUDA 13.2.0 devel image. It is not a
+product or release image.
+
+- The base image is pinned by its linux/amd64 manifest digest.
+- Every source revision is published under its commit SHA.
+- Consumers must pin a verified GHCR digest, never a mutable tag. This pull
+  request still lets release-binaries pin the official NVIDIA digest until a
+  GHCR digest exists.
+- The publish workflow verifies C/C++, CMake, nvcc, ALSA, and Python before a
+  digest is eligible for consumers.
+- The default user is a fixed non-root CI account.
+
+To change the dependency contract, update the Dockerfile in the same pull
+request. After the image workflow succeeds, copy its immutable digest into the
+consumer workflow declarations and a future `.github/ci/linux-cuda.lock`.

--- a/.github/ci/linux-cuda/verify.sh
+++ b/.github/ci/linux-cuda/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "OpenASR routine CI must run as a non-root user" >&2
+  exit 1
+fi
+
+cmake --version
+cc --version
+nvcc --version
+pkg-config --exists alsa
+python3 --version

--- a/.github/ci/linux-rocm.lock
+++ b/.github/ci/linux-rocm.lock
@@ -1,1 +1,1 @@
-ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:fc83ea993728463fc6666139304fc1221d4b34327179af223102459f73193212
+ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:98ed26463af7dfd6bb4a3235145a914531fcd2c2a7c3ea8422cc8c9ad30b5917

--- a/.github/ci/linux-rocm.lock
+++ b/.github/ci/linux-rocm.lock
@@ -1,0 +1,1 @@
+ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:fc83ea993728463fc6666139304fc1221d4b34327179af223102459f73193212

--- a/.github/ci/linux-rocm/Dockerfile
+++ b/.github/ci/linux-rocm/Dockerfile
@@ -1,8 +1,7 @@
 # Linux ROCm CI build environment
 #
-# Wrapper around the official AMD ROCm 7.2.1 devel image. Release consumers in
-# this change still pin that official digest directly; switch them to the
-# published GHCR digest only after this workflow has produced one.
+# Wrapper around the official AMD ROCm 7.2.1 devel image plus hipBLAS/rocBLAS
+# (the official devel image has hipcc but not the BLAS cmake packages).
 #
 # Base digest verified 2026-08-20 with `docker buildx imagetools inspect`
 # rocm/dev-ubuntu-22.04:7.2.1:
@@ -30,7 +29,8 @@ RUN success=0; \
           python3-pip \
           unzip \
           xz-utils \
-          zstd; then \
+          zstd \
+          rocm-hip-sdk; then \
         success=1; \
         break; \
       fi; \

--- a/.github/ci/linux-rocm/Dockerfile
+++ b/.github/ci/linux-rocm/Dockerfile
@@ -1,0 +1,63 @@
+# Linux ROCm CI build environment
+#
+# Wrapper around the official AMD ROCm 7.2.1 devel image. Release consumers in
+# this change still pin that official digest directly; switch them to the
+# published GHCR digest only after this workflow has produced one.
+#
+# Base digest verified 2026-08-20 with `docker buildx imagetools inspect`
+# rocm/dev-ubuntu-22.04:7.2.1:
+#   sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df
+
+FROM rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN success=0; \
+    for attempt in 1 2 3; do \
+      if apt-get update -o Acquire::Retries=5 \
+        && apt-get install -y --no-install-recommends \
+          build-essential \
+          ca-certificates \
+          cmake \
+          curl \
+          git \
+          libasound2-dev \
+          ninja-build \
+          pkg-config \
+          python3 \
+          python3-pip \
+          unzip \
+          xz-utils \
+          zstd; then \
+        success=1; \
+        break; \
+      fi; \
+      echo "apt attempt ${attempt}/3 failed" >&2; \
+      sleep $((attempt * 10)); \
+    done; \
+    test "${success}" -eq 1; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1001 openasr-ci \
+    && useradd --uid 1001 --gid 1001 --home-dir /github/home \
+      --create-home --shell /bin/bash openasr-ci
+
+ENV ROCM_PATH=/opt/rocm \
+    HIP_PATH=/opt/rocm \
+    PATH="/opt/rocm/bin:/github/home/.cargo/bin:${PATH}"
+
+COPY --chmod=0755 verify.sh /usr/local/bin/openasr-ci-verify
+
+USER 1001:1001
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain 1.95.0 --profile minimal \
+    && /github/home/.cargo/bin/rustup default 1.95.0
+
+RUN openasr-ci-verify
+
+LABEL org.opencontainers.image.source="https://github.com/QuintinShaw/openasr" \
+      org.opencontainers.image.description="Pinned Linux ROCm 7.2.1 build environment for OpenASR CI" \
+      org.opencontainers.image.licenses="Apache-2.0"

--- a/.github/ci/linux-rocm/README.md
+++ b/.github/ci/linux-rocm/README.md
@@ -1,0 +1,17 @@
+# Linux ROCm CI build environment
+
+Wrapper around the official AMD ROCm 7.2.1 devel image. It is not a product
+or release image.
+
+- The base image is pinned by its manifest digest.
+- Every source revision is published under its commit SHA.
+- Consumers must pin a verified GHCR digest, never a mutable tag. This pull
+  request still lets release-binaries pin the official ROCm digest until a
+  GHCR digest exists.
+- The publish workflow verifies C/C++, CMake, hipcc, ALSA, and Python before a
+  digest is eligible for consumers.
+- The default user is a fixed non-root CI account.
+
+To change the dependency contract, update the Dockerfile in the same pull
+request. After the image workflow succeeds, copy its immutable digest into the
+consumer workflow declarations and a future `.github/ci/linux-rocm.lock`.

--- a/.github/ci/linux-rocm/verify.sh
+++ b/.github/ci/linux-rocm/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "OpenASR routine CI must run as a non-root user" >&2
+  exit 1
+fi
+
+cmake --version
+cc --version
+hipcc --version
+pkg-config --exists alsa
+python3 --version

--- a/.github/ci/linux-rocm/verify.sh
+++ b/.github/ci/linux-rocm/verify.sh
@@ -11,3 +11,5 @@ cc --version
 hipcc --version
 pkg-config --exists alsa
 python3 --version
+test -e /opt/rocm/lib/cmake/hipblas/hipblas-config.cmake
+test -e /opt/rocm/lib/cmake/rocblas/rocblas-config.cmake

--- a/.github/workflows/ci-linux-build-env.yml
+++ b/.github/workflows/ci-linux-build-env.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   publish:
     name: Build, publish, and verify
+    if: github.ref_type != 'tag'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci-linux-cuda-env.yml
+++ b/.github/workflows/ci-linux-cuda-env.yml
@@ -1,0 +1,61 @@
+name: CI Linux CUDA build environment
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/ci/linux-cuda/**"
+      - ".github/workflows/ci-linux-cuda-env.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ci-linux-cuda-env-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build, publish, and verify
+    if: github.ref_type != 'tag'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish immutable image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .github/ci/linux-cuda
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/quintinshaw/openasr-ci-linux-cuda:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify published image contract
+        env:
+          IMAGE: ghcr.io/quintinshaw/openasr-ci-linux-cuda@${{ steps.build.outputs.digest }}
+        run: docker run --rm "$IMAGE" openasr-ci-verify
+
+      - name: Record immutable consumer reference
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "### Linux CUDA CI build environment"
+            echo
+            echo '```text'
+            echo "ghcr.io/quintinshaw/openasr-ci-linux-cuda@${DIGEST}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-linux-rocm-env.yml
+++ b/.github/workflows/ci-linux-rocm-env.yml
@@ -1,0 +1,61 @@
+name: CI Linux ROCm build environment
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/ci/linux-rocm/**"
+      - ".github/workflows/ci-linux-rocm-env.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ci-linux-rocm-env-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build, publish, and verify
+    if: github.ref_type != 'tag'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish immutable image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .github/ci/linux-rocm
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/quintinshaw/openasr-ci-linux-rocm:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify published image contract
+        env:
+          IMAGE: ghcr.io/quintinshaw/openasr-ci-linux-rocm@${{ steps.build.outputs.digest }}
+        run: docker run --rm "$IMAGE" openasr-ci-verify
+
+      - name: Record immutable consumer reference
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "### Linux ROCm CI build environment"
+            echo
+            echo '```text'
+            echo "ghcr.io/quintinshaw/openasr-ci-linux-rocm@${DIGEST}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,7 @@ jobs:
           python3 -m unittest discover -s tooling/family-regression -p 'test_*.py'
           python3 -m unittest discover -s tooling/release-manifest -p '*_test.py'
       - run: cargo clippy --all-targets -- -D warnings
-      - name: Install cbindgen
-        run: cargo install cbindgen --locked
+      - uses: ./.github/actions/setup-cbindgen
       - name: FFI header drift gate
         run: scripts/generate-ffi-header.sh --check
 

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -26,8 +26,16 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: docker/setup-buildx-action@v3
+
       - name: Build image
-        run: docker build -t openasr:ci .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: openasr:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Start container
         # Mock smoke: the image default CMD is the fail-closed native server,

--- a/.github/workflows/family-regression.yml
+++ b/.github/workflows/family-regression.yml
@@ -41,18 +41,69 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 90
     steps:
+      - name: Try published release CLI
+        id: published
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSET_SUFFIX: linux-x86_64
+        run: |
+          set -uo pipefail
+          available=false
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          asset="openasr-${version}-${ASSET_SUFFIX}.tar.gz"
+          workdir="${RUNNER_TEMP}/published-cli"
+          mkdir -p "${workdir}"
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
+          if json="$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "${api}")" \
+            && asset_url="$(ASSET="${asset}" python3 -c '
+          import json, os, sys
+          rel = json.loads(sys.stdin.read())
+          name = os.environ["ASSET"]
+          for item in rel.get("assets", []):
+              if item.get("name") == name and item.get("url"):
+                  print(item["url"])
+                  raise SystemExit(0)
+          raise SystemExit(2)
+          ' <<<"${json}")" \
+            && curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/octet-stream" \
+              -o "${workdir}/${asset}" \
+              "${asset_url}" \
+            && tar -xzf "${workdir}/${asset}" -C "${workdir}" \
+            && bin="$(find "${workdir}" -type f -name openasr | head -n 1)" \
+            && test -n "${bin}" \
+            && cp "${bin}" "${workdir}/openasr" \
+            && chmod +x "${workdir}/openasr" \
+            && "${workdir}/openasr" --version; then
+            available=true
+          fi
+          echo "available=${available}" >> "${GITHUB_OUTPUT}"
+          if [ "${available}" != "true" ]; then
+            echo "published ${asset} is not usable; falling back to a local release build"
+          fi
       - uses: actions/checkout@v7
+        if: steps.published.outputs.available != 'true'
         with:
           submodules: recursive
       - name: Prepare pinned Linux build environment
+        if: steps.published.outputs.available != 'true'
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           openasr-ci-verify
       - uses: dtolnay/rust-toolchain@1.95.0
+        if: steps.published.outputs.available != 'true'
       - uses: Swatinem/rust-cache@v2
+        if: steps.published.outputs.available != 'true'
         with:
           shared-key: family-regression-ubuntu-latest
       - name: Build openasr CLI
+        if: steps.published.outputs.available != 'true'
         # The binary is shared with the case jobs via an artifact, and
         # GitHub's x86 runner fleet mixes CPU generations, so host-tuned ggml
         # kernels can SIGILL on a different case runner (same rule as
@@ -60,6 +111,12 @@ jobs:
         env:
           OPENASR_GGML_NATIVE: "0"
         run: cargo build --release -p openasr-cli
+      - name: Stage published release CLI
+        if: steps.published.outputs.available == 'true'
+        run: |
+          mkdir -p target/release
+          cp "${RUNNER_TEMP}/published-cli/openasr" target/release/openasr
+          chmod +x target/release/openasr
       - uses: actions/upload-artifact@v7
         with:
           name: openasr-cli-ubuntu-latest
@@ -71,17 +128,73 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 90
     steps:
+      - name: Try published release CLI
+        id: published
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSET_SUFFIX: macos-arm64
+        run: |
+          set -uo pipefail
+          available=false
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          asset="openasr-${version}-${ASSET_SUFFIX}.tar.gz"
+          workdir="${RUNNER_TEMP}/published-cli"
+          mkdir -p "${workdir}"
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
+          if json="$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "${api}")" \
+            && asset_url="$(ASSET="${asset}" python3 -c '
+          import json, os, sys
+          rel = json.loads(sys.stdin.read())
+          name = os.environ["ASSET"]
+          for item in rel.get("assets", []):
+              if item.get("name") == name and item.get("url"):
+                  print(item["url"])
+                  raise SystemExit(0)
+          raise SystemExit(2)
+          ' <<<"${json}")" \
+            && curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/octet-stream" \
+              -o "${workdir}/${asset}" \
+              "${asset_url}" \
+            && tar -xzf "${workdir}/${asset}" -C "${workdir}" \
+            && bin="$(find "${workdir}" -type f -name openasr | head -n 1)" \
+            && test -n "${bin}" \
+            && cp "${bin}" "${workdir}/openasr" \
+            && chmod +x "${workdir}/openasr" \
+            && "${workdir}/openasr" --version; then
+            available=true
+          fi
+          echo "available=${available}" >> "${GITHUB_OUTPUT}"
+          if [ "${available}" != "true" ]; then
+            echo "published ${asset} is not usable; falling back to a local release build"
+          fi
       - uses: actions/checkout@v7
+        if: steps.published.outputs.available != 'true'
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.95.0
+        if: steps.published.outputs.available != 'true'
       - uses: Swatinem/rust-cache@v2
+        if: steps.published.outputs.available != 'true'
         with:
           shared-key: family-regression-macos-15
       - name: Build openasr CLI
+        if: steps.published.outputs.available != 'true'
         env:
           OPENASR_GGML_NATIVE: "0"
         run: cargo build --release -p openasr-cli
+      - name: Stage published release CLI
+        if: steps.published.outputs.available == 'true'
+        run: |
+          mkdir -p target/release
+          cp "${RUNNER_TEMP}/published-cli/openasr" target/release/openasr
+          chmod +x target/release/openasr
       - uses: actions/upload-artifact@v7
         with:
           name: openasr-cli-macos-15

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -269,7 +269,7 @@ jobs:
       # preinstalled toolchains this job never touches first. Same action
       # llama.cpp's ubuntu-rocm release job uses.
       - name: Free up disk space
-        if: runner.os == 'Linux' && contains(matrix.features, 'hip')
+        if: runner.os == 'Linux' && contains(matrix.features, 'hip') && !matrix.container
         uses: ./.github/actions/free-disk-space
         with:
           tool-cache: true

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -219,32 +219,24 @@ jobs:
         include: ${{ fromJSON(needs.select-matrix.outputs.include) }}
 
     steps:
-      # Official CUDA/ROCm devel images do not ship git. actions/checkout then
-      # falls back to the REST zip API, which cannot fetch submodules. Clone
-      # with git after installing it; every other runner already has git.
-      - uses: actions/checkout@v7
-        if: ${{ !contains(matrix.container, 'nvidia/cuda') && !contains(matrix.container, 'rocm/') }}
-        with:
-          submodules: recursive
-          ref: ${{ inputs.ref || github.ref }}
-
-      - name: Install git and clone (official GPU image)
+      # Official CUDA/ROCm devel images do not ship git. Without it,
+      # actions/checkout falls back to the REST zip API and cannot fetch
+      # submodules. Install git first, mark the workspace safe, then use
+      # the same checkout as every other leg.
+      - name: Install git (official GPU image)
         if: ${{ contains(matrix.container, 'nvidia/cuda') || contains(matrix.container, 'rocm/') }}
-        env:
-          REPO_REF: ${{ inputs.ref || github.sha }}
-          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
           export DEBIAN_FRONTEND=noninteractive
           apt-get update -y
           apt-get install -y --no-install-recommends git ca-certificates
-          git clone --depth 1 \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" .
-          git fetch --depth 1 origin "${REPO_REF}"
-          git checkout --force FETCH_HEAD
-          git submodule update --init --recursive --depth 1
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          git config --global --add safe.directory '*'
+
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Resolve workspace version
         shell: bash

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -66,10 +66,11 @@ on:
 permissions:
   contents: write
 
-# Serialize by target ref. Never cancel a release that is already building:
-# a later dispatch or tag retry must wait, not preempt in-flight artifacts.
+# Serialize a full matrix by ref. Diagnostic only_target dispatches share the
+# ref but must not queue behind (or replace) each other. Never cancel a
+# release that is already building: a later retry must wait.
 concurrency:
-  group: release-binaries-${{ inputs.ref || github.ref_name || github.ref }}
+  group: release-binaries-${{ inputs.ref || github.ref_name || github.ref }}-${{ inputs.only_target || 'all' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -110,6 +110,11 @@ jobs:
     if: ${{ inputs.source_run_id == '' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout || 60 }}
+    # Container images (CUDA/ROCm wrappers, official devel) default to sh.
+    # Windows steps that need PowerShell set shell: pwsh explicitly.
+    defaults:
+      run:
+        shell: bash
     # Escape hatch for future legs whose toolchain story is still settling:
     # mark them `experimental: true` and they may fail without failing the
     # run (their archives simply drop out of the required artifact set) until

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -122,15 +122,9 @@ jobs:
     permissions:
       contents: read
       packages: read
-    # Linux CPU uses the locked openasr-ci-linux image
-    # (ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc).
-    # Linux CUDA pins the official nvidia/cuda 13.2.0 devel amd64 digest
-    # nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3
-    # (index sha256:46a7128f65491ae6ed6e3a4ef31fc140a4ca77d5dddb68a4350fea9d53a95c5f,
-    # verified 2026-08-20 via docker buildx imagetools inspect).
-    # Linux ROCm pins the official rocm/dev-ubuntu-22.04:7.2.1 digest
-    # rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df
-    # (verified 2026-08-20 via docker buildx imagetools inspect).
+    # Linux CPU / CUDA / ROCm pins live in
+    # .github/ci/linux-build-env.lock, linux-cuda.lock, linux-rocm.lock
+    # and tooling/release-manifest/release_binaries_matrix.json.
     # Windows/macOS/arm64/musl/vulkan omit matrix.container and run on the host.
     # Credentials are sent only to GHCR; Docker Hub pulls stay anonymous.
     container: ${{ matrix.container && fromJSON(startsWith(matrix.container, 'ghcr.io/') && format('{{"image":{0},"credentials":{{"username":{1},"password":{2}}}}}', toJSON(matrix.container), toJSON(github.actor), toJSON(github.token)) || format('{{"image":{0}}}', toJSON(matrix.container))) || fromJSON('null') }}
@@ -254,6 +248,7 @@ jobs:
 
       - name: Prepare Linux container
         if: runner.os == 'Linux' && matrix.container
+        shell: bash
         run: |
           set -euo pipefail
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -290,7 +285,7 @@ jobs:
           tool-cache: true
 
       - name: Install Linux ROCm/HIP SDK
-        if: runner.os == 'Linux' && contains(matrix.features, 'hip') && !contains(matrix.container, 'rocm/')
+        if: runner.os == 'Linux' && contains(matrix.features, 'hip') && !contains(matrix.container, 'rocm/') && !contains(matrix.container, 'openasr-ci-linux-rocm')
         # AMD's official apt repo (the recipe llama.cpp's ubuntu-22-rocm)
         # release job uses). rocm-hip-sdk provides hipcc/the HIP clang
         # toolchain, rocBLAS, and hipBLAS; ROCM_PATH lets both cmake's
@@ -426,7 +421,7 @@ jobs:
           Add-Content $env:GITHUB_PATH "$hipRoot\bin"
 
       - name: Install CUDA toolkit (Linux)
-        if: runner.os == 'Linux' && contains(matrix.features, 'cuda') && !contains(matrix.container, 'nvidia/cuda')
+        if: runner.os == 'Linux' && contains(matrix.features, 'cuda') && !contains(matrix.container, 'nvidia/cuda') && !contains(matrix.container, 'openasr-ci-linux-cuda')
         uses: ./.github/actions/install-cuda-toolkit-linux
         with:
           cuda: "13.2.0"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -66,6 +66,12 @@ on:
 permissions:
   contents: write
 
+# Serialize by target ref. Never cancel a release that is already building:
+# a later dispatch or tag retry must wait, not preempt in-flight artifacts.
+concurrency:
+  group: release-binaries-${{ inputs.ref || github.ref_name || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   select-matrix:
     name: Select release matrix
@@ -114,6 +120,19 @@ jobs:
     # a transparency-log outage can retry without rebuilding every GPU target.
     permissions:
       contents: read
+      packages: read
+    # Linux CPU uses the locked openasr-ci-linux image
+    # (ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc).
+    # Linux CUDA pins the official nvidia/cuda 13.2.0 devel amd64 digest
+    # nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3
+    # (index sha256:46a7128f65491ae6ed6e3a4ef31fc140a4ca77d5dddb68a4350fea9d53a95c5f,
+    # verified 2026-08-20 via docker buildx imagetools inspect).
+    # Linux ROCm pins the official rocm/dev-ubuntu-22.04:7.2.1 digest
+    # rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df
+    # (verified 2026-08-20 via docker buildx imagetools inspect).
+    # Windows/macOS/arm64/musl/vulkan omit matrix.container and run on the host.
+    # Credentials are sent only to GHCR; Docker Hub pulls stay anonymous.
+    container: ${{ matrix.container && fromJSON(startsWith(matrix.container, 'ghcr.io/') && format('{{"image":{0},"credentials":{{"username":{1},"password":{2}}}}}', toJSON(matrix.container), toJSON(github.actor), toJSON(github.token)) || format('{{"image":{0}}}', toJSON(matrix.container))) || fromJSON('null') }}
     # Distributed binaries must be portable. build.rs auto-enables GGML_NATIVE
     # (-march=native) when host==target on x86, which is correct for local
     # build-and-run but would tune these released x86 binaries to the CI
@@ -218,8 +237,17 @@ jobs:
           fi
           echo "OPENASR_VERSION=${version}" >> "${GITHUB_ENV}"
 
+      - name: Prepare Linux container
+        if: runner.os == 'Linux' && matrix.container
+        run: |
+          set -euo pipefail
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if command -v openasr-ci-verify >/dev/null 2>&1; then
+            openasr-ci-verify
+          fi
+
       - name: Install Linux audio build dependencies
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && !matrix.container
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
 
       - name: Install Linux Vulkan SDK
@@ -247,7 +275,7 @@ jobs:
           tool-cache: true
 
       - name: Install Linux ROCm/HIP SDK
-        if: runner.os == 'Linux' && contains(matrix.features, 'hip')
+        if: runner.os == 'Linux' && contains(matrix.features, 'hip') && !contains(matrix.container, 'rocm/')
         # AMD's official apt repo (the recipe llama.cpp's ubuntu-22-rocm)
         # release job uses). rocm-hip-sdk provides hipcc/the HIP clang
         # toolchain, rocBLAS, and hipBLAS; ROCM_PATH lets both cmake's
@@ -383,7 +411,7 @@ jobs:
           Add-Content $env:GITHUB_PATH "$hipRoot\bin"
 
       - name: Install CUDA toolkit (Linux)
-        if: runner.os == 'Linux' && contains(matrix.features, 'cuda')
+        if: runner.os == 'Linux' && contains(matrix.features, 'cuda') && !contains(matrix.container, 'nvidia/cuda')
         uses: ./.github/actions/install-cuda-toolkit-linux
         with:
           cuda: "13.2.0"
@@ -419,8 +447,36 @@ jobs:
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "thrust"]'
           use-github-cache: true
 
-      - name: Install Rust toolchain
+      - name: Install official Linux GPU image extras
+        if: runner.os == 'Linux' && (contains(matrix.container, 'nvidia/cuda') || contains(matrix.container, 'rocm/'))
+        # Official devel images ship the toolkit but not ALSA/cmake/ninja.
+        # Our GHCR wrappers add those; consumers stay on the official digest
+        # until a published wrapper digest exists.
         run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -y
+          apt-get install -y --no-install-recommends \
+            cmake ninja-build libasound2-dev pkg-config git curl python3 ca-certificates
+          if [ -d /usr/local/cuda ]; then
+            echo "CUDA_PATH=/usr/local/cuda" >> "${GITHUB_ENV}"
+            echo "CUDA_HOME=/usr/local/cuda" >> "${GITHUB_ENV}"
+          fi
+          if [ -d /opt/rocm ]; then
+            echo "ROCM_PATH=/opt/rocm" >> "${GITHUB_ENV}"
+            echo "HIP_PATH=/opt/rocm" >> "${GITHUB_ENV}"
+            echo "/opt/rocm/bin" >> "${GITHUB_PATH}"
+          fi
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v rustup >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+            echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
+            export PATH="${HOME}/.cargo/bin:${PATH}"
+          fi
           rustup toolchain install 1.95.0 --profile minimal
           rustup default 1.95.0
           rustc --version
@@ -435,9 +491,15 @@ jobs:
         run: rustup target add ${{ matrix.rust_target }}
 
       - uses: ./.github/actions/rust-cache
+        id: rust-cache
         continue-on-error: true
         with:
           shared-key: release-binaries-${{ matrix.target }}
+
+      - name: Report rust-cache outcome
+        if: steps.rust-cache.outcome != 'success'
+        shell: bash
+        run: echo "::warning::rust-cache failed (outcome=${{ steps.rust-cache.outcome }}); continuing compile without cache"
 
       # musl legs are cross-compiled with cargo-zigbuild: zig cc/c++ is a
       # self-contained clang + bundled musl libc/libc++ cross toolchain, so no
@@ -509,10 +571,15 @@ jobs:
           if [ "${{ runner.os }}" = "Windows" ]; then
             export OPENASR_BUNDLED_VULKAN_LOADER_SHA256="$VULKAN_LOADER_DLL_SHA256"
           fi
-          if [ "${{ matrix.zigbuild }}" = "true" ]; then
-            cargo zigbuild --release -p openasr-cli --target ${{ matrix.rust_target }} ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
+          if [ "${{ matrix.distribution }}" = "plugin" ]; then
+            crate="openasr-core"
           else
-            cargo build --release -p openasr-cli ${{ matrix.rust_target && format('--target {0}', matrix.rust_target) || '' }} ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
+            crate="openasr-cli"
+          fi
+          if [ "${{ matrix.zigbuild }}" = "true" ]; then
+            cargo zigbuild --release -p "${crate}" --target ${{ matrix.rust_target }} ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
+          else
+            cargo build --release -p "${crate}" ${{ matrix.rust_target && format('--target {0}', matrix.rust_target) || '' }} ${{ matrix.features && format('--features {0}', matrix.features) || '' }}
           fi
 
       # Same GPU-less-runner caveat as the Windows CUDA/HIP legs: those two
@@ -1168,12 +1235,17 @@ jobs:
           cargo --version
 
       - uses: ./.github/actions/rust-cache
+        id: rust-cache
         continue-on-error: true
         with:
           shared-key: release-binaries-xcframework
 
-      - name: Install cbindgen
-        run: cargo install cbindgen --locked
+      - name: Report rust-cache outcome
+        if: steps.rust-cache.outcome != 'success'
+        shell: bash
+        run: echo "::warning::rust-cache failed (outcome=${{ steps.rust-cache.outcome }}); continuing compile without cache"
+
+      - uses: ./.github/actions/setup-cbindgen
 
       - name: Header drift gate
         run: scripts/generate-ffi-header.sh --check

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -219,10 +219,32 @@ jobs:
         include: ${{ fromJSON(needs.select-matrix.outputs.include) }}
 
     steps:
+      # Official CUDA/ROCm devel images do not ship git. actions/checkout then
+      # falls back to the REST zip API, which cannot fetch submodules. Clone
+      # with git after installing it; every other runner already has git.
       - uses: actions/checkout@v7
+        if: ${{ !contains(matrix.container, 'nvidia/cuda') && !contains(matrix.container, 'rocm/') }}
         with:
           submodules: recursive
           ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install git and clone (official GPU image)
+        if: ${{ contains(matrix.container, 'nvidia/cuda') || contains(matrix.container, 'rocm/') }}
+        env:
+          REPO_REF: ${{ inputs.ref || github.sha }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -y
+          apt-get install -y --no-install-recommends git ca-certificates
+          git clone --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" .
+          git fetch --depth 1 origin "${REPO_REF}"
+          git checkout --force FETCH_HEAD
+          git submodule update --init --recursive --depth 1
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Resolve workspace version
         shell: bash

--- a/.github/workflows/xcframework-manual.yml
+++ b/.github/workflows/xcframework-manual.yml
@@ -37,8 +37,7 @@ jobs:
         with:
           targets: aarch64-apple-ios,aarch64-apple-ios-sim,aarch64-apple-darwin
       - uses: Swatinem/rust-cache@v2
-      - name: Install cbindgen
-        run: cargo install cbindgen --locked
+      - uses: ./.github/actions/setup-cbindgen
       - name: Header drift gate
         run: scripts/generate-ffi-header.sh --check
       - name: Build xcframework

--- a/docs/GPU_PLUGIN_BUILD.md
+++ b/docs/GPU_PLUGIN_BUILD.md
@@ -88,6 +88,11 @@ cmake --build E:\hip --target ggml-hip -j
 `AMDGPU_TARGETS`, which is deprecated; not `CMAKE_HIP_ARCHITECTURES`, which is
 only read on the Linux `enable_language(HIP)` path).
 
+Release plugin legs do not invoke this cmake recipe directly. They run
+`cargo build -p openasr-core --release --features hip` so `build.rs` keeps the
+same cmake flag contract and stages
+`target\release\openasr-backend-packs\hip\ggml-hip.dll`.
+
 **`GGML_HIP_ROCWMMA_FATTN=OFF` is load-bearing.** OFF keeps the native MMA-F16
 flash-attn path that the vendored naive-masked-attention workaround (pinned to
 ggml commit `643b5659`) targets; ON would divert to the slower `fattn-wmma-f16`
@@ -116,12 +121,23 @@ extracts that DLL, stages the CUDA runtime/cuBLAS vendor tree separately,
 compiles one signed catalog entry, and publishes both byte identities. Other
 platforms retain their platform-specific static distribution topology.
 
-For a local Windows build, use the normal release command and select the GPU
+Release plugin legs compile `openasr-core` only so CMake still stages
+`target\release\openasr-backend-packs\cuda\ggml-cuda.dll` with the same flags
+the CLI build would have used. They do not compile `openasr-cli`.
+
+For a local Windows host+plugin build, use the CLI crate and select the GPU
 targets explicitly when validating one machine:
 
 ```text
 set OPENASR_CUDA_GPU_TARGETS=86
 cargo build -p openasr-cli --release --features cuda
+```
+
+The matching release plugin command is:
+
+```text
+set OPENASR_CUDA_GPU_TARGETS=86
+cargo build -p openasr-core --release --features cuda
 ```
 
 The resulting optional module is staged under

--- a/docs/design/ci-build-environments.md
+++ b/docs/design/ci-build-environments.md
@@ -27,30 +27,23 @@ change.
 
 ### CUDA 13.2.0
 
-- Official pin used by release-binaries today:
-  `nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3`
-  (linux/amd64 manifest). Index digest
-  `sha256:46a7128f65491ae6ed6e3a4ef31fc140a4ca77d5dddb68a4350fea9d53a95c5f`.
-- Verified on 2026-08-20 with `docker buildx imagetools inspect`.
-- Wrapper (not yet consumed): `.github/ci/linux-cuda/`, published by
+- Consumer pin: `.github/ci/linux-cuda.lock`
+  (`ghcr.io/quintinshaw/openasr-ci-linux-cuda@sha256:7d3a80aa…`).
+- Wrapper source: `.github/ci/linux-cuda/`, published by
   `.github/workflows/ci-linux-cuda-env.yml` on its own path changes only.
-- After that workflow produces a GHCR digest, copy it into a future
-  `.github/ci/linux-cuda.lock` and point the CUDA release leg at GHCR.
-
-The official image already has nvcc 13.2.0. The release job rustups from
-`rust-toolchain.toml` and apt-installs CMake/Ninja/ALSA until the wrapper
-digest exists.
+- Base: official
+  `nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3`
+  (linux/amd64). The wrapper adds git, cmake, ninja, ALSA, and a non-root user
+  so `actions/checkout` and bash steps work.
 
 ### ROCm 7.2.1
 
-- Official pin used by release-binaries today:
-  `rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df`.
-- Verified on 2026-08-20 with `docker buildx imagetools inspect`.
-- Wrapper (not yet consumed): `.github/ci/linux-rocm/`, published by
+- Consumer pin: `.github/ci/linux-rocm.lock`
+  (`ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:fc83ea99…`).
+- Wrapper source: `.github/ci/linux-rocm/`, published by
   `.github/workflows/ci-linux-rocm-env.yml` on its own path changes only.
-
-Same extras story as CUDA: hipcc comes from the official image; rustup and
-a short apt extras step run in the job.
+- Base: official
+  `rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df`.
 
 Do not change those CUDA/ROCm versions to match a newer toolkit. Live
 release pins win.

--- a/docs/design/ci-build-environments.md
+++ b/docs/design/ci-build-environments.md
@@ -39,7 +39,7 @@ change.
 ### ROCm 7.2.1
 
 - Consumer pin: `.github/ci/linux-rocm.lock`
-  (`ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:fc83ea99…`).
+  (`ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:98ed2646…`).
 - Wrapper source: `.github/ci/linux-rocm/`, published by
   `.github/workflows/ci-linux-rocm-env.yml` on its own path changes only.
 - Base: official

--- a/docs/design/ci-build-environments.md
+++ b/docs/design/ci-build-environments.md
@@ -1,0 +1,102 @@
+# CI build environments
+
+OpenASR's public GitHub Actions stay on free hosted runners. The expensive
+work is compiling ggml plus the CUDA/ROCm toolkits, so the release matrix
+pins three Linux environments and leaves Windows on the hosted VS image.
+
+## Three Linux environments
+
+### CPU (`openasr-ci-linux`)
+
+- Image: `ghcr.io/quintinshaw/openasr-ci-linux`, digest in
+  `.github/ci/linux-build-env.lock`.
+- Source: `.github/ci/linux-build-env/`.
+- Publish: `.github/workflows/ci-linux-build-env.yml`, only when that tree
+  changes. Tag pushes do not publish.
+- Consumers: `ci.yml`, `family-regression.yml`, `public-hf-e2e.yml`,
+  `release-core.yml`, `serve-batch-parity.yml`, and the
+  `x86_64-unknown-linux-gnu` release-binaries leg.
+- Contract: `.github/ci/check-linux-build-env.py` requires every listed
+  consumer to pin the lock digest. Fully migrated consumers must not
+  `apt-get`.
+
+The image is Ubuntu 24.04 with C/C++, CMake, Ninja, ALSA, and Python. It
+does not ship a Vulkan SDK. The Linux Vulkan release leg therefore stays on
+`ubuntu-22.04` and LunarG's jammy apt recipe so the live SDK source does not
+change.
+
+### CUDA 13.2.0
+
+- Official pin used by release-binaries today:
+  `nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3`
+  (linux/amd64 manifest). Index digest
+  `sha256:46a7128f65491ae6ed6e3a4ef31fc140a4ca77d5dddb68a4350fea9d53a95c5f`.
+- Verified on 2026-08-20 with `docker buildx imagetools inspect`.
+- Wrapper (not yet consumed): `.github/ci/linux-cuda/`, published by
+  `.github/workflows/ci-linux-cuda-env.yml` on its own path changes only.
+- After that workflow produces a GHCR digest, copy it into a future
+  `.github/ci/linux-cuda.lock` and point the CUDA release leg at GHCR.
+
+The official image already has nvcc 13.2.0. The release job rustups from
+`rust-toolchain.toml` and apt-installs CMake/Ninja/ALSA until the wrapper
+digest exists.
+
+### ROCm 7.2.1
+
+- Official pin used by release-binaries today:
+  `rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df`.
+- Verified on 2026-08-20 with `docker buildx imagetools inspect`.
+- Wrapper (not yet consumed): `.github/ci/linux-rocm/`, published by
+  `.github/workflows/ci-linux-rocm-env.yml` on its own path changes only.
+
+Same extras story as CUDA: hipcc comes from the official image; rustup and
+a short apt extras step run in the job.
+
+Do not change those CUDA/ROCm versions to match a newer toolkit. Live
+release pins win.
+
+## Why Windows is not containerized
+
+Windows CUDA 12.6.3 / 12.8.1 and HIP SDK 26.Q1 are installed by the existing
+composite actions onto `windows-2022`. There is no official, digest-pinned
+Windows container on GitHub-hosted runners that already contains those
+toolkits, and pulling a Windows container would not remove the VS / CUDA /
+HIP install cost that dominates those legs. Plugin legs now compile
+`openasr-core` instead of `openasr-cli` so CMake still emits
+`openasr-backend-packs/<provider>/ggml-<provider>.dll` without linking the
+CLI.
+
+## Cache keys
+
+| Cache | Key | Failure mode |
+| --- | --- | --- |
+| `./.github/actions/rust-cache` | `release-binaries-${{ matrix.target }}` (and `release-binaries-xcframework`) | `continue-on-error: true` plus an explicit `::warning::`. A cache miss or action outage must not fail the release. |
+| cbindgen | `cbindgen-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}` | Miss installs with `cargo install cbindgen --locked`. |
+| docker-smoke buildx | `type=gha` | Layer cache only; the smoke assertions are unchanged. |
+| Windows HIP SDK | `hip-sdk-${{ env.HIPSDK_INSTALLER_VERSION }}-${{ runner.os }}` | Unchanged. |
+| Vulkan loader zip | `vulkan-loader-${{ env.VULKAN_LOADER_VERSION }}` | Unchanged; hash is rechecked on every run. |
+
+There is no remote sccache. Do not add one: forks cannot write a shared
+cache safely, and a poisoned cache would ship into release artifacts.
+
+## Rollback
+
+Revert the workflow and matrix commits. Consumers that still pin a digest
+keep working; the previous `apt-get` / `Jimver/cuda-toolkit` / ROCm apt
+paths remain in git history. Wrapper image workflows are additive: deleting
+or ignoring them does not affect a consumer that still uses the official
+NVIDIA/ROCm digest.
+
+A failed rust-cache step is not a rollback trigger. Re-run the job.
+
+## Forks and `packages:write`
+
+Image publish workflows need `packages: write` to push to
+`ghcr.io/quintinshaw/...`. Forks do not receive that permission on the
+canonical package namespace, so a fork PR that only touches
+`.github/ci/linux-*` will fail the publish job. That is expected. Routine
+PR CI (`ci.yml`, `docker-smoke.yml`, `serve-batch-parity.yml`) only *pulls*
+the already-published CPU image with `packages: read` and does not publish.
+
+Do not point a consumer at a mutable tag such as `:latest` or `:${{ github.sha }}`
+from an unpublished fork build.

--- a/tooling/release-manifest/release_binaries_matrix.json
+++ b/tooling/release-manifest/release_binaries_matrix.json
@@ -357,7 +357,7 @@
     "archive_ext": "tar.gz",
     "features": "cuda",
     "timeout": 120,
-    "container": "nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3"
+    "container": "ghcr.io/quintinshaw/openasr-ci-linux-cuda@sha256:7d3a80aae720b6e726c71f2da726857039abf52e9f32d0f8ae1f68b8a7de3a77"
   },
   {
     "os": "ubuntu-22.04",
@@ -367,6 +367,6 @@
     "archive_ext": "tar.gz",
     "features": "hip",
     "timeout": 240,
-    "container": "rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df"
+    "container": "ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:fc83ea993728463fc6666139304fc1221d4b34327179af223102459f73193212"
   }
 ]

--- a/tooling/release-manifest/release_binaries_matrix.json
+++ b/tooling/release-manifest/release_binaries_matrix.json
@@ -4,7 +4,8 @@
     "target": "x86_64-unknown-linux-gnu",
     "asset": "linux-x86_64",
     "binary_name": "openasr",
-    "archive_ext": "tar.gz"
+    "archive_ext": "tar.gz",
+    "container": "ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc"
   },
   {
     "os": "ubuntu-22.04-arm",
@@ -355,7 +356,8 @@
     "binary_name": "openasr",
     "archive_ext": "tar.gz",
     "features": "cuda",
-    "timeout": 120
+    "timeout": 120,
+    "container": "nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3"
   },
   {
     "os": "ubuntu-22.04",
@@ -364,6 +366,7 @@
     "binary_name": "openasr",
     "archive_ext": "tar.gz",
     "features": "hip",
-    "timeout": 240
+    "timeout": 240,
+    "container": "rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df"
   }
 ]

--- a/tooling/release-manifest/release_binaries_matrix.json
+++ b/tooling/release-manifest/release_binaries_matrix.json
@@ -367,6 +367,6 @@
     "archive_ext": "tar.gz",
     "features": "hip",
     "timeout": 240,
-    "container": "ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:fc83ea993728463fc6666139304fc1221d4b34327179af223102459f73193212"
+    "container": "ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:98ed26463af7dfd6bb4a3235145a914531fcd2c2a7c3ea8422cc8c9ad30b5917"
   }
 ]

--- a/tooling/release-manifest/select_release_matrix_test.py
+++ b/tooling/release-manifest/select_release_matrix_test.py
@@ -67,6 +67,24 @@ class SelectReleaseMatrixTests(unittest.TestCase):
         self.assertIn("fromJSON(needs.select-matrix.outputs.include)", workflow)
         self.assertIn("\n  select-matrix:\n", workflow)
 
+    def test_linux_release_legs_pin_digest_containers(self) -> None:
+        rows = {row["target"]: row for row in load_matrix()}
+        self.assertEqual(
+            rows["x86_64-unknown-linux-gnu"]["container"],
+            "ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc",
+        )
+        self.assertEqual(
+            rows["x86_64-unknown-linux-gnu-cuda"]["container"],
+            "nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3",
+        )
+        self.assertEqual(
+            rows["x86_64-unknown-linux-gnu-rocm"]["container"],
+            "rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df",
+        )
+        self.assertNotIn("container", rows["x86_64-unknown-linux-gnu-vulkan"])
+        self.assertNotIn("container", rows["aarch64-unknown-linux-gnu"])
+        self.assertNotIn("container", rows["x86_64-pc-windows-msvc-neutral"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tooling/release-manifest/select_release_matrix_test.py
+++ b/tooling/release-manifest/select_release_matrix_test.py
@@ -75,11 +75,11 @@ class SelectReleaseMatrixTests(unittest.TestCase):
         )
         self.assertEqual(
             rows["x86_64-unknown-linux-gnu-cuda"]["container"],
-            "nvidia/cuda:13.2.0-devel-ubuntu22.04@sha256:c7732db6b0128a468fab3d4c45d7063e075e7001c96e0b5303bb406cd59eb8c3",
+            "ghcr.io/quintinshaw/openasr-ci-linux-cuda@sha256:7d3a80aae720b6e726c71f2da726857039abf52e9f32d0f8ae1f68b8a7de3a77",
         )
         self.assertEqual(
             rows["x86_64-unknown-linux-gnu-rocm"]["container"],
-            "rocm/dev-ubuntu-22.04:7.2.1@sha256:42851dac319afce41cf993e25f95005b7f2cd0a0f6abd32ad8f25cd876ec56df",
+            "ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:fc83ea993728463fc6666139304fc1221d4b34327179af223102459f73193212",
         )
         self.assertNotIn("container", rows["x86_64-unknown-linux-gnu-vulkan"])
         self.assertNotIn("container", rows["aarch64-unknown-linux-gnu"])

--- a/tooling/release-manifest/select_release_matrix_test.py
+++ b/tooling/release-manifest/select_release_matrix_test.py
@@ -79,7 +79,7 @@ class SelectReleaseMatrixTests(unittest.TestCase):
         )
         self.assertEqual(
             rows["x86_64-unknown-linux-gnu-rocm"]["container"],
-            "ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:fc83ea993728463fc6666139304fc1221d4b34327179af223102459f73193212",
+            "ghcr.io/quintinshaw/openasr-ci-linux-rocm@sha256:98ed26463af7dfd6bb4a3235145a914531fcd2c2a7c3ea8422cc8c9ad30b5917",
         )
         self.assertNotIn("container", rows["x86_64-unknown-linux-gnu-vulkan"])
         self.assertNotIn("container", rows["aarch64-unknown-linux-gnu"])

--- a/tooling/release-manifest/windows_backend_release_contract_test.py
+++ b/tooling/release-manifest/windows_backend_release_contract_test.py
@@ -327,6 +327,19 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
         )[1].split(";", 1)[0]
         self.assertIn("is_windows_arm64", openmp_contract)
 
+    def test_plugin_legs_build_openasr_core_not_cli(self) -> None:
+        build = self.workflow.split("\n  build:\n", 1)[1].split(
+            "\n  xcframework:\n", 1
+        )[0]
+        self.assertIn('[ "${{ matrix.distribution }}" = "plugin" ]', build)
+        self.assertIn('crate="openasr-core"', build)
+        self.assertIn('crate="openasr-cli"', build)
+        self.assertIn('-p "${crate}"', build)
+        self.assertNotIn("cargo build --release -p openasr-cli", build)
+        self.assertNotIn("cargo zigbuild --release -p openasr-cli", build)
+        self.assertIn("Verify optional backend PE contract", build)
+        self.assertIn("openasr-backend-packs\\$provider\\ggml-$provider.dll", build)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Cut hosted CI and release wall time on free GitHub-hosted runners. Toolchains that almost never change now come from digest-pinned images. Windows GPU plugin legs compile `openasr-core` only. SHA, PE, ABI, Trusted Signing, provenance, and completeness gates stay fail-closed.

## Why

A full release matrix spends most of its wall clock reinstalling CUDA/ROCm and rebuilding the CLI on every plugin target. Public standard runners are free and 4-core; the cheaper win is to stop repeating that work, not to buy larger machines.

## Changes

- Cache `cbindgen` and Docker smoke layers.
- Pin Linux CPU builds to the existing `openasr-ci-linux` digest. Pin Linux CUDA 13.2.0 and ROCm 7.2.1 to official devel image digests.
- Add wrapper Dockerfiles and path-scoped publish workflows for those GPU images. Consumers stay on the official digests until a GHCR lock exists.
- Windows plugin legs build `-p openasr-core` and still stage `ggml-cuda.dll` / `ggml-hip.dll` through `build.rs`. Host, Linux fat, macOS, and xcframework still build the CLI.
- Serialize `release-binaries` by ref and never cancel an in-flight release.
- Skip Linux image publishes on tag pushes. On tag events, family-regression tries the same-tag CLI and rebuilds if the download fails.
- Skip host disk cleanup inside GPU containers.

## Tests run

- [x] `python3 -m unittest discover -s tooling/release-manifest -p '*_test.py'`
- [x] `python3 .github/ci/check-linux-build-env.py`
- [x] `actionlint .github/workflows/*.yml` (no new findings; remaining notes are pre-existing)
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Workflow-only change. Rust sources and `build.rs` are untouched, so the Cargo gates were not re-run.

## Manual smoke checks

Not run yet. This draft is the first hosted check. Do not dispatch `release-binaries` against `v0.1.34` or any live draft assets. A later `workflow_dispatch` with `dry_run=true` on this branch can A/B the GPU matrix without uploading.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

Not applicable.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

Added `docs/design/ci-build-environments.md`. Updated `docs/GPU_PLUGIN_BUILD.md` so the release plugin command matches the workflow.

## Scope / non-goals

Does not change the public catalog, tags, or any GitHub Release assets. Does not split Linux GPU into plugins. Does not add remote sccache or paid runners. Does not remove the Windows CPU zip. Linux Vulkan, arm64, and musl still install packages on the host. Linux CUDA/ROCm legs still build the full CLI.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
