### PR TITLE
fix(windows): compile backend file locking path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,26 @@ jobs:
       - name: Doctests
         run: cargo test --workspace --doc
 
+  windows-core-compile:
+    name: Windows core compile gate
+    runs-on: windows-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-core-compile
+      # The Linux system-audio cross-check does not compile openasr-core's
+      # cfg(windows) trust and plugin-loading paths. Keep one native Windows
+      # compile gate so platform-only production code cannot merge unparsed.
+      - run: cargo check --locked -p openasr-core
+
   system-audio-macos:
     runs-on: macos-latest
     steps:

--- a/crates/openasr-core/src/ggml_runtime/backend.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend.rs
@@ -984,6 +984,9 @@ fn lock_verified_backend_load_files(
     plugin_path: &Path,
     dependency_dirs: &[PathBuf],
 ) -> Result<Vec<std::fs::File>, BackendPluginActivationError> {
+    use std::{fs::OpenOptions, os::windows::fs::OpenOptionsExt};
+    use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+
     fn collect_dlls(directory: &Path, files: &mut Vec<PathBuf>) -> std::io::Result<()> {
         for entry in std::fs::read_dir(directory)? {
             let entry = entry?;


### PR DESCRIPTION
## Summary

Make the verified backend-file locking path compile on Windows and add native Windows compile coverage to core CI.

## Why

The downstream Desktop Windows job compiled merged core commit `6f5c8950048e387e026f518c560ae0495459a8fb` and found that the `cfg(windows)` backend activation path referenced `OpenOptions`, `OpenOptionsExt::share_mode`, and `FILE_SHARE_READ` without importing them. Existing core CI cross-compiled only the standalone system-audio workspace for Windows, so it could not catch this production-path name-resolution failure before merge.

## Changes

- Keep the three Windows-only imports local to `lock_verified_backend_load_files`.
- Add a native `windows-latest` `cargo check --locked -p openasr-core` job so core's Windows production code is compiled on every non-doc PR.

## Tests run

- [x] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings` (CI)
- [ ] `cargo nextest run --workspace` (CI)
- [ ] `cargo test --workspace --doc` (CI)
- [ ] `cargo deny check` (CI dependency-policy gate)
- [x] `cargo check --locked -p openasr-core` (macOS host)
- [x] `actionlint .github/workflows/ci.yml`
- [x] `git diff --check`
- [ ] Native Windows core compile gate (this PR's CI)

## Manual smoke checks

The exact downstream Windows failure was independently reproduced from CircleCI job 31: Rust name resolution failed at `backend.rs` for the three missing imports before the CLI serve-contract smoke could run. This PR's native Windows CI job is the acceptance gate for the fix.

## Model-family changes (when applicable)

Not applicable.

## Docs updated

- [x] No user-facing behavior or capability claim changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

This PR restores Windows compilation and closes the CI coverage gap. It does not qualify CUDA, HIP, or physical Vulkan hardware and does not activate any backend.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] The maintainer has reviewed the applicable repository policies and owns this change.
- AI usage disclosure: YES — AI assisted with diagnosis, implementation, and validation under maintainer direction.
