### PR TITLE
feat(core): stream snapshot partials without overflowing FireRed

### DIFF
--- a/crates/openasr-core/src/api/backend/mod.rs
+++ b/crates/openasr-core/src/api/backend/mod.rs
@@ -11,7 +11,6 @@ mod native;
 mod request_context;
 
 pub use mock::transcribe_with_mock_backend;
-pub(crate) use native::WorkProgressObserver;
 pub use native::{
     GgmlAbortCallbackGuard, LegacyNativeTranscriptionProgress, NativeBackend,
     NativeBackendExecutor, NativeRuntimeModelAdapter, NativeRuntimeModelIdSource,
@@ -26,6 +25,7 @@ pub use native::{
     resolve_local_native_runtime_model_identity, validate_local_native_model_pack_path,
     verify_native_runtime_model_pack_path,
 };
+pub(crate) use native::{UnstableDecodeTextObserver, WorkProgressObserver};
 pub use request_context::{
     FailureCategory, RequestSource, format_failure_context_line, format_request_context_line,
     log_failure_context, log_request_context,

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -18,7 +18,6 @@ use crate::api::native::{
 use crate::arch::{
     GRANITE_SPEECH_GGML_ADAPTER_ID, GRANITE_SPEECH_GGML_ARCHITECTURE_ID,
     GRANITE_SPEECH_MODEL_FAMILY, OpenAsrArchitectureRegistry, OpenAsrPhraseBiasStrategy,
-    StreamingPartialGranularity,
 };
 use crate::device::{
     execution_policy::{
@@ -60,7 +59,7 @@ pub use native_transcribe::{
     refine_existing_transcription_timeline,
 };
 pub use request_execution_context::RequestExecutionContext;
-pub(crate) use request_execution_context::WorkProgressObserver;
+pub(crate) use request_execution_context::{UnstableDecodeTextObserver, WorkProgressObserver};
 pub use transcription_control::{
     GgmlAbortCallbackGuard, SliceBoundaryControl, TranscriptionControl,
 };
@@ -397,16 +396,16 @@ fn native_runtime_streaming_capabilities_for_descriptor(
         return NativeAsrCapabilities::native_offline();
     };
     // Partial granularity is a property of the registered streaming executor:
-    // frame-sync (append-only, never revises) vs buffered (re-decodes a growing
-    // window). Only xasr-zipformer is frame-sync today.
+    // frame-sync-append (append-only, never revises) vs revisable snapshot
+    // vs utterance-complete snapshot. Only xasr-zipformer is frame-sync today.
     NativeAsrCapabilities::native_true_streaming()
         .with_partial_results(true)
-        .with_frame_sync_partials(matches!(
+        .with_frame_sync_partials(
             architecture
                 .execution_contract
-                .streaming_partial_granularity,
-            StreamingPartialGranularity::FrameSync
-        ))
+                .streaming_partial_granularity
+                .is_frame_sync_append(),
+        )
 }
 
 /// Phrase-bias capability for one runtime pack.

--- a/crates/openasr-core/src/api/backend/request_execution_context.rs
+++ b/crates/openasr-core/src/api/backend/request_execution_context.rs
@@ -71,10 +71,12 @@ impl fmt::Debug for UnstableDecodeTextObserver {
 }
 
 impl UnstableDecodeTextObserver {
+    #[allow(dead_code)] // installed only by tests; live Poll must not fan prefixes
     pub(crate) fn new(observer: impl Fn(&str) + Send + Sync + 'static) -> Self {
         Self(Arc::new(observer))
     }
 
+    #[allow(dead_code)] // paired with `new`; production Poll leaves the observer unset
     pub(crate) fn report(&self, text: &str) {
         (self.0)(text);
     }

--- a/crates/openasr-core/src/api/backend/request_execution_context.rs
+++ b/crates/openasr-core/src/api/backend/request_execution_context.rs
@@ -55,6 +55,31 @@ impl WorkProgressObserver {
     }
 }
 
+/// Cloneable request-local observer for postprocessed unstable decode text.
+///
+/// The shared greedy loop reports each new displayable prefix before EOT so a
+/// streaming Poll can emit `transcript.partial` without waiting for the stop
+/// token. Empty postprocessed prefixes (for example FunASR `/sil` stripped to
+/// nothing) are not reported.
+#[derive(Clone)]
+pub(crate) struct UnstableDecodeTextObserver(Arc<dyn Fn(&str) + Send + Sync + 'static>);
+
+impl fmt::Debug for UnstableDecodeTextObserver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("UnstableDecodeTextObserver(..)")
+    }
+}
+
+impl UnstableDecodeTextObserver {
+    pub(crate) fn new(observer: impl Fn(&str) + Send + Sync + 'static) -> Self {
+        Self(Arc::new(observer))
+    }
+
+    pub(crate) fn report(&self, text: &str) {
+        (self.0)(text);
+    }
+}
+
 /// Per-request execution context threaded explicitly through every decode
 /// dispatch surface. See the module docs for why this replaced the
 /// thread-local control binding.
@@ -71,6 +96,10 @@ pub struct RequestExecutionContext {
     /// use the typed constructor below instead of inventing another callback
     /// transport or process-global registry.
     decode_work_progress: Option<WorkProgressObserver>,
+    /// Optional mid-greedy unstable text sink. Streaming partials install this
+    /// so the shared decode driver can emit revisable prefixes before EOT;
+    /// FINAL / offline paths leave it unset.
+    unstable_decode_text: Option<UnstableDecodeTextObserver>,
 }
 
 // Manual, not derived: `TranscriptionControl` holds a `Mutex`/`Condvar` and
@@ -94,6 +123,7 @@ impl RequestExecutionContext {
             request_id,
             control,
             decode_work_progress: None,
+            unstable_decode_text: None,
         }
     }
 
@@ -108,11 +138,28 @@ impl RequestExecutionContext {
             request_id: self.request_id.clone(),
             control: Arc::clone(&self.control),
             decode_work_progress: Some(observer),
+            unstable_decode_text: self.unstable_decode_text.clone(),
         }
     }
 
     pub(crate) fn decode_work_progress_observer(&self) -> Option<&WorkProgressObserver> {
         self.decode_work_progress.as_ref()
+    }
+
+    pub(crate) fn with_unstable_decode_text_observer(
+        &self,
+        observer: UnstableDecodeTextObserver,
+    ) -> Self {
+        Self {
+            request_id: self.request_id.clone(),
+            control: Arc::clone(&self.control),
+            decode_work_progress: self.decode_work_progress.clone(),
+            unstable_decode_text: Some(observer),
+        }
+    }
+
+    pub(crate) fn unstable_decode_text_observer(&self) -> Option<&UnstableDecodeTextObserver> {
+        self.unstable_decode_text.as_ref()
     }
 
     /// A context with no external owner: nothing can ever cancel or pause
@@ -172,6 +219,7 @@ impl RequestExecutionContext {
             request_id: None,
             control: Arc::new(TranscriptionControl::detached()),
             decode_work_progress: None,
+            unstable_decode_text: None,
         }
     }
 

--- a/crates/openasr-core/src/api/backend/request_execution_context.rs
+++ b/crates/openasr-core/src/api/backend/request_execution_context.rs
@@ -146,6 +146,7 @@ impl RequestExecutionContext {
         self.decode_work_progress.as_ref()
     }
 
+    #[allow(dead_code)] // reserved for a live mid-decode flush; snapshot Poll must not fan out prefixes
     pub(crate) fn with_unstable_decode_text_observer(
         &self,
         observer: UnstableDecodeTextObserver,

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -543,16 +543,49 @@ pub(crate) enum OpenAsrEncoderAttentionSpan {
     LocalChunked,
 }
 
-/// Partial-result granularity of a family's streaming executor. Infrastructure
-/// property (how partials are produced), not a per-model semantic: `FrameSync`
-/// appends fixed low-latency chunks and never revises already-emitted text;
-/// `Buffered` re-decodes a growing/windowed buffer and may revise prior
-/// partials. Declared once on the architecture descriptor and
-/// derived into the streaming dispatch at build time.
+/// How a family produces streaming partials. Declared once on the architecture
+/// descriptor and derived into streaming dispatch at build time -- not a second
+/// per-model table.
+///
+/// `FrameSyncAppend` (xasr): `push_audio` emits append-only token chunks and
+/// never revises already-emitted text.
+/// `RevisableSnapshot`: each Poll re-decodes a growing/windowed buffer;
+/// incomplete windows are expected to produce displayable text that may revise
+/// prior partials (qwen, firered-aed, whisper, moonshine, CTC, ...).
+/// `UtteranceComplete`: ChatML utterance LLMs whose incomplete windows may
+/// legally decode to empty (for example FunASR `/sil`); partials may append a
+/// short endpoint-silence tail to elicit unstable overlay text. FINAL always
+/// uses the real unpadded audio.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamingPartialGranularity {
-    FrameSync,
-    Buffered,
+    FrameSyncAppend,
+    RevisableSnapshot,
+    UtteranceComplete,
+}
+
+impl StreamingPartialGranularity {
+    pub const fn is_frame_sync_append(self) -> bool {
+        matches!(self, Self::FrameSyncAppend)
+    }
+
+    /// Only utterance-complete snapshot families may pad a short silence tail
+    /// onto a PARTIAL window. FINAL / FinalizeReuse never take this hint.
+    pub const fn allows_partial_endpoint_hint(self) -> bool {
+        matches!(self, Self::UtteranceComplete)
+    }
+}
+
+/// Streaming partial granularity declared on a builtin architecture row, looked
+/// up by GGUF `model_architecture`. Unknown architectures fail closed to
+/// [`StreamingPartialGranularity::RevisableSnapshot`] (no endpoint-silence
+/// hint) rather than inventing frame-sync or utterance-complete behavior.
+pub(crate) fn streaming_partial_granularity_for_model_architecture(
+    model_architecture: &str,
+) -> StreamingPartialGranularity {
+    OpenAsrArchitectureRegistry::with_builtins()
+        .find_by_model_architecture(model_architecture)
+        .map(|descriptor| descriptor.execution_contract.streaming_partial_granularity)
+        .unwrap_or(StreamingPartialGranularity::RevisableSnapshot)
 }
 
 /// Which decode driver owns the family's token loop. A dedicated topology is
@@ -1584,7 +1617,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::SharedCohereTranscribeV1,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::Native,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -1689,7 +1722,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeSensitive,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::Native,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -1773,7 +1806,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Qwen3AsrLoraV1,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::SharedQwen3AsrV1,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::Native,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -1872,7 +1905,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::Native,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -1971,7 +2004,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::Native,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2057,7 +2090,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::Native,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2147,7 +2180,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::FrameSync,
+            streaming_partial_granularity: StreamingPartialGranularity::FrameSyncAppend,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::Native,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2247,7 +2280,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::MoonshineLoraV1,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::Native,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2348,7 +2381,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::ForcedAligner,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2447,7 +2480,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::ForcedAligner,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2538,7 +2571,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::ForcedAligner,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2636,7 +2669,8 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            // ChatML utterance LLM: incomplete windows may legally decode empty.
+            streaming_partial_granularity: StreamingPartialGranularity::UtteranceComplete,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::ForcedAligner,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2731,7 +2765,9 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            // ChatML utterance LLM: incomplete windows often decode `/sil` and
+            // may legally be empty until an endpoint hint or real pause.
+            streaming_partial_granularity: StreamingPartialGranularity::UtteranceComplete,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::ForcedAligner,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2818,7 +2854,8 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            // ChatML utterance LLM: incomplete windows may legally decode empty.
+            streaming_partial_granularity: StreamingPartialGranularity::UtteranceComplete,
             speaker_segmentation: SpeakerSegmentationSource::External,
             word_timestamp_source: WordTimestampSource::ForcedAligner,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
@@ -2911,7 +2948,8 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            // ChatML utterance LLM: incomplete windows may legally decode empty.
+            streaming_partial_granularity: StreamingPartialGranularity::UtteranceComplete,
             speaker_segmentation: SpeakerSegmentationSource::InDecoder,
             word_timestamp_source: WordTimestampSource::ForcedAligner,
             // Product invocation envelope: ordinary VAD slicing aims at 30s and
