### PR TITLE
docs(ci): say release legs pin GHCR wrapper locks

### DIFF
--- a/.github/ci/linux-cuda/Dockerfile
+++ b/.github/ci/linux-cuda/Dockerfile
@@ -1,8 +1,7 @@
 # Linux CUDA CI build environment
 #
-# Wrapper around the official NVIDIA CUDA 13.2.0 devel image. Release consumers
-# in this change still pin that official digest directly; switch them to the
-# published GHCR digest only after this workflow has produced one.
+# Wrapper around the official NVIDIA CUDA 13.2.0 devel image. Release
+# consumers pin the published GHCR digest in .github/ci/linux-cuda.lock.
 #
 # Base digest verified 2026-08-20 with `docker buildx imagetools inspect`
 # nvidia/cuda:13.2.0-devel-ubuntu22.04:

--- a/.github/ci/linux-cuda/README.md
+++ b/.github/ci/linux-cuda/README.md
@@ -5,13 +5,12 @@ product or release image.
 
 - The base image is pinned by its linux/amd64 manifest digest.
 - Every source revision is published under its commit SHA.
-- Consumers must pin a verified GHCR digest, never a mutable tag. This pull
-  request still lets release-binaries pin the official NVIDIA digest until a
-  GHCR digest exists.
+- Consumers pin the verified GHCR digest in `.github/ci/linux-cuda.lock`,
+  never a mutable tag.
 - The publish workflow verifies C/C++, CMake, nvcc, ALSA, and Python before a
   digest is eligible for consumers.
 - The default user is a fixed non-root CI account.
 
 To change the dependency contract, update the Dockerfile in the same pull
-request. After the image workflow succeeds, copy its immutable digest into the
-consumer workflow declarations and a future `.github/ci/linux-cuda.lock`.
+request. After the image workflow succeeds, copy its immutable digest into
+`.github/ci/linux-cuda.lock` and `tooling/release-manifest/release_binaries_matrix.json`.

--- a/.github/ci/linux-rocm/README.md
+++ b/.github/ci/linux-rocm/README.md
@@ -1,17 +1,16 @@
 # Linux ROCm CI build environment
 
-Wrapper around the official AMD ROCm 7.2.1 devel image. It is not a product
-or release image.
+Wrapper around the official AMD ROCm 7.2.1 devel image plus hipBLAS. It is
+not a product or release image.
 
 - The base image is pinned by its manifest digest.
 - Every source revision is published under its commit SHA.
-- Consumers must pin a verified GHCR digest, never a mutable tag. This pull
-  request still lets release-binaries pin the official ROCm digest until a
-  GHCR digest exists.
-- The publish workflow verifies C/C++, CMake, hipcc, ALSA, and Python before a
-  digest is eligible for consumers.
+- Consumers pin the verified GHCR digest in `.github/ci/linux-rocm.lock`,
+  never a mutable tag.
+- The publish workflow verifies C/C++, CMake, hipcc, hipBLAS, ALSA, and
+  Python before a digest is eligible for consumers.
 - The default user is a fixed non-root CI account.
 
 To change the dependency contract, update the Dockerfile in the same pull
-request. After the image workflow succeeds, copy its immutable digest into the
-consumer workflow declarations and a future `.github/ci/linux-rocm.lock`.
+request. After the image workflow succeeds, copy its immutable digest into
+`.github/ci/linux-rocm.lock` and `tooling/release-manifest/release_binaries_matrix.json`.

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -464,9 +464,8 @@ jobs:
 
       - name: Install official Linux GPU image extras
         if: runner.os == 'Linux' && (contains(matrix.container, 'nvidia/cuda') || contains(matrix.container, 'rocm/'))
-        # Official devel images ship the toolkit but not ALSA/cmake/ninja.
-        # Our GHCR wrappers add those; consumers stay on the official digest
-        # until a published wrapper digest exists.
+        # Fallback only if a matrix row still points at an official NVIDIA/ROCm
+        # devel image. Current CUDA/ROCm legs use GHCR wrappers and skip this.
         run: |
           set -euo pipefail
           export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary

Correct leftover comments that still said Linux CUDA/ROCm consumers pin official devel digests. They pin `.github/ci/linux-cuda.lock` and `.github/ci/linux-rocm.lock`.

## Why

#323 merged from a stale remote tip after a push timeout, so this wording missed main.

## Tests run

- [x] `python3 -m unittest discover -s tooling/release-manifest -p '*_test.py'`
- [x] `python3 .github/ci/check-linux-build-env.py`

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES