### PR TITLE
fix(core): rebind default model in-process and hash only load images

### DIFF
--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -654,7 +654,7 @@ pub(super) async fn serve(
             ),
             ffmpeg_bin,
             ffmpeg_bin_explicit,
-            model_pack_path: model_source.model_pack_path,
+            model_pack_path: model_source.model_pack_path.into(),
         },
         launch_options,
     )

--- a/crates/openasr-core/src/ggml_runtime/backend.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend.rs
@@ -3,6 +3,7 @@ use std::{
     ffi::{CStr, CString, c_char, c_int, c_void},
     path::{Component, Path, PathBuf},
     ptr::{self, NonNull},
+    time::Instant,
 };
 
 use serde::Deserialize;
@@ -24,7 +25,8 @@ use crate::{
         BackendBundleContractEntry, backend_bundle_contract_sha256, pe_image_identity,
     },
     pull::{
-        backend_artifact_fingerprint, backend_pack_install_dir, read_and_verify_installed_backend,
+        backend_artifact_fingerprint, backend_pack_install_dir,
+        read_and_verify_installed_backend_for_activation,
     },
     resolve_catalog_backend_pull, resolve_compatible_catalog_backend_pull_for_driver,
     resolve_local_catalog_env_override,
@@ -1099,13 +1101,17 @@ fn activate_selected_backend_plugin()
             reason: error.to_string(),
         }
     })?;
-    let installed =
-        read_and_verify_installed_backend(&install_dir, &requested).map_err(|error| {
-            BackendPluginActivationError::InstalledPackInvalid {
-                backend_id: backend_id.clone(),
-                reason: error.to_string(),
-            }
+    let stage_started = Instant::now();
+    let installed = read_and_verify_installed_backend_for_activation(&install_dir, &requested)
+        .map_err(|error| BackendPluginActivationError::InstalledPackInvalid {
+            backend_id: backend_id.clone(),
+            reason: error.to_string(),
         })?;
+    crate::stage_timing::log_stage(
+        "server_boot",
+        "ggml_backend_verify1",
+        stage_started.elapsed(),
+    );
     let canonical_dir = std::fs::canonicalize(&install_dir).map_err(|error| {
         BackendPluginActivationError::InstalledPackInvalid {
             backend_id: backend_id.clone(),
@@ -1134,17 +1140,27 @@ fn activate_selected_backend_plugin()
     if requested.vendor == CatalogBackendVendor::Hip {
         crate::backend_distribution::bind_verified_hip_kernel_libpaths(&dependency_dirs);
     }
+    let stage_started = Instant::now();
     let _load_guards =
         lock_verified_backend_load_files(&backend_id, &plugin_path, &dependency_dirs)?;
-    // Rehash while write/delete sharing is denied. The first verification
-    // establishes paths and the second proves those locked bytes still match
-    // the signed catalog immediately before any DllMain can run.
-    read_and_verify_installed_backend(&install_dir, &requested).map_err(|error| {
-        BackendPluginActivationError::InstalledPackInvalid {
+    crate::stage_timing::log_stage("server_boot", "ggml_backend_lock", stage_started.elapsed());
+    // Rehash mapped images while write/delete sharing is denied. Both
+    // passes use LoadImages: the first establishes identity and image
+    // hashes, the second proves the locked DLL bytes still match the
+    // signed catalog immediately before any DllMain can run.
+    let stage_started = Instant::now();
+    read_and_verify_installed_backend_for_activation(&install_dir, &requested).map_err(
+        |error| BackendPluginActivationError::InstalledPackInvalid {
             backend_id: backend_id.clone(),
             reason: error.to_string(),
-        }
-    })?;
+        },
+    )?;
+    crate::stage_timing::log_stage(
+        "server_boot",
+        "ggml_backend_verify2",
+        stage_started.elapsed(),
+    );
+    let stage_started = Instant::now();
     let live_driver = probe_exact_backend_plugin_candidate(
         &backend_id,
         requested.vendor,
@@ -1153,6 +1169,7 @@ fn activate_selected_backend_plugin()
         &device_target,
         live_backend_driver_floor(requested.vendor, requested.min_driver_api.as_deref()),
     )?;
+    crate::stage_timing::log_stage("server_boot", "ggml_backend_probe", stage_started.elapsed());
     let resolved = resolve_compatible_catalog_backend_pull_for_driver(
         &catalog,
         requested.vendor,
@@ -1173,6 +1190,7 @@ fn activate_selected_backend_plugin()
             ),
         });
     }
+    let stage_started = Instant::now();
     load_exact_backend_plugin(
         &backend_id,
         resolved.vendor,
@@ -1181,6 +1199,7 @@ fn activate_selected_backend_plugin()
         &device_target,
         live_backend_driver_floor(resolved.vendor, resolved.min_driver_api.as_deref()),
     )?;
+    crate::stage_timing::log_stage("server_boot", "ggml_backend_load", stage_started.elapsed());
     Ok(Some(ActivatedBackendRuntime {
         backend_id,
         provider: execution_provider_for_catalog_vendor(resolved.vendor),

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -4872,11 +4872,36 @@ fn materialized_tree_sha256(files: &[InstalledBackendMaterializedFile]) -> Strin
     format!("{:x}", hasher.finalize())
 }
 
-fn collect_materialized_files(
+fn installed_backend_relative_path(root: &Path, path: &Path) -> Result<String, PullError> {
+    let relative = path
+        .strip_prefix(root)
+        .map_err(|_| PullError::BackendFilePreflight {
+            path: path.to_path_buf(),
+            reason: "payload path escaped its content object".to_string(),
+        })?;
+    let relative_path = relative
+        .components()
+        .map(|component| component.as_os_str().to_str())
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| PullError::BackendFilePreflight {
+            path: path.to_path_buf(),
+            reason: "payload path is not UTF-8".to_string(),
+        })?
+        .join("/");
+    validate_safe_relative_path("backend payload path", &relative_path).map_err(|reason| {
+        PullError::BackendFilePreflight {
+            path: path.to_path_buf(),
+            reason,
+        }
+    })?;
+    Ok(relative_path)
+}
+
+fn walk_installed_backend_files(
     root: &Path,
-) -> Result<Vec<InstalledBackendMaterializedFile>, PullError> {
+    mut on_file: impl FnMut(&Path, &str) -> Result<(), PullError>,
+) -> Result<(), PullError> {
     let mut pending = vec![root.to_path_buf()];
-    let mut files = Vec::new();
     while let Some(dir) = pending.pop() {
         let entries = fs::read_dir(&dir).map_err(|source| PullError::Io {
             path: dir.clone(),
@@ -4910,37 +4935,69 @@ fn collect_materialized_files(
                         .to_string(),
                 });
             }
-            let relative =
-                path.strip_prefix(root)
-                    .map_err(|_| PullError::BackendFilePreflight {
-                        path: path.clone(),
-                        reason: "payload path escaped its content object".to_string(),
-                    })?;
-            let relative_path = relative
-                .components()
-                .map(|component| component.as_os_str().to_str())
-                .collect::<Option<Vec<_>>>()
-                .ok_or_else(|| PullError::BackendFilePreflight {
-                    path: path.clone(),
-                    reason: "payload path is not UTF-8".to_string(),
-                })?
-                .join("/");
-            validate_safe_relative_path("backend payload path", &relative_path).map_err(
-                |reason| PullError::BackendFilePreflight {
-                    path: path.clone(),
-                    reason,
-                },
-            )?;
-            let (size_bytes, sha256) = file_size_and_sha256(&path)?;
-            files.push(InstalledBackendMaterializedFile {
-                relative_path,
-                sha256,
-                size_bytes,
-            });
+            let relative_path = installed_backend_relative_path(root, &path)?;
+            on_file(&path, &relative_path)?;
         }
     }
+    Ok(())
+}
+
+fn collect_materialized_files(
+    root: &Path,
+) -> Result<Vec<InstalledBackendMaterializedFile>, PullError> {
+    let mut files = Vec::new();
+    walk_installed_backend_files(root, |path, relative_path| {
+        let (size_bytes, sha256) = file_size_and_sha256(path)?;
+        files.push(InstalledBackendMaterializedFile {
+            relative_path: relative_path.to_string(),
+            sha256,
+            size_bytes,
+        });
+        Ok(())
+    })?;
     files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
     Ok(files)
+}
+
+fn is_backend_load_image_relative_path(relative_path: &str) -> bool {
+    Path::new(relative_path)
+        .extension()
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("dll")
+                || extension.eq_ignore_ascii_case("so")
+                || extension.eq_ignore_ascii_case("dylib")
+        })
+}
+
+/// How thoroughly an installed backend pack is checked before use.
+///
+/// `Full` is the fail-closed install/repair gate: every materialized file is
+/// size/hash verified and the install tree is a closed set.
+///
+/// `LoadImages` is the activation hot path. HIP vendor trees contain thousands
+/// of Tensile/hsaco objects that DllMain never maps; hashing them twice at
+/// process start dominated `ggml_backend` on hosts without SHA-NI. Activation
+/// still authenticates `backend.json`, still checks the signed archive tree
+/// digest from recorded materialized hashes, still hashes the plugin and every
+/// native library image, and still rejects extra sibling libraries the loader
+/// would map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstalledBackendVerifyScope {
+    Full,
+    LoadImages,
+}
+
+fn should_hash_installed_backend_file(
+    relative_path: &str,
+    plugin_filename: &str,
+    scope: InstalledBackendVerifyScope,
+) -> bool {
+    match scope {
+        InstalledBackendVerifyScope::Full => true,
+        InstalledBackendVerifyScope::LoadImages => {
+            relative_path == plugin_filename || is_backend_load_image_relative_path(relative_path)
+        }
+    }
 }
 
 fn backend_content_object_dir(home: &Path, file: &CatalogBackendFile) -> PathBuf {
@@ -5341,10 +5398,24 @@ fn materialize_backend_content_object(
 /// Verify an installed backend against the exact signed-catalog resolution.
 /// Marker paths are never trusted: `dir` is supplied by the caller and every
 /// declared artifact is size/hash/preflight checked before native code loads.
+///
+/// This is the install/repair gate ([`InstalledBackendVerifyScope::Full`]).
+/// Runtime plugin activation must use
+/// [`read_and_verify_installed_backend_for_activation`] so Tensile/hsaco
+/// payloads are not re-hashed on the load path.
 pub fn verify_installed_backend(
     dir: &Path,
     installed: &InstalledBackend,
     resolved: &ResolvedCatalogBackendPull,
+) -> Result<(), PullError> {
+    verify_installed_backend_with_scope(dir, installed, resolved, InstalledBackendVerifyScope::Full)
+}
+
+pub fn verify_installed_backend_with_scope(
+    dir: &Path,
+    installed: &InstalledBackend,
+    resolved: &ResolvedCatalogBackendPull,
+    scope: InstalledBackendVerifyScope,
 ) -> Result<(), PullError> {
     let expected_vendor = backend_vendor_dirname(resolved.vendor)?;
     if installed.schema_version != INSTALLED_BACKEND_SCHEMA_VERSION
@@ -5405,6 +5476,13 @@ pub fn verify_installed_backend(
                 });
             }
             allowed_relative_paths.insert(materialized.relative_path.clone());
+            if !should_hash_installed_backend_file(
+                &materialized.relative_path,
+                &installed.plugin_filename,
+                scope,
+            ) {
+                continue;
+            }
             let path = dir.join(&materialized.relative_path);
             let (actual_size, actual_sha256) = file_size_and_sha256(&path)?;
             if actual_size != materialized.size_bytes {
@@ -5471,22 +5549,42 @@ pub fn verify_installed_backend(
             }
         }
     }
