### PR TITLE
feat(transport): race catalog replicas and order artifact fetches by region

### DIFF
--- a/crates/openasr-core/src/download_source.rs
+++ b/crates/openasr-core/src/download_source.rs
@@ -24,7 +24,8 @@ pub enum DownloadSource {
     /// ModelScope resolve URL derived from the signed Hugging Face pack URL.
     /// Not a catalog identity: owner is the live ModelScope org `openasr`,
     /// path `/models/<owner>/<repo>/resolve/<rev>/<file>`. User-facing config
-    /// stays `china` / `global`; this variant is the China-chain primary.
+    /// stays `china` / `global`; this variant is the China-chain primary and an
+    /// independent overseas replica after the first-party HF proxy.
     #[serde(rename = "modelscope")]
     ModelScope,
 }
@@ -158,9 +159,13 @@ fn auto_source_chain(prefer_china: bool) -> Vec<DownloadSource> {
             DownloadSource::Hf,
         ]
     } else {
+        // Canonical is Hugging Face. The first-party proxy shares HF
+        // revision semantics; ModelScope is an independent replica; hf-mirror
+        // is a third-party HF transport last.
         vec![
             DownloadSource::Hf,
             DownloadSource::Weights,
+            DownloadSource::ModelScope,
             DownloadSource::HfMirror,
         ]
     }
@@ -215,14 +220,15 @@ mod tests {
     }
 
     #[test]
