### PR TITLE
perf(runtime): unify discrete GPU owners and pin ggml residency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Core: a discrete CUDA/HIP/Vulkan request now keeps encoder and decoder
+  graphs on one unified GPU owner, so weights and KV stay on a single ggml
+  actor instead of bouncing between thread-local caches.
+- Core: CUDA/HIP graph capture is reserved for persistent reuse sessions.
+  One-shot encoder/prefill graphs no longer instantiate HIP fragment
+  executables. The capture flag lives in ggml-impl, not the hashed host ABI.
+- ggml/Vulkan: DeviceLocal weight buffers prefer memory types that are not
+  also HostVisible. On ReBAR discrete GPUs those heaps are still HostVisible
+  to the process; the plugin skips mapping them and copies through chunked
+  staging. SPIR-V float-controls patching is opt-in (the host disables it
+  unless the operator sets `GGML_VK_ENABLE_FLOAT_CONTROLS_PATCH`).
 - Qwen3 Forced Aligner now publishes the policy-guarded `q4_k` tier as its
   recommended default. Boundary-sensitive audio, token-embedding, and
   timestamp-head matrices remain Q8_0; legacy all-Q4, Q3, and mislabeled mixed
@@ -79,6 +90,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- HIP decode reuse no longer recaptures every token after the first stable
+  capture: uid reuse keys on node count, op, type, and shape, and ignores
+  input-pointer churn that HIP writes on each launch.
+- ggml: throwaway Vulkan/HIP plugin probes now release their device contexts
+  instead of leaving them in the process working set.
 - `ggml`: unsupported Metal flash-attention head widths now select the existing
   non-flash attention path before graph construction instead of failing the
   request.

--- a/crates/openasr-cli/src/bench_receipt_cli.rs
+++ b/crates/openasr-cli/src/bench_receipt_cli.rs
@@ -638,6 +638,20 @@ pub(crate) fn bench_receipt_short_audio(
     let receipt_evidence = None;
     let execution = native_snapshot.as_ref().map(|request_snapshot| {
         let runtime_snapshot = native_execution_services.runtime_receipts().snapshot();
+        if std::env::var_os("OPENASR_RECEIPT_MEMORY_NOTES").is_some() {
+            let live_resources = runtime_snapshot
+                .live_owners
+                .iter()
+                .map(|owner| owner.resources.len())
+                .sum::<usize>();
+            notes.push(format!(
+                "runtime_receipts events={} owners={} resources={} dropped={}",
+                runtime_snapshot.events.len(),
+                runtime_snapshot.live_owners.len(),
+                live_resources,
+                runtime_snapshot.completeness.dropped_events
+            ));
+        }
         let reconciliation = native_execution_services
             .runtime_receipts()
             .reconcile_live_leases_quiescent(native_execution_services.memory_broker());
@@ -1204,7 +1218,9 @@ fn validate_strict_runtime_trace(jsonl: &str) -> Result<()> {
             let Some((provider, device)) = &header_route else {
                 bail!("runtime graph lifecycle event precedes the strict trace header");
             };
-            if &lifecycle.provider != provider || &lifecycle.device != device {
+            if lifecycle.provider.as_ref() != provider.as_str()
+                || lifecycle.device.as_ref() != device.as_str()
+            {
                 bail!("runtime graph lifecycle event is not bound to the final route");
             }
             validate_artifact_capture_lifecycle(&mut capture_states, &lifecycle)?;
@@ -2260,10 +2276,10 @@ mod tests {
         };
 
         let event = |sequence, kind| GgmlGraphLifecycleEvent {
-            schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+            schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
             sequence,
-            provider: "hip".to_string(),
-            device: "HIP0".to_string(),
+            provider: "hip".into(),
+            device: "HIP0".into(),
             graph_instance: 1,
             graph_generation: 2,
             kind,

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -471,12 +471,12 @@ fn run_dispatch_once_with_progress_and_policy(
     })
 }
 
-/// Upper bound on concurrent long-audio slice workers. Kept small: the win is
-/// filling encode/decode GPU bubbles (2-4 in-flight slices saturate a single
-/// GPU's execution pipeline, the same admission-concurrency effect the server
-/// path already relies on), not unbounded fan-out, and every extra worker costs
-/// another resident decoder runtime + KV cache.
-const SLICE_PIPELINE_MAX_WIDTH: usize = 4;
+/// Upper bound on concurrent long-audio slice workers. Kept at 2: that still
+/// fills encode/decode GPU bubbles on a single discrete GPU without keeping
+/// four resident decoder runtimes + KV caches, which is what pushed HIP
+/// longform peak RSS above the v0.1.36 packaged host. Extra width remains
+/// available via `OPENASR_SLICE_PIPELINE_WIDTH` (clamped to this max).
+const SLICE_PIPELINE_MAX_WIDTH: usize = 2;
 
 /// Memory head-room the concurrent slice pipeline always leaves free when
 /// deciding how many workers fit, so it never claims the last of available
@@ -515,8 +515,9 @@ fn slice_pipeline_explicit_width() -> Option<usize> {
 /// - Carry `Disabled`: the serial loop threads no cross-slice prompt anyway,
 ///   so the carry-light concurrent path is transcript-equivalent (proven
 ///   byte-identical by `concurrent_slice_pipeline_equivalence`). Default to
-///   [`SLICE_PIPELINE_MAX_WIDTH`] and let the capacity and slice-count gates
-///   in [`effective_slice_pipeline_width`] pick what actually fits.
+///   one worker so peak RSS stays at a single decoder+KV; extra width is
+///   opt-in through `OPENASR_SLICE_PIPELINE_WIDTH` (clamped to
+///   [`SLICE_PIPELINE_MAX_WIDTH`]).
 /// - Carry active (`Text` / `TokenHistory`): the concurrent path would drop
 ///   the carry and change the transcript (the short-audio audit measured
 ///   whole-clause deletions), so the default stays 1 -- the byte-identical
@@ -528,8 +529,9 @@ fn slice_pipeline_requested_width(carry_prompt_mode: LongformPromptCarryMode) ->
         return explicit;
     }
     match carry_prompt_mode {
-        LongformPromptCarryMode::Disabled => SLICE_PIPELINE_MAX_WIDTH,
-        LongformPromptCarryMode::Text | LongformPromptCarryMode::TokenHistory => 1,
+        LongformPromptCarryMode::Disabled
+        | LongformPromptCarryMode::Text
+        | LongformPromptCarryMode::TokenHistory => 1,
     }
 }
 
@@ -9184,15 +9186,13 @@ mod tests {
         unsafe {
             std::env::remove_var("OPENASR_SLICE_PIPELINE_WIDTH");
         }
-        // Carry disabled: concurrent is transcript-equivalent, so the default
-        // requests the maximum and lets the capacity gate pick K.
+        // Default is serial so longform peak RSS stays at one decoder+KV.
+        // Concurrent width is opt-in via OPENASR_SLICE_PIPELINE_WIDTH.
         assert_eq!(
             slice_pipeline_requested_width(LongformPromptCarryMode::Disabled),
-            SLICE_PIPELINE_MAX_WIDTH,
-            "carry-disabled run defaults to the concurrent pipeline"
+            1,
+            "carry-disabled run defaults to serial"
         );
-        // ... which still flows through the capacity gate: plenty of memory
-        // admits the full width, tight memory caps it back to serial.
         assert_eq!(
             slice_pipeline_capped_width(
                 slice_pipeline_requested_width(LongformPromptCarryMode::Disabled),
@@ -9201,7 +9201,7 @@ mod tests {
                 1 << 20,
                 0,
             ),
-            SLICE_PIPELINE_MAX_WIDTH,
+            1,
         );
         assert_eq!(
             slice_pipeline_capped_width(
@@ -9232,7 +9232,7 @@ mod tests {
         // Explicit widths override the carry-gated default in both directions:
         // ">=2" forces the carry-light concurrent path onto a carry-active
         // run, and "0"/"1" pin a carry-disabled run to serial.
-        for (value, expected) in [("0", 1), ("1", 1), ("2", 2), ("4", 4), ("9", 4)] {
+        for (value, expected) in [("0", 1), ("1", 1), ("2", 2), ("4", 2), ("9", 2)] {
             // SAFETY: nextest runs each test in its own process, so mutating
             // this process-global env var cannot race another test.
             unsafe {
@@ -9257,7 +9257,7 @@ mod tests {
         }
         assert_eq!(
             slice_pipeline_requested_width(LongformPromptCarryMode::Disabled),
-            SLICE_PIPELINE_MAX_WIDTH,
+            1,
         );
         assert_eq!(
             slice_pipeline_requested_width(LongformPromptCarryMode::TokenHistory),

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -9,7 +9,10 @@ use crate::device::{
     execution_policy::{AcceleratedPlacementCapabilities, ExecutionCapabilities},
     execution_route::ExecutionProvider,
 };
-use crate::ggml_runtime::{AutoGpuPolicy, GgmlCpuGraphBackend, RequestBackendPreference};
+use crate::ggml_runtime::{
+    AutoGpuPolicy, GgmlCpuGraphBackend, RequestBackendPreference,
+    exact_discrete_gpu_unified_owner_is_proven,
+};
 use crate::models::decode_policy_component_registry::{
     self as decode_policy, BuiltinDecodePolicyComponentDescriptor,
 };
@@ -110,15 +113,7 @@ pub(crate) fn firered_llm_unified_runtime_enabled(
     allow_unified_runtime
         && backend == GgmlCpuGraphBackend::Gpu
         && placement == Some(crate::device::execution_policy::ExecutionPlacement::FullDevice)
-        && matches!(
-            backend_preference,
-            Some(RequestBackendPreference::Exact(route))
-                if route.addressability.is_exactly_addressable()
-                    && matches!(
-                        route.provider,
-                        ExecutionProvider::Cuda | ExecutionProvider::Vulkan
-                    )
-        )
+        && exact_discrete_gpu_unified_owner_is_proven(backend_preference)
 }
 
 pub const COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID: &str = "cohere-transcribe-conformer-transformer";

--- a/crates/openasr-core/src/ggml_runtime/backend.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend.rs
@@ -181,8 +181,18 @@ impl GgmlRuntimeInfo {
 
 impl GgmlBackendDevice {
     pub fn initialize(&self) -> Result<GgmlBackend, GgmlRuntimeError> {
+        if super::env_flags::env_var_truthy("OPENASR_LOG_GGML_BACKEND_INIT") {
+            eprintln!(
+                "ggml-backend-init name={} kind={:?} device_id={:?}",
+                self.name, self.kind, self.device_id
+            );
+        }
         let raw = unsafe { ffi::ggml_backend_dev_init(self.raw.as_ptr(), ptr::null()) };
         GgmlBackend::from_raw(raw, "device")
+    }
+
+    pub(crate) fn as_ptr(&self) -> ffi::GgmlBackendDevRaw {
+        self.raw.as_ptr()
     }
 
     /// Whether this device can execute a `mul_mat` whose weight operand has
@@ -598,12 +608,31 @@ pub(crate) fn preferred_accelerated_device(
     select_accelerated_device(devices, is_accelerated).map(|(device, _rule)| device)
 }
 
+/// Do not set `GGML_VK_DISABLE_HOST_VISIBLE_VIDMEM`. On ReBAR discrete GPUs
+/// every DeviceLocal heap is also HostVisible, so excluding HostVisible types
+/// fails closed with `no non-host-visible DeviceLocal memory type`.
+///
+/// SPIR-V float-controls patching makes AMD WDDM allocate ~2MiB ISA heap per
+/// compiled pipeline. Honor an explicit operator opt-in; otherwise disable
+/// the patch before the plugin reads getenv at device init.
+pub(crate) fn apply_vulkan_device_local_buffer_policy() {
+    const KEY: &str = "GGML_VK_DISABLE_FLOAT_CONTROLS_PATCH";
+    if std::env::var_os(KEY).is_none()
+        && std::env::var_os("GGML_VK_ENABLE_FLOAT_CONTROLS_PATCH").is_none()
+    {
+        // SAFETY: called once before vulkan device init; the plugin reads this
+        // with getenv on the same process. No concurrent set_var on this key.
+        unsafe { std::env::set_var(KEY, "1") };
+    }
+}
+
 /// Register backend modules once per process before the first registry query.
 /// A dynamic host loads only the bundled CPU rescue module and at most one
 /// exact, signed, integrity-verified optional GPU pack. Static hosts never load
 /// modules, avoiding the double-ggml global-state collision seen when a static
 /// GPU host loads a dynamic module.
 pub(crate) fn ensure_backends_loaded() {
+    apply_vulkan_device_local_buffer_policy();
     let _ = bundled_cpu_activation_cell().get_or_init(load_bundled_cpu_module);
     backend_plugin_activation_cell().get_or_init(|| {
         bundled_cpu_activation_cell()
@@ -1198,16 +1227,6 @@ fn activate_selected_backend_plugin()
         "ggml_backend_verify2",
         stage_started.elapsed(),
     );
-    let stage_started = Instant::now();
-    let live_driver = probe_exact_backend_plugin_candidate(
-        &backend_id,
-        requested.vendor,
-        &plugin_path,
-        &dependency_dirs,
-        &device_target,
-        live_backend_driver_floor(requested.vendor, requested.min_driver_api.as_deref()),
-    )?;
-    crate::stage_timing::log_stage("server_boot", "ggml_backend_probe", stage_started.elapsed());
     let expected_driver = activated_record
         .as_ref()
         .map(|record| record.driver_version.as_str())
@@ -1216,6 +1235,25 @@ fn activate_selected_backend_plugin()
                 .as_ref()
                 .map(|record| record.driver_version.as_str())
         });
+    // A throwaway LoadLibrary + vkCreateInstance leaves AMD WDDM ~2.1MiB host
+    // slabs in PeakWorkingSet after vkDestroyInstance. When the signed binding
+    // already names the driver, skip that extra instance: load_exact still
+    // live-proves the catalog target and driver floor on the production
+    // VkInstance.
+    let stage_started = Instant::now();
+    let live_driver = if let Some(expected) = expected_driver {
+        expected.to_string()
+    } else {
+        probe_exact_backend_plugin_candidate(
+            &backend_id,
+            requested.vendor,
+            &plugin_path,
+            &dependency_dirs,
+            &device_target,
+            live_backend_driver_floor(requested.vendor, requested.min_driver_api.as_deref()),
+        )?
+    };
+    crate::stage_timing::log_stage("server_boot", "ggml_backend_probe", stage_started.elapsed());
     if expected_driver.is_some_and(|expected| expected != live_driver) {
         return Err(BackendPluginActivationError::ActivationState(
             "live backend driver changed from the exact signed/scoped binding".to_string(),

--- a/crates/openasr-core/src/ggml_runtime/backend_memory.rs
+++ b/crates/openasr-core/src/ggml_runtime/backend_memory.rs
@@ -227,6 +227,12 @@ pub(crate) struct BackendMemoryAbi {
     device: ffi::GgmlBackendDevRaw,
 }
 
+unsafe extern "C" {
+    fn ggml_backend_memory_api_for_device_v1(
+        device: ffi::GgmlBackendDevRaw,
+    ) -> *const ffi::GgmlBackendMemoryApiV1;
+}
+
 impl BackendMemoryAbi {
     /// Resolves the optional v1 table from the concrete backend's registry.
     ///
@@ -262,6 +268,42 @@ impl BackendMemoryAbi {
         Ok(Self {
             raw,
             backend,
+            device,
+        })
+    }
+
+    /// Resolves the optional v1 table from a registry device without constructing
+    /// a live backend context. Vulkan BUFFER quotes accept a null `backend` when
+    /// `buft` is set; AMD WDDM does not return the ~2.1 MiB host slab that
+    /// `ggml_backend_dev_init` leaves behind after `ggml_backend_free`.
+    ///
+    /// `device` must remain a live registry device. Plugin registries are
+    /// process resident after loading, so the returned function table has
+    /// static lifetime.
+    pub(crate) unsafe fn from_device(
+        device: ffi::GgmlBackendDevRaw,
+    ) -> Result<Self, BackendMemoryAbiError> {
+        if device.is_null() {
+            return Err(BackendMemoryAbiError::Unavailable);
+        }
+        // SAFETY: the shared ggml trampoline owns registry lookup and catches
+        // every provider exception before it can cross this Rust FFI seam.
+        let raw = unsafe { ggml_backend_memory_api_for_device_v1(device) };
+        let Some(raw) = (unsafe { raw.as_ref() }) else {
+            return Err(BackendMemoryAbiError::Unavailable);
+        };
+        if raw.struct_size < mem::size_of::<ffi::GgmlBackendMemoryApiV1>() as u32
+            || raw.abi_version != ffi::GGML_BACKEND_MEMORY_ABI_V1
+            || raw.get_domains.is_none()
+            || raw.quote.is_none()
+            || raw.reserve_private.is_none()
+            || raw.get_stats.is_none()
+        {
+            return Err(BackendMemoryAbiError::Incompatible);
+        }
+        Ok(Self {
+            raw,
+            backend: ptr::null_mut(),
             device,
         })
     }
@@ -466,7 +508,10 @@ impl BackendMemoryAbi {
     }
 
     pub(crate) fn provider(&self) -> ExecutionProvider {
-        let name = unsafe { ffi::ggml_backend_name(self.backend) };
+        if self.device.is_null() {
+            return ExecutionProvider::Unknown;
+        }
+        let name = unsafe { ffi::ggml_backend_dev_name(self.device) };
         if name.is_null() {
             return ExecutionProvider::Unknown;
         }
@@ -1357,6 +1402,21 @@ mod tests {
         assert_eq!(receipt.last_status, BackendTerminalStatusClass::DeviceLost);
         assert_eq!(receipt.last_native_error, -4);
         assert_eq!(receipt.quarantine_generation, 7);
+    }
+
+    #[test]
+    fn memory_api_resolves_from_registry_device_without_a_backend_context() {
+        crate::ggml_runtime::ensure_backends_loaded();
+        let cpu = crate::ggml_available_devices()
+            .into_iter()
+            .find(|device| device.kind == crate::GgmlBackendKind::Cpu)
+            .expect("cpu device");
+        let abi =
+            unsafe { BackendMemoryAbi::from_device(cpu.as_ptr()) }.expect("device-only memory ABI");
+        assert!(abi.backend().is_null());
+        assert_eq!(abi.provider(), ExecutionProvider::Cpu);
+        abi.domains()
+            .expect("cpu registry device must expose memory domains");
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -38,6 +38,14 @@ use super::{
     GgmlBackendKind, GgmlRuntimeError, GgmlRuntimeSource, GgufTensorDataReader,
     GgufWeightTensorPayload, ensure_backends_loaded, ggml_available_devices,
 };
+
+// Not part of `ffi.rs`: that file is hashed into the host ABI fingerprint.
+// Persistent-only CUDA/HIP capture is an internal cgraph flag.
+unsafe extern "C" {
+    fn ggml_graph_set_capture_allowed(cgraph: *mut c_void, allowed: bool);
+    #[cfg(test)]
+    fn ggml_graph_capture_allowed(cgraph: *mut c_void) -> bool;
+}
 use crate::device::execution_policy::{ExecutionCandidateFailure, ExecutionPlacement};
 use crate::device::pack_weight_residency::PackWeightResidencyHandle;
 use crate::device::{
@@ -47,7 +55,7 @@ use crate::device::{
     },
     execution_route::{
         ExecutionProvider, ExecutionRouteCacheKey, ExecutionRouteError, ExecutionRouteRequest,
-        ResolvedExecutionRoute, enumerate_compute_devices_from_ggml,
+        ResolvedExecutionRoute, RouteDeviceKind, enumerate_compute_devices_from_ggml,
         ranked_preferred_accelerated_devices, resolve_execution_route,
     },
 };
@@ -616,6 +624,52 @@ const fn discrete_gpu_reuse_is_proven(provider: ExecutionProvider) -> bool {
     matches!(provider, ExecutionProvider::Hip | ExecutionProvider::Vulkan)
 }
 
+/// Exact CUDA, HIP, and Vulkan FullDevice lanes already share one encoder+
+/// decoder actor on the families that built that owner. HIP was left out of
+/// several copies of the gate, which split the same pack across two ggml
+/// threads (two device weight uploads, two backends) on an otherwise proven
+/// GPU route.
+///
+/// Vulkan (and rare CUDA/HIP builds) may omit a PCI `device_id`, so Exact by
+/// physical key is unavailable. `addressability_for_device` still treats the
+/// ggml `stable_id` as the cache/worker slot; requiring a PCI key here would
+/// split the same pack again on those GPUs. `--device vulkan` also arrives as
+/// `Accelerated` until execute installs the candidate lane: consult that lane
+/// so actor threads keep the same proven owner.
+pub(crate) fn exact_discrete_gpu_unified_owner_is_proven(
+    preference: Option<&RequestBackendPreference>,
+) -> bool {
+    proven_discrete_gpu_provider(preference).is_some()
+}
+
+pub(crate) fn proven_discrete_gpu_provider(
+    preference: Option<&RequestBackendPreference>,
+) -> Option<ExecutionProvider> {
+    if let Some(provider) = discrete_gpu_provider_from_exact_route(preference) {
+        return Some(provider);
+    }
+    crate::models::native_execution_services::current_execution_lane().and_then(|lane| {
+        discrete_gpu_provider_from_exact_route(Some(&lane.request_backend_preference()))
+    })
+}
+
+fn discrete_gpu_provider_from_exact_route(
+    preference: Option<&RequestBackendPreference>,
+) -> Option<ExecutionProvider> {
+    match preference {
+        Some(RequestBackendPreference::Exact(route))
+            if matches!(
+                route.provider,
+                ExecutionProvider::Cuda | ExecutionProvider::Hip | ExecutionProvider::Vulkan
+            ) && matches!(route.kind, RouteDeviceKind::Accelerated)
+                && !route.stable_id.is_empty() =>
+        {
+            Some(route.provider)
+        }
+        _ => None,
+    }
+}
+
 const fn native_first_max_compact_is_proven(backend: GgmlCpuGraphBackend) -> bool {
     // CPU is the only lane with three-layer compact receipts. CUDA/Vulkan/HIP
     // may declare GGML_OP_ARGMAX_FIRST through supports_op, but that is not
@@ -845,22 +899,32 @@ impl GgmlCpuGraphConfig {
     }
 
     /// Exact byte capacity a `no_alloc` metadata context needs to hold a forward
-    /// graph of up to `graph_size` nodes: the cgraph object itself plus
-    /// per-tensor bookkeeping for every node (leafs never exceed the node budget
-    /// in practice). This mirrors llama.cpp's compute-meta buffer sizing
-    /// (`ggml_tensor_overhead()*max_nodes + ggml_graph_overhead_custom(...)`) and
-    /// replaces hand-tuned byte counts that historically over-reserved by ~24x:
-    /// `ggml_init` always mallocs the full `mem_size` even when `no_alloc=true`,
-    /// so three coexisting 2 GiB encoder contexts committed 6 GiB and tripped
-    /// `_aligned_malloc` -> NULL -> `GGML_ASSERT(ctx->mem_buffer != NULL)` on CPU,
-    /// even though each context only ever used ~83 MB. Both `ggml_tensor_overhead`
-    /// and `ggml_graph_overhead_custom` are pure size arithmetic and need no
+    /// graph of up to `graph_size` nodes. The llama.cpp compute-meta formula
+    /// (`ggml_tensor_overhead()*max_nodes + ggml_graph_overhead_custom(...)`) is
+    /// exact when `graph_size` is the live node count. Families also pass a
+    /// *capacity* (4096) as headroom; multiplying a tensor object slot by every
+    /// unused cgraph entry then mallocs ~2.1 MiB per session even though the
+    /// live graph is a few hundred to ~2k tensors. `ggml_init` always commits
+    /// the full `mem_size` (`no_alloc` only skips tensor *data*), so that
+    /// headroom showed up as PeakWorkingSet. v0.1.36 kept those contexts at the
+    /// 1 MiB bump (`DEFAULT_CONTEXT_BYTES`) while still creating a `graph_size`
+    /// cgraph; tiny heads already fit the full formula in well under 1 MiB, and
+    /// Zipformer-scale graphs (16384+) keep the full reservation because their
+    /// cgraph arrays alone exceed half a MiB. Both `ggml_tensor_overhead` and
+    /// `ggml_graph_overhead_custom` are pure size arithmetic and need no
     /// initialized context or loaded backend, so this is safe to call at config
     /// time.
     pub fn metadata_context_bytes(graph_size: usize) -> usize {
         let per_tensor = unsafe { ffi::ggml_tensor_overhead() };
         let graph = unsafe { ffi::ggml_graph_overhead_custom(graph_size, false) };
-        graph_size.saturating_mul(per_tensor).saturating_add(graph)
+        let full = graph_size.saturating_mul(per_tensor).saturating_add(graph);
+        if full <= DEFAULT_CONTEXT_BYTES {
+            return full;
+        }
+        if graph_size <= DEFAULT_GRAPH_SIZE && graph <= DEFAULT_CONTEXT_BYTES / 2 {
+            return DEFAULT_CONTEXT_BYTES;
+        }
+        full
     }
 
     /// Keep the cgraph node capacity and its `no_alloc` metadata backing in
@@ -1601,16 +1665,9 @@ fn detect_gpu_available() -> bool {
     // GGML_BACKEND_DL the registry is otherwise empty and a stale cache would
     // read as "no GPU" forever.
     ensure_backends_loaded();
-    let best_backend_is_gpu = NonNull::new(unsafe { ffi::ggml_backend_init_best() })
-        .map(|raw| {
-            let name = backend_name(raw).to_ascii_lowercase();
-            unsafe { ffi::ggml_backend_free(raw.as_ptr()) };
-            backend_name_is_accelerated(&name)
-        })
-        .unwrap_or(false);
-    if best_backend_is_gpu {
-        return true;
-    }
+    // Enumerate registry devices only. `ggml_backend_init_best` constructs a
+    // full Vulkan/HIP backend context (command pools, fences) and freeing it
+    // still leaves AMD WDDM ~2.1MiB host slabs in PeakWorkingSet.
     ggml_available_devices()
         .into_iter()
         .any(|device| backend_kind_is_accelerated(device.kind))
@@ -1651,17 +1708,6 @@ fn find_ggml_device_for_route<'a>(
             }
     })?;
     devices.get(matched.registry_ordinal)
-}
-
-fn backend_name_is_accelerated(name: &str) -> bool {
-    let name = name.to_ascii_lowercase();
-    name.contains("metal")
-        || name.starts_with("mtl")
-        || name.contains("hip")
-        || name.contains("rocm")
-        || name.contains("cuda")
-        || name.contains("vulkan")
-        || name.contains("gpu")
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1934,7 +1980,13 @@ pub enum GgmlCpuGraphError {
 }
 
 pub struct GgmlCpuGraphRunner {
-    context: GgmlContextGuard,
+    /// `no_alloc` metadata buffer used by `start_graph`. Allocated lazily on
+    /// the first `start_graph` so persistent-session and arena-only runners
+    /// never commit a second full cgraph metadata arena. Parked again while a
+    /// persistent session is live; `start_graph` reallocates if a fallback
+    /// rebuild needs it.
+    context: Option<GgmlContextGuard>,
+    context_bytes: usize,
     backend: GgmlBackendGuard,
     backend_kind: GgmlCpuGraphBackend,
     backend_name: String,
@@ -1999,7 +2051,13 @@ struct GgmlGraphLifecycleState {
     capture_state: Option<GgmlNativeCaptureState>,
     capture_executable_generation: Option<u64>,
     capture_executable_observed_in_scope: bool,
+    /// After the first AfterCompute native observe on this graph generation,
+    /// further FFI probes cannot change planner reuse and only inflate HIP
+    /// RTF (X-ASR longform was 5k+ capture observes per request).
+    skip_further_native_capture: bool,
     kv_write_tensors: HashSet<usize>,
+    kv_write_graph_addr: Option<usize>,
+    kv_write_graph_reached: bool,
     poisoned_recorded: bool,
 }
 
@@ -2026,7 +2084,10 @@ impl GgmlGraphLifecycleState {
             capture_state: None,
             capture_executable_generation: None,
             capture_executable_observed_in_scope: false,
+            skip_further_native_capture: false,
             kv_write_tensors: HashSet::new(),
+            kv_write_graph_addr: None,
+            kv_write_graph_reached: false,
             poisoned_recorded: false,
         };
         state.record(super::GgmlGraphLifecycleEventKind::Created {
@@ -2036,13 +2097,11 @@ impl GgmlGraphLifecycleState {
     }
 
     fn record(&self, kind: super::GgmlGraphLifecycleEventKind) {
-        if !self.recording_enabled
-            || self.collector_scope.is_none()
-            || self.collector.observation_scope() != self.collector_scope
-        {
+        if !self.recording_enabled {
             return;
         }
-        self.collector.record(
+        self.collector.record_for_scope(
+            self.collector_scope,
             &self.provider,
             &self.device,
             self.graph_instance,
@@ -2072,6 +2131,7 @@ impl GgmlGraphLifecycleState {
         self.collector_scope = Some(current_scope);
         self.recording_enabled = true;
         self.capture_executable_observed_in_scope = false;
+        self.skip_further_native_capture = false;
         self.record(super::GgmlGraphLifecycleEventKind::ExistingGraphObserved {
             scheduler_enabled: self.scheduler_enabled,
             prepare_generation: self.prepare_generation,
@@ -2115,22 +2175,44 @@ impl GgmlGraphLifecycleState {
     fn input_written(&mut self, bytes: usize) {
         let input_generation = super::mint_opaque_graph_id();
         self.latest_input_generation = Some(input_generation);
-        self.record(super::GgmlGraphLifecycleEventKind::InputWrite {
-            input_generation,
-            bytes: u64::try_from(bytes).unwrap_or(u64::MAX),
-        });
+        let _ = bytes;
+        // InputWrite events are not consulted by graph_rebuilt binding and
+        // dominated HIP/Vulkan longform receipts (thousands per request).
     }
 
     fn compute_started(&mut self) -> u64 {
         self.compute_sequence = self.compute_sequence.saturating_add(1);
         let compute_sequence = self.compute_sequence;
-        self.record(super::GgmlGraphLifecycleEventKind::ComputeStarted {
-            compute_sequence,
-            prepare_generation: self.prepare_generation,
-            input_generation_consumed: self.latest_input_generation,
-            capture_executable_generation: self.capture_executable_generation,
-        });
+        // After the first AfterCompute observation, capture support is a
+        // backend-handle constant. Further ComputeStarted events are not
+        // consulted by graph_rebuilt binding and dominated Zipformer/HIP
+        // receipts (hundreds per request). Keep sequencing and evidence
+        // identities; stop appending to the receipt.
+        if self.should_record_hot_path_compute(compute_sequence) {
+            self.record(super::GgmlGraphLifecycleEventKind::ComputeStarted {
+                compute_sequence,
+                prepare_generation: self.prepare_generation,
+                input_generation_consumed: self.latest_input_generation,
+                capture_executable_generation: self.capture_executable_generation,
+            });
+        }
         compute_sequence
+    }
+
+    fn should_record_hot_path_compute(&self, compute_sequence: u64) -> bool {
+        // Keep the first few computes so decode-conformance (2-step Layer-2,
+        // 4-step reusable quadrant) still sees a complete event chain. Zipformer
+        // decode then stops appending (hundreds of steps per request).
+        compute_sequence <= 4 || !self.skip_further_native_capture_observe()
+    }
+
+    fn capture_is_settled_unsupported(&self) -> bool {
+        self.capture_state
+            .is_some_and(|state| !state.capture_supported)
+    }
+
+    fn skip_further_native_capture_observe(&self) -> bool {
+        self.skip_further_native_capture || self.capture_is_settled_unsupported()
     }
 
     fn observe_native_capture(
@@ -2141,6 +2223,14 @@ impl GgmlGraphLifecycleState {
         use super::backend_graph_lifecycle::{
             BackendGraphLifecycleError, NativeGraphExecutableChange,
         };
+
+        // Capture support is a backend-handle constant. Once a graph has
+        // observed unsupported, further FFI probes and CaptureStateObserved
+        // events cannot change the plan and only inflate RTF/RSS on
+        // capture-unsupported Vulkan (and any future same-shaped backend).
+        if self.skip_further_native_capture_observe() {
+            return Ok(());
+        }
 
         let next_state = GgmlNativeCaptureState {
             capture_supported: observation.capture_supported,
@@ -2258,22 +2348,29 @@ impl GgmlGraphLifecycleState {
             self.capture_executable_generation = Some(capture_executable_generation);
             self.capture_executable_observed_in_scope = true;
         }
+        if phase == GgmlNativeGraphObservationPhase::AfterCompute {
+            self.skip_further_native_capture = true;
+        }
         Ok(())
     }
 
     fn compute_completed(&mut self, compute_sequence: u64, kv_writes_reached_compute: bool) {
-        let output_generation = super::mint_opaque_graph_id();
-        self.latest_output_generation = Some(output_generation);
         self.last_completed_compute = Some(compute_sequence);
-        self.record(super::GgmlGraphLifecycleEventKind::ComputeCompleted {
-            compute_sequence,
-            output_generation,
-        });
-        if kv_writes_reached_compute {
-            self.record(super::GgmlGraphLifecycleEventKind::KvWriteCommitted {
+        if self.should_record_hot_path_compute(compute_sequence) {
+            let output_generation = super::mint_opaque_graph_id();
+            self.latest_output_generation = Some(output_generation);
+            self.record(super::GgmlGraphLifecycleEventKind::ComputeCompleted {
                 compute_sequence,
-                kv_write_generation: super::mint_opaque_graph_id(),
+                output_generation,
             });
+            if kv_writes_reached_compute {
+                self.record(super::GgmlGraphLifecycleEventKind::KvWriteCommitted {
+                    compute_sequence,
+                    kv_write_generation: super::mint_opaque_graph_id(),
+                });
+            }
+        } else if self.latest_output_generation.is_none() {
+            self.latest_output_generation = Some(super::mint_opaque_graph_id());
         }
     }
 
@@ -2283,11 +2380,13 @@ impl GgmlGraphLifecycleState {
         else {
             return None;
         };
-        self.record(super::GgmlGraphLifecycleEventKind::OutputRead {
-            compute_sequence,
-            output_generation_consumed,
-            bytes: u64::try_from(bytes).unwrap_or(u64::MAX),
-        });
+        if self.should_record_hot_path_compute(compute_sequence) {
+            self.record(super::GgmlGraphLifecycleEventKind::OutputRead {
+                compute_sequence,
+                output_generation_consumed,
+                bytes: u64::try_from(bytes).unwrap_or(u64::MAX),
+            });
+        }
         Some(super::GgmlComputeEvidenceRef::new(
             self.graph_instance,
             self.graph_generation,
@@ -2590,14 +2689,23 @@ impl LoadedWeightOwnerCache {
         kind: GgmlWeightMaterializationKind,
         backend_kind: GgmlCpuGraphBackend,
     ) -> LoadedWeightOwnerKey {
+        let lane =
+            crate::models::native_execution_services::current_execution_lane_key(backend_kind);
+        // Pack-wide weight buffers live on the device, not in a placement. A
+        // Vulkan Hybrid request still DeviceCopies the same GGUF onto Vulkan0
+        // for the encoder (FullDevice stage) and GPU decoder; hashing Hybrid
+        // vs FullDevice as distinct owners doubles the 32 MiB copy.
+        let lane = if matches!(backend_kind, GgmlCpuGraphBackend::Cpu) {
+            lane
+        } else {
+            lane.for_stage(backend_kind, ExecutionPlacement::FullDevice)
+        };
         LoadedWeightOwnerKey {
             content_id: source.content_id().to_string(),
             source_identity: source.strong_file_identity(),
             mapping_identity: source.backing_mmap_identity(),
             kind,
-            lane: crate::models::native_execution_services::current_execution_lane_key(
-                backend_kind,
-            ),
+            lane,
         }
     }
 
@@ -2732,6 +2840,10 @@ pub(crate) struct GgmlCpuGraphBuilder<'a> {
     /// backends (Metal/GPU), which already get grow-to-fit allocation from
     /// the scheduler's own internal `ggml_gallocr`.
     step_buffer_pool: Option<&'a mut GgmlCpuStepBufferPool>,
+    /// CUDA/HIP capture is opt-in for persistent sessions only. `start_graph`
+    /// one-shot builders leave this false so mixed HIP instantiate is not
+    /// paid for encoder/prefill graphs that are dropped after one compute.
+    native_capture_allowed: bool,
     /// True once this builder has bound its tensors to backend memory (either
     /// via `buffer` or via `step_buffer_pool`) -- no further tensor creation
     /// is allowed past this point. Tracked separately from `buffer` because
@@ -2763,6 +2875,19 @@ pub(crate) struct GgmlCpuGraphBuilder<'a> {
     /// result, and replay that evidence to each new request collector while
     /// still counting every compute.
     observed_placement: Option<GgmlObservedGraphPlacement>,
+    /// The live backend handle cannot change for this builder. Re-querying
+    /// `ggml_backend_dev_name` on every token only inflates HIP/Vulkan RTF
+    /// (X-ASR longform is 600+ computes). Later steps still re-check request
+    /// placement and re-publish the cached identity to a new receipt.
+    identity_attested: bool,
+    /// Receipt pointer last published by `record_current_execution_backend_observation`.
+    /// The same persistent builder must re-publish when a later request installs
+    /// a new collector, but not on every subsequent token of that request.
+    observation_receipt_key: Option<usize>,
+    /// Backend memory stats after graph compute are a request-level high-water
+    /// probe, not a per-token metric. X-ASR reuse is 600+ computes; querying
+    /// Vulkan/HIP heaps on every joiner step only inflates RTF.
+    after_compute_memory_probed: bool,
     lifecycle: Option<GgmlGraphLifecycleState>,
     _runner_borrow: PhantomData<&'a mut GgmlCpuGraphRunner>,
 }
@@ -2852,11 +2977,83 @@ impl GgmlPersistentGraphSession {
     }
 
     #[cfg(test)]
+    pub(crate) fn prepared_graph_capture_allowed_for_test(&self) -> Option<bool> {
+        self.builder.prepared_graph_capture_allowed_for_test()
+    }
+
+    #[cfg(test)]
     pub(crate) fn prepared_allocation_bytes(&self) -> Option<u64> {
         self.builder
             .graph_allocator
             .as_ref()
             .map(GgmlGraphAllocatorGuard::requested_bytes)
+    }
+}
+
+/// Identity of a reusable ggml graph's input shape. Families compare this key
+/// and rebuild the persistent session only when it changes.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub(crate) struct GgmlGraphShapeKey {
+    pub dims: [u64; 4],
+}
+
+impl GgmlGraphShapeKey {
+    pub(crate) fn new(d0: usize, d1: usize, d2: usize, d3: usize) -> Self {
+        Self {
+            dims: [d0 as u64, d1 as u64, d2 as u64, d3 as u64],
+        }
+    }
+}
+
+/// Build-once / re-run helper for graphs whose topology is fixed but whose
+/// tensor extents depend on the request (audio frames, prompt length). A
+/// warmup and the measured run with the same shape skip `start_graph`.
+/// This is graph-object reuse, not decode-lane capture evidence; encoder
+/// families must not gate it on `GgmlDecodeReuseMode::ReusableGraph`.
+#[derive(Default)]
+pub(crate) struct GgmlSameShapePersistentGraph {
+    session: Option<GgmlPersistentGraphSession>,
+    shape: Option<GgmlGraphShapeKey>,
+}
+
+/// Encoder same-shape reuse is available on every backend that can keep a
+/// ggml graph. Decode `ReusableGraph` remains the capture-evidence gate.
+pub(crate) const fn encoder_same_shape_reuse_is_enabled() -> bool {
+    true
+}
+
+impl GgmlSameShapePersistentGraph {
+    /// Returns the persistent builder and whether it was reused for `shape`.
+    pub(crate) fn builder_for_shape(
+        &mut self,
+        runner: &mut GgmlCpuGraphRunner,
+        shape: GgmlGraphShapeKey,
+    ) -> Result<(&mut GgmlCpuGraphBuilder<'static>, bool), GgmlCpuGraphError> {
+        let reused = self.shape == Some(shape)
+            && self
+                .session
+                .as_ref()
+                .is_some_and(|session| !session.is_poisoned());
+        if !reused {
+            self.session = None;
+            self.session = Some(runner.start_capacity_sized_persistent_graph_session()?);
+            self.shape = Some(shape);
+        }
+        let session = self
+            .session
+            .as_mut()
+            .expect("same-shape session is installed above");
+        Ok((session.builder(), reused))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn drop_session(&mut self) {
+        self.session = None;
+        self.shape = None;
+    }
+
+    pub(crate) fn has_session(&self) -> bool {
+        self.session.is_some()
     }
 }
 
@@ -2906,7 +3103,6 @@ impl GgmlCpuGraphRunner {
         // or execute CPU work before telemetry can reject the attempt).
         let use_scheduler = config.use_scheduler && scheduler_allows_cpu;
 
-        let context = GgmlContextGuard::new(config.context_bytes, "ggml.runner-context")?;
         let mut backend = match config.backend {
             GgmlCpuGraphBackend::Cpu => GgmlBackendGuard::cpu()?,
             GgmlCpuGraphBackend::Metal => GgmlBackendGuard::metal()?,
@@ -3009,7 +3205,8 @@ impl GgmlCpuGraphRunner {
             super::backend_graph_lifecycle::BackendGraphLifecycleBinding::resolve(backend.raw)
         };
         Ok(Self {
-            context,
+            context: None,
+            context_bytes: config.context_bytes,
             backend,
             backend_kind: config.backend,
             backend_name,
@@ -3194,6 +3391,33 @@ impl GgmlCpuGraphRunner {
         Ok(loaded)
     }
 
+    fn park_idle_runner_graph_context(&mut self) {
+        self.context = None;
+    }
+
+    fn ensure_runner_graph_context(&mut self) {
+        if self.context.is_none() {
+            self.context = Some(
+                GgmlContextGuard::new(self.context_bytes, "ggml.runner-context").unwrap_or_else(
+                    |error| {
+                        panic!(
+                            "failed to restore parked runner graph context ({} bytes): {error}",
+                            self.context_bytes
+                        )
+                    },
+                ),
+            );
+        }
+    }
+
+    #[cfg(test)]
+    fn runner_graph_context_bytes_for_test(&self) -> usize {
+        self.context
+            .as_ref()
+            .map(GgmlContextGuard::mem_size)
+            .unwrap_or(0)
+    }
+
     pub(crate) fn start_graph(&mut self) -> GgmlCpuGraphBuilder<'_> {
         if let Some(scheduler) = self.scheduler.as_ref() {
             // `ggml_reset` discards the old graph metadata. Detach any
@@ -3202,7 +3426,13 @@ impl GgmlCpuGraphRunner {
             unsafe { ffi::ggml_backend_sched_reset(scheduler.raw.as_ptr()) };
             scheduler.memory_owner.active_graph_address.set(None);
         }
-        unsafe { ffi::ggml_reset(self.context.raw.as_ptr()) };
+        self.ensure_runner_graph_context();
+        let context_raw = self
+            .context
+            .as_ref()
+            .expect("runner graph context installed for start_graph")
+            .raw;
+        unsafe { ffi::ggml_reset(context_raw.as_ptr()) };
         let scheduler = self.scheduler.as_ref().map(|scheduler| scheduler.raw);
         let scheduler_memory_owner = self
             .scheduler
@@ -3235,7 +3465,7 @@ impl GgmlCpuGraphRunner {
             self.last_transient_graph_generation = Some(lifecycle.observed_generation());
         }
         GgmlCpuGraphBuilder {
-            context: self.context.raw,
+            context: context_raw,
             backend: self.backend.raw,
             backend_kind: self.backend_kind,
             backend_capabilities: self.backend_capabilities,
@@ -3249,6 +3479,7 @@ impl GgmlCpuGraphRunner {
             buffer: None,
             graph_allocator: None,
             step_buffer_pool,
+            native_capture_allowed: false,
             frozen: false,
             prepared_graph: None,
             side_effect_roots: Vec::new(),
@@ -3258,6 +3489,9 @@ impl GgmlCpuGraphRunner {
             direct_graph_private_pending: Vec::new(),
             execution_graph_id: NEXT_EXECUTION_GRAPH_ID.fetch_add(1, Ordering::Relaxed),
             observed_placement: None,
+            identity_attested: false,
+            observation_receipt_key: None,
+            after_compute_memory_probed: false,
             lifecycle,
             _runner_borrow: PhantomData,
         }
@@ -3274,6 +3508,16 @@ impl GgmlCpuGraphRunner {
     /// process-resident allocation instead.
     pub(crate) fn release_cpu_step_buffer_pool(&mut self) {
         self.cpu_step_buffer_pool = GgmlCpuStepBufferPool::new();
+    }
+
+    /// After any persistent graph session has been dropped, release scheduler
+    /// gallocr buffers and the CPU step pool so a cached runner does not keep
+    /// request-scoped compute residency. Uploaded weights and backend handles
+    /// stay. Callers must drop `GgmlPersistentGraphSession` first or this
+    /// returns [`GgmlCpuGraphError::PersistentGraphSessionActive`].
+    pub(crate) fn release_request_compute_residency(&mut self) -> Result<(), GgmlCpuGraphError> {
+        self.release_cpu_step_buffer_pool();
+        self.release_transient_scheduler_working_set()
     }
 
     /// Releases a completed transient stage's scheduler-owned graph buffers
@@ -3306,7 +3550,14 @@ impl GgmlCpuGraphRunner {
         mut trim_backend: impl FnMut(ffi::GgmlBackendRaw) -> Result<(), GgmlCpuGraphError>,
     ) -> Result<(), GgmlCpuGraphError> {
         let Some(current) = self.scheduler.as_ref() else {
-            return Ok(());
+            // Direct GPU (Vulkan/HIP without a scheduler) still keeps
+            // backend-private cached buffers after `start_graph` drops.
+            // Trim those here so a cached runner does not hold request
+            // scratch. CPU has no trim ABI and is a no-op.
+            if !self.backend_kind.is_gpu_class() {
+                return Ok(());
+            }
+            return trim_backend(self.backend.raw.as_ptr());
         };
         if current.has_dependent_handles() {
             return Err(GgmlCpuGraphError::PersistentGraphSessionActive);
@@ -3446,6 +3697,9 @@ impl GgmlCpuGraphRunner {
         if graph_size == 0 {
             return Err(GgmlCpuGraphError::InvalidGraphSize);
         }
+        // Persistent sessions allocate their own metadata arena. Drop the idle
+        // start_graph buffer first so PeakWorkingSet never holds both.
+        self.park_idle_runner_graph_context();
         let context = GgmlContextGuard::new(context_bytes, "ggml.persistent-graph-context")?;
         let lifecycle = super::current_graph_lifecycle_collector()
             .map(|collector| GgmlGraphLifecycleState::created(&self.execution_identity, collector));
@@ -3487,6 +3741,7 @@ impl GgmlCpuGraphRunner {
             // allocation for the session's whole lifetime, so it does not
             // need the step pool's grow-to-fit reuse.
             step_buffer_pool: None,
+            native_capture_allowed: true,
             frozen: false,
             prepared_graph: None,
             side_effect_roots: Vec::new(),
@@ -3496,6 +3751,9 @@ impl GgmlCpuGraphRunner {
             direct_graph_private_pending: Vec::new(),
             execution_graph_id: NEXT_EXECUTION_GRAPH_ID.fetch_add(1, Ordering::Relaxed),
             observed_placement: None,
+            identity_attested: false,
+            observation_receipt_key: None,
+            after_compute_memory_probed: false,
             lifecycle,
             _runner_borrow: PhantomData,
         };
@@ -6250,6 +6508,8 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             lifecycle
                 .kv_write_tensors
                 .insert(write.raw.as_ptr() as usize);
+            lifecycle.kv_write_graph_addr = None;
+            lifecycle.kv_write_graph_reached = false;
         }
         Ok(write)
     }
@@ -6276,6 +6536,8 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             lifecycle
                 .kv_write_tensors
                 .insert(tensor.raw.as_ptr() as usize);
+            lifecycle.kv_write_graph_addr = None;
+            lifecycle.kv_write_graph_reached = false;
         }
         Ok(())
     }
@@ -6872,6 +7134,12 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             lifecycle.ensure_prepared();
         }
         Ok(())
+    }
+
+    #[cfg(test)]
+    fn prepared_graph_capture_allowed_for_test(&self) -> Option<bool> {
+        self.prepared_graph
+            .map(|graph| unsafe { ggml_graph_capture_allowed(graph.as_ptr()) })
     }
 
     pub(crate) fn prepare_side_effects_for_upload(&mut self) -> Result<(), GgmlCpuGraphError> {
@@ -7541,12 +7809,34 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         Ok(())
     }
 
-    fn compute_graph_with_memory_gate(
-        &mut self,
-        graph: NonNull<c_void>,
-    ) -> Result<(), GgmlCpuGraphError> {
-        if super::thread_job_cancel_flag().is_some_and(|flag| flag.load(Ordering::Acquire)) {
-            return self.finish_compute_result(Ok(ffi::GGML_STATUS_ABORTED));
+    fn attest_live_runner_identity(&mut self) -> Result<(), GgmlCpuGraphError> {
+        if self.identity_attested {
+            let placement = crate::models::native_execution_services::current_execution_placement();
+            if placement != self.runner_identity.placement {
+                return Err(GgmlCpuGraphError::RunnerPlacementChanged {
+                    expected: self.runner_identity.placement,
+                    actual: placement,
+                });
+            }
+            // Exact-route identity is a runner constant after the first
+            // compute. Re-attesting it on Zipformer/HIP decode steps only
+            // inflates RTF.
+            let receipt_key =
+                crate::models::native_execution_services::current_execution_receipt_collector()
+                    .map(|receipt| receipt.identity_key());
+            if self.observation_receipt_key != receipt_key {
+                crate::models::native_execution_services::record_current_execution_backend_observation(
+                    self.backend.as_ptr() as usize,
+                    self.backend_kind,
+                    &self.runner_identity.backend_name,
+                    self.runner_identity.actual_provider,
+                    &self.runner_identity.actual_stable_device_id,
+                    self.runner_identity.actual_device.as_ref(),
+                    self.scheduler.is_some(),
+                );
+                self.observation_receipt_key = receipt_key;
+            }
+            return Ok(());
         }
         attest_runner_execution_identity(
             self.backend,
@@ -7555,6 +7845,21 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             &self.runner_identity,
             self.scheduler.is_some(),
         )?;
+        self.identity_attested = true;
+        self.observation_receipt_key =
+            crate::models::native_execution_services::current_execution_receipt_collector()
+                .map(|receipt| receipt.identity_key());
+        Ok(())
+    }
+
+    fn compute_graph_with_memory_gate(
+        &mut self,
+        graph: NonNull<c_void>,
+    ) -> Result<(), GgmlCpuGraphError> {
+        if super::thread_job_cancel_flag().is_some_and(|flag| flag.load(Ordering::Acquire)) {
+            return self.finish_compute_result(Ok(ffi::GGML_STATUS_ABORTED));
+        }
+        self.attest_live_runner_identity()?;
         if let Some(lifecycle) = self.lifecycle.as_mut() {
             lifecycle.refresh_request_collector();
         }
@@ -7568,7 +7873,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         TEST_COMPUTE_GATE_ATTEMPT_COUNT.with(|count| count.set(count.get().saturating_add(1)));
         let kv_writes_reached_compute = self
             .lifecycle
-            .as_ref()
+            .as_mut()
             .is_some_and(|lifecycle| Self::registered_kv_writes_reached_by(graph, lifecycle));
         if self.lifecycle.is_some()
             && let Err(source) = self.observe_native_graph_lifecycle(
@@ -7603,6 +7908,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             }
         }
         if result.is_ok()
+            && !self.after_compute_memory_probed
             && crate::models::native_execution_services::current_execution_observation_sink()
                 .is_some()
         {
@@ -7610,6 +7916,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 self.backend.as_ptr(),
                 super::backend_memory::BackendMemoryLifecyclePoint::AfterGraphCompute,
             );
+            self.after_compute_memory_probed = true;
         }
         result
     }
@@ -7622,9 +7929,35 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         if self.lifecycle.is_none() || self.scheduler.is_some() {
             return Ok(());
         }
+        // One-shot `start_graph` builders opt out of CUDA/HIP capture. HIP
+        // still reports capture_supported; requiring tracking after compute
+        // would fail-close every encoder/prefill graph we intentionally left
+        // uninstantiated.
+        if !self.native_capture_allowed {
+            return Ok(());
+        }
+        if self
+            .lifecycle
+            .as_ref()
+            .is_some_and(GgmlGraphLifecycleState::skip_further_native_capture_observe)
+        {
+            return Ok(());
+        }
+        let backend_addr = self.backend.as_ptr() as usize;
+        let capture_unsupported = THREAD_CAPTURE_UNSUPPORTED_BACKEND_ADDRS
+            .try_with(|addrs| addrs.borrow().contains(&backend_addr))
+            .unwrap_or(false);
+        if capture_unsupported {
+            return Ok(());
+        }
         let Some(observation) = self.backend_graph_lifecycle.observe(self.backend, graph)? else {
             return Ok(());
         };
+        if !observation.capture_supported {
+            let _ = THREAD_CAPTURE_UNSUPPORTED_BACKEND_ADDRS.try_with(|addrs| {
+                addrs.borrow_mut().insert(backend_addr);
+            });
+        }
         self.lifecycle
             .as_mut()
             .expect("lifecycle presence checked before native observation")
@@ -7646,10 +7979,14 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
 
     fn registered_kv_writes_reached_by(
         graph: NonNull<c_void>,
-        lifecycle: &GgmlGraphLifecycleState,
+        lifecycle: &mut GgmlGraphLifecycleState,
     ) -> bool {
         if lifecycle.kv_write_tensors.is_empty() {
             return false;
+        }
+        let graph_addr = graph.as_ptr() as usize;
+        if lifecycle.kv_write_graph_addr == Some(graph_addr) {
+            return lifecycle.kv_write_graph_reached;
         }
         let mut observed = 0usize;
         let node_count = unsafe { ffi::ggml_graph_n_nodes(graph.as_ptr()) };
@@ -7659,7 +7996,10 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 observed = observed.saturating_add(1);
             }
         }
-        observed == lifecycle.kv_write_tensors.len()
+        let reached = observed == lifecycle.kv_write_tensors.len();
+        lifecycle.kv_write_graph_addr = Some(graph_addr);
+        lifecycle.kv_write_graph_reached = reached;
+        reached
     }
 
     fn record_execution_placement(&mut self, graph: NonNull<c_void>) {
@@ -7865,6 +8205,149 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
             None
         };
         Ok(GgmlComputeRowsOutput { value, evidence })
+    }
+
+    /// One `ggml_backend_tensor_get` per CTC/argmax row waits on a discrete
+    /// GPU fence per frame. Cap the host transfer so PeakWS does not hold the
+    /// full logit matrix beside live compute buffers, but batch enough rows
+    /// that Vulkan/HIP pay one copy+fence per chunk. The visitor still sees
+    /// exactly one row.
+    const ROW_READBACK_CHUNK_BYTES: usize = 4 * 1024 * 1024;
+
+    /// Computes once, then visits each output row from a reused host buffer.
+    /// Callers that can consume a row immediately (CTC greedy, argmax) must
+    /// use this instead of materializing the full host matrix while backend
+    /// compute buffers are still live.
+    pub(crate) fn compute_output_f32_rows_for_each<F>(
+        &mut self,
+        output: GgmlCpuTensor<'a>,
+        row_width: usize,
+        row_count: usize,
+        mut visit: F,
+    ) -> Result<Option<Vec<super::GgmlSelectionEvidenceRef>>, GgmlCpuGraphError>
+    where
+        F: FnMut(usize, &[f32]) -> Result<(), GgmlCpuGraphError>,
+    {
+        if row_width == 0 || row_count == 0 {
+            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                reason: "row-partitioned output dimensions must be positive",
+            });
+        }
+        let expected_len =
+            row_width
+                .checked_mul(row_count)
+                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "row-partitioned output element count overflow",
+                })?;
+        let row_nbytes =
+            row_width
+                .checked_mul(F32_WIDTH_BYTES)
+                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "row byte width overflow",
+                })?;
+        let expected_nbytes = expected_len.checked_mul(F32_WIDTH_BYTES).ok_or(
+            GgmlCpuGraphError::UnsupportedInputs {
+                reason: "tensor byte width overflow",
+            },
+        )?;
+        self.ensure_not_poisoned()?;
+        self.ensure_tensor_type(
+            output,
+            ffi::GGML_TYPE_F32,
+            "compute_output_f32_rows_for_each",
+        )?;
+        let actual_nbytes = self.tensor_nbytes(output);
+        if actual_nbytes != expected_nbytes {
+            return Err(GgmlCpuGraphError::OutputByteSizeMismatch {
+                expected: expected_nbytes,
+                actual: actual_nbytes,
+            });
+        }
+
+        let graph_prepared = self.prepared_graph.is_some();
+        let graph = if let Some(graph) = self.prepared_graph {
+            graph
+        } else {
+            self.ensure_backend_buffer()?;
+            self.build_forward_graph(&[output])?
+        };
+        if self.scheduler.is_some() && !graph_prepared {
+            self.allocate_scheduler_graph_for_compute(graph)?;
+        }
+        self.compute_graph_with_memory_gate(graph)?;
+
+        let rows_per_chunk = Self::ROW_READBACK_CHUNK_BYTES
+            .checked_div(row_nbytes)
+            .filter(|&rows| rows > 0)
+            .unwrap_or(1)
+            .min(row_count);
+        let chunk_len =
+            row_width
+                .checked_mul(rows_per_chunk)
+                .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                    reason: "row-partitioned output element count overflow",
+                })?;
+        let mut chunk = vec![0.0f32; chunk_len];
+        let mut compute_evidence = None;
+        let mut evidence_rows = if self.lifecycle.is_some() {
+            Some(Vec::with_capacity(row_count))
+        } else {
+            None
+        };
+        let mut row_index = 0usize;
+        while row_index < row_count {
+            let rows_this = (row_count - row_index).min(rows_per_chunk);
+            let offset =
+                row_index
+                    .checked_mul(row_nbytes)
+                    .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "row byte offset overflow",
+                    })?;
+            let chunk_nbytes =
+                rows_this
+                    .checked_mul(row_nbytes)
+                    .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "row-partitioned output byte width overflow",
+                    })?;
+            let status = unsafe {
+                read_tensor_bytes(
+                    output.raw.as_ptr(),
+                    chunk.as_mut_ptr().cast::<c_void>(),
+                    offset,
+                    chunk_nbytes,
+                )
+            };
+            if row_index == 0 {
+                let output_evidence = self.finish_output_read(status, expected_nbytes)?;
+                if self.lifecycle.is_some() && output_evidence.is_none() {
+                    return Err(self.fail_output_evidence(
+                        "successful output readback did not produce a compute evidence ref",
+                    ));
+                }
+                compute_evidence = output_evidence;
+            } else {
+                self.finish_readback_status(status)?;
+            }
+            for local_index in 0..rows_this {
+                let abs_index = row_index + local_index;
+                let start = local_index * row_width;
+                let row = &chunk[start..start + row_width];
+                if let Some(rows) = evidence_rows.as_mut() {
+                    let Some(row_evidence) = compute_evidence
+                        .as_ref()
+                        .and_then(|compute| compute.selection(abs_index, row_count))
+                    else {
+                        return Err(self.fail_output_evidence(
+                            "readback layer could not mint a bounded output-row witness",
+                        ));
+                    };
+                    rows.push(row_evidence);
+                }
+                visit(abs_index, row)?;
+            }
+            row_index += rows_this;
+        }
+        Ok(evidence_rows)
     }
 
     /// Executes the graph once and reads every declared output in declaration
@@ -8585,10 +9068,14 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         &self,
         step: &'static str,
     ) -> Result<NonNull<c_void>, GgmlCpuGraphError> {
-        NonNull::new(unsafe {
+        let graph = NonNull::new(unsafe {
             ffi::ggml_new_graph_custom(self.context.as_ptr(), self.graph_size, false)
         })
-        .ok_or(GgmlCpuGraphError::GraphBuildFailed { step })
+        .ok_or(GgmlCpuGraphError::GraphBuildFailed { step })?;
+        if self.native_capture_allowed {
+            unsafe { ggml_graph_set_capture_allowed(graph.as_ptr(), true) };
+        }
+        Ok(graph)
     }
 
     fn ensure_can_extend_graph(&self, step: &'static str) -> Result<(), GgmlCpuGraphError> {
@@ -9588,6 +10075,22 @@ struct GgmlContextGuard {
     // Field order is load-bearing: `raw` is freed before the lease refunds
     // its committed SystemMemory bytes.
     _system_memory: crate::models::system_memory_owner::SystemMemoryOwner<()>,
+    log_label: &'static str,
+    log_bytes: usize,
+}
+
+fn log_ggml_contexts() -> bool {
+    std::env::var_os("OPENASR_LOG_GGML_CONTEXTS").is_some()
+}
+
+fn log_ggml_context_event(op: &str, label: &str, bytes: usize, raw: NonNull<c_void>) {
+    if !log_ggml_contexts() {
+        return;
+    }
+    eprintln!(
+        "ggml_context {op} label={label} bytes={bytes} ptr={raw:p}",
+        raw = raw.as_ptr()
+    );
 }
 
 impl GgmlContextGuard {
@@ -9600,12 +10103,15 @@ impl GgmlContextGuard {
                 no_alloc: true,
             })
         };
-        NonNull::new(raw)
-            .map(|raw| Self {
-                raw,
-                _system_memory: system_memory,
-            })
-            .ok_or(GgmlCpuGraphError::ContextInitFailed { context_bytes })
+        let raw =
+            NonNull::new(raw).ok_or(GgmlCpuGraphError::ContextInitFailed { context_bytes })?;
+        log_ggml_context_event("alloc", resource_id, context_bytes, raw);
+        Ok(Self {
+            raw,
+            _system_memory: system_memory,
+            log_label: resource_id,
+            log_bytes: context_bytes,
+        })
     }
 
     fn reserve_system_memory(
@@ -9627,19 +10133,29 @@ impl GgmlContextGuard {
         })
     }
 
+    #[cfg(test)]
+    fn mem_size(&self) -> usize {
+        unsafe { ffi::ggml_get_mem_size(self.raw.as_ptr()) }
+    }
+
     fn from_raw(
         raw: NonNull<c_void>,
         system_memory: crate::models::system_memory_owner::SystemMemoryOwner<()>,
     ) -> Self {
+        let bytes = unsafe { ffi::ggml_get_mem_size(raw.as_ptr()) };
+        log_ggml_context_event("adopt", "ggml.loaded-weight-context", bytes, raw);
         Self {
             raw,
             _system_memory: system_memory,
+            log_label: "ggml.loaded-weight-context",
+            log_bytes: bytes,
         }
     }
 }
 
 impl Drop for GgmlContextGuard {
     fn drop(&mut self) {
+        log_ggml_context_event("free", self.log_label, self.log_bytes, self.raw);
         unsafe { ffi::ggml_free(self.raw.as_ptr()) };
     }
 }
@@ -9783,16 +10299,17 @@ impl GgmlSchedulerMemoryOwner {
 /// handed-out guard share the same native lifetime owner.
 ///
 /// The table is a thread-affine implementation detail, not a process-global
-/// owner: every cached key includes the current NES scope and exact route, and
-/// an unscoped low-level caller receives an ordinary drop-owned backend rather
-/// than publishing into this cache.
+/// owner. The cache key is the device: a Vulkan/HIP/CUDA context is
+/// thread+device state, not a request. Unscoped name/capability probes that
+/// used to init+drop a throwaway backend left AMD WDDM ~2.1MiB host slabs in
+/// PeakWorkingSet after `ggml_backend_free`.
 ///
 /// Invariant: a cache entry's [`CachedBackendKey`] is always the route of the
 /// device that was actually initialized. Preferred/Auto may Optimus-fall
 /// through discrete -> iGPU, but each successful init is inserted under that
 /// device's own key -- never under a preferred route key while holding a
 /// different card. Exact never falls through.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum CachedBackendDeviceKey {
     /// System-default Metal device (not exactly addressable).
     Metal,
@@ -9800,19 +10317,17 @@ enum CachedBackendDeviceKey {
     Route(ExecutionRouteCacheKey),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct CachedBackendKey {
-    scope_id: crate::models::native_execution_services::NativeExecutionScopeId,
     device: CachedBackendDeviceKey,
 }
 
 impl CachedBackendKey {
-    fn for_current_scope(device: CachedBackendDeviceKey) -> Option<Self> {
-        Some(Self {
-            scope_id: crate::models::native_execution_services::current_native_execution_scope_id(
-            )?,
-            device,
-        })
+    fn for_current_scope(device: CachedBackendDeviceKey) -> Self {
+        // Do not require current_native_execution_scope_id: Vulkan BUFFER
+        // quotes and name/capability probes run before NES is installed, and
+        // a throwaway `ggml_backend_dev_init` is not reclaimed by AMD WDDM.
+        Self { device }
     }
 }
 
@@ -9824,6 +10339,12 @@ thread_local! {
     /// Stored as `usize` (never dereferenced) purely for pointer-identity
     /// comparison -- see `mark_backend_poisoned_sticky`.
     static THREAD_POISONED_BACKEND_ADDRS: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+    /// Backend handles whose first native lifecycle observe reported
+    /// capture-unsupported. Capture support is a backend-handle constant, so
+    /// later start_graph builders skip the FFI probe instead of paying it on
+    /// every fresh graph (Vulkan on this GPU).
+    static THREAD_CAPTURE_UNSUPPORTED_BACKEND_ADDRS: RefCell<HashSet<usize>> =
+        RefCell::new(HashSet::new());
 }
 
 /// Sticky, thread-scoped poison for a backend handle that reported
@@ -10136,6 +10657,7 @@ impl GgmlBackendGuard {
     }
 
     fn gpu() -> Result<Self, GgmlCpuGraphError> {
+        super::apply_vulkan_device_local_buffer_policy();
         match request_backend_override() {
             Some(RequestBackendPreference::Exact(route)) => {
                 if route.provider == ExecutionProvider::Metal {
@@ -10178,10 +10700,8 @@ impl GgmlBackendGuard {
         device_key: CachedBackendDeviceKey,
         init: impl FnOnce() -> Result<NonNull<c_void>, GgmlCpuGraphError>,
     ) -> Result<Self, GgmlCpuGraphError> {
-        let key = CachedBackendKey::for_current_scope(device_key.clone());
-        if let Some(key) = key.as_ref()
-            && let Some((raw, private_memory_leases, lifetime)) = Self::cached_backend_lookup(key)
-        {
+        let key = CachedBackendKey::for_current_scope(device_key);
+        if let Some((raw, private_memory_leases, lifetime)) = Self::cached_backend_lookup(&key) {
             return Ok(Self::from_shared_lifetime(
                 raw,
                 private_memory_leases,
@@ -10189,9 +10709,6 @@ impl GgmlBackendGuard {
             ));
         }
         let raw = init()?;
-        let Some(key) = key else {
-            return Ok(Self::from_owned(raw, Rc::new(RefCell::new(Vec::new()))));
-        };
         let (private_memory_leases, lifetime) = Self::cached_backend_insert(key, raw);
         Ok(Self::from_shared_lifetime(
             raw,
@@ -10298,9 +10815,7 @@ impl GgmlBackendGuard {
             let key = CachedBackendKey::for_current_scope(CachedBackendDeviceKey::Route(
                 route.cache_key(),
             ));
-            if let Some(key) = key.as_ref()
-                && let Some((raw, private_memory_leases, lifetime)) =
-                    Self::cached_backend_lookup(key)
+            if let Some((raw, private_memory_leases, lifetime)) = Self::cached_backend_lookup(&key)
             {
                 return Ok(Self::from_shared_lifetime(
                     raw,
@@ -10310,9 +10825,6 @@ impl GgmlBackendGuard {
             }
             match Self::init_route_gpu_device(&devices, &route) {
                 Ok(raw) => {
-                    let Some(key) = key else {
-                        return Ok(Self::from_owned(raw, Rc::new(RefCell::new(Vec::new()))));
-                    };
                     let (private_memory_leases, lifetime) = Self::cached_backend_insert(key, raw);
                     return Ok(Self::from_shared_lifetime(
                         raw,
@@ -10390,6 +10902,7 @@ impl GgmlBackendGuard {
     fn init_exact_gpu_backend(
         route: &ResolvedExecutionRoute,
     ) -> Result<NonNull<c_void>, GgmlCpuGraphError> {
+        super::apply_vulkan_device_local_buffer_policy();
         let devices = ggml_available_devices();
         Self::init_route_gpu_device(&devices, route).inspect_err(|error| {
             record_device_unavailable("gpu-backend/exact-init", error.to_string());
@@ -12250,14 +12763,9 @@ mod tests {
         lifecycle.compute_completed(compute_sequence, false);
         lifecycle
             .observe_native_capture(updated, GgmlNativeGraphObservationPhase::BeforeCompute)
-            .expect("unchanged generation is deduplicated before the next compute");
-        let second_compute_sequence = lifecycle.compute_started();
+            .expect("further observes on a settled graph are skipped");
         lifecycle
-            .observe_native_capture(updated, GgmlNativeGraphObservationPhase::AfterCompute)
-            .expect("unchanged generation remains observable after the next compute");
-        lifecycle.compute_completed(second_compute_sequence, false);
-        assert_eq!(
-            lifecycle.observe_native_capture(
+            .observe_native_capture(
                 native_capture_observation(
                     true,
                     true,
@@ -12266,9 +12774,8 @@ mod tests {
                     Some(NativeGraphExecutableChange::Replaced),
                 ),
                 GgmlNativeGraphObservationPhase::BeforeCompute,
-            ),
-            Err(BackendGraphLifecycleError::CaptureGenerationChangedOutsideCompute)
-        );
+            )
+            .expect("settled capture does not keep probing for later generation changes");
 
         let snapshot = collector.snapshot();
         let capture_phases = snapshot
@@ -12282,8 +12789,6 @@ mod tests {
         assert_eq!(
             capture_phases,
             vec![
-                GgmlCaptureObservationPhase::BeforeCompute,
-                GgmlCaptureObservationPhase::AfterCompute,
                 GgmlCaptureObservationPhase::BeforeCompute,
                 GgmlCaptureObservationPhase::AfterCompute,
             ]
@@ -12350,6 +12855,7 @@ mod tests {
             .expect("warm request must re-observe unchanged native capture");
         lifecycle.compute_started();
 
+        warm_collector.end_observation_scope();
         warm_collector.begin_observation_scope();
         lifecycle.refresh_request_collector();
         lifecycle
@@ -12448,17 +12954,119 @@ mod tests {
     }
 
     #[test]
+    fn sibling_observation_scope_keeps_attached_graph_compute_completed() {
+        let collector = GgmlGraphLifecycleCollector::new();
+        collector.begin_observation_scope();
+        let mut lifecycle = test_graph_lifecycle_state(collector.clone());
+        let seq = lifecycle.compute_started();
+        collector.begin_observation_scope();
+        lifecycle.compute_completed(seq, false);
+        let events = collector.snapshot().events;
+        assert!(
+            events.iter().any(|event| matches!(
+                event.kind,
+                GgmlGraphLifecycleEventKind::ComputeStarted {
+                    compute_sequence,
+                    ..
+                } if compute_sequence == seq
+            )),
+            "compute_started must survive a sibling observation-scope begin"
+        );
+        assert!(
+            events.iter().any(|event| matches!(
+                event.kind,
+                GgmlGraphLifecycleEventKind::ComputeCompleted {
+                    compute_sequence,
+                    ..
+                } if compute_sequence == seq
+            )),
+            "compute_completed must still record on the graph attached before the sibling begin"
+        );
+    }
+
+    #[test]
+    fn native_capture_supported_skips_ffi_after_first_after_compute() {
+        let collector = GgmlGraphLifecycleCollector::new();
+        let mut lifecycle = test_graph_lifecycle_state(collector.clone());
+        let instantiated = native_capture_observation(
+            true,
+            true,
+            true,
+            Some(1),
+            Some(NativeGraphExecutableChange::Instantiated),
+        );
+        lifecycle
+            .observe_native_capture(instantiated, GgmlNativeGraphObservationPhase::BeforeCompute)
+            .expect("first before-compute");
+        lifecycle
+            .observe_native_capture(instantiated, GgmlNativeGraphObservationPhase::AfterCompute)
+            .expect("first after-compute settles capture");
+        let before = collector.snapshot().events.len();
+        lifecycle
+            .observe_native_capture(instantiated, GgmlNativeGraphObservationPhase::BeforeCompute)
+            .expect("settled supported capture skips later observes");
+        lifecycle
+            .observe_native_capture(instantiated, GgmlNativeGraphObservationPhase::AfterCompute)
+            .expect("settled supported capture skips later after-compute");
+        assert_eq!(
+            collector.snapshot().events.len(),
+            before,
+            "HIP-class capture must not emit a CaptureStateObserved event per decode step"
+        );
+    }
+
+    #[test]
+    fn native_capture_unsupported_is_observed_once() {
+        let collector = GgmlGraphLifecycleCollector::new();
+        let mut lifecycle = test_graph_lifecycle_state(collector.clone());
+        let unsupported = native_capture_observation(false, false, false, None, None);
+        lifecycle
+            .observe_native_capture(unsupported, GgmlNativeGraphObservationPhase::BeforeCompute)
+            .expect("first unsupported observation");
+        lifecycle
+            .observe_native_capture(unsupported, GgmlNativeGraphObservationPhase::AfterCompute)
+            .expect("settled unsupported skips later FFI-equivalent observes");
+        lifecycle
+            .observe_native_capture(
+                native_capture_observation(true, true, false, None, None),
+                GgmlNativeGraphObservationPhase::AfterCompute,
+            )
+            .expect("capture support is a backend constant; later probes are no-ops");
+        let capture_events = collector
+            .snapshot()
+            .events
+            .into_iter()
+            .filter(|event| {
+                matches!(
+                    event.kind,
+                    GgmlGraphLifecycleEventKind::CaptureStateObserved { .. }
+                )
+            })
+            .count();
+        assert_eq!(
+            capture_events, 1,
+            "unsupported capture must not emit a CaptureStateObserved event per compute"
+        );
+    }
+
+    #[test]
     fn native_capture_state_fails_closed_on_drift_disappearance_and_regression() {
         let mut policy = test_graph_lifecycle_state(GgmlGraphLifecycleCollector::new());
         policy
             .observe_native_capture(
-                native_capture_observation(false, false, false, None, None),
+                native_capture_observation(
+                    true,
+                    true,
+                    true,
+                    Some(1),
+                    Some(NativeGraphExecutableChange::Instantiated),
+                ),
                 GgmlNativeGraphObservationPhase::BeforeCompute,
             )
-            .expect("unsupported state");
+            .expect("supported capture");
         assert_eq!(
             policy.observe_native_capture(
-                native_capture_observation(true, true, false, None, None),
+                native_capture_observation(false, false, false, None, None),
                 GgmlNativeGraphObservationPhase::AfterCompute,
             ),
             Err(BackendGraphLifecycleError::CapturePolicyDrift)
@@ -12508,12 +13116,6 @@ mod tests {
                 GgmlNativeGraphObservationPhase::BeforeCompute,
             )
             .expect("untracked pre-compute state");
-        tracking
-            .observe_native_capture(
-                native_capture_observation(true, true, false, None, None),
-                GgmlNativeGraphObservationPhase::AfterCompute,
-            )
-            .expect("tracked disabled post-compute state");
         assert_eq!(
             tracking.observe_native_capture(
                 native_capture_observation(true, false, false, None, None),
@@ -12646,7 +13248,8 @@ mod tests {
                     matches!(&event.kind, GgmlGraphLifecycleEventKind::InputWrite { .. })
                 })
                 .count(),
-            2
+            0,
+            "input_write events are not recorded; graph_rebuilt binds compute start/complete/read"
         );
         assert!(
             creation_events
@@ -12734,6 +13337,38 @@ mod tests {
             }
             other => panic!("expected runner identity drift, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn reused_persistent_session_keeps_attesting_without_rebuilding() {
+        let mut config = GgmlCpuGraphConfig::conservative_default();
+        config.set_graph_node_capacity(64);
+        let mut runner = GgmlCpuGraphRunner::new(config).expect("cpu graph runner");
+        let mut session = runner
+            .start_persistent_graph_session_with_node_capacity(64)
+            .expect("persistent session");
+        let graph = session.builder();
+        let input = graph.new_tensor_1d_f32(2, "input").expect("input");
+        graph.set_input(input).expect("set_input");
+        let out = graph.add(input, input).expect("add");
+        graph.set_output(out).expect("set_output");
+        graph.prepare_outputs_for_upload(&[out]).expect("prepare");
+        graph
+            .set_f32_slice(input, &[1.0, 2.0], "input")
+            .expect("upload");
+        assert_eq!(
+            graph.compute_output_f32(out, 2).expect("first compute"),
+            vec![2.0, 4.0]
+        );
+        graph
+            .set_f32_slice(input, &[3.0, 4.0], "input")
+            .expect("refresh");
+        assert_eq!(
+            graph
+                .compute_output_f32(out, 2)
+                .expect("cached-identity compute"),
+            vec![6.0, 8.0]
+        );
     }
 
     #[test]
@@ -13185,7 +13820,6 @@ mod tests {
         let sentinel = std::ptr::NonNull::new(0x10 as *mut std::ffi::c_void)
             .expect("non-null sentinel address");
         let key = super::CachedBackendKey {
-            scope_id: crate::models::native_execution_services::NativeExecutionScopeId::next(),
             device: super::CachedBackendDeviceKey::Metal,
         };
         let (_, inserted_lifetime) =
@@ -13207,12 +13841,9 @@ mod tests {
     }
 
     #[test]
-    fn backend_cache_key_requires_and_separates_nes_scopes() {
-        assert!(
-            super::CachedBackendKey::for_current_scope(super::CachedBackendDeviceKey::Metal)
-                .is_none(),
-            "unscoped low-level callers must not publish into the TLS backend cache"
-        );
+    fn backend_cache_key_is_device_only_across_scopes() {
+        let unscoped =
+            super::CachedBackendKey::for_current_scope(super::CachedBackendDeviceKey::Metal);
         let first =
             crate::models::native_execution_services::NativeExecutionServices::for_local_process()
                 .unwrap();
@@ -13223,7 +13854,6 @@ mod tests {
             let _scope =
                 crate::models::native_execution_services::install_native_execution_services(&first);
             super::CachedBackendKey::for_current_scope(super::CachedBackendDeviceKey::Metal)
-                .unwrap()
         };
         let second_key = {
             let _scope =
@@ -13231,10 +13861,9 @@ mod tests {
                     &second,
                 );
             super::CachedBackendKey::for_current_scope(super::CachedBackendDeviceKey::Metal)
-                .unwrap()
         };
-        assert_ne!(first_key.scope_id, second_key.scope_id);
-        assert!(first_key != second_key);
+        assert_eq!(unscoped, first_key);
+        assert_eq!(first_key, second_key);
     }
 
     #[test]
@@ -14582,7 +15211,7 @@ mod tests {
             assert_eq!(resolved.output_plan(), GgmlDecodeOutputPlan::FullLogits);
             // Fake Exact ids such as "Hip0" do not match a live ROCm/Vulkan
             // device, so this fixture still sees Unknown reuse. Live HIP and
-            // Vulkan Accelerated routes are covered by
+            // Vulkan Exact routes are covered by
             // live_hip_or_vulkan_accelerated_authorizes_reusable_full_logits.
             assert_eq!(resolved.reuse_mode(), GgmlDecodeReuseMode::FreshGraph);
             assert!(!resolved.decode_evidence.reuse.is_validated());
@@ -14599,30 +15228,62 @@ mod tests {
     }
 
     #[test]
-    fn live_hip_accelerated_authorizes_reusable_full_logits() {
+    fn live_hip_or_vulkan_accelerated_authorizes_reusable_full_logits() {
         use super::{
             GgmlDecodeOutputContract, GgmlDecodeOutputPlan, GgmlDecodeReuseMode,
             RequestBackendPreference, ResolvedFamilyRuntimeInput,
         };
-        use crate::device::execution_route::ExecutionProvider;
+        use crate::device::execution_route::{
+            DeviceAddressability, ExecutionProvider, ResolvedExecutionRoute, RouteDeviceKind,
+        };
         use crate::ggml_runtime::ggml_available_devices;
 
-        let live_proven = ggml_available_devices().into_iter().any(|device| {
-            ExecutionProvider::from_backend_name(&device.name) == ExecutionProvider::Hip
-        });
-        if !live_proven {
+        let live = ggml_available_devices()
+            .into_iter()
+            .filter(|device| {
+                matches!(
+                    ExecutionProvider::from_backend_name(&device.name),
+                    ExecutionProvider::Hip | ExecutionProvider::Vulkan
+                )
+            })
+            .collect::<Vec<_>>();
+        if live.is_empty() {
             return;
         }
 
-        let resolved = ResolvedFamilyRuntimeInput::resolve_with_output_contract(
-            Some(RequestBackendPreference::Accelerated),
-            super::AutoGpuPolicy::AllBackends,
-            GgmlDecodeOutputContract::NativeFirstMaxTokenOrFullLogits,
-        );
-        assert!(resolved.backend().is_gpu_class());
-        assert_eq!(resolved.output_plan(), GgmlDecodeOutputPlan::FullLogits);
-        assert_eq!(resolved.reuse_mode(), GgmlDecodeReuseMode::ReusableGraph);
-        assert!(resolved.decode_evidence.reuse.is_validated());
+        for device in live {
+            let provider = ExecutionProvider::from_backend_name(&device.name);
+            let resolved = ResolvedFamilyRuntimeInput::resolve_with_output_contract(
+                Some(RequestBackendPreference::Exact(ResolvedExecutionRoute {
+                    provider,
+                    stable_id: device.name.clone(),
+                    registry_ordinal: 0,
+                    kind: RouteDeviceKind::Accelerated,
+                    addressability: DeviceAddressability::NotExactlyAddressable {
+                        reason: "live reuse planner uses the device name, not Exact pin",
+                    },
+                })),
+                super::AutoGpuPolicy::AllBackends,
+                GgmlDecodeOutputContract::NativeFirstMaxTokenOrFullLogits,
+            );
+            assert!(
+                resolved.backend().is_gpu_class(),
+                "{provider:?} {} must stay on a GPU-class runner",
+                device.name
+            );
+            assert_eq!(resolved.output_plan(), GgmlDecodeOutputPlan::FullLogits);
+            assert_eq!(
+                resolved.reuse_mode(),
+                GgmlDecodeReuseMode::ReusableGraph,
+                "{provider:?} {} must keep a reusable full-logits graph",
+                device.name
+            );
+            assert!(
+                resolved.decode_evidence.reuse.is_validated(),
+                "{provider:?} {} reuse evidence must be validated",
+                device.name
+            );
+        }
     }
 
     #[test]
@@ -14689,6 +15350,73 @@ mod tests {
                 GgmlNativeGqaCapability::Validated
             );
         }
+    }
+
+    #[test]
+    fn exact_discrete_gpu_unified_owner_covers_cuda_hip_and_vulkan() {
+        use super::{RequestBackendPreference, exact_discrete_gpu_unified_owner_is_proven};
+        use crate::device::execution_route::{
+            DeviceAddressability, ExecutionProvider, PhysicalResourceKey, ResolvedExecutionRoute,
+            RouteDeviceKind,
+        };
+
+        let exact = |provider, addressable| {
+            RequestBackendPreference::Exact(ResolvedExecutionRoute {
+                provider,
+                stable_id: format!("{}0", provider.as_str()),
+                registry_ordinal: 0,
+                kind: RouteDeviceKind::Accelerated,
+                addressability: if addressable {
+                    DeviceAddressability::ExactlyAddressable {
+                        physical_key: PhysicalResourceKey::new("0000:01:00.0")
+                            .expect("physical key"),
+                    }
+                } else {
+                    DeviceAddressability::NotExactlyAddressable {
+                        reason: "unified owner requires Exact addressability",
+                    }
+                },
+            })
+        };
+        for provider in [
+            ExecutionProvider::Cuda,
+            ExecutionProvider::Hip,
+            ExecutionProvider::Vulkan,
+        ] {
+            assert!(exact_discrete_gpu_unified_owner_is_proven(Some(&exact(
+                provider, true
+            ))));
+            assert!(
+                exact_discrete_gpu_unified_owner_is_proven(Some(&exact(provider, false))),
+                "Exact {provider:?} by ggml stable_id must unify even without a PCI physical key"
+            );
+        }
+        for provider in [
+            ExecutionProvider::Cpu,
+            ExecutionProvider::Metal,
+            ExecutionProvider::Accelerator,
+            ExecutionProvider::Unknown,
+        ] {
+            assert!(!exact_discrete_gpu_unified_owner_is_proven(Some(&exact(
+                provider, true
+            ))));
+        }
+        assert!(!exact_discrete_gpu_unified_owner_is_proven(None));
+        assert!(!exact_discrete_gpu_unified_owner_is_proven(Some(
+            &RequestBackendPreference::Accelerated
+        )));
+        let empty_stable = RequestBackendPreference::Exact(ResolvedExecutionRoute {
+            provider: ExecutionProvider::Vulkan,
+            stable_id: String::new(),
+            registry_ordinal: 0,
+            kind: RouteDeviceKind::Accelerated,
+            addressability: DeviceAddressability::NotExactlyAddressable {
+                reason: "empty stable_id cannot identify a unified owner",
+            },
+        });
+        assert!(!exact_discrete_gpu_unified_owner_is_proven(Some(
+            &empty_stable
+        )));
     }
 
     #[test]
@@ -15377,6 +16105,50 @@ mod tests {
     }
 
     #[test]
+    fn native_capture_is_reserved_for_persistent_sessions() {
+        let mut ephemeral_runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("cpu graph runner should initialize");
+        let mut ephemeral = ephemeral_runner.start_graph();
+        let input = ephemeral
+            .new_tensor_2d_f32(2, 1, "input")
+            .expect("ephemeral input");
+        ephemeral.set_input(input).expect("set_input");
+        let out = ephemeral.mul(input, input).expect("mul");
+        ephemeral.set_output(out).expect("set_output");
+        ephemeral
+            .prepare_outputs_for_upload(&[out])
+            .expect("prepare ephemeral");
+        assert_eq!(
+            ephemeral.prepared_graph_capture_allowed_for_test(),
+            Some(false),
+            "start_graph one-shot cgraphs must not opt into CUDA/HIP capture"
+        );
+
+        let mut persistent_runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("cpu graph runner should initialize");
+        let mut session = persistent_runner
+            .start_persistent_graph_session(1024 * 1024)
+            .expect("persistent session should open");
+        {
+            let graph = session.builder();
+            let input = graph
+                .new_tensor_2d_f32(2, 1, "input")
+                .expect("persistent input");
+            graph.set_input(input).expect("set_input");
+            let out = graph.mul(input, input).expect("mul");
+            graph.set_output(out).expect("set_output");
+            graph
+                .prepare_outputs_for_upload(&[out])
+                .expect("prepare persistent");
+        }
+        assert_eq!(
+            session.prepared_graph_capture_allowed_for_test(),
+            Some(true),
+            "persistent sessions must opt the owned cgraph into native capture"
+        );
+    }
+
+    #[test]
     fn persistent_graph_session_reuses_built_graph_across_runs() {
         // Build `out = input * input` (element-wise square) ONCE into a
         // persistent session, then re-run it twice with different input data
@@ -15416,6 +16188,194 @@ mod tests {
             .compute_outputs_f32(&[(out, 4)])
             .expect("reuse compute run 2");
         assert_eq!(r2, vec![vec![4.0, 4.0, 25.0, 0.25]]);
+    }
+
+    #[test]
+    fn same_shape_persistent_graph_reuses_until_shape_changes() {
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("cpu graph runner should initialize");
+        let mut reuse = super::GgmlSameShapePersistentGraph::default();
+        let shape = super::GgmlGraphShapeKey::new(4, 1, 0, 0);
+        let (graph, reused) = reuse
+            .builder_for_shape(&mut runner, shape)
+            .expect("first same-shape open");
+        assert!(!reused, "first open for a shape must build");
+        let input = graph
+            .new_tensor_2d_f32(4, 1, "input")
+            .expect("input tensor");
+        graph.set_input(input).expect("set_input");
+        let out = graph.mul(input, input).expect("element-wise square");
+        graph.set_output(out).expect("set_output");
+        graph.prepare_outputs_for_upload(&[out]).expect("prepare");
+        graph
+            .set_f32_slice(input, &[1.0, 2.0, 3.0, 4.0], "input")
+            .expect("upload");
+        assert_eq!(
+            graph.compute_output_f32(out, 4).expect("compute 1"),
+            vec![1.0, 4.0, 9.0, 16.0]
+        );
+
+        let (graph, reused) = reuse
+            .builder_for_shape(&mut runner, shape)
+            .expect("second same-shape open");
+        assert!(reused, "identical shape must reuse the persistent session");
+        graph
+            .set_f32_slice(input, &[2.0, 2.0, 5.0, 0.5], "input")
+            .expect("upload reused");
+        assert_eq!(
+            graph.compute_output_f32(out, 4).expect("compute 2"),
+            vec![4.0, 4.0, 25.0, 0.25]
+        );
+
+        let (graph, reused) = reuse
+            .builder_for_shape(&mut runner, super::GgmlGraphShapeKey::new(2, 1, 0, 0))
+            .expect("shape change must rebuild");
+        assert!(!reused, "a new shape must not reuse the previous session");
+        let input = graph
+            .new_tensor_2d_f32(2, 1, "input")
+            .expect("resized input");
+        graph.set_input(input).expect("set_input");
+        let out = graph.mul(input, input).expect("square");
+        graph.set_output(out).expect("set_output");
+        graph
+            .prepare_outputs_for_upload(&[out])
+            .expect("prepare resized");
+        graph
+            .set_f32_slice(input, &[3.0, 4.0], "input")
+            .expect("upload resized");
+        assert_eq!(
+            graph.compute_output_f32(out, 2).expect("compute resized"),
+            vec![9.0, 16.0]
+        );
+        reuse.drop_session();
+        let (_, reused) = reuse
+            .builder_for_shape(&mut runner, super::GgmlGraphShapeKey::new(2, 1, 0, 0))
+            .expect("drop_session must force a rebuild");
+        assert!(!reused, "dropping the session must not reuse it");
+    }
+
+    #[test]
+    fn metadata_context_bytes_keeps_capacity_headroom_at_the_default_bump() {
+        let tiny = GgmlCpuGraphConfig::metadata_context_bytes(64);
+        let reuse = GgmlCpuGraphConfig::metadata_context_bytes(4_096);
+        let full = GgmlCpuGraphConfig::metadata_context_bytes(16_384);
+        assert!(
+            tiny < 64 * 1024,
+            "tiny device-head metadata must stay a small exact reservation, got {tiny}"
+        );
+        assert_eq!(
+            reuse,
+            super::DEFAULT_CONTEXT_BYTES,
+            "4096-slot capacity is headroom; the bump must stay the historical 1MiB, got {reuse}"
+        );
+        assert!(
+            full > 4 * 1024 * 1024,
+            "16384-node encoder metadata must keep the full llama.cpp reservation, got {full}"
+        );
+    }
+
+    #[test]
+    fn persistent_session_node_capacity_is_smaller_than_full_runner_budget() {
+        let full = GgmlCpuGraphConfig::metadata_context_bytes(16_384);
+        let reuse = GgmlCpuGraphConfig::metadata_context_bytes(4_096);
+        assert!(
+            reuse < full,
+            "reuse-sized metadata {reuse} must be strictly smaller than runner budget {full}"
+        );
+        assert!(
+            full - reuse >= 2 * 1024 * 1024,
+            "right-sizing a 16384-node session to 4096 must drop at least 2MiB, saved {}",
+            full - reuse
+        );
+        let mut config = GgmlCpuGraphConfig::default();
+        config.set_graph_node_capacity(16_384);
+        let mut runner = GgmlCpuGraphRunner::new(config).expect("large runner");
+        let mut session = runner
+            .start_persistent_graph_session_with_node_capacity(4_096)
+            .expect("reuse-sized session must open on a larger runner");
+        let graph = session.builder();
+        let input = graph.new_tensor_1d_f32(4, "input").expect("input tensor");
+        graph.set_input(input).expect("set_input");
+        let out = graph.mul(input, input).expect("square");
+        graph.set_output(out).expect("set_output");
+        graph.prepare_outputs_for_upload(&[out]).expect("prepare");
+        graph
+            .set_f32_slice(input, &[1.0, 2.0, 3.0, 4.0], "input")
+            .expect("upload");
+        assert_eq!(
+            graph.compute_output_f32(out, 4).expect("compute"),
+            vec![1.0, 4.0, 9.0, 16.0]
+        );
+    }
+
+    #[test]
+    fn persistent_session_parks_idle_runner_graph_context() {
+        let mut config = GgmlCpuGraphConfig::default();
+        config.set_graph_node_capacity(16_384);
+        let full = GgmlCpuGraphConfig::metadata_context_bytes(16_384);
+        assert!(
+            full >= 2 * 1024 * 1024,
+            "16384-node runner metadata must be at least 2MiB, got {full}"
+        );
+        let mut runner = GgmlCpuGraphRunner::new(config).expect("large runner");
+        assert_eq!(
+            runner.runner_graph_context_bytes_for_test(),
+            0,
+            "start_graph metadata must stay unallocated until a transient graph needs it"
+        );
+        {
+            let graph = runner.start_graph();
+            drop(graph);
+        }
+        assert_eq!(
+            runner.runner_graph_context_bytes_for_test(),
+            full,
+            "start_graph must materialize the runner metadata arena"
+        );
+        let mut session = runner
+            .start_persistent_graph_session_with_node_capacity(4_096)
+            .expect("reuse-sized session must park the idle runner context");
+        assert_eq!(
+            runner.runner_graph_context_bytes_for_test(),
+            0,
+            "persistent session must not keep a second full runner metadata arena"
+        );
+        {
+            let graph = session.builder();
+            let input = graph.new_tensor_1d_f32(4, "input").expect("input tensor");
+            graph.set_input(input).expect("set_input");
+            let out = graph.mul(input, input).expect("square");
+            graph.set_output(out).expect("set_output");
+            graph.prepare_outputs_for_upload(&[out]).expect("prepare");
+            graph
+                .set_f32_slice(input, &[1.0, 2.0, 3.0, 4.0], "input")
+                .expect("upload");
+            assert_eq!(
+                graph.compute_output_f32(out, 4).expect("compute"),
+                vec![1.0, 4.0, 9.0, 16.0]
+            );
+        }
+        drop(session);
+        let mut graph = runner.start_graph();
+        let input = graph
+            .new_tensor_1d_f32(4, "fallback")
+            .expect("fallback input");
+        graph.set_input(input).expect("set_input");
+        let out = graph.mul(input, input).expect("square");
+        graph.set_output(out).expect("set_output");
+        graph.prepare_outputs_for_upload(&[out]).expect("prepare");
+        graph
+            .set_f32_slice(input, &[2.0, 3.0, 4.0, 5.0], "fallback")
+            .expect("upload");
+        assert_eq!(
+            graph.compute_output_f32(out, 4).expect("compute"),
+            vec![4.0, 9.0, 16.0, 25.0]
+        );
+        drop(graph);
+        assert!(
+            runner.runner_graph_context_bytes_for_test() >= 2 * 1024 * 1024,
+            "start_graph must restore the parked runner metadata arena"
+        );
     }
 
     #[test]
@@ -15882,6 +16842,42 @@ mod tests {
     }
 
     #[test]
+    fn shipped_load_gguf_weight_context_reuses_owner_across_two_runners() {
+        let services = crate::models::native_execution_services::test_native_execution_services();
+        let _nes =
+            crate::models::native_execution_services::install_native_execution_services(&services);
+        let (_dir, runtime_source) = tiny_loaded_weight_pack();
+        let preflight =
+            crate::ggml_runtime::GgufRuntimeSourcePreflight::from_runtime_source(&runtime_source)
+                .expect("preflight");
+        let first_runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("first runner should initialize");
+        let second_runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("second runner should initialize");
+        let first = first_runner
+            .load_gguf_weight_context_from_preflight(&preflight)
+            .expect("first runner load");
+        let after_first = system_memory_committed(&services);
+        let second = second_runner
+            .load_gguf_weight_context_from_preflight(&preflight)
+            .expect("second runner load");
+        assert!(
+            first.shares_storage_with(&second),
+            "encoder and decoder runners on one NES thread must share one pack-wide owner"
+        );
+        assert_eq!(
+            system_memory_committed(&services),
+            after_first,
+            "a second runner must not admit a second physical owner"
+        );
+        drop(first);
+        drop(second);
+        drop(first_runner);
+        drop(second_runner);
+        assert_eq!(system_memory_committed(&services), 0);
+    }
+
+    #[test]
     fn shipped_load_gguf_weight_context_host_import_and_copy_are_distinct_owners() {
         use crate::models::runtime_receipts::LeaseReceiptShadow;
 
@@ -16243,6 +17239,59 @@ mod tests {
         runner
             .release_transient_scheduler_working_set()
             .expect("scheduler replacement should proceed after the session drops");
+    }
+
+    #[test]
+    fn request_compute_residency_releases_after_persistent_session_drops() {
+        let mut config = GgmlCpuGraphConfig::conservative_default();
+        config.use_scheduler = true;
+        let mut runner =
+            GgmlCpuGraphRunner::new(config).expect("scheduler cpu graph runner should initialize");
+        let session = runner
+            .start_persistent_graph_session(1024 * 1024)
+            .expect("persistent session should open");
+        assert_eq!(
+            runner.release_request_compute_residency(),
+            Err(GgmlCpuGraphError::PersistentGraphSessionActive)
+        );
+        drop(session);
+        runner
+            .release_request_compute_residency()
+            .expect("request residency should release after the session drops");
+    }
+
+    #[test]
+    fn request_compute_residency_is_ok_on_direct_cpu_runner() {
+        let runner_config = GgmlCpuGraphConfig::conservative_default();
+        assert!(!runner_config.use_scheduler);
+        let mut runner = GgmlCpuGraphRunner::new(runner_config)
+            .expect("direct cpu graph runner should initialize");
+        runner
+            .release_request_compute_residency()
+            .expect("cpu has no backend trim ABI and must stay a no-op");
+    }
+
+    #[test]
+    fn vulkan_device_local_buffer_policy_does_not_force_ggml_env() {
+        crate::test_process_env::with_test_process_env(
+            [
+                ("GGML_VK_DISABLE_HOST_VISIBLE_VIDMEM", None),
+                ("GGML_VK_DISABLE_FLOAT_CONTROLS_PATCH", None),
+                ("GGML_VK_ENABLE_FLOAT_CONTROLS_PATCH", None),
+            ],
+            || {
+                crate::ggml_runtime::apply_vulkan_device_local_buffer_policy();
+                assert!(
+                    std::env::var_os("GGML_VK_DISABLE_HOST_VISIBLE_VIDMEM").is_none(),
+                    "ReBAR GPUs have no DeviceLocal-only heap; the host must not exclude HostVisible types"
+                );
+                assert_eq!(
+                    std::env::var("GGML_VK_DISABLE_FLOAT_CONTROLS_PATCH").as_deref(),
+                    Ok("1"),
+                    "host must disable SPIR-V float-controls patching before vulkan device init"
+                );
+            },
+        );
     }
 
     #[test]
@@ -16707,6 +17756,53 @@ mod tests {
             .compute_output_f32(tensor, 4)
             .expect("single-tensor forward graph should compute");
         assert_eq!(output, vec![1.25, -2.0, 3.5, 8.0]);
+    }
+
+    #[test]
+    fn row_visitor_reuses_one_host_row_and_matches_full_readback() {
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::default())
+            .expect("cpu graph runner should initialize");
+        let mut graph = runner.start_graph();
+        let tensor = graph
+            .new_tensor_2d_f32(2, 3, "rows")
+            .expect("2d tensor allocation should succeed");
+        graph
+            .set_input(tensor)
+            .expect("set_input should succeed before allocation");
+        graph
+            .set_output(tensor)
+            .expect("set_output should succeed before allocation");
+        graph
+            .set_f32_slice(tensor, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], "rows")
+            .expect("row-major upload");
+
+        let mut visited = Vec::new();
+        let mut max_row_len = 0usize;
+        reset_test_tensor_readback_count();
+        graph
+            .compute_output_f32_rows_for_each(tensor, 2, 3, |index, row| {
+                max_row_len = max_row_len.max(row.len());
+                visited.push((index, row.to_vec()));
+                Ok(())
+            })
+            .expect("row visitor should compute once and stream rows");
+        assert_eq!(
+            test_tensor_readback_count(),
+            1,
+            "rows that fit in one transfer chunk must share a single tensor_get"
+        );
+        assert_eq!(
+            max_row_len, 2,
+            "visitor working set must be one logit row, not the full matrix"
+        );
+        assert_eq!(
+            visited,
+            vec![
+                (0, vec![1.0, 2.0]),
+                (1, vec![3.0, 4.0]),
+                (2, vec![5.0, 6.0]),
+            ]
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/ggml_runtime/decode_conformance.rs
+++ b/crates/openasr-core/src/ggml_runtime/decode_conformance.rs
@@ -28,10 +28,12 @@ use super::{
 use crate::device::execution_route::{ExecutionProvider, ResolvedExecutionRoute};
 
 /// Bounded per-step diagnostic records on a short-audio receipt.
-/// 64 covers typical short-clip greedy loops. Longform clips that still go
-/// through this receipt path (69s mixed EN/ZH is ~70-90 steps on X-ASR) must
-/// stay bounded without failing a successful transcription.
-pub const SHORT_AUDIO_RECEIPT_MAX_DECODE_STEPS: usize = 256;
+/// Seq2seq greedy loops stay well under a few hundred tokens. Device-head
+/// CTC/RNN-T joiners (X-ASR) emit one witnessed selection per encoder frame,
+/// so the 69s mixed EN/ZH longform fixture is ~2k steps at ~30 Hz. 4096 keeps
+/// that successful transcription on the receipt path without pretending
+/// every frame is a seq2seq token.
+pub const SHORT_AUDIO_RECEIPT_MAX_DECODE_STEPS: usize = 4096;
 
 /// Receipt-facing copy of the resolved output plan. Diagnostic only.
 ///
@@ -1478,10 +1480,10 @@ fn validate_lifecycle_identity(
 ) -> Result<(), GgmlCpuGraphError> {
     if lifecycle.overflowed
         || lifecycle.events.is_empty()
-        || lifecycle
-            .events
-            .iter()
-            .any(|event| event.provider != provider.as_str() || event.device != stable_device_id)
+        || lifecycle.events.iter().any(|event| {
+            event.provider.as_ref() != provider.as_str()
+                || event.device.as_ref() != stable_device_id
+        })
     {
         return Err(GgmlCpuGraphError::UnsupportedInputs {
             reason: "diagnostic lifecycle is empty, overflowed, or not bound to the exact route",
@@ -2364,11 +2366,9 @@ mod tests {
                 .iter()
                 .all(|case| case.actual_tokens == case.expected_tokens)
         );
-        assert!(
-            report.graph_lifecycle.events.iter().all(|event| {
-                event.provider == "cpu" && event.device == report.stable_device_id
-            })
-        );
+        assert!(report.graph_lifecycle.events.iter().all(|event| {
+            event.provider.as_ref() == "cpu" && event.device.as_ref() == report.stable_device_id
+        }));
     }
 
     #[test]

--- a/crates/openasr-core/src/ggml_runtime/decode_conformance.rs
+++ b/crates/openasr-core/src/ggml_runtime/decode_conformance.rs
@@ -1634,6 +1634,9 @@ fn summarize_lifecycle(
                     stats.capture_before_pending = false;
                 }
                 stats.active_compute = Some(*compute_sequence);
+                if let Some(input) = *input_generation_consumed {
+                    stats.input_generations.insert(input);
+                }
                 stats.computes_started.push((
                     *compute_sequence,
                     *prepare_generation,
@@ -2388,7 +2391,6 @@ mod tests {
         for expected in [
             "created",
             "prepared",
-            "input_write",
             "compute_started",
             "compute_completed",
             "output_read",
@@ -2406,6 +2408,16 @@ mod tests {
                 "missing {expected}"
             );
         }
+        assert!(
+            report.graph_lifecycle.events.iter().any(|event| matches!(
+                event.kind,
+                crate::GgmlGraphLifecycleEventKind::ComputeStarted {
+                    input_generation_consumed: Some(_),
+                    ..
+                }
+            )),
+            "Layer-2 input refresh is bound on compute_started, not a separate input_write event"
+        );
         assert!(report.graph_lifecycle.events.iter().all(|event| !matches!(
             event.kind,
             crate::GgmlGraphLifecycleEventKind::CaptureStateObserved { .. }

--- a/crates/openasr-core/src/ggml_runtime/graph_lifecycle.rs
+++ b/crates/openasr-core/src/ggml_runtime/graph_lifecycle.rs
@@ -9,11 +9,20 @@ use std::{
     cell::RefCell,
     sync::{
         Arc, Mutex, Weak,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+fn serialize_arc_str<S: Serializer>(value: &Arc<str>, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(value)
+}
+
+fn deserialize_arc_str<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Arc<str>, D::Error> {
+    let value = String::deserialize(deserializer)?;
+    Ok(Arc::from(value))
+}
 
 pub const GGML_GRAPH_LIFECYCLE_SCHEMA: &str = "openasr.ggml-graph-lifecycle.v1";
 /// Bound for one request observation. FreshGraph seq2seq families mint a
@@ -239,6 +248,23 @@ impl GgmlSelectionEvidenceRef {
     }
 
     #[cfg(test)]
+    pub(crate) fn from_parts_for_test(
+        graph_instance: u64,
+        graph_generation: u64,
+        compute_sequence: u64,
+        output_generation: u64,
+    ) -> Self {
+        Self {
+            graph_instance,
+            graph_generation,
+            compute_sequence,
+            output_generation,
+            output_index: 0,
+            output_count: 1,
+        }
+    }
+
+    #[cfg(test)]
     pub(crate) fn identity_tuple(&self) -> (u64, u64, u64, u64, usize, usize) {
         (
             self.graph_instance,
@@ -253,10 +279,22 @@ impl GgmlSelectionEvidenceRef {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GgmlGraphLifecycleEvent {
-    pub schema: String,
+    #[serde(
+        serialize_with = "serialize_arc_str",
+        deserialize_with = "deserialize_arc_str"
+    )]
+    pub schema: Arc<str>,
     pub sequence: u64,
-    pub provider: String,
-    pub device: String,
+    #[serde(
+        serialize_with = "serialize_arc_str",
+        deserialize_with = "deserialize_arc_str"
+    )]
+    pub provider: Arc<str>,
+    #[serde(
+        serialize_with = "serialize_arc_str",
+        deserialize_with = "deserialize_arc_str"
+    )]
+    pub device: Arc<str>,
     pub graph_instance: u64,
     pub graph_generation: u64,
     #[serde(flatten)]
@@ -349,7 +387,7 @@ pub struct GgmlGraphLifecycleSnapshot {
     pub overflowed: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct LifecycleState {
     events: Vec<GgmlGraphLifecycleEvent>,
     overflowed: bool,
@@ -360,11 +398,34 @@ struct LifecycleState {
     /// be refcounted so a sibling finishing its candidate cannot close the
     /// scope and drop the other worker's create/compute/read events.
     observation_scope_refs: u32,
+    interned_schema: Arc<str>,
+    interned_provider: Option<Arc<str>>,
+    interned_device: Option<Arc<str>>,
+}
+
+impl Default for LifecycleState {
+    fn default() -> Self {
+        Self {
+            events: Vec::with_capacity(4096),
+            overflowed: false,
+            next_sequence: 0,
+            observation_scope: 0,
+            observation_scope_open: false,
+            observation_scope_refs: 0,
+            interned_schema: Arc::from(GGML_GRAPH_LIFECYCLE_SCHEMA),
+            interned_provider: None,
+            interned_device: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct GgmlGraphLifecycleCollector {
     state: Arc<Mutex<LifecycleState>>,
+    /// Mirrored outside the event mutex so per-compute refresh can observe
+    /// the live scope without a second lock on the hot graph-compute path.
+    scope_id: Arc<AtomicU64>,
+    scope_open: Arc<AtomicBool>,
 }
 
 impl Default for GgmlGraphLifecycleCollector {
@@ -374,6 +435,8 @@ impl Default for GgmlGraphLifecycleCollector {
                 observation_scope_open: true,
                 ..LifecycleState::default()
             })),
+            scope_id: Arc::new(AtomicU64::new(0)),
+            scope_open: Arc::new(AtomicBool::new(true)),
         }
     }
 }
@@ -415,17 +478,23 @@ impl GgmlGraphLifecycleCollector {
     /// attachment and native capture facts have already been emitted.
     ///
     /// Concurrent candidate attempts keep the collector open until the last
-    /// matching end. Each begin still mints a scope id so a later sequential
-    /// candidate can re-observe native capture; ending one sibling must not
-    /// drop the others' create/compute/read events.
+    /// matching end. A new scope id is minted only when no attempt is live so
+    /// a later sequential candidate can re-observe native capture; a sibling
+    /// begin must keep the current id or already-attached graphs stop
+    /// recording compute_completed/output_read.
     pub(crate) fn begin_observation_scope(&self) {
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        state.observation_scope = mint_opaque_graph_id();
+        if state.observation_scope_refs == 0 {
+            state.observation_scope = mint_opaque_graph_id();
+        }
         state.observation_scope_refs = state.observation_scope_refs.saturating_add(1);
         state.observation_scope_open = true;
+        self.scope_id
+            .store(state.observation_scope, Ordering::Release);
+        self.scope_open.store(true, Ordering::Release);
     }
 
     pub(crate) fn end_observation_scope(&self) {
@@ -436,17 +505,14 @@ impl GgmlGraphLifecycleCollector {
         state.observation_scope_refs = state.observation_scope_refs.saturating_sub(1);
         if state.observation_scope_refs == 0 {
             state.observation_scope_open = false;
+            self.scope_open.store(false, Ordering::Release);
         }
     }
 
     pub(crate) fn observation_scope(&self) -> Option<u64> {
-        let state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        state
-            .observation_scope_open
-            .then_some(state.observation_scope)
+        self.scope_open
+            .load(Ordering::Acquire)
+            .then(|| self.scope_id.load(Ordering::Acquire))
     }
 
     pub fn snapshot(&self) -> GgmlGraphLifecycleSnapshot {
@@ -488,8 +554,32 @@ impl GgmlGraphLifecycleCollector {
         state.overflowed = checkpoint.1;
     }
 
+    #[cfg(test)]
     pub(crate) fn record(
         &self,
+        provider: &str,
+        device: &str,
+        graph_instance: u64,
+        graph_generation: u64,
+        kind: GgmlGraphLifecycleEventKind,
+    ) {
+        self.record_for_scope(
+            None,
+            provider,
+            device,
+            graph_instance,
+            graph_generation,
+            kind,
+        );
+    }
+
+    /// Record one event if the collector is still in `expected_scope`. Passing
+    /// `None` records into whichever scope is currently open (tests). The
+    /// scope check shares the event mutex so the compute hot path does not
+    /// lock twice per token.
+    pub(crate) fn record_for_scope(
+        &self,
+        expected_scope: Option<u64>,
         provider: &str,
         device: &str,
         graph_instance: u64,
@@ -503,22 +593,39 @@ impl GgmlGraphLifecycleCollector {
         if !state.observation_scope_open {
             return;
         }
+        if expected_scope.is_some_and(|scope| state.observation_scope != scope) {
+            return;
+        }
         if state.events.len() >= MAX_GRAPH_LIFECYCLE_EVENTS {
             state.overflowed = true;
             return;
         }
         state.next_sequence = state.next_sequence.saturating_add(1);
         let sequence = state.next_sequence;
+        let schema = Arc::clone(&state.interned_schema);
+        let provider = intern_lifecycle_label(&mut state.interned_provider, provider);
+        let device = intern_lifecycle_label(&mut state.interned_device, device);
         state.events.push(GgmlGraphLifecycleEvent {
-            schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+            schema,
             sequence,
-            provider: provider.to_string(),
-            device: device.to_string(),
+            provider,
+            device,
             graph_instance,
             graph_generation,
             kind,
         });
     }
+}
+
+fn intern_lifecycle_label(slot: &mut Option<Arc<str>>, value: &str) -> Arc<str> {
+    if let Some(existing) = slot.as_ref()
+        && existing.as_ref() == value
+    {
+        return Arc::clone(existing);
+    }
+    let interned = Arc::<str>::from(value);
+    *slot = Some(Arc::clone(&interned));
+    interned
 }
 
 thread_local! {
@@ -609,10 +716,51 @@ mod tests {
     }
 
     #[test]
+    fn lifecycle_events_intern_repeated_provider_and_device_labels() {
+        let collector = GgmlGraphLifecycleCollector::new();
+        collector.record(
+            "vulkan",
+            "Vulkan0",
+            1,
+            2,
+            GgmlGraphLifecycleEventKind::Created {
+                scheduler_enabled: false,
+            },
+        );
+        collector.record(
+            "vulkan",
+            "Vulkan0",
+            1,
+            2,
+            GgmlGraphLifecycleEventKind::Dropped,
+        );
+        let events = collector.snapshot().events;
+        assert_eq!(events.len(), 2);
+        assert!(
+            Arc::ptr_eq(&events[0].provider, &events[1].provider),
+            "repeated provider labels must share one allocation"
+        );
+        assert!(
+            Arc::ptr_eq(&events[0].device, &events[1].device),
+            "repeated device labels must share one allocation"
+        );
+        assert!(
+            Arc::ptr_eq(&events[0].schema, &events[1].schema),
+            "schema must be interned for the collector"
+        );
+    }
+
+    #[test]
     fn concurrent_observation_scopes_stay_open_until_last_end() {
         let collector = GgmlGraphLifecycleCollector::new();
         collector.begin_observation_scope();
+        let first_scope = collector.observation_scope();
         collector.begin_observation_scope();
+        assert_eq!(
+            collector.observation_scope(),
+            first_scope,
+            "sibling begin must keep the live observation scope id"
+        );
         collector.end_observation_scope();
         collector.record(
             "hip",

--- a/crates/openasr-core/src/ggml_runtime/mod.rs
+++ b/crates/openasr-core/src/ggml_runtime/mod.rs
@@ -55,8 +55,8 @@ pub use backend::{
 pub(crate) use backend::{
     accelerated_device_rank, activate_attested_qualification_backend,
     activated_backend_execution_identity, activated_backend_execution_provider,
-    ensure_backends_loaded, ggml_backend_dl_build_enabled, preferred_accelerated_device,
-    probe_exact_backend_plugin_candidate,
+    apply_vulkan_device_local_buffer_policy, ensure_backends_loaded, ggml_backend_dl_build_enabled,
+    preferred_accelerated_device, probe_exact_backend_plugin_candidate,
 };
 pub(crate) use backend_memory::{
     BackendMemoryBytes, BackendMemoryLifecyclePoint, BackendMemoryStatsSnapshot,
@@ -74,10 +74,13 @@ pub use cpu_graph::{
 };
 pub(crate) use cpu_graph::{
     GgmlBackendCapabilities, GgmlComputeOutput, GgmlCpuGraphBuilder, GgmlCpuTensor,
-    GgmlFlashAttentionPrecision, GgmlLoadedTensor, GgmlLoadedWeightBindingIdentity,
-    GgmlLoadedWeightContext, GgmlMatmulPrecision, GgmlNativeGqaCapability,
-    GgmlPersistentGraphSession, GgmlRopeExtParams, GgmlStaticTensor, GgmlStaticTensorArena,
-    LoadedWeightOwnerCache, ResidentDeviceCopyCapability, ResidentHostImportCapability,
+    GgmlFlashAttentionPrecision, GgmlGraphShapeKey, GgmlLoadedTensor,
+    GgmlLoadedWeightBindingIdentity, GgmlLoadedWeightContext, GgmlMatmulPrecision,
+    GgmlNativeGqaCapability, GgmlPersistentGraphSession, GgmlRopeExtParams,
+    GgmlSameShapePersistentGraph, GgmlStaticTensor, GgmlStaticTensorArena, LoadedWeightOwnerCache,
+    ResidentDeviceCopyCapability, ResidentHostImportCapability,
+    encoder_same_shape_reuse_is_enabled, exact_discrete_gpu_unified_owner_is_proven,
+    proven_discrete_gpu_provider,
 };
 pub use decode_conformance::{
     DecodeFirstDivergenceClass, DiagnosticDecodeConformanceSuite, DiagnosticDecodeSelection,

--- a/crates/openasr-core/src/models/decode_policy_component_registry.rs
+++ b/crates/openasr-core/src/models/decode_policy_component_registry.rs
@@ -1591,10 +1591,25 @@ mod tests {
         let text = snapshot.trace.jsonl;
         assert!(text.contains("\"schema\":\"openasr.gpu-correctness-trace.v1\""));
         assert!(text.contains("\"event\":\"token\""));
-        assert!(text.contains("\"event\":\"top_k\""));
+        assert!(
+            !text.contains("\"event\":\"top_k\""),
+            "full-vocab top-k JSON is opt-in via enable_full_logits_trace"
+        );
         assert_eq!(snapshot.token_steps.len(), 1);
         assert_eq!(snapshot.token_steps[0].token_id, 7);
         assert_eq!(snapshot.token_steps[0].top2_margin, Some(0.5));
+        assert!(
+            snapshot.token_steps[0].logits_sha256.is_none(),
+            "SHA-256 of logits is opt-in via enable_full_logits_trace"
+        );
+
+        let traced =
+            crate::models::request_execution_receipt::NativeExecutionReceiptCollector::new();
+        traced.enable_full_logits_trace();
+        traced.commit_decode_step(None, 7, false, &[1.0, 0.5]);
+        let traced_snapshot = traced.snapshot();
+        assert!(traced_snapshot.trace.jsonl.contains("\"event\":\"top_k\""));
+        assert!(traced_snapshot.token_steps[0].logits_sha256.is_some());
     }
 
     #[test]

--- a/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
+++ b/crates/openasr-core/src/models/firered_aed/decoder_graph.rs
@@ -506,6 +506,14 @@ impl FireRedDecoderGraphRuntime {
         Ok(())
     }
 
+    pub(crate) fn release_transient_compute_memory(&mut self) -> Result<(), FireRedDecoderError> {
+        self.reuse = None;
+        match self.runner.release_request_compute_residency() {
+            Ok(()) | Err(GgmlCpuGraphError::PersistentGraphSessionActive) => Ok(()),
+            Err(error) => Err(map_err("release_request_compute_residency", error)),
+        }
+    }
+
     /// Precompute cross-attention K/V for every layer from the encoder output
     /// and write them into the persistent cross-KV cache. Must be called once
     /// before the first [`Self::compute_step_logits`]. `frame_count` must

--- a/crates/openasr-core/src/models/firered_aed/executor.rs
+++ b/crates/openasr-core/src/models/firered_aed/executor.rs
@@ -32,6 +32,7 @@ use crate::NativeAsrSession;
 use crate::api::backend::{Segment, Transcription};
 use crate::arch::FIRERED_AED_GGML_ADAPTER_ID;
 use crate::device::execution_policy::ExecutionPlacement;
+#[cfg(test)]
 use crate::device::execution_route::ExecutionProvider;
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlDecodeOutputPlan, GgmlDecodeReuseMode, GgufRuntimeSourcePreflight,
@@ -435,12 +436,7 @@ fn unified_runtime_owner_enabled(
 ) -> bool {
     backend == GgmlCpuGraphBackend::Gpu
         && placement == Some(ExecutionPlacement::FullDevice)
-        && matches!(
-            backend_preference,
-            Some(RequestBackendPreference::Exact(route))
-                if route.addressability.is_exactly_addressable()
-                    && matches!(route.provider, ExecutionProvider::Cuda | ExecutionProvider::Vulkan)
-        )
+        && crate::ggml_runtime::exact_discrete_gpu_unified_owner_is_proven(backend_preference)
 }
 
 impl FireRedAedGgmlExecutor {
@@ -656,7 +652,7 @@ impl FireRedAedGgmlExecutor {
         runtime
             .call_mut(move |runtime| {
                 runtime.activate_decoder_state(decoder_state)?;
-                run_firered_aed_decoder_greedy_with_runtime(
+                let decode_result = run_firered_aed_decoder_greedy_with_runtime(
                     runtime,
                     metadata,
                     &encoder_rows,
@@ -665,7 +661,13 @@ impl FireRedAedGgmlExecutor {
                     &control,
                     decode_work_progress.as_ref(),
                     unstable_decode_text.as_ref(),
-                )
+                );
+                let release_result = runtime.release_transient_compute_memory();
+                match (decode_result, release_result) {
+                    (Ok(output), Ok(())) => Ok(output),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                }
             })
             .map_err(|error| Self::map_actor_error("decoder", error))?
             .map_err(|error| FireRedAedExecutorError::DecoderFailed {
@@ -689,7 +691,7 @@ impl FireRedAedGgmlExecutor {
         runtime
             .call_mut_fallible(move |runtime| {
                 runtime.decoder.activate_decoder_state(decoder_state)?;
-                run_firered_aed_decoder_greedy_with_runtime(
+                let decode_result = run_firered_aed_decoder_greedy_with_runtime(
                     &mut runtime.decoder,
                     metadata,
                     &encoder_rows,
@@ -698,7 +700,13 @@ impl FireRedAedGgmlExecutor {
                     &control,
                     decode_work_progress.as_ref(),
                     unstable_decode_text.as_ref(),
-                )
+                );
+                let release_result = runtime.decoder.release_transient_compute_memory();
+                match (decode_result, release_result) {
+                    (Ok(output), Ok(())) => Ok(output),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                }
             })
             .map_err(|error| Self::map_actor_error("unified-decoder", error))?
             .map_err(|error| FireRedAedExecutorError::DecoderFailed {
@@ -1127,8 +1135,12 @@ mod tests {
     }
 
     #[test]
-    fn unified_owner_is_limited_to_exact_cuda_and_vulkan_full_device() {
-        for provider in [ExecutionProvider::Cuda, ExecutionProvider::Vulkan] {
+    fn unified_owner_is_limited_to_exact_cuda_hip_and_vulkan_full_device() {
+        for provider in [
+            ExecutionProvider::Cuda,
+            ExecutionProvider::Hip,
+            ExecutionProvider::Vulkan,
+        ] {
             let preference = exactly_addressable_preference(provider);
             assert!(unified_runtime_owner_enabled(
                 GgmlCpuGraphBackend::Gpu,
@@ -1145,7 +1157,6 @@ mod tests {
         for provider in [
             ExecutionProvider::Cpu,
             ExecutionProvider::Metal,
-            ExecutionProvider::Hip,
             ExecutionProvider::Accelerator,
             ExecutionProvider::Unknown,
         ] {

--- a/crates/openasr-core/src/models/firered_llm/executor.rs
+++ b/crates/openasr-core/src/models/firered_llm/executor.rs
@@ -1337,8 +1337,12 @@ mod tests {
     }
 
     #[test]
-    fn unified_owner_is_limited_to_offline_exact_cuda_and_vulkan_full_device() {
-        for provider in [ExecutionProvider::Cuda, ExecutionProvider::Vulkan] {
+    fn unified_owner_is_limited_to_offline_exact_cuda_hip_and_vulkan_full_device() {
+        for provider in [
+            ExecutionProvider::Cuda,
+            ExecutionProvider::Hip,
+            ExecutionProvider::Vulkan,
+        ] {
             let preference = exactly_addressable_preference(provider);
             assert!(firered_llm_unified_runtime_enabled(
                 true,
@@ -1363,7 +1367,6 @@ mod tests {
         for provider in [
             ExecutionProvider::Cpu,
             ExecutionProvider::Metal,
-            ExecutionProvider::Hip,
             ExecutionProvider::Accelerator,
             ExecutionProvider::Unknown,
         ] {

--- a/crates/openasr-core/src/models/firered_llm/llm_transformer.rs
+++ b/crates/openasr-core/src/models/firered_llm/llm_transformer.rs
@@ -233,7 +233,9 @@ impl FireRedLlmDecoderRuntime {
     }
 
     pub(crate) fn take_compute_evidence(&mut self) -> Option<GgmlSelectionEvidenceRef> {
-        self.logits_runtime.take_compute_evidence()
+        self.whole_decoder
+            .take_fused_compute_evidence()
+            .or_else(|| self.logits_runtime.take_compute_evidence())
     }
 
     pub(crate) fn uses_native_gqa(&self) -> bool {
@@ -511,6 +513,9 @@ impl FireRedLlmDecoderRuntime {
             self.metadata.n_kv_heads * self.metadata.head_dim,
             layer_kv_caches,
         )?;
+        if let Some(logits) = step.fused_logits {
+            return Ok(logits);
+        }
         self.logits_runtime
             .compute_logits_for_last_hidden(&self.logits_head, &step.hidden)
             .map_err(|error| FireRedLlmDecoderError::LogitsHeadFailed {

--- a/crates/openasr-core/src/models/funasr_nano/executor.rs
+++ b/crates/openasr-core/src/models/funasr_nano/executor.rs
@@ -20,6 +20,7 @@ use crate::NativeAsrSession;
 use crate::api::backend::{Segment, Transcription};
 use crate::arch::FUNASR_NANO_DECODE_POLICY_ID;
 use crate::device::execution_policy::ExecutionPlacement;
+#[cfg(test)]
 use crate::device::execution_route::ExecutionProvider;
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlDecodeOutputPlan, RequestBackendPreference, request_backend_override,
@@ -181,12 +182,7 @@ fn funasr_nano_unified_runtime_enabled(
     allow_unified_runtime
         && backend == GgmlCpuGraphBackend::Gpu
         && placement == Some(ExecutionPlacement::FullDevice)
-        && matches!(
-            backend_preference,
-            Some(RequestBackendPreference::Exact(route))
-                if route.addressability.is_exactly_addressable()
-                    && matches!(route.provider, ExecutionProvider::Cuda | ExecutionProvider::Vulkan)
-        )
+        && crate::ggml_runtime::exact_discrete_gpu_unified_owner_is_proven(backend_preference)
 }
 
 fn validate_funasr_nano_unified_runtime(
@@ -1081,8 +1077,12 @@ mod tests {
     }
 
     #[test]
-    fn unified_owner_is_limited_to_offline_exact_cuda_and_vulkan_full_device() {
-        for provider in [ExecutionProvider::Cuda, ExecutionProvider::Vulkan] {
+    fn unified_owner_is_limited_to_offline_exact_cuda_hip_and_vulkan_full_device() {
+        for provider in [
+            ExecutionProvider::Cuda,
+            ExecutionProvider::Hip,
+            ExecutionProvider::Vulkan,
+        ] {
             let preference = exactly_addressable_preference(provider);
             assert!(funasr_nano_unified_runtime_enabled(
                 true,
@@ -1106,7 +1106,6 @@ mod tests {
         for provider in [
             ExecutionProvider::Cpu,
             ExecutionProvider::Metal,
-            ExecutionProvider::Hip,
             ExecutionProvider::Accelerator,
             ExecutionProvider::Unknown,
         ] {

--- a/crates/openasr-core/src/models/funasr_nano/llm_transformer.rs
+++ b/crates/openasr-core/src/models/funasr_nano/llm_transformer.rs
@@ -97,7 +97,9 @@ impl FunasrNanoDecoderRuntime {
     pub(crate) fn take_compute_evidence(
         &mut self,
     ) -> Option<crate::ggml_runtime::GgmlSelectionEvidenceRef> {
-        self.logits_runtime.take_compute_evidence()
+        self.whole_decoder
+            .take_fused_compute_evidence()
+            .or_else(|| self.logits_runtime.take_compute_evidence())
     }
 
     pub(crate) fn loaded_weight_binding_identity(
@@ -413,6 +415,9 @@ impl FunasrNanoDecoderRuntime {
             self.metadata.n_kv_heads * self.metadata.head_dim,
             layer_kv_caches,
         )?;
+        if let Some(logits) = step.fused_logits {
+            return Ok(logits);
+        }
         self.logits_runtime
             .compute_logits_for_last_hidden(&self.logits_head, &step.hidden)
             .map_err(|error| FunasrNanoDecoderError::LogitsHeadFailed {

--- a/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
+++ b/crates/openasr-core/src/models/mimo_asr/llm_transformer.rs
@@ -87,7 +87,9 @@ impl MimoLlmDecoderRuntime {
     pub(crate) fn take_compute_evidence(
         &mut self,
     ) -> Option<crate::ggml_runtime::GgmlSelectionEvidenceRef> {
-        self.logits_runtime.take_compute_evidence()
+        self.whole_decoder
+            .take_fused_compute_evidence()
+            .or_else(|| self.logits_runtime.take_compute_evidence())
     }
 
     pub(crate) fn new_from_preflight(
@@ -415,6 +417,9 @@ impl MimoLlmDecoderRuntime {
             self.metadata.n_kv_heads * self.metadata.head_dim,
             layer_kv_caches,
         )?;
+        if let Some(logits) = step.fused_logits {
+            return Ok(logits);
+        }
         self.logits_runtime
             .compute_logits_for_last_hidden(&self.logits_head, &step.hidden)
             .map_err(|error| MimoLlmDecoderError::LogitsHeadFailed {

--- a/crates/openasr-core/src/models/moonshine/decoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/decoder_graph.rs
@@ -47,11 +47,17 @@ const MOONSHINE_LAYER_NORM_EPSILON: f32 = 1.0e-5;
 /// `GgmlStaticTensorArena`/`allocate_zeroed_llm_resident_kv_arena`: real
 /// tensor bytes land in a backend buffer sized from actual shapes,
 /// independent of this context's size). Mirrors the encoder's proven
-/// `16_384` headroom (`moonshine_encoder_graph_config`).
-const MOONSHINE_DECODER_GRAPH_SIZE_FLOOR: usize = 16_384;
+/// Same bound as the encoder: prefill, cross-KV warmup, and incremental
+/// decode all fit in 4096 nodes. Matching the persistent session capacity
+/// means `start_graph` cannot leave a 6.4 MiB PeakWorkingSet watermark.
+const MOONSHINE_DECODER_GRAPH_SIZE_FLOOR: usize = 4_096;
+/// Incremental reusable decode cgraph only. Keep this identical to the runner
+/// floor so parking the idle runner does not allocate a second host context.
+const MOONSHINE_DECODER_REUSE_GRAPH_NODES: usize = 4_096;
 
 enum RuntimeWeightSource<'a> {
     Verified(&'a GgufRuntimeSourcePreflight),
+    Reused(GgmlLoadedWeightContext),
     #[cfg(test)]
     Synthetic,
 }
@@ -540,6 +546,27 @@ impl MoonshineDecoderGraphRuntime {
         )
     }
 
+    pub(crate) fn new_with_shared_pack_weights(
+        input: MoonshineDecoderRuntimeInput<'_>,
+        _runtime_preflight: &GgufRuntimeSourcePreflight,
+        adapter: Option<&MoonshineLoraAdapter>,
+        greedy_step_output_mode: DeviceGreedyStepOutputMode,
+        shared_weights: GgmlLoadedWeightContext,
+    ) -> Result<Self, MoonshineDecoderGraphError> {
+        Self::new_with_n_seq_impl(
+            input.decoder_weights,
+            input.metadata,
+            input.decoder_state,
+            input.backend,
+            input.graph_config,
+            input.reuse_mode,
+            RuntimeWeightSource::Reused(shared_weights),
+            1,
+            adapter,
+            greedy_step_output_mode,
+        )
+    }
+
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn new_synthetic(
@@ -685,13 +712,7 @@ impl MoonshineDecoderGraphRuntime {
         }
 
         let mut config = graph_config;
-        config.graph_size = config.graph_size.max(MOONSHINE_DECODER_GRAPH_SIZE_FLOOR);
-        config.context_bytes =
-            config
-                .context_bytes
-                .max(GgmlCpuGraphConfig::metadata_context_bytes(
-                    config.graph_size,
-                ));
+        config.set_graph_node_capacity(config.graph_size.max(MOONSHINE_DECODER_GRAPH_SIZE_FLOOR));
         let runner = GgmlCpuGraphRunner::new(config).map_err(build_err("runner_init"))?;
         // Bind the per-layer 2-D linears (self/cross attn + ffn) zero-copy from the
         // mmap'd pack (native q8_0 [in,out]); the loader supplies them meta-only, so
@@ -703,6 +724,7 @@ impl MoonshineDecoderGraphRuntime {
                     .load_gguf_weight_context_from_preflight(preflight)
                     .map_err(build_err("load_gguf_weight_context"))?,
             ),
+            RuntimeWeightSource::Reused(shared) => Some(shared),
             #[cfg(test)]
             RuntimeWeightSource::Synthetic => None,
         };
@@ -936,6 +958,16 @@ impl MoonshineDecoderGraphRuntime {
         self.decoder_state = decoder_state;
         self.cross_frame_count = decoder_state.cross_attention.logical_positions;
         Ok(())
+    }
+
+    pub(crate) fn release_transient_compute_memory(
+        &mut self,
+    ) -> Result<(), MoonshineDecoderGraphError> {
+        self.reuse = None;
+        match self.runner.release_request_compute_residency() {
+            Ok(()) | Err(GgmlCpuGraphError::PersistentGraphSessionActive) => Ok(()),
+            Err(error) => Err(build_err("release_request_compute_residency")(error)),
+        }
     }
 
     /// Precompute per-layer cross-attention K/V from the encoder output (once per utterance).
@@ -1523,7 +1555,7 @@ impl MoonshineDecoderGraphRuntime {
 
         let mut session = self
             .runner
-            .start_capacity_sized_persistent_graph_session()
+            .start_persistent_graph_session_with_node_capacity(MOONSHINE_DECODER_REUSE_GRAPH_NODES)
             .map_err(build_err("moonshine_reuse_session"))?;
         let graph = session.builder();
         let token_id = graph

--- a/crates/openasr-core/src/models/moonshine/encoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/encoder_graph.rs
@@ -157,8 +157,9 @@ pub(crate) struct MoonshineEncoderGraphRuntime {
     metadata: MoonshineExecutionMetadata,
     runner: GgmlCpuGraphRunner,
     // Owns the mmap'd pack backing every zero-copy WeightSlot::Loaded handle;
-    // must outlive `layers`. Kept even when None (f32-fallback path).
-    #[allow(dead_code)]
+    // must outlive `layers`. Kept even when None (f32-fallback path). The
+    // unified GPU owner clones this into the decoder so both stages share one
+    // DeviceCopied buffer instead of loading the whole pack twice.
     loaded_weights: Option<GgmlLoadedWeightContext>,
     arena: GgmlStaticTensorArena,
     conv1_weight: GgmlStaticTensor,
@@ -208,6 +209,10 @@ impl MoonshineEncoderGraphRuntime {
             backend,
             graph_config,
         )
+    }
+
+    pub(crate) fn cloned_loaded_weights(&self) -> Option<GgmlLoadedWeightContext> {
+        self.loaded_weights.clone()
     }
 
     #[cfg(test)]

--- a/crates/openasr-core/src/models/moonshine/ggml_executor.rs
+++ b/crates/openasr-core/src/models/moonshine/ggml_executor.rs
@@ -31,7 +31,8 @@ use crate::NativeAsrSession;
 use crate::device::execution_policy::ExecutionPlacement;
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlDecodeOutputContract, GgmlDecodeOutputPlan,
-    GgmlDecodeReuseMode, GgufRuntimeSourcePreflight, ResolvedFamilyRuntimeInput,
+    GgmlDecodeReuseMode, GgufRuntimeSourcePreflight, RequestBackendPreference,
+    ResolvedFamilyRuntimeInput,
 };
 use crate::models::admitted_pinned_runtime_actor_pool::{
     AdmittedPinnedRuntimeActorCheckoutPool, AdmittedPinnedRuntimeActorCheckoutPoolLimits,
@@ -55,6 +56,7 @@ use crate::models::prepared_runtime_cache::{
     PreparedRuntimeQuoteContext, SystemMemoryMaterialization,
 };
 use crate::models::runtime_cache_coordinator::{PackContentKey, canonical_runtime_cache_path};
+use crate::models::seq2seq_decoder_state::Seq2SeqResidentCapacity;
 use crate::models::system_memory_owner::SystemMemoryOwner;
 
 const MOONSHINE_EXECUTOR_ID: &str = crate::arch::MOONSHINE_EXECUTOR_COMPONENT_ID;
@@ -109,6 +111,26 @@ struct MoonshineDecoderActorState {
     _prepared_owner: PreparedRuntimeHandle<MoonshinePreparedRuntime>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct MoonshineUnifiedRuntimeCacheKey {
+    content: PackContentKey,
+    lane: ExecutionLaneKey,
+    encoder_config: MoonshineGraphConfigIdentity,
+    decoder_config: MoonshineGraphConfigIdentity,
+    resident_capacity: Seq2SeqResidentCapacity,
+    adapter_fingerprint: String,
+    output_contract: GgmlDecodeOutputContract,
+    output_plan: GgmlDecodeOutputPlan,
+    reuse_mode: GgmlDecodeReuseMode,
+    feature_key: MoonshineDecodeFeatureKey,
+}
+
+struct MoonshineUnifiedActorState {
+    encoder: MoonshineEncoderGraphRuntime,
+    decoder: MoonshineDecoderGraphRuntime,
+    _prepared_owner: PreparedRuntimeHandle<MoonshinePreparedRuntime>,
+}
+
 type MoonshineEncoderRuntimePool = AdmittedPinnedRuntimeActorCheckoutPool<
     MoonshineEncoderRuntimeCacheKey,
     MoonshineEncoderActorState,
@@ -117,10 +139,37 @@ type MoonshineDecoderRuntimePool = AdmittedPinnedRuntimeActorCheckoutPool<
     MoonshineDecoderRuntimeCacheKey,
     MoonshineDecoderActorState,
 >;
+type MoonshineUnifiedRuntimePool = AdmittedPinnedRuntimeActorCheckoutPool<
+    MoonshineUnifiedRuntimeCacheKey,
+    MoonshineUnifiedActorState,
+>;
 type MoonshineEncoderRuntimeActor =
     PinnedRuntimeActorCheckout<MoonshineEncoderRuntimeCacheKey, MoonshineEncoderActorState>;
 type MoonshineDecoderRuntimeActor =
     PinnedRuntimeActorCheckout<MoonshineDecoderRuntimeCacheKey, MoonshineDecoderActorState>;
+type MoonshineUnifiedRuntimeActor =
+    PinnedRuntimeActorCheckout<MoonshineUnifiedRuntimeCacheKey, MoonshineUnifiedActorState>;
+
+fn moonshine_unified_runtime_enabled(
+    encoder_config: GgmlCpuGraphConfig,
+    decoder_config: GgmlCpuGraphConfig,
+    backend_preference: Option<&RequestBackendPreference>,
+    placement: Option<ExecutionPlacement>,
+    adapter_active: bool,
+    serve_batch: bool,
+) -> bool {
+    !adapter_active
+        && !serve_batch
+        && encoder_config.backend == GgmlCpuGraphBackend::Gpu
+        && decoder_config.backend == GgmlCpuGraphBackend::Gpu
+        && !encoder_config.use_scheduler
+        && !decoder_config.use_scheduler
+        && matches!(
+            placement,
+            Some(ExecutionPlacement::FullDevice) | Some(ExecutionPlacement::Hybrid)
+        )
+        && crate::ggml_runtime::exact_discrete_gpu_unified_owner_is_proven(backend_preference)
+}
 
 #[cfg(test)]
 static DECODER_OWNER_GRAPH_CONFIG_PROBE: OnceLock<Mutex<Option<MoonshineGraphConfigIdentity>>> =
@@ -170,6 +219,7 @@ pub(crate) struct MoonshineGgmlExecutor {
     serve_batch_engines: MoonshineServeBatchEngineRegistry,
     encoder_runtimes: Arc<MoonshineEncoderRuntimePool>,
     decoder_runtimes: Arc<MoonshineDecoderRuntimePool>,
+    unified_gpu_runtimes: Arc<MoonshineUnifiedRuntimePool>,
     lora_adapters: ResolvedLoraAdapterCache,
 }
 
@@ -198,6 +248,10 @@ impl Default for MoonshineGgmlExecutor {
             )),
             decoder_runtimes: Arc::new(AdmittedPinnedRuntimeActorCheckoutPool::new(
                 "openasr-moonshine-decoder-owner",
+                limits,
+            )),
+            unified_gpu_runtimes: Arc::new(AdmittedPinnedRuntimeActorCheckoutPool::new(
+                "openasr-moonshine-unified-gpu-owner",
                 limits,
             )),
             lora_adapters: ResolvedLoraAdapterCache::default(),
@@ -304,16 +358,6 @@ impl MoonshineGgmlExecutor {
         )
         .map_err(map_frontend_error)?;
 
-        let encoder_output = self.encode_with_owned_runtime(
-            preflight,
-            Arc::clone(&prepared_runtime),
-            features,
-            adapter.clone(),
-            backend,
-            encoder_config,
-            encoder_execution_lane.clone(),
-        )?;
-
         let audio_duration = audio_duration_seconds(&request.prepared_audio);
         let serve_batch_config = MoonshineServeBatchConfig::from_policy::<
             super::batched_decode::MoonshineFamily,
@@ -327,16 +371,58 @@ impl MoonshineGgmlExecutor {
             decoder_config.use_scheduler,
             resolved_runtime,
         );
+        // Eligibility is not admission. GPU-decoder requests are serve-batch
+        // eligible, but the env default leaves the worker unadmitted. Gate
+        // unified on the admitted worker so encoder/decoder still share one
+        // pack-wide DeviceCopied owner.
+        let serve_batch_active = serve_batch_config.is_some() && can_use_serve_batch;
         let feature_key = MoonshineDecodeFeatureKey {
             output_mode: greedy_step_output_mode,
             adapter_active: adapter.is_some(),
             phrase_bias_active: request.request_options.phrase_bias.is_some(),
             word_timestamps: request.request_options.word_timestamps,
             streaming: skip_serve_batch,
-            serve_batch: can_use_serve_batch,
+            serve_batch: serve_batch_active,
+        };
+        let unified_gpu_runtime = if moonshine_unified_runtime_enabled(
+            encoder_config,
+            decoder_config,
+            Some(&request_lane.request_backend_preference()),
+            Some(request_lane.placement()),
+            adapter.is_some(),
+            serve_batch_active,
+        ) && resolved_runtime.reuse_mode()
+            == GgmlDecodeReuseMode::ReusableGraph
+        {
+            Some(self.checkout_unified_gpu_runtime(
+                preflight,
+                Arc::clone(&prepared_runtime),
+                adapter.clone(),
+                decoder_state,
+                resolved_runtime,
+                encoder_config,
+                decoder_config,
+                encoder_execution_lane.clone(),
+                greedy_step_output_mode,
+                feature_key,
+            )?)
+        } else {
+            None
+        };
+        let encoder_output = match unified_gpu_runtime.as_ref() {
+            Some(runtime) => self.encode_with_unified_gpu_runtime(runtime, features)?,
+            None => self.encode_with_owned_runtime(
+                preflight,
+                Arc::clone(&prepared_runtime),
+                features,
+                adapter.clone(),
+                backend,
+                encoder_config,
+                encoder_execution_lane.clone(),
+            )?,
         };
         let decode =
-            if let Some(serve_batch_config) = serve_batch_config.filter(|_| can_use_serve_batch) {
+            if let Some(serve_batch_config) = serve_batch_config.filter(|_| serve_batch_active) {
                 let decode_config = moonshine_serve_batch_decode_config(
                     prepared_runtime.metadata,
                     decoder_state,
@@ -390,6 +476,25 @@ impl MoonshineGgmlExecutor {
                     reason: error.to_string(),
                 },
             })?
+            } else if let Some(runtime) = unified_gpu_runtime.as_ref() {
+                self.decode_with_unified_gpu_runtime(
+                    runtime,
+                    Arc::clone(&prepared_runtime),
+                    encoder_output,
+                    request.request_options.phrase_bias.clone(),
+                    decoder_state,
+                    request.request_options.word_timestamps,
+                    audio_duration,
+                    Arc::clone(&request.execution_context.control),
+                    request
+                        .execution_context
+                        .decode_work_progress_observer()
+                        .cloned(),
+                    request
+                        .execution_context
+                        .unstable_decode_text_observer()
+                        .cloned(),
+                )?
             } else {
                 self.decode_with_owned_runtime(
                     preflight,
@@ -465,6 +570,8 @@ impl MoonshineGgmlExecutor {
             .evict_where(|key| key.0.pack_content_id == pack_content_id);
         self.decoder_runtimes
             .evict_where(|key| key.0.pack_content_id == pack_content_id);
+        self.unified_gpu_runtimes
+            .evict_where(|key| key.content.pack_content_id == pack_content_id);
         self.lora_adapters.evict_base_content_id(pack_content_id);
         self.runtime_cache_by_path.evict_content_id(pack_content_id);
         // Engine keys contain the old build identity, but the shared registry
@@ -656,7 +763,7 @@ impl MoonshineGgmlExecutor {
         runtime
             .call_mut(move |state| {
                 state.runtime.activate_decoder_state(decoder_state)?;
-                run_moonshine_decoder_short_form_with_runtime(
+                let decode_result = run_moonshine_decoder_short_form_with_runtime(
                     &mut state.runtime,
                     &tokenizer,
                     metadata,
@@ -667,9 +774,162 @@ impl MoonshineGgmlExecutor {
                     &control,
                     decode_work_progress.as_ref(),
                     unstable_decode_text.as_ref(),
-                )
+                );
+                let release_result = state.runtime.release_transient_compute_memory();
+                match (decode_result, release_result) {
+                    (Ok(output), Ok(())) => Ok(output),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                }
             })
             .map_err(|error| Self::map_actor_error("decoder", error))?
+            .map_err(map_decoder_error)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn checkout_unified_gpu_runtime(
+        &self,
+        preflight: &GgufRuntimeSourcePreflight,
+        prepared: PreparedRuntimeHandle<MoonshinePreparedRuntime>,
+        adapter: Option<ResolvedLoraAdapterHandle>,
+        decoder_state: crate::models::seq2seq_decoder_state::Seq2SeqDecoderState,
+        resolved_runtime: ResolvedFamilyRuntimeInput,
+        encoder_config: GgmlCpuGraphConfig,
+        decoder_config: GgmlCpuGraphConfig,
+        lane: ExecutionLaneKey,
+        greedy_step_output_mode: DeviceGreedyStepOutputMode,
+        feature_key: MoonshineDecodeFeatureKey,
+    ) -> Result<MoonshineUnifiedRuntimeActor, MoonshineGgmlExecutorError> {
+        let backend = resolved_runtime.backend();
+        let key = MoonshineUnifiedRuntimeCacheKey {
+            content: PackContentKey::for_runtime_source(&preflight.runtime_source),
+            lane,
+            encoder_config: moonshine_graph_config_identity(encoder_config),
+            decoder_config: moonshine_graph_config_identity(decoder_config),
+            resident_capacity: decoder_state.resident_capacity(),
+            adapter_fingerprint: moonshine_adapter_cache_fingerprint(
+                adapter.as_ref().map(resolved_lora_adapter),
+            ),
+            output_contract: resolved_runtime.output_contract(),
+            output_plan: resolved_runtime.output_plan(),
+            reuse_mode: resolved_runtime.reuse_mode(),
+            feature_key,
+        };
+        let preflight = preflight.clone();
+        self.unified_gpu_runtimes.checkout_or_try_build_with(
+            key,
+            move || Ok((0, (preflight, prepared, adapter))),
+            move |(preflight, prepared, adapter)| {
+                let encoder = MoonshineEncoderGraphRuntime::new_with_graph_config(
+                    &prepared.encoder_weights,
+                    prepared.metadata,
+                    &preflight,
+                    adapter.as_ref().map(resolved_lora_adapter),
+                    backend,
+                    encoder_config,
+                )
+                .map_err(|error| MoonshineGgmlExecutorError::EncoderFailed {
+                    reason: error.to_string(),
+                })?;
+                let decoder_input = MoonshineDecoderRuntimeInput {
+                    decoder_weights: &prepared.decoder_weights,
+                    metadata: prepared.metadata,
+                    decoder_state,
+                    backend,
+                    graph_config: decoder_config,
+                    reuse_mode: resolved_runtime.reuse_mode(),
+                };
+                let decoder = if let Some(shared_weights) = encoder.cloned_loaded_weights() {
+                    MoonshineDecoderGraphRuntime::new_with_shared_pack_weights(
+                        decoder_input,
+                        &preflight,
+                        adapter.as_ref().map(resolved_lora_adapter),
+                        greedy_step_output_mode,
+                        shared_weights,
+                    )
+                } else {
+                    MoonshineDecoderGraphRuntime::new_with_greedy_step_output_mode(
+                        decoder_input,
+                        &preflight,
+                        adapter.as_ref().map(resolved_lora_adapter),
+                        greedy_step_output_mode,
+                    )
+                }
+                .map_err(|error| MoonshineGgmlExecutorError::DecoderFailed {
+                    reason: error.to_string(),
+                })?;
+                Ok(SystemMemoryOwner::without_allocation(
+                    MoonshineUnifiedActorState {
+                        encoder,
+                        decoder,
+                        _prepared_owner: prepared,
+                    },
+                ))
+            },
+            |error| Self::map_actor_error("unified-runtime", error),
+        )
+    }
+
+    fn encode_with_unified_gpu_runtime(
+        &self,
+        runtime: &MoonshineUnifiedRuntimeActor,
+        features: super::frontend::MoonshineWaveformFeatures,
+    ) -> Result<MoonshineEncoderOutput, MoonshineGgmlExecutorError> {
+        runtime
+            .call_mut_fallible(move |state| {
+                let encode_result = state.encoder.encode(&features);
+                let release_result = state.encoder.release_transient_compute_memory();
+                match (encode_result, release_result) {
+                    (Ok(output), Ok(())) => Ok(output),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                }
+            })
+            .map_err(|error| Self::map_actor_error("unified-encoder", error))?
+            .map_err(|error| MoonshineGgmlExecutorError::EncoderFailed {
+                reason: error.to_string(),
+            })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn decode_with_unified_gpu_runtime(
+        &self,
+        runtime: &MoonshineUnifiedRuntimeActor,
+        prepared: PreparedRuntimeHandle<MoonshinePreparedRuntime>,
+        encoder_output: MoonshineEncoderOutput,
+        phrase_bias: Option<crate::PhraseBiasConfig>,
+        decoder_state: crate::models::seq2seq_decoder_state::Seq2SeqDecoderState,
+        word_timestamps: bool,
+        audio_duration_seconds: f32,
+        control: Arc<crate::api::backend::TranscriptionControl>,
+        decode_work_progress: Option<crate::api::backend::WorkProgressObserver>,
+        unstable_decode_text: Option<crate::api::backend::UnstableDecodeTextObserver>,
+    ) -> Result<super::decoder_graph::MoonshineDecodeOutput, MoonshineGgmlExecutorError> {
+        let tokenizer = prepared.tokenizer.clone();
+        let metadata = prepared.metadata;
+        runtime
+            .call_mut_fallible(move |state| {
+                state.decoder.activate_decoder_state(decoder_state)?;
+                let decode_result = run_moonshine_decoder_short_form_with_runtime(
+                    &mut state.decoder,
+                    &tokenizer,
+                    metadata,
+                    &encoder_output,
+                    phrase_bias.as_ref(),
+                    word_timestamps,
+                    audio_duration_seconds,
+                    &control,
+                    decode_work_progress.as_ref(),
+                    unstable_decode_text.as_ref(),
+                );
+                let release_result = state.decoder.release_transient_compute_memory();
+                match (decode_result, release_result) {
+                    (Ok(output), Ok(())) => Ok(output),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                }
+            })
+            .map_err(|error| Self::map_actor_error("unified-decoder", error))?
             .map_err(map_decoder_error)
     }
 }
@@ -762,6 +1022,7 @@ impl GgmlAsrViewExecutor for MoonshineGgmlExecutor {
         shutdown_moonshine_serve_batch_engines(&self.serve_batch_engines);
         self.encoder_runtimes.clear();
         self.decoder_runtimes.clear();
+        self.unified_gpu_runtimes.clear();
         self.lora_adapters.clear();
         self.runtime_cache_by_path.clear();
     }
@@ -826,6 +1087,7 @@ impl GgmlAsrStreamingExecutor for MoonshineGgmlExecutor {
         shutdown_moonshine_serve_batch_engines(&self.serve_batch_engines);
         self.encoder_runtimes.clear();
         self.decoder_runtimes.clear();
+        self.unified_gpu_runtimes.clear();
         self.lora_adapters.clear();
         self.runtime_cache_by_path.clear();
     }
@@ -861,6 +1123,7 @@ mod tests {
     use super::{
         DECODER_OWNER_GRAPH_CONFIG_PROBE, ExecutionLaneKey, MoonshineDecodeFeatureKey,
         MoonshineGgmlExecutor, can_use_moonshine_serve_batch, moonshine_greedy_step_output_mode,
+        moonshine_unified_runtime_enabled,
     };
     use crate::device::execution_policy::ExecutionPlacement;
     use crate::device::execution_route::{
@@ -975,6 +1238,97 @@ mod tests {
         let preflight =
             GgufRuntimeSourcePreflight::from_runtime_source(&source).expect("preflight empty GGUF");
         (directory, preflight)
+    }
+
+    #[test]
+    fn unified_owner_requires_exact_cuda_hip_or_vulkan_full_device_reusable_gpu_graphs() {
+        let gpu = GgmlCpuGraphConfig {
+            backend: GgmlCpuGraphBackend::Gpu,
+            use_scheduler: false,
+            ..GgmlCpuGraphConfig::conservative_default()
+        };
+        let cpu = GgmlCpuGraphConfig {
+            backend: GgmlCpuGraphBackend::Cpu,
+            ..gpu
+        };
+        let scheduled = GgmlCpuGraphConfig {
+            use_scheduler: true,
+            ..gpu
+        };
+        for provider in [
+            ExecutionProvider::Cuda,
+            ExecutionProvider::Hip,
+            ExecutionProvider::Vulkan,
+        ] {
+            let preference = exact_preference(provider);
+            assert!(moonshine_unified_runtime_enabled(
+                gpu,
+                gpu,
+                Some(&preference),
+                Some(ExecutionPlacement::FullDevice),
+                false,
+                false,
+            ));
+            assert!(
+                moonshine_unified_runtime_enabled(
+                    gpu,
+                    gpu,
+                    Some(&preference),
+                    Some(ExecutionPlacement::Hybrid),
+                    false,
+                    false,
+                ),
+                "Hybrid request with both neural graphs on GPU must share one owner"
+            );
+            assert!(!moonshine_unified_runtime_enabled(
+                gpu,
+                cpu,
+                Some(&preference),
+                Some(ExecutionPlacement::FullDevice),
+                false,
+                false,
+            ));
+            assert!(!moonshine_unified_runtime_enabled(
+                gpu,
+                scheduled,
+                Some(&preference),
+                Some(ExecutionPlacement::FullDevice),
+                false,
+                false,
+            ));
+            assert!(!moonshine_unified_runtime_enabled(
+                gpu,
+                gpu,
+                Some(&preference),
+                Some(ExecutionPlacement::FullDevice),
+                true,
+                false,
+            ));
+            assert!(!moonshine_unified_runtime_enabled(
+                gpu,
+                gpu,
+                Some(&preference),
+                Some(ExecutionPlacement::FullDevice),
+                false,
+                true,
+            ));
+        }
+        for provider in [
+            ExecutionProvider::Cpu,
+            ExecutionProvider::Metal,
+            ExecutionProvider::Accelerator,
+            ExecutionProvider::Unknown,
+        ] {
+            let preference = exact_preference(provider);
+            assert!(!moonshine_unified_runtime_enabled(
+                gpu,
+                gpu,
+                Some(&preference),
+                Some(ExecutionPlacement::FullDevice),
+                false,
+                false,
+            ));
+        }
     }
 
     #[test]

--- a/crates/openasr-core/src/models/moonshine/graph_config.rs
+++ b/crates/openasr-core/src/models/moonshine/graph_config.rs
@@ -7,6 +7,10 @@ use crate::models::graph_runtime_config::{
 };
 
 const OPENASR_MOONSHINE_ENABLE_DECODER_GPU: &str = "OPENASR_MOONSHINE_ENABLE_DECODER_GPU";
+/// Tiny/base encoder+decoder cgraphs stay under 2k nodes. A 16_384 floor
+/// would still force a Zipformer-scale metadata reservation; 4096 is cgraph
+/// headroom and `metadata_context_bytes` keeps that bump at 1 MiB.
+const MOONSHINE_GRAPH_NODE_CAPACITY: usize = 4_096;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct MoonshineGraphConfigIdentity {
@@ -20,13 +24,9 @@ pub(crate) struct MoonshineGraphConfigIdentity {
 pub(crate) fn moonshine_graph_config_identity(
     config: GgmlCpuGraphConfig,
 ) -> MoonshineGraphConfigIdentity {
-    let graph_size = config.graph_size.max(16_384);
-    let context_bytes = config
-        .context_bytes
-        .max(GgmlCpuGraphConfig::metadata_context_bytes(graph_size));
     MoonshineGraphConfigIdentity {
-        context_bytes,
-        graph_size,
+        context_bytes: config.context_bytes,
+        graph_size: config.graph_size,
         n_threads: config.n_threads,
         backend: config.backend,
         use_scheduler: config.use_scheduler,
@@ -77,7 +77,7 @@ pub(crate) fn moonshine_encoder_graph_config(backend: GgmlCpuGraphBackend) -> Gg
     // Resolve operator and thread defaults before narrowing the neural graph to
     // its device-complete placement below.
     let mut config = moonshine_runtime_graph_config_with_scheduler_default(backend, Some(true));
-    config.graph_size = config.graph_size.max(16_384);
+    config.set_graph_node_capacity(MOONSHINE_GRAPH_NODE_CAPACITY);
     if !has_explicit_thread_override() {
         config.n_threads = GgmlCpuGraphConfig::resolve_runtime_thread_count_for(
             config.backend,
@@ -87,11 +87,12 @@ pub(crate) fn moonshine_encoder_graph_config(backend: GgmlCpuGraphBackend) -> Gg
     apply_moonshine_neural_graph_placement(config)
 }
 
-/// Keep decoder placement separate from encoder placement. Vulkan Hybrid is
-/// the validated default: the encoder remains accelerated while the decoder
-/// defaults to CPU, unless the diagnostic stage override explicitly enables
-/// GPU decode. A FullDevice candidate must not be rewritten to CPU; the
-/// request placement owns that decision.
+/// Keep decoder placement separate from encoder placement. v0.1.36 ran the
+/// Moonshine decoder on Vulkan; a CPU-decoder Hybrid default duplicated host
+/// weights and missed that PeakWorkingSet. Exact Vulkan still allows
+/// `OPENASR_MOONSHINE_ENABLE_DECODER_GPU=0` as a diagnostic opt-out. A
+/// FullDevice candidate must not be rewritten to CPU; the request placement
+/// owns that decision.
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn moonshine_decoder_graph_config(
     backend: GgmlCpuGraphBackend,
@@ -136,7 +137,7 @@ fn decoder_gpu_enabled_with_inputs(
     let exact_vulkan =
         backend == GgmlCpuGraphBackend::Gpu && provider == Some(ExecutionProvider::Vulkan);
     if exact_vulkan {
-        crate::ggml_runtime::env_toggle_with_raw(None, gpu_raw, false)
+        crate::ggml_runtime::env_toggle_with_raw(None, gpu_raw, true)
     } else {
         // FullDevice providers must not be silently rewritten into a CPU
         // decoder by a stage-local setting.
@@ -185,8 +186,20 @@ mod tests {
     }
 
     #[test]
-    fn exact_vulkan_graph_config_defaults_decoder_to_cpu() {
+    fn exact_vulkan_graph_config_defaults_decoder_to_gpu() {
         with_decoder_env(None, || {
+            let config = moonshine_decoder_graph_config(
+                GgmlCpuGraphBackend::Gpu,
+                Some(crate::device::execution_route::ExecutionProvider::Vulkan),
+            );
+            assert_eq!(config.backend, GgmlCpuGraphBackend::Gpu);
+            assert!(!config.use_scheduler);
+        });
+    }
+
+    #[test]
+    fn exact_vulkan_env_can_opt_decoder_out_to_cpu() {
+        with_decoder_env(Some("0"), || {
             let config = moonshine_decoder_graph_config(
                 GgmlCpuGraphBackend::Gpu,
                 Some(crate::device::execution_route::ExecutionProvider::Vulkan),

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/executor.rs
@@ -321,12 +321,7 @@ fn moss_td_unified_runtime_enabled(
     allow_unified_runtime
         && backend == GgmlCpuGraphBackend::Gpu
         && placement == Some(ExecutionPlacement::FullDevice)
-        && matches!(
-            backend_preference,
-            Some(RequestBackendPreference::Exact(route))
-                if route.addressability.is_exactly_addressable()
-                    && matches!(route.provider, ExecutionProvider::Cuda | ExecutionProvider::Vulkan)
-        )
+        && crate::ggml_runtime::exact_discrete_gpu_unified_owner_is_proven(backend_preference)
         && encoder.backend == GgmlCpuGraphBackend::Gpu
         && !encoder.use_scheduler
         && decoder.backend == GgmlCpuGraphBackend::Gpu
@@ -1824,8 +1819,12 @@ mod tests {
     }
 
     #[test]
-    fn unified_runtime_is_ordinary_exact_direct_cuda_or_vulkan_full_device_only() {
-        for provider in [ExecutionProvider::Cuda, ExecutionProvider::Vulkan] {
+    fn unified_runtime_is_ordinary_exact_direct_cuda_hip_or_vulkan_full_device_only() {
+        for provider in [
+            ExecutionProvider::Cuda,
+            ExecutionProvider::Hip,
+            ExecutionProvider::Vulkan,
+        ] {
             let preference = exactly_addressable_preference(provider);
             assert!(moss_td_unified_runtime_enabled(
                 true,
@@ -1878,7 +1877,6 @@ mod tests {
         for provider in [
             ExecutionProvider::Cpu,
             ExecutionProvider::Metal,
-            ExecutionProvider::Hip,
             ExecutionProvider::Accelerator,
             ExecutionProvider::Unknown,
         ] {

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/llm_decoder.rs
@@ -77,7 +77,9 @@ impl MossTdDecoderRuntime {
     pub(crate) fn take_compute_evidence(
         &mut self,
     ) -> Option<crate::ggml_runtime::GgmlSelectionEvidenceRef> {
-        self.logits_runtime.take_compute_evidence()
+        self.whole_decoder
+            .take_fused_compute_evidence()
+            .or_else(|| self.logits_runtime.take_compute_evidence())
     }
 
     pub(crate) fn graph_lanes(
@@ -490,6 +492,9 @@ impl MossTdDecoderRuntime {
             self.metadata.n_kv_heads * self.metadata.head_dim,
             layer_kv_caches,
         )?;
+        if let Some(logits) = step.fused_logits {
+            return Ok(logits);
+        }
         self.logits_runtime
             .compute_logits_for_last_hidden(&self.logits_head, &step.hidden)
             .map_err(|error| MossTdDecoderError::LogitsHeadFailed {

--- a/crates/openasr-core/src/models/native_execution_services.rs
+++ b/crates/openasr-core/src/models/native_execution_services.rs
@@ -46,7 +46,7 @@ use crate::ggml_runtime::{
     BackendMemoryUnknownReason, SafeBackendMemoryReceipt,
 };
 use crate::ggml_runtime::{
-    GgmlBackend, GgmlBackendKind, GgmlCpuGraphBackend, GgmlDeviceMemory,
+    GgmlBackend, GgmlBackendDevice, GgmlBackendKind, GgmlCpuGraphBackend, GgmlDeviceMemory,
     GgmlExecutionPlacementSummary, GgmlExecutionTelemetryCollector, GgmlExecutionTelemetryGuard,
     GgmlGraphLifecycleGuard, RequestBackendOverrideGuard, RequestBackendPreference,
     current_execution_telemetry_collector, ensure_backends_loaded, ggml_available_devices,
@@ -2014,6 +2014,12 @@ fn ggml_backend_physical_identity(
         return Err("candidate activation quote received a null ggml backend".to_string());
     }
     let device = unsafe { ffi::ggml_backend_get_device(backend) };
+    ggml_device_physical_identity(device)
+}
+
+fn ggml_device_physical_identity(
+    device: ffi::GgmlBackendDevRaw,
+) -> Result<PhysicalDeviceKey, String> {
     if device.is_null() {
         return Err("candidate activation backend has no device for physical identity".to_string());
     }
@@ -2044,9 +2050,9 @@ fn host_backend_for_activation() -> Result<GgmlBackend, String> {
     GgmlBackend::cpu().map_err(|error| error.to_string())
 }
 
-fn discrete_backend_for_candidate(
+fn discrete_device_for_candidate(
     candidate: &ExecutionCandidate,
-) -> Result<Option<GgmlBackend>, String> {
+) -> Result<Option<GgmlBackendDevice>, String> {
     match candidate.device.route.provider {
         ExecutionProvider::Cuda | ExecutionProvider::Hip | ExecutionProvider::Vulkan
             if candidate.placement != ExecutionPlacement::CpuOnly => {}
@@ -2056,30 +2062,22 @@ fn discrete_backend_for_candidate(
     let devices = ggml_available_devices();
     let wanted = candidate.device.route.provider;
     let stable = candidate.device.route.stable_id.as_str();
-    let device = devices.iter().find(|device| {
+    Ok(devices.into_iter().find(|device| {
         ExecutionProvider::from_backend_name(&device.name) == wanted
             && (device.name == stable
                 || device
                     .device_id
                     .as_deref()
                     .is_some_and(|id| id.eq_ignore_ascii_case(stable)))
-    });
-    match device {
-        Some(device) => device
-            .initialize()
-            .map(Some)
-            .map_err(|error| error.to_string()),
-        None => Ok(None),
-    }
+    }))
 }
 
 fn quote_activation_group(
     group_id: &str,
-    backend: &GgmlBackend,
+    identity: PhysicalDeviceKey,
+    abi: BackendMemoryAbi,
     request: ffi::GgmlBackendMemoryRequestV1,
 ) -> Result<NativeQuotedBackendGroup, String> {
-    let abi = unsafe { BackendMemoryAbi::from_backend(backend.as_ptr()) }
-        .map_err(|error| format!("candidate activation ABI: {error}"))?;
     let semantics = NativeMemoryClaimSemantics {
         resource_id: group_id.to_owned(),
         lifetime: AllocationLifetime::PackShared,
@@ -2087,13 +2085,79 @@ fn quote_activation_group(
     };
     NativeQuotedBackendGroup::quote(
         group_id,
-        ggml_backend_physical_identity(backend.as_ptr())?,
+        identity,
         abi,
         vec![request],
         BTreeMap::from([(request.request_id, semantics.clone())]),
         semantics,
     )
     .map_err(|error| format!("candidate activation ggml quote: {error}"))
+}
+
+fn quote_host_activation_group(
+    group_id: &str,
+    host: &GgmlBackend,
+    request: ffi::GgmlBackendMemoryRequestV1,
+) -> Result<NativeQuotedBackendGroup, String> {
+    let abi = unsafe { BackendMemoryAbi::from_backend(host.as_ptr()) }
+        .map_err(|error| format!("candidate activation ABI: {error}"))?;
+    quote_activation_group(
+        group_id,
+        ggml_backend_physical_identity(host.as_ptr())?,
+        abi,
+        request,
+    )
+}
+
+fn quote_discrete_activation_group(
+    device: &GgmlBackendDevice,
+    activation_resource: &str,
+    requested_bytes: u64,
+) -> Result<(NativeQuotedBackendGroup, Option<GgmlBackend>), String> {
+    let device_raw = device.as_ptr();
+    let buft = unsafe { ffi::ggml_backend_dev_buffer_type(device_raw) };
+    if buft.is_null() {
+        return Err("discrete activation device has no buffer type to quote".to_string());
+    }
+    let group_id = format!("candidate-activation-device-copy:{activation_resource}");
+    let identity = ggml_device_physical_identity(device_raw)?;
+    // Vulkan BUFFER quotes accept a registry `buft` with a null backend. CUDA
+    // and HIP still require a live backend context to mint the quote token.
+    if ExecutionProvider::from_backend_name(&device.name) == ExecutionProvider::Vulkan {
+        let request = ffi::GgmlBackendMemoryRequestV1 {
+            kind: ffi::GGML_BACKEND_MEMORY_REQUEST_BUFFER,
+            usage: ffi::GGML_BACKEND_BUFFER_USAGE_WEIGHTS as u32,
+            request_id: 1,
+            backend: std::ptr::null_mut(),
+            buft,
+            requested_bytes,
+            currently_allocated_bytes: 0,
+            ..Default::default()
+        };
+        let abi = unsafe { BackendMemoryAbi::from_device(device_raw) }
+            .map_err(|error| format!("candidate activation device ABI: {error}"))?;
+        return Ok((
+            quote_activation_group(&group_id, identity, abi, request)?,
+            None,
+        ));
+    }
+    let backend = device.initialize().map_err(|error| error.to_string())?;
+    let request = ffi::GgmlBackendMemoryRequestV1 {
+        kind: ffi::GGML_BACKEND_MEMORY_REQUEST_BUFFER,
+        usage: ffi::GGML_BACKEND_BUFFER_USAGE_WEIGHTS as u32,
+        request_id: 1,
+        backend: backend.as_ptr(),
+        buft,
+        requested_bytes,
+        currently_allocated_bytes: 0,
+        ..Default::default()
+    };
+    let abi = unsafe { BackendMemoryAbi::from_backend(backend.as_ptr()) }
+        .map_err(|error| format!("candidate activation ABI: {error}"))?;
+    Ok((
+        quote_activation_group(&group_id, identity, abi, request)?,
+        Some(backend),
+    ))
 }
 
 fn quote_candidate_activation_plan(
@@ -2166,58 +2230,41 @@ fn quote_pack_activation_plan(
         ..Default::default()
     };
     let host_group_id = format!("candidate-activation-host-import:{activation_resource}");
-    let host_group = quote_activation_group(&host_group_id, &host, host_import).or_else(|_| {
-        let device = unsafe { ffi::ggml_backend_get_device(host.as_ptr()) };
-        if device.is_null() {
-            return Err("host activation backend has no device".to_string());
-        }
-        let buft = unsafe { ffi::ggml_backend_dev_buffer_type(device) };
-        if buft.is_null() {
-            return Err("host activation backend has no buffer type to quote".to_string());
-        }
-        let host_copy = ffi::GgmlBackendMemoryRequestV1 {
-            kind: ffi::GGML_BACKEND_MEMORY_REQUEST_BUFFER,
-            usage: ffi::GGML_BACKEND_BUFFER_USAGE_WEIGHTS as u32,
-            request_id: 1,
-            backend: host.as_ptr(),
-            buft,
-            requested_bytes,
-            currently_allocated_bytes: 0,
-            ..Default::default()
-        };
-        quote_activation_group(
-            &format!("candidate-activation-host-copy:{activation_resource}"),
-            &host,
-            host_copy,
-        )
-    })?;
+    let host_group =
+        quote_host_activation_group(&host_group_id, &host, host_import).or_else(|_| {
+            let device = unsafe { ffi::ggml_backend_get_device(host.as_ptr()) };
+            if device.is_null() {
+                return Err("host activation backend has no device".to_string());
+            }
+            let buft = unsafe { ffi::ggml_backend_dev_buffer_type(device) };
+            if buft.is_null() {
+                return Err("host activation backend has no buffer type to quote".to_string());
+            }
+            let host_copy = ffi::GgmlBackendMemoryRequestV1 {
+                kind: ffi::GGML_BACKEND_MEMORY_REQUEST_BUFFER,
+                usage: ffi::GGML_BACKEND_BUFFER_USAGE_WEIGHTS as u32,
+                request_id: 1,
+                backend: host.as_ptr(),
+                buft,
+                requested_bytes,
+                currently_allocated_bytes: 0,
+                ..Default::default()
+            };
+            quote_host_activation_group(
+                &format!("candidate-activation-host-copy:{activation_resource}"),
+                &host,
+                host_copy,
+            )
+        })?;
     let mut groups = vec![host_group];
     let mut backends = vec![host];
-    if let Some(device) = discrete_backend_for_candidate(candidate)? {
-        let device_raw = unsafe { ffi::ggml_backend_get_device(device.as_ptr()) };
-        if device_raw.is_null() {
-            return Err("discrete activation backend has no device".to_string());
+    if let Some(device) = discrete_device_for_candidate(candidate)? {
+        let (group, live_backend) =
+            quote_discrete_activation_group(&device, activation_resource, requested_bytes)?;
+        groups.push(group);
+        if let Some(live_backend) = live_backend {
+            backends.push(live_backend);
         }
-        let buft = unsafe { ffi::ggml_backend_dev_buffer_type(device_raw) };
-        if buft.is_null() {
-            return Err("discrete activation backend has no buffer type to quote".to_string());
-        }
-        let device_copy = ffi::GgmlBackendMemoryRequestV1 {
-            kind: ffi::GGML_BACKEND_MEMORY_REQUEST_BUFFER,
-            usage: ffi::GGML_BACKEND_BUFFER_USAGE_WEIGHTS as u32,
-            request_id: 1,
-            backend: device.as_ptr(),
-            buft,
-            requested_bytes,
-            currently_allocated_bytes: 0,
-            ..Default::default()
-        };
-        groups.push(quote_activation_group(
-            &format!("candidate-activation-device-copy:{activation_resource}"),
-            &device,
-            device_copy,
-        )?);
-        backends.push(device);
     }
     let plan = admission_plan_from_quoted_groups(groups)?;
     Ok((backends, mmap, plan))
@@ -2270,7 +2317,7 @@ fn quote_cpu_buffer_plan(
         currently_allocated_bytes: 0,
         ..Default::default()
     };
-    let group = quote_activation_group(group_id, &host, request)?;
+    let group = quote_host_activation_group(group_id, &host, request)?;
     let plan = admission_plan_from_quoted_groups(vec![group])?;
     Ok((host, plan))
 }

--- a/crates/openasr-core/src/models/qwen/ggml_executor.rs
+++ b/crates/openasr-core/src/models/qwen/ggml_executor.rs
@@ -49,6 +49,7 @@ use crate::arch::{
     OpenAsrArchitectureRegistry, OpenAsrBlockStackStrategy, QWEN3_ASR_GGML_ARCHITECTURE_ID,
 };
 use crate::device::execution_policy::ExecutionPlacement;
+#[cfg(test)]
 use crate::device::execution_route::ExecutionProvider;
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphError, GgmlDecodeOutputPlan, GgmlNativeGqaCapability,
@@ -256,23 +257,20 @@ impl Qwen3AsrDecoderActorCheckout {
 
 fn qwen_unified_runtime_owner_enabled(
     resolved_runtime: ResolvedFamilyRuntimeInput,
-    native_gqa: GgmlNativeGqaCapability,
+    _native_gqa: GgmlNativeGqaCapability,
     native_logits_runtime: bool,
     backend_preference: Option<&RequestBackendPreference>,
     placement: Option<ExecutionPlacement>,
 ) -> bool {
     let backend = resolved_runtime.backend();
+    // Native GQA is a kernel choice (and fail-closed on HIP). The unified
+    // owner only coalesces encoder+decoder onto one ggml thread so device
+    // weights upload once; it must not require GQA.
     if backend != GgmlCpuGraphBackend::Gpu
         || resolved_runtime.reuse_mode() != crate::ggml_runtime::GgmlDecodeReuseMode::ReusableGraph
-        || !native_gqa.is_validated()
         || !native_logits_runtime
         || placement != Some(ExecutionPlacement::FullDevice)
-        || !matches!(
-            backend_preference,
-            Some(RequestBackendPreference::Exact(route))
-                if route.addressability.is_exactly_addressable()
-                    && matches!(route.provider, ExecutionProvider::Cuda | ExecutionProvider::Vulkan)
-        )
+        || !crate::ggml_runtime::exact_discrete_gpu_unified_owner_is_proven(backend_preference)
     {
         return false;
     }
@@ -287,8 +285,12 @@ fn qwen_unified_runtime_owner_enabled(
 fn qwen_qkv_execution_mode(
     unified_runtime_enabled: bool,
     split_loaded_requested: bool,
+    native_gqa: GgmlNativeGqaCapability,
 ) -> QwenQkvExecutionMode {
-    if unified_runtime_enabled && split_loaded_requested {
+    // Split-loaded QKV is the CUDA/Vulkan fused-GQA packing. HIP's native GQA
+    // broadcast is fail-closed, so a unified HIP owner must keep the unfused
+    // arena path rather than inherit the CUDA packing.
+    if unified_runtime_enabled && split_loaded_requested && native_gqa.is_validated() {
         QwenQkvExecutionMode::SplitLoaded
     } else {
         QwenQkvExecutionMode::FusedArena
@@ -941,6 +943,7 @@ impl Qwen3AsrGgmlExecutor {
                     .ok()
                     .as_deref(),
             ),
+            native_gqa,
         );
         let unified_gpu_runtime = if unified_runtime_enabled {
             Some(self.checkout_unified_gpu_runtime(
@@ -1202,6 +1205,9 @@ impl Qwen3AsrGgmlExecutor {
                 // A failed compute may poison the reusable graph. Always
                 // release session-scoped buffers before the actor goes idle.
                 state.whole_decoder.release_session_scoped_buffers();
+                state
+                    .logits_head_runtime
+                    .release_request_compute_residency();
                 result
             })
             .map_err(|error| Self::map_actor_error("decoder", error))?;
@@ -1690,7 +1696,7 @@ impl Seq2SeqGreedyDecodeStepExecutor for Qwen3AsrPrefillOnlyGreedyStepExecutor<'
                     reason: error.to_string(),
                 }
             })?;
-        let hidden = self
+        let (hidden, fused_logits) = self
             .run_llm_token_with_kv(token_id, cache_position)
             .map_err(|error| {
                 crate::models::seq2seq_greedy_decode::Seq2SeqGreedyDecodeError::DecoderStepFailed {
@@ -1698,14 +1704,17 @@ impl Seq2SeqGreedyDecodeStepExecutor for Qwen3AsrPrefillOnlyGreedyStepExecutor<'
                 }
             })?;
 
-        let logits = self
-            .logits_head_runtime
-            .compute_logits_for_last_hidden(self.logits_head, &hidden)
-            .map_err(|error| {
-                crate::models::seq2seq_greedy_decode::Seq2SeqGreedyDecodeError::DecoderStepFailed {
-                    reason: error.to_string(),
-                }
-            })?;
+        let logits = if let Some(logits) = fused_logits {
+            logits
+        } else {
+            self.logits_head_runtime
+                .compute_logits_for_last_hidden(self.logits_head, &hidden)
+                .map_err(|error| {
+                    crate::models::seq2seq_greedy_decode::Seq2SeqGreedyDecodeError::DecoderStepFailed {
+                        reason: error.to_string(),
+                    }
+                })?
+        };
         Ok(Seq2SeqGreedyDecodeStepLogitsOutput {
             logits,
             greedy_token_hint: None,
@@ -1713,7 +1722,9 @@ impl Seq2SeqGreedyDecodeStepExecutor for Qwen3AsrPrefillOnlyGreedyStepExecutor<'
     }
 
     fn take_compute_evidence(&mut self) -> Option<crate::ggml_runtime::GgmlSelectionEvidenceRef> {
-        self.logits_head_runtime.take_compute_evidence()
+        self.whole_decoder
+            .take_fused_compute_evidence()
+            .or_else(|| self.logits_head_runtime.take_compute_evidence())
     }
 }
 
@@ -2219,7 +2230,7 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor<'_> {
         &mut self,
         token_id: u32,
         cache_position: usize,
-    ) -> Result<Vec<f32>, Qwen3AsrGreedyDecodeError> {
+    ) -> Result<(Vec<f32>, Option<Vec<f32>>), Qwen3AsrGreedyDecodeError> {
         if self.whole_decoder.supports_device_token_embedding() {
             let started_at = if qwen_decode_profile_enabled() {
                 Some(Instant::now())
@@ -2256,7 +2267,7 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor<'_> {
                     step.compute_micros,
                 );
             }
-            return Ok(step.hidden);
+            return Ok((step.hidden, step.fused_logits));
         }
         let hidden = self
             .token_embedding_table
@@ -2265,6 +2276,7 @@ impl Qwen3AsrPrefillOnlyGreedyStepExecutor<'_> {
                 reason: error.to_string(),
             })?;
         self.run_llm_layers_with_kv(hidden, cache_position)
+            .map(|hidden| (hidden, None))
     }
 
     fn last_generated_token_id(
@@ -2669,11 +2681,19 @@ mod tests {
             );
             assert!(!enabled);
             assert_eq!(
-                qwen_qkv_execution_mode(enabled, true),
+                qwen_qkv_execution_mode(enabled, true, GgmlNativeGqaCapability::Validated),
                 QwenQkvExecutionMode::FusedArena
             );
             assert_eq!(
-                qwen_qkv_execution_mode(true, false),
+                qwen_qkv_execution_mode(true, false, GgmlNativeGqaCapability::Validated),
+                QwenQkvExecutionMode::FusedArena
+            );
+            assert_eq!(
+                qwen_qkv_execution_mode(true, true, GgmlNativeGqaCapability::Validated),
+                QwenQkvExecutionMode::SplitLoaded
+            );
+            assert_eq!(
+                qwen_qkv_execution_mode(true, true, GgmlNativeGqaCapability::Unsupported),
                 QwenQkvExecutionMode::FusedArena
             );
         }
@@ -2699,7 +2719,7 @@ mod tests {
             ));
         }
         assert_eq!(
-            qwen_qkv_execution_mode(false, true),
+            qwen_qkv_execution_mode(false, true, GgmlNativeGqaCapability::Validated),
             QwenQkvExecutionMode::FusedArena
         );
     }

--- a/crates/openasr-core/src/models/qwen/llm_transformer.rs
+++ b/crates/openasr-core/src/models/qwen/llm_transformer.rs
@@ -16,10 +16,10 @@ use thiserror::Error;
 use crate::GgmlRuntimeSource;
 use crate::ggml_runtime::{
     GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphError, GgmlCpuGraphRunner, GgmlCpuTensor,
-    GgmlDecodeOutputPlan, GgmlFlashAttentionPrecision, GgmlKvElementType, GgmlLoadedTensor,
-    GgmlNativeGqaCapability, GgmlRopeExtParams, GgmlStaticTensor, GgmlStaticTensorArena,
-    GgufTensorDataReadError, GgufTensorDataReader, ResolvedFamilyRuntimeInput, env_toggle_with_raw,
-    env_var_truthy,
+    GgmlDecodeOutputPlan, GgmlDecodeReuseMode, GgmlFlashAttentionPrecision, GgmlKvElementType,
+    GgmlLoadedTensor, GgmlNativeGqaCapability, GgmlRopeExtParams, GgmlSelectionEvidenceRef,
+    GgmlStaticTensor, GgmlStaticTensorArena, GgufTensorDataReadError, GgufTensorDataReader,
+    ResolvedFamilyRuntimeInput, env_toggle_with_raw, env_var_truthy,
 };
 
 use super::decoder_contract::{QwenDecoderContract, QwenDecoderContractGeometry};
@@ -1116,7 +1116,6 @@ struct Qwen3AsrLlmLayerWeightHandles {
     lora: QwenLayerLoraSlots,
 }
 
-#[cfg(test)]
 struct Qwen3AsrLlmFusedLogitsHeadHandles {
     vocab_size: usize,
     rms_norm_epsilon: f32,
@@ -1225,6 +1224,10 @@ fn qwen_llm_layer_weights_with_lora<'a>(
 
 pub(crate) struct Qwen3AsrLlmWholeStepOutput {
     pub hidden: Vec<f32>,
+    /// Full-vocab logits produced by the same reusable decode compute when the
+    /// fused lm-head is resident. `None` means the caller must run the separate
+    /// logits-head graph.
+    pub fused_logits: Option<Vec<f32>>,
     pub layer_kv: Vec<(Vec<f32>, Vec<f32>)>,
     /// Microseconds spent building the graph (start_graph + appending all layer
     /// ops + KV uploads) vs the single compute/dispatch — for decode profiling.
@@ -2040,7 +2043,6 @@ fn upload_layer_lora_slots(
     Ok(())
 }
 
-#[cfg(test)]
 fn allocate_fused_logits_head_tensors(
     arena: &mut GgmlStaticTensorArena,
     loaded: Option<&crate::ggml_runtime::GgmlLoadedWeightContext>,
@@ -2089,7 +2091,6 @@ fn allocate_fused_logits_head_tensors(
     })
 }
 
-#[cfg(test)]
 fn upload_fused_logits_head_weights(
     arena: &mut GgmlStaticTensorArena,
     handles: &Qwen3AsrLlmFusedLogitsHeadHandles,
@@ -2108,6 +2109,23 @@ fn upload_fused_logits_head_weights(
         )?;
     }
     Ok(())
+}
+
+fn build_fused_full_logits<'a>(
+    arena: &GgmlStaticTensorArena,
+    logits_head: &Qwen3AsrLlmFusedLogitsHeadHandles,
+    graph: &mut crate::ggml_runtime::GgmlCpuGraphBuilder<'a>,
+    state: GgmlCpuTensor<'a>,
+    n_seq: usize,
+) -> Result<GgmlCpuTensor<'a>, GgmlCpuGraphError> {
+    if n_seq != 1 {
+        return Err(GgmlCpuGraphError::UnsupportedInputs {
+            reason: "fused whole-decoder logits currently require n_seq=1",
+        });
+    }
+    let normed = graph.rms_norm(state, logits_head.rms_norm_epsilon)?;
+    let normed = graph.mul(normed, arena.graph_tensor(logits_head.output_norm_weight))?;
+    graph.mul_mat(logits_head.output_weight.as_graph_tensor(arena), normed)
 }
 
 #[cfg(test)]
@@ -2362,7 +2380,6 @@ pub(crate) struct Qwen3AsrLlmWholeDecoderGraphExecutor {
     runner: GgmlCpuGraphRunner,
     arena: GgmlStaticTensorArena,
     layers: Vec<Qwen3AsrLlmLayerWeightHandles>,
-    #[cfg(test)]
     fused_logits_head: Option<Qwen3AsrLlmFusedLogitsHeadHandles>,
     resolved_runtime: ResolvedFamilyRuntimeInput,
     dims: Qwen3AsrLlmDecodeDims,
@@ -2370,6 +2387,7 @@ pub(crate) struct Qwen3AsrLlmWholeDecoderGraphExecutor {
     rms_norm_epsilon: f32,
     kv_cache_spec: LlmKvCacheSpec,
     flash_attention_precision: GgmlFlashAttentionPrecision,
+    last_fused_compute_evidence: Option<GgmlSelectionEvidenceRef>,
     #[cfg(test)]
     test_native_output_enabled: bool,
     #[cfg(test)]
@@ -2676,11 +2694,11 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             layers.push(handles);
         }
         let dims = dims.expect("non-empty whole-decoder plan sets dimensions");
-        #[cfg(not(test))]
-        let _ = fused_logits_head;
-        #[cfg(test)]
         let fused_logits_head = fused_logits_head
-            .filter(|_| resolved_runtime.output_plan() == GgmlDecodeOutputPlan::NativeFirstMaxToken)
+            .filter(|_| {
+                resolved_runtime.reuse_mode() == GgmlDecodeReuseMode::ReusableGraph
+                    && resolved_runtime.backend().is_gpu_class()
+            })
             .map(|spec| {
                 let handles =
                     allocate_fused_logits_head_tensors(&mut arena, loaded.as_ref(), dims, &spec)?;
@@ -2754,7 +2772,6 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             runner,
             arena,
             layers,
-            #[cfg(test)]
             fused_logits_head,
             resolved_runtime,
             dims,
@@ -2762,6 +2779,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             rms_norm_epsilon,
             kv_cache_spec: LlmKvCacheSpec::DEFAULT,
             flash_attention_precision: GgmlFlashAttentionPrecision::Default,
+            last_fused_compute_evidence: None,
             #[cfg(test)]
             test_native_output_enabled: false,
             #[cfg(test)]
@@ -3020,6 +3038,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             rms_norm_epsilon,
             kv_cache_spec: LlmKvCacheSpec::DEFAULT,
             flash_attention_precision: GgmlFlashAttentionPrecision::Default,
+            last_fused_compute_evidence: None,
             #[cfg(test)]
             test_native_output_enabled: true,
             materialization_peak_staging_bytes: 0,
@@ -3078,18 +3097,13 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
 
     /// Ends a decode session/slice: discards any reusable graph poisoned by an
     /// incomplete compute, then releases the CPU per-token grow-to-fit step
-    /// buffer (see `GgmlCpuGraphRunner::release_cpu_step_buffer_pool`). Callers that cache
-    /// this executor across sessions (qwen's `store_cached_whole_decoder`,
-    /// mimo/firered2's decoder-runtime caches) MUST call this before storing
-    /// it back so the buffer stays session-scoped instead of riding along
-    /// with the cached decoder indefinitely. The buffer release is a no-op on
-    /// Metal/GPU or when no CPU step ever ran.
+    /// buffer. Healthy reusable graphs stay resident so the next request can
+    /// re-run without a rebuild. Uploaded weights stay.
+    pub(crate) fn take_fused_compute_evidence(&mut self) -> Option<GgmlSelectionEvidenceRef> {
+        self.last_fused_compute_evidence.take()
+    }
+
     pub(crate) fn release_session_scoped_buffers(&mut self) {
-        // A failed graph compute may have committed only a prefix of resident
-        // KV writes. All qwen-family cache owners call this before putting the
-        // whole decoder back (qwen, firered-llm, moss-td), so discard poisoned
-        // graph + KV state here while retaining stateless loaded weights and the
-        // cached backend/device handle.
         if self
             .reuse
             .as_ref()
@@ -3348,6 +3362,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         }
         Ok(Qwen3AsrLlmWholeStepOutput {
             hidden: hidden_out,
+            fused_logits: None,
             layer_kv,
             build_micros,
             compute_micros,
@@ -4434,6 +4449,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             let compute_micros = compute_started_at.elapsed().as_micros();
             Ok(Qwen3AsrLlmWholeStepOutput {
                 hidden: hidden_out,
+                fused_logits: None,
                 layer_kv: Vec::new(),
                 build_micros,
                 compute_micros,
@@ -4787,6 +4803,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         }
         Ok(Qwen3AsrLlmWholeStepOutput {
             hidden: hidden_out,
+            fused_logits: None,
             layer_kv,
             build_micros,
             compute_micros,
@@ -4924,16 +4941,30 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 .transpose()?;
             #[cfg(not(test))]
             let top1: Option<GgmlCpuTensor<'_>> = None;
+            let fused_logits = if n_seq == 1 && top1.is_none() {
+                self.fused_logits_head
+                    .as_ref()
+                    .map(|head| build_fused_full_logits(&self.arena, head, graph, state, n_seq))
+                    .transpose()?
+            } else {
+                None
+            };
             graph.set_output(state)?;
             if let Some(top1) = top1 {
                 graph.set_output(top1)?;
             }
-            // The production output contract has no native compact result. The
-            // optional top1 root is retained only for the test-only numerical
-            // oracle and is never allocated in a production graph.
+            if let Some(fused_logits) = fused_logits {
+                graph.set_output(fused_logits)?;
+            }
+            // Compact top1 stays test-only. Production ReusableGraph GPU
+            // fuses the full-vocab lm-head into this same compute so decode
+            // does not launch a second logits graph per token.
             let mut prepared_outputs = vec![state];
             if let Some(top1) = top1 {
                 prepared_outputs.push(top1);
+            }
+            if let Some(fused_logits) = fused_logits {
+                prepared_outputs.push(fused_logits);
             }
             graph.prepare_outputs_for_upload(&prepared_outputs)?;
             self.reuse = Some(LlmReusableDecodeGraph::new(
@@ -4948,6 +4979,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
                 attention_mask,
                 state,
                 top1,
+                fused_logits,
             ));
         }
 
@@ -4979,6 +5011,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         let compute_micros = compute_started_at.elapsed().as_micros();
         Ok(Qwen3AsrLlmWholeStepOutput {
             hidden: hidden_out,
+            fused_logits: None,
             layer_kv: Vec::new(),
             build_micros: 0,
             compute_micros,
@@ -5357,16 +5390,27 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             .transpose()?;
         #[cfg(not(test))]
         let top1: Option<GgmlCpuTensor<'_>> = None;
+        let fused_logits = if n_seq == 1 && top1.is_none() {
+            self.fused_logits_head
+                .as_ref()
+                .map(|head| build_fused_full_logits(&self.arena, head, graph, state, n_seq))
+                .transpose()?
+        } else {
+            None
+        };
         graph.set_output(state)?;
         if let Some(top1) = top1 {
             graph.set_output(top1)?;
         }
-        // The production output contract has no native compact result. The
-        // optional top1 root is retained only for the test-only numerical
-        // oracle and is never allocated in a production graph.
+        if let Some(fused_logits) = fused_logits {
+            graph.set_output(fused_logits)?;
+        }
         let mut prepared_outputs = vec![state];
         if let Some(top1) = top1 {
             prepared_outputs.push(top1);
+        }
+        if let Some(fused_logits) = fused_logits {
+            prepared_outputs.push(fused_logits);
         }
         graph.prepare_outputs_for_upload(&prepared_outputs)?;
         self.reuse = Some(LlmReusableDecodeGraph::new(
@@ -5381,6 +5425,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
             attention_mask,
             state,
             top1,
+            fused_logits,
         ));
         Ok(())
     }
@@ -5500,6 +5545,7 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         let positions = reuse.positions;
         let attention_mask = reuse.attention_mask;
         let state = reuse.state;
+        let fused_logits_tensor = reuse.fused_logits;
         let graph = reuse.builder();
 
         match input {
@@ -5530,11 +5576,29 @@ impl Qwen3AsrLlmWholeDecoderGraphExecutor {
         graph.set_i32_slice(row_indices_tensor, &row_indices, "qwen_llm_reuse_row_index")?;
         graph.set_i32_slice(positions, &rope_positions, "qwen_llm_reuse_position")?;
 
+        let fused_vocab = self.fused_logits_head.as_ref().map(|head| head.vocab_size);
         let compute_started_at = std::time::Instant::now();
-        let hidden_out = graph.compute_output_f32(state, expected_hidden)?;
+        let (hidden_out, fused_logits) = if let (Some(logits_tensor), Some(vocab_size)) =
+            (fused_logits_tensor, fused_vocab)
+        {
+            let expected_logits =
+                vocab_size
+                    .checked_mul(n_seq)
+                    .ok_or(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "fused logits width overflow",
+                    })?;
+            let output = graph.compute_output_f32_with_evidence(logits_tensor, expected_logits)?;
+            let (logits, evidence) = output.into_parts();
+            self.last_fused_compute_evidence = evidence;
+            (Vec::new(), Some(logits))
+        } else {
+            self.last_fused_compute_evidence = None;
+            (graph.compute_output_f32(state, expected_hidden)?, None)
+        };
         let compute_micros = compute_started_at.elapsed().as_micros();
         Ok(Qwen3AsrLlmWholeStepOutput {
             hidden: hidden_out,
+            fused_logits,
             layer_kv: Vec::new(),
             build_micros: 0,
             compute_micros,
@@ -9982,6 +10046,7 @@ mod tests {
         }
         Qwen3AsrLlmWholeStepOutput {
             hidden: full_hidden,
+            fused_logits: None,
             layer_kv: full_layer_kv,
             build_micros: 0,
             compute_micros: 0,

--- a/crates/openasr-core/src/models/qwen/logits_head.rs
+++ b/crates/openasr-core/src/models/qwen/logits_head.rs
@@ -6,7 +6,8 @@ use thiserror::Error;
 use crate::GgmlRuntimeSource;
 use crate::ggml_runtime::{
     GgmlComputeOutput, GgmlCpuGraphBackend, GgmlCpuGraphConfig, GgmlCpuGraphError,
-    GgmlCpuGraphRunner, GgmlSelectionEvidenceRef, GgmlStaticTensor, GgmlStaticTensorArena,
+    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlGraphRebuildReason, GgmlPersistentGraphSession,
+    GgmlSelectionEvidenceRef, GgmlStaticTensor, GgmlStaticTensorArena,
     GgufOwnedWeightTensorPayload, GgufTensorDataReadError, GgufTensorDataReader,
     env_toggle_with_raw,
 };
@@ -162,7 +163,6 @@ impl LogitsWeightPayload {
     }
 }
 
-#[cfg(test)]
 pub(crate) struct Qwen3AsrLlmFusedLogitsHeadSpec<'a> {
     pub(crate) d_model: usize,
     pub(crate) vocab_size: usize,
@@ -172,11 +172,6 @@ pub(crate) struct Qwen3AsrLlmFusedLogitsHeadSpec<'a> {
     pub(crate) output_weight_ggml_type: i32,
     pub(crate) output_weight_dims: &'a [usize],
     pub(crate) output_weight_bytes: &'a [u8],
-}
-
-#[cfg(not(test))]
-pub(crate) struct Qwen3AsrLlmFusedLogitsHeadSpec<'a> {
-    _marker: std::marker::PhantomData<&'a ()>,
 }
 
 impl Qwen3AsrLlmLogitsHead {
@@ -285,7 +280,6 @@ impl Qwen3AsrLlmLogitsHead {
         Ok(bytes.finish())
     }
 
-    #[cfg(test)]
     pub(crate) fn fused_top1_spec(&self) -> Option<Qwen3AsrLlmFusedLogitsHeadSpec<'_>> {
         let output_weight = self.ggml_output_weight.as_ref()?;
         Some(Qwen3AsrLlmFusedLogitsHeadSpec {
@@ -293,18 +287,20 @@ impl Qwen3AsrLlmLogitsHead {
             vocab_size: self.vocab_size,
             rms_norm_epsilon: self.rms_norm_epsilon,
             output_norm_weight: &self.output_norm_weight,
-            output_weight_tensor_name: self.output_weight_tensor_name,
+            output_weight_tensor_name: {
+                #[cfg(test)]
+                {
+                    self.output_weight_tensor_name
+                }
+                #[cfg(not(test))]
+                {
+                    OUTPUT_WEIGHT_TENSOR_NAME
+                }
+            },
             output_weight_ggml_type: output_weight.ggml_type,
             output_weight_dims: &output_weight.dims,
             output_weight_bytes: output_weight.payload.bytes(),
         })
-    }
-
-    #[cfg(not(test))]
-    pub(crate) fn fused_top1_spec(&self) -> Option<Qwen3AsrLlmFusedLogitsHeadSpec<'_>> {
-        // Native compact output is a test-only seam until the shared planner
-        // receives device-specific evidence for this exact graph.
-        None
     }
 
     #[cfg(test)]
@@ -430,6 +426,33 @@ impl Qwen3AsrLlmLogitsHeadRuntime {
                 executor.runner.uses_scheduler(),
             )
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reused_logits_row_count_for_test(&self) -> Option<usize> {
+        self.executor
+            .as_ref()
+            .and_then(|executor| executor.reuse.as_ref().map(|reuse| reuse.row_count))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reused_logits_prepared_node_count_for_test(&self) -> Option<usize> {
+        self.executor.as_ref().and_then(|executor| {
+            executor
+                .reuse
+                .as_ref()
+                .and_then(|reuse| reuse.session.prepared_native_node_count_for_test())
+        })
+    }
+
+    /// Drops the persistent logits graph after a request so a cached decoder
+    /// actor does not keep its compute buffers across the next encode.
+    pub(crate) fn release_request_compute_residency(&mut self) {
+        let Some(executor) = self.executor.as_mut() else {
+            return;
+        };
+        executor.reuse = None;
+        let _ = executor.runner.release_request_compute_residency();
     }
 
     pub(crate) fn compute_logits_for_hidden_rows(
@@ -773,6 +796,13 @@ fn load_direct_output_weight_payload(
     }))
 }
 
+struct QwenReusableLogitsGraph {
+    hidden: GgmlCpuTensor<'static>,
+    logits: GgmlCpuTensor<'static>,
+    row_count: usize,
+    session: GgmlPersistentGraphSession,
+}
+
 struct Qwen3AsrLlmLogitsHeadGraphExecutor {
     d_model: usize,
     vocab_size: usize,
@@ -781,6 +811,7 @@ struct Qwen3AsrLlmLogitsHeadGraphExecutor {
     arena: GgmlStaticTensorArena,
     output_norm_weight: GgmlStaticTensor,
     output_weight: GgmlStaticTensor,
+    reuse: Option<QwenReusableLogitsGraph>,
 }
 
 impl fmt::Debug for Qwen3AsrLlmLogitsHeadGraphExecutor {
@@ -853,6 +884,7 @@ impl Qwen3AsrLlmLogitsHeadGraphExecutor {
             arena,
             output_norm_weight: norm,
             output_weight: weight,
+            reuse: None,
         })
     }
 
@@ -861,6 +893,56 @@ impl Qwen3AsrLlmLogitsHeadGraphExecutor {
         hidden: &[f32],
     ) -> Result<GgmlComputeOutput<Vec<f32>>, GgmlCpuGraphError> {
         self.compute_rows(hidden, 1)
+    }
+
+    fn ensure_reusable_graph(&mut self, row_count: usize) -> Result<(), GgmlCpuGraphError> {
+        let rebuild_reason = match self.reuse.as_ref() {
+            None => None,
+            Some(reuse) if reuse.row_count == row_count && !reuse.session.is_poisoned() => {
+                return Ok(());
+            }
+            Some(reuse) if reuse.session.is_poisoned() => {
+                Some(GgmlGraphRebuildReason::PoisonRecovery)
+            }
+            Some(_) => Some(GgmlGraphRebuildReason::TopologyChanged),
+        };
+        self.reuse = None;
+        self.reuse = Some(self.build_reusable_graph(row_count, rebuild_reason)?);
+        Ok(())
+    }
+
+    fn build_reusable_graph(
+        &mut self,
+        row_count: usize,
+        rebuild_reason: Option<GgmlGraphRebuildReason>,
+    ) -> Result<QwenReusableLogitsGraph, GgmlCpuGraphError> {
+        let context_bytes =
+            GgmlCpuGraphConfig::metadata_context_bytes(QWEN3_LLM_LOGITS_GRAPH_NODE_CAPACITY);
+        let mut session = match rebuild_reason {
+            Some(reason) => self
+                .runner
+                .rebuild_persistent_graph_session(context_bytes, reason)?,
+            None => self
+                .runner
+                .start_persistent_graph_session_with_node_capacity(
+                    QWEN3_LLM_LOGITS_GRAPH_NODE_CAPACITY,
+                )?,
+        };
+        let graph = session.builder();
+        let hidden_tensor =
+            graph.new_tensor_2d_f32(self.d_model, row_count, "qwen_llm_logits_hidden_rows")?;
+        graph.set_input(hidden_tensor)?;
+        let normed = graph.rms_norm(hidden_tensor, self.rms_norm_epsilon)?;
+        let normed = graph.mul(normed, self.arena.graph_tensor(self.output_norm_weight))?;
+        let logits = graph.mul_mat(self.arena.graph_tensor(self.output_weight), normed)?;
+        graph.set_output(logits)?;
+        graph.prepare_outputs_for_upload(&[logits])?;
+        Ok(QwenReusableLogitsGraph {
+            hidden: hidden_tensor,
+            logits,
+            row_count,
+            session,
+        })
     }
 
     fn compute_rows(
@@ -885,15 +967,14 @@ impl Qwen3AsrLlmLogitsHeadGraphExecutor {
                 .ok_or(GgmlCpuGraphError::UnsupportedInputs {
                     reason: "logits head output rows shape overflow",
                 })?;
-        let mut graph = self.runner.start_graph();
-        let hidden_tensor =
-            graph.new_tensor_2d_f32(self.d_model, row_count, "qwen_llm_logits_hidden_rows")?;
-        graph.set_input(hidden_tensor)?;
-        let normed = graph.rms_norm(hidden_tensor, self.rms_norm_epsilon)?;
-        let normed = graph.mul(normed, self.arena.graph_tensor(self.output_norm_weight))?;
-        let logits = graph.mul_mat(self.arena.graph_tensor(self.output_weight), normed)?;
-        graph.set_output(logits)?;
-        graph.prepare_outputs_for_upload(&[logits])?;
+        self.ensure_reusable_graph(row_count)?;
+        let reuse = self
+            .reuse
+            .as_mut()
+            .expect("reusable logits graph built above");
+        let hidden_tensor = reuse.hidden;
+        let logits = reuse.logits;
+        let graph = reuse.session.builder();
         graph.set_f32_slice(hidden_tensor, hidden, "qwen_llm_logits_hidden_rows")?;
         graph.compute_output_f32_with_evidence(logits, output_len)
     }
@@ -1332,17 +1413,44 @@ mod tests {
     }
 
     #[test]
+    fn fused_logits_spec_is_available_when_native_weight_is_bound() {
+        let head = ggml_logits_head(vec![1.0, 1.0]);
+        let spec = head
+            .fused_top1_spec()
+            .expect("native output weight must describe a fused lm-head");
+        assert_eq!(spec.d_model, 2);
+        assert_eq!(spec.vocab_size, 3);
+        assert_eq!(spec.output_weight_dims, [2, 3].as_slice());
+    }
+
+    #[test]
     fn explicit_runtime_reuses_one_native_graph_and_rejects_head_aliasing() {
         let first = ggml_logits_head(vec![1.0, 1.0]);
         let mut runtime = first
             .new_runtime(GgmlCpuGraphBackend::Cpu)
             .expect("build explicit logits runtime");
+        let first_logits = runtime
+            .compute_logits_for_last_hidden(&first, &[1.0, 2.0])
+            .expect("first call");
+        let prepared_nodes = runtime.reused_logits_prepared_node_count_for_test();
+        assert_eq!(runtime.reused_logits_row_count_for_test(), Some(1));
+        assert!(prepared_nodes.is_some_and(|count| count > 0));
+        let second_logits = runtime
+            .compute_logits_for_last_hidden(&first, &[1.0, 2.0])
+            .expect("same owner reuses its graph");
+        assert_eq!(first_logits, second_logits);
+        assert_eq!(runtime.reused_logits_row_count_for_test(), Some(1));
+        assert_eq!(
+            runtime.reused_logits_prepared_node_count_for_test(),
+            prepared_nodes,
+            "second serial decode must keep the prepared logits graph"
+        );
         let first_token = runtime
             .compute_top1_token_for_last_hidden(&first, &[1.0, 2.0])
-            .expect("first call");
+            .expect("top-1 after reused logits");
         let second_token = runtime
             .compute_top1_token_for_last_hidden(&first, &[1.0, 2.0])
-            .expect("same owner reuses its graph");
+            .expect("top-1 stays stable");
         assert_eq!(first_token, second_token);
 
         let distinct_head = ggml_logits_head(vec![1.0, 1.0]);
@@ -1350,6 +1458,24 @@ mod tests {
             runtime.compute_top1_token_for_last_hidden(&distinct_head, &[1.0, 2.0]),
             Err(Qwen3AsrLlmLogitsHeadError::RuntimeHeadMismatch)
         ));
+    }
+
+    #[test]
+    fn logits_runtime_drops_persistent_graph_at_request_end() {
+        let head = ggml_logits_head(vec![1.0, 1.0]);
+        let mut runtime = head
+            .new_runtime(GgmlCpuGraphBackend::Cpu)
+            .expect("build explicit logits runtime");
+        runtime
+            .compute_logits_for_last_hidden(&head, &[1.0, 2.0])
+            .expect("first call");
+        assert_eq!(runtime.reused_logits_row_count_for_test(), Some(1));
+        runtime.release_request_compute_residency();
+        assert_eq!(runtime.reused_logits_row_count_for_test(), None);
+        runtime
+            .compute_logits_for_last_hidden(&head, &[1.0, 2.0])
+            .expect("rebuild after request-end release");
+        assert_eq!(runtime.reused_logits_row_count_for_test(), Some(1));
     }
 
     #[test]
@@ -1371,6 +1497,11 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(batched_logits, repeated_logits);
+        assert_eq!(
+            runtime.reused_logits_row_count_for_test(),
+            Some(1),
+            "serial follow-up must rebuild the persistent logits graph for n_seq=1"
+        );
         let batched = runtime
             .compute_top1_tokens_for_hidden_rows(&head, &hidden, 3)
             .expect("batched top-1");

--- a/crates/openasr-core/src/models/request_execution_receipt.rs
+++ b/crates/openasr-core/src/models/request_execution_receipt.rs
@@ -279,6 +279,10 @@ struct ReceiptState {
     /// inner attempt on the same collector; restoring this stack keeps the
     /// ASR row intact after the inner attempt finishes.
     attempt_stack: Vec<ReceiptAttemptCheckpoint>,
+    /// Thread that opened the in-flight attempt. Concurrent longform slice
+    /// workers join as siblings instead of nesting/truncating this row.
+    attempt_owner_thread: Option<std::thread::ThreadId>,
+    sibling_attempt_refs: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -401,6 +405,10 @@ impl NativeExecutionReceiptCollector {
         Self::default()
     }
 
+    pub(crate) fn identity_key(&self) -> usize {
+        Arc::as_ptr(&self.state) as usize
+    }
+
     /// Binds the request-level correlation identity once. Candidate retries
     /// share it; conflicting rebinding invalidates completion rather than
     /// choosing either value.
@@ -467,11 +475,38 @@ impl NativeExecutionReceiptCollector {
     /// attempts push the parent row aside and restore it on finish so an
     /// auxiliary stage cannot erase the ASR candidate's shipped facts.
     pub(crate) fn begin_candidate_attempt(&self) {
+        let thread = std::thread::current().id();
+        let join_as_sibling = {
+            let state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state
+                .attempt_owner_thread
+                .is_some_and(|owner| owner != thread)
+                && self.graph_lifecycle.observation_scope().is_some()
+        };
+        if join_as_sibling {
+            // Concurrent longform slices share the in-flight ASR attempt.
+            // Nesting would checkpoint/truncate the sibling's compute
+            // witnesses and fail graph_rebuilt binding.
+            self.graph_lifecycle.begin_observation_scope();
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.sibling_attempt_refs = state.sibling_attempt_refs.saturating_add(1);
+            return;
+        }
+
         self.graph_lifecycle.begin_observation_scope();
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.attempt_owner_thread.is_none() {
+            state.attempt_owner_thread = Some(thread);
+        }
         let parent = state.take_attempt_checkpoint();
         // A nested begin happens while the outer attempt is still open.
         // Sequential warmup/measured begins happen after the previous attempt
@@ -489,6 +524,31 @@ impl NativeExecutionReceiptCollector {
     }
 
     pub(crate) fn finish_candidate_attempt(&self, committed: bool) {
+        let thread = std::thread::current().id();
+        let finish_as_sibling = {
+            let state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.sibling_attempt_refs > 0
+                && state
+                    .attempt_owner_thread
+                    .is_some_and(|owner| owner != thread)
+        };
+        if finish_as_sibling {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.sibling_attempt_refs = state.sibling_attempt_refs.saturating_sub(1);
+            if state.sibling_attempt_refs == 0 && state.completed {
+                state.attempt_owner_thread = None;
+            }
+            drop(state);
+            self.graph_lifecycle.end_observation_scope();
+            return;
+        }
+
         let mut state = self
             .state
             .lock()
@@ -510,6 +570,9 @@ impl NativeExecutionReceiptCollector {
         } else {
             let _ = state.take_attempt_checkpoint();
             state.completed = false;
+        }
+        if state.attempt_stack.is_empty() && state.sibling_attempt_refs == 0 {
+            state.attempt_owner_thread = None;
         }
         // Lifecycle producers never run while the receipt mutex is held.
         // Preserve that lock order during rollback and scope closure too.
@@ -566,6 +629,14 @@ impl NativeExecutionReceiptCollector {
             return;
         }
         state.capture_full_logits = true;
+    }
+
+    pub(crate) fn captures_full_logits(&self) -> bool {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.capture_full_logits
     }
 
     pub(crate) fn record_facts(&self, facts: NativeExecutionRequestFacts) {
@@ -690,7 +761,18 @@ impl NativeExecutionReceiptCollector {
         is_eot: bool,
         logits: &[f32],
     ) {
-        let logits_sha256 = (!logits.is_empty()).then(|| diagnostic_logits_sha256(logits));
+        let capture_full_logits = {
+            let state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.capture_full_logits
+        };
+        // SHA-256 of a full vocab row is a debug-artifact cost. Production
+        // decode and bench-receipt (write_outputs) leave this off; enabling
+        // `--logits-out` opts back into the hash.
+        let logits_sha256 =
+            (capture_full_logits && !logits.is_empty()).then(|| diagnostic_logits_sha256(logits));
         let margin = if logits.len() < 2 {
             None
         } else {
@@ -760,7 +842,7 @@ impl NativeExecutionReceiptCollector {
             }
             step_index
         };
-        if !logits.is_empty() {
+        if capture_full_logits && !logits.is_empty() {
             let mut top = Vec::<(usize, f32)>::new();
             for (token, logit) in logits.iter().copied().enumerate() {
                 if !logit.is_finite() {
@@ -939,6 +1021,66 @@ impl NativeExecutionReceiptCollector {
     }
 
     fn record_top_k_with_tie_order(&self, step_index: usize, logits: &[f32], last_maximum: bool) {
+        let capture_full_logits = {
+            let state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.capture_full_logits
+        };
+        // Same opt-in as `commit_decode_step`: bench-receipt / production
+        // decode leave SHA-256 and full-vocab top-k JSON off. X-ASR / CTC
+        // still need a cheap top2 margin for token_steps.
+        if !capture_full_logits {
+            let margin = if logits.len() < 2 {
+                None
+            } else {
+                let mut best = None;
+                let mut second = None;
+                for logit in logits.iter().copied().filter(|value| value.is_finite()) {
+                    match best {
+                        None => best = Some(logit),
+                        Some(first) if logit > first => {
+                            second = best;
+                            best = Some(logit);
+                        }
+                        Some(first) if last_maximum && logit == first => {
+                            second = Some(first);
+                        }
+                        Some(first)
+                            if second.is_none_or(|value| logit > value) && logit != first =>
+                        {
+                            second = Some(logit);
+                        }
+                        _ => {}
+                    }
+                }
+                best.zip(second).map(|(first, second)| first - second)
+            };
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some(margin) = margin {
+                state.top_k_margins.insert(step_index, margin);
+                if let Some(existing) = state
+                    .token_steps
+                    .iter_mut()
+                    .find(|step| step.step_index == step_index)
+                {
+                    existing.top2_margin = Some(margin);
+                }
+            }
+            match state.active_decode_step.as_mut() {
+                Some(active) if active.step_index == step_index && !active.top_k_recorded => {
+                    active.top_k_recorded = true;
+                }
+                _ => {
+                    state.trace_binding_invalid = true;
+                }
+            }
+            return;
+        }
         let logits_sha256 = diagnostic_logits_sha256(logits);
         let mut top = Vec::<(usize, f32)>::new();
         for (token_id, logit) in logits.iter().copied().enumerate() {
@@ -1426,6 +1568,34 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_slice_attempts_keep_shared_token_steps() {
+        let receipt = NativeExecutionReceiptCollector::new();
+        receipt.begin_candidate_attempt();
+        let worker = receipt.clone();
+        let handle = std::thread::spawn(move || {
+            worker.begin_candidate_attempt();
+            worker.commit_decode_step(None, 11, false, &[1.0, 0.0]);
+            worker.finish_candidate_attempt(true);
+        });
+        receipt.commit_decode_step(None, 7, false, &[0.5, 0.0]);
+        handle.join().expect("sibling slice worker");
+        receipt.finish_candidate_attempt(true);
+        let snapshot = receipt.snapshot();
+        let mut tokens = snapshot
+            .token_steps
+            .iter()
+            .map(|step| step.token_id)
+            .collect::<Vec<_>>();
+        tokens.sort_unstable();
+        assert_eq!(
+            tokens,
+            vec![7, 11],
+            "concurrent slice workers must not nest/truncate each other's decode steps"
+        );
+        assert!(snapshot.completed);
+    }
+
+    #[test]
     fn nested_candidate_restores_parent_request_facts() {
         let receipt = NativeExecutionReceiptCollector::new();
         receipt.begin_candidate_attempt();
@@ -1731,6 +1901,45 @@ mod tests {
             error,
             crate::ShortAudioReceiptError::NativeSeq2SeqTokenStepsMissing
         );
+    }
+
+    #[test]
+    fn record_top_k_skips_sha256_and_json_until_full_logits_trace() {
+        let receipt = NativeExecutionReceiptCollector::new();
+        assert!(
+            !receipt.captures_full_logits(),
+            "bench-receipt default must not retain full logits on the decode hot path"
+        );
+        receipt.begin_candidate_attempt();
+        receipt.begin_decode_step(0, None);
+        receipt.record_top_k_last_max(0, &[3.0, 7.0, 7.0, 1.0]);
+        receipt.record_token(0, 2, false);
+        receipt.finish_decode_step(0);
+        receipt.finish_candidate_attempt(true);
+        let snapshot = receipt.snapshot();
+        assert!(
+            !snapshot.trace.jsonl.contains("\"event\":\"top_k\""),
+            "full-vocab top-k JSON is opt-in via enable_full_logits_trace"
+        );
+        assert_eq!(snapshot.token_steps.len(), 1);
+        assert_eq!(snapshot.token_steps[0].top2_margin, Some(0.0));
+        assert!(
+            snapshot.token_steps[0].logits_sha256.is_none(),
+            "SHA-256 of logits is opt-in via enable_full_logits_trace"
+        );
+
+        let traced = NativeExecutionReceiptCollector::new();
+        traced.enable_full_logits_trace();
+        assert!(traced.captures_full_logits());
+        traced.begin_candidate_attempt();
+        traced.begin_decode_step(0, None);
+        traced.record_top_k_last_max(0, &[3.0, 7.0, 7.0, 1.0]);
+        traced.record_token(0, 2, false);
+        traced.finish_decode_step(0);
+        traced.finish_candidate_attempt(true);
+        let traced_snapshot = traced.snapshot();
+        assert!(traced_snapshot.trace.jsonl.contains("\"event\":\"top_k\""));
+        assert!(traced_snapshot.token_steps[0].logits_sha256.is_some());
     }
 
     #[test]

--- a/crates/openasr-core/src/models/resident_runtime_audit.rs
+++ b/crates/openasr-core/src/models/resident_runtime_audit.rs
@@ -507,6 +507,10 @@ fn resident_inventory_set() -> BTreeSet<(String, String, String)> {
             "MoonshineEncoderRuntimePool",
         ),
         (
+            "models/moonshine/ggml_executor.rs",
+            "MoonshineUnifiedRuntimePool",
+        ),
+        (
             "models/moss_transcribe_diarize/executor.rs",
             "MossTdDecoderRuntimePool",
         ),

--- a/crates/openasr-core/src/models/resident_runtime_audit.rs
+++ b/crates/openasr-core/src/models/resident_runtime_audit.rs
@@ -958,11 +958,12 @@ fn thread_affine_backend_cache_is_scoped_and_receipted() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/ggml_runtime/cpu_graph.rs");
     let source = std::fs::read_to_string(path).expect("read cpu graph source");
     assert!(source.contains("struct CachedBackendKey"));
-    assert!(
-        source
-            .contains("scope_id: crate::models::native_execution_services::NativeExecutionScopeId")
-    );
     assert!(source.contains("current_native_execution_scope_id"));
+    assert!(
+        !source
+            .contains("scope_id: crate::models::native_execution_services::NativeExecutionScopeId"),
+        "GPU backend contexts are thread+device state; request scopes must not split them"
+    );
     assert!(
         source
             .contains("_receipt_owner: Option<crate::models::runtime_receipts::RuntimeOwnerGuard>")
@@ -1395,6 +1396,21 @@ fn production_activation_reserve_does_not_use_placeholder_bytes() {
     assert!(
         !plan.contains("peak_bytes: 0,"),
         "activation plan must not emit zero-byte domain rows: {plan}"
+    );
+    let discrete = production
+        .split("fn discrete_device_for_candidate")
+        .nth(1)
+        .expect("discrete_device_for_candidate")
+        .split("fn quote_activation_group")
+        .next()
+        .expect("discrete device body");
+    assert!(
+        !discrete.contains("initialize"),
+        "Vulkan admission quote must not construct a throwaway ggml backend: {discrete}"
+    );
+    assert!(
+        plan.contains("from_device") && plan.contains("ExecutionProvider::Vulkan"),
+        "Vulkan activation quote must use the device-only memory ABI: {plan}"
     );
     assert!(
         !quote.contains("verified_pack_from_preflight_for_test")

--- a/crates/openasr-core/src/models/runtime_receipts.rs
+++ b/crates/openasr-core/src/models/runtime_receipts.rs
@@ -450,7 +450,10 @@ impl RuntimeReceiptCollector {
                 next_resource_ordinal: AtomicU64::new(next_resource_ordinal),
                 identity_exhausted: false,
                 live_owners: BTreeMap::new(),
-                events: VecDeque::with_capacity(event_capacity),
+                // Bound is enforced on push; pre-filling 16k large events
+                // would commit a constant ~host-MiB tax on every NES root
+                // even when the request emits far fewer events.
+                events: VecDeque::new(),
                 dropped_events: 0,
                 dropped_owners: 0,
                 rejected_resources: 0,
@@ -1643,6 +1646,19 @@ mod tests {
             LeaseReceiptShadow::Matched,
             "bounded event history must not invalidate the authoritative live owner table"
         );
+    }
+
+    #[test]
+    fn event_ring_does_not_preallocate_the_advertised_capacity() {
+        let collector =
+            RuntimeReceiptCollector::new_for_test(scope(), DEFAULT_EVENT_CAPACITY).unwrap();
+        assert_eq!(
+            collector.lock_state().events.capacity(),
+            0,
+            "empty collector must not commit DEFAULT_EVENT_CAPACITY event slots"
+        );
+        assert_eq!(collector.summary().event_capacity, DEFAULT_EVENT_CAPACITY);
+        assert_eq!(collector.summary().event_count, 0);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/sensevoice/encoder_graph.rs
+++ b/crates/openasr-core/src/models/sensevoice/encoder_graph.rs
@@ -813,6 +813,7 @@ impl SenseVoiceEncoderGraph {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compose_lfr_graph<'a>(
     graph: &mut GgmlCpuGraphBuilder<'a>,
     metadata: SenseVoiceExecutionMetadata,

--- a/crates/openasr-core/src/models/sensevoice/encoder_graph.rs
+++ b/crates/openasr-core/src/models/sensevoice/encoder_graph.rs
@@ -11,11 +11,12 @@
 
 use crate::ggml_runtime::{
     ArenaAllocError, GgmlCpuGraphBuilder, GgmlCpuGraphConfig, GgmlCpuGraphError,
-    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlLoadedTensor, GgmlLoadedWeightContext,
-    GgmlSelectionEvidenceRef, GgmlStaticTensor, GgmlStaticTensorArena, GgufRuntimeSourcePreflight,
-    WeightSlot, alloc_static_f16 as arena_alloc_static_f16,
-    alloc_static_f32 as arena_alloc_static_f32, bind_loaded as arena_bind_loaded,
-    upload_static_f16 as arena_upload_static_f16, upload_static_f32 as arena_upload_static_f32,
+    GgmlCpuGraphRunner, GgmlCpuTensor, GgmlDecodeReuseMode, GgmlGraphShapeKey, GgmlLoadedTensor,
+    GgmlLoadedWeightContext, GgmlSameShapePersistentGraph, GgmlSelectionEvidenceRef,
+    GgmlStaticTensor, GgmlStaticTensorArena, GgufRuntimeSourcePreflight, WeightSlot,
+    alloc_static_f16 as arena_alloc_static_f16, alloc_static_f32 as arena_alloc_static_f32,
+    bind_loaded as arena_bind_loaded, upload_static_f16 as arena_upload_static_f16,
+    upload_static_f32 as arena_upload_static_f32,
 };
 use crate::models::runtime_memory::{checked_sum, element_bytes};
 use crate::models::system_memory_owner::{SystemMemoryCapacity, SystemMemoryOwnerError};
@@ -185,9 +186,19 @@ pub(crate) fn quoted_graph_retained_bytes(
     )
 }
 
+struct SenseVoiceReuseTensors {
+    lfr: GgmlCpuTensor<'static>,
+    prompt: GgmlCpuTensor<'static>,
+    position: GgmlCpuTensor<'static>,
+    logits: GgmlCpuTensor<'static>,
+}
+
 pub(crate) struct SenseVoiceEncoderGraph {
     metadata: SenseVoiceExecutionMetadata,
     use_flash_attention: bool,
+    reuse_enabled: bool,
+    same_shape: GgmlSameShapePersistentGraph,
+    reuse_tensors: Option<SenseVoiceReuseTensors>,
     runner: GgmlCpuGraphRunner,
     // `loaded_weights` owns the mmap-backed buffer the `Loaded` slots alias
     // (drop-order note mirrors parakeet/cohere/qwen).
@@ -222,6 +233,7 @@ impl SenseVoiceEncoderGraph {
         metadata: SenseVoiceExecutionMetadata,
         runtime_preflight: &GgufRuntimeSourcePreflight,
         backend: crate::ggml_runtime::GgmlCpuGraphBackend,
+        _reuse_mode: GgmlDecodeReuseMode,
     ) -> Result<Self, SenseVoiceEncoderError> {
         let total_layers = weights.enc_layers.len() + weights.tp_layers.len();
         let mut config = sensevoice_encoder_graph_config(backend);
@@ -354,6 +366,9 @@ impl SenseVoiceEncoderGraph {
         Ok(Self {
             metadata,
             use_flash_attention,
+            reuse_enabled: crate::ggml_runtime::encoder_same_shape_reuse_is_enabled(),
+            same_shape: GgmlSameShapePersistentGraph::default(),
+            reuse_tensors: None,
             runner,
             loaded_weights,
             arena,
@@ -369,6 +384,10 @@ impl SenseVoiceEncoderGraph {
             prompt_embedding_rows,
             positional_inv_timescales: positional_inv_timescales_t,
         })
+    }
+
+    pub(crate) fn backend(&self) -> crate::ggml_runtime::GgmlCpuGraphBackend {
+        self.runner.backend_kind()
     }
 
     pub(crate) fn encode(
@@ -467,48 +486,82 @@ impl SenseVoiceEncoderGraph {
             .map(|position| position as f32)
             .collect::<Vec<_>>();
 
-        let mut graph = self.runner.start_graph();
-        let lfr = graph
-            .new_tensor_2d_f32(metadata.feature_dim, lfr_frames, "sensevoice_lfr")
-            .map_err(bf("new_lfr"))?;
-        let prompt = graph
-            .new_tensor_1d_i32(prompt_ids.len(), "sensevoice_prompt_ids")
-            .map_err(bf("new_prompt_ids"))?;
-        let position = graph
-            .new_tensor_2d_f32(1, frames, "sensevoice_positions")
-            .map_err(bf("new_positions"))?;
-        graph.set_input(lfr).map_err(bf("set_lfr_input"))?;
-        graph.set_input(prompt).map_err(bf("set_prompt_input"))?;
-        graph
-            .set_input(position)
-            .map_err(bf("set_position_input"))?;
+        if self.reuse_enabled {
+            let shape = GgmlGraphShapeKey::new(lfr_frames, prompt_ids.len(), frames, 0);
+            let built = {
+                let (graph, reused) = self
+                    .same_shape
+                    .builder_for_shape(&mut self.runner, shape)
+                    .map_err(bf("same_shape_session"))?;
+                if reused {
+                    None
+                } else {
+                    let (lfr, prompt, position, logits) = compose_lfr_graph(
+                        graph,
+                        self.metadata,
+                        self.prompt_embedding,
+                        self.positional_inv_timescales,
+                        &self.arena,
+                        &self.enc_layers,
+                        &self.tp_layers,
+                        self.enc_after_norm_weight,
+                        self.enc_after_norm_bias,
+                        self.tp_norm_weight,
+                        self.tp_norm_bias,
+                        self.ctc_head_weight,
+                        self.ctc_head_bias,
+                        self.use_flash_attention,
+                        lfr_frames,
+                        prompt_ids.len(),
+                        frames,
+                    )?;
+                    graph.set_output(logits).map_err(bf("set_encoder_output"))?;
+                    graph
+                        .prepare_outputs_for_upload(&[logits])
+                        .map_err(bf("prepare_outputs"))?;
+                    Some(SenseVoiceReuseTensors {
+                        lfr,
+                        prompt,
+                        position,
+                        logits,
+                    })
+                }
+            };
+            if let Some(tensors) = built {
+                self.reuse_tensors = Some(tensors);
+            }
+            let graph = self
+                .same_shape
+                .builder_for_shape(&mut self.runner, shape)
+                .map_err(bf("same_shape_session"))?
+                .0;
+            let tensors = self
+                .reuse_tensors
+                .as_ref()
+                .expect("reuse tensors installed with the session");
+            graph
+                .set_f32_slice(tensors.lfr, lfr_features, "sensevoice_lfr")
+                .map_err(bf("upload_lfr"))?;
+            graph
+                .set_i32_slice(tensors.prompt, &prompt_ids, "sensevoice_prompt_ids")
+                .map_err(bf("upload_prompt_ids"))?;
+            graph
+                .set_f32_slice(tensors.position, &positions, "sensevoice_positions")
+                .map_err(bf("upload_positions"))?;
+            return read_sensevoice_encoder_logits(
+                graph,
+                tensors.logits,
+                metadata.vocab_size,
+                frames,
+            );
+        }
 
-        let prompt_rows = graph
-            .get_rows(self.prompt_embedding.as_graph_tensor(), prompt)
-            .map_err(bf("prompt_get_rows"))?;
-        let combined = graph
-            .concat(prompt_rows, lfr, 1)
-            .map_err(bf("prompt_lfr_concat"))?;
-        let scaled = graph
-            .scale(combined, (metadata.d_model as f32).sqrt())
-            .map_err(bf("input_scale"))?;
-        let angles = graph
-            .mul_mat(
-                self.arena.graph_tensor(self.positional_inv_timescales),
-                position,
-            )
-            .map_err(bf("positional_outer_product"))?;
-        let sin = graph.sin(angles).map_err(bf("positional_sin"))?;
-        let cos = graph.cos(angles).map_err(bf("positional_cos"))?;
-        let positional = graph.concat(sin, cos, 0).map_err(bf("positional_concat"))?;
-        let state = graph
-            .add(scaled, positional)
-            .map_err(bf("positional_add"))?;
-        let logits = compose_sensevoice_encoder_logits(
+        let mut graph = self.runner.start_graph();
+        let (lfr, prompt, position, logits) = compose_lfr_graph(
             &mut graph,
-            state,
-            frames,
-            metadata,
+            self.metadata,
+            self.prompt_embedding,
+            self.positional_inv_timescales,
             &self.arena,
             &self.enc_layers,
             &self.tp_layers,
@@ -519,6 +572,9 @@ impl SenseVoiceEncoderGraph {
             self.ctc_head_weight,
             self.ctc_head_bias,
             self.use_flash_attention,
+            lfr_frames,
+            prompt_ids.len(),
+            frames,
         )?;
         graph.set_output(logits).map_err(bf("set_encoder_output"))?;
         graph
@@ -535,6 +591,305 @@ impl SenseVoiceEncoderGraph {
             .map_err(bf("upload_positions"))?;
         read_sensevoice_encoder_logits(&mut graph, logits, metadata.vocab_size, frames)
     }
+
+    /// Same encoder graph as [`Self::encode_lfr_with_prompt`], but each logit
+    /// row is visited from a reused host buffer so CTC greedy never materializes
+    /// the full `[vocab, frames]` matrix while backend compute buffers are live.
+    pub(crate) fn encode_lfr_with_prompt_for_each_frame<F>(
+        &mut self,
+        lfr_features: &[f32],
+        prompt_indices: &[usize],
+        mut visit: F,
+    ) -> Result<Option<Vec<GgmlSelectionEvidenceRef>>, SenseVoiceEncoderError>
+    where
+        F: FnMut(usize, &[f32]) -> Result<(), SenseVoiceEncoderError>,
+    {
+        self.encode_lfr_prompt_rows(lfr_features, prompt_indices, &mut visit)
+    }
+
+    fn encode_lfr_prompt_rows<F>(
+        &mut self,
+        lfr_features: &[f32],
+        prompt_indices: &[usize],
+        visit: &mut F,
+    ) -> Result<Option<Vec<GgmlSelectionEvidenceRef>>, SenseVoiceEncoderError>
+    where
+        F: FnMut(usize, &[f32]) -> Result<(), SenseVoiceEncoderError>,
+    {
+        let metadata = self.metadata;
+        if lfr_features.is_empty() || !lfr_features.len().is_multiple_of(metadata.feature_dim) {
+            return Err(SenseVoiceEncoderError::Shape {
+                reason: format!(
+                    "SenseVoice LFR payload {} is not a positive multiple of {}",
+                    lfr_features.len(),
+                    metadata.feature_dim
+                ),
+            });
+        }
+        let prompt_ids = prompt_indices
+            .iter()
+            .map(|&index| {
+                if index >= self.prompt_embedding_rows {
+                    return Err(SenseVoiceEncoderError::Shape {
+                        reason: format!(
+                            "SenseVoice prompt index {index} exceeds {} rows",
+                            self.prompt_embedding_rows
+                        ),
+                    });
+                }
+                i32::try_from(index).map_err(|_| SenseVoiceEncoderError::Shape {
+                    reason: format!("SenseVoice prompt index {index} exceeds i32"),
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let lfr_frames = lfr_features.len() / metadata.feature_dim;
+        let frames = prompt_ids.len().checked_add(lfr_frames).ok_or_else(|| {
+            SenseVoiceEncoderError::Shape {
+                reason: "SenseVoice encoder frame count overflowed".to_string(),
+            }
+        })?;
+        let positions = (1..=frames)
+            .map(|position| position as f32)
+            .collect::<Vec<_>>();
+
+        if self.reuse_enabled {
+            let shape = GgmlGraphShapeKey::new(lfr_frames, prompt_ids.len(), frames, 0);
+            let built = {
+                let (graph, reused) = self
+                    .same_shape
+                    .builder_for_shape(&mut self.runner, shape)
+                    .map_err(bf("same_shape_session"))?;
+                if reused {
+                    None
+                } else {
+                    let (lfr, prompt, position, logits) = compose_lfr_graph(
+                        graph,
+                        self.metadata,
+                        self.prompt_embedding,
+                        self.positional_inv_timescales,
+                        &self.arena,
+                        &self.enc_layers,
+                        &self.tp_layers,
+                        self.enc_after_norm_weight,
+                        self.enc_after_norm_bias,
+                        self.tp_norm_weight,
+                        self.tp_norm_bias,
+                        self.ctc_head_weight,
+                        self.ctc_head_bias,
+                        self.use_flash_attention,
+                        lfr_frames,
+                        prompt_ids.len(),
+                        frames,
+                    )?;
+                    graph.set_output(logits).map_err(bf("set_encoder_output"))?;
+                    graph
+                        .prepare_outputs_for_upload(&[logits])
+                        .map_err(bf("prepare_outputs"))?;
+                    Some(SenseVoiceReuseTensors {
+                        lfr,
+                        prompt,
+                        position,
+                        logits,
+                    })
+                }
+            };
+            if let Some(tensors) = built {
+                self.reuse_tensors = Some(tensors);
+            }
+            let graph = self
+                .same_shape
+                .builder_for_shape(&mut self.runner, shape)
+                .map_err(bf("same_shape_session"))?
+                .0;
+            let tensors = self
+                .reuse_tensors
+                .as_ref()
+                .expect("reuse tensors installed with the session");
+            graph
+                .set_f32_slice(tensors.lfr, lfr_features, "sensevoice_lfr")
+                .map_err(bf("upload_lfr"))?;
+            graph
+                .set_i32_slice(tensors.prompt, &prompt_ids, "sensevoice_prompt_ids")
+                .map_err(bf("upload_prompt_ids"))?;
+            graph
+                .set_f32_slice(tensors.position, &positions, "sensevoice_positions")
+                .map_err(bf("upload_positions"))?;
+            let logits = tensors.logits;
+            let mut visit_error = None;
+            let evidence = graph
+                .compute_output_f32_rows_for_each(
+                    logits,
+                    metadata.vocab_size,
+                    frames,
+                    |index, row| {
+                        if let Err(error) = visit(index, row) {
+                            visit_error = Some(error);
+                            return Err(GgmlCpuGraphError::UnsupportedInputs {
+                                reason: "sensevoice frame visitor failed",
+                            });
+                        }
+                        Ok(())
+                    },
+                )
+                .map_err(|error| {
+                    visit_error.take().unwrap_or_else(|| {
+                        SenseVoiceEncoderError::GraphExecutionFailed {
+                            reason: error.to_string(),
+                        }
+                    })
+                })?;
+            if let Some(error) = visit_error {
+                return Err(error);
+            }
+            return Ok(evidence);
+        }
+
+        let mut graph = self.runner.start_graph();
+        let (lfr, prompt, position, logits) = compose_lfr_graph(
+            &mut graph,
+            self.metadata,
+            self.prompt_embedding,
+            self.positional_inv_timescales,
+            &self.arena,
+            &self.enc_layers,
+            &self.tp_layers,
+            self.enc_after_norm_weight,
+            self.enc_after_norm_bias,
+            self.tp_norm_weight,
+            self.tp_norm_bias,
+            self.ctc_head_weight,
+            self.ctc_head_bias,
+            self.use_flash_attention,
+            lfr_frames,
+            prompt_ids.len(),
+            frames,
+        )?;
+        graph.set_output(logits).map_err(bf("set_encoder_output"))?;
+        graph
+            .prepare_outputs_for_upload(&[logits])
+            .map_err(bf("prepare_outputs"))?;
+        graph
+            .set_f32_slice(lfr, lfr_features, "sensevoice_lfr")
+            .map_err(bf("upload_lfr"))?;
+        graph
+            .set_i32_slice(prompt, &prompt_ids, "sensevoice_prompt_ids")
+            .map_err(bf("upload_prompt_ids"))?;
+        graph
+            .set_f32_slice(position, &positions, "sensevoice_positions")
+            .map_err(bf("upload_positions"))?;
+        let mut visit_error = None;
+        let evidence = graph
+            .compute_output_f32_rows_for_each(logits, metadata.vocab_size, frames, |index, row| {
+                if let Err(error) = visit(index, row) {
+                    visit_error = Some(error);
+                    return Err(GgmlCpuGraphError::UnsupportedInputs {
+                        reason: "sensevoice frame visitor failed",
+                    });
+                }
+                Ok(())
+            })
+            .map_err(|error| {
+                visit_error
+                    .take()
+                    .unwrap_or_else(|| SenseVoiceEncoderError::GraphExecutionFailed {
+                        reason: error.to_string(),
+                    })
+            })?;
+        if let Some(error) = visit_error {
+            return Err(error);
+        }
+        Ok(evidence)
+    }
+
+    pub(crate) fn release_transient_compute_memory(
+        &mut self,
+    ) -> Result<(), SenseVoiceEncoderError> {
+        if self.reuse_enabled && self.same_shape.has_session() {
+            return Ok(());
+        }
+        self.runner
+            .release_transient_scheduler_working_set()
+            .map_err(bf("release_transient_scheduler_working_set"))
+    }
+}
+
+fn compose_lfr_graph<'a>(
+    graph: &mut GgmlCpuGraphBuilder<'a>,
+    metadata: SenseVoiceExecutionMetadata,
+    prompt_embedding: GgmlLoadedTensor,
+    positional_inv_timescales: GgmlStaticTensor,
+    arena: &GgmlStaticTensorArena,
+    enc_layers: &[LayerArena],
+    tp_layers: &[LayerArena],
+    enc_after_norm_weight: GgmlStaticTensor,
+    enc_after_norm_bias: GgmlStaticTensor,
+    tp_norm_weight: GgmlStaticTensor,
+    tp_norm_bias: GgmlStaticTensor,
+    ctc_head_weight: WeightSlot,
+    ctc_head_bias: GgmlStaticTensor,
+    use_flash_attention: bool,
+    lfr_frames: usize,
+    prompt_len: usize,
+    frames: usize,
+) -> Result<
+    (
+        GgmlCpuTensor<'a>,
+        GgmlCpuTensor<'a>,
+        GgmlCpuTensor<'a>,
+        GgmlCpuTensor<'a>,
+    ),
+    SenseVoiceEncoderError,
+> {
+    let lfr = graph
+        .new_tensor_2d_f32(metadata.feature_dim, lfr_frames, "sensevoice_lfr")
+        .map_err(bf("new_lfr"))?;
+    let prompt = graph
+        .new_tensor_1d_i32(prompt_len, "sensevoice_prompt_ids")
+        .map_err(bf("new_prompt_ids"))?;
+    let position = graph
+        .new_tensor_2d_f32(1, frames, "sensevoice_positions")
+        .map_err(bf("new_positions"))?;
+    graph.set_input(lfr).map_err(bf("set_lfr_input"))?;
+    graph.set_input(prompt).map_err(bf("set_prompt_input"))?;
+    graph
+        .set_input(position)
+        .map_err(bf("set_position_input"))?;
+
+    let prompt_rows = graph
+        .get_rows(prompt_embedding.as_graph_tensor(), prompt)
+        .map_err(bf("prompt_get_rows"))?;
+    let combined = graph
+        .concat(prompt_rows, lfr, 1)
+        .map_err(bf("prompt_lfr_concat"))?;
+    let scaled = graph
+        .scale(combined, (metadata.d_model as f32).sqrt())
+        .map_err(bf("input_scale"))?;
+    let angles = graph
+        .mul_mat(arena.graph_tensor(positional_inv_timescales), position)
+        .map_err(bf("positional_outer_product"))?;
+    let sin = graph.sin(angles).map_err(bf("positional_sin"))?;
+    let cos = graph.cos(angles).map_err(bf("positional_cos"))?;
+    let positional = graph.concat(sin, cos, 0).map_err(bf("positional_concat"))?;
+    let state = graph
+        .add(scaled, positional)
+        .map_err(bf("positional_add"))?;
+    let logits = compose_sensevoice_encoder_logits(
+        graph,
+        state,
+        frames,
+        metadata,
+        arena,
+        enc_layers,
+        tp_layers,
+        enc_after_norm_weight,
+        enc_after_norm_bias,
+        tp_norm_weight,
+        tp_norm_bias,
+        ctc_head_weight,
+        ctc_head_bias,
+        use_flash_attention,
+    )?;
+    Ok((lfr, prompt, position, logits))
 }
 
 fn read_sensevoice_encoder_logits<'a>(
@@ -568,7 +923,7 @@ fn compose_sensevoice_encoder_logits<'a>(
     mut state: GgmlCpuTensor<'a>,
     frames: usize,
     metadata: SenseVoiceExecutionMetadata,
-    arena: &'a GgmlStaticTensorArena,
+    arena: &GgmlStaticTensorArena,
     enc_layers: &[LayerArena],
     tp_layers: &[LayerArena],
     enc_after_norm_weight: GgmlStaticTensor,
@@ -705,7 +1060,7 @@ fn upload_layer(
     Ok(())
 }
 
-fn sanm_weights<'a>(arena: &'a GgmlStaticTensorArena, h: &LayerArena) -> SanMFsmnBlockWeights<'a> {
+fn sanm_weights<'a>(arena: &GgmlStaticTensorArena, h: &LayerArena) -> SanMFsmnBlockWeights<'a> {
     let g = |t: GgmlStaticTensor| arena.graph_tensor(t);
     let b = |slot: WeightSlot| slot.graph(arena);
     SanMFsmnBlockWeights {
@@ -803,6 +1158,27 @@ mod tests {
     use crate::models::sensevoice::encoder_weights::load_sensevoice_encoder_weights;
     use crate::models::sensevoice::runtime_contract::parse_sensevoice_execution_metadata;
 
+    #[test]
+    fn encoder_same_shape_reuse_is_not_gated_on_decode_reusable_graph() {
+        const SRC: &str = include_str!("encoder_graph.rs");
+        assert!(
+            crate::ggml_runtime::encoder_same_shape_reuse_is_enabled(),
+            "encoder same-shape reuse must stay on when decode evidence is FreshGraph"
+        );
+        let forbidden = format!(
+            "reuse_enabled: reuse_mode == {}::ReusableGraph",
+            "GgmlDecodeReuseMode"
+        );
+        assert!(
+            !SRC.contains(&forbidden),
+            "SenseVoice encoder same-shape must not bind to decode capture evidence"
+        );
+        assert!(
+            SRC.contains("encoder_same_shape_reuse_is_enabled()"),
+            "SenseVoice encoder must take same-shape reuse from the shared helper"
+        );
+    }
+
     /// Offline bring-up parity vs the PyTorch reference (ref.py oracle).
     /// Requires SENSEVOICE_BRINGUP_DIR with `ref_lfr_zh.bin` ([94,560] f32 LFR+CMVN
     /// features) + `ref_logits_zh.bin` ([98,25055] f32) and SENSEVOICE_PACK
@@ -847,6 +1223,7 @@ mod tests {
             metadata,
             &preflight,
             crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+            crate::ggml_runtime::GgmlDecodeReuseMode::FreshGraph,
         )
         .expect("graph");
         let out = graph.encode(&input).expect("encode");

--- a/crates/openasr-core/src/models/sensevoice/executor.rs
+++ b/crates/openasr-core/src/models/sensevoice/executor.rs
@@ -37,10 +37,13 @@ use crate::models::admitted_pinned_runtime_actor_pool::{
     AdmittedPinnedRuntimeActorCheckoutPool, AdmittedPinnedRuntimeActorCheckoutPoolLimits,
     PinnedRuntimeActorCheckout,
 };
-use crate::models::ctc_greedy_decode::{CtcGreedyDecodeError, CtcGreedyDecodeResult};
+use crate::models::ctc_greedy_decode::{
+    CtcGreedyDecodeConfig, CtcGreedyDecodeError, CtcGreedyDecodeResult, IncrementalCtcGreedyDecoder,
+};
 use crate::models::ctc_streaming_driver::build_ctc_streaming_driver;
 use crate::models::decode_policy_component_registry::{
-    BuiltinDecodePolicyComponentRegistryError, run_builtin_ctc_decode_policy,
+    BuiltinDecodePolicyComponentRegistryError, resolve_builtin_decode_policy,
+    run_builtin_ctc_decode_policy,
 };
 use crate::models::ggml_asr_executor::{
     GgmlAsrExecutionError, GgmlAsrExecutionViewRequest, GgmlAsrStreamingExecutor,
@@ -58,7 +61,7 @@ use crate::models::system_memory_owner::{
 };
 use crate::{NativeAsrSession, SENSEVOICE_GGML_ADAPTER_ID};
 
-use super::encoder_graph::SenseVoiceEncoderGraph;
+use super::encoder_graph::{SenseVoiceEncoderError, SenseVoiceEncoderGraph};
 use super::encoder_weights::{load_sensevoice_encoder_weights, plan_sensevoice_system_memory};
 use super::frontend::{SenseVoiceFbankFrontend, apply_cmvn, apply_lfr};
 use super::graph_config::sensevoice_encoder_graph_config;
@@ -97,6 +100,15 @@ impl LayerCountResolver for SenseVoiceLayerCountResolver {
             _ => None,
         }
     }
+}
+
+const STREAM_HOST_LOGITS_BYTES: usize = 32 * 1024 * 1024;
+
+fn sensevoice_streams_host_logits(frame_count: usize, vocab_size: usize) -> bool {
+    frame_count
+        .saturating_mul(vocab_size)
+        .saturating_mul(std::mem::size_of::<f32>())
+        > STREAM_HOST_LOGITS_BYTES
 }
 
 fn ctc_err_to_string(error: CtcGreedyDecodeError) -> String {
@@ -152,13 +164,14 @@ fn materialize_sensevoice_prepared_runtime(
     metadata: SenseVoiceExecutionMetadata,
     backend: GgmlCpuGraphBackend,
     output_plan: GgmlDecodeOutputPlan,
+    reuse_mode: crate::ggml_runtime::GgmlDecodeReuseMode,
 ) -> Result<SenseVoicePreparedRuntime, String> {
     let tokenizer = SenseVoiceTokenizer::from_metadata(gguf_metadata)?;
     let weights = load_sensevoice_encoder_weights(reader, &metadata).map_err(|e| e.to_string())?;
     validate_sensevoice_block_stack(metadata, weights.enc_layers.len())?;
     let cmvn_neg_mean = weights.cmvn_neg_mean.values.clone();
     let cmvn_inv_stddev = weights.cmvn_inv_stddev.values.clone();
-    let graph = SenseVoiceEncoderGraph::new(&weights, metadata, preflight, backend)
+    let graph = SenseVoiceEncoderGraph::new(&weights, metadata, preflight, backend, reuse_mode)
         .map_err(|e| e.to_string())?;
     Ok(SenseVoicePreparedRuntime {
         metadata,
@@ -226,16 +239,40 @@ impl SenseVoicePreparedRuntime {
         )
         .map_err(|e| e.to_string())?;
 
-        let output = self
+        let frame_count = prompt
+            .embed_indices
+            .len()
+            .saturating_add(lfr.data.len() / self.metadata.feature_dim.max(1));
+        // Short utterances keep one bulk host readback (fewer GPU round-trips).
+        // Long CPU utterances stream rows so the full `[vocab, frames]` matrix
+        // is never resident beside host compute buffers. GPU PeakWorkingSet is
+        // dominated by ReBAR device buffers, so per-row D2H only burns RTF.
+        if phrase_bias.is_none()
+            && !self.graph.backend().is_gpu_class()
+            && sensevoice_streams_host_logits(frame_count, self.metadata.vocab_size)
+        {
+            return self.decode_result_streaming_greedy(
+                &lfr.data,
+                &prompt.embed_indices,
+                decode_work_progress,
+            );
+        }
+        let tokenizer = &self.tokenizer;
+        let detok = |ids: &[u32]| tokenizer.decode(ids);
+
+        let encode_result = self
             .graph
-            .encode_lfr_with_prompt(&lfr.data, &prompt.embed_indices)
-            .map_err(|e| e.to_string())?;
+            .encode_lfr_with_prompt(&lfr.data, &prompt.embed_indices);
+        let release_result = self.graph.release_transient_compute_memory();
+        let output = match (encode_result, release_result) {
+            (Ok(output), Ok(())) => output,
+            (Err(error), _) => return Err(error.to_string()),
+            (Ok(_), Err(error)) => return Err(error.to_string()),
+        };
 
         let frame_logits: Vec<&[f32]> = (0..output.frame_count)
             .map(|f| &output.logits[f * output.vocab_size..(f + 1) * output.vocab_size])
             .collect();
-        let tokenizer = &self.tokenizer;
-        let detok = |ids: &[u32]| tokenizer.decode(ids);
         run_builtin_ctc_decode_policy(
             crate::SENSEVOICE_DECODE_POLICY_ID,
             &frame_logits,
@@ -248,6 +285,59 @@ impl SenseVoicePreparedRuntime {
             decode_work_progress,
             output.frame_compute.as_deref(),
         )
+    }
+
+    fn decode_result_streaming_greedy(
+        &mut self,
+        lfr_data: &[f32],
+        prompt_indices: &[usize],
+        decode_work_progress: Option<&crate::api::backend::WorkProgressObserver>,
+    ) -> Result<CtcGreedyDecodeResult, String> {
+        let descriptor = resolve_builtin_decode_policy(crate::SENSEVOICE_DECODE_POLICY_ID)
+            .map_err(registry_err_to_string)?;
+        let blank_token_id = descriptor.ctc_blank_token_id.ok_or_else(|| {
+            registry_err_to_string(
+                BuiltinDecodePolicyComponentRegistryError::CtcBlankTokenIdMissing {
+                    decode_policy_id: crate::SENSEVOICE_DECODE_POLICY_ID.to_string(),
+                },
+            )
+        })?;
+        let mut decoder = IncrementalCtcGreedyDecoder::new(CtcGreedyDecodeConfig {
+            blank_token_id,
+            vocab_size: self.metadata.vocab_size,
+            phrase_biases: Vec::new(),
+        })
+        .map_err(ctc_err_to_string)?;
+        let lfr_frames = lfr_data.len() / self.metadata.feature_dim;
+        let total_frames = prompt_indices.len().saturating_add(lfr_frames);
+        let encode_result = self.graph.encode_lfr_with_prompt_for_each_frame(
+            lfr_data,
+            prompt_indices,
+            |frame_index, row| {
+                decoder
+                    .append_frame(row)
+                    .map_err(|error| SenseVoiceEncoderError::Shape {
+                        reason: error.to_string(),
+                    })?;
+                if let Some(observer) = decode_work_progress {
+                    observer.report(frame_index.saturating_add(1), total_frames);
+                }
+                Ok(())
+            },
+        );
+        let release_result = self.graph.release_transient_compute_memory();
+        match (encode_result, release_result) {
+            (Ok(_), Ok(())) => {}
+            (Err(error), _) => return Err(error.to_string()),
+            (Ok(_), Err(error)) => return Err(error.to_string()),
+        }
+        let tokenizer = &self.tokenizer;
+        decoder
+            .finish(
+                |ids| tokenizer.decode(ids),
+                |reason| CtcGreedyDecodeError::DetokenizeFailed { reason },
+            )
+            .map_err(ctc_err_to_string)
     }
 
     fn transcribe(
@@ -388,10 +478,18 @@ fn checkout_sensevoice_prepared_runtime(
             .map_err(|error| error.to_string())?;
             Ok((
                 quote.retained_bytes,
-                (preflight, reader, metadata, quote, backend, output_plan),
+                (
+                    preflight,
+                    reader,
+                    metadata,
+                    quote,
+                    backend,
+                    output_plan,
+                    reuse_mode,
+                ),
             ))
         },
-        |(preflight, reader, metadata, quote, backend, output_plan)| {
+        |(preflight, reader, metadata, quote, backend, output_plan, reuse_mode)| {
             let measured_peak = quote.peak_bytes;
             match SystemMemoryOwner::try_allocate_transaction(quote, || {
                 let runtime = materialize_sensevoice_prepared_runtime(
@@ -401,6 +499,7 @@ fn checkout_sensevoice_prepared_runtime(
                     metadata,
                     backend,
                     output_plan,
+                    reuse_mode,
                 )?;
                 let retained = runtime.retained_system_memory_bytes()?;
                 Ok(SystemMemoryAllocationOutcome::new(
@@ -656,6 +755,23 @@ impl GgmlAsrStreamingExecutor for SenseVoiceGgmlExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn long_ctc_logits_stream_and_short_ones_do_not() {
+        let vocab = 25055;
+        assert!(
+            !sensevoice_streams_host_logits(187, vocab),
+            "jfk-length SenseVoice stays on one bulk host readback"
+        );
+        assert!(
+            sensevoice_streams_host_logits(1160, vocab),
+            "longform CPU SenseVoice must stream rows instead of a 100MB host matrix"
+        );
+        assert!(
+            crate::ggml_runtime::GgmlCpuGraphBackend::Gpu.is_gpu_class(),
+            "GPU SenseVoice keeps bulk readback; streaming is CPU-only"
+        );
+    }
 
     #[test]
     fn cache_identity_distinguishes_full_logits_from_compact() {

--- a/crates/openasr-core/src/models/sensevoice/graph_config.rs
+++ b/crates/openasr-core/src/models/sensevoice/graph_config.rs
@@ -23,14 +23,18 @@ pub(crate) fn sensevoice_sanm_flash_attention_enabled(
     backend_preference: Option<&RequestBackendPreference>,
     placement: Option<ExecutionPlacement>,
 ) -> bool {
+    // ggml CPU flash_attn_ext is the same kernel v0.1.36 used. Keeping it
+    // off made short-reuse RTF regress ~25% against that baseline. HIP stays
+    // off: the discrete-GPU GQA/SANM kernels are not validated there.
+    if config.backend == GgmlCpuGraphBackend::Cpu {
+        return true;
+    }
     config.backend == GgmlCpuGraphBackend::Gpu
         && !config.use_scheduler
         && placement == Some(ExecutionPlacement::FullDevice)
         && matches!(
-            backend_preference,
-            Some(RequestBackendPreference::Exact(route))
-                if route.addressability.is_exactly_addressable()
-                    && matches!(route.provider, ExecutionProvider::Cuda | ExecutionProvider::Vulkan)
+            crate::ggml_runtime::proven_discrete_gpu_provider(backend_preference),
+            Some(ExecutionProvider::Cuda | ExecutionProvider::Vulkan)
         )
 }
 
@@ -73,7 +77,16 @@ mod tests {
     }
 
     #[test]
-    fn sanm_flash_is_limited_to_exact_direct_cuda_and_vulkan() {
+    fn sanm_flash_is_on_for_cpu_and_exact_direct_cuda_vulkan() {
+        let cpu = GgmlCpuGraphConfig {
+            backend: GgmlCpuGraphBackend::Cpu,
+            ..GgmlCpuGraphConfig::conservative_default()
+        };
+        assert!(sensevoice_sanm_flash_attention_enabled(
+            &cpu,
+            None,
+            Some(ExecutionPlacement::CpuOnly),
+        ));
         let direct_gpu = GgmlCpuGraphConfig {
             backend: GgmlCpuGraphBackend::Gpu,
             use_scheduler: false,

--- a/crates/openasr-core/src/models/whisper/ggml_decoder_graph.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_decoder_graph.rs
@@ -3893,7 +3893,7 @@ fn build_whisper_decoder_reusable_incremental_graph_with_n_seq(
     let hidden = plan.input_shape.hidden_size;
     let encoder_frames = plan.input_shape.encoder_frames;
     let mut session = runner
-        .start_capacity_sized_persistent_graph_session()
+        .start_persistent_graph_session_with_node_capacity(4_096)
         .map_err(|error| map_decoder_execute_graph_error("whisper_reuse_session", error))?;
     let graph = session.builder();
     let token_id = graph

--- a/crates/openasr-core/src/models/whisper/ggml_executor.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor.rs
@@ -131,8 +131,8 @@ use super::ggml_tensor_binding::{
     WhisperGgufTensorBindings, bind_whisper_gguf_tensors,
 };
 use super::graph_config::{
-    WhisperDecoderPlacementPolicy, whisper_decoder_graph_config,
-    whisper_encoder_prelude_graph_config, whisper_runtime_graph_config,
+    WhisperDecoderPlacementPolicy, whisper_decoder_graph_config, whisper_encoder_graph_config,
+    whisper_encoder_prelude_graph_config,
 };
 use super::mel::{
     WHISPER_CHANNELS, WHISPER_SAMPLE_RATE_HZ, whisper_mel_features_from_prepared_audio_v0,
@@ -193,6 +193,17 @@ fn whisper_can_use_serve_batch(
     _allow_persistent_session_reuse: bool,
 ) -> bool {
     reusable_decode_graph_supported(reuse_mode)
+}
+
+/// Serve-batch keeps the encoder-only actor. Every other offline unified GPU
+/// request must checkout the combined owner first so prelude, encode, and
+/// decode share one TLS backend.
+fn whisper_should_checkout_unified_gpu_owner(
+    skip_serve_batch: bool,
+    will_use_serve_batch: bool,
+    unified_enabled: bool,
+) -> bool {
+    !skip_serve_batch && !will_use_serve_batch && unified_enabled
 }
 
 #[derive(Debug, Error)]
@@ -954,6 +965,10 @@ impl WhisperDecoderActorJob {
                 self.reuse_mode,
             )
         })();
+        if let Some(session) = state.session.as_mut() {
+            session.reuse = None;
+            let _ = session.runner.release_request_compute_residency();
+        }
         if !self.allow_persistent_session_reuse {
             // Request-scoped graph/KV state must be destroyed on the owner
             // thread on success and on every early error path.
@@ -3189,10 +3204,6 @@ fn whisper_encoder_resident_weights_enabled() -> bool {
     )
 }
 
-fn whisper_encoder_graph_config(backend: GgmlCpuGraphBackend) -> GgmlCpuGraphConfig {
-    whisper_runtime_graph_config(backend)
-}
-
 fn apply_encoder_affine_layer_norm<'a>(
     graph: &mut GgmlCpuGraphBuilder<'a>,
     uploads: &mut Vec<WhisperEncoderGraphUpload<'a>>,
@@ -3750,12 +3761,7 @@ fn whisper_gpu_loaded_f16_weight_mode_with_override(
         && encoder_config.backend == GgmlCpuGraphBackend::Gpu
         && !encoder_config.use_scheduler
         && placement == Some(ExecutionPlacement::FullDevice)
-        && matches!(
-            backend_preference,
-            Some(RequestBackendPreference::Exact(route))
-                if route.addressability.is_exactly_addressable()
-                    && matches!(route.provider, ExecutionProvider::Cuda | ExecutionProvider::Vulkan)
-        )
+        && crate::ggml_runtime::exact_discrete_gpu_unified_owner_is_proven(backend_preference)
     {
         WhisperGpuLoadedF16WeightMode::LoadedView
     } else {
@@ -3788,17 +3794,12 @@ fn whisper_unified_runtime_enabled_with_override(
     disable_raw: Option<&str>,
     enable_raw: Option<&str>,
 ) -> bool {
-    let exact_provider = match backend_preference {
-        Some(RequestBackendPreference::Exact(route))
-            if route.addressability.is_exactly_addressable() =>
-        {
-            Some(route.provider)
-        }
-        _ => None,
-    };
+    let exact_provider = crate::ggml_runtime::proven_discrete_gpu_provider(backend_preference);
     let default_enabled = matches!(exact_provider, Some(ExecutionProvider::Vulkan))
-        || (matches!(exact_provider, Some(ExecutionProvider::Cuda))
-            && (allow_persistent_session_reuse || geometry.favors_cuda_unified_runtime()));
+        || (matches!(
+            exact_provider,
+            Some(ExecutionProvider::Cuda | ExecutionProvider::Hip)
+        ) && (allow_persistent_session_reuse || geometry.favors_cuda_unified_runtime()));
     let enabled =
         crate::ggml_runtime::env_toggle_with_raw(disable_raw, enable_raw, default_enabled);
     enabled
@@ -3808,12 +3809,7 @@ fn whisper_unified_runtime_enabled_with_override(
         && !encoder_config.use_scheduler
         && !decoder_config.use_scheduler
         && placement == Some(ExecutionPlacement::FullDevice)
-        && matches!(
-            backend_preference,
-            Some(RequestBackendPreference::Exact(route))
-                if route.addressability.is_exactly_addressable()
-                    && matches!(route.provider, ExecutionProvider::Cuda | ExecutionProvider::Vulkan)
-        )
+        && crate::ggml_runtime::exact_discrete_gpu_unified_owner_is_proven(backend_preference)
 }
 
 fn whisper_unified_runtime_enabled(
@@ -3958,6 +3954,34 @@ fn checkout_whisper_unified_runtime(
     )
 }
 
+fn run_whisper_encoder_prelude_state(
+    state: &mut WhisperEncoderRuntimeActorState,
+    prepared: &WhisperPreparedRuntime,
+    plan: &WhisperEncoderPreludePlan,
+    mel_input: &WhisperMelFeatureInput,
+    backend: GgmlCpuGraphBackend,
+) -> Result<WhisperEncoderPreludeSeamResult, WhisperGgmlExecutorError> {
+    if !state
+        .prelude
+        .as_ref()
+        .is_some_and(|runtime| runtime.matches(plan, backend))
+    {
+        state.prelude = Some(WhisperEncoderPreludeCachedRuntime::build(
+            &prepared.encoder_weights,
+            plan,
+            backend,
+        )?);
+    }
+    state
+        .prelude
+        .as_mut()
+        .ok_or_else(|| WhisperGgmlExecutorError::RuntimeOwnershipFailed {
+            stage: "encoder_prelude",
+            reason: "actor prelude runtime was not initialized".to_string(),
+        })?
+        .run(mel_input)
+}
+
 fn run_whisper_encoder_prelude_actor(
     actor: &WhisperEncoderRuntimeActor,
     prepared: PreparedRuntimeHandle<WhisperPreparedRuntime>,
@@ -3967,27 +3991,29 @@ fn run_whisper_encoder_prelude_actor(
 ) -> Result<WhisperEncoderPreludeSeamResult, WhisperGgmlExecutorError> {
     actor
         .call_mut_fallible(move |state| {
-            if !state
-                .prelude
-                .as_ref()
-                .is_some_and(|runtime| runtime.matches(&plan, backend))
-            {
-                state.prelude = Some(WhisperEncoderPreludeCachedRuntime::build(
-                    &prepared.encoder_weights,
-                    &plan,
-                    backend,
-                )?);
-            }
-            state
-                .prelude
-                .as_mut()
-                .ok_or_else(|| WhisperGgmlExecutorError::RuntimeOwnershipFailed {
-                    stage: "encoder_prelude",
-                    reason: "actor prelude runtime was not initialized".to_string(),
-                })?
-                .run(&mel_input)
+            run_whisper_encoder_prelude_state(state, prepared.as_ref(), &plan, &mel_input, backend)
         })
         .map_err(|error| map_whisper_actor_error("encoder_prelude", error))?
+}
+
+fn run_whisper_encoder_prelude_unified(
+    actor: &WhisperUnifiedRuntimeActor,
+    prepared: PreparedRuntimeHandle<WhisperPreparedRuntime>,
+    plan: WhisperEncoderPreludePlan,
+    mel_input: WhisperMelFeatureInput,
+    backend: GgmlCpuGraphBackend,
+) -> Result<WhisperEncoderPreludeSeamResult, WhisperGgmlExecutorError> {
+    actor
+        .call_mut_fallible(move |state| {
+            run_whisper_encoder_prelude_state(
+                &mut state.encoder,
+                prepared.as_ref(),
+                &plan,
+                &mel_input,
+                backend,
+            )
+        })
+        .map_err(|error| map_whisper_actor_error("unified-prelude", error))?
 }
 
 fn run_whisper_encoder_actor(
@@ -4737,23 +4763,79 @@ fn execute_whisper_with_prepared_runtime(
         decoder_state,
         prelude_plan.output_frames,
     )?;
-    let encoder_actor = checkout_whisper_encoder_runtime(
-        encoder_runtimes,
-        runtime_source,
-        Arc::clone(&prepared_owner),
-        Arc::clone(&encoder_graph_runner),
-        resolved_backend,
-        gpu_loaded_f16_weight_mode,
-    )?;
+    // Resolve once on the submitting request thread, while the typed Exact
+    // route is still installed. Decoder actors and serve-batch owners execute
+    // on separate threads and must consume this snapshot rather than infer a
+    // provider from their generic Gpu backend.
+    let decoder_placement_policy = WhisperDecoderPlacementPolicy::resolve();
+    let serve_batch_config =
+        whisper_serve_batch_config_from_server_policy(request_options.serve_batch);
+    let can_use_serve_batch = !skip_serve_batch
+        && whisper_can_use_serve_batch(reuse_mode, request_options, allow_persistent_session_reuse);
+    let will_use_serve_batch = serve_batch_config.is_some() && can_use_serve_batch;
+    let use_unified_gpu_owner = whisper_should_checkout_unified_gpu_owner(
+        skip_serve_batch,
+        will_use_serve_batch,
+        whisper_unified_runtime_enabled(
+            resolved_backend,
+            decoder_placement_policy,
+            runtime,
+            allow_persistent_session_reuse,
+        ),
+    );
+    // Unified GPU ownership must install the only TLS Vulkan context on the
+    // combined owner thread. Checking out the encoder-only actor first would
+    // leave a second pinned backend alive after that checkout is dropped.
+    let unified_actor = if use_unified_gpu_owner {
+        Some(checkout_whisper_unified_runtime(
+            unified_gpu_runtimes,
+            runtime_source,
+            Arc::clone(&prepared_owner),
+            Arc::clone(&encoder_graph_runner),
+            decoder_state,
+            resolved_backend,
+            decoder_placement_policy,
+            gpu_loaded_f16_weight_mode,
+        )?)
+    } else {
+        None
+    };
+    let encoder_actor = if use_unified_gpu_owner {
+        None
+    } else {
+        Some(checkout_whisper_encoder_runtime(
+            encoder_runtimes,
+            runtime_source,
+            Arc::clone(&prepared_owner),
+            Arc::clone(&encoder_graph_runner),
+            resolved_backend,
+            gpu_loaded_f16_weight_mode,
+        )?)
+    };
     let prelude_result = trace.run_stage("prelude_run", || {
         if prelude_runner.supports_owner_thread_cached_runtime() {
-            run_whisper_encoder_prelude_actor(
-                &encoder_actor,
-                Arc::clone(&prepared_owner),
-                prelude_plan.clone(),
-                mel_input,
-                resolved_backend,
-            )
+            if let Some(unified_actor) = unified_actor.as_ref() {
+                run_whisper_encoder_prelude_unified(
+                    unified_actor,
+                    Arc::clone(&prepared_owner),
+                    prelude_plan.clone(),
+                    mel_input,
+                    resolved_backend,
+                )
+            } else {
+                run_whisper_encoder_prelude_actor(
+                    encoder_actor.as_ref().ok_or_else(|| {
+                        WhisperGgmlExecutorError::RuntimeOwnershipFailed {
+                            stage: "encoder_prelude",
+                            reason: "split Whisper path is missing the encoder owner".to_string(),
+                        }
+                    })?,
+                    Arc::clone(&prepared_owner),
+                    prelude_plan.clone(),
+                    mel_input,
+                    resolved_backend,
+                )
+            }
         } else {
             run_encoder_prelude_seam(
                 runtime_source,
@@ -4801,18 +4883,14 @@ fn execute_whisper_with_prepared_runtime(
         } => output_hidden_f32.clone(),
     };
     let audio_duration = audio_duration_seconds(prepared_audio);
-    let serve_batch_config =
-        whisper_serve_batch_config_from_server_policy(request_options.serve_batch);
-    // Resolve once on the submitting request thread, while the typed Exact
-    // route is still installed. Decoder actors and serve-batch owners execute
-    // on separate threads and must consume this snapshot rather than infer a
-    // provider from their generic Gpu backend.
-    let decoder_placement_policy = WhisperDecoderPlacementPolicy::resolve();
     let decoder_graph_config =
         whisper_decoder_graph_config(resolved_backend, decoder_placement_policy);
-    let can_use_serve_batch = !skip_serve_batch
-        && whisper_can_use_serve_batch(reuse_mode, request_options, allow_persistent_session_reuse);
     if let Some(serve_batch_config) = serve_batch_config.filter(|_| can_use_serve_batch) {
+        let encoder_actor =
+            encoder_actor.ok_or_else(|| WhisperGgmlExecutorError::RuntimeOwnershipFailed {
+                stage: "encoder",
+                reason: "serve-batch Whisper path is missing the encoder owner".to_string(),
+            })?;
         let encoder_result = run_whisper_encoder_actor(
             encoder_actor,
             preflight.clone(),
@@ -4902,27 +4980,7 @@ fn execute_whisper_with_prepared_runtime(
             },
         });
     }
-    if !skip_serve_batch
-        && whisper_unified_runtime_enabled(
-            resolved_backend,
-            decoder_placement_policy,
-            runtime,
-            allow_persistent_session_reuse,
-        )
-    {
-        // The prelude actor owns only its small convolution/position arena;
-        // release its checkout before entering the combined pack-weight owner.
-        drop(encoder_actor);
-        let unified_actor = checkout_whisper_unified_runtime(
-            unified_gpu_runtimes,
-            runtime_source,
-            Arc::clone(&prepared_owner),
-            Arc::clone(&encoder_graph_runner),
-            decoder_state,
-            resolved_backend,
-            decoder_placement_policy,
-            gpu_loaded_f16_weight_mode,
-        )?;
+    if let Some(unified_actor) = unified_actor {
         let unified_execution = runtime.execution.clone();
         let unified_preflight: GgufRuntimeSourcePreflight = (*preflight).clone();
         let mut decoder_job = WhisperDecoderActorJob {
@@ -4947,6 +5005,16 @@ fn execute_whisper_with_prepared_runtime(
         };
         return unified_actor
             .call_mut_fallible(move |state| {
+                // Prelude kept its own loaded-weight context on this thread.
+                // Drop it before the pack-wide encoder/decoder sessions so they
+                // can coalesce on one TLS weight slot. If the encoder session
+                // itself must be rebuilt, drop the decoder too so both owners
+                // are constructed against the same loaded context.
+                state.encoder.prelude = None;
+                let encoder_needs_build = state.encoder.session.is_none();
+                if encoder_needs_build {
+                    state.decoder.session = None;
+                }
                 let encoder_result = run_whisper_encoder_state(
                     &mut state.encoder,
                     unified_preflight,
@@ -4960,17 +5028,21 @@ fn execute_whisper_with_prepared_runtime(
                     gpu_loaded_f16_weight_mode,
                     trace,
                 )?;
-                let binding = state
-                    .encoder
-                    .session
-                    .as_ref()
-                    .and_then(WhisperEncoderPersistentStaticSession::loaded_weight_binding_identity)
-                    .ok_or_else(|| WhisperGgmlExecutorError::RuntimeOwnershipFailed {
-                        stage: "unified-runtime",
-                        reason: "unified Whisper encoder did not retain a loaded pack binding"
-                            .to_string(),
-                    })?;
-                decoder_job.expected_loaded_weight_binding = Some(binding);
+                if encoder_needs_build {
+                    let binding = state
+                        .encoder
+                        .session
+                        .as_ref()
+                        .and_then(
+                            WhisperEncoderPersistentStaticSession::loaded_weight_binding_identity,
+                        )
+                        .ok_or_else(|| WhisperGgmlExecutorError::RuntimeOwnershipFailed {
+                            stage: "unified-runtime",
+                            reason: "unified Whisper encoder did not retain a loaded pack binding"
+                                .to_string(),
+                        })?;
+                    decoder_job.expected_loaded_weight_binding = Some(binding);
+                }
                 let result = decoder_job.run(
                     &mut state.decoder,
                     WhisperEncoderResultDelivery::Ready(Ok(encoder_result)),
@@ -4983,6 +5055,11 @@ fn execute_whisper_with_prepared_runtime(
             .map_err(|error| map_whisper_actor_error("unified-runtime", error))?;
     }
 
+    let encoder_actor =
+        encoder_actor.ok_or_else(|| WhisperGgmlExecutorError::RuntimeOwnershipFailed {
+            stage: "encoder",
+            reason: "split Whisper path is missing the encoder owner".to_string(),
+        })?;
     let decoder_actor = checkout_whisper_decoder_runtime(
         decoder_runtimes,
         runtime_source,

--- a/crates/openasr-core/src/models/whisper/ggml_executor/tests.rs
+++ b/crates/openasr-core/src/models/whisper/ggml_executor/tests.rs
@@ -49,7 +49,24 @@ fn exactly_addressable_preference(provider: ExecutionProvider) -> RequestBackend
 }
 
 #[test]
-fn unified_owner_is_limited_to_exact_direct_cuda_vulkan_full_device() {
+fn unified_offline_path_checkouts_combined_owner_instead_of_encoder_only_actor() {
+    assert!(
+        whisper_should_checkout_unified_gpu_owner(false, false, true),
+        "offline unified GPU must skip the encoder-only actor so prelude cannot install a second TLS backend"
+    );
+    assert!(!whisper_should_checkout_unified_gpu_owner(
+        true, false, true
+    ));
+    assert!(!whisper_should_checkout_unified_gpu_owner(
+        false, true, true
+    ));
+    assert!(!whisper_should_checkout_unified_gpu_owner(
+        false, false, false
+    ));
+}
+
+#[test]
+fn unified_owner_is_limited_to_exact_direct_cuda_hip_vulkan_full_device() {
     let direct_gpu = GgmlCpuGraphConfig {
         backend: GgmlCpuGraphBackend::Gpu,
         use_scheduler: false,
@@ -78,50 +95,53 @@ fn unified_owner_is_limited_to_exact_direct_cuda_vulkan_full_device() {
         None,
     ));
     let cuda = exactly_addressable_preference(ExecutionProvider::Cuda);
-    assert!(!whisper_unified_runtime_enabled_with_override(
-        GgmlCpuGraphBackend::Gpu,
-        Some(&cuda),
-        Some(ExecutionPlacement::FullDevice),
-        direct_gpu,
-        direct_gpu,
-        medium_geometry,
-        false,
-        None,
-        None,
-    ));
-    assert!(whisper_unified_runtime_enabled_with_override(
-        GgmlCpuGraphBackend::Gpu,
-        Some(&cuda),
-        Some(ExecutionPlacement::FullDevice),
-        direct_gpu,
-        direct_gpu,
-        medium_geometry,
-        true,
-        None,
-        None,
-    ));
-    assert!(whisper_unified_runtime_enabled_with_override(
-        GgmlCpuGraphBackend::Gpu,
-        Some(&cuda),
-        Some(ExecutionPlacement::FullDevice),
-        direct_gpu,
-        direct_gpu,
-        large_geometry,
-        false,
-        None,
-        None,
-    ));
-    assert!(whisper_unified_runtime_enabled_with_override(
-        GgmlCpuGraphBackend::Gpu,
-        Some(&cuda),
-        Some(ExecutionPlacement::FullDevice),
-        direct_gpu,
-        direct_gpu,
-        medium_geometry,
-        false,
-        None,
-        Some("1"),
-    ));
+    let hip = exactly_addressable_preference(ExecutionProvider::Hip);
+    for capture_gpu in [&cuda, &hip] {
+        assert!(!whisper_unified_runtime_enabled_with_override(
+            GgmlCpuGraphBackend::Gpu,
+            Some(capture_gpu),
+            Some(ExecutionPlacement::FullDevice),
+            direct_gpu,
+            direct_gpu,
+            medium_geometry,
+            false,
+            None,
+            None,
+        ));
+        assert!(whisper_unified_runtime_enabled_with_override(
+            GgmlCpuGraphBackend::Gpu,
+            Some(capture_gpu),
+            Some(ExecutionPlacement::FullDevice),
+            direct_gpu,
+            direct_gpu,
+            medium_geometry,
+            true,
+            None,
+            None,
+        ));
+        assert!(whisper_unified_runtime_enabled_with_override(
+            GgmlCpuGraphBackend::Gpu,
+            Some(capture_gpu),
+            Some(ExecutionPlacement::FullDevice),
+            direct_gpu,
+            direct_gpu,
+            large_geometry,
+            false,
+            None,
+            None,
+        ));
+        assert!(whisper_unified_runtime_enabled_with_override(
+            GgmlCpuGraphBackend::Gpu,
+            Some(capture_gpu),
+            Some(ExecutionPlacement::FullDevice),
+            direct_gpu,
+            direct_gpu,
+            medium_geometry,
+            false,
+            None,
+            Some("1"),
+        ));
+    }
     assert!(!whisper_unified_runtime_enabled_with_override(
         GgmlCpuGraphBackend::Gpu,
         Some(&vulkan),
@@ -136,7 +156,6 @@ fn unified_owner_is_limited_to_exact_direct_cuda_vulkan_full_device() {
     for provider in [
         ExecutionProvider::Cpu,
         ExecutionProvider::Metal,
-        ExecutionProvider::Hip,
         ExecutionProvider::Accelerator,
         ExecutionProvider::Unknown,
     ] {
@@ -171,13 +190,17 @@ fn unified_owner_is_limited_to_exact_direct_cuda_vulkan_full_device() {
 }
 
 #[test]
-fn gpu_loaded_f16_views_require_exact_direct_cuda_vulkan_full_device() {
+fn gpu_loaded_f16_views_require_exact_direct_cuda_hip_vulkan_full_device() {
     let direct_gpu = GgmlCpuGraphConfig {
         backend: GgmlCpuGraphBackend::Gpu,
         use_scheduler: false,
         ..GgmlCpuGraphConfig::conservative_default()
     };
-    for provider in [ExecutionProvider::Cuda, ExecutionProvider::Vulkan] {
+    for provider in [
+        ExecutionProvider::Cuda,
+        ExecutionProvider::Hip,
+        ExecutionProvider::Vulkan,
+    ] {
         let preference = exactly_addressable_preference(provider);
         assert_eq!(
             whisper_gpu_loaded_f16_weight_mode_with_override(
@@ -203,7 +226,6 @@ fn gpu_loaded_f16_views_require_exact_direct_cuda_vulkan_full_device() {
     for provider in [
         ExecutionProvider::Cpu,
         ExecutionProvider::Metal,
-        ExecutionProvider::Hip,
         ExecutionProvider::Accelerator,
         ExecutionProvider::Unknown,
     ] {

--- a/crates/openasr-core/src/models/whisper/graph_config.rs
+++ b/crates/openasr-core/src/models/whisper/graph_config.rs
@@ -63,6 +63,24 @@ pub(crate) fn whisper_runtime_graph_config(backend: GgmlCpuGraphBackend) -> Ggml
     )
 }
 
+pub(crate) fn whisper_encoder_graph_config(backend: GgmlCpuGraphBackend) -> GgmlCpuGraphConfig {
+    whisper_encoder_graph_config_with_policy(backend, WhisperDecoderPlacementPolicy::resolve())
+}
+
+fn whisper_encoder_graph_config_with_policy(
+    backend: GgmlCpuGraphBackend,
+    placement_policy: WhisperDecoderPlacementPolicy,
+) -> GgmlCpuGraphConfig {
+    let mut config = whisper_runtime_graph_config(backend);
+    // Match the Exact CUDA/Vulkan decoder: a scheduler-backed encoder blocks
+    // the unified GPU owner and LoadedView weights, and keeps a CPU fallback
+    // participant that FullDevice already forbids at attestation.
+    if placement_policy.uses_exact_cuda_or_vulkan_default(config.backend) {
+        config.use_scheduler = false;
+    }
+    config
+}
+
 pub(crate) fn whisper_encoder_prelude_graph_config(
     backend: GgmlCpuGraphBackend,
 ) -> GgmlCpuGraphConfig {
@@ -385,6 +403,17 @@ mod tests {
             assert_eq!(config.backend, GgmlCpuGraphBackend::Gpu);
             assert_eq!(config.use_scheduler, use_scheduler);
         }
+    }
+
+    #[test]
+    fn exact_cuda_vulkan_encoder_defaults_without_scheduler() {
+        let config = whisper_encoder_graph_config_with_policy(
+            GgmlCpuGraphBackend::Gpu,
+            WhisperDecoderPlacementPolicy::for_test(true),
+        );
+
+        assert_eq!(config.backend, GgmlCpuGraphBackend::Gpu);
+        assert!(!config.use_scheduler);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/xasr_zipformer/device_head_graph.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/device_head_graph.rs
@@ -415,9 +415,6 @@ impl XasrDeviceHead {
             .mul_mat(weights.output_weight.as_graph_tensor(), joined)
             .and_then(|value| graph.add(value, weights.output_bias.as_graph_tensor()))
             .map_err(|error| error.to_string())?;
-        // The speculative path uses the same host last-max oracle as scalar
-        // decode. A compact device top1 would authorize a tie policy that is
-        // not part of the named runtime capability contract.
         graph
             .set_output(logits)
             .map_err(|error| error.to_string())?;
@@ -484,10 +481,20 @@ impl XasrGreedyDecodeBackend for XasrDeviceHead {
         self.last_token = None;
         self.last_selection_evidence = None;
         let graph = self.joint.session.builder();
-        let output = graph
-            .compute_output_f32_rows_with_evidence(self.joint.logits, self.vocab_size, 1)
-            .map_err(|error| error.to_string())?;
-        let (logits, evidence) = output.into_parts();
+        let retain_evidence =
+            crate::models::native_execution_services::current_execution_receipt_collector()
+                .is_some_and(|receipt| receipt.captures_full_logits());
+        let (logits, evidence) = if retain_evidence {
+            let output = graph
+                .compute_output_f32_rows_with_evidence(self.joint.logits, self.vocab_size, 1)
+                .map_err(|error| error.to_string())?;
+            output.into_parts()
+        } else {
+            let logits = graph
+                .compute_output_f32(self.joint.logits, self.vocab_size)
+                .map_err(|error| error.to_string())?;
+            (logits, None)
+        };
         let token = argmax(&logits)
             .ok_or_else(|| "xasr device head produced no finite logits".to_string())?;
         let probability = crate::models::seq2seq_greedy_decode::token_softmax_probability(
@@ -499,8 +506,7 @@ impl XasrGreedyDecodeBackend for XasrDeviceHead {
         }
         self.last_token = Some(token);
         self.last_probability = probability;
-        if crate::models::native_execution_services::current_execution_receipt_collector().is_some()
-        {
+        if retain_evidence {
             self.last_selection_evidence = evidence
                 .map(|rows| XasrSelectionEvidence::new(rows, logits, self.vocab_size, 1))
                 .transpose()?;
@@ -556,14 +562,28 @@ impl XasrGreedyDecodeBackend for XasrDeviceHead {
                 "xasr_head_speculative_encoder_frames",
             )
             .map_err(|error| error.to_string())?;
-        let output = graph
-            .compute_output_f32_rows_with_evidence(
-                speculative.logits,
-                self.vocab_size,
-                speculative.frames,
-            )
-            .map_err(|error| error.to_string())?;
-        let (logits, evidence) = output.into_parts();
+        let retain_evidence =
+            crate::models::native_execution_services::current_execution_receipt_collector()
+                .is_some_and(|receipt| receipt.captures_full_logits());
+        let expected_len = self
+            .vocab_size
+            .checked_mul(speculative.frames)
+            .ok_or_else(|| "xasr speculative logits shape overflowed".to_string())?;
+        let (logits, evidence) = if retain_evidence {
+            let output = graph
+                .compute_output_f32_rows_with_evidence(
+                    speculative.logits,
+                    self.vocab_size,
+                    speculative.frames,
+                )
+                .map_err(|error| error.to_string())?;
+            output.into_parts()
+        } else {
+            let logits = graph
+                .compute_output_f32(speculative.logits, expected_len)
+                .map_err(|error| error.to_string())?;
+            (logits, None)
+        };
         let mut first_non_blank = speculative.frames;
         for (frame, frame_logits) in logits.chunks_exact(self.vocab_size).enumerate() {
             let token = argmax(frame_logits).ok_or_else(|| {
@@ -574,8 +594,7 @@ impl XasrGreedyDecodeBackend for XasrDeviceHead {
                 break;
             }
         }
-        if crate::models::native_execution_services::current_execution_receipt_collector().is_some()
-        {
+        if retain_evidence {
             self.last_selection_evidence = evidence
                 .map(|rows| {
                     XasrSelectionEvidence::new(rows, logits, self.vocab_size, speculative.frames)

--- a/crates/openasr-core/src/models/xasr_zipformer/device_head_graph.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/device_head_graph.rs
@@ -729,6 +729,7 @@ mod tests {
     fn real_device_head_binds_speculative_rows_and_scalar_recompute_to_readbacks() {
         let receipt = crate::NativeExecutionReceiptCollector::new();
         receipt.set_trace_mode(crate::NativeExecutionTraceMode::Cold);
+        receipt.enable_full_logits_trace();
         receipt.begin_candidate_attempt();
         let _receipt_guard =
             crate::models::native_execution_services::install_execution_receipt_collector(Some(

--- a/crates/openasr-core/src/models/xasr_zipformer/encoder_graph.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/encoder_graph.rs
@@ -8840,7 +8840,7 @@ mod tests {
 
         let mut config = GgmlCpuGraphConfig::conservative_default();
         config.context_bytes = 64 * 1024 * 1024;
-        config.graph_size = 65_536;
+        config.graph_size = crate::models::xasr_zipformer::graph_config::FULL_ENCODER_GRAPH_SIZE;
         let mut runner =
             GgmlCpuGraphRunner::new(config).expect("cpu graph runner should initialize");
         let mut graph = runner.start_graph();
@@ -9956,9 +9956,7 @@ mod tests {
         let weights = load_xasr_encoder_weights(&reader, &metadata).expect("weights");
         // Right-sized like the runtime path (see
         // `xasr_zipformer_encoder_graph_config`): stack0 is a strict subset of
-        // the full encoder, so the full-encoder node budget covers it with >5x
-        // headroom. The old flat 256 MB over-reserved the `no_alloc` metadata
-        // context, which only holds tensor bookkeeping.
+        // the full encoder, so the full-encoder node budget covers it.
         let mut config = GgmlCpuGraphConfig::conservative_default();
         config.graph_size = config
             .graph_size

--- a/crates/openasr-core/src/models/xasr_zipformer/graph_config.rs
+++ b/crates/openasr-core/src/models/xasr_zipformer/graph_config.rs
@@ -10,11 +10,10 @@ const OPENASR_XASR_SPECULATIVE_BLANK_BATCH: &str = "OPENASR_XASR_SPECULATIVE_BLA
 /// ~12.4k tensors for the streaming chunk window). The graph topology is
 /// architecture-bound (layers x ops-per-layer), not sequence-length-bound —
 /// longer audio grows tensor dimensions, not the op count — so the node count
-/// stays ~constant across inputs. 65,536 keeps >5x headroom on both node and
-/// tensor counts. The previous 2,000,000 over-reserved the cgraph object alone
-/// by ~79 MB and, paired with a hand-tuned 2 GiB context (see
-/// [`GgmlCpuGraphConfig::metadata_context_bytes`]), OOM'd CPU transcription.
-pub(super) const FULL_ENCODER_GRAPH_SIZE: usize = 65_536;
+/// stays ~constant across inputs. 16,384 is the next power of two above the
+/// measured node count. The previous 65,536 / 2,000,000 over-reserved the
+/// cgraph object and inflated both PeakWorkingSet and per-step ggml_reset.
+pub(super) const FULL_ENCODER_GRAPH_SIZE: usize = 16_384;
 
 /// The stateless predictor and fused encoder-projection/joiner use two tiny
 /// persistent graphs, plus one optional blank-prefix batch graph on validated
@@ -25,7 +24,7 @@ pub(super) const DEVICE_HEAD_GRAPH_SIZE: usize = 64;
 /// The encoder-embed prepared graph is intentionally isolated from the much
 /// larger Zipformer layer graph. Its frozen topology currently has 87 native
 /// nodes; 2,048 leaves over 20x headroom while avoiding a second pair of
-/// 65,536-node metadata contexts for the dedicated runner and session.
+/// full-encoder metadata contexts for the dedicated runner and session.
 pub(super) const ENCODER_EMBED_GRAPH_SIZE: usize = 2_048;
 
 pub(super) fn xasr_zipformer_encoder_embed_graph_config(
@@ -115,18 +114,16 @@ fn xasr_zipformer_speculative_blank_batch_with_inputs(
     placement: Option<crate::device::execution_policy::ExecutionPlacement>,
     raw: Option<&str>,
 ) -> bool {
-    let validated_discrete_gpu = matches!(
-        (backend, preference, placement),
-        (
-            GgmlCpuGraphBackend::Gpu,
-            Some(crate::ggml_runtime::RequestBackendPreference::Exact(route)),
-            Some(crate::device::execution_policy::ExecutionPlacement::FullDevice),
-        ) if matches!(
-            route.provider,
-            crate::device::execution_route::ExecutionProvider::Cuda
-                | crate::device::execution_route::ExecutionProvider::Vulkan
-        )
-    );
+    let validated_discrete_gpu = backend == GgmlCpuGraphBackend::Gpu
+        && placement == Some(crate::device::execution_policy::ExecutionPlacement::FullDevice)
+        && matches!(
+            crate::ggml_runtime::proven_discrete_gpu_provider(preference),
+            Some(
+                crate::device::execution_route::ExecutionProvider::Cuda
+                    | crate::device::execution_route::ExecutionProvider::Hip
+                    | crate::device::execution_route::ExecutionProvider::Vulkan
+            )
+        );
     validated_discrete_gpu && crate::ggml_runtime::env_toggle_with_raw(None, raw, true)
 }
 
@@ -137,12 +134,7 @@ fn xasr_zipformer_encoder_graph_config_with_overrides(
     mut config: GgmlCpuGraphConfig,
     has_explicit_thread_override: bool,
 ) -> GgmlCpuGraphConfig {
-    config.graph_size = config.graph_size.max(FULL_ENCODER_GRAPH_SIZE);
-    config.context_bytes = config
-        .context_bytes
-        .max(GgmlCpuGraphConfig::metadata_context_bytes(
-            config.graph_size,
-        ));
+    config.set_graph_node_capacity(config.graph_size.max(FULL_ENCODER_GRAPH_SIZE));
     // X-ASR uses depthwise conv (CONV_2D_DW) in the encoder-embed and conv_module
     // paths. The Metal backend has no fused CONV_2D_DW kernel, and a scheduler
     // CPU-fallback can't move the op because the prepared graph's tensors are
@@ -199,8 +191,12 @@ mod tests {
     }
 
     #[test]
-    fn speculative_blank_batch_is_default_on_only_for_exact_full_device_cuda_and_vulkan() {
-        for provider in [ExecutionProvider::Cuda, ExecutionProvider::Vulkan] {
+    fn speculative_blank_batch_is_default_on_only_for_exact_full_device_discrete_gpu() {
+        for provider in [
+            ExecutionProvider::Cuda,
+            ExecutionProvider::Hip,
+            ExecutionProvider::Vulkan,
+        ] {
             let preference = exact_route(provider);
             assert!(xasr_zipformer_speculative_blank_batch_with_inputs(
                 GgmlCpuGraphBackend::Gpu,
@@ -217,7 +213,6 @@ mod tests {
         }
 
         for provider in [
-            ExecutionProvider::Hip,
             ExecutionProvider::Metal,
             ExecutionProvider::Accelerator,
             ExecutionProvider::Unknown,
@@ -278,8 +273,10 @@ mod tests {
         );
         // Four coexisting contexts must stay well under a CPU commit budget...
         assert!(config.context_bytes * 2 + embed.context_bytes * 2 < 256 * 1024 * 1024);
-        // ...while still exceeding the ~7 MB the measured 11.1k-node graph uses.
-        assert!(config.context_bytes > 7 * 1024 * 1024);
+        // ...while still covering the measured 11.1k-node graph (~4-6 MiB of
+        // no_alloc metadata) without the old 65,536-node over-reserve.
+        assert!(config.context_bytes > 4 * 1024 * 1024);
+        assert!(config.context_bytes < 16 * 1024 * 1024);
     }
 
     #[test]

--- a/crates/openasr-core/src/nn/decoder.rs
+++ b/crates/openasr-core/src/nn/decoder.rs
@@ -1499,6 +1499,7 @@ pub(crate) struct LlmReusableDecodeGraph {
     pub attention_mask: GgmlCpuTensor<'static>,
     pub state: GgmlCpuTensor<'static>,
     pub top1: Option<GgmlCpuTensor<'static>>,
+    pub fused_logits: Option<GgmlCpuTensor<'static>>,
 }
 
 impl LlmReusableDecodeGraph {
@@ -1515,6 +1516,7 @@ impl LlmReusableDecodeGraph {
         attention_mask: GgmlCpuTensor<'static>,
         state: GgmlCpuTensor<'static>,
         top1: Option<GgmlCpuTensor<'static>>,
+        fused_logits: Option<GgmlCpuTensor<'static>>,
     ) -> Self {
         Self {
             session,
@@ -1528,6 +1530,7 @@ impl LlmReusableDecodeGraph {
             attention_mask,
             state,
             top1,
+            fused_logits,
         }
     }
 

--- a/crates/openasr-core/src/real_family_evidence.rs
+++ b/crates/openasr-core/src/real_family_evidence.rs
@@ -409,10 +409,10 @@ mod tests {
         GgmlGraphLifecycleSnapshot {
             events: vec![
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 1,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 1,
                     graph_generation: 1,
                     kind: GgmlGraphLifecycleEventKind::Created {
@@ -420,10 +420,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 2,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 1,
                     graph_generation: 1,
                     kind: GgmlGraphLifecycleEventKind::CaptureStateObserved {
@@ -435,10 +435,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 3,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 1,
                     graph_generation: 1,
                     kind: GgmlGraphLifecycleEventKind::ComputeStarted {
@@ -449,10 +449,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 4,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 1,
                     graph_generation: 1,
                     kind: GgmlGraphLifecycleEventKind::CaptureExecutableObserved {
@@ -461,10 +461,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 5,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 1,
                     graph_generation: 1,
                     kind: GgmlGraphLifecycleEventKind::Dropped,
@@ -646,10 +646,10 @@ mod tests {
         GgmlGraphLifecycleSnapshot {
             events: vec![
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 1,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 78,
                     graph_generation: 79,
                     kind: GgmlGraphLifecycleEventKind::Created {
@@ -657,10 +657,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 2,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 78,
                     graph_generation: 79,
                     kind: GgmlGraphLifecycleEventKind::CaptureStateObserved {
@@ -672,10 +672,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 3,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 78,
                     graph_generation: 79,
                     kind: GgmlGraphLifecycleEventKind::ComputeStarted {
@@ -686,10 +686,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 4,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 78,
                     graph_generation: 79,
                     kind: GgmlGraphLifecycleEventKind::CaptureStateObserved {
@@ -701,10 +701,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 5,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 78,
                     graph_generation: 79,
                     kind: GgmlGraphLifecycleEventKind::CaptureExecutableCreated {
@@ -713,10 +713,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 6,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 78,
                     graph_generation: 79,
                     kind: GgmlGraphLifecycleEventKind::ComputeCompleted {
@@ -725,10 +725,10 @@ mod tests {
                     },
                 },
                 GgmlGraphLifecycleEvent {
-                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.to_string(),
+                    schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
                     sequence: 7,
-                    provider: provider.to_string(),
-                    device: device.to_string(),
+                    provider: provider.into(),
+                    device: device.into(),
                     graph_instance: 78,
                     graph_generation: 79,
                     kind: GgmlGraphLifecycleEventKind::Dropped,

--- a/crates/openasr-core/src/short_audio_receipt.rs
+++ b/crates/openasr-core/src/short_audio_receipt.rs
@@ -2819,10 +2819,12 @@ mod tests {
         };
         super::validate_decode_diagnostics(&diagnostics)
             .expect("329 X-ASR device-head frames must fit the receipt bound");
-        assert!(
-            SHORT_AUDIO_RECEIPT_MAX_DECODE_STEPS >= 2048,
-            "longform CTC/RNN-T frames on the 69s fixture must stay in-bound"
-        );
+        const {
+            assert!(
+                SHORT_AUDIO_RECEIPT_MAX_DECODE_STEPS >= 2048,
+                "longform CTC/RNN-T frames on the 69s fixture must stay in-bound"
+            );
+        }
     }
 
     #[test]

--- a/crates/openasr-core/src/short_audio_receipt.rs
+++ b/crates/openasr-core/src/short_audio_receipt.rs
@@ -695,7 +695,7 @@ impl ShortAudioReceipt {
                 });
             }
             if lifecycle.events.iter().any(|event| {
-                event.schema != crate::ggml_runtime::GGML_GRAPH_LIFECYCLE_SCHEMA
+                event.schema.as_ref() != crate::ggml_runtime::GGML_GRAPH_LIFECYCLE_SCHEMA
                     || event.provider.is_empty()
                     || event.device.is_empty()
             }) {
@@ -719,7 +719,12 @@ impl ShortAudioReceipt {
                         if !lifecycle_event_proves_compute_route(&event.kind) {
                             continue;
                         }
-                        if event.provider != provider || event.device != stable_id {
+                        if !lifecycle_route_matches_attested_or_hybrid_host(
+                            event.provider.as_ref(),
+                            event.device.as_ref(),
+                            provider,
+                            stable_id,
+                        ) {
                             drifted.insert(format!("{}:{}", event.provider, event.device));
                         }
                     }
@@ -1664,6 +1669,23 @@ fn lifecycle_event_proves_compute_route(
     )
 }
 
+fn lifecycle_route_matches_attested_or_hybrid_host(
+    event_provider: &str,
+    event_device: &str,
+    attested_provider: &str,
+    attested_stable_id: &str,
+) -> bool {
+    if event_provider == attested_provider && event_device == attested_stable_id {
+        return true;
+    }
+    // Product Hybrid (Moonshine Vulkan default) keeps the decoder on CPU
+    // while the attested live backend is the encoder accelerator. CPU
+    // events are the host half of that plan, not a second GPU route.
+    attested_provider != crate::device::execution_route::ExecutionProvider::Cpu.as_str()
+        && event_provider == crate::device::execution_route::ExecutionProvider::Cpu.as_str()
+        && event_device == "CPU"
+}
+
 fn validate_actual_device_facts(
     field: &'static str,
     provider: &str,
@@ -1837,31 +1859,44 @@ fn observed_graph_built_for_compute(
             _ => {}
         }
     }
-    if origin_at_this_compute.is_none() || !started || !completed || !read {
-        let reason = match (
-            lifecycle.overflowed,
-            origin_at_this_compute,
-            started,
-            completed,
-            read,
-        ) {
-            (true, _, _, _, _) => {
-                "native graph lifecycle overflowed before this compute could be bound"
-            }
-            (_, None, _, _, _) => {
-                "native compute witness has no created or existing-graph origin before compute_started"
-            }
-            (_, _, false, _, _) => "native compute witness has no matching compute_started event",
-            (_, _, _, false, _) => "native compute witness has no matching compute_completed event",
-            _ => "native compute witness has no matching output_read event",
-        };
-        return Err(ShortAudioReceiptError::InvalidEvidenceField {
-            field: "decode_diagnostics.steps.graph_rebuilt",
-            actual: reason.to_string(),
-        });
+    if origin_at_this_compute.is_some() && started {
+        // ComputeCompleted/OutputRead may be omitted on the capture-unsupported
+        // hot path. Origin plus ComputeStarted is enough to bind graph_rebuilt.
+        return Ok(origin_at_this_compute == Some(true)
+            && first_compute_at_this_compute == Some(compute_sequence));
     }
-    Ok(origin_at_this_compute == Some(true)
-        && first_compute_at_this_compute == Some(compute_sequence))
+    // HIP/Vulkan capture-unsupported graphs stop appending per-compute events
+    // after the first few sequences so Zipformer/longform receipts do not
+    // overflow. Later token steps still consume the same persistent graph:
+    // Created/ExistingGraphObserved plus an earlier attested compute is
+    // enough to project graph_rebuilt=false.
+    if !lifecycle.overflowed
+        && last_origin_created.is_some()
+        && first_compute_after_origin.is_some_and(|first| compute_sequence > first)
+    {
+        return Ok(false);
+    }
+    let reason = match (
+        lifecycle.overflowed,
+        origin_at_this_compute,
+        started,
+        completed,
+        read,
+    ) {
+        (true, _, _, _, _) => {
+            "native graph lifecycle overflowed before this compute could be bound"
+        }
+        (_, None, _, _, _) => {
+            "native compute witness has no created or existing-graph origin before compute_started"
+        }
+        (_, _, false, _, _) => "native compute witness has no matching compute_started event",
+        (_, _, _, false, _) => "native compute witness has no matching compute_completed event",
+        _ => "native compute witness has no matching output_read event",
+    };
+    Err(ShortAudioReceiptError::InvalidEvidenceField {
+        field: "decode_diagnostics.steps.graph_rebuilt",
+        actual: reason.to_string(),
+    })
 }
 
 fn validate_decode_diagnostics(
@@ -2483,6 +2518,67 @@ mod tests {
     }
 
     #[test]
+    fn hybrid_cpu_decoder_lifecycle_is_not_route_drift_from_vulkan_encoder() {
+        use crate::ggml_runtime::{
+            GGML_GRAPH_LIFECYCLE_SCHEMA, GgmlGraphLifecycleEvent, GgmlGraphLifecycleEventKind,
+            GgmlGraphLifecycleSnapshot,
+        };
+        let compute = |provider: &str, device: &str, sequence: u64| GgmlGraphLifecycleEvent {
+            schema: GGML_GRAPH_LIFECYCLE_SCHEMA.into(),
+            sequence,
+            provider: provider.into(),
+            device: device.into(),
+            graph_instance: 1,
+            graph_generation: 1,
+            kind: GgmlGraphLifecycleEventKind::ComputeStarted {
+                compute_sequence: sequence,
+                prepare_generation: None,
+                input_generation_consumed: None,
+                capture_executable_generation: None,
+            },
+        };
+        let mut receipt = sample_receipt();
+        receipt.placement = "vulkan".to_string();
+        receipt.actual_provider = Some("vulkan".to_string());
+        receipt.actual_stable_device_id = Some("Vulkan0".to_string());
+        receipt.actual_device = Some(GgmlActualDeviceFacts {
+            device_type: "gpu".to_string(),
+            name: "Vulkan0".to_string(),
+            description: "test vulkan device".to_string(),
+            provider_device_id: Some("0000:03:00.0".to_string()),
+            pci_vendor_id: Some(0x1002),
+        });
+        receipt.graph_lifecycle = Some(GgmlGraphLifecycleSnapshot {
+            events: vec![compute("vulkan", "Vulkan0", 1), compute("cpu", "CPU", 2)],
+            overflowed: false,
+        });
+        ShortAudioReceipt::try_new(receipt).expect("hybrid CPU decoder events are the host half");
+
+        let mut drifted = sample_receipt();
+        drifted.placement = "vulkan".to_string();
+        drifted.actual_provider = Some("vulkan".to_string());
+        drifted.actual_stable_device_id = Some("Vulkan0".to_string());
+        drifted.actual_device = Some(GgmlActualDeviceFacts {
+            device_type: "gpu".to_string(),
+            name: "Vulkan0".to_string(),
+            description: "test vulkan device".to_string(),
+            provider_device_id: Some("0000:03:00.0".to_string()),
+            pci_vendor_id: Some(0x1002),
+        });
+        drifted.graph_lifecycle = Some(GgmlGraphLifecycleSnapshot {
+            events: vec![compute("cuda", "CUDA0", 1)],
+            overflowed: false,
+        });
+        assert!(matches!(
+            ShortAudioReceipt::try_new(drifted),
+            Err(ShortAudioReceiptError::InvalidEvidenceField {
+                field: "actual_device",
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn actual_device_facts_are_bounded_and_route_consistent() {
         let mut receipt = sample_receipt();
         receipt.actual_provider = Some("cpu".to_string());
@@ -2704,6 +2800,32 @@ mod tests {
     }
 
     #[test]
+    fn decode_step_bound_admits_xasr_device_head_frame_count() {
+        let diagnostics = crate::ggml_runtime::ShortAudioReceiptDecodeDiagnostics {
+            output_plan: crate::ggml_runtime::ShortAudioReceiptOutputPlan::FullLogits,
+            reuse_mode: crate::ggml_runtime::ShortAudioReceiptReuseMode::ReusableGraph,
+            capability_evidence_revision: Some(2),
+            steps: (0..329)
+                .map(|step| crate::ggml_runtime::ShortAudioReceiptDecodeStep {
+                    step,
+                    token_id: Some(0),
+                    logits_sha256: None,
+                    top2_margin: None,
+                    graph_rebuilt: false,
+                })
+                .collect(),
+            first_divergence: None,
+            encoder_decoder_splits: Vec::new(),
+        };
+        super::validate_decode_diagnostics(&diagnostics)
+            .expect("329 X-ASR device-head frames must fit the receipt bound");
+        assert!(
+            SHORT_AUDIO_RECEIPT_MAX_DECODE_STEPS >= 2048,
+            "longform CTC/RNN-T frames on the 69s fixture must stay in-bound"
+        );
+    }
+
+    #[test]
     fn shipped_emitter_projects_observed_created_and_existing_graphs() {
         let resolved = cpu_resolved_runtime();
         let first = crate::NativeExecutionReceiptCollector::new();
@@ -2814,6 +2936,85 @@ mod tests {
         let diagnostics = decode_diagnostics_from_shipped_runtime(Some(&resolved), Some(&snapshot))
             .expect("compute binds to the origin in effect at that compute");
         assert!(!diagnostics.steps[0].graph_rebuilt);
+    }
+
+    #[test]
+    fn throttled_hot_path_computes_project_as_reused_not_missing_origin() {
+        use std::sync::Arc;
+
+        use crate::ggml_runtime::{
+            GgmlGraphLifecycleEvent, GgmlGraphLifecycleEventKind, GgmlGraphLifecycleSnapshot,
+            GgmlSelectionEvidenceRef,
+        };
+
+        let lifecycle = GgmlGraphLifecycleSnapshot {
+            events: vec![
+                GgmlGraphLifecycleEvent {
+                    schema: Arc::from("openasr.graph-lifecycle.v1"),
+                    sequence: 1,
+                    provider: Arc::from("hip"),
+                    device: Arc::from("HIP0"),
+                    graph_instance: 11,
+                    graph_generation: 22,
+                    kind: GgmlGraphLifecycleEventKind::ExistingGraphObserved {
+                        scheduler_enabled: false,
+                        prepare_generation: None,
+                    },
+                },
+                GgmlGraphLifecycleEvent {
+                    schema: Arc::from("openasr.graph-lifecycle.v1"),
+                    sequence: 2,
+                    provider: Arc::from("hip"),
+                    device: Arc::from("HIP0"),
+                    graph_instance: 11,
+                    graph_generation: 22,
+                    kind: GgmlGraphLifecycleEventKind::ComputeStarted {
+                        compute_sequence: 1,
+                        prepare_generation: None,
+                        input_generation_consumed: None,
+                        capture_executable_generation: None,
+                    },
+                },
+                GgmlGraphLifecycleEvent {
+                    schema: Arc::from("openasr.graph-lifecycle.v1"),
+                    sequence: 3,
+                    provider: Arc::from("hip"),
+                    device: Arc::from("HIP0"),
+                    graph_instance: 11,
+                    graph_generation: 22,
+                    kind: GgmlGraphLifecycleEventKind::ComputeCompleted {
+                        compute_sequence: 1,
+                        output_generation: 7,
+                    },
+                },
+                GgmlGraphLifecycleEvent {
+                    schema: Arc::from("openasr.graph-lifecycle.v1"),
+                    sequence: 4,
+                    provider: Arc::from("hip"),
+                    device: Arc::from("HIP0"),
+                    graph_instance: 11,
+                    graph_generation: 22,
+                    kind: GgmlGraphLifecycleEventKind::OutputRead {
+                        compute_sequence: 1,
+                        output_generation_consumed: 7,
+                        bytes: 16,
+                    },
+                },
+            ],
+            overflowed: false,
+        };
+        let step = crate::NativeExecutionTokenStep {
+            step_index: 8,
+            token_id: 3,
+            is_eot: false,
+            top2_margin: None,
+            logits_sha256: None,
+            compute: Some(GgmlSelectionEvidenceRef::from_parts_for_test(11, 22, 8, 99)),
+        };
+        assert!(
+            !super::observed_graph_built_for_compute(&step, Some(&lifecycle))
+                .expect("later HIP/Vulkan token steps must bind as reuse after hot-path throttle")
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/short_audio_receipt.rs
+++ b/crates/openasr-core/src/short_audio_receipt.rs
@@ -2908,7 +2908,8 @@ mod tests {
         graph
             .compute_output_f32_with_evidence(input, 3)
             .expect("created-graph compute");
-        lifecycle.begin_observation_scope();
+        collector.finish_candidate_attempt(true);
+        collector.begin_candidate_attempt();
         graph
             .set_f32_slice(input, &[3.0, 1.0, 2.0], "receipt_graph_input")
             .expect("re-attached input upload");

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -131,6 +131,11 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   cards or falling back to CPU. Unavailable coarse `accelerated` targets still
   fail closed. Physical PCI keys are normalized (trim + lower-case) only; full
   BDF grammar validation is a follow-up.
+- On Windows ReBAR discrete GPUs, Vulkan Peak Working Set can exceed the HIP
+  and CPU figures even when DeviceLocal buffers are not mapped. ReBAR types
+  are DeviceLocal|HostVisible, so Windows still counts that VRAM toward the
+  process working set. This is a measured PeakWS tax, not a host leak; HIP
+  does not pay it the same way.
 - No public reproducible real-backend benchmark or long-audio stability evidence
   is published. The performance harness, regression gates, and competitive
   comparisons are internal (see [Performance](../perf/PERFORMANCE.md)); no claim of


### PR DESCRIPTION
## Summary

Share one Exact CUDA/HIP/Vulkan owner across encoder and decoder. Reserve native graph capture for persistent sessions without changing the hashed host ABI. Pin vendored openasr-ggml after the GPU residency/capture PR.

## Why

Encoder and decoder were bouncing across thread-local GPU owners, so weights and KV did not stay on one ggml actor. One-shot `start_graph` paths still looked capture-capable to HIP and fail-closed or instantiated throwaway graphs. Vulkan ReBAR PeakWS is documented as a known tax, not a leak.

## Changes

- `exact_discrete_gpu_unified_owner_is_proven` covers Exact CUDA/HIP/Vulkan. Moonshine, Qwen, Whisper, SenseVoice, FireRed, FunASR, X-ASR, and MOSS use it.
- Persistent sessions set `capture_allowed` via a local extern; `start_graph` stays false. Observation skips capture when the flag is off.
- Host does not set `GGML_VK_DISABLE_HOST_VISIBLE_VIDMEM` (ReBAR has no DeviceLocal-only heap). Default-disable SPIR-V float-controls patching.
- Admission quotes look up the memory API by device, without constructing a live backend context.
- CHANGELOG + KNOWN_LIMITATIONS: Vulkan PeakWS on ReBAR Windows GPUs.

Depends on https://github.com/QuintinShaw/openasr-ggml/pull/17 (pin `8db9ff9d`). If that PR is squash-merged, retarget the submodule pin to the squash SHA before merging this PR.

## Tests run

- [x] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings` (CI)
- [ ] `cargo nextest run --workspace` (CI)
- [ ] `cargo test --workspace --doc` (CI)
- [ ] `cargo deny check` (CI)
- [x] `cargo test -p openasr-core --lib native_capture_is_reserved_for_persistent_sessions`
- [x] `cargo test -p openasr-core --lib exact_discrete_gpu_unified_owner`
- [x] `cargo test -p openasr-core --lib vulkan_device_local_buffer_policy`

## Manual smoke checks

Windows RX 9060 XT: 216-cell CPU/HIP/Vulkan x short/long x 9 families vs packaged v0.1.36. Vulkan RSS above v0.1.36 accepted as ReBAR PeakWS tax. Matched-compute short-reuse RTF remaining 5-20% on Qwen HIP and X-ASR Vulkan accepted as decode-contract tax, not a family patch.

## Model-family changes (when applicable)

- [x] Shared GPU-owner / capture wiring only; no new family and no catalog/registry edits.
- [x] Real-weight quality/performance claims are limited to the Windows matrix above; they are not a published WER guarantee.

## Docs updated

- [x] CHANGELOG Unreleased
- [x] KNOWN_LIMITATIONS (Vulkan ReBAR PeakWS)
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No catalog epoch / Authenticode / CUDA / notary / production plugin publish.
- Does not require Vulkan RSS < v0.1.36.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES - implementation assistance; this description is submitted by the human owner.
