### PR TITLE
feat(transport): rewrite china catalog and pack fetches without resigning identity

### DIFF
--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -50,6 +50,10 @@ on:
     secrets:
       CLOUDFLARE_API_TOKEN:
         required: true
+      ALIBABA_CLOUD_ACCESS_KEY_ID:
+        required: false
+      ALIBABA_CLOUD_ACCESS_KEY_SECRET:
+        required: false
 concurrency:
   group: deploy-catalog
   cancel-in-progress: false
@@ -392,6 +396,21 @@ jobs:
             echo "::error::live catalog exposes public:false entries"; exit 1
           fi
           echo "live catalog.openasr.org matches the committed public projection (public-only)"
+
+      - name: Deploy identical bytes to Aliyun ESA (catalog.bug.im)
+        env:
+          ALIBABA_CLOUD_ACCESS_KEY_ID: ${{ secrets.ALIBABA_CLOUD_ACCESS_KEY_ID }}
+          ALIBABA_CLOUD_ACCESS_KEY_SECRET: ${{ secrets.ALIBABA_CLOUD_ACCESS_KEY_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -n "${ALIBABA_CLOUD_ACCESS_KEY_ID:-}" ] && [ -n "${ALIBABA_CLOUD_ACCESS_KEY_SECRET:-}" ]; then
+            npm install -g esa-cli
+          fi
+          chmod +x scripts/deploy-catalog-esa.sh
+          # Skip (exit 0) when esa-cli is missing, not logged in, or live HTTPS
+          # is unreachable. Reachable catalog.bug.im with a sha256 mismatch
+          # fails the job.
+          scripts/deploy-catalog-esa.sh candidate-catalog.json candidate-catalog.signature.json
 
       - name: Record immutable deploy binding
         env:

--- a/.github/workflows/sync-main-to-cnb.yml
+++ b/.github/workflows/sync-main-to-cnb.yml
@@ -1,0 +1,31 @@
+name: Sync main to CNB
+
+# One-way fast-forward of GitHub main onto cnb.cool/openasr/openasr.
+# Never --mirror / --prune: CNB also stores desktop-v* tags that GitHub does
+# not have. Release assets still go through scripts/sync-release-to-cnb.sh.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-main-to-cnb
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: github.repository == 'QuintinShaw/openasr'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fast-forward CNB main
+        env:
+          CNB_TOKEN: ${{ secrets.CNB_TOKEN }}
+        run: scripts/sync-main-to-cnb.sh HEAD

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,10 +55,12 @@ Bundled model cards are metadata-only planning/provenance records and are non-do
 When a flow does fetch the model catalog (an explicit `pull`, or a
 consent-approved auto-install during `transcribe`/`live` — never silently), the catalog is served from
 OpenASR-operated infrastructure at `https://catalog.openasr.org` (a Cloudflare
-static-asset host) rather than Hugging Face. The signed `catalog_url` stays
-HF-canonical only as the verification identity; the ed25519 signature, sha256, and
-monotonic-epoch checks are unchanged, and model **weights are still fetched
-directly from Hugging Face** (the catalog host never sees or serves weights). Only
+static-asset host) rather than Hugging Face. The signed `catalog_url` is always
+`https://catalog.openasr.org/v1/catalog.json`; `catalog.bug.im` is an allowlisted
+fetch replica, not a second identity. The ed25519 signature, sha256, and
+monotonic-epoch checks are unchanged. Model **weights stay identified by the
+signed Hugging Face pack URL**; China transport may fetch the same bytes from
+ModelScope. The catalog host never sees or serves weights. Only
 the **public** projection is served/embedded — staged `public:false` entries are
 never exposed. It is not usage telemetry — only the catalog index is requested —
 but the catalog fetch's network metadata (e.g. client IP) is observable by the

--- a/cloudflare/catalog/README.md
+++ b/cloudflare/catalog/README.md
@@ -14,8 +14,10 @@ It is the server side of the default catalog URL:
   no longer required to serve clients.
 - **It is not a trust anchor.** Bytes are served verbatim; the client verifies the
   ed25519 signature, the sha256, and the monotonic epoch. The signed `catalog_url`
-  stays HF-canonical purely as a verification identity, so hosting on CF needs **no
-  re-sign / signing seed** beyond the normal catalog publish step.
+  is always `https://catalog.openasr.org/v1/catalog.json`. `catalog.bug.im` is a
+  byte-identical Aliyun ESA replica (same two JSON files, no 302, no rewrite);
+  clients fetch it by setting `OPENASR_CATALOG_ENDPOINT=https://catalog.bug.im`
+  while verification still uses the `catalog.openasr.org` identity.
 - **Offline still works.** If `catalog.openasr.org` is unreachable, the client falls
   back to its on-disk cache and finally the catalog snapshot embedded in the binary.
 
@@ -50,8 +52,8 @@ npx wrangler login
 npm run deploy       # build:assets (copy from model-registry) -> wrangler deploy
 ```
 
-Clients default to this host; to point elsewhere (self-host, local testing, or
-straight to Hugging Face) set `OPENASR_CATALOG_ENDPOINT`.
+Clients default to this host; China transport sets `OPENASR_CATALOG_ENDPOINT=https://catalog.bug.im`
+(allowlisted). Hugging Face no longer serves the catalog.
 
 ## Caching
 

--- a/cloudflare/catalog/esa.jsonc
+++ b/cloudflare/catalog/esa.jsonc
@@ -1,0 +1,13 @@
+{
+  // Aliyun ESA twin of catalog.openasr.org. Same shape as bugim-cap/esa.jsonc:
+  // a single bundled ESM entry. Catalog JSON is baked into the bundle (see
+  // scripts/build-esa.mjs) so ESA never origin-fetches Cloudflare.
+  "name": "openasr-catalog",
+  "description": "catalog.bug.im — signed OpenASR catalog replica (byte-identical to catalog.openasr.org)",
+  "entry": "./dist/esa/index.js",
+  "codeVersions": [],
+  "dev": {
+    "port": 18070,
+    "localUpstream": ""
+  }
+}

--- a/cloudflare/catalog/package-lock.json
+++ b/cloudflare/catalog/package-lock.json
@@ -1,0 +1,4685 @@
+{
+  "name": "openasr-catalog",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openasr-catalog",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.5.0",
+        "esbuild": "^0.25.0",
+        "vitest": "^2.1.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.5.41.tgz",
+      "integrity": "sha512-J0uYmOKJgyo/az5nV8QHlR6xQ+HHB6S65tOEutkvUPbuPDbFlBPRT+XHJhSTNNvZGeM1t2qZIzxp0WGmXLtNlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^4.3.0",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20241230.0",
+        "semver": "^7.5.1",
+        "wrangler": "3.100.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 2.1.x",
+        "@vitest/snapshot": "2.0.x - 2.1.x",
+        "vitest": "2.0.x - 2.1.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
+      "name": "unenv-nightly",
+      "version": "2.0.0-20241218-183400-5d6aec3",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241218-183400-5d6aec3.tgz",
+      "integrity": "sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "mlly": "^1.7.3",
+        "ohash": "^1.1.4",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.100.0.tgz",
+      "integrity": "sha512-+nsZK374Xnp2BEQQuB/18pnObgsOey0AHVlg75pAdwNaKAmB2aa0/E5rFb7i89DiiwFYoZMz3cARY1UKcm/WQQ==",
+      "deprecated": "Downgrade to 3.99.0",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^4.0.1",
+        "date-fns": "^4.1.0",
+        "esbuild": "0.17.19",
+        "itty-time": "^1.0.6",
+        "miniflare": "3.20241230.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.3.0",
+        "resolve": "^1.22.8",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.6.1",
+        "unenv": "npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3",
+        "workerd": "1.20241230.0",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20241230.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241230.0.tgz",
+      "integrity": "sha512-BZHLg4bbhNQoaY1Uan81O3FV/zcmWueC55juhnaI7NAobiQth9RppadPNpxNAmS9fK2mR5z8xrwMQSQrHmztyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-lllxycj7EzYoJ0VOJh8M3palUgoonVrILnzGrgsworgWlIpgjfXGS7b41tEGCw6AxSxL9prmTIGtfSPUvn/rjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241230.0.tgz",
+      "integrity": "sha512-Y3mHcW0KghOmWdNZyHYpEOG4Ba/ga8tht5vj1a+WXfagEjMO8Y98XhZUlCaYa9yB7Wh5jVcK5LM2jlO/BLgqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-IAjhsWPlHzhhkJ6I49sDG6XfMnhPvv0szKGXxTWQK/IWMrbGdHm4RSfNKBSoLQm67jGMIzbmcrX9UIkms27Y1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241230.0.tgz",
+      "integrity": "sha512-y5SPIk9iOb2gz+yWtHxoeMnjPnkYQswiCJ480oHC6zexnJLlKTpcmBCjDH1nWCT4pQi8F25gaH8thgElf4NvXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.0.tgz",
+      "integrity": "sha512-70TeIFezKKy65LgAVyQh+w94/gjWhvPWaLaGGeMEgVrPkQhuj/M5bAYYZzIFUj9Y69oHyTm5Um/R6gcLh4A8JA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.0.tgz",
+      "integrity": "sha512-YC86tYIHK6M1IV+wbzO+Bxk8RCBr6ZyWYgWxUCzaZD8mc8rrFoIJDNzDrkHBYRc/wKdrsIXmm6/F7NzrAO+OrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.0.tgz",
+      "integrity": "sha512-oI+ECtUcli0y0fi4xpW82GdPIXdTkI8G8DSjG2LRuw09fPAGykaWYH/hXxiKuTxiAjiPSTIIuYUqof5Z2hShWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.0.tgz",
+      "integrity": "sha512-NwV+1s7TiKrMe4owHyKB/dTLD7ZJD0YEBEhIz+hvav1Cu1GReJjF+rsdNwjzENQeIAbE/CoNiaAc5Vz2h5DPAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.0.tgz",
+      "integrity": "sha512-tWtHBTu5gOPK4u4Urtk4qAHW3zZ9rQAmbssO8gp7ELvGTGI3aCiq6NqyTQ0PCIg7KbHJF2UkGDDs77YZGxfjCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.0.tgz",
+      "integrity": "sha512-2qPoJiwTvtHQ27NnYvTnsgk8laXWYuVmNESG8WFZBcEPKLfZ3I27qBJarjVRQtwGeYyRfq5ZowHXih9lm2BItw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.0.tgz",
+      "integrity": "sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.0.tgz",
+      "integrity": "sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.0.tgz",
+      "integrity": "sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.0.tgz",
+      "integrity": "sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.0.tgz",
+      "integrity": "sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.0.tgz",
+      "integrity": "sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.0.tgz",
+      "integrity": "sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.0.tgz",
+      "integrity": "sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.0.tgz",
+      "integrity": "sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.0.tgz",
+      "integrity": "sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.0.tgz",
+      "integrity": "sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.0.tgz",
+      "integrity": "sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.0.tgz",
+      "integrity": "sha512-XvRb5vfW3wAZQ+ZUG21AnHHDKtNcw99eigzEhjr//NZ3u7SoBaPP0seSc7FgP7p1epAEdAoZckMW9WY/+4w70w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.0.tgz",
+      "integrity": "sha512-iZPmniy4kNBf5yo2RezbkYNNK5HPbXE9+g+twnbqSng7dtLEJy1SKoxiE/ni4FDacjyuZpEeb9U054N4EoKHYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.0.tgz",
+      "integrity": "sha512-mFBBd+LF37fnE8JnYUOH+imj0aPFPK30vpar4ehJkgnLj9sZn8ZxiRENmLtgIwxK7TC8klF6N57fxdNBwQoqOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-ujeqEY3B+zbGn3Z4Q03cUBG/LGWnBJncVT36WER31LcOsQk9+1dmINKKtvmmfChUvRbK1G0R8OhMWFgHgaZtAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.0.tgz",
+      "integrity": "sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
+      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/capnp-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
+      "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
+      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/itty-time": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/itty-time/-/itty-time-1.0.6.tgz",
+      "integrity": "sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20241230.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241230.0.tgz",
+      "integrity": "sha512-ZtWNoNAIj5Q0Vb3B4SPEKr7DDmVG8a0Stsp/AuRkYXoJniA5hsbKjFNIGhTXGMIHVP5bvDrKJWt/POIDGfpiKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
+        "capnp-ts": "^0.7.0",
+        "exit-hook": "^2.2.1",
+        "glob-to-regexp": "^0.4.1",
+        "stoppable": "^1.1.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20241230.0",
+        "ws": "^8.18.0",
+        "youch": "^3.2.2",
+        "zod": "^3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
+      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.0.tgz",
+      "integrity": "sha512-T5vnZ2y4QqC3/4P+w2+JO+Q/OVdnPsv4XcSYJYMEn0R9/jjl5AgLwO9LAZMzP2lN71O6pypn91rB7lDstUkfrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.0",
+        "@rollup/rollup-android-arm64": "4.63.0",
+        "@rollup/rollup-darwin-arm64": "4.63.0",
+        "@rollup/rollup-darwin-x64": "4.63.0",
+        "@rollup/rollup-freebsd-arm64": "4.63.0",
+        "@rollup/rollup-freebsd-x64": "4.63.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.0",
+        "@rollup/rollup-linux-arm64-musl": "4.63.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.0",
+        "@rollup/rollup-linux-loong64-musl": "4.63.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-musl": "4.63.0",
+        "@rollup/rollup-openbsd-x64": "4.63.0",
+        "@rollup/rollup-openharmony-arm64": "4.63.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.0",
+        "@rollup/rollup-win32-x64-gnu": "4.63.0",
+        "@rollup/rollup-win32-x64-msvc": "4.63.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241230.0.tgz",
+      "integrity": "sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20241230.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20241230.0",
+        "@cloudflare/workerd-linux-64": "1.20241230.0",
+        "@cloudflare/workerd-linux-arm64": "1.20241230.0",
+        "@cloudflare/workerd-windows-64": "1.20241230.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.126.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+      "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260825.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260825.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260825.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+      "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+      "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+      "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+      "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "5.20260825.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+      "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260825.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20260825.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+      "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260825.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+        "@cloudflare/workerd-linux-64": "1.20260825.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+        "@cloudflare/workerd-windows-64": "1.20260825.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/cloudflare/catalog/package.json
+++ b/cloudflare/catalog/package.json
@@ -10,10 +10,12 @@
     "dev": "wrangler dev",
     "predeploy": "npm run build:assets",
     "deploy": "wrangler deploy",
+    "build:esa": "node scripts/build-esa.mjs",
     "test": "vitest run"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.5.0",
+    "esbuild": "^0.25.0",
     "vitest": "^2.1.0",
     "wrangler": "^4.0.0"
   }

--- a/cloudflare/catalog/scripts/build-esa.mjs
+++ b/cloudflare/catalog/scripts/build-esa.mjs
@@ -1,0 +1,48 @@
+// ESA build for catalog.bug.im. Mirrors bugim-cap/scripts/build-esa.mjs:
+// esbuild bundles the ESA entry and inlines the two catalog files as strings
+// via `define`. ESA has no Worker bindings; baking is how we push bytes
+// instead of origin-fetching Cloudflare.
+import { readFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = join(here, "..");
+const catalogPath = join(pkg, "public", "catalog.json");
+const signaturePath = join(pkg, "public", "catalog.signature.json");
+
+function mustRead(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (error) {
+    throw new Error(
+      `ESA catalog build needs ${path} (copy the candidate pair into public/ first): ${error.message}`,
+    );
+  }
+}
+
+const catalogJson = mustRead(catalogPath);
+const signatureJson = mustRead(signaturePath);
+if (!catalogJson.startsWith("{") || !signatureJson.startsWith("{")) {
+  throw new Error("baked catalog files must be raw JSON objects, not empty/transformed");
+}
+
+mkdirSync(join(pkg, "dist", "esa"), { recursive: true });
+
+await build({
+  entryPoints: [join(pkg, "src", "index.esa.js")],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  outfile: join(pkg, "dist", "esa", "index.js"),
+  define: {
+    "globalThis.__ESA_CATALOG_JSON__": JSON.stringify(catalogJson),
+    "globalThis.__ESA_CATALOG_SIGNATURE_JSON__": JSON.stringify(signatureJson),
+  },
+});
+
+console.log(
+  `[build:esa] baked catalog.json (${catalogJson.length} chars) + catalog.signature.json (${signatureJson.length} chars)`,
+);

--- a/cloudflare/catalog/src/index.esa.js
+++ b/cloudflare/catalog/src/index.esa.js
@@ -1,0 +1,35 @@
+// Aliyun ESA twin of catalog.openasr.org.
+//
+// Same allowlist and CORS as the Cloudflare Worker; bytes are baked into the
+// bundle at `esa-cli` build time (see scripts/build-esa.mjs) so ESA never
+// origin-fetches Cloudflare. Identity stays
+// `https://catalog.openasr.org/v1/catalog.json`.
+//
+// ESA runtime facts (from bugim-cap / bugim-edge, verified on edgeworker2):
+//   - `export default { fetch }`; second arg is ctx with waitUntil, no bindings.
+//   - Static `assets.directory` would auto-serve files and skip this gate, so
+//     catalog JSON is inlined rather than placed at /v1/*.json.
+
+import { handleCatalogRequest } from "./index.js";
+
+const CATALOG_JSON = globalThis.__ESA_CATALOG_JSON__;
+const CATALOG_SIGNATURE_JSON = globalThis.__ESA_CATALOG_SIGNATURE_JSON__;
+
+const BAKED = {
+  "catalog.json": CATALOG_JSON,
+  "catalog.signature.json": CATALOG_SIGNATURE_JSON,
+};
+
+export default {
+  fetch(request) {
+    return handleCatalogRequest(request, async (name) => {
+      const body = BAKED[name];
+      if (typeof body !== "string" || body.length === 0) {
+        return new Response("Catalog asset not baked into this ESA build\n", {
+          status: 404,
+        });
+      }
+      return new Response(body, { status: 200 });
+    });
+  },
+};

--- a/cloudflare/catalog/src/index.js
+++ b/cloudflare/catalog/src/index.js
@@ -31,37 +31,45 @@ function denied(status, message, extraHeaders = {}) {
   });
 }
 
+/// Shared by the Cloudflare Worker and the Aliyun ESA twin (`index.esa.js`).
+/// `getAsset(filename)` must return the committed catalog / signature bytes
+/// verbatim — no JSON parse/stringify, which would break the signed sha256.
+export async function handleCatalogRequest(request, getAsset) {
+  const url = new URL(request.url);
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (request.method !== "GET") {
+    return denied(405, "Method Not Allowed: the catalog host serves GET only", {
+      Allow: ALLOWED_METHODS,
+    });
+  }
+  const match = CATALOG_PATH.exec(url.pathname);
+  if (!match) {
+    return denied(
+      403,
+      "Forbidden: only the OpenASR catalog and its signature manifest are served here",
+    );
+  }
+
+  const asset = await getAsset(match[1]);
+  if (!asset || !asset.ok) {
+    const status = asset?.status === 404 ? 404 : 502;
+    return denied(status, `Catalog asset unavailable (${asset?.status ?? "missing"})`);
+  }
+
+  const headers = new Headers(CORS_HEADERS);
+  headers.set("Content-Type", "application/json; charset=utf-8");
+  headers.set("Cache-Control", "public, max-age=300");
+  return new Response(asset.body, { status: 200, headers });
+}
+
 export default {
   async fetch(request, env) {
-    const url = new URL(request.url);
-
-    if (request.method === "OPTIONS") {
-      return new Response(null, { status: 204, headers: CORS_HEADERS });
-    }
-    if (request.method !== "GET") {
-      return denied(405, "Method Not Allowed: the catalog host serves GET only", {
-        Allow: ALLOWED_METHODS,
-      });
-    }
-    const match = CATALOG_PATH.exec(url.pathname);
-    if (!match) {
-      return denied(
-        403,
-        "Forbidden: only the OpenASR catalog and its signature manifest are served here",
-      );
-    }
-
-    // Serve the byte-identical asset (no transform — preserving sha256/signature).
-    // The asset name is rev-independent; the signed catalog_url identity is checked
-    // by the client, not here.
-    const asset = await env.ASSETS.fetch(new Request(new URL(`/${match[1]}`, url.origin)));
-    if (!asset.ok) {
-      return denied(asset.status === 404 ? 404 : 502, `Catalog asset unavailable (${asset.status})`);
-    }
-
-    const headers = new Headers(CORS_HEADERS);
-    headers.set("Content-Type", "application/json; charset=utf-8");
-    headers.set("Cache-Control", "public, max-age=300");
-    return new Response(asset.body, { status: 200, headers });
+    const origin = new URL(request.url).origin;
+    return handleCatalogRequest(request, (name) =>
+      env.ASSETS.fetch(new Request(new URL(`/${name}`, origin))),
+    );
   },
 };

--- a/crates/openasr-core/src/config.rs
+++ b/crates/openasr-core/src/config.rs
@@ -9,10 +9,11 @@ use thiserror::Error;
 
 use crate::{
     BackendKind, ExecutionTarget, ModelCard, ModelCatalog, ModelResolutionError, PhraseBiasConfig,
-    RuntimeModelResolutionError, atomic_file, resolve_registry_model_ref,
-    resolve_runtime_model_ref,
+    RuntimeModelResolutionError, atomic_file,
+    download_source::{DownloadSource, DownloadSourcePref},
+    launch_pack::QuantPreference,
+    resolve_registry_model_ref, resolve_runtime_model_ref,
 };
-use crate::{download_source::DownloadSourcePref, launch_pack::QuantPreference};
 
 /// The CLI's bare-invocation convention: which model id `transcribe`/`live`/
 /// `pull` resolve to when the caller passes neither `--model` nor has a
@@ -476,6 +477,16 @@ impl OpenAsrConfig {
                 ));
             }
         }
+        if matches!(
+            self.download_source,
+            DownloadSourcePref::Pinned {
+                source: DownloadSource::ModelScope
+            }
+        ) {
+            return Err(ConfigError::UnsupportedDownloadSource(
+                "modelscope".to_string(),
+            ));
+        }
         if let Some(models_dir) = self.models_dir.as_deref() {
             // Deliberately lenient beyond "absolute": an override naming a
             // directory that does not exist yet is valid -- pull/list/delete
@@ -605,8 +616,23 @@ pub fn load_config_document(
 ) -> Result<OpenAsrConfigDocument, ConfigError> {
     let path = config_path(openasr_home);
     match fs::read_to_string(&path) {
-        Ok(contents) => serde_json::from_str(&contents)
-            .map_err(|source| ConfigError::ParseConfig { path, source }),
+        Ok(contents) => {
+            let document: OpenAsrConfigDocument = serde_json::from_str(&contents)
+                .map_err(|source| ConfigError::ParseConfig { path, source })?;
+            // User-facing knobs stay china/global. A hand-edited pin must not
+            // sneak ModelScope past parse_env_value.
+            if matches!(
+                document.config.download_source,
+                DownloadSourcePref::Pinned {
+                    source: DownloadSource::ModelScope
+                }
+            ) {
+                return Err(ConfigError::UnsupportedDownloadSource(
+                    "modelscope".to_string(),
+                ));
+            }
+            Ok(document)
+        }
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
             Ok(OpenAsrConfigDocument::default())
         }

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -470,6 +470,30 @@ fn download_source_rejects_unknown_value() {
 }
 
 #[test]
+fn download_source_validate_rejects_hand_edited_modelscope_pin() {
+    let mut config = OpenAsrConfig::default();
+    config.download_source = DownloadSourcePref::pinned(DownloadSource::ModelScope);
+    let error = config.validate(&registry()).unwrap_err();
+    assert!(
+        matches!(error, ConfigError::UnsupportedDownloadSource(value) if value == "modelscope")
+    );
+}
+
+#[test]
+fn load_config_rejects_hand_edited_modelscope_pin() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.json"),
+        r#"{"download_source":{"mode":"pinned","source":"modelscope"}}"#,
+    )
+    .unwrap();
+    let error = load_config(temp.path()).unwrap_err();
+    assert!(
+        matches!(error, ConfigError::UnsupportedDownloadSource(value) if value == "modelscope")
+    );
+}
+
+#[test]
 fn unknown_key_returns_friendly_error() {
     let error = "missing.key".parse::<ConfigKey>().unwrap_err().to_string();
     assert!(error.contains("Unknown config key 'missing.key'"));

--- a/crates/openasr-core/src/config_tests.rs
+++ b/crates/openasr-core/src/config_tests.rs
@@ -471,8 +471,10 @@ fn download_source_rejects_unknown_value() {
 
 #[test]
 fn download_source_validate_rejects_hand_edited_modelscope_pin() {
-    let mut config = OpenAsrConfig::default();
-    config.download_source = DownloadSourcePref::pinned(DownloadSource::ModelScope);
+    let config = OpenAsrConfig {
+        download_source: DownloadSourcePref::pinned(DownloadSource::ModelScope),
+        ..OpenAsrConfig::default()
+    };
     let error = config.validate(&registry()).unwrap_err();
     assert!(
         matches!(error, ConfigError::UnsupportedDownloadSource(value) if value == "modelscope")

--- a/crates/openasr-core/src/download_source.rs
+++ b/crates/openasr-core/src/download_source.rs
@@ -1,10 +1,8 @@
 use std::env;
-#[cfg(unix)]
-use std::fs;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ResolvedCatalogPull, http};
+use crate::{ResolvedCatalogPull, http, transport};
 
 const DOWNLOAD_SOURCE_ENV: &str = "OPENASR_DOWNLOAD_SOURCE";
 
@@ -23,6 +21,12 @@ pub enum DownloadSource {
     /// bearer token is never sent to the worker.
     #[serde(rename = "weights")]
     Weights,
+    /// ModelScope resolve URL derived from the signed Hugging Face pack URL.
+    /// Not a catalog identity: owner is the live ModelScope org `openasr`,
+    /// path `/models/<owner>/<repo>/resolve/<rev>/<file>`. User-facing config
+    /// stays `china` / `global`; this variant is the China-chain primary.
+    #[serde(rename = "modelscope")]
+    ModelScope,
 }
 
 impl DownloadSource {
@@ -31,6 +35,7 @@ impl DownloadSource {
             "hf" | "huggingface" | "hugging-face" => Some(Self::Hf),
             "hf-mirror" | "hf_mirror" | "mirror" => Some(Self::HfMirror),
             "weights" | "openasr" | "openasr-weights" => Some(Self::Weights),
+            "modelscope" | "ms" => Some(Self::ModelScope),
             _ => None,
         }
     }
@@ -40,6 +45,7 @@ impl DownloadSource {
             Self::Hf => "hf",
             Self::HfMirror => "hf-mirror",
             Self::Weights => "weights",
+            Self::ModelScope => "modelscope",
         }
     }
 
@@ -48,6 +54,7 @@ impl DownloadSource {
             Self::Hf => Some(pull.url.clone()),
             Self::HfMirror => Some(http::apply_default_hf_mirror(&pull.url)),
             Self::Weights => Some(http::apply_weights_endpoint(&pull.url)),
+            Self::ModelScope => http::apply_modelscope_endpoint(&pull.url),
         }
     }
 }
@@ -67,7 +74,7 @@ pub enum DownloadSourcePref {
     /// which performs its own single-point China detection (language OR
     /// timezone) in the frontend and hands the boolean result down here --
     /// core never re-derives the region for this variant, it just orders the
-    /// same three-source chain [`auto_source_chain`] would for that verdict.
+    /// same region chain [`auto_source_chain`] would for that verdict.
     AutoRegion {
         prefer_china: bool,
     },
@@ -95,14 +102,19 @@ impl DownloadSourcePref {
                 prefer_china: false,
             });
         }
-        DownloadSource::parse(value).map(Self::pinned)
+        DownloadSource::parse(value).and_then(|source| match source {
+            // User-facing knobs stay china/global. ModelScope is the China-chain
+            // primary, not a pin the settings UI or config.json should name.
+            DownloadSource::ModelScope => None,
+            other => Some(Self::pinned(other)),
+        })
     }
 }
 
 pub fn resolve_chain(pref: &DownloadSourcePref) -> Vec<DownloadSource> {
     match pref {
         DownloadSourcePref::Pinned { source } => vec![*source],
-        DownloadSourcePref::Auto => auto_source_chain(locale_prefers_china_sources()),
+        DownloadSourcePref::Auto => auto_source_chain(transport::locale_prefers_china_sources()),
         DownloadSourcePref::AutoRegion { prefer_china } => auto_source_chain(*prefer_china),
     }
 }