@@ -3039,7 +3077,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             adapter_binding: GgmlAdapterBindingStrategy::Unsupported,
             prepared_runtime: OpenAsrPreparedRuntimeStrategy::FamilyOwned,
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
-            streaming_partial_granularity: StreamingPartialGranularity::Buffered,
+            streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             // Greedy decode rides the one shared seq2seq driver via the policy
             // embedded in this row (see AGENTS.md's single-driver invariant);
             // this family provides a `Seq2SeqGreedyDecodeStepExecutor` and a

--- a/crates/openasr-core/src/family_inventory.rs
+++ b/crates/openasr-core/src/family_inventory.rs
@@ -260,8 +260,9 @@ fn project_descriptor(descriptor: OpenAsrArchitectureDescriptor) -> ModelFamilyI
                 execution_contract.execution_capabilities,
             ),
             streaming_partial_granularity: match execution_contract.streaming_partial_granularity {
-                StreamingPartialGranularity::FrameSync => "frame-sync",
-                StreamingPartialGranularity::Buffered => "buffered",
+                StreamingPartialGranularity::FrameSyncAppend => "frame-sync-append",
+                StreamingPartialGranularity::RevisableSnapshot => "revisable-snapshot",
+                StreamingPartialGranularity::UtteranceComplete => "utterance-complete",
             }
             .to_string(),
             speaker_segmentation: match execution_contract.speaker_segmentation {

--- a/crates/openasr-core/src/models/builtin_execution_dispatch.rs
+++ b/crates/openasr-core/src/models/builtin_execution_dispatch.rs
@@ -503,7 +503,7 @@ mod tests {
             if architecture
                 .execution_contract
                 .streaming_partial_granularity
-                == StreamingPartialGranularity::FrameSync
+                == StreamingPartialGranularity::FrameSyncAppend
             {
                 manifest_frame_sync.insert(descriptor.model_architecture);
             }
@@ -523,7 +523,55 @@ mod tests {
         }
         assert_eq!(
             manifest_frame_sync, dispatch_frame_sync,
-            "FrameSync architecture set must equal the streaming dispatch FrameSync set"
+            "FrameSyncAppend architecture set must equal the streaming dispatch FrameSync set"
+        );
+    }
+
+    #[test]
+    fn utterance_complete_is_declared_on_chatml_utterance_llms_only() {
+        let architecture_registry = OpenAsrArchitectureRegistry::with_builtins();
+        let granularity = |architecture: &str| {
+            architecture_registry
+                .find_by_model_architecture(architecture)
+                .expect(architecture)
+                .execution_contract
+                .streaming_partial_granularity
+        };
+        assert_eq!(
+            granularity(crate::arch::FUNASR_NANO_GGML_ARCHITECTURE_ID),
+            StreamingPartialGranularity::UtteranceComplete
+        );
+        assert_eq!(
+            granularity(crate::arch::FIRERED_LLM_GGML_ARCHITECTURE_ID),
+            StreamingPartialGranularity::UtteranceComplete
+        );
+        assert_eq!(
+            granularity(crate::arch::MIMO_ASR_GGML_ARCHITECTURE_ID),
+            StreamingPartialGranularity::UtteranceComplete
+        );
+        assert_eq!(
+            granularity(crate::arch::MOSS_TD_GGML_ARCHITECTURE_ID),
+            StreamingPartialGranularity::UtteranceComplete
+        );
+        assert_eq!(
+            granularity(crate::arch::QWEN3_ASR_GGML_ARCHITECTURE_ID),
+            StreamingPartialGranularity::RevisableSnapshot
+        );
+        assert_eq!(
+            granularity(crate::arch::FIRERED_AED_GGML_ARCHITECTURE_ID),
+            StreamingPartialGranularity::RevisableSnapshot
+        );
+        assert_eq!(
+            granularity(crate::arch::WHISPER_GGML_ARCHITECTURE_ID),
+            StreamingPartialGranularity::RevisableSnapshot
+        );
+        assert_eq!(
+            granularity(crate::arch::GRANITE_SPEECH_GGML_ARCHITECTURE_ID),
+            StreamingPartialGranularity::RevisableSnapshot
+        );
+        assert_eq!(
+            granularity(crate::arch::XASR_ZIPFORMER_GGML_ARCHITECTURE_ID),
+            StreamingPartialGranularity::FrameSyncAppend
         );
     }
 

--- a/crates/openasr-core/src/models/cohere/decoder_graph.rs
+++ b/crates/openasr-core/src/models/cohere/decoder_graph.rs
@@ -174,6 +174,7 @@ pub(crate) fn run_cohere_decoder_graph_short_form_with_runtime(
     audio_duration_seconds: f32,
     control: &Arc<crate::TranscriptionControl>,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<CohereDecoderGraphDecodeOutput, CohereDecoderGraphError> {
     let decode_text_token_ids = |token_ids: &[u32]| {
         tokenizer.decode_text_token_ids(token_ids).map_err(|error| {
@@ -215,6 +216,7 @@ pub(crate) fn run_cohere_decoder_graph_short_form_with_runtime(
         &decode_text_token_ids,
         control,
         decode_work_progress,
+        unstable_decode_text,
     ) {
         Ok(output) => output,
         Err(CohereTranscribeGreedyDecodeError::EotNotReachedBeforeMaxTokens {

--- a/crates/openasr-core/src/models/cohere/ggml_executor.rs
+++ b/crates/openasr-core/src/models/cohere/ggml_executor.rs
@@ -619,6 +619,7 @@ impl CohereTranscribeGgmlExecutor {
                 audio_duration,
                 &request.execution_context.control,
                 request.execution_context.decode_work_progress_observer(),
+                request.execution_context.unstable_decode_text_observer(),
             )
             .map_err(map_decoder_error)?
         } else if let Some(serve_batch_config) = serve_batch_config.filter(|_| can_use_serve_batch)
@@ -694,6 +695,7 @@ impl CohereTranscribeGgmlExecutor {
                 audio_duration,
                 &request.execution_context.control,
                 request.execution_context.decode_work_progress_observer(),
+                request.execution_context.unstable_decode_text_observer(),
                 Arc::clone(&prepared_runtime_owner),
             )
             .map_err(map_decoder_error)?
@@ -1076,6 +1078,7 @@ impl CohereTranscribeGgmlExecutor {
         audio_duration_seconds: f32,
         control: &Arc<crate::TranscriptionControl>,
         decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+        unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
         prepared_owner: PreparedRuntimeHandle<BuiltinPreparedRuntime>,
     ) -> Result<super::decoder_graph::CohereDecoderGraphDecodeOutput, CohereDecoderGraphError> {
         let actor = self
@@ -1096,6 +1099,7 @@ impl CohereTranscribeGgmlExecutor {
         let phrase_bias = phrase_bias.cloned();
         let control = Arc::clone(control);
         let decode_work_progress = decode_work_progress.cloned();
+        let unstable_decode_text = unstable_decode_text.cloned();
         actor
             .call_mut(move |state| {
                 state.runtime.activate_decoder_state(decoder_state)?;
@@ -1111,6 +1115,7 @@ impl CohereTranscribeGgmlExecutor {
                     audio_duration_seconds,
                     &control,
                     decode_work_progress.as_ref(),
+                    unstable_decode_text.as_ref(),
                 )
             })
             .map_err(|error| CohereDecoderGraphError::GraphExecutionFailed {
@@ -1133,6 +1138,7 @@ impl CohereTranscribeGgmlExecutor {
         audio_duration_seconds: f32,
         control: &Arc<crate::TranscriptionControl>,
         decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+        unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
     ) -> Result<super::decoder_graph::CohereDecoderGraphDecodeOutput, CohereDecoderGraphError> {
         let tokenizer = tokenizer.clone();
         let initial_prompt_tokens = initial_prompt_tokens.to_vec();
@@ -1140,6 +1146,7 @@ impl CohereTranscribeGgmlExecutor {
         let phrase_bias = phrase_bias.cloned();
         let control = Arc::clone(control);
         let decode_work_progress = decode_work_progress.cloned();
+        let unstable_decode_text = unstable_decode_text.cloned();
         actor
             .call_mut_fallible(move |state| {
                 state.decoder.activate_decoder_state(decoder_state)?;
@@ -1155,6 +1162,7 @@ impl CohereTranscribeGgmlExecutor {
                     audio_duration_seconds,
                     &control,
                     decode_work_progress.as_ref(),
+                    unstable_decode_text.as_ref(),
                 )
             })
             .map_err(|error| CohereDecoderGraphError::GraphExecutionFailed {

--- a/crates/openasr-core/src/models/cohere/greedy_decode.rs
+++ b/crates/openasr-core/src/models/cohere/greedy_decode.rs
@@ -75,6 +75,7 @@ pub(crate) fn run_cohere_transcribe_greedy_decode_loop(
     decode_text_token_ids: &dyn Fn(&[u32]) -> Result<String, CohereTranscribeGreedyDecodeError>,
     control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<CohereTranscribeGreedyDecodeResult, CohereTranscribeGreedyDecodeError> {
     let output = run_builtin_seq2seq_decode_policy(
         crate::COHERE_TRANSCRIBE_DECODE_POLICY_ID,
@@ -88,6 +89,7 @@ pub(crate) fn run_cohere_transcribe_greedy_decode_loop(
         map_registry_error,
         control,
         decode_work_progress,
+        unstable_decode_text,
     )?;
     Ok(CohereTranscribeGreedyDecodeResult {
         generated_tokens: output.generated_tokens,
@@ -293,6 +295,7 @@ mod tests {
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap();
 
@@ -335,6 +338,7 @@ mod tests {
             &mut step_executor,
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .expect_err("no EOT should fail closed");
@@ -388,6 +392,7 @@ mod tests {
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .expect("stop-token decode succeeds");
         assert_eq!(
@@ -419,6 +424,7 @@ mod tests {
             &mut looping_executor,
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .expect("guard-stopped decode still returns the kept prefix");

--- a/crates/openasr-core/src/models/decode_policy_component_registry.rs
+++ b/crates/openasr-core/src/models/decode_policy_component_registry.rs
@@ -460,6 +460,7 @@ pub(crate) fn run_builtin_seq2seq_decode_policy<E>(
     map_registry_error: fn(BuiltinDecodePolicyComponentRegistryError) -> E,
     control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<Seq2SeqGreedyDecodeResult, E> {
     let descriptor = resolve_builtin_decode_policy(decode_policy_id).map_err(map_registry_error)?;
     let config = build_builtin_seq2seq_decode_policy_config(
@@ -496,6 +497,7 @@ pub(crate) fn run_builtin_seq2seq_decode_policy<E>(
                 &mut on_topk,
                 control,
                 decode_work_progress,
+                unstable_decode_text,
             )
         }
         // Fail closed: a CTC policy must never route through the seq2seq loop.
@@ -1119,6 +1121,7 @@ mod tests {
             |error| error.to_string(),
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .expect("decode policy dispatch");
 
@@ -1164,6 +1167,7 @@ mod tests {
             |error| error.to_string(),
             |error| error.to_string(),
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .expect("decode policy dispatch");
@@ -1215,6 +1219,7 @@ mod tests {
             |error| error.to_string(),
             |error| error.to_string(),
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .expect("decode policy dispatch");

--- a/crates/openasr-core/src/models/family_integration_audit.rs
+++ b/crates/openasr-core/src/models/family_integration_audit.rs
@@ -506,7 +506,7 @@ pub(crate) mod source_tree_audit {
         use crate::ggml_runtime::AutoGpuPolicy;
         use crate::models::ggml_family_adapter::LanguageFamilyHint;
 
-        let value = StreamingPartialGranularity::FrameSync;
+        let value = StreamingPartialGranularity::FrameSyncAppend;
         let _dispatch_ty: crate::StreamingPartialGranularity = value;
         let base = base_descriptor();
         let _ = OpenAsrArchitectureDescriptor {

--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -1503,6 +1503,7 @@ pub(crate) fn run_firered_aed_decoder_greedy_with_runtime(
     decode_text: impl Fn(&[u32]) -> Result<String, String>,
     control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<FireRedAedGreedyDecodeOutput, FireRedDecoderError> {
     runtime.populate_cross_attention_cache(encoder_rows, encoder_frame_count)?;
 
@@ -1551,6 +1552,7 @@ pub(crate) fn run_firered_aed_decoder_greedy_with_runtime(
         },
         control,
         decode_work_progress,
+        unstable_decode_text,
     ) {
         Ok(output) => output,
         // Budget exhausted before `<eos>`: keep the generated prefix and

--- a/crates/openasr-core/src/models/firered_aed/executor.rs
+++ b/crates/openasr-core/src/models/firered_aed/executor.rs
@@ -628,6 +628,7 @@ impl FireRedAedGgmlExecutor {
         tokenizer: FireRedTokenizer,
         control: Arc<crate::api::backend::TranscriptionControl>,
         decode_work_progress: Option<crate::api::backend::WorkProgressObserver>,
+        unstable_decode_text: Option<crate::api::backend::UnstableDecodeTextObserver>,
         backend: GgmlCpuGraphBackend,
         greedy_step_output_mode: DeviceGreedyStepOutputMode,
     ) -> Result<super::decoder_graph::FireRedAedGreedyDecodeOutput, FireRedAedExecutorError> {
@@ -649,6 +650,7 @@ impl FireRedAedGgmlExecutor {
                     |ids| tokenizer.decode(ids).map_err(|error| error.to_string()),
                     &control,
                     decode_work_progress.as_ref(),
+                    unstable_decode_text.as_ref(),
                 )
             })
             .map_err(|error| Self::map_actor_error("decoder", error))?
@@ -668,6 +670,7 @@ impl FireRedAedGgmlExecutor {
         tokenizer: FireRedTokenizer,
         control: Arc<crate::api::backend::TranscriptionControl>,
         decode_work_progress: Option<crate::api::backend::WorkProgressObserver>,
+        unstable_decode_text: Option<crate::api::backend::UnstableDecodeTextObserver>,
     ) -> Result<super::decoder_graph::FireRedAedGreedyDecodeOutput, FireRedAedExecutorError> {
         runtime
             .call_mut_fallible(move |runtime| {
@@ -680,6 +683,7 @@ impl FireRedAedGgmlExecutor {
                     |ids| tokenizer.decode(ids).map_err(|error| error.to_string()),
                     &control,
                     decode_work_progress.as_ref(),
+                    unstable_decode_text.as_ref(),
                 )
             })
             .map_err(|error| Self::map_actor_error("unified-decoder", error))?
@@ -871,6 +875,10 @@ impl FireRedAedGgmlExecutor {
             .execution_context
             .decode_work_progress_observer()
             .cloned();
+        let unstable_decode_text = request
+            .execution_context
+            .unstable_decode_text_observer()
+            .cloned();
         let decode = match unified_gpu_runtime.as_ref() {
             Some(runtime) => self.decode_with_unified_gpu_runtime(
                 runtime,
@@ -881,6 +889,7 @@ impl FireRedAedGgmlExecutor {
                 tokenizer,
                 control,
                 decode_work_progress,
+                unstable_decode_text,
             )?,
             None => self.decode_with_owned_runtime(
                 preflight,
@@ -891,6 +900,7 @@ impl FireRedAedGgmlExecutor {
                 tokenizer,
                 control,
                 decode_work_progress,
+                unstable_decode_text,
                 backend,
                 greedy_step_output_mode,
             )?,

--- a/crates/openasr-core/src/models/firered_llm/executor.rs
+++ b/crates/openasr-core/src/models/firered_llm/executor.rs
@@ -549,6 +549,7 @@ fn run_firered_llm_decode_with_runtime(
     tokenizer: FireRedLlmTokenizer,
     control: Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<crate::api::backend::UnstableDecodeTextObserver>,
     profile_enabled: bool,
 ) -> Result<Seq2SeqGreedyDecodeResult, FireRedLlmExecutorError> {
     if profile_enabled {
@@ -598,6 +599,7 @@ fn run_firered_llm_decode_with_runtime(
         map_registry_error,
         &control,
         decode_work_progress.as_ref(),
+        unstable_decode_text.as_ref(),
     );
     decoder.release_session_scoped_buffers();
     decode_result.map_err(|error| FireRedLlmExecutorError::GreedyDecodeFailed {
@@ -1013,6 +1015,10 @@ impl FireRedLlmGgmlExecutor {
             .execution_context
             .decode_work_progress_observer()
             .cloned();
+        let decoder_unstable_decode_text = request
+            .execution_context
+            .unstable_decode_text_observer()
+            .cloned();
         let profile_enabled = std::env::var_os("OPENASR_FIRERED_LLM_PROFILE").is_some();
         let terminate_unified_after_decode = request
             .request_options
@@ -1030,6 +1036,7 @@ impl FireRedLlmGgmlExecutor {
                         decoder_tokenizer,
                         decoder_control,
                         decoder_decode_work_progress,
+                        decoder_unstable_decode_text,
                         profile_enabled,
                     )
                 };
@@ -1058,6 +1065,7 @@ impl FireRedLlmGgmlExecutor {
                             decoder_tokenizer,
                             decoder_control,
                             decoder_decode_work_progress,
+                            decoder_unstable_decode_text,
                             profile_enabled,
                         )
                     })

--- a/crates/openasr-core/src/models/funasr_nano/executor.rs
+++ b/crates/openasr-core/src/models/funasr_nano/executor.rs
@@ -831,6 +831,10 @@ impl FunasrNanoGgmlExecutor {
             .execution_context
             .decode_work_progress_observer()
             .cloned();
+        let decoder_unstable_decode_text = request
+            .execution_context
+            .unstable_decode_text_observer()
+            .cloned();
         let result = if let Some(runtime) = unified_gpu_runtime.as_ref() {
             runtime
                 .call_mut_fallible(move |state| {
@@ -843,6 +847,7 @@ impl FunasrNanoGgmlExecutor {
                         kv_capacity,
                         &decoder_control,
                         decoder_decode_work_progress.as_ref(),
+                        decoder_unstable_decode_text.as_ref(),
                     );
                     state.decoder.release_session_scoped_buffers();
                     result
@@ -862,6 +867,7 @@ impl FunasrNanoGgmlExecutor {
                         kv_capacity,
                         &decoder_control,
                         decoder_decode_work_progress.as_ref(),
+                        decoder_unstable_decode_text.as_ref(),
                     );
                     runtime.release_session_scoped_buffers();
                     result
@@ -906,6 +912,7 @@ fn decode_with_decoder(
     kv_capacity: Qwen3AsrKvCacheCapacity,
     control: &Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<Seq2SeqGreedyDecodeResult, FunasrNanoExecutorError> {
     let audio_pad_end = decode_prompt
         .audio_pad_start_index
@@ -954,6 +961,7 @@ fn decode_with_decoder(
         map_registry_error,
         control,
         decode_work_progress,
+        unstable_decode_text,
     )
     .map_err(|error| FunasrNanoExecutorError::GreedyDecodeFailed {
         reason: error.to_string(),
@@ -1231,6 +1239,7 @@ mod tests {
                 )
                 .expect("test KV capacity"),
                 &control,
+                None,
                 None,
             )
             .expect("decode");

--- a/crates/openasr-core/src/models/ggml_asr_executor.rs
+++ b/crates/openasr-core/src/models/ggml_asr_executor.rs
@@ -1700,10 +1700,8 @@ impl GgmlAsrExecutionDispatch {
     /// `false` -- fail closed to the buffered/no-partial-guarantee default
     /// rather than assume low-latency partials.
     pub fn is_frame_sync_for(&self, descriptor: &GgmlFamilyAdapterDescriptor) -> bool {
-        matches!(
-            self.streaming_partial_granularity_for(descriptor),
-            Some(StreamingPartialGranularity::FrameSync)
-        )
+        self.streaming_partial_granularity_for(descriptor)
+            .is_some_and(StreamingPartialGranularity::is_frame_sync_append)
     }
 
     /// Returns the partial-result granularity registered for `descriptor`, if
@@ -2932,11 +2930,11 @@ mod tests {
         let mixed_dispatch = GgmlAsrExecutionDispatch::default()
             .with_streaming_partial_granularity_for_adapter(
                 whisper.adapter_id,
-                StreamingPartialGranularity::FrameSync,
+                StreamingPartialGranularity::FrameSyncAppend,
             )
             .with_streaming_partial_granularity_for_adapter(
                 qwen.adapter_id,
-                StreamingPartialGranularity::Buffered,
+                StreamingPartialGranularity::RevisableSnapshot,
             );
         assert!(mixed_dispatch.is_frame_sync_for(&whisper));
         assert!(!mixed_dispatch.is_frame_sync_for(&qwen));
@@ -2944,7 +2942,7 @@ mod tests {
         let capability_dispatch = GgmlAsrExecutionDispatch::default()
             .with_streaming_partial_granularity_for_capability(
                 qwen.execution_capability,
-                StreamingPartialGranularity::FrameSync,
+                StreamingPartialGranularity::FrameSyncAppend,
             );
         assert!(capability_dispatch.is_frame_sync_for(&qwen));
     }

--- a/crates/openasr-core/src/models/granite_speech/decode_executor.rs
+++ b/crates/openasr-core/src/models/granite_speech/decode_executor.rs
@@ -527,6 +527,7 @@ mod tests {
             &mut |_step, _logits| {},
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .expect("greedy decode");
 
@@ -681,6 +682,7 @@ mod tests {
             &mut |_step, _token, _eot| {},
             &mut |_step, _logits| {},
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .expect("greedy decode");

--- a/crates/openasr-core/src/models/granite_speech/executor.rs
+++ b/crates/openasr-core/src/models/granite_speech/executor.rs
@@ -606,6 +606,10 @@ impl GraniteSpeechGgmlExecutor {
             .execution_context
             .decode_work_progress_observer()
             .cloned();
+        let unstable_decode_text = request
+            .execution_context
+            .unstable_decode_text_observer()
+            .cloned();
         let result = actor
             .call_mut(move |prepared| {
                 let decode_result = (|| {
@@ -698,6 +702,7 @@ impl GraniteSpeechGgmlExecutor {
                         map_registry_error,
                         &control,
                         decode_work_progress.as_ref(),
+                        unstable_decode_text.as_ref(),
                     )
                     .map_err(|error| {
                         GraniteSpeechGgmlExecutorError::DecodeFailed {

--- a/crates/openasr-core/src/models/incremental_streaming_driver.rs
+++ b/crates/openasr-core/src/models/incremental_streaming_driver.rs
@@ -217,6 +217,18 @@ where
             request_options.prompt = Some(prompt);
             request_options.prompt_token_ids = None;
         }
+        let clipped_audio;
+        let audio = match resident_decoder_state.invocation_envelope() {
+            Some(envelope) if audio.samples_f32.len() > envelope.max_samples() => {
+                let start = audio.samples_f32.len() - envelope.max_samples();
+                clipped_audio =
+                    crate::models::ggml_asr_executor::GgmlAsrPreparedAudioView::mono_16khz(
+                        audio.samples_f32[start..].to_vec(),
+                    );
+                &clipped_audio
+            }
+            _ => audio,
+        };
         let decoder_state = match resident_decoder_state.invocation_envelope() {
             None => resident_decoder_state.clone(),
             Some(envelope) => {
@@ -1012,8 +1024,8 @@ mod tests {
     use std::{
         collections::VecDeque,
         sync::{
-            atomic::{AtomicUsize, Ordering},
             Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
         },
     };
 
@@ -1360,8 +1372,8 @@ mod tests {
             _ => unreachable!("expected partial update"),
         };
         assert_ne!(second_id, first_id);
-        assert_eq!(second_id.0 .0, "utt_win_000002");
-        assert_eq!(second_id.1 .0, "seg_win_000002");
+        assert_eq!(second_id.0.0, "utt_win_000002");
+        assert_eq!(second_id.1.0, "seg_win_000002");
     }
 
     #[test]

--- a/crates/openasr-core/src/models/incremental_streaming_driver.rs
+++ b/crates/openasr-core/src/models/incremental_streaming_driver.rs
@@ -219,15 +219,16 @@ where
         }
         let clipped_audio;
         let audio = match resident_decoder_state.invocation_envelope() {
-            Some(envelope) if audio.samples_f32.len() > envelope.max_samples() => {
-                let start = audio.samples_f32.len() - envelope.max_samples();
-                clipped_audio =
-                    crate::models::ggml_asr_executor::GgmlAsrPreparedAudioView::mono_16khz(
-                        audio.samples_f32[start..].to_vec(),
-                    );
-                &clipped_audio
+            Some(envelope) => {
+                match clip_streaming_audio_to_max_samples(audio, envelope.max_samples()) {
+                    Some(clipped) => {
+                        clipped_audio = clipped;
+                        &clipped_audio
+                    }
+                    None => audio,
+                }
             }
-            _ => audio,
+            None => audio,
         };
         let decoder_state = match resident_decoder_state.invocation_envelope() {
             None => resident_decoder_state.clone(),
@@ -449,6 +450,21 @@ fn audio_with_endpoint_silence(
     let mut samples = audio.samples_f32.to_vec();
     samples.resize(samples.len().saturating_add(extra), 0.0);
     GgmlAsrPreparedAudioView::mono_16khz(samples)
+}
+
+/// Keep the trailing `max_samples` when a live Poll outgrows the resident
+/// invocation envelope. `None` means the buffer already fits.
+fn clip_streaming_audio_to_max_samples(
+    audio: &GgmlAsrPreparedAudioView<'static>,
+    max_samples: usize,
+) -> Option<GgmlAsrPreparedAudioView<'static>> {
+    let len = audio.samples_f32.len();
+    if len <= max_samples {
+        return None;
+    }
+    Some(GgmlAsrPreparedAudioView::mono_16khz(
+        audio.samples_f32[len - max_samples..].to_vec(),
+    ))
 }
 
 /// A PARTIAL decode that covered the WHOLE current buffer, kept so a terminal
@@ -1890,6 +1906,16 @@ mod tests {
         assert_eq!(updates.len(), 1);
         assert_eq!(text_of(&updates[0]).0, window.trim());
         assert!(!text_of(&updates[0]).2);
+    }
+
+    #[test]
+    fn clip_streaming_audio_keeps_the_trailing_envelope() {
+        let samples: Vec<f32> = (0..8).map(|i| i as f32).collect();
+        let audio = GgmlAsrPreparedAudioView::mono_16khz(samples);
+        assert!(clip_streaming_audio_to_max_samples(&audio, 8).is_none());
+        assert!(clip_streaming_audio_to_max_samples(&audio, 9).is_none());
+        let clipped = clip_streaming_audio_to_max_samples(&audio, 3).expect("overflow");
+        assert_eq!(clipped.samples_f32.as_ref(), &[5.0, 6.0, 7.0]);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/incremental_streaming_driver.rs
+++ b/crates/openasr-core/src/models/incremental_streaming_driver.rs
@@ -28,7 +28,10 @@ use crate::models::ggml_streaming_session::{
 };
 use crate::models::graph_runtime_config::install_request_inference_threads_override;
 use crate::models::streaming_partial_cadence::PartialDecodeCadence;
-use crate::{NativeAsrSession, RealtimeAudioFrame, TranscriptUpdate, Transcription};
+use crate::{
+    NativeAsrSession, RealtimeAudioFrame, StreamingPartialGranularity, TranscriptUpdate,
+    Transcription,
+};
 
 // Whisper-Streaming best practice: a PARTIAL re-decodes the whole current segment
 // with full context, not a tiny sliding window — a small window loses context and
@@ -150,6 +153,11 @@ pub(crate) const STREAMING_PARTIAL_TUNING_FAST_SNAPSHOT: StreamingPartialTuning 
 pub(crate) const STREAMING_PARTIAL_TUNING_HEAVY_SNAPSHOT: StreamingPartialTuning =
     StreamingPartialTuning::new(300, 500, None);
 
+/// Short trailing silence appended only to [`StreamingPartialGranularity::UtteranceComplete`]
+/// PARTIAL windows so ChatML utterance LLMs treat the current speech as complete
+/// enough to emit text. Never applied to FINAL or FinalizeReuse.
+pub(crate) const UTTERANCE_COMPLETE_PARTIAL_ENDPOINT_SILENCE_MS: u64 = 400;
+
 /// Build the streaming driver for a runtime family's `start_streaming_session`.
 /// Each decode rebuilds [`GgmlAsrExecutionViewRequest`] from `request` plus the
 /// current audio and installs the request's thread-count override on the decode
@@ -193,8 +201,15 @@ where
     // the session request, not a thread-local): every per-frame request this
     // driver builds for the life of the session copies it in directly.
     let resolved_runtime = request.resolved_runtime;
+    let partial_granularity = crate::arch::streaming_partial_granularity_for_model_architecture(
+        request.selected_family.model_architecture,
+    );
+    let unstable_sink: std::sync::Arc<std::sync::Mutex<Vec<String>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let unstable_sink_for_request = std::sync::Arc::clone(&unstable_sink);
     let make_request = move |audio: &GgmlAsrPreparedAudioView<'static>,
-                             partial_prompt: Option<&str>|
+                             partial_prompt: Option<&str>,
+                             emit_unstable: bool|
           -> Result<
         GgmlAsrExecutionViewRequest<'static>,
         GgmlAsrExecutionError,
@@ -246,16 +261,33 @@ where
             // transcription id and no cancel/pause control surface today --
             // an uncancellable context is a real, well-formed context that
             // simply has no other holder, not an omitted one.
-            execution_context: std::sync::Arc::new(crate::RequestExecutionContext::uncancellable(
-                "per-frame streaming decode: this request type carries no \
-                 execution-context field of its own yet, and a live session ends by \
-                 the caller dropping it rather than canceling a transcription id",
-            )),
+            execution_context: {
+                let context = crate::RequestExecutionContext::uncancellable(
+                    "per-frame streaming decode: this request type carries no \
+                     execution-context field of its own yet, and a live session ends by \
+                     the caller dropping it rather than canceling a transcription id",
+                );
+                let context = if emit_unstable {
+                    let sink = std::sync::Arc::clone(&unstable_sink_for_request);
+                    context.with_unstable_decode_text_observer(
+                        crate::api::backend::UnstableDecodeTextObserver::new(move |text: &str| {
+                            sink.lock()
+                                .expect("unstable decode text sink")
+                                .push(text.to_string());
+                        }),
+                    )
+                } else {
+                    context
+                };
+                std::sync::Arc::new(context)
+            },
         })
     };
 
     let transcribe = Box::new(
-        move |audio: &GgmlAsrPreparedAudioView<'static>, partial_prompt: Option<&str>| {
+        move |audio: &GgmlAsrPreparedAudioView<'static>,
+              partial_prompt: Option<&str>,
+              kind: StreamingDecodeKind| {
             let _execution_scope =
                 crate::models::native_execution_services::install_native_execution_services(
                     decode_execution_services.as_ref(),
@@ -271,8 +303,31 @@ where
             // carried on `make_request`'s `resolved_runtime` field above).
             let _backend_override =
                 install_request_backend_override(backend_preference.request_backend_override());
-            decode(&executor, &make_request(audio, partial_prompt)?)
-                .map(|result| result.transcription)
+            let emit_unstable = kind == StreamingDecodeKind::Partial;
+            if emit_unstable {
+                unstable_sink
+                    .lock()
+                    .expect("unstable decode text sink")
+                    .clear();
+            }
+            let transcription = decode(
+                &executor,
+                &make_request(audio, partial_prompt, emit_unstable)?,
+            )
+            .map(|result| result.transcription)?;
+            let unstable_texts = if emit_unstable {
+                unstable_sink
+                    .lock()
+                    .expect("unstable decode text sink")
+                    .drain(..)
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            Ok(StreamingDecodeOutput {
+                transcription,
+                unstable_texts,
+            })
         },
     );
     let mut driver = IncrementalStreamingTranscriptDriver::new(
@@ -287,7 +342,8 @@ where
     .with_partial_cadence(partial_floor_ms)
     .with_first_partial_audio_ms(u64::from(tuning.first_partial_audio_ms))
     .with_partial_window_ms(tuning.window_ms)
-    .with_partial_prompt_tail_words(tuning.partial_prompt_tail_words());
+    .with_partial_prompt_tail_words(tuning.partial_prompt_tail_words())
+    .with_partial_granularity(partial_granularity);
     if let Some(minimum_encodable_samples) = tuning.minimum_encodable_samples() {
         driver = driver.with_minimum_encodable_samples(minimum_encodable_samples);
     }
@@ -336,10 +392,23 @@ where
 /// Decode the accumulated audio for a streaming partial/final. Family-specific
 /// streaming decode keeps live-session semantics such as serve-batch bypass, while
 /// the returned FINAL remains byte-identical to offline `execute()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StreamingDecodeKind {
+    Partial,
+    Final,
+    WarmUp,
+}
+
+pub(crate) struct StreamingDecodeOutput {
+    transcription: Transcription,
+    unstable_texts: Vec<String>,
+}
+
 type StreamingTranscriber = dyn FnMut(
         &GgmlAsrPreparedAudioView<'static>,
         Option<&str>,
-    ) -> Result<Transcription, GgmlAsrExecutionError>
+        StreamingDecodeKind,
+    ) -> Result<StreamingDecodeOutput, GgmlAsrExecutionError>
     + Send;
 
 /// Whether a character is sentence-terminal (Chinese or ASCII), used to cut a
@@ -393,6 +462,16 @@ fn merge_partial_prompt(base_prompt: Option<&str>, partial_prompt: Option<&str>)
         return Some(partial.to_string());
     };
     Some(format!("{base}\n{partial}"))
+}
+
+fn audio_with_endpoint_silence(
+    audio: &GgmlAsrPreparedAudioView<'static>,
+    silence_ms: u64,
+) -> GgmlAsrPreparedAudioView<'static> {
+    let extra = (silence_ms as usize).saturating_mul(SAMPLES_PER_MS_16KHZ);
+    let mut samples = audio.samples_f32.to_vec();
+    samples.resize(samples.len().saturating_add(extra), 0.0);
+    GgmlAsrPreparedAudioView::mono_16khz(samples)
 }
 
 /// A PARTIAL decode that covered the WHOLE current buffer, kept so a terminal
@@ -451,6 +530,10 @@ pub(crate) struct IncrementalStreamingTranscriptDriver {
     /// Cached whole-buffer PARTIAL decode reused by an unchanged terminal
     /// finalize (see [`FinalizeReuse`]).
     finalize_reuse: Option<FinalizeReuse>,
+    /// How this family's incomplete windows produce partials. Drives the
+    /// utterance-complete endpoint-silence hint; FINAL never consults it for
+    /// audio contents.
+    partial_granularity: StreamingPartialGranularity,
     /// Instrumentation: terminal finalizes served from the reuse cache vs a full
     /// re-decode. Read by the driver's tests; the fast/slow accounting is not
     /// consumed in production builds.
@@ -492,6 +575,7 @@ impl IncrementalStreamingTranscriptDriver {
             partial_prompt_tail_words: None,
             minimum_encodable_samples: None,
             finalize_reuse: None,
+            partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             finalize_reuse_hits: 0,
             finalize_reuse_misses: 0,
         };
@@ -536,6 +620,14 @@ impl IncrementalStreamingTranscriptDriver {
         self
     }
 
+    pub(crate) fn with_partial_granularity(
+        mut self,
+        partial_granularity: StreamingPartialGranularity,
+    ) -> Self {
+        self.partial_granularity = partial_granularity;
+        self
+    }
+
     /// Whether the current buffer has fewer samples than the family's encoder
     /// can turn into output (a no-op / `None` floor never blocks a decode).
     fn buffer_below_minimum_encodable_samples(&self) -> bool {
@@ -568,7 +660,7 @@ impl IncrementalStreamingTranscriptDriver {
         prompt: Option<&str>,
     ) -> Result<Transcription, GgmlAsrExecutionError> {
         let audio = self.buffer.prepared_audio_snapshot();
-        (self.transcribe)(&audio, prompt)
+        Ok((self.transcribe)(&audio, prompt, StreamingDecodeKind::Final)?.transcription)
     }
 
     fn decode_warm_up_silence(&mut self) -> Result<(), GgmlAsrExecutionError> {
@@ -577,7 +669,7 @@ impl IncrementalStreamingTranscriptDriver {
             STREAMING_WARM_UP_AUDIO_MS
                 * SAMPLES_PER_MS_16KHZ
         ]);
-        let _ = (self.transcribe)(&audio, None)?;
+        let _ = (self.transcribe)(&audio, None, StreamingDecodeKind::WarmUp)?;
         Ok(())
     }
 
@@ -699,8 +791,21 @@ impl IncrementalStreamingTranscriptDriver {
             .min(audio_end_ms);
         let window_dur_ms = audio_end_ms.saturating_sub(window_start_ms).max(1);
         let audio = self.buffer.prepared_audio_window(window_dur_ms);
+        let used_endpoint_hint = self.partial_granularity.allows_partial_endpoint_hint();
+        let audio = if used_endpoint_hint {
+            audio_with_endpoint_silence(&audio, UTTERANCE_COMPLETE_PARTIAL_ENDPOINT_SILENCE_MS)
+        } else {
+            audio
+        };
         let prompt = self.partial_prompt_tail();
-        let transcription = (self.transcribe)(&audio, prompt.as_deref())?;
+        let output = (self.transcribe)(&audio, prompt.as_deref(), StreamingDecodeKind::Partial)?;
+        let transcription = output.transcription;
+        let mut emitted: Vec<GgmlAsrStreamingTranscriptUpdate> = Vec::new();
+        for text in &output.unstable_texts {
+            if let Some(update) = self.emit_update(text, false) {
+                emitted.push(update);
+            }
+        }
 
         // If this decode spanned the WHOLE buffer (the window reached sample 0),
         // its prepared audio is byte-identical to `prepared_audio_snapshot`, so a
@@ -708,8 +813,11 @@ impl IncrementalStreamingTranscriptDriver {
         // decode instead of re-running it. Any later drain in this same call, or
         // any new audio before finalize, changes the coverage and invalidates the
         // reuse (the match in `finish_updates` fails and it re-decodes).
-        let spans_whole_buffer = window_dur_ms.saturating_mul(SAMPLES_PER_MS_16KHZ as u64)
-            >= self.buffer.sample_count() as u64;
+        // Endpoint-silence padding must never enter FinalizeReuse: FINAL has to
+        // see the real unpadded samples.
+        let spans_whole_buffer = !used_endpoint_hint
+            && window_dur_ms.saturating_mul(SAMPLES_PER_MS_16KHZ as u64)
+                >= self.buffer.sample_count() as u64;
         self.finalize_reuse = spans_whole_buffer.then(|| FinalizeReuse {
             start_ms: self.buffer.start_ms(),
             end_ms: self.buffer.end_ms(),
@@ -731,7 +839,6 @@ impl IncrementalStreamingTranscriptDriver {
         );
         let chars: Vec<char> = decoded.chars().collect();
         let total = chars.len();
-        let mut emitted: Vec<GgmlAsrStreamingTranscriptUpdate> = Vec::new();
         if total == 0 {
             return Ok(emitted);
         }
@@ -996,6 +1103,25 @@ mod tests {
         }
     }
 
+    fn decode_ok(
+        transcription: Transcription,
+    ) -> Result<StreamingDecodeOutput, GgmlAsrExecutionError> {
+        Ok(StreamingDecodeOutput {
+            transcription,
+            unstable_texts: Vec::new(),
+        })
+    }
+
+    fn decode_with_unstables(
+        transcription: Transcription,
+        unstable_texts: Vec<String>,
+    ) -> Result<StreamingDecodeOutput, GgmlAsrExecutionError> {
+        Ok(StreamingDecodeOutput {
+            transcription,
+            unstable_texts,
+        })
+    }
+
     /// Build a driver whose streaming decode returns scripted text per tick.
     fn driver(script: VecDeque<&'static str>) -> IncrementalStreamingTranscriptDriver {
         let mut script = script;
@@ -1005,10 +1131,10 @@ mod tests {
             "utt_tok",
             "seg_tok",
             10,
-            Box::new(move |audio, _prompt| {
+            Box::new(move |audio, _prompt, _kind| {
                 assert!(!audio.samples_f32.is_empty());
                 let text = script.pop_front().unwrap_or("");
-                Ok(transcription(text))
+                decode_ok(transcription(text))
             }),
         )
     }
@@ -1032,13 +1158,13 @@ mod tests {
             "utt_warm",
             "seg_warm",
             1,
-            Box::new(move |audio, _prompt| {
+            Box::new(move |audio, _prompt, _kind| {
                 calls_for_decode.fetch_add(1, Ordering::SeqCst);
                 lengths_for_decode
                     .lock()
                     .expect("sample length mutex poisoned")
                     .push(audio.samples_f32.len());
-                Ok(transcription("ignored warm text"))
+                decode_ok(transcription("ignored warm text"))
             }),
         );
 
@@ -1105,7 +1231,7 @@ mod tests {
             // still produces stable absolute word names (w0 w1 …) — exactly what a
             // real model would, giving a deterministic, reproducible decode to test
             // the proportional time-stability segmentation against.
-            Box::new(|audio, _prompt| Ok(windowed_transcription(audio))),
+            Box::new(|audio, _prompt, _kind| decode_ok(windowed_transcription(audio))),
         )
         .with_partial_window_ms(window_ms)
     }
@@ -1160,12 +1286,12 @@ mod tests {
             "utt_prompt",
             "seg_prompt",
             0,
-            Box::new(move |audio, prompt| {
+            Box::new(move |audio, prompt, _kind| {
                 prompts_for_decode
                     .lock()
                     .expect("prompt mutex poisoned")
                     .push(prompt.map(str::to_string));
-                Ok(windowed_transcription(audio))
+                decode_ok(windowed_transcription(audio))
             }),
         )
         .with_partial_window_ms(40)
@@ -1194,12 +1320,12 @@ mod tests {
             "utt_no_prompt",
             "seg_no_prompt",
             0,
-            Box::new(move |audio, prompt| {
+            Box::new(move |audio, prompt, _kind| {
                 prompts_for_decode
                     .lock()
                     .expect("prompt mutex poisoned")
                     .push(prompt.map(str::to_string));
-                Ok(windowed_transcription(audio))
+                decode_ok(windowed_transcription(audio))
             }),
         )
         .with_partial_window_ms(40);
@@ -1224,9 +1350,9 @@ mod tests {
             "utt_text_only",
             "seg_text_only",
             0,
-            Box::new(move |_audio, _prompt| {
+            Box::new(move |_audio, _prompt, _kind| {
                 let text = script.pop_front().unwrap_or("");
-                Ok(text_only_transcription(text))
+                decode_ok(text_only_transcription(text))
             }),
         )
         .with_partial_window_ms(2_000);
@@ -1322,13 +1448,13 @@ mod tests {
             "utt_trim_final",
             "seg_trim_final",
             0,
-            Box::new(move |_audio, _prompt| {
+            Box::new(move |_audio, _prompt, _kind| {
                 let text = texts_for_decode
                     .lock()
                     .expect("script mutex poisoned")
                     .pop_front()
                     .unwrap_or("");
-                Ok(text_only_transcription(text))
+                decode_ok(text_only_transcription(text))
             }),
         )
         .with_partial_window_ms(30_000);
@@ -1371,9 +1497,9 @@ mod tests {
             "utt_reuse",
             "seg_reuse",
             0,
-            Box::new(move |audio, _prompt| {
+            Box::new(move |audio, _prompt, _kind| {
                 calls.fetch_add(1, Ordering::SeqCst);
-                Ok(windowed_transcription(audio))
+                decode_ok(windowed_transcription(audio))
             }),
         )
         .with_partial_window_ms(window_ms)
@@ -1510,9 +1636,9 @@ mod tests {
             "utt_min_final",
             "seg_min_final",
             0,
-            Box::new(move |_audio, _prompt| {
+            Box::new(move |_audio, _prompt, _kind| {
                 calls_for_decode.fetch_add(1, Ordering::SeqCst);
-                Ok(transcription("should never be reached"))
+                decode_ok(transcription("should never be reached"))
             }),
         )
         .with_partial_results(false)
@@ -1774,5 +1900,126 @@ mod tests {
             observed_backend_during_decode(crate::GgmlAsrBackendPreference::Accelerated);
         assert_eq!(accel_override, Some(RequestBackendPreference::Accelerated));
         assert_ne!(accel_backend, GgmlCpuGraphBackend::Cpu);
+    }
+
+    #[test]
+    fn mid_decode_unstable_prefixes_emit_partials_before_the_complete_window_text() {
+        let mut driver = IncrementalStreamingTranscriptDriver::new(
+            "token-incremental-test-executor",
+            crate::QWEN3_ASR_GGML_ADAPTER_ID,
+            "utt_unstable",
+            "seg_unstable",
+            1,
+            Box::new(move |audio, _prompt, kind| {
+                assert_eq!(kind, StreamingDecodeKind::Partial);
+                assert!(!audio.samples_f32.is_empty());
+                decode_with_unstables(
+                    transcription("hello world"),
+                    vec!["hello".to_string(), "hello world".to_string()],
+                )
+            }),
+        );
+        driver.push_audio(frame(1, 0)).unwrap();
+        let updates = driver.poll_updates().unwrap();
+        let texts: Vec<_> = updates.iter().map(|update| text_of(update).0).collect();
+        assert_eq!(texts, vec!["hello", "hello world"]);
+        assert!(updates.iter().all(|update| !text_of(update).2));
+    }
+
+    #[test]
+    fn utterance_complete_endpoint_silence_is_partial_only_and_final_matches_unpadded_greedy() {
+        let kinds = Arc::new(Mutex::new(Vec::new()));
+        let lengths = Arc::new(Mutex::new(Vec::new()));
+        let kinds_for_decode = Arc::clone(&kinds);
+        let lengths_for_decode = Arc::clone(&lengths);
+        let mut driver = IncrementalStreamingTranscriptDriver::new(
+            "token-incremental-test-executor",
+            crate::QWEN3_ASR_GGML_ADAPTER_ID,
+            "utt_endpoint",
+            "seg_endpoint",
+            1,
+            Box::new(move |audio, _prompt, kind| {
+                kinds_for_decode.lock().expect("kind mutex").push(kind);
+                lengths_for_decode
+                    .lock()
+                    .expect("length mutex")
+                    .push(audio.samples_f32.len());
+                let text = match kind {
+                    StreamingDecodeKind::WarmUp => "",
+                    StreamingDecodeKind::Partial | StreamingDecodeKind::Final => "hello",
+                };
+                decode_ok(transcription(text))
+            }),
+        )
+        .with_partial_granularity(StreamingPartialGranularity::UtteranceComplete)
+        .with_partial_window_ms(30_000);
+
+        driver.push_audio(frame(1, 0)).unwrap();
+        let partial = driver.poll_updates().unwrap();
+        assert_eq!(text_of(&partial[0]), ("hello", 1, false));
+        let final_ = driver.finish_updates().unwrap();
+        assert_eq!(text_of(&final_[0]), ("hello", 2, true));
+        assert_eq!(driver.finalize_reuse_hits, 0);
+
+        let recorded_kinds = kinds.lock().expect("kind mutex").clone();
+        let recorded_lengths = lengths.lock().expect("length mutex").clone();
+        assert_eq!(
+            recorded_kinds,
+            vec![StreamingDecodeKind::Partial, StreamingDecodeKind::Final]
+        );
+        assert_eq!(recorded_lengths.len(), 2);
+        assert!(
+            recorded_lengths[0] > recorded_lengths[1],
+            "partial must carry endpoint silence the final does not: {recorded_lengths:?}"
+        );
+        assert_eq!(
+            recorded_lengths[0] - recorded_lengths[1],
+            (UTTERANCE_COMPLETE_PARTIAL_ENDPOINT_SILENCE_MS as usize) * SAMPLES_PER_MS_16KHZ
+        );
+    }
+
+    #[test]
+    fn empty_stripped_partial_does_not_swallow_a_later_non_empty_update() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_decode = Arc::clone(&calls);
+        let mut driver = IncrementalStreamingTranscriptDriver::new(
+            "token-incremental-test-executor",
+            crate::QWEN3_ASR_GGML_ADAPTER_ID,
+            "utt_sil",
+            "seg_sil",
+            1,
+            Box::new(move |audio, _prompt, kind| {
+                assert!(!audio.samples_f32.is_empty());
+                let text = match kind {
+                    StreamingDecodeKind::WarmUp => "",
+                    StreamingDecodeKind::Partial => {
+                        if calls_for_decode.fetch_add(1, Ordering::SeqCst) == 0 {
+                            ""
+                        } else {
+                            "hello"
+                        }
+                    }
+                    StreamingDecodeKind::Final => "hello",
+                };
+                decode_ok(transcription(text))
+            }),
+        );
+        driver.push_audio(frame(1, 0)).unwrap();
+        let first = driver.poll_updates().unwrap();
+        assert!(
+            first.is_empty(),
+            "stripped-empty incomplete window must not emit a successful empty partial: {first:?}"
+        );
+        let mut second = Vec::new();
+        for i in 2..=8 {
+            driver.push_audio(frame(i, (i - 1) * 20)).unwrap();
+            second = driver.poll_updates().unwrap();
+            if !second.is_empty() {
+                break;
+            }
+        }
+        assert_eq!(text_of(&second[0]), ("hello", 1, false));
+        let final_ = driver.finish_updates().unwrap();
+        assert_eq!(text_of(&final_[0]), ("hello", 2, true));
     }
 }

--- a/crates/openasr-core/src/models/incremental_streaming_driver.rs
+++ b/crates/openasr-core/src/models/incremental_streaming_driver.rs
@@ -204,12 +204,8 @@ where
     let partial_granularity = crate::arch::streaming_partial_granularity_for_model_architecture(
         request.selected_family.model_architecture,
     );
-    let unstable_sink: std::sync::Arc<std::sync::Mutex<Vec<String>>> =
-        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-    let unstable_sink_for_request = std::sync::Arc::clone(&unstable_sink);
     let make_request = move |audio: &GgmlAsrPreparedAudioView<'static>,
-                             partial_prompt: Option<&str>,
-                             emit_unstable: bool|
+                             partial_prompt: Option<&str>|
           -> Result<
         GgmlAsrExecutionViewRequest<'static>,
         GgmlAsrExecutionError,
@@ -262,24 +258,16 @@ where
             // an uncancellable context is a real, well-formed context that
             // simply has no other holder, not an omitted one.
             execution_context: {
-                let context = crate::RequestExecutionContext::uncancellable(
+                // Snapshot Poll is synchronous: the websocket only sees events after
+                // greedy returns. Installing a per-token observer here would collect
+                // one prefix per token and fan them out as transcript.partials, which
+                // trips Native ASR `max_queued_events` (64) and kills the live session.
+                // The completed window text below is the one overlay this driver emits.
+                std::sync::Arc::new(crate::RequestExecutionContext::uncancellable(
                     "per-frame streaming decode: this request type carries no \
                      execution-context field of its own yet, and a live session ends by \
                      the caller dropping it rather than canceling a transcription id",
-                );
-                let context = if emit_unstable {
-                    let sink = std::sync::Arc::clone(&unstable_sink_for_request);
-                    context.with_unstable_decode_text_observer(
-                        crate::api::backend::UnstableDecodeTextObserver::new(move |text: &str| {
-                            sink.lock()
-                                .expect("unstable decode text sink")
-                                .push(text.to_string());
-                        }),
-                    )
-                } else {
-                    context
-                };
-                std::sync::Arc::new(context)
+                ))
             },
         })
     };
@@ -287,7 +275,7 @@ where
     let transcribe = Box::new(
         move |audio: &GgmlAsrPreparedAudioView<'static>,
               partial_prompt: Option<&str>,
-              kind: StreamingDecodeKind| {
+              _kind: StreamingDecodeKind| {
             let _execution_scope =
                 crate::models::native_execution_services::install_native_execution_services(
                     decode_execution_services.as_ref(),
@@ -303,31 +291,9 @@ where
             // carried on `make_request`'s `resolved_runtime` field above).
             let _backend_override =
                 install_request_backend_override(backend_preference.request_backend_override());
-            let emit_unstable = kind == StreamingDecodeKind::Partial;
-            if emit_unstable {
-                unstable_sink
-                    .lock()
-                    .expect("unstable decode text sink")
-                    .clear();
-            }
-            let transcription = decode(
-                &executor,
-                &make_request(audio, partial_prompt, emit_unstable)?,
-            )
-            .map(|result| result.transcription)?;
-            let unstable_texts = if emit_unstable {
-                unstable_sink
-                    .lock()
-                    .expect("unstable decode text sink")
-                    .drain(..)
-                    .collect()
-            } else {
-                Vec::new()
-            };
-            Ok(StreamingDecodeOutput {
-                transcription,
-                unstable_texts,
-            })
+            let transcription = decode(&executor, &make_request(audio, partial_prompt)?)
+                .map(|result| result.transcription)?;
+            Ok(StreamingDecodeOutput { transcription })
         },
     );
     let mut driver = IncrementalStreamingTranscriptDriver::new(
@@ -401,7 +367,6 @@ pub(crate) enum StreamingDecodeKind {
 
 pub(crate) struct StreamingDecodeOutput {
     transcription: Transcription,
-    unstable_texts: Vec<String>,
 }
 
 type StreamingTranscriber = dyn FnMut(
@@ -801,11 +766,6 @@ impl IncrementalStreamingTranscriptDriver {
         let output = (self.transcribe)(&audio, prompt.as_deref(), StreamingDecodeKind::Partial)?;
         let transcription = output.transcription;
         let mut emitted: Vec<GgmlAsrStreamingTranscriptUpdate> = Vec::new();
-        for text in &output.unstable_texts {
-            if let Some(update) = self.emit_update(text, false) {
-                emitted.push(update);
-            }
-        }
 
         // If this decode spanned the WHOLE buffer (the window reached sample 0),
         // its prepared audio is byte-identical to `prepared_audio_snapshot`, so a
@@ -1052,8 +1012,8 @@ mod tests {
     use std::{
         collections::VecDeque,
         sync::{
-            Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
         },
     };
 
@@ -1106,20 +1066,7 @@ mod tests {
     fn decode_ok(
         transcription: Transcription,
     ) -> Result<StreamingDecodeOutput, GgmlAsrExecutionError> {
-        Ok(StreamingDecodeOutput {
-            transcription,
-            unstable_texts: Vec::new(),
-        })
-    }
-
-    fn decode_with_unstables(
-        transcription: Transcription,
-        unstable_texts: Vec<String>,
-    ) -> Result<StreamingDecodeOutput, GgmlAsrExecutionError> {
-        Ok(StreamingDecodeOutput {
-            transcription,
-            unstable_texts,
-        })
+        Ok(StreamingDecodeOutput { transcription })
     }
 
     /// Build a driver whose streaming decode returns scripted text per tick.
@@ -1413,8 +1360,8 @@ mod tests {
             _ => unreachable!("expected partial update"),
         };
         assert_ne!(second_id, first_id);
-        assert_eq!(second_id.0.0, "utt_win_000002");
-        assert_eq!(second_id.1.0, "seg_win_000002");
+        assert_eq!(second_id.0 .0, "utt_win_000002");
+        assert_eq!(second_id.1 .0, "seg_win_000002");
     }
 
     #[test]
@@ -1903,27 +1850,34 @@ mod tests {
     }
 
     #[test]
-    fn mid_decode_unstable_prefixes_emit_partials_before_the_complete_window_text() {
+    fn snapshot_poll_keeps_overlay_events_under_native_backpressure() {
+        // Native ASR sessions cap queued events at 64. A snapshot Poll that
+        // fanned out one transcript.partial per decoded token would kill a live
+        // FireRed/Qwen session mid-utterance. The overlay is one window text.
+        let window: String = (0..80).map(|index| format!("token{index} ")).collect();
+        let window_for_decode = window.clone();
         let mut driver = IncrementalStreamingTranscriptDriver::new(
             "token-incremental-test-executor",
             crate::QWEN3_ASR_GGML_ADAPTER_ID,
-            "utt_unstable",
-            "seg_unstable",
+            "utt_backpressure",
+            "seg_backpressure",
             1,
             Box::new(move |audio, _prompt, kind| {
                 assert_eq!(kind, StreamingDecodeKind::Partial);
                 assert!(!audio.samples_f32.is_empty());
-                decode_with_unstables(
-                    transcription("hello world"),
-                    vec!["hello".to_string(), "hello world".to_string()],
-                )
+                decode_ok(transcription(&window_for_decode))
             }),
         );
         driver.push_audio(frame(1, 0)).unwrap();
         let updates = driver.poll_updates().unwrap();
-        let texts: Vec<_> = updates.iter().map(|update| text_of(update).0).collect();
-        assert_eq!(texts, vec!["hello", "hello world"]);
-        assert!(updates.iter().all(|update| !text_of(update).2));
+        assert!(
+            updates.len() < 64,
+            "snapshot poll emitted {} events, which would trip max_queued_events",
+            updates.len()
+        );
+        assert_eq!(updates.len(), 1);
+        assert_eq!(text_of(&updates[0]).0, window.trim());
+        assert!(!text_of(&updates[0]).2);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/mimo_asr/executor.rs
+++ b/crates/openasr-core/src/models/mimo_asr/executor.rs
@@ -713,6 +713,10 @@ impl MimoAsrGgmlExecutor {
             .execution_context
             .decode_work_progress_observer()
             .cloned();
+        let unstable_decode_text = request
+            .execution_context
+            .unstable_decode_text_observer()
+            .cloned();
         let result = actor
             .call_mut(move |runtime| {
                 let result = Self::transcribe_with_prepared(
@@ -722,6 +726,7 @@ impl MimoAsrGgmlExecutor {
                     kv_capacity,
                     control,
                     decode_work_progress,
+                    unstable_decode_text,
                 );
                 runtime.decoder.release_session_scoped_buffers();
                 result
@@ -770,6 +775,7 @@ impl MimoAsrGgmlExecutor {
         kv_capacity: Qwen3AsrKvCacheCapacity,
         control: Arc<crate::api::backend::TranscriptionControl>,
         decode_work_progress: Option<crate::api::backend::WorkProgressObserver>,
+        unstable_decode_text: Option<crate::api::backend::UnstableDecodeTextObserver>,
     ) -> Result<Seq2SeqGreedyDecodeResult, MimoAsrExecutorError> {
         // The OpenASR pipeline delivers 16kHz mono to every executor, but
         // MiMo's audio tokenizer (and its baked mel filterbank/window) is
@@ -942,6 +948,7 @@ impl MimoAsrGgmlExecutor {
             map_registry_error,
             &control,
             decode_work_progress.as_ref(),
+            unstable_decode_text.as_ref(),
         )
         .map_err(|error| MimoAsrExecutorError::GreedyDecodeFailed {
             reason: error.to_string(),

--- a/crates/openasr-core/src/models/moonshine/decoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/decoder_graph.rs
@@ -93,6 +93,7 @@ pub(crate) fn run_moonshine_decoder_short_form_with_runtime(
     audio_duration_seconds: f32,
     control: &Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<MoonshineDecodeOutput, MoonshineDecoderGraphError> {
     runtime.populate_cross_attention_cache(encoder_output)?;
     let mut step_executor = MoonshineDecoderStepExecutor { runtime };
@@ -159,6 +160,7 @@ pub(crate) fn run_moonshine_decoder_short_form_with_runtime(
         },
         control,
         decode_work_progress,
+        unstable_decode_text,
     ) {
         Ok(output) => output,
         Err(Seq2SeqGreedyDecodeError::EotNotReachedBeforeMaxTokens {

--- a/crates/openasr-core/src/models/moonshine/ggml_executor.rs
+++ b/crates/openasr-core/src/models/moonshine/ggml_executor.rs
@@ -326,6 +326,10 @@ impl MoonshineGgmlExecutor {
                         .execution_context
                         .decode_work_progress_observer()
                         .cloned(),
+                    request
+                        .execution_context
+                        .unstable_decode_text_observer()
+                        .cloned(),
                 )?
             };
 
@@ -521,6 +525,7 @@ impl MoonshineGgmlExecutor {
         greedy_step_output_mode: DeviceGreedyStepOutputMode,
         control: Arc<crate::api::backend::TranscriptionControl>,
         decode_work_progress: Option<crate::api::backend::WorkProgressObserver>,
+        unstable_decode_text: Option<crate::api::backend::UnstableDecodeTextObserver>,
     ) -> Result<super::decoder_graph::MoonshineDecodeOutput, MoonshineGgmlExecutorError> {
         let tokenizer = prepared.tokenizer.clone();
         let metadata = prepared.metadata;
@@ -545,6 +550,7 @@ impl MoonshineGgmlExecutor {
                     audio_duration_seconds,
                     &control,
                     decode_work_progress.as_ref(),
+                    unstable_decode_text.as_ref(),
                 )
             })
             .map_err(|error| Self::map_actor_error("decoder", error))?

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -859,6 +859,7 @@ fn run_moss_td_decoder_with_runtime(
     tokenizer: MossTdTokenizer,
     control: Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<MossTdDecodeOutput, MossTdExecutorError> {
     if std::env::var_os("OPENASR_MOSS_TD_PROFILE").is_some() {
         eprintln!(
@@ -910,6 +911,7 @@ fn run_moss_td_decoder_with_runtime(
         map_registry_error,
         &control,
         decode_work_progress.as_ref(),
+        unstable_decode_text.as_ref(),
     );
     // Release this request's per-token grow-to-fit host buffer before the
     // runtime goes back into the cache -- unconditionally, on both success
@@ -961,6 +963,7 @@ fn run_moss_td_decoder_with_cached_runtime(
     tokenizer: MossTdTokenizer,
     control: Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<MossTdDecodeOutput, MossTdExecutorError> {
     let decode_prompt_token_ids = decode_prompt_token_ids.to_vec();
     let audio_pad_positions = audio_pad_positions.to_vec();
@@ -978,6 +981,7 @@ fn run_moss_td_decoder_with_cached_runtime(
                 tokenizer,
                 control,
                 decode_work_progress,
+                unstable_decode_text,
             )
         })
         .map_err(|error| MossTdExecutorError::RuntimeOwnershipFailed {
@@ -1528,6 +1532,10 @@ impl MossTdGgmlExecutor {
             .execution_context
             .decode_work_progress_observer()
             .cloned();
+        let unstable_decode_text = request
+            .execution_context
+            .unstable_decode_text_observer()
+            .cloned();
         let decoded = match unified_runtime.as_ref() {
             Some(actor) => {
                 let token_ids = decode_prompt.token_ids;
@@ -1545,6 +1553,7 @@ impl MossTdGgmlExecutor {
                             tokenizer,
                             control,
                             decode_work_progress,
+                            unstable_decode_text,
                         )
                     })
                     .map_err(|error| MossTdExecutorError::RuntimeOwnershipFailed {
@@ -1566,6 +1575,7 @@ impl MossTdGgmlExecutor {
                     tokenizer,
                     control,
                     decode_work_progress,
+                    unstable_decode_text,
                 )?
             }
         };

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -1144,6 +1144,10 @@ impl Qwen3AsrGgmlExecutor {
             .execution_context
             .decode_work_progress_observer()
             .cloned();
+        let unstable_decode_text_for_actor = request
+            .execution_context
+            .unstable_decode_text_observer()
+            .cloned();
         let fused_top1_hint_allowed = qwen_fused_top1_hint_allowed(
             request.request_options.word_timestamps,
             request
@@ -1195,6 +1199,7 @@ impl Qwen3AsrGgmlExecutor {
                     &decode_text_token_ids_for_actor,
                     &control_for_actor,
                     decode_work_progress_for_actor.as_ref(),
+                    unstable_decode_text_for_actor.as_ref(),
                 );
                 // A failed compute may poison the reusable graph. Always
                 // release session-scoped buffers before the actor goes idle.

--- a/crates/openasr-core/src/models/qwen/greedy_decode.rs
+++ b/crates/openasr-core/src/models/qwen/greedy_decode.rs
@@ -75,6 +75,7 @@ pub(crate) fn run_qwen3_greedy_decode_loop(
     decode_text_token_ids: &dyn Fn(&[u32]) -> Result<String, Qwen3AsrGreedyDecodeError>,
     control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<Qwen3AsrGreedyDecodeResult, Qwen3AsrGreedyDecodeError> {
     let output = run_builtin_seq2seq_decode_policy(
         crate::QWEN3_ASR_DECODE_POLICY_ID,
@@ -88,6 +89,7 @@ pub(crate) fn run_qwen3_greedy_decode_loop(
         map_registry_error,
         control,
         decode_work_progress,
+        unstable_decode_text,
     )?;
     Ok(Qwen3AsrGreedyDecodeResult {
         generated_tokens: output.generated_tokens,
@@ -306,6 +308,7 @@ mod tests {
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap();
 
@@ -351,6 +354,7 @@ mod tests {
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap();
 
@@ -390,6 +394,7 @@ mod tests {
             &mut step_executor,
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .expect_err("no EOT should fail closed");
@@ -441,6 +446,7 @@ mod tests {
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .expect("stop-token decode succeeds");
         assert_eq!(
@@ -471,6 +477,7 @@ mod tests {
             &mut looping_executor,
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .expect("guard-stopped decode still returns the kept prefix");

--- a/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
+++ b/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
-use crate::api::backend::WorkProgressObserver;
 use crate::api::backend::{DecodeTruncation, DecodeTruncationReason};
+use crate::api::backend::{UnstableDecodeTextObserver, WorkProgressObserver};
 use crate::models::phrase_bias_decode::{TokenPhraseBias, apply_phrase_bias_to_logits};
 
 /// Largest token n-gram the degenerate-loop guard inspects (token ids, not
@@ -234,6 +234,7 @@ pub(crate) fn run_seq2seq_greedy_decode_loop_with_adapter_v0<E>(
     on_topk: &mut dyn FnMut(usize, &[f32]),
     control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&WorkProgressObserver>,
+    unstable_decode_text: Option<&UnstableDecodeTextObserver>,
 ) -> Result<Seq2SeqGreedyDecodeResult, E> {
     struct ClosureTokenDecoder<'a, E> {
         decode_text_token_ids: &'a dyn Fn(&[u32]) -> Result<String, E>,
@@ -253,6 +254,27 @@ pub(crate) fn run_seq2seq_greedy_decode_loop_with_adapter_v0<E>(
         decode_text_token_ids,
         map_family_error_to_shared: map_token_decoder_error_to_shared,
     };
+    let mut last_unstable = String::new();
+    let mut on_generated_tokens = |tokens: &[u32]| {
+        let Some(observer) = unstable_decode_text else {
+            return;
+        };
+        let Ok(raw) = (decode_text_token_ids)(tokens) else {
+            return;
+        };
+        let text = normalize_text(raw);
+        let trimmed = text.trim();
+        if trimmed.is_empty() || trimmed == last_unstable {
+            return;
+        }
+        last_unstable.clear();
+        last_unstable.push_str(trimmed);
+        observer.report(&last_unstable);
+    };
+    let mut on_generated_tokens_ref: Option<&mut dyn FnMut(&[u32])> = None;
+    if unstable_decode_text.is_some() {
+        on_generated_tokens_ref = Some(&mut on_generated_tokens);
+    }
     let output = run_seq2seq_greedy_decode_loop_v0(
         config,
         step_executor,
@@ -261,6 +283,7 @@ pub(crate) fn run_seq2seq_greedy_decode_loop_with_adapter_v0<E>(
         on_topk,
         control,
         decode_work_progress,
+        on_generated_tokens_ref,
     )
     .map_err(map_shared_error_to_family)?;
     Ok(Seq2SeqGreedyDecodeResult {
@@ -290,6 +313,7 @@ pub(crate) fn run_seq2seq_greedy_decode_loop_v0(
     on_topk: &mut dyn FnMut(usize, &[f32]),
     control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&WorkProgressObserver>,
+    mut on_generated_tokens: Option<&mut dyn FnMut(&[u32])>,
 ) -> Result<Seq2SeqGreedyDecodeResult, Seq2SeqGreedyDecodeError> {
     if config.initial_prompt_tokens.is_empty() {
         return Err(Seq2SeqGreedyDecodeError::EmptyInitialPrompt);
@@ -339,6 +363,9 @@ pub(crate) fn run_seq2seq_greedy_decode_loop_v0(
         }
         generated.push(selection.token_id);
         generated_probabilities.push(selection.probability);
+        if let Some(hook) = on_generated_tokens.as_mut() {
+            hook(&generated);
+        }
 
         // Degenerate greedy loops (the same short phrase emitted back to back
         // forever - "gugugu", or a phrase repeated 5+ times) are not honest
@@ -360,6 +387,9 @@ pub(crate) fn run_seq2seq_greedy_decode_loop_v0(
             );
             generated.truncate(loop_hit.keep_len);
             generated_probabilities.truncate(loop_hit.keep_len);
+            if let Some(hook) = on_generated_tokens.as_mut() {
+                hook(&generated);
+            }
             // Reported as its own stop reason, never as a stop token: the
             // decode ends here, but the audio past the loop was never
             // transcribed and callers must be able to see that.
@@ -700,6 +730,7 @@ mod tests {
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap();
 
@@ -761,6 +792,7 @@ mod tests {
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap_err();
 
@@ -817,6 +849,7 @@ mod tests {
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap();
 
@@ -857,6 +890,7 @@ mod tests {
             &mut no_token_trace,
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .unwrap();
@@ -905,6 +939,7 @@ mod tests {
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             Some(&observer),
+            None,
         )
         .unwrap();
 
@@ -1192,6 +1227,7 @@ mod tests {
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap_err();
 
@@ -1256,6 +1292,7 @@ mod tests {
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap();
 
@@ -1313,6 +1350,7 @@ mod tests {
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap();
 
@@ -1364,6 +1402,7 @@ mod tests {
             &mut no_token_trace,
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .unwrap();
@@ -1636,6 +1675,7 @@ mod tests {
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .expect("guard should finish the decode, not error out");
 
@@ -1752,6 +1792,7 @@ mod tests {
                 &mut no_topk_trace,
                 &worker_control,
                 None,
+                None,
             );
             (result, step_executor.logits_calls)
         });
@@ -1823,9 +1864,129 @@ mod tests {
             &mut no_topk_trace,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .expect("no-control path stays successful");
         assert_eq!(output.text, "hello");
         assert_eq!(step_executor.logits_calls, 3);
+    }
+
+    #[test]
+    fn greedy_loop_reports_postprocessed_unstable_prefixes_before_eot() {
+        let mut step_executor = SyntheticStepExecutor {
+            vocab_size: 16,
+            sequence: vec![1, 2, 7],
+            logits_calls: 0,
+        };
+        let token_decoder_table = BTreeMap::from([(1_u32, "/sil"), (2_u32, " hello")]);
+        let decode_text_token_ids = move |token_ids: &[u32]| {
+            let mut out = String::new();
+            for token_id in token_ids {
+                out.push_str(token_decoder_table.get(token_id).copied().unwrap_or("?"));
+            }
+            Ok::<String, Seq2SeqGreedyDecodeError>(out)
+        };
+        let config = Seq2SeqGreedyDecodeConfig {
+            initial_prompt_tokens: vec![42],
+            eot_token_id: 7,
+            stop_token_ids: Vec::new(),
+            vocab_size: 16,
+            max_generated_tokens: 8,
+            suppress_first_step_token_ids: Vec::new(),
+            suppress_token_ids: Vec::new(),
+            phrase_biases: Vec::new(),
+        };
+        let mut no_token_trace = |_: usize, _: u32, _: bool| {};
+        let mut no_topk_trace = |_: usize, _: &[f32]| {};
+        let observed = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let observed_for_observer = std::sync::Arc::clone(&observed);
+        let observer = UnstableDecodeTextObserver::new(move |text: &str| {
+            observed_for_observer
+                .lock()
+                .expect("unstable observations")
+                .push(text.to_string());
+        });
+
+        let output = run_seq2seq_greedy_decode_loop_with_adapter_v0(
+            &config,
+            &mut step_executor,
+            &decode_text_token_ids,
+            |error| error,
+            |error| error,
+            &|text| {
+                crate::models::decode_policy_component_registry::apply_seq2seq_text_postprocess(
+                    crate::models::decode_policy_component_registry::BuiltinDecodePolicySeq2SeqTextPostprocessKind::FunAsrNanoStripControlMarkersV0,
+                    &text,
+                )
+            },
+            &mut no_token_trace,
+            &mut no_topk_trace,
+            &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
+            Some(&observer),
+        )
+        .unwrap();
+
+        assert_eq!(output.text, "hello");
+        assert_eq!(
+            *observed.lock().expect("unstable observations"),
+            vec!["hello".to_string()]
+        );
+    }
+
+    #[test]
+    fn greedy_loop_emits_each_new_displayable_prefix_before_the_final_text() {
+        let mut step_executor = SyntheticStepExecutor {
+            vocab_size: 16,
+            sequence: vec![1, 2, 7],
+            logits_calls: 0,
+        };
+        let token_decoder = SyntheticTokenDecoder {
+            table: BTreeMap::from([(1, "he"), (2, "llo")]),
+        };
+        let config = Seq2SeqGreedyDecodeConfig {
+            initial_prompt_tokens: vec![42],
+            eot_token_id: 7,
+            stop_token_ids: Vec::new(),
+            vocab_size: 16,
+            max_generated_tokens: 8,
+            suppress_first_step_token_ids: Vec::new(),
+            suppress_token_ids: Vec::new(),
+            phrase_biases: Vec::new(),
+        };
+        let mut no_token_trace = |_: usize, _: u32, _: bool| {};
+        let mut no_topk_trace = |_: usize, _: &[f32]| {};
+        let observed = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let observed_for_observer = std::sync::Arc::clone(&observed);
+        let observer = UnstableDecodeTextObserver::new(move |text: &str| {
+            observed_for_observer
+                .lock()
+                .expect("unstable observations")
+                .push(text.to_string());
+        });
+        let decode_text_token_ids =
+            |token_ids: &[u32]| token_decoder.decode_text_token_ids(token_ids);
+
+        let output = run_seq2seq_greedy_decode_loop_with_adapter_v0(
+            &config,
+            &mut step_executor,
+            &decode_text_token_ids,
+            |error| error,
+            |error| error,
+            &|text| text,
+            &mut no_token_trace,
+            &mut no_topk_trace,
+            &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
+            Some(&observer),
+        )
+        .unwrap();
+
+        assert_eq!(output.generated_tokens, vec![1, 2]);
+        assert_eq!(output.text, "hello");
+        assert_eq!(
+            *observed.lock().expect("unstable observations"),
+            vec!["he".to_string(), "hello".to_string()]
+        );
     }
 }

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -810,6 +810,7 @@ struct WhisperDecoderActorJob {
     loaded_f16_weight_mode: WhisperGpuLoadedF16WeightMode,
     control: Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<crate::api::backend::UnstableDecodeTextObserver>,
     expected_loaded_weight_binding: Option<GgmlLoadedWeightBindingIdentity>,
 }
 
@@ -947,6 +948,7 @@ impl WhisperDecoderActorJob {
                 &self.trace,
                 &self.control,
                 self.decode_work_progress.as_ref(),
+                self.unstable_decode_text.as_ref(),
             )
         })();
         if !self.allow_persistent_session_reuse {
@@ -4935,6 +4937,7 @@ fn execute_whisper_with_prepared_runtime(
             loaded_f16_weight_mode: gpu_loaded_f16_weight_mode,
             control: Arc::clone(&execution_context.control),
             decode_work_progress: execution_context.decode_work_progress_observer().cloned(),
+            unstable_decode_text: execution_context.unstable_decode_text_observer().cloned(),
             expected_loaded_weight_binding: None,
         };
         return unified_actor
@@ -5001,6 +5004,7 @@ fn execute_whisper_with_prepared_runtime(
         loaded_f16_weight_mode: gpu_loaded_f16_weight_mode,
         control: Arc::clone(&execution_context.control),
         decode_work_progress: execution_context.decode_work_progress_observer().cloned(),
+        unstable_decode_text: execution_context.unstable_decode_text_observer().cloned(),
         expected_loaded_weight_binding: None,
     };
     let run_encoder = || {
@@ -6157,6 +6161,7 @@ fn run_whisper_decode_loop(
     trace: &WhisperGgmlTrace,
     control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<WhisperExecutionOutput, WhisperGgmlExecutorError> {
     let prelude_summary = match prelude_result {
         WhisperEncoderPreludeSeamResult::GraphExecuted {
@@ -6368,6 +6373,7 @@ fn run_whisper_decode_loop(
         &decode_text_token_ids,
         control,
         decode_work_progress,
+        unstable_decode_text,
     ) {
         Ok(decode) => {
             decode_loop_span.finish_with_extra(

--- a/crates/openasr-core/src/models/whisper/greedy_decode.rs
+++ b/crates/openasr-core/src/models/whisper/greedy_decode.rs
@@ -77,6 +77,7 @@ pub(crate) fn run_whisper_greedy_decode_loop(
     decode_text_token_ids: &dyn Fn(&[u32]) -> Result<String, WhisperGreedyDecodeError>,
     control: &std::sync::Arc<crate::api::backend::TranscriptionControl>,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    unstable_decode_text: Option<&crate::api::backend::UnstableDecodeTextObserver>,
 ) -> Result<WhisperGreedyDecodeResult, WhisperGreedyDecodeError> {
     let shared = run_builtin_seq2seq_decode_policy(
         crate::WHISPER_DECODE_POLICY_ID,
@@ -90,6 +91,7 @@ pub(crate) fn run_whisper_greedy_decode_loop(
         map_registry_error,
         control,
         decode_work_progress,
+        unstable_decode_text,
     )?;
     Ok(WhisperGreedyDecodeResult {
         generated_tokens: shared.generated_tokens,
@@ -323,6 +325,7 @@ mod tests {
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .unwrap();
 
@@ -367,6 +370,7 @@ mod tests {
             &mut step_executor,
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .expect_err("no EOT should fail closed");
@@ -440,6 +444,7 @@ mod tests {
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
             None,
+            None,
         )
         .expect("stop-token decode succeeds");
         assert_eq!(
@@ -471,6 +476,7 @@ mod tests {
             &mut looping_executor,
             &decode_text_token_ids,
             &std::sync::Arc::new(crate::api::backend::TranscriptionControl::new()),
+            None,
             None,
         )
         .expect("guard-stopped decode still returns the kept prefix");

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -21,9 +21,12 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   streaming executor gets live partials, and every built-in ASR family
   (Qwen3-ASR, Whisper, Cohere Transcribe, Moonshine, Parakeet-CTC, wav2vec2-CTC,
   SenseVoice, Dolphin, and X-ASR) registers one -- a startup completeness gate
-  rejects any family that does not. X-ASR is frame-sync (append-only partials);
-  every other family re-decodes a growing window (may revise partials, FINAL is
-  byte-identical to offline). Official published packs with public product
+  rejects any family that does not. X-ASR is frame-sync-append (append-only
+  partials); ChatML utterance LLMs (FunASR-Nano, FireRed-LLM, MiMo-ASR, MOSS)
+  are utterance-complete snapshots (incomplete windows may be empty; partials
+  may use a short endpoint-silence hint); every other family is a revisable
+  snapshot (incomplete windows should produce text, FINAL is byte-identical to
+  offline). Official published packs with public product
   guarantees are still pending.
 - Universal Voice ID is currently a local **file-transcription** feature. MOSS
   supplies its own speaker turns; all other ASR families use FireRed Stream-VAD,

--- a/docs/MODEL_ONBOARDING.md
+++ b/docs/MODEL_ONBOARDING.md
@@ -180,21 +180,26 @@ Live captions / dictation cadence is **descriptor-driven**, not something you
 tune per family and not something the `.oasr` pack declares. There is no pack
 metadata streaming flag and there is no third "buffered file-per-utterance"
 realtime mode to wire up — that old path was removed. A realtime session can only
-land on one of two shared mechanisms:
+land on one of the shared mechanisms declared by `StreamingPartialGranularity`:
 
-- **Incremental re-decode** (the default for every non-frame-sync family): the
+- **Revisable snapshot** (the default for encoder-decoder / CTC families): the
   shared driver re-decodes a growing/windowed buffer on an adaptive cadence, so
   partials appear *while the user is still speaking* and the FINAL is
-  byte-identical to offline `execute()`. Implement
-  `GgmlAsrStreamingExecutor` for your executor — reuse
-  `build_seq2seq_streaming_session` (offline re-decode; works for CTC/attention
-  and seq2seq alike) or `build_ctc_streaming_driver` (when you have a cheap
-  CTC-greedy partial surface) — and declare
-  `StreamingPartialGranularity::Buffered` in the execution facet. The shared
-  inventory projection wires it into the dispatch.
-- **Frame-sync** (append-only, never revises emitted text): only for genuinely
-  frame-synchronous architectures like X-ASR. Declare
-  `StreamingPartialGranularity::FrameSync` in the same facet.
+  byte-identical to offline `execute()`. Incomplete windows are expected to
+  produce displayable text. Implement `GgmlAsrStreamingExecutor` for your
+  executor — reuse `build_seq2seq_streaming_session` (offline re-decode; works
+  for CTC/attention and seq2seq alike) or `build_ctc_streaming_driver` (when you
+  have a cheap CTC-greedy partial surface) — and declare
+  `StreamingPartialGranularity::RevisableSnapshot` in the execution facet. The
+  shared inventory projection wires it into the dispatch.
+- **Utterance-complete snapshot** (ChatML utterance LLMs such as FunASR-Nano):
+  incomplete windows may legally decode empty. Declare
+  `StreamingPartialGranularity::UtteranceComplete` in the same facet. The shared
+  driver may pad a short silence tail onto PARTIAL windows only; FINAL still
+  uses the real unpadded audio.
+- **Frame-sync append** (append-only, never revises emitted text): only for
+  genuinely frame-synchronous architectures like X-ASR. Declare
+  `StreamingPartialGranularity::FrameSyncAppend` in the same facet.
 
 If the descriptor factory returns an executor without a valid streaming path, the startup
 completeness gate in `build_builtin_ggml_streaming_execution_dispatch` **fails

--- a/tooling/model-family-inventory.v1.json
+++ b/tooling/model-family-inventory.v1.json
@@ -93,7 +93,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": true,
         "supports_phrase_bias": true,
@@ -224,7 +224,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": false,
         "supports_phrase_bias": true,
@@ -346,7 +346,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": false,
         "supports_phrase_bias": false,
@@ -470,7 +470,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "utterance-complete",
         "speaker_segmentation": "external",
         "emits_punctuation": null,
         "supports_phrase_bias": false,
@@ -593,7 +593,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "utterance-complete",
         "speaker_segmentation": "external",
         "emits_punctuation": null,
         "supports_phrase_bias": false,
@@ -729,7 +729,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": true,
         "supports_phrase_bias": true,
@@ -876,7 +876,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "utterance-complete",
         "speaker_segmentation": "external",
         "emits_punctuation": null,
         "supports_phrase_bias": false,
@@ -989,7 +989,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": true,
         "supports_phrase_bias": true,
@@ -1120,7 +1120,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "utterance-complete",
         "speaker_segmentation": "in-decoder",
         "emits_punctuation": null,
         "supports_phrase_bias": false,
@@ -1230,7 +1230,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": null,
         "supports_phrase_bias": true,
@@ -1370,7 +1370,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": true,
         "supports_phrase_bias": false,
@@ -1516,7 +1516,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": true,
         "supports_phrase_bias": true,
@@ -1628,7 +1628,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": true,
         "supports_phrase_bias": true,
@@ -1736,7 +1736,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": null,
         "supports_phrase_bias": true,
@@ -1941,7 +1941,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "buffered",
+        "streaming_partial_granularity": "revisable-snapshot",
         "speaker_segmentation": "external",
         "emits_punctuation": true,
         "supports_phrase_bias": true,
@@ -2056,7 +2056,7 @@
             }
           ]
         },
-        "streaming_partial_granularity": "frame-sync",
+        "streaming_partial_granularity": "frame-sync-append",
         "speaker_segmentation": "external",
         "emits_punctuation": true,
         "supports_phrase_bias": false,


### PR DESCRIPTION
## Summary

Live snapshot families emit revisable partials before VAD endpoint, without fanning one websocket event per decoded token.

## Why

FunASR stayed silent until pause. FireRed live sessions died when a Poll outgrew the resident encoder envelope (`encoder shape overflowed`) or when per-token prefixes filled `max_queued_events`.

## Changes

- Shared incremental driver emits the current window overlay on each Poll and drops empty text.
- Snapshot Poll no longer installs a per-token prefix observer (that path trips the 64-event cap).
- Audio longer than `envelope.max_samples()` is clipped to the trailing envelope before planning and encode.
- FunASR utterance-complete partials still get the 400ms silence hint; FINAL does not.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core --lib incremental_streaming_driver`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

Local notarized Desktop against FireRed-AED-L q4: live captions continue past the previous ~7s overflow crash.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any staged/public-ready work completes Model Onboarding Step 5 without hand-editing generated catalog/registry truth.
- [x] Real-weight quality/performance claims have artifact-backed evidence; otherwise they are explicitly listed as unverified.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not shorten the 30s product window, does not add a Metal fused rel-pos default, and does not flush overlay mid-greedy.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES