### PR TITLE
fix(core): recover Windows backend promote from AV directory locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   role `/usr/bin/afconvert` plays on macOS. AAC-LC and bare ADTS stay
   in-process. If system decoding also fails, the error says so and points at
   ffmpeg.
+- Windows: promoting an installed GPU backend pack retries antivirus directory
+  locks (`os error 5` / sharing / lock violation) and copies the readable
+  staging tree if rename stays locked. A failed copy does not leave a truncated
+  directory that the next install would treat as already complete.
 - HIP decode reuse no longer recaptures every token after the first stable
   capture: uid reuse keys on node count, op, type, and shape, and ignores
   input-pointer churn that HIP writes on each launch.

--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -6308,16 +6308,104 @@ fn install_backend_pack_with_client_locked<C: DownloadClient>(
     read_and_verify_installed_backend(&dir, resolved)
 }
 
+fn is_transient_lock_error(error: &io::Error) -> bool {
+    #[cfg(windows)]
+    {
+        matches!(error.raw_os_error(), Some(5 | 32 | 33))
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = error;
+        false
+    }
+}
+
+fn retry_transient_io<T>(mut op: impl FnMut() -> io::Result<T>) -> io::Result<T> {
+    const DELAYS_MS: [u64; 6] = [200, 400, 800, 1600, 3200, 6400];
+    let mut attempt = 0usize;
+    loop {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(error) if attempt < DELAYS_MS.len() && is_transient_lock_error(&error) => {
+                std::thread::sleep(Duration::from_millis(DELAYS_MS[attempt]));
+                attempt += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn copy_dir_all_retry(from: &Path, to: &Path) -> io::Result<()> {
+    retry_transient_io(|| fs::create_dir_all(to))?;
+    for entry in retry_transient_io(|| fs::read_dir(from))? {
+        let entry = entry?;
+        let source = entry.path();
+        reject_symlink(&source).map_err(|error| io::Error::other(error.to_string()))?;
+        let destination = to.join(entry.file_name());
+        let file_type = retry_transient_io(|| entry.file_type())?;
+        if file_type.is_dir() {
+            copy_dir_all_retry(&source, &destination)?;
+        } else if file_type.is_file() {
+            retry_transient_io(|| {
+                fs::copy(&source, &destination)?;
+                Ok(())
+            })?;
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "backend tree contains a non-file object",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn lock_exhausted_io(path: PathBuf, source: io::Error) -> PullError {
+    PullError::Io {
+        path,
+        source: io::Error::new(
+            source.kind(),
+            format!(
+                "{source}. Windows had the files open (antivirus real-time scanning is the usual cause). Retry the install. If it keeps failing, exclude the OpenASR backends folder from scanning. OpenASR does not change folder permissions."
+            ),
+        ),
+    }
+}
+
+fn fs_rename(from: &Path, to: &Path) -> io::Result<()> {
+    fs::rename(from, to)
+}
+
+fn fs_remove_dir_all(path: &Path) -> io::Result<()> {
+    fs::remove_dir_all(path)
+}
+
 fn promote_backend_directory(
     staging_dir: &Path,
     final_dir: &Path,
     fingerprint: &str,
 ) -> Result<(), PullError> {
+    promote_backend_directory_with(
+        staging_dir,
+        final_dir,
+        fingerprint,
+        fs_rename,
+        fs_remove_dir_all,
+    )
+}
+
+fn promote_backend_directory_with(
+    staging_dir: &Path,
+    final_dir: &Path,
+    fingerprint: &str,
+    rename: impl Fn(&Path, &Path) -> io::Result<()>,
+    remove_dir_all: impl Fn(&Path) -> io::Result<()>,
+) -> Result<(), PullError> {
     let final_parent = final_dir.parent().ok_or_else(|| PullError::InvalidTarget {
         field: "backend install path",
         reason: "final backend directory has no parent".to_string(),
     })?;
-    fs::create_dir_all(final_parent).map_err(|source| PullError::Io {
+    retry_transient_io(|| fs::create_dir_all(final_parent)).map_err(|source| PullError::Io {
         path: final_parent.to_path_buf(),
         source,
     })?;
@@ -6327,22 +6415,35 @@ fn promote_backend_directory(
         .join(format!(".replaced-{fingerprint}-{}", unix_seconds_now()));
     let had_previous = final_dir.exists();
     if had_previous {
-        fs::rename(final_dir, &displaced).map_err(|source| PullError::Io {
+        retry_transient_io(|| rename(final_dir, &displaced)).map_err(|source| PullError::Io {
             path: final_dir.to_path_buf(),
             source,
         })?;
     }
-    if let Err(source) = fs::rename(staging_dir, final_dir) {
-        if had_previous {
-            let _ = fs::rename(&displaced, final_dir);
+    match retry_transient_io(|| rename(staging_dir, final_dir)) {
+        Ok(()) => {}
+        Err(source) if is_transient_lock_error(&source) => {
+            if let Err(copy_error) = copy_dir_all_retry(staging_dir, final_dir) {
+                let _ = retry_transient_io(|| remove_dir_all(final_dir));
+                if had_previous {
+                    let _ = rename(&displaced, final_dir);
+                }
+                return Err(lock_exhausted_io(final_dir.to_path_buf(), copy_error));
+            }
+            let _ = retry_transient_io(|| remove_dir_all(staging_dir));
         }
-        return Err(PullError::Io {
-            path: final_dir.to_path_buf(),
-            source,
-        });
+        Err(source) => {
+            if had_previous {
+                let _ = rename(&displaced, final_dir);
+            }
+            return Err(PullError::Io {
+                path: final_dir.to_path_buf(),
+                source,
+            });
+        }
     }
     if had_previous {
-        let _ = fs::remove_dir_all(displaced);
+        let _ = retry_transient_io(|| remove_dir_all(&displaced));
     }
     Ok(())
 }

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -5538,3 +5538,106 @@ fn model_store_lifecycle_converts_and_reclaims_a_leaking_store() {
         "the store must shrink (before {before}, after {after})"
     );
 }
+
+#[test]
+fn retry_transient_io_succeeds_on_the_first_ok() {
+    let mut calls = 0;
+    let value = retry_transient_io(|| {
+        calls += 1;
+        Ok::<_, io::Error>(7)
+    })
+    .unwrap();
+    assert_eq!(value, 7);
+    assert_eq!(calls, 1);
+}
+
+#[test]
+fn retry_transient_io_does_not_retry_a_non_transient_error() {
+    let mut calls = 0;
+    let error = retry_transient_io(|| {
+        calls += 1;
+        Err::<(), _>(io::Error::from_raw_os_error(1))
+    })
+    .unwrap_err();
+    assert_eq!(calls, 1);
+    assert_eq!(error.raw_os_error(), Some(1));
+}
+
+#[cfg(windows)]
+#[test]
+fn retry_transient_io_gives_up_after_the_lock_budget() {
+    let mut calls = 0;
+    let error = retry_transient_io(|| {
+        calls += 1;
+        Err::<(), _>(io::Error::from_raw_os_error(32))
+    })
+    .unwrap_err();
+    assert_eq!(calls, 7);
+    assert_eq!(error.raw_os_error(), Some(32));
+}
+
+#[cfg(windows)]
+#[test]
+fn promote_backend_directory_copies_when_rename_stays_locked() {
+    let temp = tempfile::tempdir().unwrap();
+    let staging = temp.path().join("staging");
+    let dest = temp.path().join("final");
+    fs::create_dir_all(&staging).unwrap();
+    fs::write(staging.join("ggml-cuda.dll"), b"plugin").unwrap();
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(dest.join("stale.dll"), b"stale").unwrap();
+
+    promote_backend_directory_with(
+        &staging,
+        &dest,
+        "fp",
+        |from, to| {
+            if from.ends_with("staging") {
+                return Err(io::Error::from_raw_os_error(5));
+            }
+            fs::rename(from, to)
+        },
+        super::fs_remove_dir_all,
+    )
+    .expect("locked rename must still promote by copying the readable staging tree");
+
+    assert_eq!(fs::read(dest.join("ggml-cuda.dll")).unwrap(), b"plugin");
+    assert!(!dest.join("stale.dll").exists());
+}
+
+#[cfg(windows)]
+#[test]
+fn promote_backend_directory_clears_dest_when_copy_fallback_fails() {
+    let temp = tempfile::tempdir().unwrap();
+    let staging = temp.path().join("staging");
+    let dest = temp.path().join("final");
+    fs::create_dir_all(&staging).unwrap();
+    fs::write(staging.join("ggml-cuda.dll"), b"plugin").unwrap();
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(dest.join("prior.dll"), b"prior").unwrap();
+
+    let error = promote_backend_directory_with(
+        &staging,
+        &dest,
+        "fp",
+        |from, to| {
+            if from.ends_with("staging") {
+                fs::create_dir_all(to.join("ggml-cuda.dll")).unwrap();
+                return Err(io::Error::from_raw_os_error(5));
+            }
+            fs::rename(from, to)
+        },
+        super::fs_remove_dir_all,
+    )
+    .unwrap_err();
+    let message = error.to_string();
+    assert!(
+        message.contains("antivirus") && message.contains("Retry the install"),
+        "{message}"
+    );
+    assert_eq!(
+        fs::read(dest.join("prior.dll")).unwrap(),
+        b"prior",
+        "the previous install must be restored after a failed copy fallback"
+    );
+}


### PR DESCRIPTION
## Summary

Windows GPU backend install promote (`staging` -> final pack directory) now retries antivirus directory locks and copies the readable staging tree if rename stays locked. A failed copy is deleted so the next install cannot treat a truncated tree as already complete.

## Why

Antivirus real-time scanning on Windows commonly holds a just-extracted CUDA/HIP tree open. `fs::rename` then fails with `os error 5` (also 32/33). Desktop no longer extracts sidecars itself; open-core `promote_backend_directory` is the install path.

## Changes

- Retry budget `[200, 400, 800, 1600, 3200, 6400]` ms (7 attempts) on transient Win32 locks.
- After rename retries are exhausted, copy the readable staging tree into place and remove staging.
- On copy failure, delete the incomplete destination and restore any displaced previous install.
- Error text names antivirus, retry, backends-folder exclusion, and that OpenASR does not change folder permissions.

## Tests run

- [x] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p openasr-core --lib promote_backend_directory` (copy fallback + failed-copy restore)
- [x] `cargo test -p openasr-core --lib retry_transient_io` (including 7-attempt budget)
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

Unit tests inject a persistent `os error 5` on staging rename. Live Defender scan of a CUDA pack install was not re-run on this branch.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

CHANGELOG Unreleased Fixed entry added.

## Scope / non-goals

- Does not change occupancy/admission, catalog, or CUDA activation.
- Does not restore the pre-neutral Desktop sidecar extractor. That path is gone on `main`; this fixes the current open-core promote.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES — implementation and tests were written with AI assistance; this description was reviewed before opening.