-    // Installed packs are a closed file set. Windows LoadLibraryEx with
-    // LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR will load unsigned sibling DLLs that
-    // never appear in the signed materialized list.
-    for actual in collect_materialized_files(dir)? {
-        if !allowed_relative_paths.contains(&actual.relative_path) {
-            return Err(PullError::UnexpectedInstalledBackendFile {
-                path: dir.join(&actual.relative_path),
-            });
+    match scope {
+        InstalledBackendVerifyScope::Full => {
+            // Installed packs are a closed file set. Windows LoadLibraryEx with
+            // LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR will load unsigned sibling DLLs
+            // that never appear in the signed materialized list.
+            for actual in collect_materialized_files(dir)? {
+                if !allowed_relative_paths.contains(&actual.relative_path) {
+                    return Err(PullError::UnexpectedInstalledBackendFile {
+                        path: dir.join(&actual.relative_path),
+                    });
+                }
+            }
+        }
+        InstalledBackendVerifyScope::LoadImages => {
+            // Activation only has to refuse extra mapped images. Extra Tensile
+            // objects are not a DllMain TOCTOU; hashing or enumerating them as
+            // unexpected files is the install-path job.
+            walk_installed_backend_files(dir, |path, relative_path| {
+                if is_backend_load_image_relative_path(relative_path)
+                    && !allowed_relative_paths.contains(relative_path)
+                {
+                    return Err(PullError::UnexpectedInstalledBackendFile {
+                        path: path.to_path_buf(),
+                    });
+                }
+                Ok(())
+            })?;
         }
     }
     Ok(())
 }
 
-pub fn read_and_verify_installed_backend(
+fn read_and_verify_installed_backend_with_scope(
     dir: &Path,
     resolved: &ResolvedCatalogBackendPull,
+    scope: InstalledBackendVerifyScope,
 ) -> Result<InstalledBackend, PullError> {
     let marker_path = dir.join("backend.json");
     let text = fs::read_to_string(&marker_path).map_err(|source| PullError::Io {
@@ -5498,9 +5596,31 @@ pub fn read_and_verify_installed_backend(
             path: marker_path,
             source,
         })?;
-    verify_installed_backend(dir, &installed, resolved)?;
+    verify_installed_backend_with_scope(dir, &installed, resolved, scope)?;
     installed.dir = dir.to_path_buf();
     Ok(installed)
+}
+
+pub fn read_and_verify_installed_backend(
+    dir: &Path,
+    resolved: &ResolvedCatalogBackendPull,
+) -> Result<InstalledBackend, PullError> {
+    read_and_verify_installed_backend_with_scope(dir, resolved, InstalledBackendVerifyScope::Full)
+}
+
+/// Activation-path verification: identity + mapped images only.
+///
+/// Install and other callers must keep using [`read_and_verify_installed_backend`],
+/// which remains [`InstalledBackendVerifyScope::Full`].
+pub fn read_and_verify_installed_backend_for_activation(
+    dir: &Path,
+    resolved: &ResolvedCatalogBackendPull,
+) -> Result<InstalledBackend, PullError> {
+    read_and_verify_installed_backend_with_scope(
+        dir,
+        resolved,
+        InstalledBackendVerifyScope::LoadImages,
+    )
 }
 
 /// Download, verify, and install a resolved backend plugin pack into

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -3416,6 +3416,68 @@ fn installed_backend_full_verification_accepts_declared_files_only() {
 }
 
 #[test]
+fn installed_backend_load_images_skips_tampered_non_dll_archive_payload() {
+    let home = tempfile::tempdir().unwrap();
+    let plugin = minimal_pe_bytes();
+    let archive = tensile_zip_bytes();
+    let resolved = hip_pack_resolved(&plugin, &archive);
+    let mut client = FakeClient::with_responses(vec![
+        ResponseSpec {
+            status: 200,
+            body: plugin,
+        },
+        ResponseSpec {
+            status: 200,
+            body: archive,
+        },
+    ]);
+    let installed =
+        install_backend_pack_with_client(&resolved, home.path(), &mut client, |_| {}).unwrap();
+    let hsaco = installed
+        .dir
+        .join("rocblas")
+        .join("library")
+        .join("Kernels.so-000-gfx1200.hsaco");
+    let mut bytes = fs::read(&hsaco).unwrap();
+    bytes[0] ^= 0xff;
+    fs::write(&hsaco, bytes).unwrap();
+
+    assert!(matches!(
+        read_and_verify_installed_backend(&installed.dir, &resolved),
+        Err(PullError::ShaMismatch { .. })
+    ));
+    read_and_verify_installed_backend_for_activation(&installed.dir, &resolved).unwrap();
+}
+
+#[test]
+fn installed_backend_load_images_rejects_unexpected_dll() {
+    let home = tempfile::tempdir().unwrap();
+    let plugin = minimal_pe_bytes();
+    let archive = tensile_zip_bytes();
+    let resolved = hip_pack_resolved(&plugin, &archive);
+    let mut client = FakeClient::with_responses(vec![
+        ResponseSpec {
+            status: 200,
+            body: plugin,
+        },
+        ResponseSpec {
+            status: 200,
+            body: archive,
+        },
+    ]);
+    let installed =
+        install_backend_pack_with_client(&resolved, home.path(), &mut client, |_| {}).unwrap();
+    fs::write(installed.dir.join("planted.dll"), b"planted").unwrap();
+
+    let error =
+        read_and_verify_installed_backend_for_activation(&installed.dir, &resolved).unwrap_err();
+    assert!(matches!(
+        error,
+        PullError::UnexpectedInstalledBackendFile { .. }
+    ));
+}
+
+#[test]
 fn backend_install_lock_is_os_owned_and_exclusive() {
     let home = tempfile::tempdir().unwrap();
     let path = home.path().join("backend-install.lock");

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1381,6 +1381,7 @@ impl ServerRuntime {
         self.native_execution.has_active_sessions()
             || idle_activity::native_activity_active_count() > 0
             || realtime::native_streaming_workers_occupy_slot()
+            || realtime::native_warmup_in_flight()
     }
 
     /// Rebinds the single in-process native pack. Fail-closed with 409 when a

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -24,7 +24,7 @@ use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::{
-        Arc, Mutex, OnceLock,
+        Arc, Mutex, OnceLock, RwLock,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -262,30 +262,24 @@ pub async fn serve_with_launch_options(
     launch_options: ServerLaunchOptions,
 ) -> anyhow::Result<()> {
     // Boot stage timing: each phase logged as its own timestamped line so a
-    // slow daemon start (validate/bind/router-build/model-bind) can be
-    // attributed to a specific phase from `daemon.log` alone, instead of
-    // guessing from wall-clock reads of surrounding, untimed events. Additive
-    // only -- the existing "OpenASR server listening on ..." banners below are
-    // left byte-for-byte unchanged, since `crates/openasr-cli/tests/cli.rs`
-    // waits on that exact prefix and the desktop sidecar's readiness probe
-    // must keep working unmodified.
+    // slow daemon start (validate/bind/router-build) can be attributed to a
+    // specific phase from `daemon.log` alone, instead of guessing from
+    // wall-clock reads of surrounding, untimed events. Additive only -- the
+    // existing "OpenASR server listening on ..." banners below are left
+    // byte-for-byte unchanged, since `crates/openasr-cli/tests/cli.rs` waits
+    // on that exact prefix and the desktop sidecar's readiness probe must keep
+    // working unmodified.
+    //
+    // Listen and `/health` must succeed before optional GPU plugin load
+    // (`ggml_runtime_info` / `ensure_backends_loaded`). CUDA and HIP are the
+    // same signed-plugin path; a missing model pack is a normal start, and
+    // plugin init is process-lifetime work, not model-bind work.
     let boot_started = Instant::now();
-    let mut stage_started = boot_started;
-    // Device/backend metadata only (name, kind, memory, buffer alignment) --
-    // never model, audio, or file-path data -- so a Vulkan/Metal/CPU
-    // misdetection or misalignment (see issues #153/#154/#155) is visible
-    // from `daemon.log` alone, without relying on the reporter's own
-    // "backend used" field.
-    openasr_core::stage_timing::log_event(
-        "server_boot",
-        format_args!(
-            "stage=ggml_backend {}",
-            openasr_core::ggml_runtime_boot_summary(&openasr_core::ggml_runtime_info())
-        ),
-    );
     // Host system facts (OS/CPU/RAM) -- diagnostics only, no user data -- so a
     // bug report's `daemon.log` + the desktop's `desktop.log` are enough to
-    // triage without asking the reporter for their OS/CPU/RAM by hand.
+    // triage without asking the reporter for their OS/CPU/RAM by hand. Cheap
+    // and independent of optional GPU plugins, so it stays on the listen path.
+    let stage_started = Instant::now();
     openasr_core::stage_timing::log_event(
         "server_boot",
         format_args!(
@@ -293,20 +287,22 @@ pub async fn serve_with_launch_options(
             openasr_core::host_system_boot_summary()
         ),
     );
+    openasr_core::stage_timing::log_stage("server_boot", "host_system", stage_started.elapsed());
+    let stage_started = Instant::now();
     validate_listen_security(addr, &launch_options)?;
     openasr_core::stage_timing::log_stage(
         "server_boot",
         "validate_listen_security",
         stage_started.elapsed(),
     );
-    stage_started = Instant::now();
+    let stage_started = Instant::now();
     runtime.validate()?;
     openasr_core::stage_timing::log_stage(
         "server_boot",
         "runtime_validate",
         stage_started.elapsed(),
     );
-    stage_started = Instant::now();
+    let stage_started = Instant::now();
     let listener = TcpListener::bind(addr).await?;
     // Shadow the requested `addr` (which may be an OS-assigned wildcard like
     // `:0`) with the listener's actual bound address so everything below --
@@ -336,7 +332,7 @@ pub async fn serve_with_launch_options(
     }
     match &launch_options.tls.clone() {
         ServerTlsConfig::Disabled => {
-            stage_started = Instant::now();
+            let stage_started = Instant::now();
             let app = app_with_runtime_and_distribution_and_launch_options(
                 runtime,
                 DistributionRuntime::default(),
@@ -355,10 +351,11 @@ pub async fn serve_with_launch_options(
                 ),
             );
             println!("OpenASR server listening on http://{addr}");
+            spawn_ggml_backend_boot_log();
             axum::serve(listener, app).await?;
         }
         ServerTlsConfig::SelfSigned { subject_alt_names } => {
-            stage_started = Instant::now();
+            let stage_started = Instant::now();
             let identity = load_or_generate_self_signed_tls_identity(
                 subject_alt_names,
                 launch_options.tls_identity_store.as_deref(),
@@ -372,7 +369,7 @@ pub async fn serve_with_launch_options(
             launch_options.auth = launch_options.auth.with_pairing_safety_code(Some(
                 pairing_safety_code_for_certificate_fingerprint(&identity.certificate_sha256),
             ));
-            stage_started = Instant::now();
+            let stage_started = Instant::now();
             let app = app_with_runtime_and_distribution_and_launch_options(
                 runtime,
                 DistributionRuntime::default(),
@@ -394,10 +391,37 @@ pub async fn serve_with_launch_options(
                 "OpenASR server listening on https://{addr} (certificate sha256:{}, pairing code {})",
                 identity.certificate_sha256, identity.pairing_safety_code
             );
+            spawn_ggml_backend_boot_log();
             axum::serve(TlsListener::new(listener, identity.acceptor), app).await?;
         }
     }
     Ok(())
+}
+
+/// Loads optional signed GPU plugins (CUDA/HIP/Vulkan via the same
+/// `ggml_runtime_info` path) after the process is already listening.
+/// CUDA and HIP are not special-cased: both are process-lifetime plugins
+/// selected by the current `active.json`, independent of which model pack
+/// is bound. Blocking the listen path on `ggml_cuda_init` / `LoadLibrary`
+/// made `--no-model` start pay GPU init; the banner and `/health` must not
+/// wait for that.
+fn spawn_ggml_backend_boot_log() {
+    tokio::task::spawn_blocking(|| {
+        let stage_started = Instant::now();
+        let info = openasr_core::ggml_runtime_info();
+        openasr_core::stage_timing::log_stage(
+            "server_boot",
+            "ggml_backend",
+            stage_started.elapsed(),
+        );
+        openasr_core::stage_timing::log_event(
+            "server_boot",
+            format_args!(
+                "stage=ggml_backend {}",
+                openasr_core::ggml_runtime_boot_summary(&info)
+            ),
+        );
+    });
 }
 
 /// Validity window for a freshly generated self-signed TLS identity: long
@@ -1205,6 +1229,76 @@ fn resolve_instance_token(launch_option: Option<String>) -> Option<String> {
         .or_else(|| launch_option.filter(|value| !value.is_empty()))
 }
 
+/// Process-wide bound native pack path shared by every `ServerRuntime` clone.
+///
+/// Model bind is in-process state, independent of optional GPU plugin load
+/// (CUDA/HIP/Vulkan via `active.json`). `POST /v1/models/default` rebinds this
+/// without restarting the process. One bound pack at a time.
+#[derive(Clone)]
+pub struct BoundModelPackPath {
+    inner: Arc<RwLock<Option<PathBuf>>>,
+}
+
+impl std::fmt::Debug for BoundModelPackPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("BoundModelPackPath")
+            .field(&self.current())
+            .finish()
+    }
+}
+
+impl PartialEq for BoundModelPackPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.current() == other.current()
+    }
+}
+
+impl Eq for BoundModelPackPath {}
+
+impl Default for BoundModelPackPath {
+    fn default() -> Self {
+        Self::from(None)
+    }
+}
+
+impl From<Option<PathBuf>> for BoundModelPackPath {
+    fn from(path: Option<PathBuf>) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(path)),
+        }
+    }
+}
+
+impl BoundModelPackPath {
+    fn lock_read(&self) -> std::sync::RwLockReadGuard<'_, Option<PathBuf>> {
+        self.inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn lock_write(&self) -> std::sync::RwLockWriteGuard<'_, Option<PathBuf>> {
+        self.inner
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    pub fn current(&self) -> Option<PathBuf> {
+        self.lock_read().clone()
+    }
+
+    pub fn is_some(&self) -> bool {
+        self.lock_read().is_some()
+    }
+
+    pub fn is_none(&self) -> bool {
+        self.lock_read().is_none()
+    }
+
+    fn set(&self, path: Option<PathBuf>) {
+        *self.lock_write() = path;
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServerRuntime {
     pub backend: BackendKind,
@@ -1217,7 +1311,7 @@ pub struct ServerRuntime {
     /// `AudioPreparationOptions::with_ffmpeg_bin_explicit`. Only an explicit
     /// choice skips the in-process symphonia decode path.
     pub ffmpeg_bin_explicit: bool,
-    pub model_pack_path: Option<std::path::PathBuf>,
+    pub model_pack_path: BoundModelPackPath,
 }
 
 impl Default for ServerRuntime {
@@ -1227,7 +1321,7 @@ impl Default for ServerRuntime {
             native_execution: NativeExecutionSupervisor::default(),
             ffmpeg_bin: None,
             ffmpeg_bin_explicit: false,
-            model_pack_path: None,
+            model_pack_path: BoundModelPackPath::default(),
         }
     }
 }
@@ -1253,7 +1347,7 @@ impl ServerRuntime {
     }
 
     /// Validates the runtime is *safe to serve with*, not that a model is
-    /// installed: no model bound at all (`model_pack_path: None`) is a normal
+    /// installed: no model bound at all (`model_pack_path` empty) is a normal
     /// state for a fresh install with zero pulled models, and the daemon must
     /// still start and answer `/health` in that state. Only a `model_pack_path`
     /// that is actually set but fails to validate (bad path, corrupt/foreign
@@ -1264,10 +1358,10 @@ impl ServerRuntime {
         match self.backend {
             BackendKind::Mock => Ok(()),
             BackendKind::Native => {
-                let Some(model_pack_path) = self.model_pack_path.as_deref() else {
+                let Some(model_pack_path) = self.model_pack_path.current() else {
                     return Ok(());
                 };
-                let _ = validate_native_runtime_pack(model_pack_path)?;
+                let _ = validate_native_runtime_pack(&model_pack_path)?;
                 Ok(())
             }
         }
@@ -1281,6 +1375,44 @@ impl ServerRuntime {
             BackendKind::Mock => true,
             BackendKind::Native => self.model_pack_path.is_some(),
         }
+    }
+
+    pub(crate) fn native_rebind_blocked(&self) -> bool {
+        self.native_execution.has_active_sessions()
+            || idle_activity::native_activity_active_count() > 0
+            || realtime::native_streaming_workers_occupy_slot()
+    }
+
+    /// Rebinds the single in-process native pack. Fail-closed with 409 when a
+    /// native transcription or realtime worker currently occupies a slot so
+    /// in-flight work is not torn down. Unloads idle runtime caches so a
+    /// same-id reinstall (path unchanged, file replaced) cannot keep serving
+    /// the previous bytes. Mock backends never call this.
+    pub(crate) fn rebind_native_model_pack(
+        &self,
+        new_path: Option<PathBuf>,
+    ) -> Result<(), ApiError> {
+        if self.backend != BackendKind::Native {
+            return Ok(());
+        }
+        if self.native_rebind_blocked() {
+            return Err(ApiError::Conflict(
+                "Cannot change the default model while a native transcription or realtime session is running."
+                    .to_string(),
+            ));
+        }
+        if let Some(path) = new_path.as_deref() {
+            let _ = validate_native_runtime_pack(path).map_err(ApiError::Backend)?;
+        }
+        self.model_pack_path.set(new_path);
+        if !self.native_rebind_blocked() {
+            self.native_execution
+                .execution_services()
+                .unload_idle_native_model_runtime_caches();
+            idle_activity::bump_native_unload_generation();
+            invalidate_cached_native_realtime_capabilities();
+        }
+        Ok(())
     }
 
     /// Whether the bound model's runtime is resident right now (surfaced by
@@ -2025,11 +2157,11 @@ async fn models(State(runtime): State<ServerRuntime>) -> Result<Json<ModelsRespo
             // No model bound is a normal fresh-install state, not an error:
             // report an empty model list rather than fail-closed here (the
             // transcription path is the fail-closed boundary for "no model").
-            match runtime.model_pack_path.as_deref() {
+            match runtime.model_pack_path.current() {
                 None => Vec::new(),
                 Some(model_pack_path) => {
-                    let adapter =
-                        validate_native_runtime_pack(model_pack_path).map_err(ApiError::Backend)?;
+                    let adapter = validate_native_runtime_pack(&model_pack_path)
+                        .map_err(ApiError::Backend)?;
                     let identity = resolve_verified_native_runtime_model_identity(&adapter, None)
                         .map_err(ApiError::Backend)?;
                     vec![identity.model_id]
@@ -2066,6 +2198,7 @@ async fn capabilities(
     let transcription = if runtime.backend == BackendKind::Native {
         runtime
             .model_pack_path
+            .current()
             .as_deref()
             .map(native_runtime_transcription_capabilities_for_path)
             .unwrap_or_else(|| TranscriptionBackendCapabilities::for_backend_kind(runtime.backend))
@@ -2102,6 +2235,7 @@ pub(crate) fn realtime_capabilities_for_runtime(
     let mut capabilities = if runtime.backend == BackendKind::Native {
         runtime
             .model_pack_path
+            .current()
             .as_deref()
             .map(cached_native_realtime_capabilities_for_path)
             .unwrap_or_else(|| RealtimeBackendCapabilities::for_backend_kind(runtime.backend))
@@ -2124,14 +2258,11 @@ pub(crate) fn realtime_capabilities_for_runtime_and_distribution(
 }
 
 /// Deriving realtime capabilities reads GGUF metadata from disk; every session
-/// asks 2-3 times, so memoize per pack path. Installed packs are
-/// content-immutable (a model switch relaunches the daemon with a new
-/// `--model-pack`), so path-keyed caching is safe for the daemon's lifetime.
+/// asks 2-3 times, so memoize per pack path. A default-model rebind can replace
+/// the file at the same path (same-id reinstall) or switch to another pack, so
+/// the cache is dropped on rebind rather than trusted for the process lifetime.
 fn cached_native_realtime_capabilities_for_path(path: &Path) -> RealtimeBackendCapabilities {
-    static CACHE: std::sync::OnceLock<
-        std::sync::Mutex<std::collections::HashMap<PathBuf, RealtimeBackendCapabilities>>,
-    > = std::sync::OnceLock::new();
-    let cache = CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    let cache = native_realtime_capabilities_cache();
     if let Ok(cache) = cache.lock()
         && let Some(capabilities) = cache.get(path)
     {
@@ -2142,6 +2273,18 @@ fn cached_native_realtime_capabilities_for_path(path: &Path) -> RealtimeBackendC
         cache.insert(path.to_path_buf(), capabilities);
     }
     capabilities
+}
+
+fn native_realtime_capabilities_cache()
+-> &'static Mutex<HashMap<PathBuf, RealtimeBackendCapabilities>> {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, RealtimeBackendCapabilities>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn invalidate_cached_native_realtime_capabilities() {
+    if let Ok(mut cache) = native_realtime_capabilities_cache().lock() {
+        cache.clear();
+    }
 }
 
 // TS export for the HTTP daemon response wire contract (`/health`,

--- a/crates/openasr-server/src/model_admission.rs
+++ b/crates/openasr-server/src/model_admission.rs
@@ -100,6 +100,10 @@ impl NativeExecutionSupervisor {
         self.admission.try_acquire(model_identity)
     }
 
+    pub(crate) fn has_active_sessions(&self) -> bool {
+        self.admission.has_active_sessions()
+    }
+
     pub fn max_concurrent_sessions_per_model(&self) -> NonZeroUsize {
         self.admission.limit()
     }
@@ -152,6 +156,10 @@ impl ModelSessionAdmission {
             model_identity,
             permit: Some(permit),
         })
+    }
+
+    pub(crate) fn has_active_sessions(&self) -> bool {
+        self.lock_state().slots.values().any(|slot| slot.active > 0)
     }
 
     #[cfg(test)]
@@ -233,6 +241,18 @@ mod tests {
 
         assert_eq!(admission.active_slot_count(), 0);
         assert!(admission.try_acquire("native:whisper-small@pack-a").is_ok());
+    }
+
+    #[test]
+    fn has_active_sessions_tracks_live_permits() {
+        let admission = admission(1);
+        assert!(!admission.has_active_sessions());
+        let first = admission
+            .try_acquire("native:whisper-small@pack-a")
+            .unwrap();
+        assert!(admission.has_active_sessions());
+        drop(first);
+        assert!(!admission.has_active_sessions());
     }
 
     #[test]

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -1052,6 +1052,21 @@ pub(crate) fn warm_up_native_streaming_session_once(
 /// `WARMED_AT_GENERATION` gate in `warm_up_native_streaming_session_once`);
 /// every later attach on that thread reuses the now-warm state, until an
 /// `idle_unload` eviction bumps the generation and forces a re-warm.
+/// Whether any native streaming worker currently has an attached (or attaching)
+/// session occupying its slot. Used by default-model rebind to fail closed
+/// rather than tearing down in-flight realtime work.
+pub(crate) fn native_streaming_workers_occupy_slot() -> bool {
+    let Some(registry) = SHARED_NATIVE_STREAMING_WORKERS.get() else {
+        return false;
+    };
+    let workers = registry
+        .lock()
+        .expect("native streaming worker registry mutex poisoned");
+    workers
+        .values()
+        .any(|entry| entry.state.active_or_attaching.load(Ordering::Acquire) > 0)
+}
+
 pub(crate) fn spawn_boot_native_warmup(runtime: ServerRuntime) {
     tokio::spawn(async move {
         warm_up_default_native_streaming_worker(runtime).await;
@@ -1062,9 +1077,10 @@ pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime
     if runtime.backend != openasr_core::BackendKind::Native {
         return;
     }
-    let Some(model_pack_path) = runtime.model_pack_path.clone() else {
+    let Some(model_pack_path) = runtime.model_pack_path.current() else {
         // Fresh install / no model installed yet: nothing to warm. The daemon
-        // still serves `/health`; a bound pack arrives on a future restart.
+        // still serves `/health`; a later default-model rebind binds a pack
+        // in-process without restart, and the next request path loads it.
         return;
     };
     // Warmup is opportunistic. It must not queue behind an active request or
@@ -1237,7 +1253,7 @@ impl RealtimeBackendWorkerKey {
         Self {
             backend: runtime.backend.to_string(),
             ffmpeg_bin: runtime.ffmpeg_bin.clone(),
-            model_pack_path: runtime.model_pack_path.clone(),
+            model_pack_path: runtime.model_pack_path.current(),
         }
     }
 }

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -5,13 +5,13 @@
 use std::{
     collections::HashMap,
     sync::{
-        Arc, Mutex,
+        Arc, Mutex, OnceLock,
         atomic::{AtomicBool, Ordering},
     },
     time::{Duration, Instant},
 };
 
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 
 use crate::ModelSessionPermit;
 
@@ -1041,17 +1041,16 @@ pub(crate) fn warm_up_native_streaming_session_once(
 /// `inference_threads`/`execution_target` override that differs from the
 /// saved preference, or the bound pack having changed since boot.
 ///
-/// Dedup with a concurrent real attach is structural, not a flag: this
-/// attaches its own short-lived "session" to the same
-/// [`NativeStreamingWorkerKey`] a matching real WS attach would use, sends
-/// `Warm`, waits for it to finish, and only then releases the worker -- the
-/// worker thread processes one attached session's commands at a time, so a
-/// real attach for the same key that arrives mid-warm-up queues behind this
-/// one instead of racing a second cold build. Whichever attach's `Warm`
-/// actually runs first pays the cost once (see the thread-local
-/// `WARMED_AT_GENERATION` gate in `warm_up_native_streaming_session_once`);
-/// every later attach on that thread reuses the now-warm state, until an
-/// `idle_unload` eviction bumps the generation and forces a re-warm.
+/// Dedup with a concurrent real attach is a process-wide warmup lease, not a
+/// user session permit: this never takes `max-native-sessions-per-model`. A
+/// real WS/transcription acquire waits until the lease drops, then takes the
+/// user slot and attaches. If a user session already holds a slot, warmup is
+/// opportunistic and returns without attaching -- the live request's own `Warm`
+/// pays the load. Whichever `Warm` actually runs first pays the cost once
+/// (see the thread-local `WARMED_AT_GENERATION` gate in
+/// `warm_up_native_streaming_session_once`); every later attach on that thread
+/// reuses the now-warm state, until an `idle_unload` eviction bumps the
+/// generation and forces a re-warm.
 /// Whether any native streaming worker currently has an attached (or attaching)
 /// session occupying its slot. Used by default-model rebind to fail closed
 /// rather than tearing down in-flight realtime work.
@@ -1065,6 +1064,52 @@ pub(crate) fn native_streaming_workers_occupy_slot() -> bool {
     workers
         .values()
         .any(|entry| entry.state.active_or_attaching.load(Ordering::Acquire) > 0)
+}
+
+static NATIVE_WARMUP_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+fn native_warmup_notify() -> &'static Notify {
+    static NOTIFY: OnceLock<Notify> = OnceLock::new();
+    NOTIFY.get_or_init(Notify::new)
+}
+
+pub(crate) fn native_warmup_in_flight() -> bool {
+    NATIVE_WARMUP_IN_FLIGHT.load(Ordering::Acquire)
+}
+
+pub(crate) struct NativeWarmupLease {
+    _private: (),
+}
+
+pub(crate) fn try_begin_native_warmup() -> Option<NativeWarmupLease> {
+    NATIVE_WARMUP_IN_FLIGHT
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .ok()
+        .map(|_| NativeWarmupLease { _private: () })
+}
+
+impl Drop for NativeWarmupLease {
+    fn drop(&mut self) {
+        NATIVE_WARMUP_IN_FLIGHT.store(false, Ordering::Release);
+        native_warmup_notify().notify_waiters();
+    }
+}
+
+pub(crate) async fn wait_while_native_warmup_in_flight() {
+    let started = Instant::now();
+    let notify = native_warmup_notify();
+    while native_warmup_in_flight() && started.elapsed() < Duration::from_secs(60) {
+        let _ = tokio::time::timeout(Duration::from_millis(50), notify.notified()).await;
+    }
+}
+
+/// Blocking counterpart for `spawn_blocking` transcription: same 60s cap, no
+/// tokio runtime. Call immediately before `acquire_native_execution`.
+pub(crate) fn wait_while_native_warmup_in_flight_blocking() {
+    let started = Instant::now();
+    while native_warmup_in_flight() && started.elapsed() < Duration::from_secs(60) {
+        std::thread::sleep(Duration::from_millis(50));
+    }
 }
 
 pub(crate) fn spawn_boot_native_warmup(runtime: ServerRuntime) {
@@ -1083,8 +1128,15 @@ pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime
         // in-process without restart, and the next request path loads it.
         return;
     };
-    // Warmup is opportunistic. It must not queue behind an active request or
-    // allocate a second runtime; a real request owns the capacity slot first.
+    // Opportunistic: a live user session already owns the slot and will Warm
+    // itself. Never take `max-native-sessions-per-model`; that slot is only
+    // for transcription/realtime. Coalesce overlapping boot/rebind spawns.
+    if runtime.native_execution.has_active_sessions() {
+        return;
+    }
+    let Some(_lease) = try_begin_native_warmup() else {
+        return;
+    };
     let preferences_home = openasr_core::openasr_home().ok();
     let inference_threads = preferences_home
         .as_deref()
@@ -1098,15 +1150,6 @@ pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime
     .ok()
     .flatten();
     let Some(adapter) = openasr_core::native_runtime_model_adapter_for_path(&model_pack_path)
-    else {
-        return;
-    };
-    let Ok(model_session_key) = crate::routes::transcription::native_model_session_key(&adapter)
-    else {
-        return;
-    };
-    let Ok(model_session_permit) =
-        runtime.acquire_native_execution(&model_session_key, resolved_route.as_ref())
     else {
         return;
     };
@@ -1159,7 +1202,7 @@ pub(in crate::realtime) async fn warm_up_default_native_streaming_worker(runtime
         inference_threads,
     );
     let diagnostic_key = key.clone();
-    if let Err(error) = attach_and_run_boot_warmup(key, session, Some(model_session_permit)).await {
+    if let Err(error) = attach_and_run_boot_warmup(key, session, None).await {
         openasr_core::stage_timing::log_event(
             "realtime_warmup",
             format_args!(

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -2699,6 +2699,51 @@ async fn boot_native_warmup_skips_when_the_runtime_slot_is_occupied() {
 }
 
 #[tokio::test]
+async fn boot_warmup_does_not_consume_the_user_session_slot() {
+    let warm_calls = Arc::new(AtomicUsize::new(0));
+    let session = Box::new(SlowWarmNativeSession {
+        inner: TestServerNativeSession::new("boot-warmup-no-permit"),
+        warm_sleep: Duration::from_millis(200),
+        warm_calls: Arc::clone(&warm_calls),
+    });
+    let key = test_native_streaming_worker_key("boot-warmup-no-permit");
+    let runtime = ServerRuntime {
+        backend: openasr_core::BackendKind::Native,
+        native_execution: NativeExecutionSupervisor::new(NonZeroUsize::new(1).unwrap()),
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: None.into(),
+    };
+    let handle = tokio::spawn(attach_and_run_boot_warmup(key, session, None));
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let permit = runtime
+        .acquire_native_execution("native:boot-warmup-no-permit", None)
+        .expect("boot warmup must not occupy the user session slot");
+    drop(permit);
+    handle
+        .await
+        .expect("boot warmup task must not panic")
+        .expect("boot warmup must succeed");
+    assert_eq!(warm_calls.load(Ordering::Acquire), 1);
+}
+
+#[tokio::test]
+async fn wait_while_native_warmup_in_flight_unblocks_when_lease_drops() {
+    let lease = try_begin_native_warmup().expect("warmup lease must be free");
+    let waiter = tokio::spawn(wait_while_native_warmup_in_flight());
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        !waiter.is_finished(),
+        "waiter must block while the warmup lease is held"
+    );
+    drop(lease);
+    tokio::time::timeout(Duration::from_millis(200), waiter)
+        .await
+        .expect("waiter must unblock when the warmup lease drops")
+        .expect("waiter must not panic");
+}
+
+#[tokio::test]
 async fn health_answers_immediately_while_boot_warmup_is_artificially_slow() {
     use tower::ServiceExt;
 

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -386,7 +386,7 @@ async fn realtime_backend_job_canceled_before_dispatch_releases_capacity_promptl
         native_execution: NativeExecutionSupervisor::new(NonZeroUsize::new(1).unwrap()),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
 
     // One second of a real (non-silent) tone rather than jfk.wav: keeps input
@@ -2441,7 +2441,7 @@ async fn session_start_waits_for_native_warm_without_publishing_lifecycle() {
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
     let (event_sender, mut event_receiver) = mpsc::channel(16);
     let mut session = WsSession::new(runtime, test_distribution(), event_sender);
@@ -2670,7 +2670,7 @@ async fn boot_native_warmup_skips_when_the_runtime_slot_is_occupied() {
         native_execution: NativeExecutionSupervisor::new(NonZeroUsize::new(1).unwrap()),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
     let occupied_slot = runtime
         .acquire_native_execution("test-content", None)
@@ -3366,7 +3366,7 @@ async fn native_realtime_server_smoke_with_real_qwen_pack() {
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
     let mut session = WsSession::new(runtime, test_distribution(), event_sender);
     session.native_decode_timeout_override = Some(Duration::from_secs(180));
@@ -3751,7 +3751,7 @@ async fn session_capabilities_event_reports_frame_sync_only_for_xasr_zipformer()
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(xasr_path),
+        model_pack_path: Some(xasr_path).into(),
     };
     let (xasr_event_sender, mut xasr_event_receiver) = mpsc::channel(8);
     let mut xasr_session = WsSession::new(xasr_runtime, test_distribution(), xasr_event_sender);
@@ -3771,7 +3771,7 @@ async fn session_capabilities_event_reports_frame_sync_only_for_xasr_zipformer()
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(qwen_path),
+        model_pack_path: Some(qwen_path).into(),
     };
     let (qwen_event_sender, mut qwen_event_receiver) = mpsc::channel(8);
     let mut qwen_session = WsSession::new(qwen_runtime, test_distribution(), qwen_event_sender);
@@ -3984,7 +3984,7 @@ async fn fallback_capacity_rejection_is_backend_not_ready_and_recoverable() {
         native_execution: NativeExecutionSupervisor::new(NonZeroUsize::new(1).unwrap()),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
     let occupied_route = crate::routes::transcription::resolve_execution_route_for_target(None)
         .expect("fixture route resolve must succeed")
@@ -4117,7 +4117,7 @@ async fn session_start_rejects_xasr_hotwords_from_active_native_capabilities() {
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
     let (event_sender, mut event_receiver) = mpsc::channel(8);
     let mut session = WsSession::new(runtime, test_distribution(), event_sender);
@@ -4160,7 +4160,7 @@ async fn session_start_accepts_hotwords_for_supporting_native_model() {
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
     let (event_sender, _event_receiver) = mpsc::channel(8);
     let mut session = WsSession::new(runtime, test_distribution(), event_sender);
@@ -4203,7 +4203,7 @@ async fn local_native_streaming_session_rejects_voice_id() {
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
     let (event_sender, mut event_receiver) = mpsc::channel(8);
     let mut session = WsSession::new(runtime, test_distribution(), event_sender);

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -1067,6 +1067,7 @@ impl WsSession {
                     return Err(());
                 }
             };
+        super::wait_while_native_warmup_in_flight().await;
         let model_session_permit = match self
             .runtime
             .acquire_native_execution(&model_session_key, resolved_route.as_ref())

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -466,8 +466,8 @@ fn realtime_phrase_bias_rejection_message(
     capability: openasr_core::api::backend::BackendFeatureCapability,
 ) -> String {
     if runtime.backend == openasr_core::BackendKind::Native
-        && let Some(path) = runtime.model_pack_path.as_deref()
-        && let Some(adapter) = native_runtime_model_adapter_for_path(path)
+        && let Some(path) = runtime.model_pack_path.current()
+        && let Some(adapter) = native_runtime_model_adapter_for_path(&path)
     {
         return format!(
             "Realtime phrase bias / hotword boosting is not supported by the active native model family '{}' ({}); session.start was rejected instead of silently ignoring hotwords.",
@@ -1012,7 +1012,7 @@ impl WsSession {
         partial_results: bool,
         word_timestamps: bool,
     ) -> Result<(), ()> {
-        let Some(model_pack_path) = self.runtime.model_pack_path.clone() else {
+        let Some(model_pack_path) = self.runtime.model_pack_path.current() else {
             self.emit_error(
                 RealtimeErrorCode::StartupConfigError,
                 "Native realtime streaming requires an explicit local runtime pack path.",

--- a/crates/openasr-server/src/routes/models_api.rs
+++ b/crates/openasr-server/src/routes/models_api.rs
@@ -49,6 +49,7 @@ pub(crate) async fn set_default_model(
     persist_default_pack(&home, &pack, preference)?;
     if runtime.backend == BackendKind::Native {
         runtime.rebind_native_model_pack(Some(pack.path.clone()))?;
+        crate::realtime::spawn_boot_native_warmup(runtime.clone());
     }
     Ok(Json(default_model_response(
         &home,

--- a/crates/openasr-server/src/routes/models_api.rs
+++ b/crates/openasr-server/src/routes/models_api.rs
@@ -33,13 +33,23 @@ pub(crate) async fn default_model(
 }
 
 pub(crate) async fn set_default_model(
+    State(runtime): State<ServerRuntime>,
     Extension(distribution): Extension<DistributionContext>,
     Json(request): Json<SetDefaultRequest>,
 ) -> Result<Json<DefaultModelResponse>, ApiError> {
     let home = distribution.openasr_home()?;
     let pack = resolve_installed_pack_for_default(&home, distribution.catalog_source(), &request)?;
     let preference = request.quant_preference_for_pack(&pack);
+    if runtime.backend == BackendKind::Native && runtime.native_rebind_blocked() {
+        return Err(ApiError::Conflict(
+            "Cannot change the default model while a native transcription or realtime session is running."
+                .to_string(),
+        ));
+    }
     persist_default_pack(&home, &pack, preference)?;
+    if runtime.backend == BackendKind::Native {
+        runtime.rebind_native_model_pack(Some(pack.path.clone()))?;
+    }
     Ok(Json(default_model_response(
         &home,
         distribution.catalog_source(),

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -2061,6 +2061,7 @@ pub(crate) async fn transcribe_with_runtime(
                 let resolved_route = resolve_execution_route_for_target(request.execution_target)
                     .map_err(ApiError::Backend)?;
                 let model_session_key = native_model_session_key(&adapter)?;
+                crate::realtime::wait_while_native_warmup_in_flight_blocking();
                 let model_session_permit = runtime
                     .acquire_native_execution(&model_session_key, resolved_route.as_ref())?;
                 run_admitted_native_transcription(model_session_permit, move || {

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -2027,7 +2027,7 @@ pub(crate) async fn transcribe_with_runtime(
         }
         BackendKind::Native => {
             tokio::task::spawn_blocking(move || {
-                let model_pack_path = runtime.model_pack_path.clone().ok_or_else(|| {
+                let model_pack_path = runtime.model_pack_path.current().ok_or_else(|| {
                     ApiError::Backend(openasr_core::BackendError::NativeModelPackPathRejected {
                         reason: format!(
                             "Model '{}' is not installed. No models are installed on this server yet -- install one first (openasr pull {}, or via the model market).",

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -1586,7 +1586,7 @@ fn realtime_capabilities_for_native_runtime_come_from_model_pack() {
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     };
 
     let capabilities = realtime_capabilities_for_runtime(&runtime);
@@ -1601,6 +1601,184 @@ fn realtime_capabilities_for_native_runtime_come_from_model_pack() {
         capabilities.diarization.reason,
         Some(openasr_core::realtime::REALTIME_VOICE_ID_UNSUPPORTED_REASON)
     );
+}
+
+#[test]
+fn bound_model_pack_path_is_shared_across_runtime_clones() {
+    let temp = tempfile::tempdir().unwrap();
+    let pack_a = temp.path().join("pack-a.oasr");
+    let pack_b = temp.path().join("pack-b.oasr");
+    write_mock_gguf_runtime_source(&pack_a, Some("whisper-tiny"));
+    write_mock_gguf_runtime_source(&pack_b, Some("whisper-base"));
+    let runtime = ServerRuntime {
+        backend: BackendKind::Native,
+        native_execution: NativeExecutionSupervisor::default(),
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: Some(pack_a.clone()).into(),
+    };
+    let cloned = runtime.clone();
+
+    runtime
+        .rebind_native_model_pack(Some(pack_b.clone()))
+        .expect("idle native runtime must rebind in-process");
+
+    assert_eq!(
+        cloned.model_pack_path.current().as_deref(),
+        Some(pack_b.as_path())
+    );
+    assert_eq!(
+        runtime.model_pack_path.current().as_deref(),
+        Some(pack_b.as_path())
+    );
+}
+
+#[test]
+fn rebind_native_model_pack_returns_conflict_while_session_is_active() {
+    let temp = tempfile::tempdir().unwrap();
+    let pack_a = temp.path().join("pack-a.oasr");
+    let pack_b = temp.path().join("pack-b.oasr");
+    write_mock_gguf_runtime_source(&pack_a, Some("whisper-tiny"));
+    write_mock_gguf_runtime_source(&pack_b, Some("whisper-base"));
+    let runtime = ServerRuntime {
+        backend: BackendKind::Native,
+        native_execution: NativeExecutionSupervisor::default(),
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: Some(pack_a.clone()).into(),
+    };
+    let _permit = runtime
+        .acquire_native_execution("native:whisper-tiny@busy-rebind", None)
+        .unwrap();
+
+    let error = runtime
+        .rebind_native_model_pack(Some(pack_b))
+        .expect_err("busy rebind must fail closed");
+    assert!(
+        matches!(error, ApiError::Conflict(_)),
+        "expected 409 conflict, got {error}"
+    );
+    assert_eq!(
+        runtime.model_pack_path.current().as_deref(),
+        Some(pack_a.as_path())
+    );
+}
+
+#[tokio::test]
+async fn set_default_model_http_returns_conflict_when_native_session_is_busy() {
+    use axum::body::{Body, to_bytes};
+    use tower::ServiceExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let pack_a = write_installed_pack_ref(
+        &home,
+        "whisper-tiny",
+        "whisper-tiny:q4",
+        "q4_0",
+        "q4",
+        "whisper-tiny",
+    );
+    let _pack_b = write_installed_pack_ref(
+        &home,
+        "whisper-base",
+        "whisper-base:q4",
+        "q4_0",
+        "q4",
+        "whisper-base",
+    );
+
+    let runtime = ServerRuntime {
+        backend: BackendKind::Native,
+        native_execution: NativeExecutionSupervisor::default(),
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: Some(pack_a.clone()).into(),
+    };
+    let _permit = runtime
+        .acquire_native_execution("native:whisper-tiny@busy-rebind-http", None)
+        .unwrap();
+    let app = app_with_runtime_and_distribution(
+        runtime.clone(),
+        DistributionRuntime {
+            openasr_home: Some(home),
+            catalog_url: None,
+            catalog_local_override: None,
+        },
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/models/default")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "pull": "whisper-base:q4" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("native transcription or realtime session is running")
+    );
+    assert_eq!(
+        runtime.model_pack_path.current().as_deref(),
+        Some(pack_a.as_path())
+    );
+}
+
+fn write_installed_pack_ref(
+    home: &std::path::Path,
+    model_id: &str,
+    pull: &str,
+    quant: &str,
+    suffix: &str,
+    metadata_model_id: &str,
+) -> std::path::PathBuf {
+    use sha2::{Digest, Sha256};
+
+    std::fs::create_dir_all(home).unwrap();
+    let staging = home.join(format!("{model_id}-staging.oasr"));
+    write_mock_gguf_runtime_source(&staging, Some(metadata_model_id));
+    let bytes = std::fs::read(&staging).unwrap();
+    std::fs::remove_file(&staging).unwrap();
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let object = home
+        .join("models")
+        .join("objects")
+        .join("sha256")
+        .join(&sha256)
+        .join("content");
+    std::fs::create_dir_all(object.parent().unwrap()).unwrap();
+    std::fs::write(&object, &bytes).unwrap();
+    let reference = home.join(format!("models/refs/{model_id}/{quant}.json"));
+    std::fs::create_dir_all(reference.parent().unwrap()).unwrap();
+    let pack = InstalledPack {
+        model_id: model_id.to_string(),
+        display_name: model_id.to_string(),
+        quant: quant.to_string(),
+        suffix: suffix.to_string(),
+        pull: pull.to_string(),
+        filename: format!("{model_id}-{quant}.oasr"),
+        path: object.clone(),
+        url: format!("https://example.invalid/{model_id}.oasr"),
+        hf_revision: "test".to_string(),
+        sha256,
+        size_bytes: bytes.len() as u64,
+        installed_at_unix_seconds: 1,
+        source: None,
+    };
+    std::fs::write(reference, serde_json::to_vec_pretty(&pack).unwrap()).unwrap();
+    object
 }
 
 #[tokio::test]
@@ -1644,7 +1822,7 @@ fn native_server_runtime_rejects_directory_runtime_source() {
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     };
     let error = runtime.validate().unwrap_err().to_string();
     assert!(
@@ -2522,7 +2700,7 @@ fn native_server_runtime_rejects_non_gguf_runtime_source_file() {
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
     let error = runtime.validate().unwrap_err().to_string();
     assert!(
@@ -2541,7 +2719,7 @@ fn native_server_runtime_rejects_directory_runtime_source_without_file_fallback(
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     };
     let error = runtime.validate().unwrap_err().to_string();
     assert!(
@@ -2562,7 +2740,7 @@ async fn native_transcribe_stays_fail_closed_with_local_pack_only_validation() {
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     };
     let request = TranscriptionRequest::new(sample_wav, "whisper-large-v3-turbo");
     let error = transcribe_with_runtime(
@@ -2652,7 +2830,7 @@ async fn native_transcribe_accepts_a_real_uploaded_aac_file_past_audio_preparati
         native_execution: crate::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     };
     let transcription = transcribe_with_runtime(
         runtime,
@@ -2697,7 +2875,7 @@ async fn native_audio_preparation_does_not_consume_model_capacity() {
         native_execution: NativeExecutionSupervisor::new(std::num::NonZeroUsize::new(1).unwrap()),
         ffmpeg_bin: Some(converter),
         ffmpeg_bin_explicit: true,
-        model_pack_path: Some(pack_path),
+        model_pack_path: Some(pack_path).into(),
     };
     let request_runtime = runtime.clone();
     let request = TranscriptionRequest::new(input_path, "whisper-large-v3-turbo");

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -903,7 +903,7 @@ async fn capabilities_endpoint_reflects_active_xasr_phrase_bias_capability() {
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     });
 
     let response = app
@@ -1006,7 +1006,7 @@ async fn native_transcription_without_installed_model_fails_closed_and_never_dow
             native_execution: openasr_server::NativeExecutionSupervisor::default(),
             ffmpeg_bin: None,
             ffmpeg_bin_explicit: false,
-            model_pack_path: None,
+            model_pack_path: None.into(),
         },
         openasr_server::DistributionRuntime {
             openasr_home: Some(home.clone()),
@@ -1065,7 +1065,7 @@ async fn daemon_starts_and_reports_ready_with_zero_models_installed() {
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: None,
+        model_pack_path: None.into(),
     };
     runtime
         .validate()
@@ -1137,7 +1137,7 @@ async fn health_reports_model_bound_but_not_resident_before_any_load() {
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     });
 
     let response = app
@@ -1791,6 +1791,197 @@ async fn default_model_endpoint_rejects_uninstalled_pack() {
             .as_str()
             .unwrap()
             .contains("Installed model pack not found")
+    );
+}
+
+fn native_runtime_with_pack(pack: Option<std::path::PathBuf>) -> openasr_server::ServerRuntime {
+    openasr_server::ServerRuntime {
+        backend: openasr_core::BackendKind::Native,
+        native_execution: openasr_server::NativeExecutionSupervisor::default(),
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: pack.into(),
+    }
+}
+
+fn install_native_pack(
+    home: &std::path::Path,
+    model_id: &str,
+    pull: &str,
+    quant: &str,
+    suffix: &str,
+    spec: TinyGgufFixtureSpec,
+) -> std::path::PathBuf {
+    std::fs::create_dir_all(home).unwrap();
+    let staging = home.join(format!("{model_id}-staging.oasr"));
+    write_tiny_gguf_runtime_source(&staging, &spec).expect("write installed native pack");
+    let bytes = std::fs::read(&staging).unwrap();
+    std::fs::remove_file(&staging).unwrap();
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let object = home
+        .join("models")
+        .join("objects")
+        .join("sha256")
+        .join(&sha256)
+        .join("content");
+    std::fs::create_dir_all(object.parent().unwrap()).unwrap();
+    std::fs::write(&object, &bytes).unwrap();
+    let reference = home.join(format!("models/refs/{model_id}/{quant}.json"));
+    std::fs::create_dir_all(reference.parent().unwrap()).unwrap();
+    let pack = openasr_core::InstalledPack {
+        model_id: model_id.to_string(),
+        display_name: model_id.to_string(),
+        quant: quant.to_string(),
+        suffix: suffix.to_string(),
+        pull: pull.to_string(),
+        filename: format!("{model_id}-{quant}.oasr"),
+        path: object.clone(),
+        url: format!("https://example.invalid/{model_id}.oasr"),
+        hf_revision: "test".to_string(),
+        sha256,
+        size_bytes: bytes.len() as u64,
+        installed_at_unix_seconds: 1,
+        source: None,
+    };
+    std::fs::write(reference, serde_json::to_vec_pretty(&pack).unwrap()).unwrap();
+    object
+}
+
+async fn json_request(
+    app: Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    let body = if let Some(body) = body {
+        builder = builder.header(header::CONTENT_TYPE, "application/json");
+        Body::from(body.to_string())
+    } else {
+        Body::empty()
+    };
+    let response = app.oneshot(builder.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    let parsed = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, parsed)
+}
+
+#[tokio::test]
+async fn set_default_rebinds_native_bound_pack_without_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let moonshine = install_native_pack(
+        &home,
+        "moonshine-tiny",
+        "moonshine-tiny:q8",
+        "q8_0",
+        "q8",
+        TinyGgufFixtureSpec::moonshine_oasr_v1_runtime_ready("moonshine-tiny"),
+    );
+    let whisper = install_native_pack(
+        &home,
+        "whisper-tiny",
+        "whisper-tiny:q4",
+        "q4_0",
+        "q4",
+        TinyGgufFixtureSpec::whisper_oasr_v1_graph_ready_for_runtime_fail_closed("whisper-tiny"),
+    );
+    let runtime = native_runtime_with_pack(Some(moonshine.clone()));
+    let app = openasr_server::app_with_runtime_and_distribution(
+        runtime.clone(),
+        openasr_server::DistributionRuntime {
+            openasr_home: Some(home),
+            catalog_url: None,
+            catalog_local_override: None,
+        },
+    );
+
+    let (status, health) = json_request(app.clone(), "GET", "/health", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(health["model_installed"], true);
+
+    let (status, models) = json_request(app.clone(), "GET", "/v1/models", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models["data"][0]["id"], "moonshine-tiny");
+
+    let (status, default) = json_request(
+        app.clone(),
+        "POST",
+        "/v1/models/default",
+        Some(serde_json::json!({ "pull": "whisper-tiny:q4" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(default["default_model"], "whisper-tiny");
+
+    let (status, health) = json_request(app.clone(), "GET", "/health", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(health["model_installed"], true);
+
+    let (status, models) = json_request(app, "GET", "/v1/models", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models["data"][0]["id"], "whisper-tiny");
+    assert_eq!(
+        runtime.model_pack_path.current().as_deref(),
+        Some(whisper.as_path())
+    );
+}
+
+#[tokio::test]
+async fn set_default_binds_unbound_native_runtime_without_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let moonshine = install_native_pack(
+        &home,
+        "moonshine-tiny",
+        "moonshine-tiny:q8",
+        "q8_0",
+        "q8",
+        TinyGgufFixtureSpec::moonshine_oasr_v1_runtime_ready("moonshine-tiny"),
+    );
+    let runtime = native_runtime_with_pack(None);
+    let app = openasr_server::app_with_runtime_and_distribution(
+        runtime.clone(),
+        openasr_server::DistributionRuntime {
+            openasr_home: Some(home),
+            catalog_url: None,
+            catalog_local_override: None,
+        },
+    );
+
+    let (status, health) = json_request(app.clone(), "GET", "/health", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(health["model_installed"], false);
+
+    let (status, models) = json_request(app.clone(), "GET", "/v1/models", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(models["data"].as_array().unwrap().is_empty());
+
+    let (status, default) = json_request(
+        app.clone(),
+        "POST",
+        "/v1/models/default",
+        Some(serde_json::json!({ "pull": "moonshine-tiny:q8" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(default["default_model"], "moonshine-tiny");
+
+    let (status, health) = json_request(app.clone(), "GET", "/health", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(health["model_installed"], true);
+
+    let (status, models) = json_request(app, "GET", "/v1/models", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models["data"][0]["id"], "moonshine-tiny");
+    assert_eq!(
+        runtime.model_pack_path.current().as_deref(),
+        Some(moonshine.as_path())
     );
 }
 
@@ -2500,7 +2691,7 @@ fn native_server_runtime_with_no_model_pack_is_accepted_at_startup_validation() 
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: None,
+        model_pack_path: None.into(),
     }
     .validate()
     .expect("zero installed models must not block server startup");
@@ -2516,7 +2707,7 @@ fn native_server_runtime_falls_back_to_path_stem_when_metadata_model_id_is_retir
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     }
     .validate()
     .expect("runtime should fall back to path stem model id");
@@ -2532,7 +2723,7 @@ fn native_server_runtime_falls_back_to_path_stem_when_metadata_model_id_is_inval
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     }
     .validate()
     .expect("runtime should fall back to path stem model id");
@@ -2548,7 +2739,7 @@ fn native_server_runtime_rejects_reserved_oasr_container_magic() {
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     }
     .validate()
     .unwrap_err()
@@ -3439,7 +3630,7 @@ async fn failed_native_transcription_clears_id_scoped_progress_and_control() {
             native_execution: openasr_server::NativeExecutionSupervisor::default(),
             ffmpeg_bin: None,
             ffmpeg_bin_explicit: false,
-            model_pack_path: None,
+            model_pack_path: None.into(),
         },
         openasr_server::DistributionRuntime {
             openasr_home: Some(temp.path().join("home")),
@@ -4642,7 +4833,7 @@ async fn transcriptions_with_native_backend_fail_closed() {
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root.clone()),
+        model_pack_path: Some(pack_root.clone()).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request("whisper-runtime", "sample.wav", &wav_bytes);
@@ -4665,7 +4856,7 @@ async fn transcriptions_with_native_xasr_hotword_returns_model_unsupported_error
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request_with_extra_fields(
@@ -4697,7 +4888,7 @@ async fn transcriptions_with_native_backend_model_mismatch_returns_bad_request()
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root.clone()),
+        model_pack_path: Some(pack_root.clone()).into(),
     });
     let wav_bytes = sample_wav_bytes();
     // A genuinely different base id (not a quant-pin of the pack id): since
@@ -4734,7 +4925,7 @@ async fn transcriptions_with_native_backend_accepts_quant_alias_against_legacy_h
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root.clone()),
+        model_pack_path: Some(pack_root.clone()).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request("mimo-v2.5-asr:q4", "sample.wav", &wav_bytes);
@@ -4760,7 +4951,7 @@ async fn transcriptions_with_native_backend_matches_normalized_path_stem_after_r
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request("native-pack", "sample.wav", &wav_bytes);
@@ -4790,7 +4981,7 @@ async fn transcriptions_with_native_backend_and_diarize_returns_bad_request() {
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root.clone()),
+        model_pack_path: Some(pack_root.clone()).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request_with_diarize("whisper-runtime", "sample.wav", &wav_bytes, true);
@@ -4810,7 +5001,7 @@ async fn transcriptions_with_native_backend_reject_retired_legacy_model_alias() 
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: None,
+        model_pack_path: None.into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request("whisper-tiny:q4_0", "sample.wav", &wav_bytes);
@@ -4839,7 +5030,7 @@ async fn transcriptions_with_native_backend_accepts_live_catalog_family_bare_met
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root.clone()),
+        model_pack_path: Some(pack_root.clone()).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request("whisper-large-v3-turbo:q4_k", "sample.wav", &wav_bytes);
@@ -4862,7 +5053,7 @@ async fn stream_transcriptions_with_native_backend_reject_empty_model_form_value
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request_with_options(
@@ -4888,7 +5079,7 @@ async fn stream_transcriptions_with_mock_backend_emits_protocol_events() {
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: None,
+        model_pack_path: None.into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request_with_options(
@@ -4929,7 +5120,7 @@ async fn stream_transcription_succeeds_when_history_cannot_be_recorded() {
             native_execution: openasr_server::NativeExecutionSupervisor::default(),
             ffmpeg_bin: None,
             ffmpeg_bin_explicit: false,
-            model_pack_path: None,
+            model_pack_path: None.into(),
         },
         openasr_server::DistributionRuntime {
             openasr_home: Some(home),
@@ -4967,7 +5158,7 @@ async fn static_bearer_remote_compute_stream_transcription_records_server_histor
             native_execution: openasr_server::NativeExecutionSupervisor::default(),
             ffmpeg_bin: None,
             ffmpeg_bin_explicit: false,
-            model_pack_path: None,
+            model_pack_path: None.into(),
         },
         openasr_server::DistributionRuntime {
             openasr_home: Some(temp.path().join("home")),
@@ -5031,7 +5222,7 @@ async fn stream_transcriptions_with_native_backend_reject_srt_response_format() 
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request_with_options(
@@ -5060,7 +5251,7 @@ async fn stream_transcriptions_with_native_backend_reject_model_mismatch() {
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request_with_options(
@@ -5091,7 +5282,7 @@ async fn stream_transcriptions_with_native_xasr_hotword_emits_model_unsupported_
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request_with_extra_fields(
@@ -5129,7 +5320,7 @@ async fn stream_transcriptions_with_native_backend_reject_missing_model_pack_pat
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: None,
+        model_pack_path: None.into(),
     });
     let wav_bytes = sample_wav_bytes();
     // The streaming endpoint's synchronous multipart parse only runs the retired-id
@@ -5165,7 +5356,7 @@ async fn transcriptions_with_native_backend_srt_stays_fail_closed_for_unexecutab
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root.clone()),
+        model_pack_path: Some(pack_root.clone()).into(),
     });
     let wav_bytes = sample_wav_bytes();
     let request = multipart_request_with_options(
@@ -5194,7 +5385,7 @@ async fn models_with_native_backend_lists_loaded_local_pack_id() {
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: Some(pack_root),
+        model_pack_path: Some(pack_root).into(),
     });
     let response = app
         .oneshot(
@@ -5222,7 +5413,7 @@ async fn models_with_native_backend_and_no_pack_lists_empty_instead_of_erroring(
         native_execution: openasr_server::NativeExecutionSupervisor::default(),
         ffmpeg_bin: None,
         ffmpeg_bin_explicit: false,
-        model_pack_path: None,
+        model_pack_path: None.into(),
     });
     let response = app
         .oneshot(


### PR DESCRIPTION
## Summary

Default-model changes no longer restart the native server process. HIP/CUDA activation hashes only mapped plugin images instead of the whole vendor tree.

## Why

On this Windows HIP host (RX 9060 XT, gfx1200, Haswell without SHA-NI), switching models showed a 20s+ "starting" state. Two separate costs were stacked:

1. Desktop treated a model switch as a sidecar restart, so every switch paid HIP plugin load.
2. Activation SHA256'd the closed HIP vendor set twice (1974 files, including Tensile/hsaco objects DllMain never maps), which dominated `ggml_backend` (~21s). CUDA on a 3060 stayed under 10s because that vendor tree is a handful of large DLLs.

Process identity is the GPU plugin. The model pack is in-process state.

## Changes

- Listen first, then load ggml backends in the background.
- `POST /v1/models/default` persists the pack and rebinds in-process. HTTP 409 when a native session is busy.
- `InstalledBackendVerifyScope::Full` remains the install/repair gate.
- Activation uses `LoadImages`: authenticate `backend.json`, the signed archive digest, the plugin, and every mapped native library; reject extra sibling DLLs; skip Tensile/hsaco byte hashes.

## Tests run

- [x] `cargo fmt --check` (formatted `openasr-core` before commit; not a full workspace `--check`)
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`
- [x] `cargo test -p openasr-core installed_backend_load_images` (2 passed: tampered hsaco still fails Full / passes LoadImages; planted.dll rejected)

## Manual smoke checks

Local unsigned Windows pack of Desktop 0.1.22-preview.9 with core `dcdf759`, installed to `%LOCALAPPDATA%\OpenASR Desktop` and launched from that directory (not `src-tauri\target`):

- `server_boot` ready in 99ms on `http://127.0.0.1:64107`; desktop `health_first_ok` at 4032ms
- `ggml_backend` 3980ms (verify1 1079, lock 17, verify2 966, probe 65, load 70) vs ~21s Full-hash baseline
- `best_backend=ROCm0`, `activated_provider=hip`, gfx1200, no CPU fallback
- `POST /v1/models/default` `firered-aed-l-v2:q4` 289ms then `xasr-zh-en:q8` 192ms, sidecar pid 40348 unchanged both times
- default restored to `xasr-zh-en:q8`

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

Not a model-family change.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not skip bundled Vulkan load on a HIP process (~2.5s of the remaining ~4s). Does not drop the second LoadImages pass after lock. Does not cut a release.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

<!-- IMPORTANT: please do NOT delete this section. -->

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