-    fn overseas_context_leads_with_direct_then_weights_then_mirror() {
-        // Overseas: direct huggingface.co primary (zero worker load), worker and
-        // mirror as fallbacks.
+    fn overseas_context_leads_with_direct_then_weights_then_modelscope_then_mirror() {
+        // Overseas: huggingface.co primary, first-party HF proxy, independent
+        // ModelScope replica, then the third-party HF mirror.
         assert_eq!(
             default_source_chain(false, false),
             vec![
                 DownloadSource::Hf,
                 DownloadSource::Weights,
+                DownloadSource::ModelScope,
                 DownloadSource::HfMirror,
             ]
         );

--- a/crates/openasr-core/src/http.rs
+++ b/crates/openasr-core/src/http.rs
@@ -85,10 +85,6 @@ pub(crate) fn apply_modelscope_endpoint(url: &str) -> Option<String> {
     crate::transport::apply_modelscope_endpoint(url)
 }
 
-pub(crate) fn apply_dl_endpoint(url: &str) -> String {
-    crate::transport::apply_dl_endpoint(url)
-}
-
 fn hf_endpoint() -> Option<String> {
     crate::transport::hf_endpoint_env()
 }

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -3833,7 +3833,7 @@ impl PullTarget {
             suffix: String::new(),
             pull: file.filename.clone(),
             filename: file.filename.clone(),
-            url: http::apply_dl_endpoint(&file.url),
+            url: file.url.clone(),
             hf_revision: file.sha256.clone(),
             sha256: file.sha256.clone(),
             size_bytes: file.size_bytes,
@@ -4322,7 +4322,7 @@ fn is_source_fallback_error(error: &PullError) -> bool {
         // repeats the same verdict. These must fail the whole pull on the
         // first occurrence as a permanent error.
         PullError::UnexpectedStatus { status, .. } => {
-            *status >= 500 || *status == 403 || *status == 404
+            *status >= 500 || *status == 403 || *status == 404 || *status == 429
         }
         _ => false,
     }
@@ -5416,7 +5416,14 @@ fn ensure_backend_content_object_in<C: DownloadClient>(
         .is_ok_and(|(size, sha)| size == file.size_bytes && sha.eq_ignore_ascii_case(&file.sha256));
     if !source_valid {
         if let Some(urls) = signed_urls {
-            download_backend_file_from_signed_urls(client, file, urls, &source_path, progress)?;
+            download_backend_file_from_signed_urls(
+                client,
+                file,
+                urls,
+                &source_path,
+                progress,
+                parallel,
+            )?;
         } else {
             download_backend_file(client, file, &source_path, progress, parallel)?;
         }
@@ -6028,7 +6035,7 @@ fn prepare_qualification_direct_file<C: DownloadClient>(
     let lock_path = locks_root.join(format!("{}.lock", artifact.sha256));
     let _lock = BackendInstallLock::acquire(&lock_path)?;
     let path = digest_dir.join(&artifact.file_name);
-    download_backend_file_from_signed_urls(client, &file, &artifact.urls, &path, progress)?;
+    download_backend_file_from_signed_urls(client, &file, &artifact.urls, &path, progress, None)?;
     reject_qualification_file_links(&path)?;
     if let Some(format) = preflight {
         preflight_backend_file(&path, format)?;
@@ -6758,7 +6765,9 @@ fn download_backend_file_from_signed_urls<C: DownloadClient>(
     urls: &[String],
     dest: &Path,
     progress: &mut impl FnMut(PullProgress),
+    parallel: Option<&ParallelDownloadConfig>,
 ) -> Result<(), PullError> {
+    let urls = expand_artifact_fetch_urls(urls);
     if urls.is_empty() {
         return Err(PullError::InvalidTarget {
             field: "qualification artifact URLs",
@@ -6773,24 +6782,27 @@ fn download_backend_file_from_signed_urls<C: DownloadClient>(
         }
         let mut candidate = file.clone();
         candidate.url.clone_from(url);
-        match download_backend_file(client, &candidate, dest, progress, None) {
+        match download_backend_file_once(client, &candidate, dest, progress, parallel) {
             Ok(()) => return Ok(()),
-            Err(error)
-                if matches!(
-                    &error,
-                    PullError::Http { .. }
-                        | PullError::UnexpectedStatus { .. }
-                        | PullError::RestartedPartial { .. }
-                        | PullError::SizeMismatch { .. }
-                        | PullError::ShaMismatch { .. }
-                ) =>
-            {
+            Err(error) if is_source_fallback_error(&error) => {
                 last_error = Some(error);
             }
             Err(error) => return Err(error),
         }
     }
     Err(last_error.expect("non-empty signed URL list produced an error"))
+}
+
+fn expand_artifact_fetch_urls(urls: &[String]) -> Vec<String> {
+    let mut expanded = Vec::new();
+    for url in urls {
+        for fetch in crate::transport::artifact_fetch_urls(url) {
+            if !expanded.contains(&fetch) {
+                expanded.push(fetch);
+            }
+        }
+    }
+    expanded
 }
 
 fn download_backend_file<C: DownloadClient>(
@@ -6803,8 +6815,29 @@ fn download_backend_file<C: DownloadClient>(
     if backend_file_matches(dest, file) {
         return Ok(());
     }
-    if let Some(local_path) = file.url.strip_prefix("file://") {
+    if file.url.starts_with("file://") {
+        let local_path = file.url.strip_prefix("file://").unwrap_or(&file.url);
         return copy_local_backend_file(Path::new(local_path), dest, file, progress);
+    }
+    download_backend_file_from_signed_urls(
+        client,
+        file,
+        std::slice::from_ref(&file.url),
+        dest,
+        progress,
+        parallel,
+    )
+}
+
+fn download_backend_file_once<C: DownloadClient>(
+    client: &mut C,
+    file: &CatalogBackendFile,
+    dest: &Path,
+    progress: &mut impl FnMut(PullProgress),
+    parallel: Option<&ParallelDownloadConfig>,
+) -> Result<(), PullError> {
+    if backend_file_matches(dest, file) {
+        return Ok(());
     }
     if let Some(parallel) = parallel {
         return download_backend_file_via_pull(client, file, dest, progress, Some(parallel));
@@ -6956,7 +6989,7 @@ fn download_backend_file_attempt<C: DownloadClient>(
         *expected_etag = persisted_etag;
     }
     let response = client.open(
-        &http::apply_dl_endpoint(&file.url),
+        &file.url,
         (resume_from > 0).then(|| ByteRange::from_start(resume_from)),
     )?;
 

--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -3,6 +3,7 @@ use std::{
     collections::BTreeMap,
     env, fs,
     path::{Path, PathBuf},
+    sync::mpsc,
     time::Duration,
 };
 
@@ -15,7 +16,7 @@ use crate::{
     catalog_security,
     catalog_series::{CatalogSeriesSpec, catalog_series_spec},
     config::DEFAULT_MODEL_ID,
-    http,
+    http, transport,
 };
 
 mod execution_approvals;
@@ -1338,43 +1339,54 @@ pub fn load_model_catalog(
     let cache_path = default_catalog_cache_path(home);
     let source = catalog_url.unwrap_or(DEFAULT_CATALOG_URL);
 
-    match read_catalog_source(source) {
-        Ok(contents) => match read_and_verify_catalog_manifest(source, home, &contents) {
-            Ok(verified) => {
-                match parse_and_check_production_catalog(source, &contents, &verified.signature) {
-                    Ok(catalog) => {
-                        // This tier (network fetch / explicit catalog_url
-                        // override) always runs the STRICT
-                        // `enforce_catalog_epoch_for_verified` (inside
-                        // `read_and_verify_catalog_manifest` above) -- there is
-                        // no below-floor outcome to reach here, so the floor
-                        // always advances on success.
-                        persist_catalog_cache(
-                            home,
-                            &cache_path,
-                            &contents,
-                            &verified.manifest_contents,
-                            &verified.signature,
-                            true,
-                        );
-                        catalog_security::clear_catalog_degraded(home);
-                        Ok(catalog)
-                    }
-                    // Parse/validate (or the staged-entries check above) failed
-                    // even though the signature verified: fall through to the
-                    // same cache/embedded degrade chain as a transport/signature
-                    // failure, rather than hard-failing the whole load. See
-                    // docs/CATALOG_COMPATIBILITY.md's "fallback chain" section --
-                    // this is the fix for the incident where a signature-valid
-                    // but structurally-wrong cached payload bricked the daemon
-                    // with no fallback attempted.
-                    Err(error) => load_cached_signed_catalog(source, home, &cache_path, error),
+    match load_verified_catalog_bytes(source, home) {
+        Ok((contents, verified)) => {
+            match parse_and_check_production_catalog(source, &contents, &verified.signature) {
+                Ok(catalog) => {
+                    // This tier (network fetch / explicit catalog_url
+                    // override) always runs the STRICT
+                    // `enforce_catalog_epoch_for_verified` (inside
+                    // `load_verified_catalog_bytes` above) -- there is
+                    // no below-floor outcome to reach here, so the floor
+                    // always advances on success.
+                    persist_catalog_cache(
+                        home,
+                        &cache_path,
+                        &contents,
+                        &verified.manifest_contents,
+                        &verified.signature,
+                        true,
+                    );
+                    catalog_security::clear_catalog_degraded(home);
+                    Ok(catalog)
                 }
+                // Parse/validate (or the staged-entries check above) failed
+                // even though the signature verified: fall through to the
+                // same cache/embedded degrade chain as a transport/signature
+                // failure, rather than hard-failing the whole load. See
+                // docs/CATALOG_COMPATIBILITY.md's "fallback chain" section --
+                // this is the fix for the incident where a signature-valid
+                // but structurally-wrong cached payload bricked the daemon
+                // with no fallback attempted.
+                Err(error) => load_cached_signed_catalog(source, home, &cache_path, error),
             }
-            Err(error) => load_cached_signed_catalog(source, home, &cache_path, error),
-        },
+        }
         Err(error) => load_cached_signed_catalog(source, home, &cache_path, error),
     }
+}
+
+fn load_verified_catalog_bytes(
+    source: &str,
+    home: &Path,
+) -> Result<(String, VerifiedCatalogManifestContents), CatalogError> {
+    if catalog_security::classify_catalog_identity(source)
+        == catalog_security::CatalogSourceKind::Remote
+    {
+        return fetch_verified_remote_catalog(source, home);
+    }
+    let contents = read_catalog_source(source)?;
+    let verified = read_and_verify_catalog_manifest(source, home, &contents)?;
+    Ok((contents, verified))
 }
 
 /// Loads only the already-verified on-disk catalog cache. Runtime backend
@@ -2402,27 +2414,8 @@ fn read_catalog_source(source: &str) -> Result<String, CatalogError> {
                 catalog_source: source.to_string(),
                 message: http::error_message(&error),
             })?;
-        // The catalog (and its sibling signature manifest, which also flows
-        // through this function) is served from the OpenASR catalog endpoint
-        // (Cloudflare), never Hugging Face. Only the transport host is rewritten:
-        // `source` stays the canonical, signed catalog_url everywhere it feeds
-        // verification (see `read_and_verify_catalog_manifest`), so a proxy cannot
-        // substitute a tampered catalog. Unlike weight downloads (pull.rs), the
-        // catalog uses a redirect-following client and the endpoint serves bytes
-        // directly, so the per-hop CDN rewrite used by weight downloads is
-        // deliberately NOT applied here.
-        let response = client
-            .get(http::apply_catalog_endpoint(source).as_str())
-            .send()
-            .and_then(reqwest::blocking::Response::error_for_status)
-            .map_err(|error| CatalogError::ReadCatalog {
-                catalog_source: source.to_string(),
-                message: http::error_message(&error),
-            })?;
-        return response.text().map_err(|error| CatalogError::ReadCatalog {
-            catalog_source: source.to_string(),
-            message: http::error_message(&error),
-        });
+        let url = http::apply_catalog_endpoint(source);
+        return get_https_text(&client, source, &url);
     }
 
     if let Some(path) = source.strip_prefix("file://") {
@@ -2443,6 +2436,126 @@ fn read_catalog_source(source: &str) -> Result<String, CatalogError> {
         catalog_source: source.to_string(),
         message: error.to_string(),
     })
+}
+
+fn get_https_text(
+    client: &reqwest::blocking::Client,
+    catalog_source: &str,
+    url: &str,
+) -> Result<String, CatalogError> {
+    let response = client
+        .get(url)
+        .send()
+        .and_then(reqwest::blocking::Response::error_for_status)
+        .map_err(|error| CatalogError::ReadCatalog {
+            catalog_source: catalog_source.to_string(),
+            message: http::error_message(&error),
+        })?;
+    response.text().map_err(|error| CatalogError::ReadCatalog {
+        catalog_source: catalog_source.to_string(),
+        message: http::error_message(&error),
+    })
+}
+
+fn fetch_and_verify_catalog_pair(
+    identity: &str,
+    client: &reqwest::blocking::Client,
+    catalog_url: &str,
+    signature_url: &str,
+) -> Result<(String, String, catalog_security::VerifiedCatalogSignature), CatalogError> {
+    let contents = get_https_text(client, identity, catalog_url)?;
+    let manifest_contents = get_https_text(client, identity, signature_url)?;
+    let signature = verify_catalog_manifest_for_source(identity, &contents, &manifest_contents)
+        .map_err(|error| CatalogError::CatalogSecurity {
+            catalog_source: identity.to_string(),
+            message: error.to_string(),
+        })?;
+    Ok((contents, manifest_contents, signature))
+}
+
+fn fetch_verified_remote_catalog(
+    source: &str,
+    home: &Path,
+) -> Result<(String, VerifiedCatalogManifestContents), CatalogError> {
+    let catalog_urls = transport::catalog_transport_urls(source);
+    let signature_source = catalog_security::catalog_signature_source(source);
+    let signature_urls = transport::catalog_transport_urls(&signature_source);
+    let pairs: Vec<(String, String)> = catalog_urls.into_iter().zip(signature_urls).collect();
+    let client = http::blocking_client(CATALOG_HTTP_CONNECT_TIMEOUT, CATALOG_HTTP_TIMEOUT)
+        .map_err(|error| CatalogError::ReadCatalog {
+            catalog_source: source.to_string(),
+            message: http::error_message(&error),
+        })?;
+    let (contents, manifest_contents, signature) =
+        race_verified_catalog_pairs(source, client, pairs)?;
+    catalog_security::enforce_catalog_epoch_for_verified(home, &signature).map_err(|error| {
+        CatalogError::CatalogSecurity {
+            catalog_source: source.to_string(),
+            message: error.to_string(),
+        }
+    })?;
+    Ok((
+        contents,
+        VerifiedCatalogManifestContents {
+            manifest_contents,
+            signature,
+        },
+    ))
+}
+
+fn race_verified_catalog_pairs(
+    identity: &str,
+    client: reqwest::blocking::Client,
+    pairs: Vec<(String, String)>,
+) -> Result<(String, String, catalog_security::VerifiedCatalogSignature), CatalogError> {
+    if pairs.is_empty() {
+        return Err(CatalogError::ReadCatalog {
+            catalog_source: identity.to_string(),
+            message: "no catalog transport URL was available".to_string(),
+        });
+    }
+    if pairs.len() == 1 {
+        let (catalog_url, signature_url) = &pairs[0];
+        return fetch_and_verify_catalog_pair(identity, &client, catalog_url, signature_url);
+    }
+    let (tx, rx) = mpsc::channel();
+    let pair_count = pairs.len();
+    for (catalog_url, signature_url) in pairs {
+        let tx = tx.clone();
+        let client = client.clone();
+        let identity_owned = identity.to_string();
+        std::thread::Builder::new()
+            .name("openasr-catalog-race".to_string())
+            .spawn(move || {
+                let _ = tx.send(fetch_and_verify_catalog_pair(
+                    &identity_owned,
+                    &client,
+                    &catalog_url,
+                    &signature_url,
+                ));
+            })
+            .map_err(|error| CatalogError::ReadCatalog {
+                catalog_source: identity.to_string(),
+                message: error.to_string(),
+            })?;
+    }
+    drop(tx);
+    let mut last_error = None;
+    let mut remaining = pair_count;
+    while remaining > 0 {
+        match rx.recv() {
+            Ok(Ok(value)) => return Ok(value),
+            Ok(Err(error)) => {
+                last_error = Some(error);
+                remaining -= 1;
+            }
+            Err(_) => break,
+        }
+    }
+    Err(last_error.unwrap_or_else(|| CatalogError::ReadCatalog {
+        catalog_source: identity.to_string(),
+        message: "catalog race produced no result".to_string(),
+    }))
 }
 
 struct VerifiedCatalogManifestContents {

--- a/crates/openasr-core/src/transport.rs
+++ b/crates/openasr-core/src/transport.rs
@@ -13,6 +13,8 @@ pub const CANONICAL_CATALOG_ENDPOINT: &str = "https://catalog.openasr.org";
 pub const CHINA_CATALOG_ENDPOINT: &str = "https://catalog.bug.im";
 pub const CANONICAL_DL_ENDPOINT: &str = "https://dl.openasr.org";
 pub const CHINA_DL_ENDPOINT: &str = "https://dl.bug.im";
+pub const GITHUB_RELEASE_DOWNLOAD: &str =
+    "https://github.com/QuintinShaw/openasr/releases/download";
 
 pub const CATALOG_ENDPOINT_ENV: &str = "OPENASR_CATALOG_ENDPOINT";
 pub const DL_ENDPOINT_ENV: &str = "OPENASR_DL_ENDPOINT";
@@ -35,7 +37,32 @@ const ALLOWED_DL_ENDPOINTS: &[&str] = &[CANONICAL_DL_ENDPOINT, CHINA_DL_ENDPOINT
 /// `catalog.openasr.org` prefix and the retired Hugging Face catalog object
 /// paths are rewritten — never an arbitrary `huggingface.co` pack URL.
 pub(crate) fn apply_catalog_endpoint(url: &str) -> String {
-    let endpoint = resolved_catalog_endpoint();
+    rewrite_catalog_identity(url, &resolved_catalog_endpoint())
+}
+
+/// Transport URLs for one catalog identity. An explicit allowlisted
+/// `OPENASR_CATALOG_ENDPOINT` pins a single host. Otherwise Cloudflare and
+/// Aliyun ESA are both listed (preferred first) so the caller can race them.
+pub(crate) fn catalog_transport_urls(identity_url: &str) -> Vec<String> {
+    let canonical = rewrite_catalog_identity(identity_url, CANONICAL_CATALOG_ENDPOINT);
+    let china = rewrite_catalog_identity(identity_url, CHINA_CATALOG_ENDPOINT);
+    if canonical == china {
+        return vec![identity_url.to_string()];
+    }
+    if let Some(pinned) = endpoint_from_env(CATALOG_ENDPOINT_ENV) {
+        if is_allowed_https_endpoint(&pinned, ALLOWED_CATALOG_ENDPOINTS) {
+            return vec![rewrite_catalog_identity(identity_url, &pinned)];
+        }
+        return vec![canonical];
+    }
+    if prefer_china_transport_without_catalog_env() {
+        vec![china, canonical]
+    } else {
+        vec![canonical, china]
+    }
+}
+
+fn rewrite_catalog_identity(url: &str, endpoint: &str) -> String {
     if let Some(rest) = url.strip_prefix(CANONICAL_CATALOG_ENDPOINT) {
         return format!("{endpoint}{rest}");
     }
@@ -53,6 +80,127 @@ pub(crate) fn apply_catalog_endpoint(url: &str) -> String {
 /// signed identity stays on `dl.openasr.org`.
 pub(crate) fn apply_dl_endpoint(url: &str) -> String {
     rewrite_origin_prefix(url, CANONICAL_DL_ENDPOINT, &resolved_dl_endpoint(), "")
+}
+
+/// Ordered fetch URLs for a signed release artifact. Identity stays the
+/// catalog/GitHub URL; this list is transportation only.
+///
+/// China: `dl.bug.im` → official → GitHub.
+/// Overseas: GitHub → official. An explicit `OPENASR_DL_ENDPOINT` pins one host.
+pub(crate) fn artifact_fetch_urls(url: &str) -> Vec<String> {
+    if url.starts_with("file://") {
+        return vec![url.to_string()];
+    }
+    if let Some(pinned) = endpoint_from_env(DL_ENDPOINT_ENV) {
+        if is_allowed_https_endpoint(&pinned, ALLOWED_DL_ENDPOINTS) {
+            return vec![rewrite_origin_prefix(
+                &official_artifact_url(url).unwrap_or_else(|| url.to_string()),
+                CANONICAL_DL_ENDPOINT,
+                &pinned,
+                "",
+            )];
+        }
+        return vec![apply_dl_endpoint(url)];
+    }
+    let Some(artifact) = parse_release_artifact(url) else {
+        return vec![apply_dl_endpoint(url)];
+    };
+    let github = format!(
+        "{GITHUB_RELEASE_DOWNLOAD}/{}/{}",
+        artifact.tag, artifact.filename
+    );
+    let official = artifact.official;
+    let china = rewrite_origin_prefix(&official, CANONICAL_DL_ENDPOINT, CHINA_DL_ENDPOINT, "");
+    let mut urls = if prefer_china_transport_without_catalog_env() {
+        vec![china, official, github]
+    } else {
+        vec![github, official]
+    };
+    urls.dedup();
+    urls
+}
+
+fn official_artifact_url(url: &str) -> Option<String> {
+    parse_release_artifact(url).map(|artifact| artifact.official)
+}
+
+struct ReleaseArtifact {
+    tag: String,
+    filename: String,
+    official: String,
+}
+
+fn parse_release_artifact(url: &str) -> Option<ReleaseArtifact> {
+    if let Some(rest) = url.strip_prefix(GITHUB_RELEASE_DOWNLOAD) {
+        let rest = rest.strip_prefix('/')?;
+        let (tag, filename) = split_tag_filename(rest)?;
+        let official = official_url_for_github_tag(tag, filename)?;
+        return Some(ReleaseArtifact {
+            tag: tag.to_string(),
+            filename: filename.to_string(),
+            official,
+        });
+    }
+    let path = url
+        .strip_prefix(CANONICAL_DL_ENDPOINT)
+        .or_else(|| url.strip_prefix(CHINA_DL_ENDPOINT))?;
+    if let Some(rest) = path.strip_prefix("/core/") {
+        let (tag, filename) = split_tag_filename(rest)?;
+        return Some(ReleaseArtifact {
+            tag: tag.to_string(),
+            filename: filename.to_string(),
+            official: format!("{CANONICAL_DL_ENDPOINT}/core/{tag}/{filename}"),
+        });
+    }
+    if let Some(rest) = path.strip_prefix("/cli/") {
+        let (tag, filename) = split_tag_filename(rest)?;
+        return Some(ReleaseArtifact {
+            tag: tag.to_string(),
+            filename: filename.to_string(),
+            official: format!("{CANONICAL_DL_ENDPOINT}/cli/{tag}/{filename}"),
+        });
+    }
+    if let Some(rest) = path.strip_prefix("/desktop/releases/") {
+        let (version, filename) = split_tag_filename(rest)?;
+        let version = version.strip_prefix('v')?;
+        if version.is_empty() {
+            return None;
+        }
+        return Some(ReleaseArtifact {
+            tag: format!("desktop-v{version}"),
+            filename: filename.to_string(),
+            official: format!("{CANONICAL_DL_ENDPOINT}/desktop/releases/v{version}/{filename}"),
+        });
+    }
+    None
+}
+
+fn official_url_for_github_tag(tag: &str, filename: &str) -> Option<String> {
+    if let Some(version) = tag.strip_prefix("desktop-v") {
+        if version.is_empty() {
+            return None;
+        }
+        return Some(format!(
+            "{CANONICAL_DL_ENDPOINT}/desktop/releases/v{version}/{filename}"
+        ));
+    }
+    if !tag.starts_with('v') {
+        return None;
+    }
+    Some(format!("{CANONICAL_DL_ENDPOINT}/core/{tag}/{filename}"))
+}
+
+fn split_tag_filename(rest: &str) -> Option<(&str, &str)> {
+    let (tag, filename) = rest.split_once('/')?;
+    if tag.is_empty()
+        || filename.is_empty()
+        || filename.contains('/')
+        || filename.contains("..")
+        || filename.contains('\\')
+    {
+        return None;
+    }
+    Some((tag, filename))
 }
 
 /// Map a signed Hugging Face pack URL onto ModelScope's resolve path.
@@ -435,5 +583,103 @@ mod tests {
             "/var/db/timezone/zoneinfo/Asia/Shanghai"
         ));
         assert!(!timezone_value_prefers_china_sources("America/Los_Angeles"));
+    }
+
+    #[test]
+    fn catalog_transport_races_both_hosts_when_unpinned() {
+        use std::ffi::OsString;
+        crate::test_process_env::with_test_process_env(
+            [
+                (CATALOG_ENDPOINT_ENV, None),
+                ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("global"))),
+            ],
+            || {
+                assert_eq!(
+                    catalog_transport_urls(IDENTITY),
+                    vec![
+                        IDENTITY.to_string(),
+                        "https://catalog.bug.im/v1/catalog.json".to_string(),
+                    ]
+                );
+            },
+        );
+        crate::test_process_env::with_test_process_env(
+            [
+                (CATALOG_ENDPOINT_ENV, None),
+                ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("china"))),
+            ],
+            || {
+                assert_eq!(
+                    catalog_transport_urls(IDENTITY),
+                    vec![
+                        "https://catalog.bug.im/v1/catalog.json".to_string(),
+                        IDENTITY.to_string(),
+                    ]
+                );
+            },
+        );
+        crate::test_process_env::with_test_process_env(
+            [
+                (
+                    CATALOG_ENDPOINT_ENV,
+                    Some(OsString::from(CHINA_CATALOG_ENDPOINT)),
+                ),
+                ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("global"))),
+            ],
+            || {
+                assert_eq!(
+                    catalog_transport_urls(IDENTITY),
+                    vec!["https://catalog.bug.im/v1/catalog.json".to_string()]
+                );
+            },
+        );
+        assert_eq!(catalog_transport_urls(HF_PACK), vec![HF_PACK.to_string()]);
+    }
+
+    #[test]
+    fn artifact_fetch_urls_order_by_region() {
+        use std::ffi::OsString;
+        let core = "https://dl.openasr.org/core/v0.1.36/plugin.dll";
+        let github = format!("{GITHUB_RELEASE_DOWNLOAD}/v0.1.36/plugin.dll");
+        let china = "https://dl.bug.im/core/v0.1.36/plugin.dll";
+        crate::test_process_env::with_test_process_env(
+            [
+                (DL_ENDPOINT_ENV, None),
+                ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("global"))),
+            ],
+            || {
+                assert_eq!(
+                    artifact_fetch_urls(core),
+                    vec![github.clone(), core.to_string()]
+                );
+            },
+        );
+        crate::test_process_env::with_test_process_env(
+            [
+                (DL_ENDPOINT_ENV, None),
+                ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("china"))),
+            ],
+            || {
+                assert_eq!(
+                    artifact_fetch_urls(core),
+                    vec![china.to_string(), core.to_string(), github]
+                );
+            },
+        );
+        let desktop = "https://dl.openasr.org/desktop/releases/v0.1.22/OpenASR-Desktop-0.1.22-aarch64.app.tar.gz";
+        crate::test_process_env::with_test_process_env(
+            [
+                (DL_ENDPOINT_ENV, None),
+                ("OPENASR_DOWNLOAD_SOURCE", Some(OsString::from("global"))),
+            ],
+            || {
+                assert_eq!(
+                    artifact_fetch_urls(desktop)[0],
+                    format!(
+                        "{GITHUB_RELEASE_DOWNLOAD}/desktop-v0.1.22/OpenASR-Desktop-0.1.22-aarch64.app.tar.gz"
+                    )
+                );
+            },
+        );
     }
 }

--- a/scripts/sync-release-to-cnb.sh
+++ b/scripts/sync-release-to-cnb.sh
@@ -9,8 +9,9 @@
 #   scripts/sync-release-to-cnb.sh <tag> [file ...]
 #
 # If no files are given, downloads every asset of GitHub release <tag> into a
-# temp dir and uploads those. Desktop callers pass extra local files that are
-# not on GitHub (macOS .app.tar.gz).
+# temp dir and uploads those. Desktop callers still pass extra local files
+# (macOS .app.tar.gz plus its .sig) so the minisign signature, which is not
+# a GitHub asset, lands on CNB.
 #
 # Env:
 #   CNB_TOKEN            required for upload (Bearer)

--- a/tooling/release-manifest/b2_sync.py
+++ b/tooling/release-manifest/b2_sync.py
@@ -52,6 +52,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import quote, urlparse
 
+from retention import apply_release_retention
+
 ALGORITHM = "AWS4-HMAC-SHA256"
 SERVICE = "s3"
 DEFAULT_BUCKET = "openasr-releases"
@@ -341,6 +343,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     sync.add_argument("--dl-base-url", default=DEFAULT_DL_BASE_URL)
     sync.add_argument("files", nargs="+", type=Path)
 
+    prune = subparsers.add_parser(
+        "prune",
+        help="Plan Official (B2) retention. Dry-run unless --execute or OPENASR_RELEASE_PRUNE=1.",
+    )
+    prune.add_argument("--latest-stable", required=True)
+    prune.add_argument(
+        "--keys-file",
+        type=Path,
+        help="Object keys to consider, one per line. Without this, only the policy is logged.",
+    )
+    prune.add_argument("--execute", action="store_true", help="Actually delete (also honors OPENASR_RELEASE_PRUNE=1).")
+
     return parser.parse_args(argv)
 
 
@@ -356,6 +370,23 @@ def main(argv: list[str]) -> int:
             return 1
         for url in urls:
             print(url)
+        apply_release_retention(profile="official", latest_stable=args.version)
+        return 0
+    if args.command == "prune":
+        keys = args.keys_file.read_text(encoding="utf-8").splitlines() if args.keys_file else []
+        keys = [line.strip() for line in keys if line.strip() and not line.startswith("#")]
+        apply_release_retention(
+            profile="official",
+            latest_stable=args.latest_stable,
+            keys=keys,
+            prune=False,
+        )
+        if args.execute or os.environ.get("OPENASR_RELEASE_PRUNE") == "1":
+            print(
+                "b2_sync.py: --execute/OPENASR_RELEASE_PRUNE is set but object "
+                "delete is not wired; listed would-delete only",
+                file=sys.stderr,
+            )
         return 0
     raise SystemExit(f"unknown command: {args.command}")
 

--- a/tooling/release-manifest/retention.py
+++ b/tooling/release-manifest/retention.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Hot-cache retention planner for Official (B2) and China (CNB) releases.
+
+GitHub keeps the full archive. B2 keeps the last 30 stables + 5 prereleases;
+CNB keeps 15 + 3. The live latest stable is pinned so a prune cannot delete
+the objects the current pointer still names.
+
+Default is log-only. Real deletes require OPENASR_RELEASE_PRUNE=1 and a
+caller-supplied delete_keys callback. This module does not talk to the
+network.
+"""
+from __future__ import annotations
+
+import os
+import re
+from functools import cmp_to_key
+from typing import Callable, Iterable
+
+OFFICIAL_RETENTION = {"keep_stable": 30, "keep_prerelease": 5}
+CHINA_RETENTION = {"keep_stable": 15, "keep_prerelease": 3}
+
+_SEMVER = re.compile(
+    r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$"
+)
+_VERSIONED_KEY = re.compile(r"^(?:desktop/releases|core|cli)/v([^/]+)/")
+
+
+class RetentionError(Exception):
+    pass
+
+
+def parse_semver(version: str) -> tuple[int, int, int, list[str]] | None:
+    match = _SEMVER.match((version or "").strip())
+    if not match:
+        return None
+    prerelease = match.group(4).split(".") if match.group(4) else []
+    return int(match.group(1)), int(match.group(2)), int(match.group(3)), prerelease
+
+
+def is_prerelease_version(version: str) -> bool:
+    parsed = parse_semver(version)
+    return bool(parsed and parsed[3])
+
+
+def compare_semver(left: str, right: str) -> int:
+    """Return -1 / 0 / 1. Twin of apps/desktop/scripts/release-publish.mjs."""
+    pa = parse_semver(left)
+    pb = parse_semver(right)
+    if pa is None or pb is None:
+        raise RetentionError(f"Cannot compare non-semver versions: {left!r} vs {right!r}")
+    for index in range(3):
+        if pa[index] != pb[index]:
+            return -1 if pa[index] < pb[index] else 1
+    a_pre, b_pre = pa[3], pb[3]
+    if not a_pre and not b_pre:
+        return 0
+    if not a_pre:
+        return 1
+    if not b_pre:
+        return -1
+    length = max(len(a_pre), len(b_pre))
+    for index in range(length):
+        if index >= len(a_pre):
+            return -1
+        if index >= len(b_pre):
+            return 1
+        ia, ib = a_pre[index], b_pre[index]
+        na = int(ia) if ia.isdigit() else None
+        nb = int(ib) if ib.isdigit() else None
+        if na is not None and nb is not None:
+            if na != nb:
+                return -1 if na < nb else 1
+        elif na is not None:
+            return -1
+        elif nb is not None:
+            return 1
+        elif ia != ib:
+            return -1 if ia < ib else 1
+    return 0
+
+
+def version_from_object_key(key: str) -> str | None:
+    match = _VERSIONED_KEY.match(key)
+    return match.group(1) if match else None
+
+
+def plan_release_retention(
+    versions: Iterable[str],
+    latest_stable: str | None,
+    keep_stable: int,
+    keep_prerelease: int,
+) -> dict[str, list[str]]:
+    unique = list(dict.fromkeys(version for version in versions if version))
+    by_semver = cmp_to_key(compare_semver)
+    stable = sorted(
+        (version for version in unique if not is_prerelease_version(version)),
+        key=by_semver,
+        reverse=True,
+    )
+    prerelease = sorted(
+        (version for version in unique if is_prerelease_version(version)),
+        key=by_semver,
+        reverse=True,
+    )
+    keep: set[str] = set()
+    if latest_stable:
+        keep.add(latest_stable)
+    keep.update(stable[:keep_stable])
+    keep.update(prerelease[:keep_prerelease])
+    prune = sorted((version for version in unique if version not in keep), key=by_semver, reverse=True)
+    kept = sorted((version for version in unique if version in keep), key=by_semver, reverse=True)
+    return {"keep": kept, "prune": prune}
+
+
+def plan_retention_for_keys(
+    keys: Iterable[str],
+    latest_stable: str | None,
+    keep_stable: int,
+    keep_prerelease: int,
+) -> dict[str, list[str]]:
+    key_list = list(keys)
+    versions = list(dict.fromkeys(version for version in (version_from_object_key(key) for key in key_list) if version))
+    plan = plan_release_retention(versions, latest_stable, keep_stable, keep_prerelease)
+    prune_set = set(plan["prune"])
+    plan["prune_keys"] = [key for key in key_list if version_from_object_key(key) in prune_set]
+    return plan
+
+
+def apply_release_retention(
+    *,
+    profile: str = "official",
+    latest_stable: str | None = None,
+    keys: Iterable[str] | None = None,
+    prune: bool | None = None,
+    delete_keys: Callable[[list[str]], None] | None = None,
+    log: Callable[[str], None] = print,
+) -> dict:
+    limits = CHINA_RETENTION if profile == "china" else OFFICIAL_RETENTION
+    if prune is None:
+        prune = os.environ.get("OPENASR_RELEASE_PRUNE") == "1"
+    log(
+        f"release retention ({profile}): keepStable={limits['keep_stable']} "
+        f"keepPrerelease={limits['keep_prerelease']} pin={latest_stable or '(none)'}"
+    )
+    key_list = list(keys or [])
+    if not key_list:
+        log("release retention: no object list supplied; skip would-delete")
+        return {"keep": [latest_stable] if latest_stable else [], "prune": [], "prune_keys": [], "applied": False}
+    plan = plan_retention_for_keys(key_list, latest_stable, limits["keep_stable"], limits["keep_prerelease"])
+    if not plan["prune"]:
+        log("release retention: nothing to prune")
+        plan["applied"] = False
+        return plan
+    if not prune:
+        log(
+            f"release retention: would delete {', '.join(plan['prune'])} "
+            f"({len(plan['prune_keys'])} objects); set OPENASR_RELEASE_PRUNE=1 to apply"
+        )
+        plan["applied"] = False
+        return plan
+    if delete_keys is None:
+        raise RetentionError("OPENASR_RELEASE_PRUNE=1 requires a delete_keys callback")
+    log(f"release retention: deleting {', '.join(plan['prune'])} ({len(plan['prune_keys'])} objects)")
+    delete_keys(plan["prune_keys"])
+    plan["applied"] = True
+    return plan

--- a/tooling/release-manifest/retention_test.py
+++ b/tooling/release-manifest/retention_test.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import unittest
+
+from retention import (
+    CHINA_RETENTION,
+    OFFICIAL_RETENTION,
+    apply_release_retention,
+    is_prerelease_version,
+    plan_release_retention,
+    plan_retention_for_keys,
+    version_from_object_key,
+)
+
+
+class PrereleaseTest(unittest.TestCase):
+    def test_classifies_preview_and_stable(self) -> None:
+        self.assertFalse(is_prerelease_version("0.1.22"))
+        self.assertTrue(is_prerelease_version("0.1.22-preview.9"))
+        self.assertTrue(is_prerelease_version("0.1.36-rc.1"))
+
+
+class PlanRetentionTest(unittest.TestCase):
+    def test_pins_latest_even_when_outside_the_window(self) -> None:
+        stables = [f"0.1.{i}" for i in range(1, 41)]
+        plan = plan_release_retention(stables, "0.1.1", **OFFICIAL_RETENTION)
+        self.assertIn("0.1.1", plan["keep"])
+        self.assertIn("0.1.40", plan["keep"])
+        self.assertEqual(len(plan["keep"]), 31)
+        self.assertIn("0.1.2", plan["prune"])
+        self.assertNotIn("0.1.1", plan["prune"])
+
+    def test_prereleases_do_not_squeeze_stables(self) -> None:
+        versions = [f"0.1.{i}" for i in range(1, 17)] + [f"0.2.0-preview.{i}" for i in range(1, 9)]
+        plan = plan_release_retention(versions, "0.1.16", **CHINA_RETENTION)
+        kept_stable = [version for version in plan["keep"] if not is_prerelease_version(version)]
+        kept_pre = [version for version in plan["keep"] if is_prerelease_version(version)]
+        self.assertEqual(len(kept_stable), 15)
+        self.assertEqual(kept_pre, ["0.2.0-preview.8", "0.2.0-preview.7", "0.2.0-preview.6"])
+        self.assertIn("0.2.0-preview.1", plan["prune"])
+        self.assertIn("0.1.1", plan["prune"])
+
+
+class PlanKeysTest(unittest.TestCase):
+    def test_never_proposes_deleting_latest_json(self) -> None:
+        keys = [
+            "desktop/releases/v0.1.1/OpenASR-Desktop-0.1.1-aarch64.dmg",
+            "desktop/releases/v0.1.2/OpenASR-Desktop-0.1.2-aarch64.dmg",
+            "desktop/stable/latest.json",
+            "core/v0.1.1/openasr-windows-cuda.zip",
+        ]
+        plan = plan_retention_for_keys(keys, "0.1.2", keep_stable=1, keep_prerelease=0)
+        self.assertEqual(plan["prune"], ["0.1.1"])
+        self.assertEqual(
+            plan["prune_keys"],
+            [
+                "desktop/releases/v0.1.1/OpenASR-Desktop-0.1.1-aarch64.dmg",
+                "core/v0.1.1/openasr-windows-cuda.zip",
+            ],
+        )
+        self.assertNotIn("desktop/stable/latest.json", plan["prune_keys"])
+
+    def test_parses_prefixes(self) -> None:
+        self.assertEqual(
+            version_from_object_key("desktop/releases/v0.1.22-preview.9/x.app.tar.gz"),
+            "0.1.22-preview.9",
+        )
+        self.assertEqual(version_from_object_key("core/v0.1.36/openasr.zip"), "0.1.36")
+        self.assertIsNone(version_from_object_key("desktop/stable/latest.json"))
+
+
+class ApplyRetentionTest(unittest.TestCase):
+    def test_dry_run_does_not_delete(self) -> None:
+        deleted: list[str] = []
+        logs: list[str] = []
+        keys = [f"desktop/releases/v0.1.{i}/a.dmg" for i in range(1, 33)]
+        result = apply_release_retention(
+            profile="official",
+            latest_stable="0.1.32",
+            keys=keys,
+            prune=False,
+            delete_keys=deleted.extend,
+            log=logs.append,
+        )
+        self.assertFalse(result["applied"])
+        self.assertEqual(deleted, [])
+        self.assertTrue(any("would delete" in line and "0.1.1" in line for line in logs))
+
+    def test_prune_deletes_old_keys(self) -> None:
+        deleted: list[str] = []
+        keys = [f"desktop/releases/v0.1.{i}/a.dmg" for i in range(1, 18)]
+        result = apply_release_retention(
+            profile="china",
+            latest_stable="0.1.17",
+            keys=keys,
+            prune=True,
+            delete_keys=deleted.extend,
+            log=lambda _line: None,
+        )
+        self.assertTrue(result["applied"])
+        self.assertEqual(deleted, ["desktop/releases/v0.1.1/a.dmg", "desktop/releases/v0.1.2/a.dmg"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Race Cloudflare and ESA catalog fetches on matching host pairs, then verify before use.
- Order artifact downloads by region: China CNB then official then GitHub; overseas GitHub then official.
- Insert ModelScope into the overseas model chain after the first-party HF proxy.

## Why
Keep signed catalog and `dl.openasr.org` identity URLs, while making China and overseas transport actually fallback instead of pinning a single host.

## Changes
- `catalog_transport_urls` / `fetch_verified_remote_catalog` race same-host catalog+signature pairs.
- `artifact_fetch_urls` expands signed core/cli/desktop URLs onto the regional source chain.
- Overseas `DownloadSource` chain is HF, weights, ModelScope, hf-mirror.
- Official retention planner logs would-delete only; no production deletes.

## Tests run
- [x] `cargo test -p openasr-core --lib -- download_source catalog_transport artifact_fetch`
- [x] `python3 -m unittest discover -s tooling/release-manifest -p 'retention_test.py'`
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

`cargo fmt` was applied to the touched files. Full workspace clippy/nextest were not run in this slice.

## Manual smoke checks
- None against live catalog or B2. Retention delete is not wired.

## Model-family changes (when applicable)
- Not applicable.

## Docs updated
- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals
- Does not rewrite signed catalog bytes, pack URLs, or `files[].url`.
- Does not prune B2/CNB objects. `OPENASR_RELEASE_PRUNE=1` remains log-only until a list/delete adapter exists.

## Artifact confirmation
- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements
- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES


Made with [Cursor](https://cursor.com)