### PR TITLE
fix(capture): keep live resampler drain inside the held chunk (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Core: live capture no longer panics when a downsampled mic callback (for
+  example 44.1 kHz stereo in 512-frame chunks) leaves the resampler read head
+  past the current buffer. The leftover position continues in the next chunk
+  instead of draining past the held samples.
 - Core: long-form slices no longer exceed the decoder-state `max_chunk`
   envelope after overlap, packing, or a short-tail remainder. A request that
   previously failed closed with `decoder invocation lies outside its declared

--- a/crates/openasr-core/src/realtime/capture/core.rs
+++ b/crates/openasr-core/src/realtime/capture/core.rs
@@ -208,7 +208,7 @@ impl CaptureEngine {
             output.push(f32_to_i16(a + (b - a) * fraction));
             self.resample_pos += self.resample_step;
         }
-        let consumed = self.resample_pos.floor() as usize;
+        let consumed = resample_consumed_len(self.resample_pos, self.resample_input.len());
         if consumed > 0 {
             self.resample_input.drain(0..consumed);
             self.resample_pos -= consumed as f64;
@@ -235,6 +235,16 @@ impl CaptureEngine {
         }
         Ok(frames)
     }
+}
+
+/// How many held input samples the resampler can drop after a pass.
+///
+/// The interpolate loop stops when `pos + 1 >= len`, then advances by `step`.
+/// Any downsample (`step > 1`) can leave the read head past this chunk. Drop
+/// only samples still in the buffer; leftover `pos` is the head in the next
+/// chunk, so the timeline stays contiguous.
+fn resample_consumed_len(pos: f64, input_len: usize) -> usize {
+    (pos.floor() as usize).min(input_len)
 }
 
 fn downmix_interleaved<T: Copy>(

--- a/crates/openasr-core/src/realtime/capture/tests.rs
+++ b/crates/openasr-core/src/realtime/capture/tests.rs
@@ -109,6 +109,68 @@ mod tests {
     }
 
     #[test]
+    fn resample_consumed_len_never_exceeds_held_samples() {
+        assert_eq!(resample_consumed_len(513.3, 512), 512);
+        assert_eq!(resample_consumed_len(512.0, 512), 512);
+        assert_eq!(resample_consumed_len(100.2, 512), 100);
+        assert_eq!(resample_consumed_len(0.9, 512), 0);
+    }
+
+    fn collect_pcm(frames: &[RealtimeAudioFrame]) -> Vec<i16> {
+        frames
+            .iter()
+            .flat_map(|frame| frame.samples().iter().copied())
+            .collect()
+    }
+
+    fn tone_interleaved(sample_rate_hz: u32, channels: u16, frames: usize) -> Vec<f32> {
+        let channels = channels as usize;
+        (0..frames * channels)
+            .map(|index| {
+                let frame = index / channels;
+                (frame as f32 / sample_rate_hz as f32 * std::f32::consts::TAU * 440.0).sin() * 0.5
+            })
+            .collect()
+    }
+
+    fn chunked_resample_matches_oneshot(
+        sample_rate_hz: u32,
+        channels: u16,
+        frames_per_chunk: usize,
+        chunks: usize,
+    ) {
+        let tone = tone_interleaved(sample_rate_hz, channels, frames_per_chunk * chunks);
+        let mut oneshot = engine(sample_rate_hz, channels, 20);
+        let oneshot_pcm = collect_pcm(&oneshot.push_f32_interleaved(&tone).unwrap());
+
+        let mut chunked = engine(sample_rate_hz, channels, 20);
+        let mut chunked_pcm = Vec::new();
+        let stride = frames_per_chunk * channels as usize;
+        for chunk in tone.chunks(stride) {
+            chunked_pcm.extend(collect_pcm(&chunked.push_f32_interleaved(chunk).unwrap()));
+        }
+
+        assert_eq!(
+            chunked_pcm, oneshot_pcm,
+            "chunked resample diverged from oneshot at {sample_rate_hz} Hz / {channels} ch / {frames_per_chunk}-frame callbacks"
+        );
+        assert!(
+            !chunked_pcm.is_empty(),
+            "expected at least one 16 kHz frame from {chunks} chunks"
+        );
+    }
+
+    #[test]
+    fn downsampling_read_head_may_overshoot_a_512_sample_chunk() {
+        // Live capture commonly delivers 512 frames. After the first 44.1 kHz
+        // chunk the leftover pos plus step>1 puts floor(pos) past the buffer
+        // (513 vs 512). 48 kHz / 512 is the same class (step = 3).
+        chunked_resample_matches_oneshot(44_100, 2, 512, 8);
+        chunked_resample_matches_oneshot(44_100, 1, 512, 8);
+        chunked_resample_matches_oneshot(48_000, 1, 512, 8);
+    }
+
+    #[test]
     fn downmixes_stereo_and_converts_i16_u16() {
         let mut i16_capture = engine(16_000, 2, 20);
         let i16_samples = (0..320)


### PR DESCRIPTION
## Summary

Live capture no longer panics when a downsampled mic callback leaves the resampler read head past the current buffer. 512-frame 44.1 kHz stereo (and 48 kHz / 512) now matches a oneshot resample of the same PCM.

Fixes #352.

## Why

`resample_to_pcm16` interpolates while `pos + 1 < len`, then advances `pos` by `step`. Any downsample (`step > 1`) can put `floor(pos)` past the held chunk. The next `drain(0..consumed)` then panics (`513` vs `512` in the report).

This is the live callback shape, not a one-second oneshot. Clamping consume to the held length is the correct timeline: leftover `pos` is the read head in the next chunk, not a skip.

@CCLL-0x01 identified the overflow and the consume clamp in #358. This PR keeps that bound, names it, and locks chunked-vs-oneshot identity plus the 48 kHz / 512 sibling.

## Changes

- Drain only `min(floor(pos), held_len)`.
- Tests: helper bound `513.3 -> 512`; 44.1 kHz stereo / mono and 48 kHz mono in 512-frame chunks match oneshot output.

## Tests run

- [x] `cargo fmt --check` (`openasr-core`)
- [x] `cargo clippy -p openasr-core --lib --tests -- -D warnings`
- [x] `cargo test -p openasr-core --lib realtime::capture::` (18 passed)
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

Not re-run on Ubuntu 44.1 kHz stereo hardware. The regression is the reported 512-frame callback shape plus chunked-vs-oneshot identity.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

CHANGELOG Unreleased Fixed entry added.

## Scope / non-goals

- Does not change the FFT file-decoder resampler.
- Does not retune live VAD or frame duration.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES
