### PR TITLE
fix(core): decode Windows HE-AAC through Media Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Windows: HE-AAC (and other formats the in-process decoder cannot handle)
+  fall back to Media Foundation to produce 16 kHz mono PCM16 WAV, the same
+  role `/usr/bin/afconvert` plays on macOS. AAC-LC and bare ADTS stay
+  in-process. If system decoding also fails, the error says so and points at
+  ffmpeg.
 - HIP decode reuse no longer recaptures every token after the first stable
   capture: uid reuse keys on node count, op, type, and shape, and ignores
   input-pointer churn that HIP writes on each launch.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,6 +1686,7 @@ dependencies = [
  "toml",
  "ts-rs",
  "unicode-general-category",
+ "windows",
  "windows-sys 0.61.2",
  "zip",
 ]

--- a/crates/openasr-core/Cargo.toml
+++ b/crates/openasr-core/Cargo.toml
@@ -104,6 +104,13 @@ objc.workspace = true
 # crashed/killed download's stale lock is reclaimed immediately instead of waiting
 # out the 6h mtime timeout. The unix path uses libc::kill; this is its Windows peer.
 windows-sys.workspace = true
+# System AAC (including HE-AAC SBR/PS) via Media Foundation. Same role as
+# macOS `/usr/bin/afconvert`: no FDK, not linked into the public ABI.
+windows = { version = "0.62", default-features = false, features = [
+    "Win32_Foundation",
+    "Win32_Media_MediaFoundation",
+    "Win32_System_Com",
+] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/openasr-core/src/audio.rs
+++ b/crates/openasr-core/src/audio.rs
@@ -6,6 +6,8 @@ mod probe;
 mod symphonia_decode;
 mod types;
 mod validation;
+#[cfg(windows)]
+mod windows_mf;
 
 use std::path::Path;
 

--- a/crates/openasr-core/src/audio/prepare.rs
+++ b/crates/openasr-core/src/audio/prepare.rs
@@ -102,27 +102,7 @@ pub(crate) fn prepare_external_input(
         .tempdir()
         .map_err(|source| AudioPreparationError::TempDir { source })?;
     let prepared_path = temp_dir.path().join("prepared.wav");
-    let output = tool
-        .build_command(&info.path, &prepared_path)
-        .output()
-        .map_err(|source| AudioPreparationError::ConversionSpawn {
-            tool: tool.label().to_string(),
-            path: tool.path().clone(),
-            source,
-        })?;
-
-    if !output.status.success() {
-        return Err(AudioPreparationError::ConversionFailed {
-            backend: options.backend,
-            tool: tool.label().to_string(),
-            status: output.status.code().map_or_else(
-                || "terminated by signal".to_string(),
-                |code| code.to_string(),
-            ),
-            stderr: format_stderr_suffix(tool.label(), &String::from_utf8_lossy(&output.stderr)),
-            codec_note: codec_note(&diagnostic),
-        });
-    }
+    tool.convert(&info.path, &prepared_path, options.backend, &diagnostic)?;
 
     match fs::metadata(&prepared_path) {
         Ok(metadata) if metadata.is_file() => Ok(PreparedAudioInput {
@@ -232,14 +212,15 @@ impl From<Option<String>> for Diagnostic {
     }
 }
 
-/// An external tool used to convert a non-WAV input into a 16 kHz mono PCM16
-/// WAV. macOS ships `/usr/bin/afconvert` on every install (no Homebrew
-/// required), so it is used as a fallback conversion path when ffmpeg is not
-/// configured and cannot be found on PATH.
+/// An external or system converter used to produce a 16 kHz mono PCM16 WAV
+/// when the in-process decoder cannot. macOS uses `/usr/bin/afconvert`;
+/// Windows uses Media Foundation (same role, no FDK, no bundled ffmpeg).
 enum ConversionTool {
     Ffmpeg(PathBuf),
     #[cfg(target_os = "macos")]
     Afconvert(PathBuf),
+    #[cfg(windows)]
+    MediaFoundation,
 }
 
 impl ConversionTool {
@@ -248,14 +229,70 @@ impl ConversionTool {
             Self::Ffmpeg(_) => "ffmpeg",
             #[cfg(target_os = "macos")]
             Self::Afconvert(_) => "afconvert",
+            #[cfg(windows)]
+            Self::MediaFoundation => "mediafoundation",
         }
     }
 
-    fn path(&self) -> &PathBuf {
+    fn convert(
+        &self,
+        input: &std::path::Path,
+        output: &std::path::Path,
+        backend: BackendKind,
+        diagnostic: &Diagnostic,
+    ) -> Result<(), AudioPreparationError> {
+        match self {
+            #[cfg(windows)]
+            Self::MediaFoundation => {
+                crate::audio::windows_mf::convert_to_wav16k_mono(input, output).map_err(
+                    |message| AudioPreparationError::ConversionFailed {
+                        backend,
+                        tool: self.label().to_string(),
+                        status: "failed".to_string(),
+                        stderr: format!(
+                            "\nmediafoundation: {message}. Windows system decoding failed; install ffmpeg and add it to PATH, pass --ffmpeg-bin, set OPENASR_FFMPEG_BIN, or run `openasr config set media.ffmpeg_bin`."
+                        ),
+                        codec_note: codec_note(diagnostic),
+                    },
+                )
+            }
+            _ => {
+                let output_status = self
+                    .build_command(input, output)
+                    .output()
+                    .map_err(|source| AudioPreparationError::ConversionSpawn {
+                        tool: self.label().to_string(),
+                        path: self.spawn_path().clone(),
+                        source,
+                    })?;
+                if output_status.status.success() {
+                    Ok(())
+                } else {
+                    Err(AudioPreparationError::ConversionFailed {
+                        backend,
+                        tool: self.label().to_string(),
+                        status: output_status.status.code().map_or_else(
+                            || "terminated by signal".to_string(),
+                            |code| code.to_string(),
+                        ),
+                        stderr: format_stderr_suffix(
+                            self.label(),
+                            &String::from_utf8_lossy(&output_status.stderr),
+                        ),
+                        codec_note: codec_note(diagnostic),
+                    })
+                }
+            }
+        }
+    }
+
+    fn spawn_path(&self) -> &PathBuf {
         match self {
             Self::Ffmpeg(path) => path,
             #[cfg(target_os = "macos")]
             Self::Afconvert(path) => path,
+            #[cfg(windows)]
+            Self::MediaFoundation => unreachable!("Media Foundation does not spawn a process"),
         }
     }
 
@@ -299,6 +336,8 @@ impl ConversionTool {
                     .arg(output);
                 command
             }
+            #[cfg(windows)]
+            Self::MediaFoundation => unreachable!("Media Foundation does not spawn a process"),
         }
     }
 }
@@ -310,7 +349,8 @@ const MACOS_AFCONVERT_PATH: &str = "/usr/bin/afconvert";
 
 fn resolve_conversion_tool(
     options: &AudioPreparationOptions,
-    diagnostic: &Diagnostic,
+    #[cfg(not(windows))] diagnostic: &Diagnostic,
+    #[cfg(windows)] _diagnostic: &Diagnostic,
 ) -> Result<ConversionTool, AudioPreparationError> {
     if let Some(path) = options.ffmpeg_bin.clone() {
         if path.components().count() == 1 {
@@ -330,6 +370,12 @@ fn resolve_conversion_tool(
         }
     }
 
+    #[cfg(windows)]
+    {
+        Ok(ConversionTool::MediaFoundation)
+    }
+
+    #[cfg(not(windows))]
     Err(AudioPreparationError::MissingFfmpeg {
         backend: options.backend,
         hint: missing_converter_hint(diagnostic),
@@ -386,6 +432,7 @@ fn codec_note(diagnostic: &Diagnostic) -> String {
     }
 }
 
+#[cfg(not(windows))]
 fn missing_converter_hint(diagnostic: &Diagnostic) -> String {
     let codec_phrase = match diagnostic {
         // See `codec_note`'s matching arms: a fallback carrying the "Opus"

--- a/crates/openasr-core/src/audio/symphonia_decode.rs
+++ b/crates/openasr-core/src/audio/symphonia_decode.rs
@@ -416,19 +416,120 @@ fn decode_opus_track(
 /// Detects explicit-signaling HE-AAC (SBR / PS) from the ISO 14496-3
 /// `AudioSpecificConfig` so callers can fall back to an external converter
 /// instead of silently producing bandwidth-limited audio: the plain AAC-LC
-/// decoder these features enable ignores the SBR high-band extension. This
-/// only recognizes *explicit* backward-compatible signaling (object type 5 =
-/// SBR, 29 = PS), which is how mainstream m4a/mp4 encoders signal HE-AAC;
-/// implicit signaling in raw ADTS streams is not detected here.
+/// decoder these features enable ignores the SBR high-band extension.
+///
+/// Two explicit forms are recognized:
+/// - Hierarchical: the ASC itself starts with object type 5 (SBR) or 29 (PS).
+/// - Backward-compatible: the ASC starts as AAC-LC (object type 2) and then
+///   carries `syncExtensionType` `0x2B7` with `sbrPresentFlag = 1` (and
+///   optionally `0x548` for PS). ffmpeg's HE-AAC m4a encoder writes this
+///   form; AAC-LC often writes the same extension with `sbrPresentFlag = 0`
+///   and must stay in-process.
+///
+/// Implicit SBR in raw ADTS (no ASC extra data) is not detected here.
+/// Neither are unusual ASCs that need `program_config_element()`
+/// (`channelConfiguration == 0`) or extra GASpecificConfig fields
+/// (`extensionFlag == 1`, AOT 6 `layerNr`): those stay on the in-process
+/// AAC-LC path, same class as implicit ADTS SBR.
 fn is_unsupported_aac_extension(codec: &CodecType, extra_data: &[u8]) -> bool {
-    if *codec != CODEC_TYPE_AAC {
-        return false;
-    }
-    let Some(&first_byte) = extra_data.first() else {
+    *codec == CODEC_TYPE_AAC && asc_signals_he_aac(extra_data)
+}
+
+/// ISO 14496-3 `syncExtensionType` for SBR (11 bits).
+const SBR_SYNC_EXTENSION: u32 = 0x2B7;
+/// ISO 14496-3 `syncExtensionType` for Parametric Stereo (11 bits).
+const PS_SYNC_EXTENSION: u32 = 0x548;
+
+fn asc_signals_he_aac(extra_data: &[u8]) -> bool {
+    let mut bits = BitReader::new(extra_data);
+    let Some(audio_object_type) = bits.read_audio_object_type() else {
         return false;
     };
-    let audio_object_type = first_byte >> 3;
-    matches!(audio_object_type, 5 | 29)
+    if matches!(audio_object_type, 5 | 29) {
+        return true;
+    }
+
+    let Some(sampling_frequency_index) = bits.read(4) else {
+        return false;
+    };
+    if sampling_frequency_index == 15 && bits.read(24).is_none() {
+        return false;
+    }
+    if bits.read(4).is_none() {
+        return false;
+    }
+
+    // GASpecificConfig for AAC-LC and the other MPEG-4 General Audio types
+    // that can carry a trailing SBR/PS extension.
+    if matches!(audio_object_type, 1 | 2 | 3 | 4 | 6 | 7) {
+        if bits.read(1).is_none() {
+            return false;
+        }
+        match bits.read(1) {
+            Some(1) if bits.read(14).is_none() => return false,
+            Some(_) => {}
+            None => return false,
+        }
+        if bits.read(1).is_none() {
+            return false;
+        }
+    }
+
+    let Some(sync) = bits.read(11) else {
+        return false;
+    };
+    if sync == SBR_SYNC_EXTENSION {
+        let Some(extension_aot) = bits.read_audio_object_type() else {
+            return false;
+        };
+        if extension_aot == 29 {
+            return true;
+        }
+        if extension_aot == 5 {
+            return bits.read(1) == Some(1);
+        }
+        return false;
+    }
+    sync == PS_SYNC_EXTENSION && bits.read(1) == Some(1)
+}
+
+struct BitReader<'a> {
+    data: &'a [u8],
+    bit: usize,
+}
+
+impl<'a> BitReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, bit: 0 }
+    }
+
+    fn remaining_bits(&self) -> usize {
+        self.data.len().saturating_mul(8).saturating_sub(self.bit)
+    }
+
+    fn read(&mut self, n: u32) -> Option<u32> {
+        let n = n as usize;
+        if n == 0 || n > 32 || self.remaining_bits() < n {
+            return None;
+        }
+        let mut value = 0_u32;
+        for _ in 0..n {
+            let byte = self.data[self.bit / 8];
+            let shift = 7 - (self.bit % 8);
+            value = (value << 1) | u32::from((byte >> shift) & 1);
+            self.bit += 1;
+        }
+        Some(value)
+    }
+
+    fn read_audio_object_type(&mut self) -> Option<u32> {
+        let audio_object_type = self.read(5)?;
+        if audio_object_type == 31 {
+            Some(32 + self.read(6)?)
+        } else {
+            Some(audio_object_type)
+        }
+    }
 }
 
 fn push_downmixed_samples(decoded: &AudioBufferRef<'_>, out: &mut Vec<f32>) {
@@ -555,6 +656,49 @@ mod tests {
     /// `prepare::codec_note`/`missing_converter_hint` name the actual codec
     /// in an error instead of a generic "unsupported format" message (#159:
     /// dictaphone/conferencing-system wav uploads are commonly MS/IMA ADPCM).
+    #[test]
+    fn he_aac_backward_compatible_sbr_flag_is_detected() {
+        // DecoderSpecificInfo from tests/fixtures/tone_heaac.m4a: AAC-LC
+        // (AOT 2) + syncExtensionType 0x2B7 with sbrPresentFlag = 1.
+        assert!(asc_signals_he_aac(&[0x15, 0x88, 0x56, 0xe5, 0xc0]));
+        assert!(is_unsupported_aac_extension(
+            &CODEC_TYPE_AAC,
+            &[0x15, 0x88, 0x56, 0xe5, 0xc0]
+        ));
+    }
+
+    #[test]
+    fn hierarchical_sbr_and_ps_object_types_are_detected() {
+        // First five bits 00101 = AOT 5 (SBR). Remaining bits unused.
+        assert!(asc_signals_he_aac(&[0x28]));
+        // First five bits 11101 = AOT 29 (PS).
+        assert!(asc_signals_he_aac(&[0xe8]));
+    }
+
+    #[test]
+    fn aac_lc_with_sbr_not_present_stays_in_process() {
+        // DecoderSpecificInfo from tests/fixtures/tone_mono.m4a: same 0x2B7
+        // extension as HE-AAC, but sbrPresentFlag = 0.
+        assert!(!asc_signals_he_aac(&[0x14, 0x08, 0x56, 0xe5, 0x00]));
+        assert!(!is_unsupported_aac_extension(
+            &CODEC_TYPE_AAC,
+            &[0x14, 0x08, 0x56, 0xe5, 0x00]
+        ));
+    }
+
+    #[test]
+    fn he_aac_m4a_fixture_is_not_decoded_in_process() {
+        let fixture =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/tone_heaac.m4a");
+        assert!(
+            matches!(
+                try_decode_to_pcm16_mono_16k(&fixture, Some("m4a")),
+                SymphoniaOutcome::Unsupported { .. }
+            ),
+            "HE-AAC must fall through to the system converter, not the AAC-LC decoder"
+        );
+    }
+
     #[test]
     fn probe_codec_label_identifies_ms_adpcm_wav() {
         let fixture =

--- a/crates/openasr-core/src/audio/tests.rs
+++ b/crates/openasr-core/src/audio/tests.rs
@@ -282,7 +282,7 @@ fn native_float_wav_passthrough_without_ffmpeg() {
 }
 
 #[test]
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn native_non_wav_conversion_mode_requires_ffmpeg_when_enabled() {
     let temp = tempfile::tempdir().unwrap();
     let input = temp.path().join("sample.mp3");
@@ -304,7 +304,37 @@ fn native_non_wav_conversion_mode_requires_ffmpeg_when_enabled() {
 }
 
 #[test]
-#[cfg(not(target_os = "macos"))]
+#[cfg(windows)]
+fn native_non_wav_conversion_reaches_media_foundation_when_ffmpeg_absent() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("sample.mp3");
+    fs::write(&input, b"mock bytes").unwrap();
+
+    let error = prepare_audio_input(
+        &input,
+        &AudioPreparationOptions::new(BackendKind::Native).with_native_non_wav_conversion(true),
+    )
+    .unwrap_err();
+
+    let message = error.to_string();
+    assert!(
+        matches!(&error, AudioPreparationError::ConversionFailed { tool, .. } if tool == "mediafoundation"),
+        "garbage mp3 must reach Media Foundation, not MissingFfmpeg: {message}"
+    );
+    assert!(
+        message.contains("Windows system decoding failed"),
+        "MF failure must name system decoding: {message}"
+    );
+    assert!(
+        message.contains("--ffmpeg-bin")
+            && message.contains("OPENASR_FFMPEG_BIN")
+            && message.contains("media.ffmpeg_bin"),
+        "MF failure must point at ffmpeg knobs: {message}"
+    );
+}
+
+#[test]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn native_qta_input_is_recognized_and_reaches_ffmpeg_conversion() {
     let temp = tempfile::tempdir().unwrap();
     let input = temp.path().join("sample.qta");
@@ -326,6 +356,25 @@ fn native_qta_input_is_recognized_and_reaches_ffmpeg_conversion() {
             ..
         }
     ));
+}
+
+#[test]
+#[cfg(windows)]
+fn native_qta_input_is_recognized_and_reaches_media_foundation_conversion() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("sample.qta");
+    fs::write(&input, b"mock bytes").unwrap();
+
+    let error = prepare_audio_input(
+        &input,
+        &AudioPreparationOptions::new(BackendKind::Native).with_native_non_wav_conversion(true),
+    )
+    .unwrap_err();
+
+    assert!(
+        matches!(&error, AudioPreparationError::ConversionFailed { tool, .. } if tool == "mediafoundation"),
+        "a .qta file must reach Media Foundation, not be rejected as unrecognized: {error}"
+    );
 }
 
 // On macOS these same inputs reach the afconvert fallback instead of erroring
@@ -483,6 +532,10 @@ fn assert_prepared_16k_mono_audio(prepared: &PreparedAudioInput) {
 fn symphonia_decodes_m4a_aac_lc_in_process() {
     let prepared = prepare_native_conversion(&crate_fixture("tone_mono.m4a"))
         .expect("m4a/AAC-LC should decode via the in-process symphonia path");
+    assert!(
+        prepared.temp_dir.is_none(),
+        "AAC-LC must stay in-process and not take the Media Foundation or ffmpeg path"
+    );
     assert_prepared_16k_mono_audio(&prepared);
 }
 
@@ -536,6 +589,10 @@ fn symphonia_decodes_m4a_alac_in_process() {
 fn symphonia_decodes_bare_adts_aac_in_process() {
     let prepared = prepare_native_conversion(&crate_fixture("tone_mono.aac"))
         .expect("bare ADTS .aac should decode via the in-process symphonia path");
+    assert!(
+        prepared.temp_dir.is_none(),
+        "AAC-LC / ADTS must stay in-process and not spawn Media Foundation or ffmpeg"
+    );
     assert_prepared_16k_mono_audio(&prepared);
 }
 
@@ -589,7 +646,7 @@ fn wma_falls_back_to_afconvert_or_succeeds_without_symphonia_support() {
 }
 
 #[test]
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn wma_reaches_missing_ffmpeg_without_symphonia_support() {
     let error = prepare_native_conversion(&crate_fixture("tone_mono.wma")).unwrap_err();
     assert!(
@@ -597,6 +654,18 @@ fn wma_reaches_missing_ffmpeg_without_symphonia_support() {
         "a real .wma file must reach the ffmpeg-required path, not be rejected as an \
          unrecognized extension: {error}"
     );
+}
+
+#[test]
+#[cfg(windows)]
+fn wma_reaches_media_foundation_without_symphonia_support() {
+    match prepare_native_conversion(&crate_fixture("tone_mono.wma")) {
+        Ok(prepared) => assert_prepared_16k_mono_audio(&prepared),
+        Err(AudioPreparationError::ConversionFailed { tool, .. }) if tool == "mediafoundation" => {}
+        Err(error) => panic!(
+            "a real .wma file must reach Media Foundation, not be rejected as an unrecognized extension: {error}"
+        ),
+    }
 }
 
 /// Beyond routing, this proves ffmpeg genuinely decodes the format when it is
@@ -676,7 +745,7 @@ fn malformed_webm_falls_back_to_typed_error_instead_of_panicking() {
 }
 
 #[test]
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn malformed_webm_falls_back_to_typed_error_instead_of_panicking() {
     // See the macOS counterpart above for the vint-underflow panic this
     // guards against. Without ffmpeg configured and no afconvert fallback,
@@ -689,6 +758,21 @@ fn malformed_webm_falls_back_to_typed_error_instead_of_panicking() {
     assert!(
         message.contains("malformed or corrupted"),
         "missing-ffmpeg hint should report the parser-internal-error condition: {message}"
+    );
+}
+
+#[test]
+#[cfg(windows)]
+fn malformed_webm_falls_back_to_typed_error_instead_of_panicking() {
+    let error = prepare_native_conversion(&crate_fixture("malformed_vint_zero.webm")).unwrap_err();
+    let message = error.to_string();
+    assert!(
+        matches!(&error, AudioPreparationError::ConversionFailed { tool, .. } if tool == "mediafoundation"),
+        "malformed webm must fail closed through Media Foundation, not panic: {error}"
+    );
+    assert!(
+        message.contains("internal error while inspecting this file"),
+        "error should report a parser-internal-error, not a bare tool failure: {message}"
     );
 }
 
@@ -750,7 +834,7 @@ fn garbage_bytes_wav_fails_closed_instead_of_passing_through() {
 }
 
 #[test]
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn garbage_bytes_wav_fails_closed_instead_of_passing_through() {
     let temp = tempfile::tempdir().unwrap();
     let wav = temp.path().join("garbage.wav");
@@ -765,6 +849,21 @@ fn garbage_bytes_wav_fails_closed_instead_of_passing_through() {
 }
 
 #[test]
+#[cfg(windows)]
+fn garbage_bytes_wav_fails_closed_instead_of_passing_through() {
+    let temp = tempfile::tempdir().unwrap();
+    let wav = temp.path().join("garbage.wav");
+    fs::write(&wav, garbage_bytes()).unwrap();
+
+    let error = prepare_native_conversion(&wav).unwrap_err();
+
+    assert!(
+        matches!(&error, AudioPreparationError::ConversionFailed { tool, .. } if tool == "mediafoundation"),
+        "garbage-byte wav must fail closed through Media Foundation, not pass through: {error}"
+    );
+}
+
+#[test]
 #[cfg(target_os = "macos")]
 fn he_aac_falls_back_to_afconvert_when_symphonia_cannot_decode_it() {
     // HE-AAC (SBR) is outside what the enabled symphonia `aac` feature can
@@ -773,6 +872,19 @@ fn he_aac_falls_back_to_afconvert_when_symphonia_cannot_decode_it() {
     // silently emitting bandwidth-limited audio.
     let prepared = prepare_native_conversion(&crate_fixture("tone_heaac.m4a"))
         .expect("HE-AAC should fall back to afconvert and still succeed");
+    assert_prepared_16k_mono_audio(&prepared);
+}
+
+#[test]
+#[cfg(windows)]
+fn he_aac_falls_back_to_media_foundation_when_symphonia_cannot_decode_it() {
+    let prepared = prepare_native_conversion(&crate_fixture("tone_heaac.m4a")).expect(
+        "HE-AAC should fall back to Windows Media Foundation and still succeed without ffmpeg",
+    );
+    assert!(
+        prepared.temp_dir.is_some(),
+        "the Media Foundation path writes prepared.wav; AAC-LC must not take this path"
+    );
     assert_prepared_16k_mono_audio(&prepared);
 }
 
@@ -862,7 +974,7 @@ fn truncated_opus_is_handled_without_panicking() {
 /// The non-macOS counterpart: with no ffmpeg configured and no afconvert
 /// fallback, the typed `MissingFfmpeg` surfaces instead of a panic.
 #[test]
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn truncated_opus_is_handled_without_panicking() {
     let (_temp, path) = write_truncated_opus_fixture();
 
@@ -871,6 +983,16 @@ fn truncated_opus_is_handled_without_panicking() {
         matches!(error, AudioPreparationError::MissingFfmpeg { .. }),
         "truncated opus must fail closed with a typed error: {error}"
     );
+}
+
+#[test]
+#[cfg(windows)]
+fn truncated_opus_is_handled_without_panicking() {
+    let (_temp, path) = write_truncated_opus_fixture();
+    match prepare_native_conversion(&path) {
+        Ok(_) | Err(AudioPreparationError::ConversionFailed { .. }) => {}
+        Err(error) => panic!("truncated opus must fail closed with a typed error: {error}"),
+    }
 }
 
 /// Corrupt Opus bytes must fail closed with a typed error (never a panic,
@@ -904,7 +1026,12 @@ fn assert_corrupt_opus_is_typed_error(bytes: Vec<u8>) {
         matches!(&error, AudioPreparationError::ConversionFailed { tool, .. } if tool == "afconvert"),
         "corrupt opus must fail closed through the external converter: {message}"
     );
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(windows)]
+    assert!(
+        matches!(&error, AudioPreparationError::ConversionFailed { tool, .. } if tool == "mediafoundation"),
+        "corrupt opus must fail closed through Media Foundation: {message}"
+    );
+    #[cfg(not(any(target_os = "macos", windows)))]
     assert!(
         matches!(&error, AudioPreparationError::MissingFfmpeg { .. }),
         "corrupt opus must fail closed with a typed error: {message}"

--- a/crates/openasr-core/src/audio/windows_mf.rs
+++ b/crates/openasr-core/src/audio/windows_mf.rs
@@ -1,0 +1,239 @@
+//! Windows Media Foundation converter for formats the in-process decoder
+//! refuses (HE-AAC SBR/PS, and other containers the OS can decode).
+//!
+//! This is the Windows peer of macOS `/usr/bin/afconvert`: system APIs only,
+//! never Fraunhofer FDK, never a spawned ffmpeg.
+
+use std::fs;
+use std::path::Path;
+
+use windows::Win32::Media::MediaFoundation::{
+    IMFMediaBuffer, IMFMediaType, IMFSample, IMFSourceReader, MF_ACCESSMODE_READ,
+    MF_FILEFLAGS_NONE, MF_MT_AUDIO_AVG_BYTES_PER_SECOND, MF_MT_AUDIO_BITS_PER_SAMPLE,
+    MF_MT_AUDIO_BLOCK_ALIGNMENT, MF_MT_AUDIO_NUM_CHANNELS, MF_MT_AUDIO_SAMPLES_PER_SECOND,
+    MF_MT_MAJOR_TYPE, MF_MT_SUBTYPE, MF_OPENMODE_FAIL_IF_NOT_EXIST, MF_SOURCE_READER_ALL_STREAMS,
+    MF_SOURCE_READER_FIRST_AUDIO_STREAM, MF_SOURCE_READERF_ENDOFSTREAM, MF_SOURCE_READERF_ERROR,
+    MF_VERSION, MFAudioFormat_PCM, MFCreateFile, MFCreateMediaType,
+    MFCreateSourceReaderFromByteStream, MFMediaType_Audio, MFSTARTUP_NOSOCKET, MFShutdown,
+    MFStartup,
+};
+use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize};
+use windows::core::{HRESULT, HSTRING};
+
+/// `RPC_E_CHANGED_MODE`: this thread already has a different COM apartment.
+const RPC_E_CHANGED_MODE: HRESULT = HRESULT(0x8001_0106_u32 as i32);
+
+const TARGET_RATE_HZ: u32 = 16_000;
+const TARGET_CHANNELS: u32 = 1;
+const TARGET_BITS: u32 = 16;
+
+pub(super) fn convert_to_wav16k_mono(input: &Path, output: &Path) -> Result<(), String> {
+    let _com = ComApartment::enter()?;
+    let _mf = MediaFoundation::startup()?;
+    unsafe { convert_with_source_reader(input, output) }
+}
+
+struct ComApartment {
+    owned: bool,
+}
+
+impl ComApartment {
+    fn enter() -> Result<Self, String> {
+        let hr = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+        if hr.is_ok() {
+            return Ok(Self { owned: hr.0 == 0 });
+        }
+        if hr == RPC_E_CHANGED_MODE {
+            return Ok(Self { owned: false });
+        }
+        Err(format!("COM init failed: {hr}"))
+    }
+}
+
+impl Drop for ComApartment {
+    fn drop(&mut self) {
+        if self.owned {
+            unsafe { CoUninitialize() };
+        }
+    }
+}
+
+struct MediaFoundation;
+
+impl MediaFoundation {
+    fn startup() -> Result<Self, String> {
+        unsafe { MFStartup(MF_VERSION, MFSTARTUP_NOSOCKET) }
+            .map_err(|error| format!("Media Foundation startup failed: {error}"))?;
+        Ok(Self)
+    }
+}
+
+impl Drop for MediaFoundation {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = MFShutdown();
+        }
+    }
+}
+
+unsafe fn convert_with_source_reader(input: &Path, output: &Path) -> Result<(), String> {
+    let path = HSTRING::from(input.to_string_lossy().as_ref());
+    let stream = unsafe {
+        MFCreateFile(
+            MF_ACCESSMODE_READ,
+            MF_OPENMODE_FAIL_IF_NOT_EXIST,
+            MF_FILEFLAGS_NONE,
+            &path,
+        )
+    }
+    .map_err(|error| format!("could not open input for Media Foundation: {error}"))?;
+
+    let reader: IMFSourceReader = unsafe { MFCreateSourceReaderFromByteStream(&stream, None) }
+        .map_err(|error| format!("Media Foundation could not open this file: {error}"))?;
+    let all_streams = MF_SOURCE_READER_ALL_STREAMS.0 as u32;
+    let audio_stream = MF_SOURCE_READER_FIRST_AUDIO_STREAM.0 as u32;
+
+    unsafe {
+        reader
+            .SetStreamSelection(all_streams, false)
+            .map_err(|error| format!("could not deselect Media Foundation streams: {error}"))?;
+        reader
+            .SetStreamSelection(audio_stream, true)
+            .map_err(|error| format!("no audio stream for Media Foundation: {error}"))?;
+    }
+
+    let media_type: IMFMediaType = unsafe { MFCreateMediaType() }
+        .map_err(|error| format!("could not create PCM media type: {error}"))?;
+    unsafe {
+        media_type
+            .SetGUID(&MF_MT_MAJOR_TYPE, &MFMediaType_Audio)
+            .map_err(|error| format!("could not set audio major type: {error}"))?;
+        media_type
+            .SetGUID(&MF_MT_SUBTYPE, &MFAudioFormat_PCM)
+            .map_err(|error| format!("could not set PCM subtype: {error}"))?;
+        media_type
+            .SetUINT32(&MF_MT_AUDIO_NUM_CHANNELS, TARGET_CHANNELS)
+            .map_err(|error| format!("could not set channel count: {error}"))?;
+        media_type
+            .SetUINT32(&MF_MT_AUDIO_SAMPLES_PER_SECOND, TARGET_RATE_HZ)
+            .map_err(|error| format!("could not set sample rate: {error}"))?;
+        media_type
+            .SetUINT32(&MF_MT_AUDIO_BITS_PER_SAMPLE, TARGET_BITS)
+            .map_err(|error| format!("could not set bit depth: {error}"))?;
+        media_type
+            .SetUINT32(&MF_MT_AUDIO_BLOCK_ALIGNMENT, 2)
+            .map_err(|error| format!("could not set block alignment: {error}"))?;
+        media_type
+            .SetUINT32(&MF_MT_AUDIO_AVG_BYTES_PER_SECOND, 32_000)
+            .map_err(|error| format!("could not set byte rate: {error}"))?;
+        reader
+            .SetCurrentMediaType(audio_stream, None, &media_type)
+            .map_err(|error| {
+                format!(
+                    "Windows Media Foundation cannot produce 16 kHz mono PCM16 from this file: {error}"
+                )
+            })?;
+    }
+
+    let mut pcm = Vec::new();
+    loop {
+        let mut flags = 0_u32;
+        let mut sample: Option<IMFSample> = None;
+        unsafe {
+            reader
+                .ReadSample(
+                    audio_stream,
+                    0,
+                    None,
+                    Some(&mut flags),
+                    None,
+                    Some(&mut sample),
+                )
+                .map_err(|error| format!("Media Foundation read failed: {error}"))?;
+        }
+        if flags & MF_SOURCE_READERF_ERROR.0 as u32 != 0 {
+            return Err("Media Foundation reported a decode error".to_string());
+        }
+        if flags & MF_SOURCE_READERF_ENDOFSTREAM.0 as u32 != 0 {
+            break;
+        }
+        let Some(sample) = sample else {
+            continue;
+        };
+        let buffer = unsafe { sample.ConvertToContiguousBuffer() }
+            .map_err(|error| format!("Media Foundation sample buffer failed: {error}"))?;
+        let locked = LockedBuffer::lock(&buffer)?;
+        let chunk = locked.bytes().to_vec();
+        drop(locked);
+        if !chunk.is_empty() {
+            pcm.extend_from_slice(&chunk);
+        }
+    }
+
+    if pcm.is_empty() {
+        return Err("Media Foundation produced no PCM audio".to_string());
+    }
+    write_pcm16_wav(output, &pcm).map_err(|error| format!("could not write prepared WAV: {error}"))
+}
+
+struct LockedBuffer<'a> {
+    buffer: &'a IMFMediaBuffer,
+    data: *mut u8,
+    length: u32,
+}
+
+impl<'a> LockedBuffer<'a> {
+    fn lock(buffer: &'a IMFMediaBuffer) -> Result<Self, String> {
+        let mut data: *mut u8 = std::ptr::null_mut();
+        let mut length = 0_u32;
+        unsafe {
+            buffer
+                .Lock(&mut data, None, Some(&mut length))
+                .map_err(|error| format!("Media Foundation buffer lock failed: {error}"))?;
+        }
+        Ok(Self {
+            buffer,
+            data,
+            length,
+        })
+    }
+
+    fn bytes(&self) -> &[u8] {
+        if self.data.is_null() || self.length == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(self.data, self.length as usize) }
+        }
+    }
+}
+
+impl Drop for LockedBuffer<'_> {
+    fn drop(&mut self) {
+        let _ = unsafe { self.buffer.Unlock() };
+    }
+}
+
+fn write_pcm16_wav(path: &Path, pcm: &[u8]) -> std::io::Result<()> {
+    let data_len = u32::try_from(pcm.len()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "decoded PCM exceeded WAV size",
+        )
+    })?;
+    let mut bytes = Vec::with_capacity(44 + pcm.len());
+    bytes.extend_from_slice(b"RIFF");
+    bytes.extend_from_slice(&(36 + data_len).to_le_bytes());
+    bytes.extend_from_slice(b"WAVE");
+    bytes.extend_from_slice(b"fmt ");
+    bytes.extend_from_slice(&16_u32.to_le_bytes());
+    bytes.extend_from_slice(&1_u16.to_le_bytes());
+    bytes.extend_from_slice(&1_u16.to_le_bytes());
+    bytes.extend_from_slice(&TARGET_RATE_HZ.to_le_bytes());
+    bytes.extend_from_slice(&32_000_u32.to_le_bytes());
+    bytes.extend_from_slice(&2_u16.to_le_bytes());
+    bytes.extend_from_slice(&16_u16.to_le_bytes());
+    bytes.extend_from_slice(b"data");
+    bytes.extend_from_slice(&data_len.to_le_bytes());
+    bytes.extend_from_slice(pcm);
+    fs::write(path, bytes)
+}


### PR DESCRIPTION
## Summary

Windows HE-AAC (SBR/PS) that the in-process AAC-LC decoder cannot decode correctly now falls back to Media Foundation, the same role `/usr/bin/afconvert` already plays on macOS. AAC-LC and bare ADTS stay in-process. No FDK and no bundled ffmpeg.

## Why

Symphonia's enabled `aac` feature ignores the SBR high band, so HE-AAC would otherwise come out bandwidth-limited. ffmpeg is not on PATH for many Windows installs. Media Foundation is the OS decoder.

## Changes

- New `windows_mf.rs`: COM + MF Source Reader to 16 kHz mono PCM16 WAV.
- `ConversionTool::MediaFoundation` on the existing prepare/resolve chain.
- HE-AAC ASC detection now covers hierarchical AOT 5/29 and backward-compatible `0x2B7` with `sbrPresentFlag=1`. AAC-LC fixtures that carry `0x2B7` with `sbrPresentFlag=0` stay in-process.
- If MF also fails, the error says Windows system decoding failed and points at `--ffmpeg-bin` / `OPENASR_FFMPEG_BIN` / `openasr config set media.ffmpeg_bin`.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --lib -- -D warnings`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core --lib audio::` (73 passed on Windows, including HE-AAC via MF and AAC-LC/ADTS in-process)
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

Not a model-family change. Verified against `tests/fixtures/tone_heaac.m4a` and `tone_mono.m4a` / `tone_mono.aac`.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

CHANGELOG Unreleased Fixed entry added.

## Scope / non-goals

- Does not bundle ffmpeg or link FDK.
- Does not change catalog, occupancy, or CUDA activation.
- Implicit ADTS SBR and unusual ASCs (`channelConfiguration == 0` PCE, extra GASpecificConfig) stay on the in-process AAC-LC path, same as before.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — implementation and tests were written with AI assistance; this description was reviewed before opening.