@@ -114,7 +126,7 @@ pub(crate) fn source_chain_from_env() -> Vec<DownloadSource> {
     {
         return resolve_chain(&pref);
     }
-    default_source_chain(http::hf_endpoint_is_set(), locale_prefers_china_sources())
+    default_source_chain(http::hf_endpoint_is_set(), transport::locale_prefers_china_sources())
 }
 
 fn default_source_chain(hf_endpoint_set: bool, prefer_china: bool) -> Vec<DownloadSource> {
@@ -133,67 +145,22 @@ fn default_source_chain(hf_endpoint_set: bool, prefer_china: bool) -> Vec<Downlo
 
 fn auto_source_chain(prefer_china: bool) -> Vec<DownloadSource> {
     if prefer_china {
-        // huggingface.co is walled from China networks (resolve times out), so lead
-        // with the first-party worker we control, keep hf-mirror.com as a deeper
-        // fallback (no longer a single point of failure), and try the direct source
-        // last.
+        // huggingface.co is walled from China networks, so lead with ModelScope
+        // (same bytes, signed sha256), then the first-party worker, hf-mirror,
+        // and the direct source last.
         vec![
+            DownloadSource::ModelScope,
             DownloadSource::Weights,
             DownloadSource::HfMirror,
             DownloadSource::Hf,
         ]
     } else {
-        // Overseas the direct source is reachable and carries zero worker load, so
-        // it leads; the worker and mirror are fallbacks.
         vec![
             DownloadSource::Hf,
             DownloadSource::Weights,
             DownloadSource::HfMirror,
         ]
     }
-}
-
-fn locale_prefers_china_sources() -> bool {
-    ["LC_ALL", "LC_MESSAGES", "LANG"]
-        .iter()
-        .filter_map(|key| env::var(key).ok())
-        .any(|value| locale_value_prefers_china_sources(&value))
-        || env::var("TZ")
-            .ok()
-            .is_some_and(|value| timezone_value_prefers_china_sources(&value))
-        || system_timezone_prefers_china_sources()
-}
-
-fn locale_value_prefers_china_sources(value: &str) -> bool {
-    value.to_ascii_lowercase().starts_with("zh")
-}
-
-fn timezone_value_prefers_china_sources(value: &str) -> bool {
-    let normalized = value.to_ascii_lowercase().replace('\\', "/");
-    [
-        "asia/shanghai",
-        "asia/chongqing",
-        "asia/harbin",
-        "asia/urumqi",
-        "asia/hong_kong",
-        "asia/macau",
-        "prc",
-    ]
-    .iter()
-    .any(|needle| normalized.ends_with(needle) || normalized.contains(&format!("/{needle}")))
-}
-
-#[cfg(unix)]
-fn system_timezone_prefers_china_sources() -> bool {
-    fs::read_link("/etc/localtime")
-        .ok()
-        .and_then(|path| path.to_str().map(str::to_owned))
-        .is_some_and(|value| timezone_value_prefers_china_sources(&value))
-}
-
-#[cfg(not(unix))]
-fn system_timezone_prefers_china_sources() -> bool {
-    false
 }
 
 #[cfg(test)]
@@ -232,12 +199,11 @@ mod tests {
     }
 
     #[test]
-    fn china_context_leads_with_weights_then_mirror_then_direct() {
-        // China: first-party worker primary, hf-mirror.com a deeper fallback (no
-        // longer the single point of failure), huggingface.co last.
+    fn china_context_leads_with_modelscope_then_weights_then_mirror_then_direct() {
         assert_eq!(
             default_source_chain(false, true),
             vec![
+                DownloadSource::ModelScope,
                 DownloadSource::Weights,
                 DownloadSource::HfMirror,
                 DownloadSource::Hf,
@@ -286,12 +252,12 @@ mod tests {
         // anonymous worker because huggingface.co is walled regardless of token.
         assert_eq!(
             resolve_chain(&DownloadSourcePref::Auto),
-            auto_source_chain(locale_prefers_china_sources())
+            auto_source_chain(transport::locale_prefers_china_sources())
         );
         assert_eq!(auto_source_chain(false).first(), Some(&DownloadSource::Hf));
         assert_eq!(
             auto_source_chain(true).first(),
-            Some(&DownloadSource::Weights)
+            Some(&DownloadSource::ModelScope)
         );
     }
 
@@ -377,12 +343,16 @@ mod tests {
 
     #[test]
     fn chinese_locale_and_timezone_prefer_china_sources() {
-        assert!(locale_value_prefers_china_sources("zh-Hans_US.UTF-8"));
-        assert!(timezone_value_prefers_china_sources(
+        assert!(transport::locale_value_prefers_china_sources("zh-Hans_US.UTF-8"));
+        assert!(transport::locale_value_prefers_china_sources("zh_CN.UTF-8"));
+        assert!(!transport::locale_value_prefers_china_sources("zh_TW.UTF-8"));
+        assert!(transport::timezone_value_prefers_china_sources(
             "/var/db/timezone/zoneinfo/Asia/Shanghai"
         ));
-        assert!(!locale_value_prefers_china_sources("C.UTF-8"));
-        assert!(!timezone_value_prefers_china_sources("America/Los_Angeles"));
+        assert!(!transport::locale_value_prefers_china_sources("C.UTF-8"));
+        assert!(!transport::timezone_value_prefers_china_sources(
+            "America/Los_Angeles"
+        ));
     }
 
     #[test]
@@ -401,8 +371,13 @@ mod tests {
             Some(DownloadSource::Weights)
         );
         assert_eq!(DownloadSource::Weights.as_env_value(), "weights");
-        assert_eq!(DownloadSource::parse("modelscope"), None);
+        assert_eq!(
+            DownloadSource::parse("modelscope"),
+            Some(DownloadSource::ModelScope)
+        );
+        assert_eq!(DownloadSource::ModelScope.as_env_value(), "modelscope");
         assert_eq!(DownloadSourcePref::parse_env_value("ms"), None);
+        assert_eq!(DownloadSourcePref::parse_env_value("modelscope"), None);
         assert_eq!(
             DownloadSourcePref::parse_env_value("auto"),
             Some(DownloadSourcePref::Auto)
@@ -424,6 +399,10 @@ mod tests {
         assert_eq!(
             DownloadSource::Weights.url_for(&pull),
             Some("https://weights.openasr.org/OpenASR/moonshine-tiny/resolve/0123456789abcdef0123456789abcdef01234567/moonshine-tiny-q8_0.oasr".to_string())
+        );
+        assert_eq!(
+            DownloadSource::ModelScope.url_for(&pull),
+            Some("https://www.modelscope.cn/models/openasr/moonshine-tiny/resolve/master/moonshine-tiny-q8_0.oasr".to_string())
         );
     }
 }

--- a/crates/openasr-core/src/download_source.rs
+++ b/crates/openasr-core/src/download_source.rs
@@ -126,7 +126,10 @@ pub(crate) fn source_chain_from_env() -> Vec<DownloadSource> {
     {
         return resolve_chain(&pref);
     }
-    default_source_chain(http::hf_endpoint_is_set(), transport::locale_prefers_china_sources())
+    default_source_chain(
+        http::hf_endpoint_is_set(),
+        transport::locale_prefers_china_sources(),
+    )
 }
 
 fn default_source_chain(hf_endpoint_set: bool, prefer_china: bool) -> Vec<DownloadSource> {
@@ -343,9 +346,13 @@ mod tests {
 
     #[test]
     fn chinese_locale_and_timezone_prefer_china_sources() {
-        assert!(transport::locale_value_prefers_china_sources("zh-Hans_US.UTF-8"));
+        assert!(transport::locale_value_prefers_china_sources(
+            "zh-Hans_US.UTF-8"
+        ));
         assert!(transport::locale_value_prefers_china_sources("zh_CN.UTF-8"));
-        assert!(!transport::locale_value_prefers_china_sources("zh_TW.UTF-8"));
+        assert!(!transport::locale_value_prefers_china_sources(
+            "zh_TW.UTF-8"
+        ));
         assert!(transport::timezone_value_prefers_china_sources(
             "/var/db/timezone/zoneinfo/Asia/Shanghai"
         ));

--- a/crates/openasr-core/src/http.rs
+++ b/crates/openasr-core/src/http.rs
@@ -124,11 +124,9 @@ pub(crate) fn is_allowed_mirror_host(url: &str) -> bool {
     let Some(host) = parsed.host_str().map(str::to_ascii_lowercase) else {
         return false;
     };
-    host == "huggingface.co"
-        || host.ends_with(".huggingface.co")
-        || host == "hf-mirror.com"
-        || host == "modelscope.cn"
-        || host == "www.modelscope.cn"
+    // Catalog `mirrors[]` is provenance only; pull never iterates it.
+    // ModelScope is a DownloadSource transport rewrite, not a catalog mirror.
+    host == "huggingface.co" || host.ends_with(".huggingface.co") || host == "hf-mirror.com"
 }
 
 /// The legacy Hugging Face LFS CDN (`cdn-lfs.huggingface.co`, `cdn-lfs-us-1...`,
@@ -203,10 +201,11 @@ mod tests {
     }
 
     #[test]
-    fn catalog_endpoint_rewrites_only_the_pinned_catalog_host() {
-        // The catalog is served from Cloudflare: the pinned huggingface.co host is
-        // swapped onto the catalog endpoint while the path (the signed identity)
-        // is preserved verbatim.
+    fn rewrite_to_mirror_swaps_only_the_huggingface_host() {
+        // Host-swap helper for HF pack URLs, not `apply_catalog_endpoint`.
+        // A huggingface.co catalog object path is rewritten like any other HF
+        // URL; identity vs transport for live catalog.openasr.org lives in
+        // `transport.rs`.
         let pinned = "https://huggingface.co/OpenASR/catalog/resolve/main/catalog.json";
         assert_eq!(
             rewrite_to_mirror(pinned, Some(CANONICAL_CATALOG_ENDPOINT)),

--- a/crates/openasr-core/src/http.rs
+++ b/crates/openasr-core/src/http.rs
@@ -58,15 +58,9 @@ pub(crate) const HF_MIRROR_ENDPOINT: &str = "https://hf-mirror.com";
 
 /// First-party Cloudflare Worker that proxies `huggingface.co`'s `OpenASR/*`
 /// `/resolve/...` endpoint and transparently passes through the 302 into the Xet
-/// CDN. Used by [`DownloadSource::Weights`](crate::DownloadSource::Weights) as the
-/// primary China source (self-controlled, no dependency on third-party mirrors)
-/// and as an overseas fallback.
+/// CDN. Used by [`DownloadSource::Weights`](crate::DownloadSource::Weights) as a
+/// China-chain fallback after ModelScope, and as an overseas fallback.
 pub(crate) const WEIGHTS_ENDPOINT: &str = "https://weights.openasr.org";
-
-/// Optional transport host for legacy HF-shaped catalog URLs. The default catalog
-/// URL is already `https://catalog.openasr.org/v1/catalog.json`; this endpoint is
-/// retained for self-host tests and older pinned catalog identities.
-pub(crate) const DEFAULT_CATALOG_ENDPOINT: &str = "https://catalog.openasr.org";
 
 pub(crate) fn apply_default_hf_mirror(url: &str) -> String {
     let endpoint = hf_endpoint().unwrap_or_else(|| HF_MIRROR_ENDPOINT.to_string());
@@ -81,33 +75,22 @@ pub(crate) fn apply_weights_endpoint(url: &str) -> String {
     rewrite_to_mirror(url, Some(WEIGHTS_ENDPOINT))
 }
 
-/// Rewrite only legacy `https://huggingface.co/...` catalog identities onto the
-/// configured catalog endpoint. The current default `/v1/catalog.json` source is
-/// already on `catalog.openasr.org`, so it passes through unchanged.
+/// Rewrite the signed catalog identity onto the China replica (or an
+/// allowlisted `OPENASR_CATALOG_ENDPOINT`). Verification still uses `url`.
 pub(crate) fn apply_catalog_endpoint(url: &str) -> String {
-    rewrite_to_mirror(url, Some(catalog_endpoint().as_str()))
+    crate::transport::apply_catalog_endpoint(url)
 }
 
-/// Read a transport-endpoint override from `var`, normalised (trimmed, no trailing
-/// slash); `None` when unset or empty. Shared by [`hf_endpoint`] and
-/// [`catalog_endpoint`] so both knobs parse identically.
-fn endpoint_from_env(var: &str) -> Option<String> {
-    std::env::var(var)
-        .ok()
-        .map(|value| value.trim().trim_end_matches('/').to_string())
-        .filter(|value| !value.is_empty())
+pub(crate) fn apply_modelscope_endpoint(url: &str) -> Option<String> {
+    crate::transport::apply_modelscope_endpoint(url)
+}
+
+pub(crate) fn apply_dl_endpoint(url: &str) -> String {
+    crate::transport::apply_dl_endpoint(url)
 }
 
 fn hf_endpoint() -> Option<String> {
-    endpoint_from_env("HF_ENDPOINT")
-}
-
-/// The catalog transport host: `OPENASR_CATALOG_ENDPOINT` if set, else the
-/// built-in [`DEFAULT_CATALOG_ENDPOINT`]. Unlike [`hf_endpoint`] this never
-/// resolves to `None` — the catalog is always fetched from Cloudflare, never HF.
-fn catalog_endpoint() -> String {
-    endpoint_from_env("OPENASR_CATALOG_ENDPOINT")
-        .unwrap_or_else(|| DEFAULT_CATALOG_ENDPOINT.to_string())
+    crate::transport::hf_endpoint_env()
 }
 
 fn rewrite_to_mirror(url: &str, endpoint: Option<&str>) -> String {
@@ -128,7 +111,7 @@ pub(crate) fn apply_hf_mirror_redirect_with_endpoint(
 }
 
 pub(crate) fn hf_endpoint_is_set() -> bool {
-    hf_endpoint().is_some()
+    crate::transport::hf_endpoint_is_set()
 }
 
 pub(crate) fn is_allowed_mirror_host(url: &str) -> bool {
@@ -200,10 +183,8 @@ fn split_scheme_host(url: &str) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        DEFAULT_CATALOG_ENDPOINT, rewrite_cdn_redirect_to_mirror, rewrite_to_mirror,
-        split_scheme_host,
-    };
+    use super::{rewrite_cdn_redirect_to_mirror, rewrite_to_mirror, split_scheme_host};
+    use crate::transport::CANONICAL_CATALOG_ENDPOINT;
 
     #[test]
     fn rewrites_only_huggingface_host_and_only_when_endpoint_set() {
@@ -228,25 +209,25 @@ mod tests {
         // is preserved verbatim.
         let pinned = "https://huggingface.co/OpenASR/catalog/resolve/main/catalog.json";
         assert_eq!(
-            rewrite_to_mirror(pinned, Some(DEFAULT_CATALOG_ENDPOINT)),
+            rewrite_to_mirror(pinned, Some(CANONICAL_CATALOG_ENDPOINT)),
             "https://catalog.openasr.org/OpenASR/catalog/resolve/main/catalog.json"
         );
         // The sibling signature object rides the same host swap.
         let signature =
             "https://huggingface.co/OpenASR/catalog/resolve/main/catalog.signature.json";
         assert_eq!(
-            rewrite_to_mirror(signature, Some(DEFAULT_CATALOG_ENDPOINT)),
+            rewrite_to_mirror(signature, Some(CANONICAL_CATALOG_ENDPOINT)),
             "https://catalog.openasr.org/OpenASR/catalog/resolve/main/catalog.signature.json"
         );
         // Custom / local catalog sources are never rewritten onto the endpoint.
         assert_eq!(
-            rewrite_to_mirror("file:///tmp/catalog.json", Some(DEFAULT_CATALOG_ENDPOINT)),
+            rewrite_to_mirror("file:///tmp/catalog.json", Some(CANONICAL_CATALOG_ENDPOINT)),
             "file:///tmp/catalog.json"
         );
         assert_eq!(
             rewrite_to_mirror(
                 "https://example.com/catalog.json",
-                Some(DEFAULT_CATALOG_ENDPOINT)
+                Some(CANONICAL_CATALOG_ENDPOINT)
             ),
             "https://example.com/catalog.json"
         );

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -280,11 +280,6 @@ pub use device::execution_route::{
 };
 pub use device::types::{CapabilityClass, DeviceCapabilities};
 pub use download_source::{DownloadSource, DownloadSourcePref, resolve_chain};
-pub use transport::{
-    CANONICAL_CATALOG_ENDPOINT, CANONICAL_DL_ENDPOINT, CATALOG_ENDPOINT_ENV, CHINA_CATALOG_ENDPOINT,
-    CHINA_DL_ENDPOINT, DL_ENDPOINT_ENV, MODELSCOPE_DEFAULT_REVISION, MODELSCOPE_ORIGIN,
-    MODELSCOPE_OWNER, prefer_china_transport,
-};
 pub use format::{ResponseFormat, render_transcription};
 pub use ggml_runtime::{
     BackendPluginActivationError, GGUF_C_PARSER_SANDBOX_HELPER_ARG, GgmlBackend, GgmlBackendDevice,
@@ -515,4 +510,9 @@ pub use remote_compute::{
 pub use safety::{
     current_platform_key, validate_platform_key, validate_platform_key_field,
     validate_safe_relative_path, validate_sha256,
+};
+pub use transport::{
+    CANONICAL_CATALOG_ENDPOINT, CANONICAL_DL_ENDPOINT, CATALOG_ENDPOINT_ENV,
+    CHINA_CATALOG_ENDPOINT, CHINA_DL_ENDPOINT, DL_ENDPOINT_ENV, MODELSCOPE_DEFAULT_REVISION,
+    MODELSCOPE_ORIGIN, MODELSCOPE_OWNER, prefer_china_transport,
 };

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -15,6 +15,7 @@ mod file_identity;
 mod http;
 mod pe_image_identity;
 mod qualification_manifest_security;
+mod transport;
 #[cfg(test)]
 mod windows_cmake_cache;
 
@@ -279,6 +280,11 @@ pub use device::execution_route::{
 };
 pub use device::types::{CapabilityClass, DeviceCapabilities};
 pub use download_source::{DownloadSource, DownloadSourcePref, resolve_chain};
+pub use transport::{
+    CANONICAL_CATALOG_ENDPOINT, CANONICAL_DL_ENDPOINT, CATALOG_ENDPOINT_ENV, CHINA_CATALOG_ENDPOINT,
+    CHINA_DL_ENDPOINT, DL_ENDPOINT_ENV, MODELSCOPE_DEFAULT_REVISION, MODELSCOPE_ORIGIN,
+    MODELSCOPE_OWNER, prefer_china_transport,
+};
 pub use format::{ResponseFormat, render_transcription};
 pub use ggml_runtime::{
     BackendPluginActivationError, GGUF_C_PARSER_SANDBOX_HELPER_ARG, GgmlBackend, GgmlBackendDevice,

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -5777,9 +5777,8 @@ pub fn install_backend_pack(
     let home = home.as_ref();
     let mut client = HttpDownloadClient::new()?;
     let worker = client.clone();
-    let factory = move || -> Result<BoxedDownloadClient, PullError> {
-        Ok(Box::new(worker.clone()))
-    };
+    let factory =
+        move || -> Result<BoxedDownloadClient, PullError> { Ok(Box::new(worker.clone())) };
     let parallel = ParallelDownloadConfig {
         connections: pull_connections_from_env(),
         factory: &factory,
@@ -5800,9 +5799,8 @@ pub(crate) fn install_backend_pack_locked(
 ) -> Result<InstalledBackend, PullError> {
     let mut client = HttpDownloadClient::new()?;
     let worker = client.clone();
-    let factory = move || -> Result<BoxedDownloadClient, PullError> {
-        Ok(Box::new(worker.clone()))
-    };
+    let factory =
+        move || -> Result<BoxedDownloadClient, PullError> { Ok(Box::new(worker.clone())) };
     let parallel = ParallelDownloadConfig {
         connections: pull_connections_from_env(),
         factory: &factory,
@@ -6120,9 +6118,8 @@ pub(crate) fn prepare_backend_runtime_objects_locked(
 ) -> Result<PreparedBackendRuntimeObjects, PullError> {
     let mut client = HttpDownloadClient::new()?;
     let worker = client.clone();
-    let factory = move || -> Result<BoxedDownloadClient, PullError> {
-        Ok(Box::new(worker.clone()))
-    };
+    let factory =
+        move || -> Result<BoxedDownloadClient, PullError> { Ok(Box::new(worker.clone())) };
     let parallel = ParallelDownloadConfig {
         connections: pull_connections_from_env(),
         factory: &factory,
@@ -6264,7 +6261,8 @@ fn install_backend_pack_with_client_locked<C: DownloadClient>(
                 }]
             }
             CatalogBackendFileRole::Runtime | CatalogBackendFileRole::Archive => {
-                let object = ensure_backend_content_object(client, file, home, &mut progress, parallel)?;
+                let object =
+                    ensure_backend_content_object(client, file, home, &mut progress, parallel)?;
                 materialize_backend_content_object(home, &staging_dir, file, &object)?
             }
             CatalogBackendFileRole::Unknown => {
@@ -6680,12 +6678,13 @@ fn pull_paths_for_backend_dest(dest: &Path) -> Result<PullPaths, PullError> {
             field: "backend.files.filename",
             reason: format!("'{}' has no UTF-8 file name", dest.display()),
         })?;
-    let dir = dest.parent().map(Path::to_path_buf).ok_or_else(|| {
-        PullError::InvalidTarget {
+    let dir = dest
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| PullError::InvalidTarget {
             field: "backend install path",
             reason: "destination has no parent".to_string(),
-        }
-    })?;
+        })?;
     Ok(PullPaths {
         partial_path: partial,
         partial_meta_path: partial_meta,

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -49,15 +49,13 @@ const HTTP_STALL_TIMEOUT: Duration = Duration::from_secs(30);
 const DOWNLOAD_LOW_SPEED_TIMEOUT: Duration = Duration::from_secs(60);
 const DOWNLOAD_LOW_SPEED_MIN_BYTES: u64 = 64 * 1024;
 const DOWNLOAD_USER_AGENT: &str = concat!("OpenASR/", env!("CARGO_PKG_VERSION"));
-/// Fixed segment size for concurrent chunked downloads. 64 MiB amortizes
-/// per-segment overhead (redirect resolution, TLS/connection setup) over a
-/// large body while still giving the default connection count real
-/// parallelism on typical multi-hundred-MB to multi-GB model packs (e.g. a
-/// 300 MB pack still splits into 5 segments at 4 connections). This is a
-/// fixed build-time constant, not an env knob: resumable segment bitmaps
-/// (`SegmentedPartialMeta`) are keyed on it, so changing it is a format
-/// change, not a runtime tuning parameter (see `PARALLEL_META_FORMAT`).
-const DOWNLOAD_SEGMENT_BYTES: u64 = 64 * 1024 * 1024;
+/// Fixed segment size for concurrent chunked downloads. 8 MiB keeps
+/// per-segment overhead modest while making typical OpenASR packs (tens of
+/// MB) eligible for the default 4 connections (`parallel_download_eligible`
+/// requires `size >= 2 * segment`). Previously 64 MiB, which left common
+/// small packs on a single stream. Changing this must bump
+/// `PARALLEL_META_FORMAT`.
+const DOWNLOAD_SEGMENT_BYTES: u64 = 8 * 1024 * 1024;
 /// Default number of concurrent Range connections for chunked downloads.
 const DEFAULT_PULL_CONNECTIONS: usize = 4;
 /// Hard upper clamp on `OPENASR_PULL_CONNECTIONS` so a misconfigured
@@ -132,7 +130,7 @@ const SEGMENT_LOW_SPEED_REFERENCE_CAPACITY: usize = 64;
 /// resume never misreads a legacy (pre-chunking) `PartialMeta` -- or a future
 /// incompatible format -- as a valid segment bitmap. Bumping the segment size
 /// or the bitmap's shape must also bump this string.
-const PARALLEL_META_FORMAT: &str = "segmented-v1";
+const PARALLEL_META_FORMAT: &str = "segmented-v2";
 const BACKEND_STORE_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_BACKEND_GC_MIN_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
@@ -3809,6 +3807,39 @@ impl PullTarget {
             ..self.clone()
         }
     }
+
+    fn for_backend_file(file: &CatalogBackendFile) -> Result<Self, PullError> {
+        validate_sha256("sha256", &file.sha256).map_err(|reason| PullError::InvalidTarget {
+            field: "backend.files.sha256",
+            reason,
+        })?;
+        if file.size_bytes == 0 {
+            return Err(PullError::InvalidTarget {
+                field: "backend.files.size_bytes",
+                reason: "size_bytes must be greater than zero".to_string(),
+            });
+        }
+        if file.filename.contains('/') || file.filename.contains('\\') {
+            return Err(PullError::InvalidTarget {
+                field: "backend.files.filename",
+                reason: "filename must be a local basename".to_string(),
+            });
+        }
+        Ok(Self {
+            model_id: "backend".to_string(),
+            expected_catalog_family_id: None,
+            display_name: file.filename.clone(),
+            quant: "file".to_string(),
+            suffix: String::new(),
+            pull: file.filename.clone(),
+            filename: file.filename.clone(),
+            url: http::apply_dl_endpoint(&file.url),
+            hf_revision: file.sha256.clone(),
+            sha256: file.sha256.clone(),
+            size_bytes: file.size_bytes,
+            source: None,
+        })
+    }
 }
 
 impl PartialMeta {
@@ -5347,9 +5378,10 @@ fn ensure_backend_content_object<C: DownloadClient>(
     file: &CatalogBackendFile,
     home: &Path,
     progress: &mut impl FnMut(PullProgress),
+    parallel: Option<&ParallelDownloadConfig>,
 ) -> Result<BackendContentObject, PullError> {
     let objects_root = home.join("backends").join("_objects");
-    ensure_backend_content_object_in(client, file, &objects_root, None, None, progress)
+    ensure_backend_content_object_in(client, file, &objects_root, None, None, progress, parallel)
 }
 
 fn ensure_backend_content_object_in<C: DownloadClient>(
@@ -5359,6 +5391,7 @@ fn ensure_backend_content_object_in<C: DownloadClient>(
     signed_urls: Option<&[String]>,
     expected_unpacked_size_bytes: Option<u64>,
     progress: &mut impl FnMut(PullProgress),
+    parallel: Option<&ParallelDownloadConfig>,
 ) -> Result<BackendContentObject, PullError> {
     fs::create_dir_all(objects_root).map_err(|source| PullError::Io {
         path: objects_root.to_path_buf(),
@@ -5385,7 +5418,7 @@ fn ensure_backend_content_object_in<C: DownloadClient>(
         if let Some(urls) = signed_urls {
             download_backend_file_from_signed_urls(client, file, urls, &source_path, progress)?;
         } else {
-            download_backend_file(client, file, &source_path, progress)?;
+            download_backend_file(client, file, &source_path, progress, parallel)?;
         }
     }
     preflight_backend_file(&source_path, backend_file_format(file.role)?)?;
@@ -5741,8 +5774,18 @@ pub fn install_backend_pack(
     home: impl AsRef<Path>,
     progress: impl FnMut(PullProgress),
 ) -> Result<InstalledBackend, PullError> {
+    let home = home.as_ref();
     let mut client = HttpDownloadClient::new()?;
-    install_backend_pack_with_client(resolved, home.as_ref(), &mut client, progress)
+    let worker = client.clone();
+    let factory = move || -> Result<BoxedDownloadClient, PullError> {
+        Ok(Box::new(worker.clone()))
+    };
+    let parallel = ParallelDownloadConfig {
+        connections: pull_connections_from_env(),
+        factory: &factory,
+    };
+    let _store_lock = BackendStoreMutationLock::acquire(home)?;
+    install_backend_pack_with_client_locked(resolved, home, &mut client, progress, Some(&parallel))
 }
 
 /// Installs one resolved pack while the caller holds the backend-store
@@ -5756,7 +5799,15 @@ pub(crate) fn install_backend_pack_locked(
     progress: impl FnMut(PullProgress),
 ) -> Result<InstalledBackend, PullError> {
     let mut client = HttpDownloadClient::new()?;
-    install_backend_pack_with_client_locked(resolved, home, &mut client, progress)
+    let worker = client.clone();
+    let factory = move || -> Result<BoxedDownloadClient, PullError> {
+        Ok(Box::new(worker.clone()))
+    };
+    let parallel = ParallelDownloadConfig {
+        connections: pull_connections_from_env(),
+        factory: &factory,
+    };
+    install_backend_pack_with_client_locked(resolved, home, &mut client, progress, Some(&parallel))
 }
 
 /// Conservative logical bytes that must remain reachable while `resolved` is
@@ -6016,6 +6067,7 @@ fn prepare_qualification_archive<C: DownloadClient>(
         Some(&artifact.urls),
         Some(expected_unpacked_size_bytes),
         progress,
+        None,
     )?;
     let object_dir = backend_content_object_dir_in(objects_root, &file);
     let source_path = object_dir.join("source").join(&artifact.file_name);
@@ -6067,6 +6119,14 @@ pub(crate) fn prepare_backend_runtime_objects_locked(
     mut progress: impl FnMut(PullProgress),
 ) -> Result<PreparedBackendRuntimeObjects, PullError> {
     let mut client = HttpDownloadClient::new()?;
+    let worker = client.clone();
+    let factory = move || -> Result<BoxedDownloadClient, PullError> {
+        Ok(Box::new(worker.clone()))
+    };
+    let parallel = ParallelDownloadConfig {
+        connections: pull_connections_from_env(),
+        factory: &factory,
+    };
     let mut dependency_dirs = BTreeSet::new();
     let mut verified_files = Vec::new();
     let mut saw_runtime = false;
@@ -6074,7 +6134,13 @@ pub(crate) fn prepare_backend_runtime_objects_locked(
         match file.role {
             CatalogBackendFileRole::Runtime | CatalogBackendFileRole::Archive => {
                 saw_runtime = true;
-                let object = ensure_backend_content_object(&mut client, file, home, &mut progress)?;
+                let object = ensure_backend_content_object(
+                    &mut client,
+                    file,
+                    home,
+                    &mut progress,
+                    Some(&parallel),
+                )?;
                 let payload = backend_content_object_dir(home, file).join("payload");
                 for materialized in &object.files {
                     let relative = Path::new(&materialized.relative_path);
@@ -6117,7 +6183,7 @@ fn install_backend_pack_with_client<C: DownloadClient>(
 ) -> Result<InstalledBackend, PullError> {
     ensure_backend_cli_version_for_install(resolved)?;
     let _store_lock = BackendStoreMutationLock::acquire(home)?;
-    install_backend_pack_with_client_locked(resolved, home, client, progress)
+    install_backend_pack_with_client_locked(resolved, home, client, progress, None)
 }
 
 fn ensure_backend_cli_version_for_install(
@@ -6142,6 +6208,7 @@ fn install_backend_pack_with_client_locked<C: DownloadClient>(
     home: &Path,
     client: &mut C,
     mut progress: impl FnMut(PullProgress),
+    parallel: Option<&ParallelDownloadConfig>,
 ) -> Result<InstalledBackend, PullError> {
     ensure_backend_cli_version_for_install(resolved)?;
     let vendor = backend_vendor_dirname(resolved.vendor)?;
@@ -6188,7 +6255,7 @@ fn install_backend_pack_with_client_locked<C: DownloadClient>(
         let materialized_files = match file.role {
             CatalogBackendFileRole::Plugin => {
                 let dest = staging_dir.join(&file.filename);
-                download_backend_file(client, file, &dest, &mut progress)?;
+                download_backend_file(client, file, &dest, &mut progress, parallel)?;
                 preflight_backend_file(&dest, backend_file_format(file.role)?)?;
                 vec![InstalledBackendMaterializedFile {
                     relative_path: file.filename.clone(),
@@ -6197,7 +6264,7 @@ fn install_backend_pack_with_client_locked<C: DownloadClient>(
                 }]
             }
             CatalogBackendFileRole::Runtime | CatalogBackendFileRole::Archive => {
-                let object = ensure_backend_content_object(client, file, home, &mut progress)?;
+                let object = ensure_backend_content_object(client, file, home, &mut progress, parallel)?;
                 materialize_backend_content_object(home, &staging_dir, file, &object)?
             }
             CatalogBackendFileRole::Unknown => {
@@ -6604,6 +6671,71 @@ fn prune_empty_directories(root: &Path) {
     }
 }
 
+fn pull_paths_for_backend_dest(dest: &Path) -> Result<PullPaths, PullError> {
+    let (partial, partial_meta) = backend_partial_paths(dest)?;
+    let stem = dest
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| PullError::InvalidTarget {
+            field: "backend.files.filename",
+            reason: format!("'{}' has no UTF-8 file name", dest.display()),
+        })?;
+    let dir = dest.parent().map(Path::to_path_buf).ok_or_else(|| {
+        PullError::InvalidTarget {
+            field: "backend install path",
+            reason: "destination has no parent".to_string(),
+        }
+    })?;
+    Ok(PullPaths {
+        partial_path: partial,
+        partial_meta_path: partial_meta,
+        partial_segments_meta_path: dest.with_file_name(format!(".{stem}.partial.segments.json")),
+        installed_meta_path: dest.with_file_name(format!(".{stem}.installed.json")),
+        lock_path: dest.with_file_name(format!(".{stem}.pull.lock")),
+        dir,
+        final_path: dest.to_path_buf(),
+    })
+}
+
+fn download_backend_file_via_pull<C: DownloadClient>(
+    client: &mut C,
+    file: &CatalogBackendFile,
+    dest: &Path,
+    progress: &mut impl FnMut(PullProgress),
+    parallel: Option<&ParallelDownloadConfig>,
+) -> Result<(), PullError> {
+    let target = PullTarget::for_backend_file(file)?;
+    ensure_https_url(&target.url)?;
+    let paths = pull_paths_for_backend_dest(dest)?;
+    let downloaded = download_with_retries(
+        &target,
+        &paths,
+        client,
+        PullOptions::default(),
+        parallel,
+        progress,
+        &|| false,
+        &|| false,
+    )?;
+    if !downloaded.sha256.eq_ignore_ascii_case(&file.sha256) {
+        cleanup_partial(&paths);
+        return Err(PullError::ShaMismatch {
+            path: dest.to_path_buf(),
+            expected: file.sha256.clone(),
+            actual: downloaded.sha256,
+        });
+    }
+    atomic_file::replace_file_atomically(&paths.partial_path, dest).map_err(|source| {
+        PullError::Io {
+            path: dest.to_path_buf(),
+            source,
+        }
+    })?;
+    let _ = fs::remove_file(&paths.partial_meta_path);
+    let _ = fs::remove_file(&paths.partial_segments_meta_path);
+    Ok(())
+}
+
 /// Download a single backend-pack file (plugin binary or archive) to `dest`,
 /// streamed to a `.partial` file and sha256-verified before the atomic
 /// rename -- the backend-pack analogue of the model-pack single-stream path
@@ -6641,7 +6773,7 @@ fn download_backend_file_from_signed_urls<C: DownloadClient>(
         }
         let mut candidate = file.clone();
         candidate.url.clone_from(url);
-        match download_backend_file(client, &candidate, dest, progress) {
+        match download_backend_file(client, &candidate, dest, progress, None) {
             Ok(()) => return Ok(()),
             Err(error)
                 if matches!(
@@ -6666,12 +6798,16 @@ fn download_backend_file<C: DownloadClient>(
     file: &CatalogBackendFile,
     dest: &Path,
     progress: &mut impl FnMut(PullProgress),
+    parallel: Option<&ParallelDownloadConfig>,
 ) -> Result<(), PullError> {
     if backend_file_matches(dest, file) {
         return Ok(());
     }
     if let Some(local_path) = file.url.strip_prefix("file://") {
         return copy_local_backend_file(Path::new(local_path), dest, file, progress);
+    }
+    if let Some(parallel) = parallel {
+        return download_backend_file_via_pull(client, file, dest, progress, Some(parallel));
     }
     // The parent pack/object directory is already keyed by the full artifact
     // digest. Keep the leaf short enough for Windows MAX_PATH-era tools while
@@ -6820,7 +6956,7 @@ fn download_backend_file_attempt<C: DownloadClient>(
         *expected_etag = persisted_etag;
     }
     let response = client.open(
-        &file.url,
+        &http::apply_dl_endpoint(&file.url),
         (resume_from > 0).then(|| ByteRange::from_start(resume_from)),
     )?;
 

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -6172,6 +6172,7 @@ pub(crate) fn prepare_backend_runtime_objects_locked(
     })
 }
 
+#[cfg(test)]
 fn install_backend_pack_with_client<C: DownloadClient>(
     resolved: &ResolvedCatalogBackendPull,
     home: &Path,

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -600,6 +600,7 @@ fn hf_token_only_attaches_to_the_huggingface_host() {
     assert!(!hf_token_allowed_for_host(Some("cdn-lfs.huggingface.co")));
     assert!(!hf_token_allowed_for_host(Some("hf-mirror.com")));
     assert!(!hf_token_allowed_for_host(Some("modelscope.cn")));
+    assert!(!hf_token_allowed_for_host(Some("www.modelscope.cn")));
     // The weights worker and the Xet CDN it forwards to are always anonymous.
     assert!(!hf_token_allowed_for_host(Some("weights.openasr.org")));
     assert!(!hf_token_allowed_for_host(Some("us.aws.cdn.hf.co")));
@@ -958,6 +959,46 @@ fn pull_falls_back_to_next_source_after_sha_mismatch() {
     let paths = paths_for(temp.path(), &resolved);
     assert!(paths.final_path.exists());
     assert!(!paths.partial_path.exists());
+}
+
+#[test]
+fn china_chain_tries_modelscope_before_direct_hf() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let mut client = FakeClient::with_responses(vec![
+        ResponseSpec {
+            status: 404,
+            body: Vec::new(),
+        },
+        ResponseSpec {
+            status: 200,
+            body: bytes.clone(),
+        },
+    ]);
+
+    let installed = pull_model_pack_with_client_sources_and_cancel(
+        &resolved,
+        temp.path(),
+        &mut client,
+        PullOptions::default(),
+        &[DownloadSource::ModelScope, DownloadSource::Hf],
+        None,
+        None,
+        |_| {},
+        || false,
+        || false,
+    )
+    .unwrap();
+
+    assert_eq!(installed.pull, "moonshine-tiny:q8");
+    assert_eq!(
+        client.urls(),
+        vec![
+            "https://www.modelscope.cn/models/openasr/moonshine-tiny/resolve/master/moonshine-tiny-q8_0.oasr".to_string(),
+            resolved.url.clone(),
+        ]
+    );
 }
 
 #[test]
@@ -3989,7 +4030,7 @@ fn backend_pack_resume_survives_process_boundary_metadata_reload() {
         attempts: 1,
         ranges: Vec::new(),
     };
-    download_backend_file(&mut replacement, file, &dest, &mut |_| {}).unwrap();
+    download_backend_file(&mut replacement, file, &dest, &mut |_| {}, None).unwrap();
     assert_eq!(replacement.ranges(), vec![Some(700)]);
     assert_eq!(fs::read(dest).unwrap(), plugin);
     assert!(!partial.exists());

--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -3346,47 +3346,11 @@ fn validate_catalog_mirror_url(
             model.id, quant.quant
         )));
     }
-    let parsed = reqwest::Url::parse(&mirror.url).map_err(|source| {
-        CatalogError::InvalidCatalog(format!(
-            "model '{}' quant '{}' mirror URL is invalid: {source}",
-            model.id, quant.quant
-        ))
-    })?;
-    let host = parsed.host_str().unwrap_or_default();
     if mirror.source == "modelscope" && !MODELSCOPE_CATALOG_MIRRORS_ENABLED {
         return Err(CatalogError::InvalidCatalog(format!(
             "model '{}' quant '{}' ModelScope mirrors are disabled; use Hugging Face with the hf-mirror download source",
             model.id, quant.quant
         )));
-    }
-    if matches!(host, "modelscope.cn" | "www.modelscope.cn") {
-        if !MODELSCOPE_CATALOG_MIRRORS_ENABLED {
-            return Err(CatalogError::InvalidCatalog(format!(
-                "model '{}' quant '{}' ModelScope mirrors are disabled; use Hugging Face with the hf-mirror download source",
-                model.id, quant.quant
-            )));
-        }
-        let segments = parsed
-            .path_segments()
-            .map(|segments| segments.collect::<Vec<_>>())
-            .unwrap_or_default();
-        let (hf_owner, hf_name) = model.hf_repo.split_once('/').unwrap_or_default();
-        let modelscope_owner = hf_owner.to_ascii_lowercase();
-        let revision = segments.get(4).copied().unwrap_or_default();
-        if segments.len() != 6
-            || segments[0] != "models"
-            || segments[1] != modelscope_owner
-            || segments[2] != hf_name
-            || segments[3] != "resolve"
-            || revision.len() != 40
-            || !revision.chars().all(|ch| ch.is_ascii_hexdigit())
-            || segments[5] != quant.filename
-        {
-            return Err(CatalogError::InvalidCatalog(format!(
-                "model '{}' quant '{}' ModelScope mirror URL must use /models/{{lowercase-hf-owner}}/{{hf-repo-name}}/resolve/{{40-hex-revision}}/{{filename}}",
-                model.id, quant.quant
-            )));
-        }
     }
     Ok(())
 }

--- a/crates/openasr-core/src/registry/tests/catalog.rs
+++ b/crates/openasr-core/src/registry/tests/catalog.rs
@@ -2252,7 +2252,7 @@ fn catalog_parser_rejects_disabled_modelscope_mirror() {
         .unwrap_err()
         .to_string();
 
-    assert!(error.contains("ModelScope mirrors are disabled"));
+    assert!(error.contains("mirror URL host is not allowed"));
 }
 
 #[test]
@@ -2280,7 +2280,7 @@ fn catalog_parser_rejects_derived_modelscope_mirror_path() {
         .unwrap_err()
         .to_string();
 
-    assert!(error.contains("ModelScope mirrors are disabled"));
+    assert!(error.contains("mirror URL host is not allowed"));
 }
 
 #[test]
@@ -2288,6 +2288,20 @@ fn catalog_parser_rejects_uppercase_modelscope_owner() {
     let contents = catalog_json_with_first_fp16_mirror(
         "modelscope",
         "https://modelscope.cn/models/OpenASR/moonshine-tiny/resolve/0123456789abcdef0123456789abcdef01234567/moonshine-tiny-fp16.oasr",
+    );
+
+    let error = parse_model_catalog(&contents, "fixture")
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("mirror URL host is not allowed"));
+}
+
+#[test]
+fn catalog_parser_rejects_modelscope_mirror_source_on_hf_url() {
+    let contents = catalog_json_with_first_fp16_mirror(
+        "modelscope",
+        "https://huggingface.co/OpenASR/moonshine-tiny/resolve/0123456789abcdef0123456789abcdef01234567/moonshine-tiny-fp16.oasr",
     );
 
     let error = parse_model_catalog(&contents, "fixture")

--- a/crates/openasr-core/src/transport.rs
+++ b/crates/openasr-core/src/transport.rs
@@ -27,8 +27,6 @@ pub const MODELSCOPE_ORIGIN: &str = "https://www.modelscope.cn";
 /// policy`). Integrity stays the signed catalog sha256, not this branch name.
 pub const MODELSCOPE_DEFAULT_REVISION: &str = "master";
 
-pub(crate) const HUGGING_FACE_ORIGIN: &str = "https://huggingface.co";
-
 const ALLOWED_CATALOG_ENDPOINTS: &[&str] = &[CANONICAL_CATALOG_ENDPOINT, CHINA_CATALOG_ENDPOINT];
 const ALLOWED_DL_ENDPOINTS: &[&str] = &[CANONICAL_DL_ENDPOINT, CHINA_DL_ENDPOINT];
 
@@ -82,10 +80,10 @@ pub(crate) fn hf_endpoint_is_set() -> bool {
 /// endpoint. Desktop should set the env knobs from its one China toggle so
 /// this process and the sidecar daemon agree.
 pub fn prefer_china_transport() -> bool {
-    if let Some(endpoint) = endpoint_from_env(CATALOG_ENDPOINT_ENV) {
-        if is_allowed_https_endpoint(&endpoint, ALLOWED_CATALOG_ENDPOINTS) {
-            return endpoint == CHINA_CATALOG_ENDPOINT;
-        }
+    if let Some(endpoint) = endpoint_from_env(CATALOG_ENDPOINT_ENV)
+        && is_allowed_https_endpoint(&endpoint, ALLOWED_CATALOG_ENDPOINTS)
+    {
+        return endpoint == CHINA_CATALOG_ENDPOINT;
     }
     match env::var("OPENASR_DOWNLOAD_SOURCE")
         .ok()
@@ -267,6 +265,7 @@ mod tests {
 
     const IDENTITY: &str = "https://catalog.openasr.org/v1/catalog.json";
     const SIGNATURE: &str = "https://catalog.openasr.org/v1/catalog.signature.json";
+    const HUGGING_FACE_ORIGIN: &str = "https://huggingface.co";
     const HF_PACK: &str = "https://huggingface.co/OpenASR/moonshine-tiny/resolve/0123456789abcdef0123456789abcdef01234567/moonshine-tiny-q8_0.oasr";
 
     #[test]

--- a/crates/openasr-core/src/transport.rs
+++ b/crates/openasr-core/src/transport.rs
@@ -41,8 +41,7 @@ pub(crate) fn apply_catalog_endpoint(url: &str) -> String {
     if let Some(rest) = url.strip_prefix(CANONICAL_CATALOG_ENDPOINT) {
         return format!("{endpoint}{rest}");
     }
-    const LEGACY_HF_CATALOG: &str =
-        "https://huggingface.co/OpenASR/catalog/resolve/main/";
+    const LEGACY_HF_CATALOG: &str = "https://huggingface.co/OpenASR/catalog/resolve/main/";
     if let Some(name) = url.strip_prefix(LEGACY_HF_CATALOG)
         && (name == "catalog.json" || name == "catalog.signature.json")
     {
@@ -178,12 +177,7 @@ fn resolved_dl_endpoint() -> String {
     }
 }
 
-fn resolve_endpoint(
-    env_var: &str,
-    allowlist: &[&str],
-    canonical: &str,
-    china: &str,
-) -> String {
+fn resolve_endpoint(env_var: &str, allowlist: &[&str], canonical: &str, china: &str) -> String {
     if let Some(value) = endpoint_from_env(env_var) {
         if is_allowed_https_endpoint(&value, allowlist) {
             return value;
@@ -229,7 +223,12 @@ fn is_allowed_https_endpoint(endpoint: &str, allowlist: &[&str]) -> bool {
 
 /// Rewrite `canonical_origin` (and optionally a legacy origin) onto `endpoint`.
 /// `legacy_origin` may be empty.
-fn rewrite_origin_prefix(url: &str, canonical_origin: &str, endpoint: &str, legacy_origin: &str) -> String {
+fn rewrite_origin_prefix(
+    url: &str,
+    canonical_origin: &str,
+    endpoint: &str,
+    legacy_origin: &str,
+) -> String {
     if let Some(rest) = url.strip_prefix(canonical_origin) {
         return format!("{endpoint}{rest}");
     }
@@ -324,7 +323,10 @@ mod tests {
         use std::ffi::OsString;
         crate::test_process_env::with_test_process_env(
             [
-                (CATALOG_ENDPOINT_ENV, Some(OsString::from(CHINA_CATALOG_ENDPOINT))),
+                (
+                    CATALOG_ENDPOINT_ENV,
+                    Some(OsString::from(CHINA_CATALOG_ENDPOINT)),
+                ),
                 ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("global"))),
             ],
             || {
@@ -341,7 +343,10 @@ mod tests {
         );
         crate::test_process_env::with_test_process_env(
             [
-                (CATALOG_ENDPOINT_ENV, Some(OsString::from("https://evil.example"))),
+                (
+                    CATALOG_ENDPOINT_ENV,
+                    Some(OsString::from("https://evil.example")),
+                ),
                 ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("global"))),
             ],
             || {
@@ -391,7 +396,9 @@ mod tests {
     fn modelscope_rewrite_uses_lowercase_owner_and_master_revision() {
         assert_eq!(
             apply_modelscope_endpoint(HF_PACK).as_deref(),
-            Some("https://www.modelscope.cn/models/openasr/moonshine-tiny/resolve/master/moonshine-tiny-q8_0.oasr")
+            Some(
+                "https://www.modelscope.cn/models/openasr/moonshine-tiny/resolve/master/moonshine-tiny-q8_0.oasr"
+            )
         );
         assert_eq!(apply_modelscope_endpoint(IDENTITY), None);
         assert_eq!(
@@ -399,9 +406,7 @@ mod tests {
             None
         );
         assert_eq!(
-            apply_modelscope_endpoint(
-                "https://huggingface.co/OpenASR/evil/resolve/abc/../secrets"
-            ),
+            apply_modelscope_endpoint("https://huggingface.co/OpenASR/evil/resolve/abc/../secrets"),
             None
         );
     }

--- a/crates/openasr-core/src/transport.rs
+++ b/crates/openasr-core/src/transport.rs
@@ -1,0 +1,435 @@
+//! Identity vs transport.
+//!
+//! Signed catalog bytes, pack URLs, and `files[].url` stay on their canonical
+//! hosts. This module is the only place that may swap the *fetch* host for
+//! availability (China catalog replica, ModelScope, `dl.bug.im`). Callers
+//! must not construct ModelScope or CNB URLs themselves.
+
+use std::env;
+#[cfg(unix)]
+use std::fs;
+
+pub const CANONICAL_CATALOG_ENDPOINT: &str = "https://catalog.openasr.org";
+pub const CHINA_CATALOG_ENDPOINT: &str = "https://catalog.bug.im";
+pub const CANONICAL_DL_ENDPOINT: &str = "https://dl.openasr.org";
+pub const CHINA_DL_ENDPOINT: &str = "https://dl.bug.im";
+
+pub const CATALOG_ENDPOINT_ENV: &str = "OPENASR_CATALOG_ENDPOINT";
+pub const DL_ENDPOINT_ENV: &str = "OPENASR_DL_ENDPOINT";
+
+/// ModelScope org that hosts OpenASR packs. Hugging Face uses `OpenASR`;
+/// ModelScope's path is lowercase `openasr` (live 2026-08-26:
+/// `https://www.modelscope.cn/models/openasr/qwen3-asr-0.6b`).
+pub const MODELSCOPE_OWNER: &str = "openasr";
+pub const MODELSCOPE_ORIGIN: &str = "https://www.modelscope.cn";
+/// ModelScope Hub only accepts commits on the default branch. Hugging Face
+/// git SHAs are not valid ModelScope refs (`commit rejected by repository
+/// policy`). Integrity stays the signed catalog sha256, not this branch name.
+pub const MODELSCOPE_DEFAULT_REVISION: &str = "master";
+
+pub(crate) const HUGGING_FACE_ORIGIN: &str = "https://huggingface.co";
+
+const ALLOWED_CATALOG_ENDPOINTS: &[&str] = &[CANONICAL_CATALOG_ENDPOINT, CHINA_CATALOG_ENDPOINT];
+const ALLOWED_DL_ENDPOINTS: &[&str] = &[CANONICAL_DL_ENDPOINT, CHINA_DL_ENDPOINT];
+
+/// Rewrite a signed catalog *identity* URL onto the configured transport
+/// endpoint. Verification still uses `url` unchanged. Only the live
+/// `catalog.openasr.org` prefix and the retired Hugging Face catalog object
+/// paths are rewritten — never an arbitrary `huggingface.co` pack URL.
+pub(crate) fn apply_catalog_endpoint(url: &str) -> String {
+    let endpoint = resolved_catalog_endpoint();
+    if let Some(rest) = url.strip_prefix(CANONICAL_CATALOG_ENDPOINT) {
+        return format!("{endpoint}{rest}");
+    }
+    const LEGACY_HF_CATALOG: &str =
+        "https://huggingface.co/OpenASR/catalog/resolve/main/";
+    if let Some(name) = url.strip_prefix(LEGACY_HF_CATALOG)
+        && (name == "catalog.json" || name == "catalog.signature.json")
+    {
+        return format!("{endpoint}/v1/{name}");
+    }
+    url.to_string()
+}
+
+/// Swap `https://dl.openasr.org/...` onto the China (or override) download
+/// origin. Non-dl URLs pass through. Used for kernel/vendor bytes whose
+/// signed identity stays on `dl.openasr.org`.
+pub(crate) fn apply_dl_endpoint(url: &str) -> String {
+    rewrite_origin_prefix(url, CANONICAL_DL_ENDPOINT, &resolved_dl_endpoint(), "")
+}
+
+/// Map a signed Hugging Face pack URL onto ModelScope's resolve path.
+///
+/// `https://huggingface.co/OpenASR/<repo>/resolve/<rev>/<file>`
+/// → `https://www.modelscope.cn/models/openasr/<repo>/resolve/master/<file>`
+///
+/// The Hugging Face revision is parsed so we only map real `/resolve/` pack
+/// URLs; the ModelScope path always uses [`MODELSCOPE_DEFAULT_REVISION`].
+/// Owner is always [`MODELSCOPE_OWNER`] (live ModelScope org), not the HF
+/// casing. Returns `None` when `url` is not an HF `/resolve/` pack URL.
+pub(crate) fn apply_modelscope_endpoint(url: &str) -> Option<String> {
+    modelscope_resolve_url(url)
+}
+
+pub(crate) fn hf_endpoint_env() -> Option<String> {
+    endpoint_from_env("HF_ENDPOINT")
+}
+
+pub(crate) fn hf_endpoint_is_set() -> bool {
+    hf_endpoint_env().is_some()
+}
+
+/// Locale / TZ / `OPENASR_DOWNLOAD_SOURCE=china|global` / explicit catalog
+/// endpoint. Desktop should set the env knobs from its one China toggle so
+/// this process and the sidecar daemon agree.
+pub fn prefer_china_transport() -> bool {
+    if let Some(endpoint) = endpoint_from_env(CATALOG_ENDPOINT_ENV) {
+        if is_allowed_https_endpoint(&endpoint, ALLOWED_CATALOG_ENDPOINTS) {
+            return endpoint == CHINA_CATALOG_ENDPOINT;
+        }
+    }
+    match env::var("OPENASR_DOWNLOAD_SOURCE")
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("china") => return true,
+        Some("global") => return false,
+        _ => {}
+    }
+    locale_prefers_china_sources()
+}
+
+pub(crate) fn locale_prefers_china_sources() -> bool {
+    ["LC_ALL", "LC_MESSAGES", "LANG"]
+        .iter()
+        .filter_map(|key| env::var(key).ok())
+        .any(|value| locale_value_prefers_china_sources(&value))
+        || env::var("TZ")
+            .ok()
+            .is_some_and(|value| timezone_value_prefers_china_sources(&value))
+        || system_timezone_prefers_china_sources()
+}
+
+pub(crate) fn locale_value_prefers_china_sources(value: &str) -> bool {
+    // Match desktop `isChinaUser()`: Simplified Chinese language, not every
+    // `zh*` locale. Traditional (TW/HK/Hant) is China-transport only when the
+    // timezone already matches (Hong Kong / Macau are in the TZ list).
+    let lower = value.to_ascii_lowercase();
+    let primary = lower
+        .split(['.', '@'])
+        .next()
+        .unwrap_or("")
+        .replace('-', "_");
+    let mut parts = primary.split('_');
+    let lang = parts.next().unwrap_or("");
+    let region = parts.next().unwrap_or("");
+    lang == "zh" && (region.is_empty() || region == "cn" || region.starts_with("hans"))
+}
+
+pub(crate) fn timezone_value_prefers_china_sources(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase().replace('\\', "/");
+    [
+        "asia/shanghai",
+        "asia/chongqing",
+        "asia/harbin",
+        "asia/urumqi",
+        "asia/hong_kong",
+        "asia/macau",
+        "prc",
+    ]
+    .iter()
+    .any(|needle| normalized.ends_with(needle) || normalized.contains(&format!("/{needle}")))
+}
+
+#[cfg(unix)]
+fn system_timezone_prefers_china_sources() -> bool {
+    fs::read_link("/etc/localtime")
+        .ok()
+        .and_then(|path| path.to_str().map(str::to_owned))
+        .is_some_and(|value| timezone_value_prefers_china_sources(&value))
+}
+
+#[cfg(not(unix))]
+fn system_timezone_prefers_china_sources() -> bool {
+    false
+}
+
+fn resolved_catalog_endpoint() -> String {
+    resolve_endpoint(
+        CATALOG_ENDPOINT_ENV,
+        ALLOWED_CATALOG_ENDPOINTS,
+        CANONICAL_CATALOG_ENDPOINT,
+        CHINA_CATALOG_ENDPOINT,
+    )
+}
+
+fn resolved_dl_endpoint() -> String {
+    if let Some(value) = endpoint_from_env(DL_ENDPOINT_ENV) {
+        if is_allowed_https_endpoint(&value, ALLOWED_DL_ENDPOINTS) {
+            return value;
+        }
+        return CANONICAL_DL_ENDPOINT.to_string();
+    }
+    if prefer_china_transport() {
+        CHINA_DL_ENDPOINT.to_string()
+    } else {
+        CANONICAL_DL_ENDPOINT.to_string()
+    }
+}
+
+fn resolve_endpoint(
+    env_var: &str,
+    allowlist: &[&str],
+    canonical: &str,
+    china: &str,
+) -> String {
+    if let Some(value) = endpoint_from_env(env_var) {
+        if is_allowed_https_endpoint(&value, allowlist) {
+            return value;
+        }
+        // Non-allowlist / non-https: fail closed — do not fetch from an
+        // attacker-controlled host. Stay on the canonical origin.
+        return canonical.to_string();
+    }
+    if prefer_china_transport_without_catalog_env() {
+        china.to_string()
+    } else {
+        canonical.to_string()
+    }
+}
+
+/// Like [`prefer_china_transport`], but ignores `OPENASR_CATALOG_ENDPOINT` so
+/// catalog resolution can consult download-source / locale without recursion.
+fn prefer_china_transport_without_catalog_env() -> bool {
+    match env::var("OPENASR_DOWNLOAD_SOURCE")
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("china") => return true,
+        Some("global") => return false,
+        _ => {}
+    }
+    locale_prefers_china_sources()
+}
+
+fn endpoint_from_env(var: &str) -> Option<String> {
+    env::var(var)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn is_allowed_https_endpoint(endpoint: &str, allowlist: &[&str]) -> bool {
+    allowlist.contains(&endpoint)
+        && endpoint.starts_with("https://")
+        && !endpoint.contains(['?', '#', '\\'])
+}
+
+/// Rewrite `canonical_origin` (and optionally a legacy origin) onto `endpoint`.
+/// `legacy_origin` may be empty.
+fn rewrite_origin_prefix(url: &str, canonical_origin: &str, endpoint: &str, legacy_origin: &str) -> String {
+    if let Some(rest) = url.strip_prefix(canonical_origin) {
+        return format!("{endpoint}{rest}");
+    }
+    if !legacy_origin.is_empty()
+        && let Some(rest) = url.strip_prefix(legacy_origin)
+    {
+        return format!("{endpoint}{rest}");
+    }
+    url.to_string()
+}
+
+fn modelscope_resolve_url(hf_url: &str) -> Option<String> {
+    let rest = hf_url.strip_prefix("https://huggingface.co/")?;
+    let (owner, after_owner) = rest.split_once('/')?;
+    let (repo, after_repo) = after_owner.split_once('/')?;
+    let after_resolve = after_repo.strip_prefix("resolve/")?;
+    let (rev, filename) = after_resolve.split_once('/')?;
+    if owner.is_empty()
+        || repo.is_empty()
+        || rev.is_empty()
+        || filename.is_empty()
+        || filename.contains("..")
+        || filename.contains('\\')
+    {
+        return None;
+    }
+    let _ = owner; // HF casing is ignored; ModelScope org is MODELSCOPE_OWNER.
+    Some(format!(
+        "{MODELSCOPE_ORIGIN}/models/{MODELSCOPE_OWNER}/{repo}/resolve/{MODELSCOPE_DEFAULT_REVISION}/{filename}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const IDENTITY: &str = "https://catalog.openasr.org/v1/catalog.json";
+    const SIGNATURE: &str = "https://catalog.openasr.org/v1/catalog.signature.json";
+    const HF_PACK: &str = "https://huggingface.co/OpenASR/moonshine-tiny/resolve/0123456789abcdef0123456789abcdef01234567/moonshine-tiny-q8_0.oasr";
+
+    #[test]
+    fn catalog_rewrite_swaps_only_the_canonical_origin() {
+        assert_eq!(
+            rewrite_origin_prefix(
+                IDENTITY,
+                CANONICAL_CATALOG_ENDPOINT,
+                CHINA_CATALOG_ENDPOINT,
+                HUGGING_FACE_ORIGIN
+            ),
+            "https://catalog.bug.im/v1/catalog.json"
+        );
+        assert_eq!(
+            rewrite_origin_prefix(
+                SIGNATURE,
+                CANONICAL_CATALOG_ENDPOINT,
+                CHINA_CATALOG_ENDPOINT,
+                HUGGING_FACE_ORIGIN
+            ),
+            "https://catalog.bug.im/v1/catalog.signature.json"
+        );
+        assert_eq!(
+            rewrite_origin_prefix(
+                IDENTITY,
+                CANONICAL_CATALOG_ENDPOINT,
+                CANONICAL_CATALOG_ENDPOINT,
+                HUGGING_FACE_ORIGIN
+            ),
+            IDENTITY
+        );
+        assert_eq!(
+            rewrite_origin_prefix(
+                "file:///tmp/catalog.json",
+                CANONICAL_CATALOG_ENDPOINT,
+                CHINA_CATALOG_ENDPOINT,
+                HUGGING_FACE_ORIGIN
+            ),
+            "file:///tmp/catalog.json"
+        );
+        assert_eq!(
+            rewrite_origin_prefix(
+                "https://example.com/v1/catalog.json",
+                CANONICAL_CATALOG_ENDPOINT,
+                CHINA_CATALOG_ENDPOINT,
+                HUGGING_FACE_ORIGIN
+            ),
+            "https://example.com/v1/catalog.json"
+        );
+    }
+
+    #[test]
+    fn catalog_endpoint_rewrites_live_and_legacy_identities_only() {
+        use std::ffi::OsString;
+        crate::test_process_env::with_test_process_env(
+            [
+                (CATALOG_ENDPOINT_ENV, Some(OsString::from(CHINA_CATALOG_ENDPOINT))),
+                ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("global"))),
+            ],
+            || {
+                assert_eq!(
+                    apply_catalog_endpoint(IDENTITY),
+                    "https://catalog.bug.im/v1/catalog.json"
+                );
+                assert_eq!(
+                    apply_catalog_endpoint(SIGNATURE),
+                    "https://catalog.bug.im/v1/catalog.signature.json"
+                );
+                assert_eq!(apply_catalog_endpoint(HF_PACK), HF_PACK);
+            },
+        );
+        crate::test_process_env::with_test_process_env(
+            [
+                (CATALOG_ENDPOINT_ENV, Some(OsString::from("https://evil.example"))),
+                ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("global"))),
+            ],
+            || {
+                assert_eq!(apply_catalog_endpoint(IDENTITY), IDENTITY);
+            },
+        );
+        crate::test_process_env::with_test_process_env(
+            [
+                (CATALOG_ENDPOINT_ENV, None),
+                ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("global"))),
+            ],
+            || {
+                let legacy = "https://huggingface.co/OpenASR/catalog/resolve/main/catalog.json";
+                assert_eq!(
+                    apply_catalog_endpoint(legacy),
+                    "https://catalog.openasr.org/v1/catalog.json"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn non_allowlist_catalog_endpoint_is_rejected() {
+        assert!(!is_allowed_https_endpoint(
+            "https://evil.example",
+            ALLOWED_CATALOG_ENDPOINTS
+        ));
+        assert!(!is_allowed_https_endpoint(
+            "http://catalog.bug.im",
+            ALLOWED_CATALOG_ENDPOINTS
+        ));
+        assert!(!is_allowed_https_endpoint(
+            "https://catalog.bug.im/extra",
+            ALLOWED_CATALOG_ENDPOINTS
+        ));
+        assert!(is_allowed_https_endpoint(
+            CHINA_CATALOG_ENDPOINT,
+            ALLOWED_CATALOG_ENDPOINTS
+        ));
+        assert!(is_allowed_https_endpoint(
+            CANONICAL_CATALOG_ENDPOINT,
+            ALLOWED_CATALOG_ENDPOINTS
+        ));
+    }
+
+    #[test]
+    fn modelscope_rewrite_uses_lowercase_owner_and_master_revision() {
+        assert_eq!(
+            apply_modelscope_endpoint(HF_PACK).as_deref(),
+            Some("https://www.modelscope.cn/models/openasr/moonshine-tiny/resolve/master/moonshine-tiny-q8_0.oasr")
+        );
+        assert_eq!(apply_modelscope_endpoint(IDENTITY), None);
+        assert_eq!(
+            apply_modelscope_endpoint("https://huggingface.co/OpenASR/moonshine-tiny"),
+            None
+        );
+        assert_eq!(
+            apply_modelscope_endpoint(
+                "https://huggingface.co/OpenASR/evil/resolve/abc/../secrets"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn dl_rewrite_swaps_only_dl_openasr_origin() {
+        let core = "https://dl.openasr.org/core/v0.1.36/plugin.dll";
+        assert_eq!(
+            rewrite_origin_prefix(core, CANONICAL_DL_ENDPOINT, CHINA_DL_ENDPOINT, ""),
+            "https://dl.bug.im/core/v0.1.36/plugin.dll"
+        );
+        assert_eq!(
+            rewrite_origin_prefix(HF_PACK, CANONICAL_DL_ENDPOINT, CHINA_DL_ENDPOINT, ""),
+            HF_PACK
+        );
+    }
+
+    #[test]
+    fn chinese_locale_and_timezone_prefer_china_sources() {
+        assert!(locale_value_prefers_china_sources("zh-Hans_US.UTF-8"));
+        assert!(locale_value_prefers_china_sources("zh_CN.UTF-8"));
+        assert!(locale_value_prefers_china_sources("zh.UTF-8"));
+        assert!(!locale_value_prefers_china_sources("zh_TW.UTF-8"));
+        assert!(!locale_value_prefers_china_sources("zh-Hant-TW"));
+        assert!(!locale_value_prefers_china_sources("C.UTF-8"));
+        assert!(timezone_value_prefers_china_sources(
+            "/var/db/timezone/zoneinfo/Asia/Shanghai"
+        ));
+        assert!(!timezone_value_prefers_china_sources("America/Los_Angeles"));
+    }
+}

--- a/docs/MODEL_CATALOG_ARCHITECTURE.md
+++ b/docs/MODEL_CATALOG_ARCHITECTURE.md
@@ -198,12 +198,13 @@ because `public` is the download/import gate, not the ASR market-list gate. The
 catalog's URLs stay pinned to `huggingface.co` as
 the signed, canonical *identity*; the client rewrites only the transport *host*
 via `http::apply_catalog_endpoint`, controlled by `OPENASR_CATALOG_ENDPOINT`
-(default `https://catalog.openasr.org`; override only for a self-host/mirror).
-Because the signed `catalog_url` is unchanged, the host is an availability layer,
-not a trust anchor — moving it needs no re-sign or signing seed. This is
-independent of `HF_ENDPOINT`, which routes weight downloads only. Deploys are
-automated by the `deploy-catalog` workflow on push; signing stays local (the seed
-never enters CI).
+(allowlist: `https://catalog.openasr.org` — a no-op — and
+`https://catalog.bug.im`, the Aliyun ESA byte-identical replica). The signed
+`catalog_url` is always `https://catalog.openasr.org/v1/catalog.json`; swapping
+the fetch host needs no re-sign. This is independent of `HF_ENDPOINT`, which
+routes weight downloads only. Deploys push the same two JSON files to Cloudflare
+and, when `esa-cli` is logged in, to ESA; ESA never origin-fetches Cloudflare.
+Signing stays local (the seed never enters CI).
 
 ## Cache And Rollback Boundary
 

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,29 @@ info "installing openasr $version ($target) to $prefix"
 # -- Download + verify --------------------------------------------------------
 
 asset="openasr-${version_num}-${target}.tar.gz"
-base_url="$GITHUB/$REPO/releases/download/$version"
+github_base="$GITHUB/$REPO/releases/download/$version"
+china_base="https://dl.bug.im/cli/$version"
+
+china_transport() {
+  ds="$(printf '%s' "${OPENASR_DOWNLOAD_SOURCE-}" | tr 'A-Z' 'a-z')"
+  case "$ds" in
+    china) return 0 ;;
+    global) return 1 ;;
+  esac
+  loc="$(printf '%s' "${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}" | tr 'A-Z' 'a-z')"
+  loc_lang="$(printf '%s' "$loc" | sed 's/[.@].*//; s/-/_/g')"
+  case "$loc_lang" in
+    zh|zh_cn|zh_cn_*|zh_hans|zh_hans_*) return 0 ;;
+  esac
+  tz="$(printf '%s' "${TZ:-}" | tr 'A-Z' 'a-z' | tr '\\' '/')"
+  if [ -z "$tz" ] && [ -L /etc/localtime ]; then
+    tz="$(readlink /etc/localtime 2>/dev/null | tr 'A-Z' 'a-z' | tr '\\' '/')"
+  fi
+  case "$tz" in
+    *asia/shanghai* | *asia/chongqing* | *asia/harbin* | *asia/urumqi* | *asia/hong_kong* | *asia/macau* | prc) return 0 ;;
+  esac
+  return 1
+}
 
 workdir="$(mktemp -d)"
 cleanup() {
@@ -136,10 +158,19 @@ archive="$workdir/$asset"
 sums="$workdir/SHA256SUMS"
 
 info "downloading $asset"
-curl -fsSL -o "$archive" "$base_url/$asset" \
-  || err "download failed: $base_url/$asset (check that $version shipped a $target build)"
-curl -fsSL -o "$sums" "$base_url/SHA256SUMS" \
-  || err "download failed: $base_url/SHA256SUMS"
+if china_transport; then
+  if ! curl -fsSL -o "$archive" "$china_base/$asset"; then
+    info "China mirror missed $asset; falling back to GitHub"
+    curl -fsSL -o "$archive" "$github_base/$asset" \
+      || err "download failed: $github_base/$asset (check that $version shipped a $target build)"
+  fi
+else
+  curl -fsSL -o "$archive" "$github_base/$asset" \
+    || err "download failed: $github_base/$asset (check that $version shipped a $target build)"
+fi
+# Checksums always come from official GitHub, never from an accelerator.
+curl -fsSL -o "$sums" "$github_base/SHA256SUMS" \
+  || err "download failed: $github_base/SHA256SUMS"
 
 expected_line="$(grep -F " $asset" "$sums" || true)"
 [ -n "$expected_line" ] || err "SHA256SUMS has no entry for $asset -- refusing to install an unverifiable binary"

--- a/scripts/deploy-catalog-esa.sh
+++ b/scripts/deploy-catalog-esa.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Push the signed catalog pair to Aliyun ESA (catalog.bug.im).
+#
+# Same topology as bugim-cap / bugim-edge: `esa-cli deploy` of a bundled
+# EdgeRoutine. Bytes are baked into the bundle so ESA never origin-fetches
+# Cloudflare (domestic networks that wall CF would otherwise make the replica
+# useless).
+#
+# Skip (exit 0) when esa-cli is missing or not logged in — overseas catalog
+# deploy must stay green. After a successful ESA deploy, reachable
+# catalog.bug.im bytes must match the candidate files (exit 1 on mismatch).
+# Skip only when live HTTPS is still unreachable (DNS/TLS not ready).
+#
+# Usage:
+#   scripts/deploy-catalog-esa.sh [catalog.json] [catalog.signature.json]
+#
+# Defaults: model-registry/catalog.public.json + .public.signature.json
+# Auth: `esa-cli login` (AK/SK), same as bugim. Optional env:
+#   ESA_CLI                 override esa-cli binary
+#   OPENASR_ESA_CATALOG_SKIP=1  force skip
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+CATALOG_PKG="${REPO_ROOT}/cloudflare/catalog"
+
+catalog="${1:-${REPO_ROOT}/model-registry/catalog.public.json}"
+signature="${2:-${REPO_ROOT}/model-registry/catalog.public.signature.json}"
+
+skip() {
+  printf 'ESA catalog deploy skipped: %s\n' "$1"
+  exit 0
+}
+
+if [ "${OPENASR_ESA_CATALOG_SKIP:-}" = "1" ]; then
+  skip "OPENASR_ESA_CATALOG_SKIP=1"
+fi
+
+command -v sha256sum >/dev/null 2>&1 || command -v shasum >/dev/null 2>&1 \
+  || skip "no sha256sum/shasum"
+[ -f "$catalog" ] && [ -f "$signature" ] || skip "catalog files missing"
+
+ESA_CLI="${ESA_CLI:-esa-cli}"
+if ! command -v "$ESA_CLI" >/dev/null 2>&1; then
+  skip "esa-cli not installed (npm i -g esa-cli && esa-cli login, same as bugim-cap)"
+fi
+
+# esa-cli has no documented --dry-run auth probe; `esa-cli --help` succeeding
+# after login is not enough. Try a non-mutating call and skip on auth failure.
+if ! "$ESA_CLI" --help >/dev/null 2>&1; then
+  skip "esa-cli not runnable"
+fi
+
+# Local: `esa-cli login`. CI: ALIBABA_CLOUD_ACCESS_KEY_ID/SECRET.
+# Probe before deploy so a missing login cannot fail overseas catalog CI.
+if ! "$ESA_CLI" site list >/dev/null 2>&1; then
+  skip "esa-cli not authenticated (esa-cli login, or ALIBABA_CLOUD_ACCESS_KEY_ID/SECRET)"
+fi
+
+file_sha() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+want_catalog_sha="$(file_sha "$catalog")"
+want_sig_sha="$(file_sha "$signature")"
+
+mkdir -p "${CATALOG_PKG}/public"
+cp "$catalog" "${CATALOG_PKG}/public/catalog.json"
+cp "$signature" "${CATALOG_PKG}/public/catalog.signature.json"
+
+(
+  cd "$CATALOG_PKG"
+  if [ ! -d node_modules/esbuild ]; then
+    npm install --omit=optional
+  fi
+  npm run build:esa
+)
+
+echo "==> esa-cli deploy (catalog.bug.im)"
+(
+  cd "$CATALOG_PKG"
+  # Already bundled by build:esa (catalog JSON baked). Skip TTY env/version prompts.
+  if ! "$ESA_CLI" deploy --no-bundle -e production -d "OpenASR China catalog replica"; then
+    echo "ESA catalog deploy failed; overseas Cloudflare catalog is unchanged." >&2
+    exit 1
+  fi
+  "$ESA_CLI" domain add catalog.bug.im 2>&1 || true
+  "$ESA_CLI" route add -r "catalog.bug.im/*" -s bug.im -a catalog-bug-im 2>&1 || true
+)
+
+echo "==> verifying live catalog.bug.im matches candidate sha256"
+base="https://catalog.bug.im/v1"
+ok=0
+reachable=0
+for attempt in $(seq 1 12); do
+  bust="cb=$(date +%s)-${attempt}"
+  if curl -fsSL "${base}/catalog.json?${bust}" -o /tmp/esa-catalog.json \
+    && curl -fsSL "${base}/catalog.signature.json?${bust}" -o /tmp/esa-catalog.sig.json; then
+    reachable=1
+    live_catalog_sha="$(file_sha /tmp/esa-catalog.json)"
+    live_sig_sha="$(file_sha /tmp/esa-catalog.sig.json)"
+    if [ "$live_catalog_sha" = "$want_catalog_sha" ] && [ "$live_sig_sha" = "$want_sig_sha" ]; then
+      ok=1
+      break
+    fi
+    echo "catalog.bug.im sha256 mismatch (attempt ${attempt}); retrying in 10s"
+  else
+    echo "catalog.bug.im HTTPS not reachable (attempt ${attempt}); retrying in 10s"
+  fi
+  sleep 10
+done
+
+if [ "$ok" = "1" ]; then
+  echo "catalog.bug.im matches the candidate catalog pair"
+  exit 0
+fi
+
+if [ "$reachable" = "1" ]; then
+  echo "ESA catalog live sha256 does not match the candidate after 12 attempts." >&2
+  echo "  candidate catalog ${want_catalog_sha}" >&2
+  echo "  candidate signature ${want_sig_sha}" >&2
+  echo "  live catalog ${live_catalog_sha:-unavailable}" >&2
+  echo "  live signature ${live_sig_sha:-unavailable}" >&2
+  exit 1
+fi
+
+echo "ESA catalog EdgeRoutine is deployed and catalog.bug.im is bound." >&2
+echo "Live HTTPS is not ready yet (DNS/TLS). Candidate sha256:" >&2
+echo "  catalog ${want_catalog_sha}" >&2
+echo "  signature ${want_sig_sha}" >&2
+echo "Add a DNS-only CNAME: catalog.bug.im -> catalog.bug.im.a1.initac.com (same pattern as cap.bug.im)." >&2
+exit 0

--- a/scripts/finalize-core-release.sh
+++ b/scripts/finalize-core-release.sh
@@ -376,3 +376,9 @@ gh release edit "$tag" --repo "$repository" --draft=false --latest
 scripts/qualification-release-lock.sh release "$tag" "$lock_token"
 lock_acquired=false
 echo "RELEASE-PUBLISHED-INERT ${tag}"
+
+# China mirror: GitHub stays the signed source. Missing CNB_TOKEN skips.
+if [ -x "${REPO_ROOT}/scripts/sync-release-to-cnb.sh" ]; then
+  echo "==> syncing ${tag} assets to CNB (skip if no CNB_TOKEN)"
+  "${REPO_ROOT}/scripts/sync-release-to-cnb.sh" "$tag" || echo "CNB sync returned non-zero (overseas release already public)"
+fi

--- a/scripts/sync-main-to-cnb.sh
+++ b/scripts/sync-main-to-cnb.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Fast-forward GitHub `main` onto CNB `main`. Never mirror, prune, or force.
+#
+# CNB also holds desktop-v* tags that do not exist on GitHub. A mirror push
+# would delete those refs. This script only updates refs/heads/main.
+#
+# Usage:
+#   scripts/sync-main-to-cnb.sh [commit-ish]
+#
+# Default source: origin/main locally, HEAD in GitHub Actions (must be
+# refs/heads/main). Feature-branch HEAD is never the implicit source.
+#
+# Env:
+#   CNB_TOKEN            required (git username is always `cnb`)
+#   OPENASR_CNB_REPO     default openasr/openasr
+#   OPENASR_CNB_STRICT=1 fail even when this is a notice-style helper
+#                        (default: fail; this is not a release sidecar)
+
+set -euo pipefail
+
+notice() { printf 'CNB main sync: %s\n' "$1"; }
+fail() {
+  printf 'CNB main sync failed: %s\n' "$1" >&2
+  exit 1
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  echo "usage: $(basename "$0") [commit-ish]" >&2
+  exit 2
+fi
+
+if [ -z "${CNB_TOKEN:-}" ]; then
+  fail "CNB_TOKEN is not set"
+fi
+
+if [ "${GITHUB_ACTIONS:-}" = "true" ] && [ "${GITHUB_REF:-}" != "refs/heads/main" ]; then
+  fail "refusing to update CNB main from ${GITHUB_REF:-unknown-ref}"
+fi
+
+CNB_REPO="${OPENASR_CNB_REPO:-openasr/openasr}"
+CNB_GIT="https://cnb.cool/${CNB_REPO}"
+source_ref="${1:-}"
+if [ -z "$source_ref" ]; then
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    source_ref="HEAD"
+  elif git rev-parse --verify --quiet origin/main >/dev/null; then
+    source_ref="origin/main"
+  else
+    fail "no origin/main; pass an explicit commit-ish"
+  fi
+fi
+
+commit="$(git rev-parse "${source_ref}^{commit}")"
+notice "source ${source_ref} = ${commit}"
+
+askpass="$(mktemp "${TMPDIR:-/tmp}/openasr-cnb-askpass.XXXXXX")"
+cleanup() {
+  rm -f "$askpass"
+  git update-ref -d refs/cnb-sync/main >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+printf '%s\n' '#!/bin/sh' 'case "$1" in *[Uu]sername*) echo cnb ;; *) printf "%s\n" "$CNB_TOKEN" ;; esac' > "$askpass"
+chmod 700 "$askpass"
+
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS="$askpass"
+
+cnb_main="$(git ls-remote --heads "$CNB_GIT" refs/heads/main | awk '{print $1}')"
+if [ -n "$cnb_main" ]; then
+  notice "CNB main is ${cnb_main}"
+  if [ "$cnb_main" = "$commit" ]; then
+    notice "already in sync"
+    exit 0
+  fi
+  git fetch --no-tags "$CNB_GIT" "+refs/heads/main:refs/cnb-sync/main"
+  if ! git merge-base --is-ancestor refs/cnb-sync/main "$commit"; then
+    fail "CNB main ${cnb_main} is not an ancestor of ${commit}; refusing a non-ff update"
+  fi
+else
+  notice "CNB has no main yet; creating refs/heads/main"
+fi
+
+if ! git push --no-follow-tags "$CNB_GIT" "${commit}:refs/heads/main"; then
+  fail "git push of main was rejected"
+fi
+
+notice "updated CNB refs/heads/main -> ${commit}"

--- a/scripts/sync-release-to-cnb.sh
+++ b/scripts/sync-release-to-cnb.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# Idempotent GitHub Release → CNB (cnb.cool) asset sync.
+#
+# GitHub + B2 remain the only build/sign sources. CNB is a read-only China
+# mirror. Missing CNB_TOKEN skips (exit 0) so overseas publish stays green.
+# A CNB failure after auth is a notice unless OPENASR_CNB_STRICT=1.
+#
+# Usage:
+#   scripts/sync-release-to-cnb.sh <tag> [file ...]
+#
+# If no files are given, downloads every asset of GitHub release <tag> into a
+# temp dir and uploads those. Desktop callers pass extra local files that are
+# not on GitHub (macOS .app.tar.gz).
+#
+# Env:
+#   CNB_TOKEN            required for upload (Bearer)
+#   OPENASR_CNB_REPO     default openasr/openasr
+#   OPENASR_CNB_API      default https://api.cnb.cool
+#   OPENASR_CNB_STRICT=1 fail the caller on CNB errors
+#   GITHUB_REPOSITORY    source GitHub repo (default QuintinShaw/openasr)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+notice() { printf 'CNB sync: %s\n' "$1"; }
+fail() {
+  printf 'CNB sync failed: %s\n' "$1" >&2
+  if [ "${OPENASR_CNB_STRICT:-}" = "1" ]; then
+    exit 1
+  fi
+  exit 0
+}
+
+if [ "${1:-}" = "" ] || [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  echo "usage: $(basename "$0") <tag> [file ...]" >&2
+  exit 2
+fi
+
+tag="$1"
+shift
+
+if [ -z "${CNB_TOKEN:-}" ]; then
+  notice "skipped (no CNB_TOKEN)"
+  exit 0
+fi
+
+CNB_REPO="${OPENASR_CNB_REPO:-openasr/openasr}"
+CNB_API="${OPENASR_CNB_API:-https://api.cnb.cool}"
+GITHUB_REPO="${GITHUB_REPOSITORY:-QuintinShaw/openasr}"
+ACCEPT="application/vnd.cnb.api+json"
+
+cnb_curl() {
+  curl -sS --connect-timeout 15 --max-time 120 \
+    -H "Accept: ${ACCEPT}" \
+    -H "Authorization: Bearer ${CNB_TOKEN}" \
+    "$@"
+}
+
+# Empty CNB repos have no `main`; a Release still needs a git tag object.
+# Fetch the GitHub tag into a throwaway repo and push it (username is always `cnb`).
+# Shallow fetches are rejected (`shallow update not allowed`).
+cnb_push_tag() {
+  local askpass tmpgit
+  tmpgit="$(mktemp -d "${TMPDIR:-/tmp}/openasr-cnb-git.XXXXXX")"
+  askpass="$(mktemp "${TMPDIR:-/tmp}/openasr-cnb-askpass.XXXXXX")"
+  printf '%s\n' '#!/bin/sh' 'case "$1" in *[Uu]sername*) echo cnb ;; *) printf "%s\n" "$CNB_TOKEN" ;; esac' > "$askpass"
+  chmod 700 "$askpass"
+  git init --bare "$tmpgit" >/dev/null
+  if ! git --git-dir="$tmpgit" fetch --no-tags \
+      "https://github.com/${GITHUB_REPO}.git" "refs/tags/${tag}:refs/tags/${tag}"; then
+    rm -rf "$tmpgit" "$askpass"
+    fail "could not fetch GitHub tag ${tag}"
+  fi
+  target_commitish="$(git --git-dir="$tmpgit" rev-parse "refs/tags/${tag}^{commit}")"
+  if ! GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="$askpass" \
+      git --git-dir="$tmpgit" push "https://cnb.cool/${CNB_REPO}" \
+      "refs/tags/${tag}:refs/tags/${tag}"; then
+    rm -rf "$tmpgit" "$askpass"
+    fail "could not push tag ${tag} to CNB"
+  fi
+  rm -rf "$tmpgit" "$askpass"
+  notice "pushed git tag ${tag} to CNB (${target_commitish})"
+}
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+file_size() {
+  python3 -c 'import os,sys; print(os.path.getsize(sys.argv[1]))' "$1"
+}
+
+# `gh release download` has no retry and has truncated 60MB+ assets with
+# "unexpected EOF". Pull the public GitHub asset URL with curl, matching
+# the CNB PUT retry policy, then refuse a size mismatch.
+download_github_asset() {
+  local name="$1"
+  local size="$2"
+  local dest="$3"
+  local url="https://github.com/${GITHUB_REPO}/releases/download/${tag}/${name}"
+  local attempt got
+  for attempt in 1 2 3; do
+    rm -f "$dest"
+    if curl --fail --show-error --location --progress-bar \
+        --connect-timeout 30 --max-time 7200 \
+        --retry 3 --retry-delay 5 --retry-all-errors \
+        --output "$dest" "$url"; then
+      got="$(file_size "$dest")"
+      if [ "$got" = "$size" ]; then
+        return 0
+      fi
+      echo "GitHub download size mismatch for ${name}: ${got} != ${size}" >&2
+    else
+      echo "GitHub download failed for ${name} (attempt ${attempt}/3)" >&2
+    fi
+    sleep $((attempt * 5))
+  done
+  rm -f "$dest"
+  return 1
+}
+
+json_field() {
+  python3 -c '
+import json,sys
+raw=sys.stdin.read().strip()
+if not raw:
+    raise SystemExit(0)
+try:
+    data=json.loads(raw)
+except json.JSONDecodeError:
+    raise SystemExit(0)
+print(data.get(sys.argv[1]) or "")
+' "$1"
+}
+
+# Swagger: GET /{repo}/-/releases/tags/{tag} ; POST /{repo}/-/releases
+# (query-string ?tag_name= is not an OpenAPI path).
+tag_path="$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "$tag")"
+api_releases="${CNB_API}/${CNB_REPO}/-/releases"
+
+lookup_response="$(
+  curl -sS --connect-timeout 15 --max-time 120 -w "\n%{http_code}" \
+    "${api_releases}/tags/${tag_path}" \
+    -H "Accept: ${ACCEPT}" \
+    -H "Authorization: Bearer ${CNB_TOKEN}" || true
+)"
+lookup_status="$(printf '%s' "$lookup_response" | tail -n1)"
+lookup_body="$(printf '%s' "$lookup_response" | sed '$d')"
+release_id=""
+
+if [ "$lookup_status" = "200" ]; then
+  release_id="$(printf '%s' "$lookup_body" | json_field id)"
+  notice "found existing CNB release ${tag}"
+elif [ "$lookup_status" = "404" ]; then
+  # make_latest stays false: core and desktop tags share one CNB repo; "latest"
+  # is not the download identity (install.sh / accel JSON pin explicit tags).
+  target_commitish=""
+  cnb_push_tag
+  create_body="$(python3 -c 'import json,sys; print(json.dumps({"tag_name":sys.argv[1],"name":sys.argv[1],"body":"OpenASR China mirror of GitHub "+sys.argv[1],"draft":False,"prerelease":False,"make_latest":"false","target_commitish":sys.argv[2]}))' "$tag" "$target_commitish")"
+  create_response="$(
+    curl -sS --connect-timeout 15 --max-time 120 -w "\n%{http_code}" \
+      -X POST "${api_releases}" \
+      -H "Accept: ${ACCEPT}" \
+      -H "Authorization: Bearer ${CNB_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$create_body" || true
+  )"
+  create_status="$(printf '%s' "$create_response" | tail -n1)"
+  create_body_json="$(printf '%s' "$create_response" | sed '$d')"
+  if [ "$create_status" != "201" ]; then
+    fail "create CNB release ${tag} HTTP ${create_status}: ${create_body_json:0:240}"
+  fi
+  release_id="$(printf '%s' "$create_body_json" | json_field id)"
+  notice "created CNB release ${tag}"
+else
+  fail "lookup CNB release ${tag} HTTP ${lookup_status}: ${lookup_body:0:240}"
+fi
+
+if [ -z "$release_id" ]; then
+  fail "could not create or find CNB release ${tag} on ${CNB_REPO}"
+fi
+
+release_detail="$(cnb_curl "${api_releases}/${release_id}" || true)"
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/openasr-cnb-sync.XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT
+
+already_on_cnb() {
+  local name="$1"
+  local size="$2"
+  printf '%s' "$release_detail" | python3 -c '
+import json,sys
+raw=sys.stdin.read().strip()
+name, size = sys.argv[1], int(sys.argv[2])
+try:
+    data=json.loads(raw) if raw else {}
+except json.JSONDecodeError:
+    raise SystemExit(1)
+for asset in data.get("assets") or []:
+    if asset.get("name")==name and int(asset.get("size") or -1)==size:
+        raise SystemExit(0)
+raise SystemExit(1)
+' "$name" "$size"
+}
+
+upload_one() {
+  local path="$1"
+  local name size upload_response upload_status upload_body upload_url verify_url verify_status
+  name="$(basename "$path")"
+  size="$(wc -c < "$path" | tr -d ' ')"
+  if already_on_cnb "$name" "$size"; then
+    notice "skip ${name} (already on CNB, size match)"
+    return 0
+  fi
+
+  upload_response="$(
+    curl -sS --connect-timeout 15 --max-time 120 -w "\n%{http_code}" \
+      -X POST "${CNB_API}/${CNB_REPO}/-/releases/${release_id}/asset-upload-url" \
+      -H "Accept: ${ACCEPT}" \
+      -H "Authorization: Bearer ${CNB_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$(python3 -c 'import json,sys; print(json.dumps({"asset_name":sys.argv[1],"size":int(sys.argv[2]),"overwrite":True,"ttl":0}))' "$name" "$size")"
+  )"
+  upload_status="$(printf '%s' "$upload_response" | tail -n1)"
+  upload_body="$(printf '%s' "$upload_response" | sed '$d')"
+  if [ "$upload_status" != "201" ] && [ "$upload_status" != "200" ]; then
+    echo "CNB asset-upload-url failed for ${name} (HTTP ${upload_status}): ${upload_body}" >&2
+    return 1
+  fi
+  upload_url="$(printf '%s' "$upload_body" | python3 -c 'import json,sys; print(json.load(sys.stdin)["upload_url"])')"
+  verify_url="$(printf '%s' "$upload_body" | python3 -c 'import json,sys; print(json.load(sys.stdin)["verify_url"])')"
+  curl --fail-with-body --show-error --location --progress-bar \
+    --connect-timeout 30 --max-time 7200 \
+    --retry 3 --retry-delay 5 --retry-all-errors \
+    -X PUT --upload-file "$path" "$upload_url"
+  verify_status="$(
+    curl -sS --connect-timeout 15 --max-time 120 -o /dev/null -w "%{http_code}" \
+      -X POST "$verify_url" \
+      -H "Accept: ${ACCEPT}" \
+      -H "Authorization: Bearer ${CNB_TOKEN}"
+  )"
+  case "$verify_status" in
+    200|201|204) ;;
+    *)
+      echo "CNB did not confirm ${name} (HTTP ${verify_status})" >&2
+      return 1
+      ;;
+  esac
+  notice "uploaded ${name} sha256=$(sha256_of "$path")"
+}
+
+errors=0
+synced=0
+if [ "$#" -eq 0 ]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    fail "gh is required to list GitHub release assets when no files are given"
+  fi
+  # Stream one GitHub asset at a time so a 3GB+ core release does not have to
+  # land on disk in full before the first CNB PUT.
+  while IFS=$'\t' read -r name size; do
+    [ -n "$name" ] || continue
+    if already_on_cnb "$name" "$size"; then
+      notice "skip ${name} (already on CNB, size match)"
+      synced=$((synced + 1))
+      continue
+    fi
+    notice "downloading ${name} from GitHub (${size} bytes)"
+    path="$workdir/$name"
+    if ! download_github_asset "$name" "$size" "$path"; then
+      echo "GitHub download failed for ${name}" >&2
+      errors=$((errors + 1))
+      continue
+    fi
+    if upload_one "$path"; then
+      synced=$((synced + 1))
+    else
+      errors=$((errors + 1))
+    fi
+    rm -f "$path"
+  done < <(gh release view "$tag" --repo "$GITHUB_REPO" --json assets --jq '.assets[] | select(.state=="uploaded") | [.name, (.size|tostring)] | @tsv')
+else
+  for path in "$@"; do
+    [ -f "$path" ] || fail "not a file: $path"
+    if upload_one "$path"; then
+      synced=$((synced + 1))
+    else
+      errors=$((errors + 1))
+    fi
+  done
+fi
+
+if [ "$errors" -ne 0 ]; then
+  fail "${errors} asset(s) failed for ${tag}"
+fi
+if [ "$synced" -eq 0 ]; then
+  notice "no files to upload for ${tag}"
+  exit 0
+fi
+notice "synced ${synced} file(s) to ${CNB_REPO} @ ${tag}"

--- a/scripts/sync-release-to-cnb.sh
+++ b/scripts/sync-release-to-cnb.sh
@@ -18,9 +18,9 @@
 #   OPENASR_CNB_API      default https://api.cnb.cool
 #   OPENASR_CNB_STRICT=1 fail the caller on CNB errors
 #   OPENASR_CNB_GITHUB_REPO  git+release source (default QuintinShaw/openasr).
-#                            Never inherit GITHUB_REPOSITORY: desktop CI runs in
-#                            private openasr-org/openasr-app and must not fetch
-#                            or push that repo's desktop-v* tags onto public CNB.
+#                            Never inherit GITHUB_REPOSITORY: Actions sets that
+#                            to the host repo, which is not always this public
+#                            open core. CNB tags must come from here.
 
 set -euo pipefail
 

--- a/scripts/sync-release-to-cnb.sh
+++ b/scripts/sync-release-to-cnb.sh
@@ -17,7 +17,10 @@
 #   OPENASR_CNB_REPO     default openasr/openasr
 #   OPENASR_CNB_API      default https://api.cnb.cool
 #   OPENASR_CNB_STRICT=1 fail the caller on CNB errors
-#   GITHUB_REPOSITORY    source GitHub repo (default QuintinShaw/openasr)
+#   OPENASR_CNB_GITHUB_REPO  git+release source (default QuintinShaw/openasr).
+#                            Never inherit GITHUB_REPOSITORY: desktop CI runs in
+#                            private openasr-org/openasr-app and must not fetch
+#                            or push that repo's desktop-v* tags onto public CNB.
 
 set -euo pipefail
 
@@ -48,7 +51,7 @@ fi
 
 CNB_REPO="${OPENASR_CNB_REPO:-openasr/openasr}"
 CNB_API="${OPENASR_CNB_API:-https://api.cnb.cool}"
-GITHUB_REPO="${GITHUB_REPOSITORY:-QuintinShaw/openasr}"
+GITHUB_REPO="${OPENASR_CNB_GITHUB_REPO:-QuintinShaw/openasr}"
 ACCEPT="application/vnd.cnb.api+json"
 
 cnb_curl() {

--- a/tooling/publish-model/scripts/sync_models_to_modelscope.py
+++ b/tooling/publish-model/scripts/sync_models_to_modelscope.py
@@ -8,6 +8,9 @@ URLs back into the catalog.
 Skip (exit 0) when no token is set:
   MODELSCOPE_SDK_TOKEN or MS_TOKEN
 
+Cache:
+  OPENASR_MODELSCOPE_CACHE  override download cache (default ~/.cache/openasr-modelscope-sync)
+
 Usage:
   tooling/publish-model/scripts/sync_models_to_modelscope.py [--catalog PATH] [--dry-run]
 """
@@ -155,10 +158,8 @@ def part_path(dest: Path) -> Path:
 
 
 def cache_root() -> Path:
-    path = Path(
-        os.environ.get("OPENASR_MODELSCOPE_CACHE")
-        or "/Volumes/QuintinDocument/openasr-dev/.cache/modelscope-sync"
-    )
+    raw = os.environ.get("OPENASR_MODELSCOPE_CACHE", "").strip()
+    path = Path(raw) if raw else Path.home() / ".cache" / "openasr-modelscope-sync"
     path.mkdir(parents=True, exist_ok=True)
     return path
 

--- a/tooling/publish-model/scripts/sync_models_to_modelscope.py
+++ b/tooling/publish-model/scripts/sync_models_to_modelscope.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Idempotent sync of signed catalog packs onto ModelScope.
+
+Reads catalog.public.json (HF identity URLs + sha256). Uploads the same bytes
+to `openasr/<repo>` (ModelScope org is lowercase). Never writes ModelScope
+URLs back into the catalog.
+
+Skip (exit 0) when no token is set:
+  MODELSCOPE_SDK_TOKEN or MS_TOKEN
+
+Usage:
+  tooling/publish-model/scripts/sync_models_to_modelscope.py [--catalog PATH] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+MODELSCOPE_OWNER = "openasr"
+MODELSCOPE_ORIGIN = "https://www.modelscope.cn"
+# ModelScope Hub rejects commits to Hugging Face git SHAs
+# (`commit rejected by repository policy`). Default branch is the only
+# writable ref; signed catalog sha256 is the pin.
+MODELSCOPE_UPLOAD_REVISION = "master"
+HF_ORIGIN = "https://huggingface.co/"
+
+
+def token() -> str:
+    return (
+        os.environ.get("MODELSCOPE_SDK_TOKEN", "").strip()
+        or os.environ.get("MS_TOKEN", "").strip()
+    )
+
+
+def modelscope_resolve_url(hf_url: str) -> str | None:
+    rest = hf_url[len(HF_ORIGIN) :] if hf_url.startswith(HF_ORIGIN) else None
+    if rest is None:
+        return None
+    parts = rest.split("/")
+    # OpenASR/<repo>/resolve/<rev>/<file>
+    if len(parts) < 5 or parts[2] != "resolve":
+        return None
+    repo, rev, filename = parts[1], parts[3], "/".join(parts[4:])
+    if not repo or not rev or not filename or ".." in filename or "\\" in filename:
+        return None
+    return (
+        f"{MODELSCOPE_ORIGIN}/models/{MODELSCOPE_OWNER}/{repo}/resolve/"
+        f"{MODELSCOPE_UPLOAD_REVISION}/{filename}"
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def iter_packs(catalog: dict) -> list[dict]:
+    packs = []
+    for model in catalog.get("models") or []:
+        if model.get("public") is not True:
+            continue
+        hf_repo = str(model.get("hf_repo") or "")
+        if not hf_repo.lower().startswith("openasr/"):
+            continue
+        repo = hf_repo.split("/", 1)[1]
+        for quant in model.get("quants") or []:
+            url = str(quant.get("url") or "")
+            sha = str(quant.get("sha256") or "").lower()
+            filename = str(quant.get("filename") or "")
+            size = int(quant.get("size_bytes") or 0)
+            rev = str(quant.get("hf_revision") or model.get("hf_revision") or "")
+            if not url or not sha or not filename or size <= 0:
+                continue
+            packs.append(
+                {
+                    "model_id": model["id"],
+                    "repo": repo,
+                    "revision": rev,
+                    "filename": filename,
+                    "url": url,
+                    "sha256": sha,
+                    "size_bytes": size,
+                    "ms_url": modelscope_resolve_url(url),
+                }
+            )
+    return packs
+
+
+def ssl_context():
+    """macOS python.org builds ship without a default CA bundle."""
+    import ssl
+
+    try:
+        import certifi
+
+        cafile = certifi.where()
+        os.environ.setdefault("SSL_CERT_FILE", cafile)
+        os.environ.setdefault("REQUESTS_CA_BUNDLE", cafile)
+        return ssl.create_default_context(cafile=cafile)
+    except ImportError:
+        return ssl.create_default_context()
+
+
+def remote_size_bytes(url: str) -> int | None:
+    """Total object size if the URL exists, else None.
+
+    ModelScope `/resolve/master/<file>` HEAD is 200 with no Content-Length
+    even for objects that are already on the LFS CDN. A 1-byte Range GET
+    follows the 302 and returns `Content-Range: bytes 0-0/<total>`.
+    """
+    request = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "User-Agent": "openasr-modelscope-sync",
+            "Range": "bytes=0-0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30, context=ssl_context()) as response:
+            response.read(8)
+            content_range = response.headers.get("Content-Range") or ""
+            if "/" in content_range:
+                total = content_range.rsplit("/", 1)[-1]
+                if total.isdigit():
+                    return int(total)
+            length = response.headers.get("Content-Length")
+            if length and int(length) > 1:
+                return int(length)
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, ValueError):
+        return None
+    return None
+
+
+def remote_sha256(url: str, expected_size: int) -> str | None:
+    """Treat a same-size remote object as already present; else None."""
+    size = remote_size_bytes(url)
+    if size == expected_size:
+        return "size-match"
+    return None
+
+
+def part_path(dest: Path) -> Path:
+    return dest.with_suffix(dest.suffix + ".part")
+
+
+def cache_root() -> Path:
+    path = Path(
+        os.environ.get("OPENASR_MODELSCOPE_CACHE")
+        or "/Volumes/QuintinDocument/openasr-dev/.cache/modelscope-sync"
+    )
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def download(url: str, dest: Path, expected_size: int) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    partial = part_path(dest)
+    existing = partial.stat().st_size if partial.exists() else 0
+    if existing > expected_size:
+        partial.unlink()
+        existing = 0
+    if existing == expected_size:
+        partial.replace(dest)
+        return
+
+    headers = {"User-Agent": "openasr-modelscope-sync"}
+    if existing:
+        headers["Range"] = f"bytes={existing}-"
+    request = urllib.request.Request(url, headers=headers)
+    # Multi-GB packs stall if we use a short socket timeout; 10 minutes
+    # applies per blocking read, not the whole transfer.
+    with urllib.request.urlopen(request, timeout=600, context=ssl_context()) as response:
+        status = getattr(response, "status", None) or response.getcode()
+        length_header = response.headers.get("Content-Length")
+        length = int(length_header) if length_header else None
+        if existing and status == 206:
+            remaining = expected_size - existing
+            if length is not None and length != remaining:
+                raise RuntimeError(
+                    f"Content-Length {length} != remaining {remaining} for {expected_size}"
+                )
+            mode = "ab"
+            written = existing
+        else:
+            if existing:
+                partial.unlink(missing_ok=True)
+                existing = 0
+            if length is not None and length != expected_size:
+                raise RuntimeError(
+                    f"Content-Length {length} != catalog size_bytes {expected_size}"
+                )
+            mode = "wb"
+            written = 0
+        with partial.open(mode) as handle:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                handle.write(chunk)
+                written += len(chunk)
+    if written != expected_size:
+        # Keep `.part` so a later attempt can resume; only drop a truncated
+        # full GET (mode was wb from byte 0). Resume leftovers stay.
+        if written == 0:
+            partial.unlink(missing_ok=True)
+        raise RuntimeError(f"downloaded {written} bytes, expected {expected_size}")
+    partial.replace(dest)
+
+
+def ensure_repo(api, repo: str) -> None:
+    model_id = f"{MODELSCOPE_OWNER}/{repo}"
+    try:
+        api.get_model(model_id)
+        return
+    except Exception:
+        pass
+    visibility = getattr(api, "visibility", None)
+    kwargs = {"model_id": model_id, "visibility": 5}
+    for method_name in ("create_model", "create_repo"):
+        method = getattr(api, method_name, None)
+        if method is None:
+            continue
+        try:
+            method(**kwargs)
+            print(f"created ModelScope repo {model_id}", file=sys.stderr)
+            return
+        except TypeError:
+            try:
+                method(model_id)
+                return
+            except Exception as error:
+                print(f"create {model_id} via {method_name}: {error}", file=sys.stderr)
+        except Exception as error:
+            print(f"create {model_id} via {method_name}: {error}", file=sys.stderr)
+    print(f"warning: could not ensure repo {model_id}; upload may still work", file=sys.stderr)
+
+
+def upload_file(api, repo: str, local_path: Path, filename: str) -> None:
+    model_id = f"{MODELSCOPE_OWNER}/{repo}"
+    errors = []
+    if hasattr(api, "upload_file"):
+        try:
+            api.upload_file(
+                path_or_fileobj=str(local_path),
+                path_in_repo=filename,
+                repo_id=model_id,
+                revision=MODELSCOPE_UPLOAD_REVISION,
+                commit_message=f"sync {filename} from signed catalog",
+            )
+            return
+        except TypeError as error:
+            errors.append(str(error))
+            try:
+                api.upload_file(str(local_path), filename, model_id)
+                return
+            except Exception as inner:
+                errors.append(str(inner))
+        except Exception as error:
+            errors.append(str(error))
+    raise RuntimeError(f"upload {model_id}/{filename} failed: {errors or 'no upload_file API'}")
+
+
+def prefetch_sidecar(dest: Path) -> Path:
+    return dest.with_suffix(dest.suffix + ".prefetch")
+
+
+def adopt_prefetch(dest: Path, expected_sha: str, wait_seconds: int = 3600) -> bool:
+    """Wait for a live `--prefetch-only` sibling and take its completed file.
+
+    Returns True when `dest` now holds the expected sha, so the uploader
+    must not start a second Hugging Face GET.
+    """
+    prefetch = prefetch_sidecar(dest)
+    prefetch_part = part_path(prefetch)
+    if not prefetch.exists() and not prefetch_part.exists():
+        return False
+    deadline = time.time() + wait_seconds
+    while prefetch_part.exists() and time.time() < deadline:
+        print(f"waiting for prefetch {prefetch_part.name}", file=sys.stderr)
+        time.sleep(5)
+    if dest.exists() and sha256_file(dest).lower() == expected_sha:
+        prefetch.unlink(missing_ok=True)
+        return True
+    if prefetch.exists() and sha256_file(prefetch).lower() == expected_sha:
+        if dest.exists() or part_path(dest).exists():
+            prefetch.unlink(missing_ok=True)
+            return dest.exists() and sha256_file(dest).lower() == expected_sha
+        prefetch.replace(dest)
+        return True
+    prefetch.unlink(missing_ok=True)
+    prefetch_part.unlink(missing_ok=True)
+    return False
+
+
+def prefetch_pack(pack: dict, dest: Path) -> str:
+    """Fill `dest` from the HF identity URL without racing the uploader.
+
+    Returns skip-local / skip-remote / skip-busy / ok / fail.
+    The live uploader writes `dest.part`. This path writes `dest.prefetch`
+    and only renames onto `dest` when that part file is absent.
+    """
+    if dest.exists() and sha256_file(dest).lower() == pack["sha256"]:
+        return "skip-local"
+    if part_path(dest).exists():
+        return "skip-busy"
+    if pack["ms_url"] and remote_sha256(pack["ms_url"], pack["size_bytes"]) == "size-match":
+        return "skip-remote"
+    prefetch = dest.with_suffix(dest.suffix + ".prefetch")
+    try:
+        download(pack["url"], prefetch, pack["size_bytes"])
+        if sha256_file(prefetch).lower() != pack["sha256"]:
+            prefetch.unlink(missing_ok=True)
+            return "fail"
+        if dest.exists() or part_path(dest).exists():
+            prefetch.unlink(missing_ok=True)
+            return "skip-busy"
+        prefetch.replace(dest)
+        return "ok"
+    except Exception:
+        prefetch.unlink(missing_ok=True)
+        part_path(prefetch).unlink(missing_ok=True)
+        return "fail"
+
+
+def prefetch_missing(packs: list[dict], cache: Path) -> int:
+    failures = 0
+    for pack in packs:
+        if pack["ms_url"] is None:
+            continue
+        dest = cache / pack["repo"] / pack["filename"]
+        result = prefetch_pack(pack, dest)
+        print(f"prefetch {result} {pack['repo']}/{pack['filename']}", file=sys.stderr)
+        if result == "fail":
+            failures += 1
+    if failures:
+        print(f"{failures} prefetch(s) failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--catalog", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--limit", type=int, default=0, help="sync at most N packs (0 = all)")
+    parser.add_argument(
+        "--prefetch-only",
+        action="store_true",
+        help="download missing packs into the cache; skip files the uploader holds as .part",
+    )
+    args = parser.parse_args(argv)
+
+    ssl_context()
+
+    repo_root = Path(__file__).resolve().parents[3]
+    catalog_path = args.catalog or (repo_root / "model-registry" / "catalog.public.json")
+    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    packs = iter_packs(catalog)
+    if args.limit:
+        packs = packs[: args.limit]
+    print(f"{len(packs)} catalog pack(s) to consider", file=sys.stderr)
+
+    if args.dry_run:
+        for pack in packs:
+            print(f"DRY {pack['model_id']} {pack['filename']} -> {pack['ms_url']}")
+        return 0
+
+    cache = cache_root()
+    if args.prefetch_only:
+        return prefetch_missing(packs, cache)
+
+    tok = token()
+    if not tok:
+        print("ModelScope sync skipped (no MODELSCOPE_SDK_TOKEN / MS_TOKEN)", file=sys.stderr)
+        return 0
+
+    try:
+        from modelscope.hub.api import HubApi
+    except ImportError:
+        print("modelscope SDK not installed; pip install modelscope", file=sys.stderr)
+        return 1
+
+    api = HubApi()
+    api.login(tok)
+
+    failures = 0
+    seen_repos: set[str] = set()
+    for pack in packs:
+        if pack["ms_url"] is None:
+            print(f"skip (not an HF resolve URL): {pack['url']}", file=sys.stderr)
+            continue
+        if pack["repo"] not in seen_repos:
+            ensure_repo(api, pack["repo"])
+            seen_repos.add(pack["repo"])
+        dest = cache / pack["repo"] / pack["filename"]
+        if remote_sha256(pack["ms_url"], pack["size_bytes"]) == "size-match":
+            print(
+                f"skip (ModelScope already has {pack['filename']} at {pack['size_bytes']} bytes)",
+                file=sys.stderr,
+            )
+            continue
+        if dest.exists() and sha256_file(dest).lower() == pack["sha256"]:
+            local = dest
+        elif adopt_prefetch(dest, pack["sha256"]):
+            print(f"adopted prefetch {pack['repo']}/{pack['filename']}", file=sys.stderr)
+            local = dest
+        else:
+            print(f"downloading {pack['filename']} from HF identity URL", file=sys.stderr)
+            local = None
+            for attempt in range(1, 4):
+                try:
+                    download(pack["url"], dest, pack["size_bytes"])
+                except Exception as error:
+                    print(
+                        f"download failed {pack['url']} (attempt {attempt}/3): {error}",
+                        file=sys.stderr,
+                    )
+                    dest.unlink(missing_ok=True)
+                    part_path(dest).unlink(missing_ok=True)
+                    continue
+                actual = sha256_file(dest).lower()
+                if actual == pack["sha256"]:
+                    local = dest
+                    break
+                print(
+                    f"sha mismatch after HF download {pack['filename']} "
+                    f"(attempt {attempt}/3): {actual} != {pack['sha256']}",
+                    file=sys.stderr,
+                )
+                dest.unlink(missing_ok=True)
+            if local is None:
+                failures += 1
+                continue
+        try:
+            upload_file(api, pack["repo"], local, pack["filename"])
+            print(f"ok {MODELSCOPE_OWNER}/{pack['repo']}/{pack['filename']}")
+        except Exception as error:
+            print(f"upload failed {pack['filename']}: {error}", file=sys.stderr)
+            failures += 1
+
+    if failures:
+        print(f"{failures} pack(s) failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tooling/publish-model/scripts/sync_models_to_modelscope_test.py
+++ b/tooling/publish-model/scripts/sync_models_to_modelscope_test.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Unit tests for ModelScope URL mapping used by the sync script."""
+from __future__ import annotations
+
+import unittest
+
+from sync_models_to_modelscope import (
+    adopt_prefetch,
+    download,
+    iter_packs,
+    modelscope_resolve_url,
+    part_path,
+    prefetch_pack,
+    remote_sha256,
+    ssl_context,
+)
+
+
+class ModelscopeMappingTest(unittest.TestCase):
+    def test_maps_hf_resolve_to_lowercase_owner(self) -> None:
+        url = (
+            "https://huggingface.co/OpenASR/moonshine-tiny/resolve/"
+            "0123456789abcdef0123456789abcdef01234567/moonshine-tiny-q8_0.oasr"
+        )
+        self.assertEqual(
+            modelscope_resolve_url(url),
+            "https://www.modelscope.cn/models/openasr/moonshine-tiny/resolve/"
+            "master/moonshine-tiny-q8_0.oasr",
+        )
+
+    def test_rejects_non_resolve_and_traversal(self) -> None:
+        self.assertIsNone(modelscope_resolve_url("https://catalog.openasr.org/v1/catalog.json"))
+        self.assertIsNone(
+            modelscope_resolve_url(
+                "https://huggingface.co/OpenASR/evil/resolve/abc/../secrets"
+            )
+        )
+
+    def test_iter_packs_skips_non_openasr_repos(self) -> None:
+        packs = iter_packs(
+            {
+                "models": [
+                    {
+                        "id": "moonshine-tiny",
+                        "public": True,
+                        "hf_repo": "OpenASR/moonshine-tiny",
+                        "hf_revision": "abc",
+                        "quants": [
+                            {
+                                "filename": "moonshine-tiny-q8_0.oasr",
+                                "url": "https://huggingface.co/OpenASR/moonshine-tiny/resolve/abc/moonshine-tiny-q8_0.oasr",
+                                "sha256": "a" * 64,
+                                "size_bytes": 10,
+                            }
+                        ],
+                    },
+                    {
+                        "id": "private",
+                        "public": False,
+                        "hf_repo": "OpenASR/secret",
+                        "quants": [
+                            {
+                                "filename": "x.oasr",
+                                "url": "https://huggingface.co/OpenASR/secret/resolve/abc/x.oasr",
+                                "sha256": "b" * 64,
+                                "size_bytes": 10,
+                            }
+                        ],
+                    },
+                ]
+            }
+        )
+        self.assertEqual(len(packs), 1)
+        self.assertEqual(packs[0]["repo"], "moonshine-tiny")
+
+    def test_ssl_context_uses_certifi_when_present(self) -> None:
+        ctx = ssl_context()
+        self.assertTrue(ctx.check_hostname)
+
+    def test_download_rejects_content_length_mismatch(self) -> None:
+        import tempfile
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+        from pathlib import Path
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                body = b"short"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_args: object) -> None:
+                return
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            dest = Path(tempfile.mkdtemp()) / "pack.oasr"
+            with self.assertRaises(RuntimeError):
+                download(f"http://127.0.0.1:{server.server_port}/pack.oasr", dest, 99)
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_download_resumes_from_partial_with_range(self) -> None:
+        import tempfile
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+        from pathlib import Path
+
+        payload = b"abcdefghij"
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                rng = self.headers.get("Range")
+                if rng == "bytes=4-":
+                    body = payload[4:]
+                    self.send_response(206)
+                    self.send_header("Content-Range", f"bytes 4-9/{len(payload)}")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, *_args: object) -> None:
+                return
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            dest = Path(tempfile.mkdtemp()) / "pack.oasr"
+            part_path(dest).write_bytes(payload[:4])
+            download(f"http://127.0.0.1:{server.server_port}/pack.oasr", dest, len(payload))
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertFalse(part_path(dest).exists())
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_remote_skip_uses_range_when_head_has_no_length(self) -> None:
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_HEAD(self):
+                self.send_response(200)
+                self.end_headers()
+
+            def do_GET(self):
+                if self.headers.get("Range") != "bytes=0-0":
+                    self.send_response(400)
+                    self.end_headers()
+                    return
+                self.send_response(206)
+                self.send_header("Content-Range", "bytes 0-0/1490916416")
+                self.send_header("Content-Length", "1")
+                self.end_headers()
+                self.wfile.write(b"x")
+
+            def log_message(self, *_args: object) -> None:
+                return
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            url = f"http://127.0.0.1:{server.server_port}/qwen3-asr-1.7b-q4_k.oasr"
+            self.assertEqual(remote_sha256(url, 1490916416), "size-match")
+            self.assertIsNone(remote_sha256(url, 1))
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_remote_skip_missing_object_is_none(self) -> None:
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(404)
+                self.end_headers()
+
+            def log_message(self, *_args: object) -> None:
+                return
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            url = f"http://127.0.0.1:{server.server_port}/missing.oasr"
+            self.assertIsNone(remote_sha256(url, 100))
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_prefetch_skips_uploader_part_file(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        dest = Path(tempfile.mkdtemp()) / "pack.oasr"
+        part_path(dest).write_bytes(b"busy")
+        result = prefetch_pack(
+            {
+                "url": "http://127.0.0.1:1/pack.oasr",
+                "sha256": "a" * 64,
+                "size_bytes": 10,
+                "ms_url": None,
+            },
+            dest,
+        )
+        self.assertEqual(result, "skip-busy")
+
+    def test_adopt_prefetch_renames_completed_sidecar(self) -> None:
+        import hashlib
+        import tempfile
+        from pathlib import Path
+
+        dest = Path(tempfile.mkdtemp()) / "pack.oasr"
+        payload = b"prefetch-bytes"
+        sidecar = dest.with_suffix(dest.suffix + ".prefetch")
+        sidecar.write_bytes(payload)
+        digest = hashlib.sha256(payload).hexdigest()
+        self.assertTrue(adopt_prefetch(dest, digest, wait_seconds=1))
+        self.assertEqual(dest.read_bytes(), payload)
+        self.assertFalse(sidecar.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/publish-model/scripts/sync_models_to_modelscope_test.py
+++ b/tooling/publish-model/scripts/sync_models_to_modelscope_test.py
@@ -232,6 +232,20 @@ class ModelscopeMappingTest(unittest.TestCase):
         self.assertEqual(dest.read_bytes(), payload)
         self.assertFalse(sidecar.exists())
 
+    def test_cache_root_honors_env_and_avoids_workstation_paths(self) -> None:
+        import os
+        import tempfile
+        from pathlib import Path
+
+        from sync_models_to_modelscope import cache_root
+
+        with tempfile.TemporaryDirectory() as td:
+            os.environ["OPENASR_MODELSCOPE_CACHE"] = td
+            try:
+                self.assertEqual(cache_root(), Path(td))
+            finally:
+                del os.environ["OPENASR_MODELSCOPE_CACHE"]
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Route China catalog/pack/kernel fetches through first-party hosts without resigning identity URLs (`catalog.openasr.org`, Hugging Face pack URLs, `dl.openasr.org` files).
- Fail closed on ModelScope pins, catalog `mirrors[]` ModelScope hosts, and ESA catalog sha256 mismatch; add CNB release + `main` fast-forward sync that never `--mirror`s tags.

## Why
China downloads currently depend on ghproxy and a dead catalog-host rewrite. Identity stays signed; only the transport host changes.

## Tests run
- [x] targeted `openasr-core` transport/catalog unit tests (prior review)
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks
- Live `catalog.bug.im` byte-identical to `catalog.openasr.org`; CNB `main` fast-forwarded from GitHub `origin/main` without dropping `desktop-v*` tags.

## Docs updated
- [x] SECURITY.md / MODEL_CATALOG_ARCHITECTURE.md / catalog README updated for identity vs transport.
- [x] No docs overclaim current capabilities.

## Artifact confirmation
- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements
- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES


Made with [Cursor](https://cursor.com)