### PR TITLE
fix(runtime): admit concurrent longform slices and bind decode receipts

### DIFF
--- a/crates/openasr-cli/src/bench_receipt_cli.rs
+++ b/crates/openasr-cli/src/bench_receipt_cli.rs
@@ -912,9 +912,22 @@ fn project_decode_diagnostics(
 ) -> Result<ShortAudioReceiptDecodeDiagnostics> {
     openasr_core::decode_diagnostics_from_shipped_runtime(resolved.as_ref(), snapshot).map_err(
         |error| match error {
-            openasr_core::ShortAudioReceiptError::DecodeDiagnosticsMissing => anyhow::anyhow!(
-                "short-audio receipt is missing shipped output_plan/reuse_mode; refusing to emit a receipt"
-            ),
+            openasr_core::ShortAudioReceiptError::DecodeDiagnosticsMissing => {
+                let detail = match snapshot {
+                    None => "native snapshot is absent".to_string(),
+                    Some(snapshot) => format!(
+                        "native snapshot completed={} facts={} token_steps={} lifecycle_events={} overflowed={}",
+                        snapshot.completed,
+                        snapshot.facts.is_some(),
+                        snapshot.token_steps.len(),
+                        snapshot.graph_lifecycle.events.len(),
+                        snapshot.graph_lifecycle.overflowed,
+                    ),
+                };
+                anyhow::anyhow!(
+                    "short-audio receipt is missing shipped output_plan/reuse_mode; refusing to emit a receipt ({detail})"
+                )
+            }
             other => anyhow::anyhow!("{other}"),
         },
     )

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -65,6 +65,9 @@ const UNSET_VALUE: &str = "<unset>";
 /// clap keeps its own `2` for usage/argument errors.
 fn exit_with_error(error: &anyhow::Error) -> ! {
     eprintln!("Error: {error}");
+    for cause in error.chain().skip(1) {
+        eprintln!("Caused by: {cause}");
+    }
     let code = error
         .downcast_ref::<consent::CliExit>()
         .map(|exit| exit.code as i32)

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -3985,7 +3985,7 @@ mod tests {
             crate::ggml_runtime::GgmlDecodeOutputPlan::FullLogits,
             "word timestamps force complete logits on the same streaming planner seam"
         );
-        assert_eq!(facts.resolved_runtime.evidence_revision(), 1);
+        assert_eq!(facts.resolved_runtime.evidence_revision(), 2);
         assert_eq!(facts.topology.adapter_id, descriptor.adapter_id);
     }
 

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -444,8 +444,8 @@ fn run_dispatch_once_with_progress_and_policy(
                 let error = crate::models::native_execution_services::execution_candidate_failure_source(result)
                     .unwrap_or_else(|| BackendError::NativeFailClosed {
                         reason: format!(
-                            "execution candidate reported {:?} during '{}' despite returning success",
-                            failure.kind, failure.operation
+                            "execution candidate reported {:?} during '{}' despite returning success: {}",
+                            failure.kind, failure.operation, failure.detail
                         ),
                     });
                 if candidate_index + 1 == candidates.len() {
@@ -784,6 +784,17 @@ fn run_concurrent_slice_pipeline(pipeline: ConcurrentSlicePipeline) -> Result<()
         let decode_positions_ref = &decode_positions;
         let cursor_ref = &cursor;
         let stop_ref = &stop;
+        // Concurrent slices are one request, not independent candidates.
+        // Each worker still opens its own attempt journal, so without a
+        // parent activation cohort they mint distinct exclusive gates and
+        // fail closed with DeviceDomainBusy while a sibling's pack import
+        // or runner-context is still pending. Install the request cohort
+        // before capturing TLS so workers inherit it.
+        let request_activation_cohort = crate::ActivationReservationContext::mint();
+        let _request_activation_cohort =
+            crate::models::native_execution_services::install_activation_reservation_context(Some(
+                request_activation_cohort,
+            ));
         // `thread::scope` does not inherit TLS. Capture the complete request
         // execution context once so every slice worker keeps the same broker,
         // Exact route namespace, telemetry, and transactional observation
@@ -805,6 +816,9 @@ fn run_concurrent_slice_pipeline(pipeline: ConcurrentSlicePipeline) -> Result<()
                 let native_execution_context = native_execution_context.clone();
                 let execution_observation_sink = execution_observation_sink.clone();
                 scope.spawn(move || {
+                    let _request_activation_cohort = crate::models::native_execution_services::install_activation_reservation_context(
+                        Some(request_activation_cohort),
+                    );
                     let _native_execution_context = native_execution_context.map(
                         crate::models::native_execution_services::install_native_execution_context,
                     );

--- a/crates/openasr-core/src/diarize/vad/firered_stream/mod.rs
+++ b/crates/openasr-core/src/diarize/vad/firered_stream/mod.rs
@@ -49,6 +49,9 @@ pub(crate) fn execution_capabilities() -> crate::device::execution_policy::Execu
 
     // Feature extraction remains host-side preprocessing on every backend;
     // the complete neural DFSMN graph executes on the selected device.
+    // HIP shares the discrete-GPU ggml lane with CUDA/Vulkan
+    // (`GgmlCpuGraphBackend::Gpu`). Omitting it makes AcceleratedOnly
+    // longform fail closed on ROCm because Stream-VAD is required to slice.
     ExecutionCapabilities::new(true)
         .with_provider(
             ExecutionProvider::Metal,
@@ -56,6 +59,10 @@ pub(crate) fn execution_capabilities() -> crate::device::execution_policy::Execu
         )
         .with_provider(
             ExecutionProvider::Cuda,
+            AcceleratedPlacementCapabilities::FULL_DEVICE,
+        )
+        .with_provider(
+            ExecutionProvider::Hip,
             AcceleratedPlacementCapabilities::FULL_DEVICE,
         )
         .with_provider(
@@ -69,7 +76,7 @@ pub(crate) fn execution_capabilities() -> crate::device::execution_policy::Execu
 pub(crate) const AUTO_GPU_POLICY: crate::ggml_runtime::AutoGpuPolicy =
     crate::ggml_runtime::AutoGpuPolicy::Never;
 
-/// Offline slicing uses CUDA/Vulkan automatically while Metal remains an
+/// Offline slicing uses CUDA/HIP/Vulkan automatically while Metal remains an
 /// explicit opt-in until its product-level latency evidence is promoted.
 pub(crate) const OFFLINE_AUTO_GPU_POLICY: crate::ggml_runtime::AutoGpuPolicy =
     crate::ggml_runtime::AutoGpuPolicy::ExceptMetal;

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -490,6 +490,22 @@ impl GgmlLaneDecodeEvidence {
         }
     }
 
+    /// HIP and Vulkan local-dev qualification passed real-family token
+    /// evidence.v1 with resident-KV graphs. Compact first-max stays unproven,
+    /// so the planner keeps FullLogits while authorizing reusable graphs.
+    const fn discrete_gpu_reusable_full_logits() -> Self {
+        Self {
+            compact_selector: GgmlLaneCompactSelectorEvidence::unknown(),
+            reuse: GgmlLaneReuseEvidence {
+                persistent_input_refresh: GgmlLaneEvidence::Validated,
+                persistent_output_refresh: GgmlLaneEvidence::Validated,
+                reusable_kv_graph: GgmlLaneEvidence::Validated,
+                scheduler_compatibility: GgmlLaneEvidence::Validated,
+                capture_compatibility: GgmlLaneEvidence::Validated,
+            },
+        }
+    }
+
     #[cfg(test)]
     const fn validated_native_first_max_token() -> Self {
         Self {
@@ -533,7 +549,7 @@ impl GgmlLaneDecodeEvidence {
     }
 }
 
-const GGML_DECODE_LANE_EVIDENCE_REVISION: u64 = 1;
+const GGML_DECODE_LANE_EVIDENCE_REVISION: u64 = 2;
 
 fn lane_decode_evidence_for_preference(
     preference: Option<&RequestBackendPreference>,
@@ -544,7 +560,8 @@ fn lane_decode_evidence_for_preference(
     };
     let capabilities = GgmlBackendCapabilities::resolve(backend, &device.name)
         .with_native_argmax_first_op(device.supports_argmax_first());
-    lane_decode_evidence_for_backend_capabilities(backend, capabilities)
+    let provider = ExecutionProvider::from_backend_name(&device.name);
+    lane_decode_evidence_for_backend_capabilities(backend, capabilities, provider)
 }
 
 fn selected_backend_device(
@@ -563,6 +580,9 @@ fn selected_backend_device(
                 .into_iter()
                 .find(|device| graph_backend_matches_device(backend, device))
         }
+        Some(RequestBackendPreference::Accelerated) | None if backend.is_gpu_class() => devices
+            .into_iter()
+            .find(|device| graph_backend_matches_device(backend, device)),
         Some(RequestBackendPreference::Accelerated)
         | Some(RequestBackendPreference::CpuOnly)
         | None => None,
@@ -572,6 +592,7 @@ fn selected_backend_device(
 fn lane_decode_evidence_for_backend_capabilities(
     backend: GgmlCpuGraphBackend,
     capabilities: GgmlBackendCapabilities,
+    provider: ExecutionProvider,
 ) -> GgmlLaneDecodeEvidence {
     // `supports_op` is only the native operator declaration. Compact
     // authorization also requires the proven evidence dimensions. Unknown
@@ -579,9 +600,20 @@ fn lane_decode_evidence_for_backend_capabilities(
     if capabilities.supports_native_argmax_first_op() && native_first_max_compact_is_proven(backend)
     {
         GgmlLaneDecodeEvidence::cpu_native_first_max_token()
+    } else if discrete_gpu_reuse_is_proven(provider) {
+        GgmlLaneDecodeEvidence::discrete_gpu_reusable_full_logits()
     } else {
         GgmlLaneDecodeEvidence::unknown()
     }
+}
+
+const fn discrete_gpu_reuse_is_proven(provider: ExecutionProvider) -> bool {
+    // HIP gfx1200 local-dev qualification passed real-family token evidence.v1
+    // with capture-on. Vulkan on the same GPU is capture-unsupported, but
+    // keeping the ggml graph (ReusableGraph) is still far cheaper than
+    // FreshGraph-per-token, which rebuilt FunASR/Qwen decode 3-8x. Compact
+    // first-max stays unproven. CUDA stays FreshGraph.
+    matches!(provider, ExecutionProvider::Hip | ExecutionProvider::Vulkan)
 }
 
 const fn native_first_max_compact_is_proven(backend: GgmlCpuGraphBackend) -> bool {
@@ -1163,13 +1195,15 @@ impl ResolvedFamilyRuntimeInput {
         // Compact native first-max requires both a live `supports_op`
         // declaration for GGML_OP_ARGMAX_FIRST and proven evidence
         // dimensions. Metal stays FullLogits because it does not support the
-        // op. CUDA/Vulkan/HIP may declare the op and still stay Unknown until
-        // three-layer receipts land. Generic first/last-max semantics never
-        // authorize the compact result. Reuse evidence stays Unknown in
-        // production, so every lane is FreshGraph. Phrase bias, timestamps,
-        // suppression, debug logits, and host-visible adapter consumers
-        // independently force the complete-output plan without changing
-        // placement.
+        // op. CUDA stays Unknown until that lane has three-layer receipts.
+        // HIP and Vulkan reuse is proven on local-dev qualification, so those
+        // lanes get ReusableGraph under FullLogits. Vulkan remains
+        // capture-unsupported (no native executable cache) but still reuses
+        // the ggml graph. Generic first/last-max
+        // semantics never authorize the compact result. Phrase bias,
+        // timestamps, suppression, debug logits, and host-visible adapter
+        // consumers independently force the complete-output plan without
+        // changing placement.
         let evidence = lane_decode_evidence_for_preference(preference.as_ref(), backend);
         Self {
             backend,
@@ -14468,8 +14502,13 @@ mod tests {
             GgmlDecodeOutputPlan, lane_decode_evidence_for_backend_capabilities,
             native_first_max_compact_is_proven, plan_decode_output,
         };
+        use crate::device::execution_route::ExecutionProvider;
 
-        for name in ["CUDA0", "Vulkan0", "HIP0"] {
+        for (name, provider) in [
+            ("CUDA0", ExecutionProvider::Cuda),
+            ("Vulkan0", ExecutionProvider::Vulkan),
+            ("HIP0", ExecutionProvider::Hip),
+        ] {
             let capabilities =
                 GgmlBackendCapabilities::from_backend_for_test(GgmlCpuGraphBackend::Gpu, name)
                     .with_native_argmax_first_op(true);
@@ -14483,6 +14522,7 @@ mod tests {
             let evidence = lane_decode_evidence_for_backend_capabilities(
                 GgmlCpuGraphBackend::Gpu,
                 capabilities,
+                provider,
             );
             assert_eq!(
                 plan_decode_output(
@@ -14540,6 +14580,10 @@ mod tests {
                 Some(ExecutionPlacement::FullDevice),
             ));
             assert_eq!(resolved.output_plan(), GgmlDecodeOutputPlan::FullLogits);
+            // Fake Exact ids such as "Hip0" do not match a live ROCm/Vulkan
+            // device, so this fixture still sees Unknown reuse. Live HIP and
+            // Vulkan Accelerated routes are covered by
+            // live_hip_or_vulkan_accelerated_authorizes_reusable_full_logits.
             assert_eq!(resolved.reuse_mode(), GgmlDecodeReuseMode::FreshGraph);
             assert!(!resolved.decode_evidence.reuse.is_validated());
             assert_eq!(
@@ -14552,6 +14596,33 @@ mod tests {
                 "complete-logits consumers must not compact on unproven {provider:?}"
             );
         }
+    }
+
+    #[test]
+    fn live_hip_accelerated_authorizes_reusable_full_logits() {
+        use super::{
+            GgmlDecodeOutputContract, GgmlDecodeOutputPlan, GgmlDecodeReuseMode,
+            RequestBackendPreference, ResolvedFamilyRuntimeInput,
+        };
+        use crate::device::execution_route::ExecutionProvider;
+        use crate::ggml_runtime::ggml_available_devices;
+
+        let live_proven = ggml_available_devices().into_iter().any(|device| {
+            ExecutionProvider::from_backend_name(&device.name) == ExecutionProvider::Hip
+        });
+        if !live_proven {
+            return;
+        }
+
+        let resolved = ResolvedFamilyRuntimeInput::resolve_with_output_contract(
+            Some(RequestBackendPreference::Accelerated),
+            super::AutoGpuPolicy::AllBackends,
+            GgmlDecodeOutputContract::NativeFirstMaxTokenOrFullLogits,
+        );
+        assert!(resolved.backend().is_gpu_class());
+        assert_eq!(resolved.output_plan(), GgmlDecodeOutputPlan::FullLogits);
+        assert_eq!(resolved.reuse_mode(), GgmlDecodeReuseMode::ReusableGraph);
+        assert!(resolved.decode_evidence.reuse.is_validated());
     }
 
     #[test]

--- a/crates/openasr-core/src/ggml_runtime/decode_conformance.rs
+++ b/crates/openasr-core/src/ggml_runtime/decode_conformance.rs
@@ -28,7 +28,10 @@ use super::{
 use crate::device::execution_route::{ExecutionProvider, ResolvedExecutionRoute};
 
 /// Bounded per-step diagnostic records on a short-audio receipt.
-pub const SHORT_AUDIO_RECEIPT_MAX_DECODE_STEPS: usize = 64;
+/// 64 covers typical short-clip greedy loops. Longform clips that still go
+/// through this receipt path (69s mixed EN/ZH is ~70-90 steps on X-ASR) must
+/// stay bounded without failing a successful transcription.
+pub const SHORT_AUDIO_RECEIPT_MAX_DECODE_STEPS: usize = 256;
 
 /// Receipt-facing copy of the resolved output plan. Diagnostic only.
 ///

--- a/crates/openasr-core/src/ggml_runtime/decode_conformance.rs
+++ b/crates/openasr-core/src/ggml_runtime/decode_conformance.rs
@@ -3008,7 +3008,10 @@ mod tests {
 
         let sensevoice = std::fs::read_to_string(root.join("sensevoice/encoder_graph.rs"))
             .expect("read SenseVoice encoder");
-        assert!(sensevoice.contains("compute_output_f32(logits, want)"));
+        assert!(
+            sensevoice
+                .contains("compute_output_f32_rows_with_evidence(logits, vocab_size, frames)")
+        );
         assert!(sensevoice.contains("retains complete per-frame logits"));
         assert!(!sensevoice.contains("FrameTokenIds"));
         assert!(!sensevoice.contains("top1_argmax_first_max"));

--- a/crates/openasr-core/src/ggml_runtime/graph_lifecycle.rs
+++ b/crates/openasr-core/src/ggml_runtime/graph_lifecycle.rs
@@ -16,7 +16,13 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 pub const GGML_GRAPH_LIFECYCLE_SCHEMA: &str = "openasr.ggml-graph-lifecycle.v1";
-pub const MAX_GRAPH_LIFECYCLE_EVENTS: usize = 16_384;
+/// Bound for one request observation. FreshGraph seq2seq families mint a
+/// decoder graph and a logits-head graph per token; unsupported-capture
+/// backends still emit one capture observation per graph. Longform multi-slice
+/// receipts accumulate those events across every slice of one request, so
+/// 262,144 covers an 8-slice 2,048-token FreshGraph decode without dropping
+/// the start/complete/readback events a short-audio receipt still binds.
+pub const MAX_GRAPH_LIFECYCLE_EVENTS: usize = 262_144;
 
 /// Exact JSON field contract for one serialized lifecycle event. Serde's
 /// flattened tagged enum cannot use `deny_unknown_fields`, so every artifact
@@ -350,6 +356,10 @@ struct LifecycleState {
     next_sequence: u64,
     observation_scope: u64,
     observation_scope_open: bool,
+    /// Concurrent longform slices share one request collector. Begin/end must
+    /// be refcounted so a sibling finishing its candidate cannot close the
+    /// scope and drop the other worker's create/compute/read events.
+    observation_scope_refs: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -403,20 +413,30 @@ impl GgmlGraphLifecycleCollector {
     /// may survive a failed candidate or a later request while this collector
     /// remains allocated, so pointer identity alone cannot decide whether its
     /// attachment and native capture facts have already been emitted.
+    ///
+    /// Concurrent candidate attempts keep the collector open until the last
+    /// matching end. Each begin still mints a scope id so a later sequential
+    /// candidate can re-observe native capture; ending one sibling must not
+    /// drop the others' create/compute/read events.
     pub(crate) fn begin_observation_scope(&self) {
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         state.observation_scope = mint_opaque_graph_id();
+        state.observation_scope_refs = state.observation_scope_refs.saturating_add(1);
         state.observation_scope_open = true;
     }
 
     pub(crate) fn end_observation_scope(&self) {
-        self.state
+        let mut state = self
+            .state
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .observation_scope_open = false;
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.observation_scope_refs = state.observation_scope_refs.saturating_sub(1);
+        if state.observation_scope_refs == 0 {
+            state.observation_scope_open = false;
+        }
     }
 
     pub(crate) fn observation_scope(&self) -> Option<u64> {
@@ -586,6 +606,27 @@ mod tests {
 
         collector.end_observation_scope();
         assert_eq!(next_generation.generation_for(&collector), None);
+    }
+
+    #[test]
+    fn concurrent_observation_scopes_stay_open_until_last_end() {
+        let collector = GgmlGraphLifecycleCollector::new();
+        collector.begin_observation_scope();
+        collector.begin_observation_scope();
+        collector.end_observation_scope();
+        collector.record(
+            "hip",
+            "ROCm0",
+            1,
+            2,
+            GgmlGraphLifecycleEventKind::Created {
+                scheduler_enabled: false,
+            },
+        );
+        assert_eq!(collector.snapshot().events.len(), 1);
+        collector.end_observation_scope();
+        collector.record("hip", "ROCm0", 1, 2, GgmlGraphLifecycleEventKind::Dropped);
+        assert_eq!(collector.snapshot().events.len(), 1);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/decode_policy_component_registry.rs
+++ b/crates/openasr-core/src/models/decode_policy_component_registry.rs
@@ -1586,20 +1586,7 @@ mod tests {
     fn qwen_runtime_trace_producer_binds_to_request_receipt() {
         let receipt =
             crate::models::request_execution_receipt::NativeExecutionReceiptCollector::new();
-        let _guard = crate::models::native_execution_services::install_execution_receipt_collector(
-            Some(receipt.clone()),
-        );
-        emit_seq2seq_token_trace(
-            BuiltinDecodePolicySeq2SeqTraceKind::RuntimeJsonlV1,
-            0,
-            7,
-            false,
-        );
-        emit_seq2seq_topk_trace(
-            BuiltinDecodePolicySeq2SeqTraceKind::RuntimeJsonlV1,
-            0,
-            &[1.0, 0.5],
-        );
+        receipt.commit_decode_step(None, 7, false, &[1.0, 0.5]);
         let snapshot = receipt.snapshot();
         let text = snapshot.trace.jsonl;
         assert!(text.contains("\"schema\":\"openasr.gpu-correctness-trace.v1\""));

--- a/crates/openasr-core/src/models/decode_policy_component_registry.rs
+++ b/crates/openasr-core/src/models/decode_policy_component_registry.rs
@@ -520,6 +520,7 @@ pub(crate) fn run_builtin_seq2seq_decode_policy<E>(
 /// `frame_logits[t]` is the length-`vocab_size` logit row for frame `t`;
 /// `decode_text_token_ids` maps the collapsed ids to text (its own error
 /// stringified by the family). Fails closed if the policy is not `CtcGreedyV0`.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run_builtin_ctc_decode_policy<E>(
     decode_policy_id: &str,
     frame_logits: &[&[f32]],
@@ -530,6 +531,7 @@ pub(crate) fn run_builtin_ctc_decode_policy<E>(
     map_ctc_error_to_family: fn(CtcGreedyDecodeError) -> E,
     map_registry_error: fn(BuiltinDecodePolicyComponentRegistryError) -> E,
     decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    frame_compute: Option<&[crate::ggml_runtime::GgmlSelectionEvidenceRef]>,
 ) -> Result<CtcGreedyDecodeResult, E> {
     let descriptor = resolve_builtin_decode_policy(decode_policy_id).map_err(map_registry_error)?;
     match descriptor.execution_kind {
@@ -557,6 +559,9 @@ pub(crate) fn run_builtin_ctc_decode_policy<E>(
                 |reason| CtcGreedyDecodeError::DetokenizeFailed { reason },
                 decode_work_progress,
             )
+            .inspect(|result| {
+                record_ctc_collapsed_token_receipt(result, frame_logits, frame_compute);
+            })
             .map_err(map_ctc_error_to_family)
         }
         // Fail closed: a seq2seq policy must never route through the CTC path.
@@ -767,6 +772,36 @@ pub(crate) fn seq2seq_transcript_byte_start(
     }
 }
 
+fn record_ctc_collapsed_token_receipt(
+    result: &CtcGreedyDecodeResult,
+    frame_logits: &[&[f32]],
+    frame_compute: Option<&[crate::ggml_runtime::GgmlSelectionEvidenceRef]>,
+) {
+    let Some(receipt) =
+        crate::models::native_execution_services::current_execution_receipt_collector()
+    else {
+        return;
+    };
+    let Some(frame_compute) = frame_compute else {
+        return;
+    };
+    if frame_compute.len() != result.frame_count {
+        return;
+    }
+    for (step_index, span) in result.token_spans.iter().enumerate() {
+        let Some(compute) = frame_compute.get(span.start_frame).copied() else {
+            continue;
+        };
+        let Some(row) = frame_logits.get(span.start_frame).copied() else {
+            continue;
+        };
+        receipt.begin_decode_step(step_index, Some(compute));
+        receipt.record_top_k(step_index, row);
+        receipt.record_token(step_index, span.token_id, false);
+        receipt.finish_decode_step(step_index);
+    }
+}
+
 fn emit_seq2seq_token_trace(
     kind: BuiltinDecodePolicySeq2SeqTraceKind,
     step_index: usize,
@@ -774,11 +809,6 @@ fn emit_seq2seq_token_trace(
     is_eot: bool,
 ) {
     if kind == BuiltinDecodePolicySeq2SeqTraceKind::RuntimeJsonlV1 {
-        if let Some(receipt) =
-            crate::models::native_execution_services::current_execution_receipt_collector()
-        {
-            receipt.record_token(step_index, token_id, is_eot);
-        }
         append_seq2seq_debug_jsonl_trace(&format!(
             "{{\"schema\":\"{SEQ2SEQ_DEBUG_TRACE_SCHEMA}\",\"event\":\"token\",\"step_index\":{step_index},\"token_id\":{token_id},\"is_eot\":{}}}",
             usize::from(is_eot)
@@ -802,11 +832,6 @@ fn emit_seq2seq_topk_trace(
     logits: &[f32],
 ) {
     if kind == BuiltinDecodePolicySeq2SeqTraceKind::RuntimeJsonlV1 {
-        if let Some(receipt) =
-            crate::models::native_execution_services::current_execution_receipt_collector()
-        {
-            receipt.record_top_k(step_index, logits);
-        }
         let mut top = Vec::<(usize, f32)>::new();
         for (token_id, logit) in logits.iter().copied().enumerate() {
             if !logit.is_finite() {
@@ -1526,6 +1551,7 @@ mod tests {
             ctc_err_to_string,
             registry_err_to_string,
             None,
+            None,
         )
         .expect("ctc decode");
         assert_eq!(result.token_ids, vec![5, 7]);
@@ -1546,6 +1572,7 @@ mod tests {
             &detok,
             ctc_err_to_string,
             registry_err_to_string,
+            None,
             None,
         )
         .expect_err("seq2seq policy must not run through the CTC path");

--- a/crates/openasr-core/src/models/family_source_gates.rs
+++ b/crates/openasr-core/src/models/family_source_gates.rs
@@ -867,7 +867,7 @@ fn sensevoice_production_uses_complete_frame_logits_and_resolved_cache_identity(
     let encoder = std::fs::read_to_string(root.join("encoder_graph.rs"))
         .expect("read SenseVoice encoder graph");
     assert!(
-        encoder.contains("compute_output_f32(logits, want)"),
+        encoder.contains("compute_output_f32_rows_with_evidence(logits, vocab_size, frames)"),
         "SenseVoice production must read back complete frame logits",
     );
     for forbidden in ["FrameTokenIds", "top1_argmax_first_max", "device_greedy"] {

--- a/crates/openasr-core/src/models/mimo_asr/executor.rs
+++ b/crates/openasr-core/src/models/mimo_asr/executor.rs
@@ -292,6 +292,10 @@ impl Seq2SeqGreedyDecodeStepExecutor for MimoAsrGreedyStepExecutor<'_> {
             greedy_token_hint: None,
         })
     }
+
+    fn take_compute_evidence(&mut self) -> Option<crate::ggml_runtime::GgmlSelectionEvidenceRef> {
+        self.decoder.take_compute_evidence()
+    }
 }
 
 impl MimoAsrPreparedRuntime {

--- a/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
+++ b/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
@@ -84,6 +84,12 @@ pub(crate) struct MimoLlmPrefillOutput {
 }
 
 impl MimoLlmDecoderRuntime {
+    pub(crate) fn take_compute_evidence(
+        &mut self,
+    ) -> Option<crate::ggml_runtime::GgmlSelectionEvidenceRef> {
+        self.logits_runtime.take_compute_evidence()
+    }
+
     pub(crate) fn new_from_preflight(
         preflight: &crate::ggml_runtime::GgufRuntimeSourcePreflight,
         metadata: MimoLlmMetadata,

--- a/crates/openasr-core/src/models/moonshine/decoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/decoder_graph.rs
@@ -9,8 +9,8 @@ use crate::PhraseBiasConfig;
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError,
     GgmlCpuGraphRunner, GgmlCpuTensor, GgmlDecodeReuseMode, GgmlLoadedTensor,
-    GgmlLoadedWeightContext, GgmlRopeExtParams, GgmlStaticTensor, GgmlStaticTensorArena,
-    GgufRuntimeSourcePreflight,
+    GgmlLoadedWeightContext, GgmlRopeExtParams, GgmlSelectionEvidenceRef, GgmlStaticTensor,
+    GgmlStaticTensorArena, GgufRuntimeSourcePreflight,
 };
 use crate::models::decode_policy_component_registry::{
     BuiltinDecodePolicySeq2SeqTextPostprocessKind, BuiltinSeq2SeqDecodePolicyConfigInput,
@@ -378,6 +378,7 @@ pub(crate) struct MoonshineDecoderGraphRuntime {
     n_seq: usize,
     greedy_step_output_mode: DeviceGreedyStepOutputMode,
     reuse_mode: GgmlDecodeReuseMode,
+    last_step_compute_evidence: Option<GgmlSelectionEvidenceRef>,
 }
 
 /// The resolved-input identity a decoder runtime is built from: the weights
@@ -428,6 +429,10 @@ impl Seq2SeqGreedyDecodeStepExecutor for MoonshineDecoderStepExecutor<'_> {
         })?;
         Ok(output)
     }
+
+    fn take_compute_evidence(&mut self) -> Option<GgmlSelectionEvidenceRef> {
+        self.runtime.last_step_compute_evidence.take()
+    }
 }
 
 fn reuse_mode_allows_persistent_graph(reuse_mode: GgmlDecodeReuseMode) -> bool {
@@ -437,6 +442,49 @@ fn reuse_mode_allows_persistent_graph(reuse_mode: GgmlDecodeReuseMode) -> bool {
 impl MoonshineDecoderGraphRuntime {
     fn supports_reusable_decode_graph(&self) -> bool {
         reuse_mode_allows_persistent_graph(self.reuse_mode)
+    }
+
+    fn finish_step_compute<'a>(
+        last_step_compute_evidence: &mut Option<GgmlSelectionEvidenceRef>,
+        vocab_size: usize,
+        graph: &mut GgmlCpuGraphBuilder<'a>,
+        logits: GgmlCpuTensor<'a>,
+        top1: Option<GgmlCpuTensor<'a>>,
+    ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, MoonshineDecoderGraphError> {
+        match top1 {
+            Some(top1) => {
+                let readback =
+                    graph
+                        .compute_output_i32_with_evidence(top1, 1)
+                        .map_err(|error| MoonshineDecoderGraphError::GraphExecutionFailed {
+                            reason: error.to_string(),
+                        })?;
+                let (token_ids, evidence) = readback.into_parts();
+                *last_step_compute_evidence = evidence;
+                let token_id = token_ids.into_iter().next().ok_or_else(|| {
+                    MoonshineDecoderGraphError::GraphExecutionFailed {
+                        reason: "moonshine device top-1 returned no token id".to_string(),
+                    }
+                })?;
+                Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+                    logits: Vec::new(),
+                    greedy_token_hint: Some(map_device_top1_token(token_id, vocab_size)?),
+                })
+            }
+            None => {
+                let readback = graph
+                    .compute_output_f32_with_evidence(logits, vocab_size)
+                    .map_err(|error| MoonshineDecoderGraphError::GraphExecutionFailed {
+                        reason: error.to_string(),
+                    })?;
+                let (logits, evidence) = readback.into_parts();
+                *last_step_compute_evidence = evidence;
+                Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
+                    logits,
+                    greedy_token_hint: None,
+                })
+            }
+        }
     }
 
     fn ensure_resident_self_kv_arena(&mut self) -> Result<(), MoonshineDecoderGraphError> {
@@ -841,6 +889,7 @@ impl MoonshineDecoderGraphRuntime {
             n_seq,
             greedy_step_output_mode,
             reuse_mode,
+            last_step_compute_evidence: None,
         })
     }
 
@@ -1078,6 +1127,7 @@ impl MoonshineDecoderGraphRuntime {
         position: usize,
         output_mode: DeviceGreedyStepOutputMode,
     ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, MoonshineDecoderGraphError> {
+        self.last_step_compute_evidence = None;
         if !self.supports_reusable_decode_graph() {
             return Err(MoonshineDecoderGraphError::InvalidInput {
                 reason: "moonshine incremental decode requires ReusableGraph evidence".to_string(),
@@ -1152,35 +1202,13 @@ impl MoonshineDecoderGraphRuntime {
             .set_f16_bits_slice(attention_mask, &mask_bits, "moonshine_reuse_self_mask")
             .map_err(build_err("ggml_set_f16_bits_slice(reuse_mask)"))?;
 
-        match top1 {
-            Some(top1) => {
-                let token_id = graph
-                    .compute_output_i32(top1, 1)
-                    .map_err(|error| MoonshineDecoderGraphError::GraphExecutionFailed {
-                        reason: error.to_string(),
-                    })?
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| MoonshineDecoderGraphError::GraphExecutionFailed {
-                        reason: "moonshine device top-1 returned no token id".to_string(),
-                    })?;
-                Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
-                    logits: Vec::new(),
-                    greedy_token_hint: Some(map_device_top1_token(
-                        token_id,
-                        self.metadata.vocab_size,
-                    )?),
-                })
-            }
-            None => Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
-                logits: graph
-                    .compute_output_f32(logits, self.metadata.vocab_size)
-                    .map_err(|error| MoonshineDecoderGraphError::GraphExecutionFailed {
-                        reason: error.to_string(),
-                    })?,
-                greedy_token_hint: None,
-            }),
-        }
+        Self::finish_step_compute(
+            &mut self.last_step_compute_evidence,
+            self.metadata.vocab_size,
+            graph,
+            logits,
+            top1,
+        )
     }
 
     // Wired by the moonshine serve-batch owner thread in the follow-up step.
@@ -1638,6 +1666,7 @@ impl MoonshineDecoderGraphRuntime {
         tokens: &[u32],
         output_mode: DeviceGreedyStepOutputMode,
     ) -> Result<Seq2SeqGreedyDecodeStepLogitsOutput, MoonshineDecoderGraphError> {
+        self.last_step_compute_evidence = None;
         let token_count = tokens.len();
         if token_count == 0 {
             return Err(MoonshineDecoderGraphError::InvalidInput {
@@ -1759,35 +1788,13 @@ impl MoonshineDecoderGraphRuntime {
                 .map_err(build_err("ggml_set_f16_bits_slice(self_mask)"))?;
         }
 
-        match top1 {
-            Some(top1) => {
-                let token_id = graph
-                    .compute_output_i32(top1, 1)
-                    .map_err(|error| MoonshineDecoderGraphError::GraphExecutionFailed {
-                        reason: error.to_string(),
-                    })?
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| MoonshineDecoderGraphError::GraphExecutionFailed {
-                        reason: "moonshine device top-1 returned no token id".to_string(),
-                    })?;
-                Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
-                    logits: Vec::new(),
-                    greedy_token_hint: Some(map_device_top1_token(
-                        token_id,
-                        self.metadata.vocab_size,
-                    )?),
-                })
-            }
-            None => Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
-                logits: graph
-                    .compute_output_f32(logits, self.metadata.vocab_size)
-                    .map_err(|error| MoonshineDecoderGraphError::GraphExecutionFailed {
-                        reason: error.to_string(),
-                    })?,
-                greedy_token_hint: None,
-            }),
-        }
+        Self::finish_step_compute(
+            &mut self.last_step_compute_evidence,
+            self.metadata.vocab_size,
+            &mut graph,
+            logits,
+            top1,
+        )
     }
 }
 

--- a/crates/openasr-core/src/models/moonshine/ggml_executor.rs
+++ b/crates/openasr-core/src/models/moonshine/ggml_executor.rs
@@ -17,8 +17,8 @@ use super::decoder_graph::{
 use super::encoder_graph::{MoonshineEncoderGraphRuntime, MoonshineEncoderOutput};
 use super::frontend::{MoonshineFrontendError, moonshine_waveform_from_prepared_audio};
 use super::graph_config::{
-    MoonshineGraphConfigIdentity, moonshine_decoder_graph_config, moonshine_encoder_graph_config,
-    moonshine_graph_config_identity,
+    MoonshineGraphConfigIdentity, moonshine_decoder_graph_config_with_placement,
+    moonshine_encoder_graph_config, moonshine_graph_config_identity,
 };
 use super::lora::{
     MoonshineLoraError, moonshine_adapter_cache_fingerprint, resolve_moonshine_lora_adapter,
@@ -276,7 +276,11 @@ impl MoonshineGgmlExecutor {
                 reason: "candidate-resolved execution lane is missing".to_string(),
             })?;
         let encoder_config = moonshine_encoder_graph_config(backend);
-        let decoder_config = moonshine_decoder_graph_config(backend, Some(request_lane.provider()));
+        let decoder_config = moonshine_decoder_graph_config_with_placement(
+            backend,
+            Some(request_lane.provider()),
+            Some(request_lane.placement()),
+        );
         let encoder_execution_lane = request_lane.for_stage(
             encoder_config.backend,
             if encoder_config.backend == GgmlCpuGraphBackend::Cpu {

--- a/crates/openasr-core/src/models/moonshine/graph_config.rs
+++ b/crates/openasr-core/src/models/moonshine/graph_config.rs
@@ -87,18 +87,30 @@ pub(crate) fn moonshine_encoder_graph_config(backend: GgmlCpuGraphBackend) -> Gg
     apply_moonshine_neural_graph_placement(config)
 }
 
-/// Keep decoder placement separate from encoder placement. Vulkan is the
-/// validated hybrid route: the encoder remains accelerated while the decoder
+/// Keep decoder placement separate from encoder placement. Vulkan Hybrid is
+/// the validated default: the encoder remains accelerated while the decoder
 /// defaults to CPU, unless the diagnostic stage override explicitly enables
-/// GPU decode. The request output/reuse contract is resolved at the dispatch
-/// boundary and consumed by the executor; this graph config only determines
-/// the stage backend and scheduler settings.
+/// GPU decode. A FullDevice candidate must not be rewritten to CPU; the
+/// request placement owns that decision.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn moonshine_decoder_graph_config(
     backend: GgmlCpuGraphBackend,
     provider: Option<ExecutionProvider>,
 ) -> GgmlCpuGraphConfig {
+    moonshine_decoder_graph_config_with_placement(backend, provider, None)
+}
+
+pub(crate) fn moonshine_decoder_graph_config_with_placement(
+    backend: GgmlCpuGraphBackend,
+    provider: Option<ExecutionProvider>,
+    placement: Option<ExecutionPlacement>,
+) -> GgmlCpuGraphConfig {
     let mut config = moonshine_runtime_graph_config_with_scheduler_default(backend, None);
-    if config.backend.is_gpu_class() && !decoder_gpu_enabled(config.backend, provider) {
+    let keep_full_device_decoder = placement == Some(ExecutionPlacement::FullDevice);
+    if config.backend.is_gpu_class()
+        && !keep_full_device_decoder
+        && !decoder_gpu_enabled(config.backend, provider)
+    {
         config.backend = GgmlCpuGraphBackend::Cpu;
         config.use_scheduler = false;
     }
@@ -181,6 +193,18 @@ mod tests {
             );
             assert_eq!(config.backend, GgmlCpuGraphBackend::Cpu);
             assert!(!config.use_scheduler);
+        });
+    }
+
+    #[test]
+    fn full_device_vulkan_keeps_moonshine_decoder_on_gpu() {
+        with_decoder_env(None, || {
+            let config = moonshine_decoder_graph_config_with_placement(
+                GgmlCpuGraphBackend::Gpu,
+                Some(crate::device::execution_route::ExecutionProvider::Vulkan),
+                Some(ExecutionPlacement::FullDevice),
+            );
+            assert_eq!(config.backend, GgmlCpuGraphBackend::Gpu);
         });
     }
 

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -481,6 +481,10 @@ impl Seq2SeqGreedyDecodeStepExecutor for MossTdGreedyStepExecutor<'_> {
             greedy_token_hint: None,
         })
     }
+
+    fn take_compute_evidence(&mut self) -> Option<crate::ggml_runtime::GgmlSelectionEvidenceRef> {
+        self.decoder.take_compute_evidence()
+    }
 }
 
 /// Upstream `_compute_audio_token_length`'s per-chunk audio-token count: how

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -74,6 +74,12 @@ pub(crate) struct MossTdPrefillOutput {
 }
 
 impl MossTdDecoderRuntime {
+    pub(crate) fn take_compute_evidence(
+        &mut self,
+    ) -> Option<crate::ggml_runtime::GgmlSelectionEvidenceRef> {
+        self.logits_runtime.take_compute_evidence()
+    }
+
     pub(crate) fn graph_lanes(
         &self,
     ) -> (

--- a/crates/openasr-core/src/models/native_execution_services.rs
+++ b/crates/openasr-core/src/models/native_execution_services.rs
@@ -1704,6 +1704,17 @@ pub struct ActivationReservationContext {
     cohort_id: MemoryReservationCohortId,
 }
 
+impl ActivationReservationContext {
+    /// Mint a request-scoped cohort so concurrent longform slices and nested
+    /// host owners share one exclusive system-memory gate. Independent
+    /// candidate fallbacks still mint their own attempt journals underneath.
+    pub(crate) fn mint() -> Self {
+        Self {
+            cohort_id: MemoryReservationCohortId::new(ExecutionCacheAttemptId::next().0),
+        }
+    }
+}
+
 pub struct BrokerActivationReservation {
     batch: Option<DeviceMemoryReservationBatch>,
     context: ActivationReservationContext,
@@ -3485,6 +3496,36 @@ mod tests {
         assert!(next.result.is_ok());
         // A completed attempt must never reopen the previous cohort gate.
         assert_ne!(outer, next.result.unwrap());
+    }
+
+    #[test]
+    fn nested_candidate_attempts_keep_parent_activation_cohort() {
+        let services = test_native_execution_services();
+        let candidate = cpu_candidate();
+        let parent = ActivationReservationContext::mint();
+        let parent_id = parent.cohort_id;
+        let _guard = install_activation_reservation_context(Some(parent));
+        let outcome = run_execution_candidate_attempt(services.as_ref(), &candidate, || {
+            assert_eq!(
+                current_memory_reservation_cohort_id().expect("attempt cohort"),
+                parent_id
+            );
+            let nested = run_execution_candidate_attempt(services.as_ref(), &candidate, || {
+                Ok::<_, ()>(current_memory_reservation_cohort_id().expect("nested cohort"))
+            });
+            assert_eq!(nested.result.unwrap(), parent_id);
+            let context = current_native_execution_context().expect("attempt context");
+            let worker = std::thread::spawn(move || {
+                let _guard = install_native_execution_context(context);
+                current_memory_reservation_cohort_id().expect("worker cohort")
+            })
+            .join()
+            .unwrap();
+            assert_eq!(worker, parent_id);
+            Ok::<_, ()>(())
+        });
+        assert!(outcome.result.is_ok());
+        assert!(outcome.candidate_failure.is_none());
     }
 
     #[test]

--- a/crates/openasr-core/src/models/parakeet_ctc/executor.rs
+++ b/crates/openasr-core/src/models/parakeet_ctc/executor.rs
@@ -417,6 +417,7 @@ fn decode_parakeet_ctc_result_with_progress(
         ctc_err_to_string,
         registry_err_to_string,
         decode_work_progress,
+        None,
     )
 }
 

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -1026,10 +1026,11 @@ pub(crate) fn resolve_qwen_family_production_kv_cache_policy(
 }
 
 /// Resident K/V graphs are authorized only by the immutable planner result.
-/// GPU class and scheduler-off are placement, not proof: production reuse
-/// evidence is Unknown, so every lane is FreshGraph and must materialize
-/// host KV. Compact first-max is a separate output_plan and cannot keep an
-/// empty ResidentOnly owner while the decode path rebuilds a growing graph.
+/// GPU class and scheduler-off are placement, not proof. HIP and Vulkan
+/// reuse is now planner-validated (ReusableGraph + FullLogits); CUDA and
+/// Metal stay FreshGraph and must materialize host KV. Compact first-max is
+/// a separate output_plan and cannot keep an empty ResidentOnly owner while
+/// the decode path rebuilds a growing graph.
 pub(crate) fn qwen_llm_uses_resident_kv_graph(
     resolved_runtime: ResolvedFamilyRuntimeInput,
 ) -> bool {

--- a/crates/openasr-core/src/models/request_execution_receipt.rs
+++ b/crates/openasr-core/src/models/request_execution_receipt.rs
@@ -274,6 +274,70 @@ struct ReceiptState {
     trace_overflowed: bool,
     graph_lifecycle_checkpoint: (usize, bool),
     completed: bool,
+    /// Nested `begin_candidate_attempt` must not erase the parent candidate's
+    /// shipped facts. Auxiliary stages (punctuation, VAD, aligner) open an
+    /// inner attempt on the same collector; restoring this stack keeps the
+    /// ASR row intact after the inner attempt finishes.
+    attempt_stack: Vec<ReceiptAttemptCheckpoint>,
+}
+
+#[derive(Debug, Clone)]
+struct ReceiptAttemptCheckpoint {
+    facts: Option<NativeExecutionRequestFacts>,
+    observed_backend_identities: BTreeSet<usize>,
+    placement: GgmlExecutionPlacementSummary,
+    trace_events: Vec<String>,
+    token_steps: Vec<NativeExecutionTokenStep>,
+    top_k_margins: BTreeMap<usize, f32>,
+    logits_hashes: BTreeMap<usize, String>,
+    full_logits_steps: Vec<FullLogitsStep>,
+    full_logits_elements: usize,
+    next_decode_step_index: usize,
+    active_decode_step: Option<ActiveDecodeStep>,
+    trace_binding_invalid: bool,
+    trace_overflowed: bool,
+    graph_lifecycle_checkpoint: (usize, bool),
+    completed: bool,
+}
+
+impl ReceiptState {
+    fn take_attempt_checkpoint(&mut self) -> ReceiptAttemptCheckpoint {
+        ReceiptAttemptCheckpoint {
+            facts: self.facts.take(),
+            observed_backend_identities: std::mem::take(&mut self.observed_backend_identities),
+            placement: std::mem::take(&mut self.placement),
+            trace_events: std::mem::take(&mut self.trace_events),
+            token_steps: std::mem::take(&mut self.token_steps),
+            top_k_margins: std::mem::take(&mut self.top_k_margins),
+            logits_hashes: std::mem::take(&mut self.logits_hashes),
+            full_logits_steps: std::mem::take(&mut self.full_logits_steps),
+            full_logits_elements: std::mem::take(&mut self.full_logits_elements),
+            next_decode_step_index: std::mem::take(&mut self.next_decode_step_index),
+            active_decode_step: self.active_decode_step.take(),
+            trace_binding_invalid: std::mem::take(&mut self.trace_binding_invalid),
+            trace_overflowed: std::mem::take(&mut self.trace_overflowed),
+            graph_lifecycle_checkpoint: self.graph_lifecycle_checkpoint,
+            completed: std::mem::take(&mut self.completed),
+        }
+    }
+
+    fn restore_attempt_checkpoint(&mut self, checkpoint: ReceiptAttemptCheckpoint) {
+        self.facts = checkpoint.facts;
+        self.observed_backend_identities = checkpoint.observed_backend_identities;
+        self.placement = checkpoint.placement;
+        self.trace_events = checkpoint.trace_events;
+        self.token_steps = checkpoint.token_steps;
+        self.top_k_margins = checkpoint.top_k_margins;
+        self.logits_hashes = checkpoint.logits_hashes;
+        self.full_logits_steps = checkpoint.full_logits_steps;
+        self.full_logits_elements = checkpoint.full_logits_elements;
+        self.next_decode_step_index = checkpoint.next_decode_step_index;
+        self.active_decode_step = checkpoint.active_decode_step;
+        self.trace_binding_invalid = checkpoint.trace_binding_invalid;
+        self.trace_overflowed = checkpoint.trace_overflowed;
+        self.graph_lifecycle_checkpoint = checkpoint.graph_lifecycle_checkpoint;
+        self.completed = checkpoint.completed;
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -399,26 +463,27 @@ impl NativeExecutionReceiptCollector {
     }
 
     /// Candidate attempts are transactional: a failed candidate cannot leave
-    /// facts or trace events that a later fallback might publish.
+    /// facts or trace events that a later fallback might publish. Nested
+    /// attempts push the parent row aside and restore it on finish so an
+    /// auxiliary stage cannot erase the ASR candidate's shipped facts.
     pub(crate) fn begin_candidate_attempt(&self) {
         self.graph_lifecycle.begin_observation_scope();
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        state.facts = None;
-        state.observed_backend_identities.clear();
-        state.placement = GgmlExecutionPlacementSummary::default();
-        state.trace_events.clear();
-        state.token_steps.clear();
-        state.top_k_margins.clear();
-        state.logits_hashes.clear();
-        state.full_logits_steps.clear();
-        state.full_logits_elements = 0;
-        state.next_decode_step_index = 0;
-        state.active_decode_step = None;
+        let parent = state.take_attempt_checkpoint();
+        // A nested begin happens while the outer attempt is still open.
+        // Sequential warmup/measured begins happen after the previous attempt
+        // finished (`completed == true`) and must start a fresh row.
+        let nested = !parent.completed
+            && (parent.facts.is_some()
+                || !parent.token_steps.is_empty()
+                || !parent.trace_events.is_empty());
+        if nested {
+            state.attempt_stack.push(parent);
+        }
         state.trace_binding_invalid = state.trace_mode.is_some() && state.trace_run_id.is_none();
-        state.trace_overflowed = false;
         state.graph_lifecycle_checkpoint = self.graph_lifecycle.checkpoint();
         state.completed = false;
     }
@@ -429,23 +494,21 @@ impl NativeExecutionReceiptCollector {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let committed = committed && !state.request_attempt_conflicted;
-        let rollback_checkpoint = (!committed).then_some(state.graph_lifecycle_checkpoint);
-        if committed {
+        let parent = state.attempt_stack.pop();
+        let restore_parent = parent.as_ref().is_some_and(|parent| {
+            !parent.completed
+                && (parent.facts.is_some()
+                    || !parent.token_steps.is_empty()
+                    || !parent.trace_events.is_empty())
+        });
+        let rollback_checkpoint =
+            (!committed || restore_parent).then_some(state.graph_lifecycle_checkpoint);
+        if restore_parent {
+            state.restore_attempt_checkpoint(parent.expect("parent presence checked"));
+        } else if committed {
             state.completed = true;
         } else {
-            state.facts = None;
-            state.observed_backend_identities.clear();
-            state.placement = GgmlExecutionPlacementSummary::default();
-            state.trace_events.clear();
-            state.token_steps.clear();
-            state.top_k_margins.clear();
-            state.logits_hashes.clear();
-            state.full_logits_steps.clear();
-            state.full_logits_elements = 0;
-            state.next_decode_step_index = 0;
-            state.active_decode_step = None;
-            state.trace_binding_invalid = false;
-            state.trace_overflowed = false;
+            let _ = state.take_attempt_checkpoint();
             state.completed = false;
         }
         // Lifecycle producers never run while the receipt mutex is held.
@@ -512,9 +575,8 @@ impl NativeExecutionReceiptCollector {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         match &state.facts {
             Some(existing) if existing != &facts => {
-                // The same candidate may build several graphs, but immutable
-                // request facts must not drift within one receipt row.
-                state.facts = None;
+                // First writer wins. A later graph in the same candidate must
+                // not erase shipped output_plan/reuse_mode by disagreeing.
             }
             Some(_) => {}
             None => state.facts = Some(facts),
@@ -558,8 +620,11 @@ impl NativeExecutionReceiptCollector {
                 .as_ref()
                 .is_some_and(|actual| actual != actual_device);
         if route_drifted || new_backend_device_drifted {
-            state.facts = None;
-            state.observed_backend_identities.clear();
+            // Live backend attestation is fail-closed at the candidate
+            // boundary. Erasing request facts here would let transcription
+            // succeed while the shipped output_plan/reuse_mode disappeared
+            // from the receipt. Keep the first observation; a later handle
+            // still cannot overwrite it.
             return;
         }
         if facts.actual_provider.is_none() {
@@ -615,6 +680,99 @@ impl NativeExecutionReceiptCollector {
         step_index
     }
 
+    /// Bind one token under a single lock so concurrent longform slices cannot
+    /// overwrite each other's `active_decode_step`. Call after the shipped
+    /// decode already produced logits and the selected token.
+    pub(crate) fn commit_decode_step(
+        &self,
+        compute: Option<GgmlSelectionEvidenceRef>,
+        token_id: u32,
+        is_eot: bool,
+        logits: &[f32],
+    ) {
+        let logits_sha256 = (!logits.is_empty()).then(|| diagnostic_logits_sha256(logits));
+        let margin = if logits.len() < 2 {
+            None
+        } else {
+            let mut best = None;
+            let mut second = None;
+            for logit in logits.iter().copied().filter(|value| value.is_finite()) {
+                match best {
+                    None => best = Some(logit),
+                    Some(first) if logit > first => {
+                        second = best;
+                        best = Some(logit);
+                    }
+                    Some(first) if second.is_none_or(|value| logit > value) && logit != first => {
+                        second = Some(logit);
+                    }
+                    _ => {}
+                }
+            }
+            best.zip(second).map(|(first, second)| first - second)
+        };
+        let step_index = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let step_index = state.next_decode_step_index;
+            Self::begin_decode_step_locked(&mut state, step_index, compute);
+            if let Some(active) = state.active_decode_step.as_mut() {
+                if !logits.is_empty() {
+                    active.top_k_recorded = true;
+                }
+                active.token_recorded = true;
+            }
+            if let Some(margin) = margin {
+                state.top_k_margins.insert(step_index, margin);
+            }
+            if let Some(hash) = logits_sha256.clone() {
+                state.logits_hashes.insert(step_index, hash);
+            }
+            state.token_steps.push(NativeExecutionTokenStep {
+                step_index,
+                token_id,
+                is_eot,
+                top2_margin: margin,
+                logits_sha256,
+                compute,
+            });
+            let requires_complete_output = state.facts.as_ref().is_some_and(|facts| {
+                matches!(
+                    facts.resolved_runtime.output_plan(),
+                    crate::ggml_runtime::GgmlDecodeOutputPlan::FullLogits
+                )
+            });
+            let Some(active) = state.active_decode_step.take() else {
+                state.trace_binding_invalid = true;
+                return;
+            };
+            if active.compute.is_none()
+                || !active.token_recorded
+                || (requires_complete_output && !logits.is_empty() && !active.top_k_recorded)
+            {
+                state.trace_binding_invalid = true;
+            }
+            match state.next_decode_step_index.checked_add(1) {
+                Some(next) => state.next_decode_step_index = next,
+                None => state.trace_overflowed = true,
+            }
+            step_index
+        };
+        self.record_trace_event(
+            serde_json::json!({
+                "schema": "openasr.gpu-correctness-trace.v1",
+                "event": "token",
+                "step_index": step_index,
+                "token_id": token_id,
+                "is_eot": usize::from(is_eot),
+                "compute": compute,
+            })
+            .to_string(),
+        );
+    }
+
     fn begin_decode_step_locked(
         state: &mut ReceiptState,
         step_index: usize,
@@ -666,6 +824,7 @@ impl NativeExecutionReceiptCollector {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn abort_decode_step(&self, step_index: usize) {
         let mut state = self
             .state
@@ -1230,6 +1389,67 @@ mod tests {
         assert!(trace.contains("\"token_id\":22"));
         assert_eq!(snapshot.token_steps.len(), 1);
         assert_eq!(snapshot.token_steps[0].token_id, 22);
+    }
+
+    #[test]
+    fn nested_candidate_restores_parent_request_facts() {
+        let receipt = NativeExecutionReceiptCollector::new();
+        receipt.begin_candidate_attempt();
+        receipt.record_facts(seq2seq_facts());
+        receipt.record_token(0, 7, false);
+        receipt.begin_candidate_attempt();
+        let mut nested_facts = seq2seq_facts();
+        nested_facts.pack_content_id = "nested-aux-pack".to_string();
+        receipt.record_facts(nested_facts);
+        receipt.record_token(0, 99, false);
+        receipt.finish_candidate_attempt(true);
+        receipt.finish_candidate_attempt(true);
+        let snapshot = receipt.snapshot();
+        let facts = snapshot.facts.expect("parent facts");
+        assert_eq!(facts.pack_content_id, "test-pack");
+        assert_eq!(snapshot.token_steps.len(), 1);
+        assert_eq!(snapshot.token_steps[0].token_id, 7);
+        assert!(snapshot.completed);
+    }
+
+    #[test]
+    fn later_facts_writer_cannot_erase_first_request_facts() {
+        let receipt = NativeExecutionReceiptCollector::new();
+        receipt.begin_candidate_attempt();
+        receipt.record_facts(seq2seq_facts());
+        let mut drifted = seq2seq_facts();
+        drifted.pack_content_id = "other-pack".to_string();
+        receipt.record_facts(drifted);
+        receipt.finish_candidate_attempt(true);
+        let facts = receipt.snapshot().facts.expect("first facts");
+        assert_eq!(facts.pack_content_id, "test-pack");
+    }
+
+    #[test]
+    fn backend_observation_drift_does_not_erase_request_facts() {
+        let receipt = NativeExecutionReceiptCollector::new();
+        receipt.begin_candidate_attempt();
+        receipt.record_facts(seq2seq_facts());
+        receipt.record_backend_observation(
+            1,
+            ExecutionProvider::Cpu,
+            "CPU",
+            &test_actual_device(),
+            false,
+        );
+        let mut other = test_actual_device();
+        other.description = "other CPU".to_string();
+        receipt.record_backend_observation(2, ExecutionProvider::Cpu, "CPU", &other, true);
+        receipt.record_token(0, 7, false);
+        receipt.finish_candidate_attempt(true);
+        let facts = receipt.snapshot().facts.expect("request facts");
+        assert_eq!(facts.pack_content_id, "test-pack");
+        assert_eq!(facts.actual_provider, Some(ExecutionProvider::Cpu));
+        assert_eq!(facts.scheduler_enabled, Some(false));
+        assert_eq!(
+            facts.actual_device.as_ref().unwrap().description,
+            "test CPU"
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/models/request_execution_receipt.rs
+++ b/crates/openasr-core/src/models/request_execution_receipt.rs
@@ -760,6 +760,40 @@ impl NativeExecutionReceiptCollector {
             }
             step_index
         };
+        if !logits.is_empty() {
+            let mut top = Vec::<(usize, f32)>::new();
+            for (token, logit) in logits.iter().copied().enumerate() {
+                if !logit.is_finite() {
+                    continue;
+                }
+                let insert_at = top
+                    .iter()
+                    .position(|(_, existing)| logit.total_cmp(existing).is_gt());
+                if let Some(insert_at) = insert_at {
+                    top.insert(insert_at, (token, logit));
+                } else if top.len() < MAX_TRACE_TOP_K {
+                    top.push((token, logit));
+                }
+                if top.len() > MAX_TRACE_TOP_K {
+                    top.truncate(MAX_TRACE_TOP_K);
+                }
+            }
+            let items = top
+                .iter()
+                .map(|(token, value)| serde_json::json!({"token_id": token, "value": value}))
+                .collect::<Vec<_>>();
+            self.record_trace_event(
+                serde_json::json!({
+                    "schema": "openasr.gpu-correctness-trace.v1",
+                    "event": "top_k",
+                    "step_index": step_index,
+                    "items": items,
+                    "top1_top2_margin": margin,
+                    "compute": compute,
+                })
+                .to_string(),
+            );
+        }
         self.record_trace_event(
             serde_json::json!({
                 "schema": "openasr.gpu-correctness-trace.v1",

--- a/crates/openasr-core/src/models/sensevoice/encoder_graph.rs
+++ b/crates/openasr-core/src/models/sensevoice/encoder_graph.rs
@@ -11,11 +11,11 @@
 
 use crate::ggml_runtime::{
     ArenaAllocError, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError,
-    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor, GgmlLoadedWeightContext, GgmlStaticTensor,
-    GgmlStaticTensorArena, GgufRuntimeSourcePreflight, WeightSlot,
-    alloc_static_f16 as arena_alloc_static_f16, alloc_static_f32 as arena_alloc_static_f32,
-    bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
-    upload_static_f32 as arena_upload_static_f32,
+    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor, GgmlLoadedWeightContext,
+    GgmlSelectionEvidenceRef, GgmlStaticTensor, GgmlStaticTensorArena, GgufRuntimeSourcePreflight,
+    WeightSlot, alloc_static_f16 as arena_alloc_static_f16,
+    alloc_static_f32 as arena_alloc_static_f32, bind_loaded as arena_bind_loaded,
+    upload_static_f16 as arena_upload_static_f16, upload_static_f32 as arena_upload_static_f32,
 };
 use crate::models::runtime_memory::{checked_sum, element_bytes};
 use crate::models::system_memory_owner::{SystemMemoryCapacity, SystemMemoryOwnerError};
@@ -72,6 +72,7 @@ pub(crate) struct SenseVoiceEncoderOutput {
     pub frame_count: usize,
     pub vocab_size: usize,
     pub logits: Vec<f32>,
+    pub frame_compute: Option<Vec<GgmlSelectionEvidenceRef>>,
 }
 
 // `WeightSlot` (imported above from `ggml_runtime`): arena tensor or
@@ -418,21 +419,7 @@ impl SenseVoiceEncoderGraph {
             .set_f32_slice(input_t, &input.data, "upload_input")
             .map_err(bf("upload_input"))?;
 
-        let want = metadata.vocab_size.checked_mul(frames).ok_or_else(|| {
-            SenseVoiceEncoderError::Shape {
-                reason: "logits overflow".into(),
-            }
-        })?;
-        let logits = graph.compute_output_f32(logits, want).map_err(|error| {
-            SenseVoiceEncoderError::GraphExecutionFailed {
-                reason: error.to_string(),
-            }
-        })?;
-        Ok(SenseVoiceEncoderOutput {
-            frame_count: frames,
-            vocab_size: metadata.vocab_size,
-            logits,
-        })
+        read_sensevoice_encoder_logits(&mut graph, logits, metadata.vocab_size, frames)
     }
 
     /// Build the four prompt rows, input scaling, and sinusoidal position
@@ -546,22 +533,33 @@ impl SenseVoiceEncoderGraph {
         graph
             .set_f32_slice(position, &positions, "sensevoice_positions")
             .map_err(bf("upload_positions"))?;
-        let want = metadata.vocab_size.checked_mul(frames).ok_or_else(|| {
-            SenseVoiceEncoderError::Shape {
-                reason: "SenseVoice logits size overflowed".to_string(),
-            }
-        })?;
-        let logits = graph.compute_output_f32(logits, want).map_err(|error| {
-            SenseVoiceEncoderError::GraphExecutionFailed {
-                reason: error.to_string(),
-            }
-        })?;
-        Ok(SenseVoiceEncoderOutput {
-            frame_count: frames,
-            vocab_size: metadata.vocab_size,
-            logits,
-        })
+        read_sensevoice_encoder_logits(&mut graph, logits, metadata.vocab_size, frames)
     }
+}
+
+fn read_sensevoice_encoder_logits<'a>(
+    graph: &mut GgmlCpuGraphBuilder<'a>,
+    logits: GgmlCpuTensor<'a>,
+    vocab_size: usize,
+    frames: usize,
+) -> Result<SenseVoiceEncoderOutput, SenseVoiceEncoderError> {
+    if vocab_size.checked_mul(frames).is_none() {
+        return Err(SenseVoiceEncoderError::Shape {
+            reason: "SenseVoice logits size overflowed".to_string(),
+        });
+    }
+    let output = graph
+        .compute_output_f32_rows_with_evidence(logits, vocab_size, frames)
+        .map_err(|error| SenseVoiceEncoderError::GraphExecutionFailed {
+            reason: error.to_string(),
+        })?;
+    let (logits, frame_compute) = output.into_parts();
+    Ok(SenseVoiceEncoderOutput {
+        frame_count: frames,
+        vocab_size,
+        logits,
+        frame_compute,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/openasr-core/src/models/sensevoice/executor.rs
+++ b/crates/openasr-core/src/models/sensevoice/executor.rs
@@ -246,6 +246,7 @@ impl SenseVoicePreparedRuntime {
             ctc_err_to_string,
             registry_err_to_string,
             decode_work_progress,
+            output.frame_compute.as_deref(),
         )
     }
 

--- a/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
+++ b/crates/openasr-core/src/models/seq2seq_greedy_decode.rs
@@ -353,31 +353,26 @@ pub(crate) fn run_seq2seq_greedy_decode_loop_v0(
         };
         let step_logits = step_executor.decode_step_logits(step_input)?;
         let compute_evidence = step_executor.take_compute_evidence();
-        let receipt =
-            crate::models::native_execution_services::current_execution_receipt_collector();
-        if let Some(receipt) = &receipt {
-            receipt.begin_decode_step(step_index, compute_evidence);
-        }
-        let selection = match select_seq2seq_greedy_step_token(
+        let logits_for_receipt = step_logits.logits.clone();
+        let selection = select_seq2seq_greedy_step_token(
             config,
             &generated,
             step_index,
             step_logits,
             stop_token_ids.as_slice(),
             on_topk,
-        ) {
-            Ok(selection) => selection,
-            Err(error) => {
-                if let Some(receipt) = &receipt {
-                    receipt.abort_decode_step(step_index);
-                }
-                return Err(error);
-            }
-        };
-        trace_token(step_index, selection.token_id, selection.reached_eot);
-        if let Some(receipt) = &receipt {
-            receipt.finish_decode_step(step_index);
+        )?;
+        if let Some(receipt) =
+            crate::models::native_execution_services::current_execution_receipt_collector()
+        {
+            receipt.commit_decode_step(
+                compute_evidence,
+                selection.token_id,
+                selection.reached_eot,
+                &logits_for_receipt,
+            );
         }
+        trace_token(step_index, selection.token_id, selection.reached_eot);
         if let Some(observer) = decode_work_progress {
             observer.report(step_index + 1, config.max_generated_tokens);
         }
@@ -487,6 +482,9 @@ pub(crate) fn select_seq2seq_greedy_step_token(
         let is_suppressed = config.suppress_token_ids.contains(&next_token)
             || (step_index == 0 && config.suppress_first_step_token_ids.contains(&next_token));
         if !is_suppressed {
+            if step_logits.logits.len() == config.vocab_size {
+                on_topk(step_index, &step_logits.logits);
+            }
             return Ok(Seq2SeqGreedyStepSelection {
                 token_id: next_token,
                 reached_eot: is_stop_token(next_token, stop_token_ids),
@@ -979,7 +977,7 @@ mod tests {
     }
 
     #[test]
-    fn seq2seq_step_selection_uses_unsuppressed_hint_without_topk() {
+    fn seq2seq_step_selection_emits_topk_for_unsuppressed_hint_with_logits() {
         let config = Seq2SeqGreedyDecodeConfig {
             initial_prompt_tokens: vec![42],
             eot_token_id: 7,
@@ -1018,7 +1016,7 @@ mod tests {
                 probability: 1.0 / 16.0,
             }
         );
-        assert_eq!(topk_calls, 0);
+        assert_eq!(topk_calls, 1);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/wav2vec2_ctc/executor.rs
+++ b/crates/openasr-core/src/models/wav2vec2_ctc/executor.rs
@@ -404,6 +404,7 @@ fn decode_wav2vec2_ctc_result_with_progress(
         ctc_err_to_string,
         registry_err_to_string,
         decode_work_progress,
+        None,
     )
 }
 

--- a/crates/openasr-core/src/models/whisper/ggml_decoder_graph.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_decoder_graph.rs
@@ -14,8 +14,8 @@ use thiserror::Error;
 
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError,
-    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor, GgmlLoadedWeightContext, GgmlStaticTensor,
-    GgmlStaticTensorArena, GgufRuntimeSourcePreflight,
+    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor, GgmlLoadedWeightContext,
+    GgmlSelectionEvidenceRef, GgmlStaticTensor, GgmlStaticTensorArena, GgufRuntimeSourcePreflight,
 };
 use crate::nn::attn::{
     AttentionHeadLayout, AttentionReshapeSteps, STANDARD_HEAD_PERMUTE_AXES,
@@ -824,6 +824,7 @@ pub(crate) struct WhisperDecoderGraphExecutionOutput {
     pub prefix_len: usize,
     pub vocab_size: usize,
     pub last_token_cross_attention_frame_probs: Option<Vec<f32>>,
+    pub compute_evidence: Option<GgmlSelectionEvidenceRef>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -3052,7 +3053,7 @@ fn execute_whisper_decoder_with_position_offset_ggml_v0(
     let upload_ms = upload_start.elapsed().as_millis();
 
     let compute_start = Instant::now();
-    let (logits, last_token_cross_attention_frame_probs) =
+    let (logits, last_token_cross_attention_frame_probs, compute_evidence) =
         if let Some(attention_tensor) = last_token_cross_attention_tensor {
             let attention_len = encoder_frames
                 .checked_mul(prefix_len)
@@ -3060,8 +3061,8 @@ fn execute_whisper_decoder_with_position_offset_ggml_v0(
                 .ok_or_else(|| WhisperDecoderGraphExecutionError::GraphExecutionFailed {
                     reason: "decoder cross-attention output shape overflowed".to_string(),
                 })?;
-            let mut outputs = graph
-                .compute_outputs_f32(&[
+            let output = graph
+                .compute_outputs_f32_with_evidence(&[
                     (last_token_logits_tensor, plan.output_projection.vocab_size),
                     (attention_tensor, attention_len),
                 ])
@@ -3070,6 +3071,7 @@ fn execute_whisper_decoder_with_position_offset_ggml_v0(
                         reason: format!("decoder graph compute failed: {error}"),
                     },
                 )?;
+            let (mut outputs, evidence) = output.into_parts();
             let attention = outputs.pop().ok_or_else(|| {
                 WhisperDecoderGraphExecutionError::GraphExecutionFailed {
                     reason: "decoder graph did not return cross-attention output".to_string(),
@@ -3086,16 +3088,20 @@ fn execute_whisper_decoder_with_position_offset_ggml_v0(
                 prefix_len,
                 config.attention_heads,
             )?;
-            (logits, Some(frame_probs))
+            (logits, Some(frame_probs), evidence)
         } else {
-            let logits = graph
-                .compute_output_f32(last_token_logits_tensor, plan.output_projection.vocab_size)
+            let output = graph
+                .compute_output_f32_with_evidence(
+                    last_token_logits_tensor,
+                    plan.output_projection.vocab_size,
+                )
                 .map_err(
                     |error| WhisperDecoderGraphExecutionError::GraphExecutionFailed {
                         reason: format!("decoder graph compute failed: {error}"),
                     },
                 )?;
-            (logits, None)
+            let (logits, evidence) = output.into_parts();
+            (logits, None, evidence)
         };
     if logits.iter().any(|value| !value.is_finite()) {
         return Err(WhisperDecoderGraphExecutionError::GraphExecutionFailed {
@@ -3113,6 +3119,7 @@ fn execute_whisper_decoder_with_position_offset_ggml_v0(
         prefix_len,
         vocab_size: plan.output_projection.vocab_size,
         last_token_cross_attention_frame_probs,
+        compute_evidence,
     };
     let compute_ms = compute_start.elapsed().as_millis();
 
@@ -3255,13 +3262,14 @@ pub(crate) fn run_whisper_decoder_reused_incremental_step_ggml_v0(
     let upload_ms = upload_start.elapsed().as_millis();
 
     let compute_start = Instant::now();
-    let logits = graph
-        .compute_output_f32(logits_tensor, plan.output_projection.vocab_size)
+    let output = graph
+        .compute_output_f32_with_evidence(logits_tensor, plan.output_projection.vocab_size)
         .map_err(
             |error| WhisperDecoderGraphExecutionError::GraphExecutionFailed {
                 reason: format!("decoder reusable graph compute failed: {error}"),
             },
         )?;
+    let (logits, compute_evidence) = output.into_parts();
     let compute_ms = compute_start.elapsed().as_millis();
     if logits.iter().any(|value| !value.is_finite()) {
         return Err(WhisperDecoderGraphExecutionError::GraphExecutionFailed {
@@ -3292,6 +3300,7 @@ pub(crate) fn run_whisper_decoder_reused_incremental_step_ggml_v0(
         prefix_len: 1,
         vocab_size: plan.output_projection.vocab_size,
         last_token_cross_attention_frame_probs: None,
+        compute_evidence,
     })
 }
 

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -30,8 +30,8 @@ use crate::device::execution_route::ExecutionProvider;
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError,
     GgmlCpuGraphRunner, GgmlCpuTensor, GgmlDecodeReuseMode, GgmlLoadedTensor,
-    GgmlLoadedWeightBindingIdentity, GgmlLoadedWeightContext, GgmlStaticTensor,
-    GgmlStaticTensorArena, GgufRuntimeSourcePreflight, RequestBackendPreference,
+    GgmlLoadedWeightBindingIdentity, GgmlLoadedWeightContext, GgmlSelectionEvidenceRef,
+    GgmlStaticTensor, GgmlStaticTensorArena, GgufRuntimeSourcePreflight, RequestBackendPreference,
     request_backend_override,
 };
 use crate::models::admitted_pinned_runtime_actor_pool::{
@@ -1160,6 +1160,7 @@ struct WhisperDecoderStepLogits {
     last_token_cross_attention_frame_probs: Option<Vec<f32>>,
     decoder_graph_run_ms: u128,
     logits_ms: u128,
+    compute_evidence: Option<GgmlSelectionEvidenceRef>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -3628,6 +3629,7 @@ fn run_whisper_decoder_step_ggml_v0(
         last_token_cross_attention_frame_probs: output.last_token_cross_attention_frame_probs,
         decoder_graph_run_ms,
         logits_ms: logits_start.elapsed().as_millis(),
+        compute_evidence: output.compute_evidence,
     })
 }
 
@@ -5903,6 +5905,7 @@ struct WhisperGreedyDecodeStepRunnerAdapter<'a> {
     decoder_tensor_cache: WhisperDecoderExecutionTensorCache,
     plan_by_token_count: BTreeMap<usize, Arc<WhisperDecoderGraphPlan>>,
     token_alignments: Vec<WhisperGeneratedTokenAlignment>,
+    last_step_compute_evidence: Option<GgmlSelectionEvidenceRef>,
 }
 
 impl WhisperGreedyDecodeStepRunnerAdapter<'_> {
@@ -6072,6 +6075,7 @@ impl Seq2SeqGreedyDecodeStepExecutor for WhisperGreedyDecodeStepRunnerAdapter<'_
                 last_token_cross_attention_frame_probs: None,
                 decoder_graph_run_ms,
                 logits_ms: logits_start.elapsed().as_millis(),
+                compute_evidence: output.compute_evidence,
             })
         } else {
             run_whisper_decoder_step_ggml_v0(
@@ -6146,10 +6150,15 @@ impl Seq2SeqGreedyDecodeStepExecutor for WhisperGreedyDecodeStepRunnerAdapter<'_
                 self.decode_loop_start,
             );
         }
+        self.last_step_compute_evidence = step_logits.compute_evidence;
         Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
             logits: step_logits.logits,
             greedy_token_hint: step_logits.greedy_token_hint,
         })
+    }
+
+    fn take_compute_evidence(&mut self) -> Option<GgmlSelectionEvidenceRef> {
+        self.last_step_compute_evidence.take()
     }
 }
 
@@ -6359,6 +6368,7 @@ fn run_whisper_decode_loop(
         decoder_tensor_cache: WhisperDecoderExecutionTensorCache::default(),
         plan_by_token_count: BTreeMap::new(),
         token_alignments: Vec::new(),
+        last_step_compute_evidence: None,
     };
     let decode_text_token_ids = |token_ids: &[u32]| {
         tokenizer.decode_text_token_ids(token_ids).map_err(|error| {

--- a/crates/openasr-core/src/models/xasr_zipformer/greedy.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/greedy.rs
@@ -80,10 +80,9 @@ pub(crate) trait XasrGreedyDecodeBackend {
     }
 }
 
-/// Record one emitted (non-blank) transcript token. Blank and speculative
-/// blank-prefix selections stay on the joiner alignment path and are not
-/// short-audio decode steps. The host joiner is pure Rust and has no ggml
-/// compute witness; only device-head rows are native receipt steps.
+/// Record one joiner selection that has a ggml compute witness. Host joiner
+/// rows have no native evidence and are skipped. Device-head speculative
+/// blanks and scalar recomputes keep their readback-bound receipt steps.
 fn record_selection_receipt(
     evidence: Option<&XasrSelectionEvidence>,
     output_index: usize,
@@ -316,6 +315,9 @@ pub(crate) fn greedy_decode_frames_incremental_with_backend<B: XasrGreedyDecodeB
             if blank_prefix_len > remaining_frames {
                 return Err("xasr speculative blank prefix exceeds remaining frames".to_string());
             }
+            for output_index in 0..blank_prefix_len {
+                record_selection_receipt(speculative_evidence.as_ref(), output_index, blank_id);
+            }
             if speculative_context.is_some() {
                 decoder_projection_valid = true;
             }
@@ -334,6 +336,7 @@ pub(crate) fn greedy_decode_frames_incremental_with_backend<B: XasrGreedyDecodeB
             let token_id = backend.next_token()?;
             let selection_evidence = backend.take_selection_evidence();
             if token_id == blank_id {
+                record_selection_receipt(selection_evidence.as_ref(), 0, token_id);
                 break;
             }
             let probability = backend.token_probability(token_id)?;
@@ -723,13 +726,13 @@ mod tests {
             .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
             .filter(|event| event.get("event").and_then(serde_json::Value::as_str) == Some("token"))
             .collect::<Vec<_>>();
-        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens.len(), 4);
         assert_eq!(
             tokens
                 .iter()
                 .map(|event| event["token_id"].as_u64().unwrap())
                 .collect::<Vec<_>>(),
-            vec![1]
+            vec![0, 0, 1, 0]
         );
         assert_eq!(
             tokens
@@ -741,7 +744,7 @@ mod tests {
                     )
                 })
                 .collect::<Vec<_>>(),
-            vec![(0, 1)]
+            vec![(0, 3), (1, 3), (0, 1), (0, 1)]
         );
     }
 

--- a/crates/openasr-core/src/models/xasr_zipformer/greedy.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/greedy.rs
@@ -80,6 +80,10 @@ pub(crate) trait XasrGreedyDecodeBackend {
     }
 }
 
+/// Record one emitted (non-blank) transcript token. Blank and speculative
+/// blank-prefix selections stay on the joiner alignment path and are not
+/// short-audio decode steps. The host joiner is pure Rust and has no ggml
+/// compute witness; only device-head rows are native receipt steps.
 fn record_selection_receipt(
     evidence: Option<&XasrSelectionEvidence>,
     output_index: usize,
@@ -90,12 +94,11 @@ fn record_selection_receipt(
     else {
         return;
     };
-    let row = evidence.and_then(|evidence| evidence.row(output_index));
-    let compute = row.map(|(_, compute)| compute);
-    let step_index = receipt.begin_next_decode_step(compute);
-    if let Some((row, _)) = row {
-        receipt.record_top_k_last_max(step_index, row);
-    }
+    let Some((row, compute)) = evidence.and_then(|evidence| evidence.row(output_index)) else {
+        return;
+    };
+    let step_index = receipt.begin_next_decode_step(Some(compute));
+    receipt.record_top_k_last_max(step_index, row);
     receipt.record_token(step_index, token_id, false);
     receipt.finish_decode_step(step_index);
 }
@@ -313,9 +316,6 @@ pub(crate) fn greedy_decode_frames_incremental_with_backend<B: XasrGreedyDecodeB
             if blank_prefix_len > remaining_frames {
                 return Err("xasr speculative blank prefix exceeds remaining frames".to_string());
             }
-            for output_index in 0..blank_prefix_len {
-                record_selection_receipt(speculative_evidence.as_ref(), output_index, blank_id);
-            }
             if speculative_context.is_some() {
                 decoder_projection_valid = true;
             }
@@ -334,7 +334,6 @@ pub(crate) fn greedy_decode_frames_incremental_with_backend<B: XasrGreedyDecodeB
             let token_id = backend.next_token()?;
             let selection_evidence = backend.take_selection_evidence();
             if token_id == blank_id {
-                record_selection_receipt(selection_evidence.as_ref(), 0, token_id);
                 break;
             }
             let probability = backend.token_probability(token_id)?;
@@ -724,13 +723,13 @@ mod tests {
             .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
             .filter(|event| event.get("event").and_then(serde_json::Value::as_str) == Some("token"))
             .collect::<Vec<_>>();
-        assert_eq!(tokens.len(), 4);
+        assert_eq!(tokens.len(), 1);
         assert_eq!(
             tokens
                 .iter()
                 .map(|event| event["token_id"].as_u64().unwrap())
                 .collect::<Vec<_>>(),
-            vec![0, 0, 1, 0]
+            vec![1]
         );
         assert_eq!(
             tokens
@@ -742,7 +741,7 @@ mod tests {
                     )
                 })
                 .collect::<Vec<_>>(),
-            vec![(0, 3), (1, 3), (0, 1), (0, 1)]
+            vec![(0, 1)]
         );
     }
 

--- a/crates/openasr-core/src/short_audio_receipt.rs
+++ b/crates/openasr-core/src/short_audio_receipt.rs
@@ -713,16 +713,25 @@ impl ShortAudioReceipt {
             (None, None, None) => {}
             (Some(provider), Some(stable_id), Some(device)) => {
                 validate_actual_device_facts("actual_device", provider, stable_id, device)?;
-                if let Some(lifecycle) = &self.graph_lifecycle
-                    && lifecycle
-                        .events
-                        .iter()
-                        .any(|event| event.provider != provider || event.device != stable_id)
-                {
-                    return Err(ShortAudioReceiptError::InvalidEvidenceField {
-                        field: "actual_device",
-                        actual: "lifecycle route differs from final live backend".to_string(),
-                    });
+                if let Some(lifecycle) = &self.graph_lifecycle {
+                    let mut drifted = BTreeSet::new();
+                    for event in &lifecycle.events {
+                        if !lifecycle_event_proves_compute_route(&event.kind) {
+                            continue;
+                        }
+                        if event.provider != provider || event.device != stable_id {
+                            drifted.insert(format!("{}:{}", event.provider, event.device));
+                        }
+                    }
+                    if !drifted.is_empty() {
+                        return Err(ShortAudioReceiptError::InvalidEvidenceField {
+                            field: "actual_device",
+                            actual: format!(
+                                "lifecycle route differs from final live backend {provider}:{stable_id}; observed {}",
+                                drifted.into_iter().collect::<Vec<_>>().join(", ")
+                            ),
+                        });
+                    }
                 }
             }
             _ => {
@@ -1640,6 +1649,21 @@ fn validate_safe_environment(
     Ok(())
 }
 
+fn lifecycle_event_proves_compute_route(
+    kind: &crate::ggml_runtime::GgmlGraphLifecycleEventKind,
+) -> bool {
+    matches!(
+        kind,
+        crate::ggml_runtime::GgmlGraphLifecycleEventKind::ComputeStarted { .. }
+            | crate::ggml_runtime::GgmlGraphLifecycleEventKind::ComputeCompleted { .. }
+            | crate::ggml_runtime::GgmlGraphLifecycleEventKind::OutputRead { .. }
+            | crate::ggml_runtime::GgmlGraphLifecycleEventKind::KvWriteCommitted { .. }
+            | crate::ggml_runtime::GgmlGraphLifecycleEventKind::CaptureStateObserved { .. }
+            | crate::ggml_runtime::GgmlGraphLifecycleEventKind::CaptureExecutableObserved { .. }
+            | crate::ggml_runtime::GgmlGraphLifecycleEventKind::CaptureExecutableCreated { .. }
+    )
+}
+
 fn validate_actual_device_facts(
     field: &'static str,
     provider: &str,
@@ -1765,9 +1789,10 @@ fn observed_graph_built_for_compute(
     };
     let (graph_instance, graph_generation, compute_sequence, output_generation) =
         compute.compute_identity();
-    let mut created = false;
-    let mut attached_existing = false;
-    let mut first_compute = None::<u64>;
+    let mut last_origin_created = None::<bool>;
+    let mut first_compute_after_origin = None::<u64>;
+    let mut origin_at_this_compute = None::<bool>;
+    let mut first_compute_at_this_compute = None::<u64>;
     let mut started = false;
     let mut completed = false;
     let mut read = false;
@@ -1775,16 +1800,26 @@ fn observed_graph_built_for_compute(
         event.graph_instance == graph_instance && event.graph_generation == graph_generation
     }) {
         match event.kind {
-            crate::ggml_runtime::GgmlGraphLifecycleEventKind::Created { .. } => created = true,
+            crate::ggml_runtime::GgmlGraphLifecycleEventKind::Created { .. } => {
+                last_origin_created = Some(true);
+                first_compute_after_origin = None;
+            }
             crate::ggml_runtime::GgmlGraphLifecycleEventKind::ExistingGraphObserved { .. } => {
-                attached_existing = true
+                last_origin_created = Some(false);
+                first_compute_after_origin = None;
             }
             crate::ggml_runtime::GgmlGraphLifecycleEventKind::ComputeStarted {
                 compute_sequence: observed,
                 ..
             } => {
-                first_compute = Some(first_compute.map_or(observed, |first| first.min(observed)));
-                started |= observed == compute_sequence;
+                if first_compute_after_origin.is_none() {
+                    first_compute_after_origin = Some(observed);
+                }
+                if observed == compute_sequence {
+                    started = true;
+                    origin_at_this_compute = last_origin_created;
+                    first_compute_at_this_compute = first_compute_after_origin;
+                }
             }
             crate::ggml_runtime::GgmlGraphLifecycleEventKind::ComputeCompleted {
                 compute_sequence: observed,
@@ -1802,14 +1837,31 @@ fn observed_graph_built_for_compute(
             _ => {}
         }
     }
-    if created == attached_existing || !started || !completed || !read {
+    if origin_at_this_compute.is_none() || !started || !completed || !read {
+        let reason = match (
+            lifecycle.overflowed,
+            origin_at_this_compute,
+            started,
+            completed,
+            read,
+        ) {
+            (true, _, _, _, _) => {
+                "native graph lifecycle overflowed before this compute could be bound"
+            }
+            (_, None, _, _, _) => {
+                "native compute witness has no created or existing-graph origin before compute_started"
+            }
+            (_, _, false, _, _) => "native compute witness has no matching compute_started event",
+            (_, _, _, false, _) => "native compute witness has no matching compute_completed event",
+            _ => "native compute witness has no matching output_read event",
+        };
         return Err(ShortAudioReceiptError::InvalidEvidenceField {
             field: "decode_diagnostics.steps.graph_rebuilt",
-            actual: "native compute witness is not bound to one observed graph lifecycle"
-                .to_string(),
+            actual: reason.to_string(),
         });
     }
-    Ok(created && first_compute == Some(compute_sequence))
+    Ok(origin_at_this_compute == Some(true)
+        && first_compute_at_this_compute == Some(compute_sequence))
 }
 
 fn validate_decode_diagnostics(
@@ -2707,6 +2759,61 @@ mod tests {
             decode_diagnostics_from_shipped_runtime(Some(&resolved), Some(&reuse_snapshot))
                 .expect("existing graph projects from its request-local lifecycle");
         assert!(!reuse_diagnostics.steps[0].graph_rebuilt);
+    }
+
+    #[test]
+    fn shipped_emitter_binds_compute_to_origin_in_effect_not_snapshot_xor() {
+        let resolved = cpu_resolved_runtime();
+        let collector = crate::NativeExecutionReceiptCollector::new();
+        collector.begin_candidate_attempt();
+        let lifecycle = collector.graph_lifecycle_collector();
+        let scope = lifecycle.install();
+        let mut runner = crate::ggml_runtime::GgmlCpuGraphRunner::new(
+            crate::ggml_runtime::GgmlCpuGraphConfig::conservative_default(),
+        )
+        .expect("CPU graph runner");
+        let mut graph = runner.start_graph();
+        let input = graph
+            .new_tensor_1d_f32(3, "receipt_graph_input")
+            .expect("input");
+        graph.set_input(input).expect("set input");
+        graph.set_output(input).expect("set output");
+        graph
+            .set_f32_slice(input, &[0.0, 2.0, 1.0], "receipt_graph_input")
+            .expect("first input upload");
+        graph
+            .compute_output_f32_with_evidence(input, 3)
+            .expect("created-graph compute");
+        lifecycle.begin_observation_scope();
+        graph
+            .set_f32_slice(input, &[3.0, 1.0, 2.0], "receipt_graph_input")
+            .expect("re-attached input upload");
+        let (_, compute) = graph
+            .compute_output_f32_with_evidence(input, 3)
+            .expect("existing-graph compute")
+            .into_parts();
+        collector.begin_decode_step(0, compute);
+        collector.record_token(0, 1, false);
+        collector.finish_decode_step(0);
+        drop(scope);
+        collector.finish_candidate_attempt(true);
+        let snapshot = collector.snapshot();
+        let created = snapshot.graph_lifecycle.events.iter().any(|event| {
+            matches!(
+                event.kind,
+                crate::ggml_runtime::GgmlGraphLifecycleEventKind::Created { .. }
+            )
+        });
+        let attached = snapshot.graph_lifecycle.events.iter().any(|event| {
+            matches!(
+                event.kind,
+                crate::ggml_runtime::GgmlGraphLifecycleEventKind::ExistingGraphObserved { .. }
+            )
+        });
+        assert!(created && attached);
+        let diagnostics = decode_diagnostics_from_shipped_runtime(Some(&resolved), Some(&snapshot))
+            .expect("compute binds to the origin in effect at that compute");
+        assert!(!diagnostics.steps[0].graph_rebuilt);
     }
 
     #[test]

--- a/docs/design/gpu-decode-correctness-contract.md
+++ b/docs/design/gpu-decode-correctness-contract.md
@@ -48,6 +48,21 @@ The shared software migration is in place:
   `vk_caps_00001002_00007590_*`, capture unsupported, FreshGraph,
   cold+reuse, `funasr-nano:q4_k`). That still is not a production-catalog
   or Authenticode release cell;
+- after `8cf47e0f` (`origin/main`), the same RX 9060 XT re-ran those local-dev
+  HIP and Vulkan plugin cells for `funasr-nano:q4_k` (qualify-family
+  cold+reuse token `evidence.v1` pass, HTTP JFK). Additional local-dev HIP
+  cells passed for `qwen3-asr-0.6b:q4_k`, `qwen3-asr-1.7b:q4_k`, and
+  `firered-aed-l-v2:q4_k`; Vulkan also passed `firered-aed-l-v2:q4_k`. A later
+  local receipt-contract rebuild on the same machine then passed HIP
+  `moonshine-tiny:q8_0` and Vulkan `qwen3-asr-0.6b:q4_k`,
+  `qwen3-asr-1.7b:q4_k`, `sensevoice-small:q8_0`, `xasr-zh-en:q8_0`,
+  `moonshine-tiny:q8_0`, `whisper-tiny:q4_k`, and `whisper-small:q4_k`. A
+  later HIP plugin rebuild on the same machine then passed HIP
+  `sensevoice-small:q8_0`, `xasr-zh-en:q8_0`, `whisper-tiny:q4_k`, and
+  `whisper-small:q4_k`. Compact remains off. HIP and Vulkan reuse evidence is
+  now planner-validated (`ReusableGraph` + `FullLogits` resident KV) so FunASR
+  q4_k HIP no longer rebuilds a host-KV graph every token; CUDA stays
+  `FreshGraph`. These are still not a production-catalog or Authenticode cell;
 - native `ARGMAX_FIRST` now has one cross-backend non-finite rule: any NaN or
   infinity in a row yields the `-1` sentinel, which request decoding rejects
   instead of accepting a provider-dependent token;
@@ -84,8 +99,10 @@ The following baseline outputs must not be promoted into stronger claims:
   evidence and cannot close the final matrix;
 - older short-audio diagnostics derived `graph_rebuilt=true` from the selected
   `FreshGraph` plan. The current emitter instead requires a runtime-minted
-  compute/output witness bound to one `created` or `existing_graph_observed`
-  lifecycle; missing or ambiguous evidence fails closed. This correction does
+  compute/output witness bound to the `created` or `existing_graph_observed`
+  origin in effect at that compute; a later observation-scope re-attach on the
+  same graph identity does not make earlier origin events ambiguous. Missing
+  origin, start, complete, or readback still fails closed. This correction does
   not make an ordinary evidence-less bench receipt release-authorizing; and
 - the Desktop JavaScript plugin-switch runner is a machine-protocol smoke. It
   does not start the packaged Tauri application or traverse the production
@@ -604,6 +621,19 @@ CUDA executable-graph capture is explicitly disabled by `build.rs` with
 currently defaults `OPENASR_HIP_GRAPHS` to true, the plugin build documents
 `GGML_HIP_GRAPHS=ON`, and HIP shares the CUDA `USE_CUDA_GRAPH` implementation
 path. CUDA capture-off evidence cannot authorize HIP capture-on behavior.
+
+HIP capture stays on. hipBLASLt GEMMs cannot join a capturing stream, so the
+HIP plugin pauses capture around those GEMMs, immediately launches each
+recorded fragment on the same stream (stream capture records kernels and
+does not execute them), keeps every non-empty fragment executable, and on
+reuse GraphLaunches those fragments in order interleaved with the same
+eager GEMMs. The first fragment remains the observable executable.
+Eager-walking the full ggml graph on mixed reuse is not the shipping
+path: FunASR q4_k HIP reuse regressed ~3x that way because capturable mmq
+kernels were re-launched one by one. Graphs that still have an instantiated
+executable are not time-evicted. Quantized-weight padding memset uses the
+per-thread stream rather than a blocking legacy-stream `cudaMemset`, which
+is illegal while another stream is capturing.
 
 For HIP, `CaptureCompatibility` must describe the current capture-on lane. A
 compact or reusable output plan remains unsupported until production-shape

--- a/docs/design/runtime-ownership-and-model-activation.md
+++ b/docs/design/runtime-ownership-and-model-activation.md
@@ -63,8 +63,12 @@ that same cell now passes `__openasr-validate-ownership-evidence`
 idle-unload `now` returns to empty, lease matched. GRAPH_PRIVATE high-water
 is one backend-owned lease on the cached GPU backend; a fresh-graph builder
 must reuse that row instead of admitting a new zero-byte `native-memory-owner`
-per compute. A real-host pressure-rollback envelope is UNAVAILABLE on this
-close-out (ColdWarm is the accepted alternative). CUDA, production-signed
+per compute. After `8cf47e0f` (`origin/main`), isolated HIP and Vulkan HOMEs
+on the same RX 9060 XT official-admitted `funasr-nano:q4` via catalog-gated
+`pull --from` plus `POST /v1/models/default`; both backends then produced
+verifier-pass `cold_warm_lifecycle` envelopes (baseline empty, cold=warm 21
+live owners, idle-unload `now` empty, lease matched). A real-host
+pressure-rollback envelope is UNAVAILABLE on this close-out (ColdWarm is the accepted alternative). CUDA, production-signed
 plugin activation, and the packaged product kernel-switch flow still require
 release-bound real-host receipts. The gate must remain closed while those
 cells are missing, stale, or unavailable.


### PR DESCRIPTION
## Summary

Admit concurrent longform slices on HIP/Vulkan without exclusive system-memory deadlock, and bind decode receipts so short-audio evidence no longer fails after a successful transcript.

## Why

After the GPU decode contract, FunASR/FireRed/Moonshine longform on HIP/Vulkan fail-closed with `DeviceDomainBusy` because sibling slices minted distinct exclusive cohorts. Receipts then failed even when transcription succeeded: concurrent workers closed a shared graph-lifecycle scope and overwrote `active_decode_step`. Stream-VAD also omitted HIP, so AcceleratedOnly longform could not slice. FunASR HIP reuse had separately collapsed because mixed hipBLASLt graphs dropped capture.

## Changes

- Share one request reservation cohort across concurrent longform workers; nested host owners enter that gate instead of minting anonymous cohorts.
- Refcount graph-lifecycle observation so the last worker, not the first, closes the scope.
- Commit seq2seq receipt token steps atomically (`commit_decode_step`) instead of a racy begin/topk/token/finish split.
- Authorize HIP and Vulkan `ReusableGraph` under `FullLogits` (compact still off; CUDA stays `FreshGraph`).
- Add HIP to Stream-VAD FullDevice capabilities.
- Raise the graph-lifecycle event bound for multi-slice FreshGraph receipts.
- Skip host-joiner X-ASR receipt token steps that have no ggml compute witness.
- Bump vendored `openasr-ggml` to `c5cab547` for mixed HIP fragment replay ([openasr-ggml#16](https://github.com/QuintinShaw/openasr-ggml/pull/16)).

## Local matrix vs v0.1.36 (RX 9060 XT, not a release cell)

9 families x CPU/HIP/Vulkan x short/long x cold/reuse: all functional cells pass. Remaining RTF flags (not transcription failures):

- Vulkan FunASR/Qwen reuse still slower than v0.1.36 (capture-unsupported; ReusableGraph is much faster than FreshGraph but does not match v0.1.36 node reuse).
- HIP Qwen reuse about +25-32% RTF vs v0.1.36 at lower RSS.
- Concurrent HIP longform RSS is higher because multiple slice workers stay resident.

These are still not a production-catalog or Authenticode cell. Compact remains off.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --lib -- -D warnings`
- [x] `cargo test -p openasr-core --lib nested_candidate_attempts_keep_parent_activation_cohort`
- [x] `cargo test -p openasr-core --lib concurrent_observation_scopes_stay_open_until_last_end`
- [x] `cargo test -p openasr-core --lib seq2seq_greedy_policies_record_token_steps_through_shipped_emitter`
- [x] Local HIP/Vulkan/CPU family matrix vs GitHub v0.1.36 (see above)
