### PR TITLE
ci(release): streamline release and distribution gates

### DIFF
--- a/.github/ci/check-linux-build-env.py
+++ b/.github/ci/check-linux-build-env.py
@@ -13,7 +13,6 @@ CONSUMERS = {
     ".github/workflows/ci.yml": 2,
     ".github/workflows/family-regression.yml": 1,
     ".github/workflows/public-hf-e2e.yml": 1,
-    ".github/workflows/release-core.yml": 1,
     ".github/workflows/serve-batch-parity.yml": 1,
 }
 
@@ -21,7 +20,6 @@ APTGET_FORBIDDEN = {
     ".github/workflows/ci.yml",
     ".github/workflows/family-regression.yml",
     ".github/workflows/public-hf-e2e.yml",
-    ".github/workflows/release-core.yml",
     ".github/workflows/serve-batch-parity.yml",
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
   # independent caches and don't clobber each other's incremental artifacts.
   lint:
     name: Rust lint (fmt, clippy, catalog, python)
-    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc
@@ -94,7 +93,6 @@ jobs:
 
   test:
     name: Rust test (nextest, doctests, sys-audio)
-    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     # GitHub-hosted: runs for pushes and every PR, including forks (the repo is
     # public, so hosted-runner minutes are free and unlimited).
     runs-on: ubuntu-latest
@@ -135,7 +133,6 @@ jobs:
         run: cargo test --workspace --doc
 
   system-audio-macos:
-    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -154,7 +151,6 @@ jobs:
 
   ios-compile:
     name: iOS compile gate (aarch64-apple-ios)
-    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -180,7 +176,6 @@ jobs:
         run: cargo check -p openasr-core -p openasr-ffi --target aarch64-apple-ios
 
   dependency-policy:
-    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,15 @@
 name: CI
 
 on:
+  # Normal changes are validated by their pull_request run. The only direct
+  # main commit allowed by RELEASING.md is the version bump, so keep a narrow
+  # push trigger for that commit without double-billing every merged PR.
   push:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "tooling/system-audio-check/Cargo.lock"
   pull_request:
     paths-ignore:
       - "docs/**"
@@ -39,6 +43,7 @@ jobs:
   # independent caches and don't clobber each other's incremental artifacts.
   lint:
     name: Rust lint (fmt, clippy, catalog, python)
+    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc
@@ -89,6 +94,7 @@ jobs:
 
   test:
     name: Rust test (nextest, doctests, sys-audio)
+    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     # GitHub-hosted: runs for pushes and every PR, including forks (the repo is
     # public, so hosted-runner minutes are free and unlimited).
     runs-on: ubuntu-latest
@@ -129,6 +135,7 @@ jobs:
         run: cargo test --workspace --doc
 
   system-audio-macos:
+    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -147,6 +154,7 @@ jobs:
 
   ios-compile:
     name: iOS compile gate (aarch64-apple-ios)
+    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -172,6 +180,7 @@ jobs:
         run: cargo check -p openasr-core -p openasr-ffi --target aarch64-apple-ios
 
   dependency-policy:
+    if: github.event_name != 'push' || startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -4,8 +4,8 @@ name: Deploy catalog
 # when it changes on main. Signing happens locally (the seed never enters CI); this
 # workflow only ships the already-signed, already-committed bytes with a scoped
 # CLOUDFLARE_API_TOKEN. The ed25519 signature is cryptographically verified by the
-# `rust` job's bundled-/public-projection gates on the same push; here we add cheap
-# consistency guardrails plus a post-deploy check.
+# self-contained pre-deploy gates below; the expensive full Rust CI intentionally
+# does not rerun for this direct release-operator catalog push.
 #
 # `gate-released-binary-compat` runs BEFORE `deploy` (see `needs:` below): catalog
 # data and CLI binaries ship on independent cadences, so a catalog edit that is
@@ -23,8 +23,11 @@ on:
   push:
     branches: [main]
     paths:
+      - "model-registry/catalog.json"
+      - "model-registry/catalog.signature.json"
       - "model-registry/catalog.public.json"
       - "model-registry/catalog.public.signature.json"
+      - "model-registry/catalog.epoch"
       - "cloudflare/catalog/**"
   workflow_dispatch:
 
@@ -41,6 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      - name: Verify generated catalog and production signatures
+        run: |
+          tooling/publish-model/scripts/regenerate_all.sh --check
+          python3 tooling/publish-model/scripts/check_catalog_consistency.py
 
       - name: Gate candidate catalog against the latest released CLI binary
         env:
@@ -72,6 +80,11 @@ jobs:
           assert all(m.get("public") is True for m in catalog["models"]), "public catalog must contain only public:true models"
           print(f"OK: {len(catalog['models'])} public model(s); sha256 + canonical url consistent")
           PY
+
+      - name: Verify signed backend payloads are live before metadata deployment
+        run: |
+          python3 tooling/release-manifest/backend_catalog.py verify-cdn \
+            --catalog model-registry/catalog.public.json
 
       - name: Deploy to Cloudflare
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,9 +1,10 @@
 name: Docker release
 
 # Build (and optionally push) CPU + CUDA runtime images to Docker Hub from
-# published GitHub Release assets. Release-core calls this after the full
-# binary matrix lands so the images match the just-published CLI; a failed
-# Docker job does not delete or roll back the GitHub Release.
+# published GitHub Release assets. publish-core-channels.yml calls this only
+# after the signed catalog/CDN finalizer publishes the draft, so secondary
+# channels cannot get ahead of the canonical CLI release; a failed Docker job
+# does not delete or roll back the GitHub Release.
 #
 # Images (Docker Hub namespace `quintinshaw`, repository `openasr`):
 #   CPU  (linux/amd64 + linux/arm64):

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,11 +1,6 @@
 name: Docker smoke
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
   pull_request:
     paths-ignore:
       - "docs/**"

--- a/.github/workflows/family-regression.yml
+++ b/.github/workflows/family-regression.yml
@@ -22,6 +22,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  attestations: read
   contents: read
   packages: read
 
@@ -35,6 +36,10 @@ env:
 jobs:
   build-cli-linux:
     name: Build CLI (ubuntu-latest)
+    # The public repository also hosts desktop-vX.Y.Z releases. Those do not
+    # carry open-core CLI assets and must skip this workflow without a red run.
+    if: >-
+      ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc
@@ -43,6 +48,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 90
     steps:
+      - uses: actions/checkout@v7
       - name: Resolve and fetch published release CLI
         id: published
         env:
@@ -60,33 +66,21 @@ jobs:
           asset="openasr-${version}-${ASSET_SUFFIX}.tar.gz"
           workdir="${RUNNER_TEMP}/published-cli"
           mkdir -p "${workdir}"
-          api="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
-          if json="$(curl -fsSL \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "${api}")" \
-            && asset_url="$(ASSET="${asset}" python3 -c '
-          import json, os, sys
-          rel = json.loads(sys.stdin.read())
-          name = os.environ["ASSET"]
-          for item in rel.get("assets", []):
-              if item.get("name") == name and item.get("url"):
-                  print(item["url"])
-                  raise SystemExit(0)
-          raise SystemExit(2)
-          ' <<<"${json}")" \
-            && curl -fsSL \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              -H "Accept: application/octet-stream" \
-              -o "${workdir}/${asset}" \
-              "${asset_url}" \
-            && tar -xzf "${workdir}/${asset}" -C "${workdir}" \
-            && bin="$(find "${workdir}" -type f -name openasr | head -n 1)" \
-            && test -n "${bin}" \
-            && cp "${bin}" "${workdir}/openasr" \
-            && chmod +x "${workdir}/openasr" \
-            && "${workdir}/openasr" --version; then
-            available=true
+          if gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" \
+              --dir "${workdir}" --pattern "${asset}" --pattern SHA256SUMS; then
+            python3 tooling/release-manifest/release_asset_verifier.py \
+              --asset "${workdir}/${asset}" --checksums "${workdir}/SHA256SUMS" || exit 1
+            gh attestation verify "${workdir}/${asset}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release-binaries.yml" || exit 1
+            if tar -xzf "${workdir}/${asset}" -C "${workdir}" \
+              && bin="$(find "${workdir}" -type f -name openasr | head -n 1)" \
+              && test -n "${bin}" \
+              && cp "${bin}" "${workdir}/openasr" \
+              && chmod +x "${workdir}/openasr" \
+              && "${workdir}/openasr" --version; then
+              available=true
+            fi
           fi
           echo "available=${available}" >> "${GITHUB_OUTPUT}"
           if [ "${available}" != "true" ]; then
@@ -96,13 +90,10 @@ jobs:
             fi
             echo "published ${asset} is not usable; falling back to a local release build for this diagnostic run"
           fi
-      - uses: actions/checkout@v7
-        if: steps.published.outputs.available != 'true'
-        with:
-          submodules: recursive
       - name: Prepare pinned Linux build environment
         if: steps.published.outputs.available != 'true'
         run: |
+          git submodule update --init --recursive
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           openasr-ci-verify
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -134,9 +125,12 @@ jobs:
 
   build-cli-macos:
     name: Build CLI (macos-15)
+    if: >-
+      ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
     runs-on: macos-15
     timeout-minutes: 90
     steps:
+      - uses: actions/checkout@v7
       - name: Resolve and fetch published release CLI
         id: published
         env:
@@ -154,33 +148,21 @@ jobs:
           asset="openasr-${version}-${ASSET_SUFFIX}.tar.gz"
           workdir="${RUNNER_TEMP}/published-cli"
           mkdir -p "${workdir}"
-          api="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
-          if json="$(curl -fsSL \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "${api}")" \
-            && asset_url="$(ASSET="${asset}" python3 -c '
-          import json, os, sys
-          rel = json.loads(sys.stdin.read())
-          name = os.environ["ASSET"]
-          for item in rel.get("assets", []):
-              if item.get("name") == name and item.get("url"):
-                  print(item["url"])
-                  raise SystemExit(0)
-          raise SystemExit(2)
-          ' <<<"${json}")" \
-            && curl -fsSL \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              -H "Accept: application/octet-stream" \
-              -o "${workdir}/${asset}" \
-              "${asset_url}" \
-            && tar -xzf "${workdir}/${asset}" -C "${workdir}" \
-            && bin="$(find "${workdir}" -type f -name openasr | head -n 1)" \
-            && test -n "${bin}" \
-            && cp "${bin}" "${workdir}/openasr" \
-            && chmod +x "${workdir}/openasr" \
-            && "${workdir}/openasr" --version; then
-            available=true
+          if gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" \
+              --dir "${workdir}" --pattern "${asset}" --pattern SHA256SUMS; then
+            python3 tooling/release-manifest/release_asset_verifier.py \
+              --asset "${workdir}/${asset}" --checksums "${workdir}/SHA256SUMS" || exit 1
+            gh attestation verify "${workdir}/${asset}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release-binaries.yml" || exit 1
+            if tar -xzf "${workdir}/${asset}" -C "${workdir}" \
+              && bin="$(find "${workdir}" -type f -name openasr | head -n 1)" \
+              && test -n "${bin}" \
+              && cp "${bin}" "${workdir}/openasr" \
+              && chmod +x "${workdir}/openasr" \
+              && "${workdir}/openasr" --version; then
+              available=true
+            fi
           fi
           echo "available=${available}" >> "${GITHUB_OUTPUT}"
           if [ "${available}" != "true" ]; then
@@ -190,10 +172,9 @@ jobs:
             fi
             echo "published ${asset} is not usable; falling back to a local release build for this diagnostic run"
           fi
-      - uses: actions/checkout@v7
+      - name: Initialize open-core submodules
         if: steps.published.outputs.available != 'true'
-        with:
-          submodules: recursive
+        run: git submodule update --init --recursive
       - uses: dtolnay/rust-toolchain@1.95.0
         if: steps.published.outputs.available != 'true'
       - uses: Swatinem/rust-cache@v2
@@ -220,6 +201,8 @@ jobs:
   family:
     name: ${{ matrix.case.name }} (${{ matrix.os }})
     needs: [build-cli-linux, build-cli-macos]
+    if: >-
+      ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
     strategy:
       # A single family failure must stay readable and must not cancel the
       # rest of the net.

--- a/.github/workflows/family-regression.yml
+++ b/.github/workflows/family-regression.yml
@@ -5,15 +5,17 @@ name: Family Regression
 # signature-verified) and transcribe a committed fixture on the CPU backend,
 # comparing against committed goldens (tooling/family-regression/goldens/).
 #
-# Runs nightly, on release tags (release gate), and on demand. Kept outside
+# Runs nightly, after a release is published, and on demand. Kept outside
 # push/PR CI because it performs real network downloads and native inference.
+# Nightly/manual runs reuse the latest published CLI too; a raw tag no longer
+# races the release matrix and falls back to two duplicate local builds.
 
 on:
   workflow_dispatch:
   schedule:
     - cron: "23 4 * * *"
-  push:
-    tags: ["v*"]
+  release:
+    types: [published]
 
 concurrency:
   group: family-regression-${{ github.ref }}
@@ -41,16 +43,19 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 90
     steps:
-      - name: Try published release CLI
+      - name: Resolve and fetch published release CLI
         id: published
-        if: github.event_name == 'push' && github.ref_type == 'tag'
         env:
           GH_TOKEN: ${{ github.token }}
           ASSET_SUFFIX: linux-x86_64
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -uo pipefail
           available=false
-          tag="${GITHUB_REF_NAME}"
+          tag="${RELEASE_TAG}"
+          if [ -z "${tag}" ]; then
+            tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
+          fi
           version="${tag#v}"
           asset="openasr-${version}-${ASSET_SUFFIX}.tar.gz"
           workdir="${RUNNER_TEMP}/published-cli"
@@ -85,7 +90,11 @@ jobs:
           fi
           echo "available=${available}" >> "${GITHUB_OUTPUT}"
           if [ "${available}" != "true" ]; then
-            echo "published ${asset} is not usable; falling back to a local release build"
+            if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+              echo "::error::published release ${tag} is missing usable ${asset}; refusing a duplicate local build"
+              exit 1
+            fi
+            echo "published ${asset} is not usable; falling back to a local release build for this diagnostic run"
           fi
       - uses: actions/checkout@v7
         if: steps.published.outputs.available != 'true'
@@ -128,16 +137,19 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 90
     steps:
-      - name: Try published release CLI
+      - name: Resolve and fetch published release CLI
         id: published
-        if: github.event_name == 'push' && github.ref_type == 'tag'
         env:
           GH_TOKEN: ${{ github.token }}
           ASSET_SUFFIX: macos-arm64
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -uo pipefail
           available=false
-          tag="${GITHUB_REF_NAME}"
+          tag="${RELEASE_TAG}"
+          if [ -z "${tag}" ]; then
+            tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
+          fi
           version="${tag#v}"
           asset="openasr-${version}-${ASSET_SUFFIX}.tar.gz"
           workdir="${RUNNER_TEMP}/published-cli"
@@ -172,7 +184,11 @@ jobs:
           fi
           echo "available=${available}" >> "${GITHUB_OUTPUT}"
           if [ "${available}" != "true" ]; then
-            echo "published ${asset} is not usable; falling back to a local release build"
+            if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+              echo "::error::published release ${tag} is missing usable ${asset}; refusing a duplicate local build"
+              exit 1
+            fi
+            echo "published ${asset} is not usable; falling back to a local release build for this diagnostic run"
           fi
       - uses: actions/checkout@v7
         if: steps.published.outputs.available != 'true'

--- a/.github/workflows/publish-core-channels.yml
+++ b/.github/workflows/publish-core-channels.yml
@@ -1,0 +1,228 @@
+name: Publish core channels
+
+# Secondary channels move only after the draft GitHub release has passed the
+# signed-catalog + backend-CDN finalizer and is actually published. Building
+# these channels from a draft used to expose Docker/Homebrew before the
+# canonical release distribution plane was ready.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Published latest core tag to repair, e.g. v0.1.35"
+        required: true
+        type: string
+
+concurrency:
+  group: publish-core-channels-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Verify published latest release
+    # The public repo also hosts desktop-vX.Y.Z releases. Ignore those release
+    # events without painting the repository red; a manual repair still runs
+    # and fails closed on an invalid tag.
+    if: >-
+      ${{
+        github.repository == 'QuintinShaw/openasr' &&
+        (github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v'))
+      }}
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${EVENT_TAG:-$INPUT_TAG}"
+          if [[ ! "$tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "::error::expected a stable vX.Y.Z release tag, got '$tag'"
+            exit 1
+          fi
+          version="${BASH_REMATCH[1]}"
+          release="$(gh api "repos/${{ github.repository }}/releases/tags/${tag}")"
+          if [ "$(jq -r .draft <<<"$release")" != "false" ] || [ "$(jq -r .prerelease <<<"$release")" != "false" ]; then
+            echo "::error::${tag} is not a published stable release"
+            exit 1
+          fi
+          latest="$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name)"
+          if [ "$latest" != "$tag" ]; then
+            echo "::error::refusing to move latest channels backwards: ${tag} is not GitHub latest (${latest})"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  distribution-gate:
+    name: Re-verify live catalog and backend CDN
+    needs: resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+      - name: Download release trust metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-metadata
+          gh release download "$TAG" \
+            --pattern 'backend-pack-*.json' \
+            --pattern 'backend-hardware-evidence-*.json' \
+            --dir release-metadata
+      - name: Require the finalizer's live distribution invariants
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          entries=(release-metadata/backend-pack-*.json)
+          cuda_entries=(release-metadata/backend-pack-cuda-sm_*.json)
+          hip_entries=(release-metadata/backend-pack-hip-gfx*.json)
+          evidence=(release-metadata/backend-hardware-evidence-*.json)
+          if [ "${#entries[@]}" -ne 20 ] || [ "${#cuda_entries[@]}" -ne 6 ] || [ "${#hip_entries[@]}" -ne 14 ]; then
+            echo "::error::release must contain exactly 6 CUDA and 14 HIP backend-pack metadata files"
+            exit 1
+          fi
+          [ "${#evidence[@]}" -gt 0 ] || {
+            echo "::error::release has no hardware evidence"; exit 1;
+          }
+
+          entry_args=()
+          for entry in "${entries[@]}"; do entry_args+=(--entry "$entry"); done
+          evidence_args=()
+          for receipt in "${evidence[@]}"; do evidence_args+=(--evidence "$receipt"); done
+          python3 tooling/release-manifest/backend_hardware_evidence.py \
+            "${entry_args[@]}" "${evidence_args[@]}" \
+            > approved-entries.txt
+          approved_args=()
+          while IFS= read -r entry || [ -n "$entry" ]; do
+            [ -n "$entry" ] || continue
+            approved_args+=(--entry "$entry")
+          done < <(tr -d '\r' < approved-entries.txt)
+          [ "${#approved_args[@]}" -gt 0 ] || {
+            echo "::error::release has no hardware-approved backend entry"; exit 1;
+          }
+
+          cache_bust="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          curl -fsSL "https://catalog.openasr.org/v1/catalog.json?channels=${cache_bust}" -o catalog.json
+          curl -fsSL "https://catalog.openasr.org/v1/catalog.signature.json?channels=${cache_bust}" -o catalog.signature.json
+          # Exercise the live pair through the currently-shipping CLI. This is
+          # the same runtime Ed25519/epoch/registry gate deploy-catalog uses,
+          # not merely a comparison against self-declared signature metadata.
+          scripts/gate-catalog-against-released-binary.sh \
+            catalog.json catalog.signature.json
+          python3 - <<'PY'
+          import hashlib, json
+          raw = open("catalog.json", "rb").read()
+          sig = json.load(open("catalog.signature.json", encoding="utf-8"))
+          assert hashlib.sha256(raw).hexdigest() == sig["catalog_sha256"], "live catalog sha256 does not match its signature record"
+          assert sig["catalog_url"] == "https://catalog.openasr.org/v1/catalog.json", "live catalog has a non-canonical signed identity"
+          PY
+          python3 tooling/release-manifest/backend_catalog.py verify-catalog \
+            --catalog catalog.json "${approved_args[@]}"
+          python3 tooling/release-manifest/backend_hardware_evidence.py \
+            "${entry_args[@]}" "${evidence_args[@]}" \
+            --catalog catalog.json --version "$VERSION" >/dev/null
+          python3 tooling/release-manifest/backend_catalog.py verify-cdn \
+            --catalog catalog.json --version "$VERSION"
+
+  docker-images:
+    name: Publish Docker Hub images
+    needs: [resolve, distribution-gate]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/docker-release.yml
+    with:
+      version: ${{ needs.resolve.outputs.version }}
+      tag: ${{ needs.resolve.outputs.tag }}
+      ref: ${{ needs.resolve.outputs.tag }}
+      push: true
+      mark_latest: true
+      variants: all
+    secrets: inherit
+
+  update-homebrew-tap:
+    name: Update Homebrew tap formula
+    needs: [resolve, distribution-gate]
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+      - name: Check for tap credentials
+        id: check
+        run: |
+          if [ -n "${{ secrets.HOMEBREW_TAP_TOKEN }}" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::HOMEBREW_TAP_TOKEN secret not set -- skipping Homebrew tap update"
+          fi
+      - name: Checkout quintinshaw/homebrew-tap
+        if: steps.check.outputs.has_token == 'true'
+        uses: actions/checkout@v7
+        with:
+          repository: QuintinShaw/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+      - name: Compute release checksums
+        if: steps.check.outputs.has_token == 'true'
+        run: |
+          set -euo pipefail
+          tag="${{ needs.resolve.outputs.tag }}"
+          version="${{ needs.resolve.outputs.version }}"
+          curl -fsSL -o SHA256SUMS \
+            "https://github.com/${{ github.repository }}/releases/download/${tag}/SHA256SUMS"
+          sha_for() {
+            grep -F " openasr-${version}-$1.tar.gz" SHA256SUMS | awk '{print $1}'
+          }
+          for target in macos-arm64 linux-x86_64 linux-arm64; do
+            sha="$(sha_for "$target")"
+            [[ "$sha" =~ ^[0-9a-f]{64}$ ]] || {
+              echo "::error::missing valid SHA256SUMS entry for openasr-${version}-${target}.tar.gz"
+              exit 1
+            }
+            echo "${target}=${sha}" >> shas.env
+          done
+      - name: Update Formula/openasr.rb
+        if: steps.check.outputs.has_token == 'true'
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS='=' read -r target sha; do
+            args+=(--sha256 "${target}=${sha}")
+          done < shas.env
+          python3 scripts/update-homebrew-formula.py \
+            homebrew-tap/Formula/openasr.rb "${{ needs.resolve.outputs.version }}" \
+            "${args[@]}"
+      - name: Commit and push
+        if: steps.check.outputs.has_token == 'true'
+        run: |
+          set -euo pipefail
+          cd homebrew-tap
+          if git diff --quiet; then
+            echo "formula already up to date -- nothing to commit"
+            exit 0
+          fi
+          git config user.name "openasr-release-bot"
+          git config user.email "release-bot@users.noreply.github.com"
+          git add Formula/openasr.rb
+          git commit -m "chore(formula): update openasr to ${{ needs.resolve.outputs.version }}"
+          git push origin main

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,16 +1,11 @@
 name: Release binaries
 
-# Three ways in:
-#   1. push: tags v* -- a maintainer pushes an annotated release tag directly
-#      (e.g. `git push --follow-tags` from scripts/bump-version.sh). Real tag
-#      pushes fire this natively.
-#   2. workflow_call -- release-core.yml calls this workflow directly (as a
-#      job, not a webhook) right after it creates the vX.Y.Z tag + GitHub
-#      Release. This is required because a tag created through the GITHUB_TOKEN
-#      API does *not* fire the `push: tags` event (GitHub does not cascade
-#      Actions-token-authored pushes into further workflow runs), so without
-#      this explicit call the full release matrix silently never builds.
-#   3. workflow_dispatch -- manual re-run/dry-run, with the same `ref` input
+# Two ways in:
+#   1. workflow_call -- release-core.yml calls this workflow directly after it
+#      creates the draft GitHub Release. This is the only formal release-matrix
+#      entrypoint; accepting the annotated tag push here as well used to race
+#      the orchestrator and could build the same expensive matrix twice.
+#   2. workflow_dispatch -- manual re-run/dry-run, with the same `ref` input
 #      as workflow_call so a maintainer can target an existing tag (e.g. to
 #      retry a failed platform leg, recover aggregation from a completed run's
 #      immutable artifacts, or dry-run the upload/completeness logic against an
@@ -59,9 +54,9 @@ on:
         required: false
         type: string
         default: ""
-  push:
-    tags:
-      - "v*"
+  # Formal releases enter through release-core.yml's workflow_call. Keeping
+  # a second push:tags entrypoint used to race the orchestrator and could run
+  # the same expensive matrix twice for one annotated tag.
 
 permissions:
   contents: write
@@ -1004,7 +999,7 @@ jobs:
         # This workflow has no `pull_request` trigger (see the trigger
         # comment at the top of this file), so a fork PR never reaches this
         # job with -- or without -- secrets. Every run that gets here is a
-        # real tag push, release-core.yml's workflow_call, or a maintainer's
+        # release-core.yml's workflow_call or a maintainer's
         # workflow_dispatch, all of which do have repo secrets. The only
         # legitimate no-secrets case is a maintainer smoke-testing build/
         # package logic via workflow_dispatch with dry_run=true before the

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -1,8 +1,8 @@
 name: Release core
 
 # Version-bump-triggered release. When the workspace version in the root
-# Cargo.toml changes on main, this builds the `openasr` CLI for the platforms the
-# desktop app consumes and publishes a GitHub Release tagged `vX.Y.Z`. Editing
+# Cargo.toml changes on main, this creates the draft GitHub Release tagged
+# `vX.Y.Z`, then delegates every distributable build to one release matrix. Editing
 # Cargo.toml without changing the version (deps, metadata) is a safe no-op because
 # the resolve job exits cleanly when a Release for `vX.Y.Z` already exists.
 # `workflow_dispatch` lets the maintainer cut the very first release (no bump)
@@ -109,144 +109,15 @@ jobs:
             echo "RELEASE_HIGHLIGHTS_EOF"
           } >> "${GITHUB_OUTPUT}"
 
-  build:
-    name: Build ${{ matrix.target }}
-    needs: resolve
-    if: needs.resolve.outputs.should_release == 'true' && success()
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    # Initial archives only bootstrap the draft release. The full release
-    # matrix replaces them and centrally attests every final subject, avoiding
-    # duplicate Rekor calls before the expensive matrix begins.
-    permissions:
-      contents: read
-    # Distributed binaries must be portable across end-user CPUs. build.rs
-    # auto-enables GGML_NATIVE (-march=native) when host==target on x86, which
-    # would tune the released Linux binary to the CI runner and SIGILL elsewhere.
-    # Force it off; power users tune locally.
-    env:
-      OPENASR_GGML_NATIVE: "0"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # macOS arm64: what the OpenASR Desktop app consumes. `asset` is the
-          # friendly, user-facing filename segment (see release-binaries.yml's
-          # naming note); it MUST match the name release-binaries.yml re-uploads
-          # for the same platform, or the release ends up with both a triple-
-          # named and a friendly-named archive (the --clobber re-upload only
-          # replaces an identically named asset).
-          - os: macos-14
-            target: aarch64-apple-darwin
-            asset: macos-arm64
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@1.95.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: release-${{ matrix.target }}
-      - name: Build release binary
-        run: cargo build --release -p openasr-cli
-      - name: Smoke release binary
-        run: |
-          ./target/release/openasr --version
-          ./target/release/openasr --help
-      - name: Package archive
-        run: |
-          set -euo pipefail
-          version="${{ needs.resolve.outputs.version }}"
-          asset="${{ matrix.asset }}"
-          stage="dist/openasr-${version}-${asset}"
-          mkdir -p "${stage}"
-          cp target/release/openasr "${stage}/"
-          cp README.md LICENSE "${stage}/"
-          tar -czf "dist/openasr-${version}-${asset}.tar.gz" -C dist "openasr-${version}-${asset}"
-      - name: Upload archive
-        uses: actions/upload-artifact@v7
-        with:
-          name: openasr-${{ matrix.target }}
-          path: dist/openasr-${{ needs.resolve.outputs.version }}-${{ matrix.asset }}.tar.gz
-          if-no-files-found: error
-
-  build-linux:
-    name: Build x86_64-unknown-linux-gnu
-    needs: resolve
-    if: needs.resolve.outputs.should_release == 'true' && success()
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/quintinshaw/openasr-ci-linux@sha256:702284855863f1c6330eec503ac4570ff2cc844a958ceb7d2e2af5837633dcdc
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      packages: read
-    env:
-      OPENASR_GGML_NATIVE: "0"
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-      - name: Prepare pinned Linux build environment
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          openasr-ci-verify
-      - uses: dtolnay/rust-toolchain@1.95.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: release-x86_64-unknown-linux-gnu
-      - name: Build release binary
-        run: cargo build --release -p openasr-cli
-      - name: Smoke release binary
-        run: |
-          ./target/release/openasr --version
-          ./target/release/openasr --help
-      - name: Package archive
-        run: |
-          set -euo pipefail
-          version="${{ needs.resolve.outputs.version }}"
-          stage="dist/openasr-${version}-linux-x86_64"
-          mkdir -p "${stage}"
-          cp target/release/openasr "${stage}/"
-          cp README.md LICENSE "${stage}/"
-          tar -czf "dist/openasr-${version}-linux-x86_64.tar.gz" \
-            -C dist "openasr-${version}-linux-x86_64"
-      - name: Upload archive
-        uses: actions/upload-artifact@v7
-        with:
-          name: openasr-x86_64-unknown-linux-gnu
-          path: dist/openasr-${{ needs.resolve.outputs.version }}-linux-x86_64.tar.gz
-          if-no-files-found: error
-
   release:
-    name: Publish release
-    needs: [resolve, build, build-linux]
+    name: Create draft release
+    needs: resolve
     if: needs.resolve.outputs.should_release == 'true' && success()
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
-      - name: Download build archives
-        uses: actions/download-artifact@v8
-        with:
-          path: staging
-          merge-multiple: true
-      - name: Collect archives and checksums
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-          find staging -name '*.tar.gz' -exec cp {} dist/ \;
-          cd dist
-          sha256sum *.tar.gz > SHA256SUMS
-          cat SHA256SUMS
-
       - name: Assemble release notes (Highlights / What's Changed / Install & Verify)
         env:
           HIGHLIGHTS: ${{ needs.resolve.outputs.highlights }}
@@ -268,11 +139,8 @@ jobs:
             -f "tag_name=${tag}" -f "target_commitish=${{ github.sha }}" \
             --jq .body > whats-changed.md
 
-          # Install & Verify: stub for now (this job's own build only covers
-          # macOS arm64 + Linux x86_64; the full multi-platform matrix hasn't
-          # built yet). The `finalize-notes` job below replaces this section
-          # with the real asset list once `binaries` (release-binaries.yml)
-          # finishes uploading everything.
+          # Install & Verify starts empty. The `finalize-notes` job below
+          # replaces it from the complete, attested matrix's real asset list.
           printf '' | scripts/render-install-verify.sh \
             "${{ needs.resolve.outputs.version }}" "${{ github.repository }}" "${tag}" \
             > install-verify.md
@@ -290,8 +158,7 @@ jobs:
           gh release create "${tag}" \
             --draft \
             --title "${tag}" \
-            --notes-file body.md \
-            dist/*.tar.gz dist/SHA256SUMS
+            --notes-file body.md
 
   binaries:
     name: Build full release matrix
@@ -337,102 +204,3 @@ jobs:
           python3 scripts/splice-install-verify.py current-body.md install-verify.md > new-body.md
 
           gh release edit "$tag" --notes-file new-body.md
-
-  docker-images:
-    name: Publish Docker Hub images
-    # Needs the full asset matrix so Dockerfile.release / Dockerfile.cuda.release
-    # can download the just-published linux-x86_64, linux-arm64, and
-    # linux-x86_64-cuda archives (+ SHA256SUMS). A red Docker job fails this
-    # workflow leg only -- it must never delete or roll back the GitHub Release
-    # the earlier jobs already published.
-    needs: [resolve, release, binaries]
-    if: needs.resolve.outputs.should_release == 'true' && success()
-    permissions:
-      contents: read
-    uses: ./.github/workflows/docker-release.yml
-    with:
-      version: ${{ needs.resolve.outputs.version }}
-      tag: ${{ needs.resolve.outputs.tag }}
-      push: true
-      mark_latest: true
-      variants: all
-    secrets: inherit
-
-  update-homebrew-tap:
-    name: Update Homebrew tap formula
-    # Needs the full asset matrix (binaries), not just the core build job's
-    # macOS arm64 + Linux x86_64 -- the formula also ships a Linux arm64
-    # target, which only release-binaries.yml's matrix produces.
-    needs: [resolve, release, binaries]
-    if: needs.resolve.outputs.should_release == 'true' && success()
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - uses: actions/checkout@v7
-      - name: Check for tap credentials
-        id: check
-        run: |
-          if [ -n "${{ secrets.HOMEBREW_TAP_TOKEN }}" ]; then
-            echo "has_token=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "has_token=false" >> "${GITHUB_OUTPUT}"
-            # ::notice, not ::error/::warning -- a maintainer who has not set
-            # up the tap yet should see a green release, not a red one, for a
-            # step that is inherently optional infrastructure.
-            echo "::notice::HOMEBREW_TAP_TOKEN secret not set -- skipping Homebrew tap formula update. See RELEASING.md for the fine-grained PAT this needs."
-          fi
-      - name: Checkout quintinshaw/homebrew-tap
-        if: steps.check.outputs.has_token == 'true'
-        uses: actions/checkout@v7
-        with:
-          repository: QuintinShaw/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-tap
-      - name: Compute per-target sha256 from the release's SHA256SUMS
-        if: steps.check.outputs.has_token == 'true'
-        id: sums
-        run: |
-          set -euo pipefail
-          tag="${{ needs.resolve.outputs.tag }}"
-          version="${{ needs.resolve.outputs.version }}"
-          curl -fsSL -o SHA256SUMS \
-            "https://github.com/${{ github.repository }}/releases/download/${tag}/SHA256SUMS"
-
-          sha_for() {
-            grep -F " openasr-${version}-$1.tar.gz" SHA256SUMS | awk '{print $1}'
-          }
-          for target in macos-arm64 linux-x86_64 linux-arm64; do
-            sha="$(sha_for "$target")"
-            if [ -z "$sha" ]; then
-              echo "::error::no SHA256SUMS entry for openasr-${version}-${target}.tar.gz -- did release-binaries.yml ship that target?"
-              exit 1
-            fi
-            echo "${target}=${sha}" >> shas.env
-          done
-          cat shas.env
-      - name: Update Formula/openasr.rb
-        if: steps.check.outputs.has_token == 'true'
-        run: |
-          set -euo pipefail
-          args=()
-          while IFS='=' read -r target sha; do
-            args+=(--sha256 "${target}=${sha}")
-          done < shas.env
-          python3 scripts/update-homebrew-formula.py \
-            homebrew-tap/Formula/openasr.rb "${{ needs.resolve.outputs.version }}" \
-            "${args[@]}"
-      - name: Commit and push
-        if: steps.check.outputs.has_token == 'true'
-        run: |
-          set -euo pipefail
-          cd homebrew-tap
-          if git diff --quiet; then
-            echo "formula already up to date -- nothing to commit"
-            exit 0
-          fi
-          git config user.name "openasr-release-bot"
-          git config user.email "release-bot@users.noreply.github.com"
-          git add Formula/openasr.rb
-          git commit -m "openasr ${{ needs.resolve.outputs.tag }}"
-          git push origin main

--- a/.github/workflows/serve-batch-parity.yml
+++ b/.github/workflows/serve-batch-parity.yml
@@ -7,14 +7,12 @@ name: Serve-batch real-pack parity
 # tests in `cargo test` run on tiny synthetic fixtures only; this lane is the
 # real-weight correctness backstop. moonshine is a seq2seq family riding the same
 # shared nn/decoder.rs seam as whisper/cohere, so it is a strong proxy for the
-# seq2seq batched path. Runs on PRs into main (gates the merge) and on demand.
+# seq2seq batched path. Runs on PRs into main (gates the merge) and on demand;
+# the already-gated merge commit is not rebuilt a second time.
 
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
-  # Post-merge backstop on main.
-  push:
     branches: [main]
 
 concurrency:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,8 @@ Feature, fix, and any other content changes go through pull requests as usual.
 The release bump itself is the exception: a maintainer pushes it directly to
 `main` as a single `chore(release)` commit plus its annotated `vX.Y.Z` tag.
 Routing the bump through a PR adds nothing (the release fires on the merge
-commit anyway) and CI runs on `main` push regardless.
+commit anyway). Routine CI is PR-only to avoid rebuilding every merge; its
+narrow `main` push gate runs only for this direct `chore(release)` commit.
 
 ## Versioning
 
@@ -62,16 +63,14 @@ bump, or CI's `--locked` builds fail:
      origin (failing loudly if it's missing -- see step 2);
    - exits cleanly if a GitHub Release for `vX.Y.Z` already exists (so
      unrelated `Cargo.toml` edits and re-runs are no-ops);
-   - otherwise builds its own macOS-arm64 + Linux-x86_64 binaries, reads the
-     tag annotation for Highlights, and creates the GitHub Release with a
-     three-part body (see below);
+   - otherwise reads the tag annotation for Highlights and immediately creates
+     an empty draft GitHub Release with a three-part body (see below);
    - then calls `.github/workflows/release-binaries.yml` directly (as a
-     `workflow_call`, not a webhook -- tags created through the
-     `GITHUB_TOKEN` API do not cascade into further Actions triggers, so a
-     real `push: tags` event alone would never fire for a tag this workflow
-     created) to build the full release matrix (Linux x86_64/arm64, macOS
+     `workflow_call`, the only formal matrix entrypoint) to build the full
+     release matrix (Linux x86_64/arm64, macOS
      x86_64/arm64, Windows, plus Vulkan/CUDA/HIP feature variants) and
-     upload every archive to the same release;
+     upload every archive to the draft. There is no bootstrap macOS/Linux
+     rebuild and no second `push: tags` matrix racing the orchestrator;
    - `release-binaries.yml`'s own completeness gate then asserts the release
      ends up with every expected platform archive, failing the run if one is
      missing instead of silently shipping a partial release;
@@ -96,8 +95,10 @@ No pre-release channels: the core releases plain `X.Y.Z` versions only.
 ## Manual runs
 
 `workflow_dispatch` on the `Release core` workflow performs the same
-resolve-and-release for the version currently on `main` (useful for retries;
-it is idempotent thanks to the existing-release check).
+resolve-and-release for the version currently on `main`. It can create a
+missing draft, but an already-existing draft is an intentional no-op; recover
+failed matrix legs through the `Release binaries` workflow below rather than
+starting a competing second orchestrator.
 
 `workflow_dispatch` on `Release binaries` (`.github/workflows/release-binaries.yml`)
 independently rebuilds/re-uploads the full matrix for an existing tag: pass
@@ -122,25 +123,29 @@ made public until the signed catalog distribution plane is complete:
    schemas require at least five fresh processes, FullDevice execution, and no
    CPU fallback. Building a target is not hardware evidence, and a matrix receipt
    is an explicit compatibility policy rather than a claim that every GPU ran.
-2. Run `scripts/prepare-windows-backend-catalog-release.sh vX.Y.Z` locally with
-   the production catalog signing seed. It downloads and hashes all 6 CUDA and
-   14 HIP build artifacts, but merges only the target entries approved by those
-   receipts. It then bumps the catalog epoch and signs the full/public
-   catalogs. Review, commit, and push those catalog files.
-3. Wait for `deploy-catalog.yml` to prove the signed public bytes are live.
-4. Run `scripts/sync-windows-backend-cdn.sh vX.Y.Z` locally with the B2
+2. Run `scripts/sync-windows-backend-cdn.sh vX.Y.Z` locally with the B2
    release credentials. It copies the hardware-approved plugin and vendor
    files to `https://dl.openasr.org/core/vX.Y.Z/`. The signed catalog's
    `files[].url` values point only at this prefix; GitHub release mirrors are
    not a runtime download fallback.
+3. Run `scripts/prepare-windows-backend-catalog-release.sh vX.Y.Z` locally with
+   the production catalog signing seed. It downloads and hashes all 6 CUDA and
+   14 HIP build artifacts, but merges only the target entries approved by those
+   receipts. Before touching the catalog it verifies that every selected CDN
+   payload is already live, then bumps the epoch and signs the full/public
+   catalogs. Review, commit, and push those catalog files.
+4. Wait for `deploy-catalog.yml` to repeat the no-credential CDN gate and prove
+   the signed public bytes are live. Metadata is never deployed ahead of its
+   immutable payloads.
 5. Run `scripts/finalize-core-release.sh vX.Y.Z`. It requires the live signed
    catalog target set to equal the hardware-approved subset exactly, and it
    HEADs every signed CDN URL for that version; only then does it publish the
    draft and mark it latest.
 
 None of these scripts publishes code or a catalog implicitly. A failure leaves
-the release draft and therefore unavailable to users; there is no partially
-usable release whose Desktop UI advertises a backend that cannot resolve.
+the release draft and therefore unavailable to users. Publishing the GitHub
+release triggers `publish-core-channels.yml`, which moves Docker/Homebrew only
+after the canonical catalog/CDN plane is complete.
 
 ## Legacy backends manifests
 
@@ -153,7 +158,7 @@ only activation trust plane.
 
 ## Homebrew tap
 
-`release-core.yml`'s final job, `update-homebrew-tap`, bumps
+`publish-core-channels.yml` bumps
 `Formula/openasr.rb` in [`QuintinShaw/homebrew-tap`](https://github.com/QuintinShaw/homebrew-tap)
 (version + per-target sha256 for `macos-arm64`, `linux-x86_64`, `linux-arm64`,
 read from the just-published release's `SHA256SUMS`) and pushes straight to
@@ -172,9 +177,9 @@ hand, once the secret exists).
 
 ## Docker Hub images
 
-`release-core.yml`'s `docker-images` job runs after the full binary matrix
-(`binaries`) and builds runtime images from the just-published Linux release
-assets (no second cargo build inside Docker):
+`publish-core-channels.yml` runs only after the GitHub draft is published by
+the catalog/CDN finalizer. It builds runtime images from the published Linux
+release assets (no second cargo build inside Docker):
 
 - CPU multi-arch (`linux/amd64` + `linux/arm64`) from
   `openasr-<version>-linux-x86_64.tar.gz` / `linux-arm64.tar.gz` via
@@ -214,4 +219,3 @@ gh workflow run docker-release.yml \
 
 Local source-build Dockerfiles (`Dockerfile`, `Dockerfile.cuda`) remain for
 development and `docker-smoke.yml`; they are not the release path.
-

--- a/docs/design/ci-build-environments.md
+++ b/docs/design/ci-build-environments.md
@@ -14,7 +14,7 @@ pins three Linux environments and leaves Windows on the hosted VS image.
 - Publish: `.github/workflows/ci-linux-build-env.yml`, only when that tree
   changes. Tag pushes do not publish.
 - Consumers: `ci.yml`, `family-regression.yml`, `public-hf-e2e.yml`,
-  `release-core.yml`, `serve-batch-parity.yml`, and the
+  `serve-batch-parity.yml`, and the
   `x86_64-unknown-linux-gnu` release-binaries leg.
 - Contract: `.github/ci/check-linux-build-env.py` requires every listed
   consumer to pin the lock digest. Fully migrated consumers must not

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,7 +24,7 @@ Local engineering scripts for validation and iteration.
     `finalize-notes` job).
 - `update-homebrew-formula.py`
   - Bump `Formula/openasr.rb`'s version and per-target sha256 in place (used
-    by `.github/workflows/release-core.yml`'s `update-homebrew-tap` job
+    by `.github/workflows/publish-core-channels.yml` after the release is public
     against a checkout of `QuintinShaw/homebrew-tap`). See `RELEASING.md`'s
     "Homebrew tap" section.
 - `generate_longform_pause_probe.py`

--- a/scripts/prepare-windows-backend-catalog-release.sh
+++ b/scripts/prepare-windows-backend-catalog-release.sh
@@ -137,6 +137,14 @@ python3 tooling/release-manifest/backend_catalog.py merge \
   --catalog model-registry/catalog.json \
   "${backend_entry_args[@]}" \
   --out "$workdir/catalog.merged.json"
+
+# Payload first, metadata last: refuse to sign URLs that are not already live.
+# deploy-catalog.yml repeats this read-only gate, and the finalizer checks the
+# deployed signed projection once more before publishing the draft release.
+python3 tooling/release-manifest/backend_catalog.py verify-cdn \
+  --catalog "$workdir/catalog.merged.json" \
+  --version "$version"
+
 python3 - "$workdir/catalog.merged.json" <<'PY'
 import json
 import sys
@@ -173,5 +181,5 @@ echo "CATALOG-PREPARED for ${tag}"
 echo "  hardware-approved backend entries: ${#approved_entries[@]} of ${#backend_entries[@]} built"
 echo "  epoch: ${old_epoch} -> ${new_epoch}"
 echo "  next: review and commit model-registry/catalog{,.public}{,.signature}.json + catalog.epoch"
-echo "  then push the catalog commit, wait for deploy-catalog.yml, and run:"
+echo "  then push the catalog commit, wait for deploy-catalog.yml (which rechecks CDN), and run:"
 echo "    scripts/finalize-core-release.sh ${tag}"

--- a/scripts/sync-windows-backend-cdn.sh
+++ b/scripts/sync-windows-backend-cdn.sh
@@ -169,4 +169,5 @@ PY
 echo
 echo "BACKEND-CDN-SYNCED for ${tag}"
 echo "  uploaded ${#sync_files[@]} hardware-approved objects to https://dl.openasr.org/core/v${version}/"
-echo "  next: scripts/finalize-core-release.sh ${tag}"
+echo "  next: load the production catalog signing seed and run:"
+echo "    scripts/prepare-windows-backend-catalog-release.sh ${tag}"

--- a/tooling/family-regression/README.md
+++ b/tooling/family-regression/README.md
@@ -4,8 +4,9 @@ Real-model regression net for every public model family: pull the family's
 smallest checkpoint at its smallest quant from the public catalog (the real
 user chain, including catalog signature verification), transcribe a committed
 fixture on the CPU backend, and compare the transcript against committed
-goldens. Driven by `.github/workflows/family-regression.yml` (nightly, `v*`
-release tags, and manual dispatch).
+goldens. Driven by `.github/workflows/family-regression.yml` (nightly, after a
+release is published, and manual dispatch). It reuses the latest published
+Linux/macOS CLI assets instead of compiling duplicate release binaries.
 
 ## Run one case locally
 

--- a/tooling/release-manifest/README.md
+++ b/tooling/release-manifest/README.md
@@ -101,7 +101,12 @@ per-mirror fetch URL there instead is the bug this fixes (#145: every mirror
 except the primary CDN failed signature verification, since the signed
 payload only ever names the canonical host).
 
-## dl.openasr.org sync
+## Legacy dl.openasr.org sync (0.1.33 and earlier only)
+
+For core 0.1.34 and later, do not use the whole-engine example below. Run
+`scripts/sync-windows-backend-cdn.sh vX.Y.Z`; it derives the exact
+hardware-approved target-scoped files from release metadata, uploads them, and
+HEAD-verifies the canonical CDN objects before catalog signing is allowed.
 
 `b2_sync.py` -- uploads files to `core/v<version>/<filename>` in the SAME
 Backblaze B2 bucket / Cloudflare Worker the desktop installers
@@ -172,72 +177,10 @@ is always a local, human-run step:
   releases ever need CI-driven publish, that is a separate, explicit
   go-ahead (which secrets, which trigger) -- not a default.
 
-## Post-release checklist (local, after `release-binaries.yml` finishes)
+## Current release checklist
 
-The GitHub Release remains a draft throughout these steps. Run them from a
-maintainer machine; none of the signing steps runs in CI.
-
-1. **Sign the manifest, attach it to the GitHub release, and self-verify** --
-   run `OPENASR_CATALOG_SIGNING_KEY_SEED_HEX=<production seed>
-   scripts/sign-and-verify-backends-manifest.sh v<version>` (see "Signing"
-   above and `RELEASING.md`). This step is REQUIRED and not optional: the
-   release is not signed until this script prints `SIGNED-AND-VERIFIED` and
-   exits 0.
-2. **Attach hardware evidence** -- add `backend-hardware-evidence-*.json`
-   release assets for each provider intended for activation. Schema v1 approves
-   one exact tested target. Schema v2 may approve an explicit provider matrix
-   from one representative target only when the receipt binds the tested plugin
-   plus the sorted target set and every target-scoped artifact fingerprint.
-   Both require at least five fresh processes and prove FullDevice execution
-   without CPU fallback. The 6 CUDA and 14 HIP build matrix is artifact coverage;
-   a schema v2 matrix receipt records an explicit compatibility policy and does
-   not claim that every target ran on hardware.
-3. **Prepare and deploy the signed backend catalog** -- run
-   `scripts/prepare-windows-backend-catalog-release.sh v<version>` with the same
-   local production signing seed, review and commit its five catalog/epoch
-   outputs, push them, and wait for `deploy-catalog.yml` to verify the live
-   endpoint. The script downloads and rehashes every CUDA/HIP release byte, but
-   merges only the target entries selected by matching hardware receipts;
-   unsigned `catalog.backends.candidate.json` is build evidence, never an
-   activation source.
-4. **Finalize the draft** -- run `scripts/finalize-core-release.sh v<version>`.
-   It verifies the published manifest signature and requires the live signed
-   catalog target set to equal the hardware-approved subset before it can
-   publish the draft.
-5. **Sync to dl.openasr.org** -- see "dl.openasr.org sync" above
-   (`b2_sync.py sync --version <version>`, uploading the Windows sidecar
-   archives -- `-vulkan`, `-cuda-sidecar`, `-rocm-sidecar` -- plus
-   `backends-manifest.json` and `backends-manifest.signature.json` to
-   `core/v<version>/` in the shared `openasr-releases` B2 bucket). The B2
-   vars (`B2_S3_ENDPOINT` / `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`)
-   come from `source ~/.openasr/b2-release.env` in the running shell -- never
-   repo secrets, never a shell-profile export. `sync-vendor` for the
-   vendor_layers archives is OPTIONAL (see above) and not part of this
-   release-blocking checklist --
-   GitHub Releases (already populated by `release-binaries.yml`) is enough.
-   `b2_sync.py` is the ONLY thing that syncs to B2/dl.openasr.org -- step 1's
-   script deliberately does not touch B2 at all, so run this step after step
-   1 if dl.openasr.org mirroring is wanted for this release.
-5. **Spot-check one signed exe with `signtool`** -- pick one of the archives
-   just uploaded (rotate which GPU leg you check across releases) and confirm
-   the Azure Trusted Signing signature is intact and trusted end to end:
-
-   ```powershell
-   Expand-Archive dist\openasr-<version>-windows-x86_64-vulkan.zip -DestinationPath tmp-verify
-   signtool verify /pa /v tmp-verify\openasr.exe
-   ```
-
-   `/pa` uses the default authenticode policy (what Windows actually enforces
-   at launch); a clean run prints a chain up to a trusted root with no
-   warnings. Treat any failure as release-blocking -- it means the archive a
-   user downloads would fail Windows' own signature check.
-6. **Manually confirm the vendor archives are present and installable** (CI
-   cannot exercise this on the GPU-less hosted runner -- see this repo's PR/
-   commit history for the full "first v2 release" manual checklist): download
-   `openasr-vendor-cuda-runtime-<sha12>.zip` /
-   `-rocm-runtime-<sha12>.zip` from the release, confirm the filename's
-   embedded short hash actually prefixes `sha256sum`'s output, and confirm the
-   corresponding sidecar archive's `openasr.exe --version` launches once the
-   vendor archive's DLLs are placed on `PATH` next to it (desktop's own
-   install-order contract: vendor layer first, then the sidecar `--version`
-   probe -- see `docs/backend-kernels.md`'s "Disk layout" section).
+For core 0.1.34 and later, the manifest workflow in this document is retired.
+Follow the authoritative checklist in `RELEASING.md`: hardware evidence, B2/CDN
+payload sync, catalog preparation/signing, catalog deployment (with a repeated
+CDN gate), then draft finalization (with the third CDN gate). Metadata must
+never become live before every URL it signs.

--- a/tooling/release-manifest/backend_catalog.py
+++ b/tooling/release-manifest/backend_catalog.py
@@ -620,7 +620,7 @@ def verify_catalog_cdn(
 
     catalog = _read_json(catalog_path)
     head_fn = head or head_cdn_url
-    seen: dict[str, tuple[str, str, int]] = {}
+    seen: dict[str, tuple[str, str, int, str]] = {}
     checked_versions: set[str] = set()
     for entry in catalog.get("backends", []):
         if not isinstance(entry, dict):
@@ -636,12 +636,17 @@ def verify_catalog_cdn(
             filename = str(file.get("filename", ""))
             url = str(file.get("url", ""))
             size = int(file.get("size_bytes", 0))
+            sha256 = str(file.get("sha256", "")).lower()
+            if not re.fullmatch(r"[0-9a-f]{64}", sha256):
+                raise BackendCatalogError(
+                    f"backend file '{filename}' has an invalid signed sha256"
+                )
             canonical_url = f"https://dl.openasr.org/core/v{entry_version}/{filename}"
             if not entry_version or url != canonical_url:
                 raise BackendCatalogError(
                     f"backend file '{filename}' is not the canonical CDN URL for {entry_version or '<missing version>'}"
                 )
-            identity = (entry_version, filename, size)
+            identity = (entry_version, filename, size, sha256)
             if url in seen:
                 if seen[url] != identity:
                     raise BackendCatalogError(
@@ -657,8 +662,8 @@ def verify_catalog_cdn(
             f"catalog has no CUDA/HIP backend files for {scope} to verify on CDN"
         )
 
-    def probe(item: tuple[str, tuple[str, str, int]]) -> str:
-        url, (entry_version, filename, size) = item
+    def probe(item: tuple[str, tuple[str, str, int, str]]) -> str:
+        url, (entry_version, filename, size, _sha256) = item
         status, length = head_fn(url)
         if status != 200 or length != size:
             raise BackendCatalogError(

--- a/tooling/release-manifest/backend_catalog.py
+++ b/tooling/release-manifest/backend_catalog.py
@@ -12,6 +12,7 @@ canonical CDN prefix is empty.
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import hashlib
 import json
 import re
@@ -571,7 +572,21 @@ def head_cdn_url(url: str) -> tuple[int, int | None]:
     # Cloudflare on dl.openasr.org rejects Python-urllib's default User-Agent
     # with HTTP 403. curl is the maintainer-host probe used everywhere else.
     completed = subprocess.run(
-        ["curl", "-sI", url],
+        [
+            "curl",
+            "-sS",
+            "-I",
+            "--connect-timeout",
+            "5",
+            "--max-time",
+            "20",
+            "--retry",
+            "2",
+            "--retry-delay",
+            "1",
+            "--retry-all-errors",
+            url,
+        ],
         check=False,
         capture_output=True,
         text=True,
@@ -598,19 +613,22 @@ def head_cdn_url(url: str) -> tuple[int, int | None]:
 
 def verify_catalog_cdn(
     catalog_path: Path,
-    version: str,
+    version: str | None = None,
     head: Callable[[str], tuple[int, int | None]] | None = None,
 ) -> dict[str, object]:
-    """Require every signed CUDA/HIP file URL for this version to be live on CDN."""
+    """Require signed CUDA/HIP file URLs to be live before catalog deployment."""
 
     catalog = _read_json(catalog_path)
     head_fn = head or head_cdn_url
-    checked: list[str] = []
-    seen: set[str] = set()
+    seen: dict[str, tuple[str, str, int]] = {}
+    checked_versions: set[str] = set()
     for entry in catalog.get("backends", []):
         if not isinstance(entry, dict):
             continue
-        if str(entry.get("version")) != version or entry.get("vendor") not in {"cuda", "hip"}:
+        entry_version = str(entry.get("version", ""))
+        if entry.get("vendor") not in {"cuda", "hip"} or (
+            version is not None and entry_version != version
+        ):
             continue
         for file in entry.get("files", []):
             if not isinstance(file, dict):
@@ -618,26 +636,53 @@ def verify_catalog_cdn(
             filename = str(file.get("filename", ""))
             url = str(file.get("url", ""))
             size = int(file.get("size_bytes", 0))
+            canonical_url = f"https://dl.openasr.org/core/v{entry_version}/{filename}"
+            if not entry_version or url != canonical_url:
+                raise BackendCatalogError(
+                    f"backend file '{filename}' is not the canonical CDN URL for {entry_version or '<missing version>'}"
+                )
+            identity = (entry_version, filename, size)
             if url in seen:
+                if seen[url] != identity:
+                    raise BackendCatalogError(
+                        f"conflicting signed metadata for duplicate CDN URL '{url}': "
+                        f"first={seen[url]!r} later={identity!r}"
+                    )
                 continue
-            seen.add(url)
-            if not url.startswith(f"https://dl.openasr.org/core/v{version}/"):
-                raise BackendCatalogError(
-                    f"backend file '{filename}' is not the canonical CDN URL for {version}"
-                )
-            status, length = head_fn(url)
-            if status != 200 or length != size:
-                raise BackendCatalogError(
-                    f"CDN object missing or size-mismatched for '{filename}': "
-                    f"HEAD {url} -> {status} content-length={length} signed_size={size}. "
-                    f"Run scripts/sync-windows-backend-cdn.sh v{version} before finalize."
-                )
-            checked.append(url)
-    if not checked:
+            seen[url] = identity
+            checked_versions.add(entry_version)
+    if not seen:
+        scope = f"version {version}" if version is not None else "the catalog"
         raise BackendCatalogError(
-            f"catalog has no CUDA/HIP backend files for version {version} to verify on CDN"
+            f"catalog has no CUDA/HIP backend files for {scope} to verify on CDN"
         )
-    return {"schema_version": 1, "version": version, "verified_urls": sorted(checked)}
+
+    def probe(item: tuple[str, tuple[str, str, int]]) -> str:
+        url, (entry_version, filename, size) = item
+        status, length = head_fn(url)
+        if status != 200 or length != size:
+            raise BackendCatalogError(
+                f"CDN object missing or size-mismatched for '{filename}': "
+                f"HEAD {url} -> {status} content-length={length} signed_size={size}. "
+                f"Run scripts/sync-windows-backend-cdn.sh v{entry_version} before catalog deployment."
+            )
+        return url
+
+    items = sorted(seen.items())
+    if head is None and len(items) > 1:
+        # Network HEADs are independent. Bound parallelism so a catalog with
+        # many target packs does not turn deploy/finalize into a long serial
+        # TLS loop, while curl's timeout/retry bounds every worker.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(items))) as pool:
+            checked = list(pool.map(probe, items))
+    else:
+        # Injected probes stay deterministic for unit tests and local callers.
+        checked = [probe(item) for item in items]
+    return {
+        "schema_version": 1,
+        "versions": sorted(checked_versions),
+        "verified_urls": sorted(checked),
+    }
 
 
 def artifact_fingerprint(entry: dict[str, Any]) -> str:
@@ -797,7 +842,10 @@ def main() -> int:
     verify_catalog_parser.add_argument("--entry", type=Path, action="append", required=True)
     verify_cdn_parser = subparsers.add_parser("verify-cdn")
     verify_cdn_parser.add_argument("--catalog", type=Path, required=True)
-    verify_cdn_parser.add_argument("--version", required=True)
+    verify_cdn_parser.add_argument(
+        "--version",
+        help="limit the gate to one X.Y.Z release; omit to verify every signed backend URL",
+    )
     hints_parser = subparsers.add_parser("hints")
     hints_parser.add_argument("--entry", type=Path, action="append", required=True)
     hints_parser.add_argument("--out", type=Path, required=True)

--- a/tooling/release-manifest/backend_catalog_test.py
+++ b/tooling/release-manifest/backend_catalog_test.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest import mock
 
 import backend_catalog
 
@@ -262,6 +263,7 @@ class BackendCatalogTest(unittest.TestCase):
             result = backend_catalog.verify_catalog_cdn(
                 catalog, "0.1.35", head=lambda url: heads[url]
             )
+            self.assertEqual(result["versions"], ["0.1.35"])
             self.assertEqual(result["verified_urls"], [plugin_url, vendor_url])
 
             heads[vendor_url] = (404, None)
@@ -269,6 +271,125 @@ class BackendCatalogTest(unittest.TestCase):
                 backend_catalog.verify_catalog_cdn(
                     catalog, "0.1.35", head=lambda url: heads[url]
                 )
+
+    def test_verify_catalog_cdn_without_version_gates_every_backend_release(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            catalog = Path(tmp) / "catalog.json"
+            urls = {
+                "https://dl.openasr.org/core/v0.1.34/cuda.dll": (200, 10),
+                "https://dl.openasr.org/core/v0.1.35/hip.dll": (200, 20),
+            }
+            catalog.write_text(
+                json.dumps(
+                    {
+                        "backends": [
+                            {
+                                "vendor": "cuda",
+                                "version": "0.1.34",
+                                "files": [
+                                    {
+                                        "filename": "cuda.dll",
+                                        "url": next(iter(urls)),
+                                        "size_bytes": 10,
+                                    }
+                                ],
+                            },
+                            {
+                                "vendor": "hip",
+                                "version": "0.1.35",
+                                "files": [
+                                    {
+                                        "filename": "hip.dll",
+                                        "url": "https://dl.openasr.org/core/v0.1.35/hip.dll",
+                                        "size_bytes": 20,
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = backend_catalog.verify_catalog_cdn(
+                catalog, head=lambda url: urls[url]
+            )
+            self.assertEqual(result["versions"], ["0.1.34", "0.1.35"])
+            self.assertEqual(result["verified_urls"], sorted(urls))
+
+    def test_verify_catalog_cdn_rejects_conflicting_duplicate_url_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            catalog = Path(tmp) / "catalog.json"
+            url = "https://dl.openasr.org/core/v0.1.35/shared.zip"
+            catalog.write_text(
+                json.dumps(
+                    {
+                        "backends": [
+                            {
+                                "vendor": "cuda",
+                                "version": "0.1.35",
+                                "files": [
+                                    {"filename": "shared.zip", "url": url, "size_bytes": 10}
+                                ],
+                            },
+                            {
+                                "vendor": "hip",
+                                "version": "0.1.35",
+                                "files": [
+                                    {"filename": "shared.zip", "url": url, "size_bytes": 999}
+                                ],
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                backend_catalog.BackendCatalogError, "conflicting signed metadata"
+            ):
+                backend_catalog.verify_catalog_cdn(catalog, head=lambda _: (200, 10))
+
+    def test_verify_catalog_cdn_requires_filename_exactly_in_canonical_url(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            catalog = Path(tmp) / "catalog.json"
+            catalog.write_text(
+                json.dumps(
+                    {
+                        "backends": [
+                            {
+                                "vendor": "cuda",
+                                "version": "0.1.35",
+                                "files": [
+                                    {
+                                        "filename": "signed-name.zip",
+                                        "url": "https://dl.openasr.org/core/v0.1.35/other-name.zip",
+                                        "size_bytes": 10,
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                backend_catalog.BackendCatalogError, "not the canonical CDN URL"
+            ):
+                backend_catalog.verify_catalog_cdn(catalog, head=lambda _: (200, 10))
+
+    def test_head_cdn_url_bounds_and_retries_curl(self):
+        completed = backend_catalog.subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="HTTP/2 200\ncontent-length: 42\n", stderr=""
+        )
+        with mock.patch.object(backend_catalog.subprocess, "run", return_value=completed) as run:
+            self.assertEqual(backend_catalog.head_cdn_url("https://example.invalid/file"), (200, 42))
+
+        command = run.call_args.args[0]
+        self.assertIn("--connect-timeout", command)
+        self.assertIn("--max-time", command)
+        self.assertIn("--retry", command)
+        self.assertIn("--retry-all-errors", command)
 
     def test_update_hints_bind_target_scoped_provider_candidates_to_one_host_abi(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tooling/release-manifest/backend_catalog_test.py
+++ b/tooling/release-manifest/backend_catalog_test.py
@@ -234,11 +234,13 @@ class BackendCatalogTest(unittest.TestCase):
                                         "filename": "hip.dll",
                                         "url": plugin_url,
                                         "size_bytes": 70,
+                                        "sha256": "a" * 64,
                                     },
                                     {
                                         "filename": "vendor.zip",
                                         "url": vendor_url,
                                         "size_bytes": 200,
+                                        "sha256": "b" * 64,
                                     },
                                 ],
                             },
@@ -251,6 +253,7 @@ class BackendCatalogTest(unittest.TestCase):
                                         "filename": "cuda.dll",
                                         "url": "https://dl.openasr.org/core/v0.1.34/cuda.dll",
                                         "size_bytes": 10,
+                                        "sha256": "c" * 64,
                                     }
                                 ],
                             },
@@ -291,6 +294,7 @@ class BackendCatalogTest(unittest.TestCase):
                                         "filename": "cuda.dll",
                                         "url": next(iter(urls)),
                                         "size_bytes": 10,
+                                        "sha256": "a" * 64,
                                     }
                                 ],
                             },
@@ -302,6 +306,7 @@ class BackendCatalogTest(unittest.TestCase):
                                         "filename": "hip.dll",
                                         "url": "https://dl.openasr.org/core/v0.1.35/hip.dll",
                                         "size_bytes": 20,
+                                        "sha256": "b" * 64,
                                     }
                                 ],
                             },
@@ -328,14 +333,24 @@ class BackendCatalogTest(unittest.TestCase):
                                 "vendor": "cuda",
                                 "version": "0.1.35",
                                 "files": [
-                                    {"filename": "shared.zip", "url": url, "size_bytes": 10}
+                                    {
+                                        "filename": "shared.zip",
+                                        "url": url,
+                                        "size_bytes": 10,
+                                        "sha256": "a" * 64,
+                                    }
                                 ],
                             },
                             {
                                 "vendor": "hip",
                                 "version": "0.1.35",
                                 "files": [
-                                    {"filename": "shared.zip", "url": url, "size_bytes": 999}
+                                    {
+                                        "filename": "shared.zip",
+                                        "url": url,
+                                        "size_bytes": 999,
+                                        "sha256": "a" * 64,
+                                    }
                                 ],
                             },
                         ]
@@ -348,6 +363,67 @@ class BackendCatalogTest(unittest.TestCase):
                 backend_catalog.BackendCatalogError, "conflicting signed metadata"
             ):
                 backend_catalog.verify_catalog_cdn(catalog, head=lambda _: (200, 10))
+
+    def test_verify_catalog_cdn_rejects_same_size_duplicate_with_different_sha256(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            catalog = Path(tmp) / "catalog.json"
+            url = "https://dl.openasr.org/core/v0.1.35/shared.zip"
+            catalog.write_text(
+                json.dumps(
+                    {
+                        "backends": [
+                            {
+                                "vendor": vendor,
+                                "version": "0.1.35",
+                                "files": [
+                                    {
+                                        "filename": "shared.zip",
+                                        "url": url,
+                                        "size_bytes": 10,
+                                        "sha256": digest * 64,
+                                    }
+                                ],
+                            }
+                            for vendor, digest in (("cuda", "a"), ("hip", "b"))
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                backend_catalog.BackendCatalogError, "conflicting signed metadata"
+            ):
+                backend_catalog.verify_catalog_cdn(catalog, head=lambda _: (200, 10))
+
+    def test_verify_catalog_cdn_probes_identical_duplicate_metadata_once(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            catalog = Path(tmp) / "catalog.json"
+            url = "https://dl.openasr.org/core/v0.1.35/shared.zip"
+            record = {
+                "filename": "shared.zip",
+                "url": url,
+                "size_bytes": 10,
+                "sha256": "a" * 64,
+            }
+            catalog.write_text(
+                json.dumps(
+                    {
+                        "backends": [
+                            {"vendor": vendor, "version": "0.1.35", "files": [record]}
+                            for vendor in ("cuda", "hip")
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            calls = []
+
+            backend_catalog.verify_catalog_cdn(
+                catalog, head=lambda candidate: calls.append(candidate) or (200, 10)
+            )
+
+            self.assertEqual(calls, [url])
 
     def test_verify_catalog_cdn_requires_filename_exactly_in_canonical_url(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -364,6 +440,7 @@ class BackendCatalogTest(unittest.TestCase):
                                         "filename": "signed-name.zip",
                                         "url": "https://dl.openasr.org/core/v0.1.35/other-name.zip",
                                         "size_bytes": 10,
+                                        "sha256": "a" * 64,
                                     }
                                 ],
                             }

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
@@ -94,6 +95,37 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertNotIn('tags: ["v*"]', family)
         self.assertIn("releases/latest", family)
         self.assertIn("refusing a duplicate local build", family)
+        self.assertEqual(family.count("release_asset_verifier.py"), 2)
+        self.assertEqual(family.count("--pattern SHA256SUMS"), 2)
+        self.assertEqual(family.count("gh attestation verify"), 2)
+        self.assertEqual(family.count("--signer-workflow"), 2)
+        self.assertIn("attestations: read", family)
+
+    def test_family_regression_ignores_non_core_release_tags(self) -> None:
+        family = (ROOT / ".github/workflows/family-regression.yml").read_text(
+            encoding="utf-8"
+        )
+        jobs = family.split("\njobs:\n", maxsplit=1)[1]
+        starts = list(re.finditer(r"(?m)^  ([a-z0-9-]+):\n", jobs))
+        self.assertGreater(len(starts), 0)
+
+        guard = (
+            "github.event_name != 'release' || "
+            "startsWith(github.event.release.tag_name, 'v')"
+        )
+        for index, match in enumerate(starts):
+            end = starts[index + 1].start() if index + 1 < len(starts) else len(jobs)
+            block = jobs[match.start() : end]
+            self.assertIn(
+                guard,
+                block,
+                f"family-regression job {match.group(1)!r} accepts desktop-v* releases",
+            )
+
+    def test_push_ci_cannot_be_bypassed_with_a_commit_message_prefix(self) -> None:
+        ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+        self.assertNotIn("github.event.head_commit.message", ci)
 
 
 if __name__ == "__main__":

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -14,6 +14,8 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         finalize = (ROOT / "scripts/finalize-core-release.sh").read_text(encoding="utf-8")
+        sync = (ROOT / "scripts/sync-windows-backend-cdn.sh").read_text(encoding="utf-8")
+        deploy = (ROOT / ".github/workflows/deploy-catalog.yml").read_text(encoding="utf-8")
         publish = (
             ROOT / "tooling/publish-model/scripts/publish_catalog.sh"
         ).read_text(encoding="utf-8")
@@ -23,6 +25,7 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn("verify-assets", prepare)
         self.assertIn("publish_catalog.sh", prepare)
         self.assertIn("verify-catalog", prepare)
+        self.assertIn("verify-cdn", prepare)
         self.assertIn("backend_hardware_evidence.py", prepare)
         self.assertIn("tr -d '\\r'", prepare)
         self.assertNotIn("mapfile -t", prepare)
@@ -34,6 +37,16 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
             prepare.index("preflighting local catalog signer toolchain"),
             prepare.index("downloading backend entries"),
         )
+        self.assertLess(prepare.index("verify-cdn"), prepare.index("publish_catalog.sh"))
+        self.assertLess(
+            prepare.index("verify-cdn"),
+            prepare.index('old_epoch="$(tr -d'),
+        )
+        self.assertIn("prepare-windows-backend-catalog-release.sh", sync)
+        self.assertIn("verify-cdn", deploy)
+        self.assertIn("check_catalog_consistency.py", deploy)
+        self.assertIn("regenerate_all.sh --check", deploy)
+        self.assertLess(deploy.index("verify-cdn"), deploy.index("Deploy to Cloudflare"))
         self.assertIn("catalog.openasr.org/v1/catalog.json", finalize)
         self.assertNotIn("backends-manifest", finalize)
         self.assertIn("verify-catalog", finalize)
@@ -49,6 +62,38 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn('"${#cuda_entries[@]}" -ne 6', finalize)
         self.assertIn('"${#hip_entries[@]}" -ne 14', finalize)
         self.assertLess(finalize.index("verify-catalog"), finalize.index("--draft=false"))
+
+    def test_release_matrix_has_one_formal_entrypoint_and_channels_wait_for_publish(self) -> None:
+        release = (ROOT / ".github/workflows/release-core.yml").read_text(encoding="utf-8")
+        binaries = (ROOT / ".github/workflows/release-binaries.yml").read_text(encoding="utf-8")
+        channels = (ROOT / ".github/workflows/publish-core-channels.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn("push:\n    tags:", binaries)
+        self.assertIn("uses: ./.github/workflows/release-binaries.yml", release)
+        self.assertNotIn("docker-images:", release)
+        self.assertNotIn("update-homebrew-tap:", release)
+        self.assertIn("types: [published]", channels)
+        self.assertIn("uses: ./.github/workflows/docker-release.yml", channels)
+        self.assertIn("releases/latest", channels)
+        self.assertIn("distribution-gate:", channels)
+        self.assertIn("backend_hardware_evidence.py", channels)
+        self.assertIn("gate-catalog-against-released-binary.sh", channels)
+        self.assertIn("verify-catalog", channels)
+        self.assertIn("verify-cdn", channels)
+        self.assertIn("needs: [resolve, distribution-gate]", channels)
+        self.assertIn("git push origin main", channels)
+
+    def test_family_regression_reuses_published_assets_instead_of_racing_raw_tag(self) -> None:
+        family = (ROOT / ".github/workflows/family-regression.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("types: [published]", family)
+        self.assertNotIn('tags: ["v*"]', family)
+        self.assertIn("releases/latest", family)
+        self.assertIn("refusing a duplicate local build", family)
 
 
 if __name__ == "__main__":

--- a/tooling/release-manifest/release_asset_verifier.py
+++ b/tooling/release-manifest/release_asset_verifier.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fail-closed SHA256SUMS verification for one downloaded release asset."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+from pathlib import Path
+
+
+class ReleaseAssetVerificationError(RuntimeError):
+    pass
+
+
+def expected_sha256(checksums_text: str, asset_name: str) -> str:
+    matches: list[str] = []
+    for raw_line in checksums_text.splitlines():
+        match = re.fullmatch(r"([0-9a-fA-F]{64})\s+\*?(.+)", raw_line.strip())
+        if match and match.group(2).strip() == asset_name:
+            matches.append(match.group(1).lower())
+    if len(matches) != 1:
+        raise ReleaseAssetVerificationError(
+            f"SHA256SUMS must contain exactly one entry for {asset_name}; found {len(matches)}"
+        )
+    return matches[0]
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_release_asset(asset: Path, checksums: Path) -> str:
+    if not asset.is_file():
+        raise ReleaseAssetVerificationError(f"release asset is missing: {asset}")
+    if not checksums.is_file():
+        raise ReleaseAssetVerificationError(f"SHA256SUMS is missing: {checksums}")
+    expected = expected_sha256(checksums.read_text(encoding="utf-8"), asset.name)
+    actual = file_sha256(asset)
+    if actual != expected:
+        raise ReleaseAssetVerificationError(
+            f"sha256 mismatch for {asset.name}: expected {expected}, got {actual}"
+        )
+    return actual
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--asset", type=Path, required=True)
+    parser.add_argument("--checksums", type=Path, required=True)
+    args = parser.parse_args()
+    digest = verify_release_asset(args.asset, args.checksums)
+    print(f"verified {args.asset.name} sha256={digest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tooling/release-manifest/release_asset_verifier_test.py
+++ b/tooling/release-manifest/release_asset_verifier_test.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+import release_asset_verifier
+
+
+class ReleaseAssetVerifierTest(unittest.TestCase):
+    def write_fixture(self, checksums_text: str) -> tuple[Path, Path, tempfile.TemporaryDirectory[str]]:
+        temp = tempfile.TemporaryDirectory()
+        root = Path(temp.name)
+        asset = root / "openasr-0.1.35-linux-x86_64.tar.gz"
+        asset.write_bytes(b"verified release bytes")
+        checksums = root / "SHA256SUMS"
+        checksums.write_text(checksums_text, encoding="utf-8")
+        return asset, checksums, temp
+
+    def test_accepts_exactly_one_matching_digest(self) -> None:
+        digest = hashlib.sha256(b"verified release bytes").hexdigest()
+        asset, checksums, temp = self.write_fixture(f"{digest}  openasr-0.1.35-linux-x86_64.tar.gz\n")
+        self.addCleanup(temp.cleanup)
+
+        self.assertEqual(release_asset_verifier.verify_release_asset(asset, checksums), digest)
+
+    def test_rejects_a_digest_mismatch(self) -> None:
+        asset, checksums, temp = self.write_fixture(
+            f"{'0' * 64}  openasr-0.1.35-linux-x86_64.tar.gz\n"
+        )
+        self.addCleanup(temp.cleanup)
+
+        with self.assertRaisesRegex(
+            release_asset_verifier.ReleaseAssetVerificationError, "sha256 mismatch"
+        ):
+            release_asset_verifier.verify_release_asset(asset, checksums)
+
+    def test_rejects_a_missing_manifest_entry(self) -> None:
+        asset, checksums, temp = self.write_fixture(f"{'0' * 64}  another.tar.gz\n")
+        self.addCleanup(temp.cleanup)
+
+        with self.assertRaisesRegex(
+            release_asset_verifier.ReleaseAssetVerificationError, "exactly one entry"
+        ):
+            release_asset_verifier.verify_release_asset(asset, checksums)
+
+    def test_rejects_duplicate_manifest_entries(self) -> None:
+        digest = hashlib.sha256(b"verified release bytes").hexdigest()
+        line = f"{digest}  openasr-0.1.35-linux-x86_64.tar.gz\n"
+        asset, checksums, temp = self.write_fixture(line + line)
+        self.addCleanup(temp.cleanup)
+
+        with self.assertRaisesRegex(
+            release_asset_verifier.ReleaseAssetVerificationError, "found 2"
+        ):
+            release_asset_verifier.verify_release_asset(asset, checksums)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Streamline release-triggered validation and harden distribution finalization gates.

## Why

Release automation was rebuilding already published artifacts, starting downstream work before publication was complete, and did not consistently bind CDN identity or published artifacts to their cryptographic provenance.

## Changes

- run family regression and downstream channel publication from published releases
- prevent Desktop `desktop-v*` releases from entering Core family regression
- verify downloaded release assets with SHA-256 and GitHub attestations
- require live CDN verification before catalog finalization
- bind duplicate CDN URL identity to SHA-256
- remove commit-message based CI bypasses
- add contract coverage for release and distribution invariants

## Tests run

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`
- [x] `python3 -m unittest discover -s tooling/release-manifest -p '*_test.py'` (117 tests)
- [x] Actionlint for all changed workflows
- [x] `git diff --check`

## Manual smoke checks

Not run locally. The PR must exercise the normal GitHub Actions gates before merge.

## Model-family changes (when applicable)

Not applicable.

## Docs updated

- [x] Release workflow comments and contracts updated.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR does not publish a release, change model artifacts, or alter release credentials.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy.
- [x] I understand every line of this change and own its maintenance.
- AI usage disclosure: YES - AI assistance was used for implementation and test execution.
