### PR TITLE
fix(client): drop needless Option as_deref in restore test

### DIFF
--- a/crates/openasr-client/src/client.rs
+++ b/crates/openasr-client/src/client.rs
@@ -998,10 +998,7 @@ mod tests {
         client.restore_connected(&fingerprint, "device-1").unwrap();
         assert_eq!(client.status(), ClientStatus::Connected);
         assert_eq!(client.device_id(), Some("device-1"));
-        assert_eq!(
-            client.server_fingerprint(),
-            Some(fingerprint.as_str())
-        );
+        assert_eq!(client.server_fingerprint(), Some(fingerprint.as_str()));
     }
 
     #[test]

--- a/crates/openasr-client/src/client.rs
+++ b/crates/openasr-client/src/client.rs
@@ -999,7 +999,7 @@ mod tests {
         assert_eq!(client.status(), ClientStatus::Connected);
         assert_eq!(client.device_id(), Some("device-1"));
         assert_eq!(
-            client.server_fingerprint().as_deref(),
+            client.server_fingerprint(),
             Some(fingerprint.as_str())
         );
     }


### PR DESCRIPTION
## Summary

Fix the clippy failure on main after #328: `needless_option_as_deref` in the restore_connected unit test.

## Why

`cargo clippy --all-targets -- -D warnings` failed on `crates/openasr-client/src/client.rs` because `server_fingerprint()` is already `Option<&str>`.

## Changes

- Compare `client.server_fingerprint()` directly.

## Tests run

- [x] `cargo fmt --check` (touched file)
- [x] `cargo clippy -p openasr-client --all-targets -- -D warnings`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

N/A

## Model-family changes (when applicable)

- [ ] N/A

## Docs updated

- [x] No docs overclaim current capabilities.

## Scope / non-goals

Clippy only. No protocol changes.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES