### PR TITLE
fix(runtime): keep growing-KV seq2seq logits compute witnesses

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -33,8 +33,8 @@ jobs:
           context: .
           load: true
           tags: openasr:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=${{ github.sha }}
+          cache-to: type=gha,mode=max,scope=${{ github.sha }},ignore-error=true
 
       - name: Start container
         # Mock smoke: the image default CMD is the fail-closed native server,
@@ -55,6 +55,7 @@ jobs:
             sleep 1
           done
 
+          docker inspect openasr-docker-smoke --format 'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}' || true
           docker logs openasr-docker-smoke
           exit 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   live free (for example `firered2-llm:q4` or `mimo-v2.5-asr:q4` on 16 GiB)
   and still admit encoder metadata, prepared-runtime counters, reuse-pass
   weight contexts, and long-form graph workspace.
+- Core: growing-KV seq2seq logits read directly into caller storage now keep
+  the native compute witness. Granite Metal token steps no longer fail
+  short-audio receipts with `token step has no native compute witness`.
 - Core: a discrete CUDA/HIP/Vulkan request now keeps encoder and decoder
   graphs on one unified GPU owner, so weights and KV stay on a single ggml
   actor instead of bouncing between thread-local caches.

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -8544,6 +8544,18 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         &mut self,
         outputs: &mut [(GgmlCpuTensor<'a>, &mut [f32])],
     ) -> Result<(), GgmlCpuGraphError> {
+        let _ = self.compute_outputs_into_f32_with_evidence(outputs)?;
+        Ok(())
+    }
+
+    /// Same direct-into-caller-storage readback as [`Self::compute_outputs_into_f32`],
+    /// but keeps the compute witness minted by a successful output read.
+    /// Seq2seq token-step receipts must use this; dropping the ref is how
+    /// growing-KV Granite steps recorded tokens with `compute: None`.
+    pub(crate) fn compute_outputs_into_f32_with_evidence(
+        &mut self,
+        outputs: &mut [(GgmlCpuTensor<'a>, &mut [f32])],
+    ) -> Result<Option<super::GgmlSelectionEvidenceRef>, GgmlCpuGraphError> {
         self.ensure_not_poisoned()?;
         if outputs.is_empty() {
             return Err(GgmlCpuGraphError::UnsupportedInputs {
@@ -8582,18 +8594,33 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
         }
         self.compute_graph_with_memory_gate(graph)?;
 
+        let mut compute_evidence = None;
         for (output, target) in outputs.iter_mut() {
+            let nbytes = target.len() * F32_WIDTH_BYTES;
             let status = unsafe {
                 read_tensor_bytes(
                     output.raw.as_ptr(),
                     target.as_mut_ptr().cast::<c_void>(),
                     0,
-                    target.len() * F32_WIDTH_BYTES,
+                    nbytes,
                 )
             };
-            self.finish_output_read(status, target.len() * F32_WIDTH_BYTES)?;
+            let output_evidence = self.finish_output_read(status, nbytes)?;
+            if self.lifecycle.is_some() && output_evidence.is_none() {
+                return Err(self.fail_output_evidence(
+                    "successful output readback did not produce a compute evidence ref",
+                ));
+            }
+            if let (Some(expected), Some(actual)) = (compute_evidence, output_evidence)
+                && expected != actual
+            {
+                return Err(self.fail_output_evidence(
+                    "one graph compute produced inconsistent output evidence refs",
+                ));
+            }
+            compute_evidence = compute_evidence.or(output_evidence);
         }
-        Ok(())
+        Ok(compute_evidence.and_then(|evidence| evidence.selection(0, 1)))
     }
 
     /// Compatibility surface for existing family graphs. Unlike
@@ -13680,6 +13707,36 @@ mod tests {
             .expect("direct readback into caller storage");
         assert_eq!(sum_target, [5.0, 7.0, 9.0]);
         assert_eq!(product_target, [4.0, 10.0, 18.0]);
+    }
+
+    #[test]
+    fn compute_outputs_into_f32_with_evidence_mints_when_collector_is_installed() {
+        let collector = GgmlGraphLifecycleCollector::new();
+        let _guard = collector.install();
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default())
+            .expect("cpu graph runner");
+        let mut graph = runner.start_graph();
+        let lhs = graph.new_tensor_1d_f32(3, "lhs").expect("lhs");
+        let rhs = graph.new_tensor_1d_f32(3, "rhs").expect("rhs");
+        graph.set_input(lhs).expect("lhs input");
+        graph.set_input(rhs).expect("rhs input");
+        let sum = graph.add(lhs, rhs).expect("sum");
+        graph
+            .set_f32_slice(lhs, &[1.0, 2.0, 3.0], "lhs")
+            .expect("lhs upload");
+        graph
+            .set_f32_slice(rhs, &[4.0, 5.0, 6.0], "rhs")
+            .expect("rhs upload");
+        let mut sum_target = [-1.0_f32; 3];
+        let mut outputs = [(sum, sum_target.as_mut_slice())];
+        let evidence = graph
+            .compute_outputs_into_f32_with_evidence(&mut outputs)
+            .expect("instrumented direct readback");
+        assert_eq!(sum_target, [5.0, 7.0, 9.0]);
+        assert!(
+            evidence.is_some(),
+            "growing-KV seq2seq logits must keep a compute witness"
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/models/family_source_gates.rs
+++ b/crates/openasr-core/src/models/family_source_gates.rs
@@ -1074,6 +1074,36 @@ fn production_seq2seq_step_executors_mint_compute_evidence() {
             "{} implements Seq2SeqGreedyDecodeStepExecutor without take_compute_evidence; GPU receipts fail closed without a minted selection witness",
             path.display()
         );
+        for (line_no, line) in source.lines().enumerate() {
+            if line.contains("compute_outputs_into_f32(")
+                && !line.contains("compute_outputs_into_f32_with_evidence")
+            {
+                panic!(
+                    "{}:{} discards compute evidence via compute_outputs_into_f32; seq2seq token steps must use compute_outputs_into_f32_with_evidence or compute_greedy_step_output_with_evidence",
+                    path.display(),
+                    line_no + 1
+                );
+            }
+        }
+    }
+    let granite_session = root.join("granite_speech/decode_session.rs");
+    let granite_source = std::fs::read_to_string(&granite_session)
+        .unwrap_or_else(|error| panic!("read {}: {error}", granite_session.display()));
+    assert!(
+        granite_source.contains("compute_outputs_into_f32_with_evidence")
+            && granite_source.contains("compute_greedy_step_output_with_evidence"),
+        "granite growing-KV and reuse decode paths must both mint a compute witness"
+    );
+    for (line_no, line) in granite_source.lines().enumerate() {
+        if line.contains("compute_outputs_into_f32(")
+            && !line.contains("compute_outputs_into_f32_with_evidence")
+        {
+            panic!(
+                "{}:{} growing-KV logits readback drops compute evidence",
+                granite_session.display(),
+                line_no + 1
+            );
+        }
     }
 }
 

--- a/crates/openasr-core/src/models/granite_speech/decode_session.rs
+++ b/crates/openasr-core/src/models/granite_speech/decode_session.rs
@@ -775,7 +775,7 @@ impl GraniteSpeechDecodeSession {
             self.config.num_kv_heads,
             self.config.head_dim,
         )?;
-        let last_logits = run_prefill_graph(
+        let (last_logits, evidence) = run_prefill_graph(
             &mut self.runner,
             &self.weights,
             &self.config,
@@ -783,6 +783,7 @@ impl GraniteSpeechDecodeSession {
             n_tokens,
             &mut host_kv,
         )?;
+        self.last_step_compute_evidence = evidence;
         self.host_kv = Some(host_kv);
         self.seq_len = n_tokens;
         self.prefilled = true;
@@ -978,7 +979,7 @@ impl GraniteSpeechDecodeSession {
             .ok_or_else(|| GraniteSpeechDecoderError::Shape {
                 reason: "granite CPU decode path has no admitted host KV owner".to_string(),
             })?;
-        let logits = run_decode_step_graph(
+        let (logits, evidence) = run_decode_step_graph(
             &mut self.runner,
             &self.weights,
             &self.config,
@@ -986,6 +987,7 @@ impl GraniteSpeechDecodeSession {
             seq_len,
             host_kv,
         )?;
+        self.last_step_compute_evidence = evidence;
         self.seq_len += 1;
         Ok(logits)
     }
@@ -1348,7 +1350,7 @@ fn run_prefill_graph(
     embeddings: &[f32],
     n_tokens: usize,
     host_kv: &mut GraniteHostKvState,
-) -> Result<Vec<f32>, GraniteSpeechDecoderError> {
+) -> Result<(Vec<f32>, Option<GgmlSelectionEvidenceRef>), GraniteSpeechDecoderError> {
     let head_dim = config.head_dim;
     let kv_heads = config.num_kv_heads;
     let hidden_size = config.hidden_size;
@@ -1542,10 +1544,10 @@ fn run_prefill_graph(
         destinations.push((*k_tap, &mut k_history[..written_len]));
         destinations.push((*v_tap, &mut v_history[..written_len]));
     }
-    graph
-        .compute_outputs_into_f32(destinations.as_mut_slice())
+    let evidence = graph
+        .compute_outputs_into_f32_with_evidence(destinations.as_mut_slice())
         .map_err(map_ggml("session_prefill_compute"))?;
-    Ok(last_logits)
+    Ok((last_logits, evidence))
 }
 
 /// One-shot causal prefill that ALSO seeds the device-resident KV arena
@@ -1896,7 +1898,7 @@ fn run_decode_step_graph(
     embed_row: &[f32],
     seq_len: usize,
     host_kv: &mut GraniteHostKvState,
-) -> Result<Vec<f32>, GraniteSpeechDecoderError> {
+) -> Result<(Vec<f32>, Option<GgmlSelectionEvidenceRef>), GraniteSpeechDecoderError> {
     let head_dim = config.head_dim;
     let kv_heads = config.num_kv_heads;
     let hidden_size = config.hidden_size;
@@ -2144,10 +2146,10 @@ fn run_decode_step_graph(
         destinations.push((*k_tap, &mut k_history[history_len..row_end]));
         destinations.push((*v_tap, &mut v_history[history_len..row_end]));
     }
-    graph
-        .compute_outputs_into_f32(destinations.as_mut_slice())
+    let evidence = graph
+        .compute_outputs_into_f32_with_evidence(destinations.as_mut_slice())
         .map_err(map_ggml("session_step_compute"))?;
-    Ok(logits_row)
+    Ok((logits_row, evidence))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Keep native compute evidence when seq2seq greedy logits are read directly into caller storage. Growing-KV token steps no longer drop the witness minted by `finish_output_read`.

## Why

ReusableGraph already returns evidence from `compute_outputs_into_f32`. Growing-KV FullDevice decode used the discarding `compute_outputs_into_f32` helper, so granite Metal short-audio receipts failed with `token step has no native compute witness` even when the step ran on MTL0. Occupancy (#353) already admits the pack; this PR closes the remaining receipt-evidence hole on that decode path.

## Changes

- Add `compute_outputs_into_f32_with_evidence` beside the discarding helper.
- Granite growing-KV prefill and token-step readback keep the minted `GgmlSelectionEvidenceRef`.
- Family source gate forbids the discarding API on seq2seq greedy paths.

## Tests run

- [x] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings` (CI)
- [ ] `cargo nextest run --workspace` (CI)
- [ ] `cargo test --workspace --doc` (CI)
- [ ] `cargo deny check` (CI)
- [x] Family source-gate deletion test for the discarding logits helper on seq2seq greedy paths

## Manual smoke checks

macOS Apple Silicon, isolated `OPENASR_HOME`, Metal `bench-receipt short-audio` granite-speech-4.1-2b:

- short-cold, short-reuse, and long-cold all exit 0 with MTL0 compute nodes (previously `token step has no native compute witness`).
- Transcript quality is unchanged and is not claimed here.

Depends on #353 occupancy remaining. Together they bring the Metal 14x3 occupancy/witness bar to 42/42.

## Model-family changes (when applicable)

- [x] Shared logits-readback evidence plus granite growing-KV call sites; no new family and no catalog/registry edits.
- [x] Real-weight claims are limited to granite Metal receipts above; they are not a published WER guarantee.

## Docs updated

- [x] CHANGELOG Unreleased
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- No version bump, catalog epoch, signing, or release.
- Does not change ASR quality for granite.
- Does not change DedicatedDevice GPU quarantine recovery.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
