### PR TITLE
ci(release): verify draft completeness with shared expected set

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -236,13 +236,9 @@ jobs:
     # published-inert provider packs with content-addressed runtimes.
     # Legacy whole-engine Vulkan/CUDA/HIP sidecars ended with core 0.1.33.
     #
-    # NOTE: jobs.verify-completeness below hardcodes this same asset/ext list
-    # (TARGETS, now friendly asset names) to assert the release ends up with
-    # every archive. Keep both in sync when adding/removing a leg. The
-    # xcframework job further below is a separate, non-matrix leg (macOS/iOS
-    # SDK, not a CLI binary) but its asset is folded into the same TARGETS list
-    # -- keep that in sync too. Legs marked `experimental: true` are NOT in
-    # TARGETS (they may drop out until proven green), so keep them out of it.
+    # NOTE: jobs.verify-completeness derives the required asset set from this
+    # matrix via tooling/release-manifest/release_completeness.py. Experimental
+    # legs may appear when they succeed; they are optional, never required.
     strategy:
       fail-fast: false
       # Include rows live in tooling/release-manifest/release_binaries_matrix.json
@@ -1693,6 +1689,8 @@ jobs:
     needs: [checksums, upload-to-release]
     if: ${{ always() && !cancelled() && inputs.formal_release == true && needs.checksums.result == 'success' && needs.upload-to-release.result == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       GH_TOKEN: ${{ github.token }}
       RELEASE_TAG: ${{ needs.upload-to-release.outputs.tag }}
@@ -1708,136 +1706,28 @@ jobs:
           echo "OPENASR_VERSION=${version}" >> "${GITHUB_ENV}"
 
       - name: Assert the release has every expected matrix asset
-        # Keep this TARGETS list (friendly asset names, matching each matrix
-        # leg's `asset:` field) in sync with jobs.build.strategy.matrix.include
-        # above, plus jobs.xcframework's asset -- this is the release-integrity
-        # gate: a release "shipped" but missing a platform's archive (e.g. one
-        # matrix leg failed and `checksums` silently dropped it, per its
-        # `!cancelled()` condition)
-        # must fail loudly here instead of quietly shipping partial coverage.
-        # `experimental: true` legs (e.g. windows-arm64) are deliberately NOT
-        # listed: they may fail without failing the run, so requiring their
-        # asset here would defeat the escape hatch. Promote such a leg (drop
-        # `experimental`, add its asset:ext here) once it proves green.
+        # Draft GitHub Releases are invisible to contents:read. This job only
+        # reads the draft, but it still needs contents:write to see it.
+        # Qualification filenames come from qualification_manifest.artifact_cell
+        # so Vulkan stays generic, not a retired windows-x86_64 sidecar name.
         run: |
           set -euo pipefail
           tag="${RELEASE_TAG}"
           [ -n "$tag" ] || { echo "release tag is empty" >&2; exit 1; }
           version="${OPENASR_VERSION}"
-
-          TARGETS=(
-            "linux-x86_64:tar.gz"
-            "linux-arm64:tar.gz"
-            "macos-x86_64:tar.gz"
-            "macos-arm64:tar.gz"
-            "windows-x86_64:zip"
-            "windows-x86_64-neutral:zip"
-            "linux-x86_64-vulkan:tar.gz"
-            "linux-x86_64-cuda:tar.gz"
-            "linux-x86_64-rocm:tar.gz"
-            # Not a CLI binary leg (see jobs.xcframework above), but still a
-            # released, version-named asset -- keep it in this same
-            # completeness gate so a broken xcframework build fails loudly
-            # instead of quietly shipping a release without the SDK.
-            "xcframework:zip"
-          )
-
-          expected_file="$(mktemp)"
-          base_expected="$(mktemp)"
-          {
-            for entry in "${TARGETS[@]}"; do
-              target="${entry%%:*}"
-              ext="${entry##*:}"
-              echo "openasr-${version}-${target}.${ext}"
-            done
-            echo "openasr-${version}-xcframework.zip.sha256"
-          } > "$base_expected"
           pack_names="$(mktemp)"
-          python3 - "$pack_names" <<'PY'
-          import json
-          import sys
-          from pathlib import Path
-
-          matrix = json.loads(Path("tooling/release-manifest/release_binaries_matrix.json").read_text())
-          names = []
-          for row in matrix:
-              provider = row.get("provider")
-              if provider == "cuda" and not row.get("experimental", False):
-                  names.append(f"backend-pack-cuda-sm_{row['cuda_gpu_target']}.json")
-              elif provider == "hip" and not row.get("experimental", False):
-                  names.append(f"backend-pack-hip-{row['hip_gpu_target']}.json")
-              elif provider == "vulkan" and row.get("distribution") == "plugin":
-                  names.append("backend-pack-vulkan-generic.json")
-          Path(sys.argv[1]).write_text("\n".join(names) + "\n", encoding="utf-8")
-          PY
+          python3 tooling/release-manifest/release_completeness.py pack-names \
+            > "$pack_names"
           pack_dir="$(mktemp -d)"
           while IFS= read -r pack_name; do
             [ -n "$pack_name" ] || continue
             gh release download "$tag" --repo "${{ github.repository }}" \
               -p "$pack_name" -D "$pack_dir"
           done < "$pack_names"
-          pack_payload_names="$(mktemp)"
-          python3 - "$pack_dir" "$version" > "$pack_payload_names" <<'PY'
-          import json
-          import sys
-          from pathlib import Path
-
-          root = Path(sys.argv[1])
-          version = sys.argv[2]
-          for entry_path in sorted(root.glob("backend-pack-*.json")):
-              entry = json.loads(entry_path.read_text(encoding="utf-8"))
-              provider = entry.get("vendor")
-              targets = entry.get("targets")
-              if provider not in {"cuda", "hip"} or not isinstance(targets, list) or len(targets) != 1:
-                  raise SystemExit(f"{entry_path.name} is not an exact CUDA/HIP target entry")
-              print(f"openasr-{version}-qualification-{provider}-{targets[0]}.json")
-              files = entry.get("files")
-              if not isinstance(files, list) or not files:
-                  raise SystemExit(f"{entry_path.name} has no files")
-              for file in files:
-                  name = file.get("filename") if isinstance(file, dict) else None
-                  if not isinstance(name, str) or not name or Path(name).name != name:
-                      raise SystemExit(f"{entry_path.name} has unsafe filename {name!r}")
-                  print(name)
-          PY
-          {
-            cat "$base_expected"
-            cat "$pack_names"
-            cat "$pack_payload_names"
-            echo "backend-plugin-hints.json"
-            echo "catalog.backends.candidate.json"
-            echo "openasr-${version}-build-provenance.bundle.json"
-            echo "openasr-${version}-qualification-vulkan-windows-x86_64.json"
-            echo "SHA256SUMS"
-          } > "$expected_file"
-          sort -u -o "$expected_file" "$expected_file"
-
           actual_file="$(mktemp)"
           gh release view "$tag" --repo "${{ github.repository }}" --json assets \
             --jq '.assets[].name' | sort > "$actual_file"
-          lock_asset="openasr-${version}-qualification-mutation.lock"
-          if grep -Fqx "$lock_asset" "$actual_file"; then
-            echo "::error::release ${tag} still has qualification mutation lock ${lock_asset}" >&2
-            exit 1
-          fi
-
-          echo "== expected =="
-          cat "$expected_file"
-          echo "== actual =="
-          cat "$actual_file"
-
-          missing="$(comm -23 "$expected_file" "$actual_file")"
-          extra="$(comm -13 "$expected_file" "$actual_file")"
-          if [ -n "$missing" ]; then
-            echo "::error::release ${tag} is missing expected asset(s):"
-            echo "$missing"
-            exit 1
-          fi
-          if [ -n "$extra" ]; then
-            echo "::error::release ${tag} contains unexpected asset(s):"
-            echo "$extra"
-            exit 1
-          fi
-          echo "release ${tag} has all $(wc -l < "$expected_file" | tr -d ' ') expected assets."
-
-          echo "release ${tag} has every plugin and content-addressed vendor archive declared by its required backend packs."
+          python3 tooling/release-manifest/release_completeness.py compare \
+            --version "$version" \
+            --pack-dir "$pack_dir" \
+            --actual-file "$actual_file"

--- a/tooling/release-manifest/release_completeness.py
+++ b/tooling/release-manifest/release_completeness.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Single source for GitHub Release completeness: required vs optional assets.
+
+The formal release completeness gate must see draft releases (contents:write)
+and must derive qualification filenames from ``qualification_manifest.artifact_cell``,
+the same helper that compiles the inert manifests. Experimental matrix rows may
+appear on the release when they succeed; they are optional, never required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import qualification_manifest
+
+MATRIX_PATH = Path(__file__).resolve().parent / "release_binaries_matrix.json"
+LOCK_ASSET_SUFFIX = "-qualification-mutation.lock"
+
+
+class CompletenessError(ValueError):
+    pass
+
+
+def load_matrix(path: Path = MATRIX_PATH) -> list[dict[str, Any]]:
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(rows, list):
+        raise CompletenessError(f"{path} must contain a JSON array")
+    return rows
+
+
+def _archive_name(version: str, row: dict[str, Any]) -> str:
+    asset = row.get("asset")
+    ext = row.get("archive_ext")
+    if not isinstance(asset, str) or not asset or not isinstance(ext, str) or not ext:
+        raise CompletenessError(f"matrix row {row.get('target')!r} lacks asset/archive_ext")
+    return f"openasr-{version}-{asset}.{ext}"
+
+
+def required_cli_archives(version: str, matrix: list[dict[str, Any]]) -> set[str]:
+    names = {
+        f"openasr-{version}-xcframework.zip",
+        f"openasr-{version}-xcframework.zip.sha256",
+    }
+    for row in matrix:
+        if not isinstance(row, dict) or row.get("experimental") or row.get("distribution") == "plugin":
+            continue
+        names.add(_archive_name(version, row))
+    return names
+
+
+def optional_experimental_archives(version: str, matrix: list[dict[str, Any]]) -> set[str]:
+    names: set[str] = set()
+    for row in matrix:
+        if not isinstance(row, dict) or not row.get("experimental"):
+            continue
+        names.add(_archive_name(version, row))
+    return names
+
+
+def backend_pack_names(matrix: list[dict[str, Any]]) -> list[str]:
+    names: list[str] = []
+    for row in matrix:
+        if not isinstance(row, dict) or row.get("experimental"):
+            continue
+        provider = row.get("provider")
+        if provider == "cuda":
+            names.append(f"backend-pack-cuda-sm_{row['cuda_gpu_target']}.json")
+        elif provider == "hip":
+            names.append(f"backend-pack-hip-{row['hip_gpu_target']}.json")
+        elif provider == "vulkan" and row.get("distribution") == "plugin":
+            names.append("backend-pack-vulkan-generic.json")
+    return names
+
+
+def _payload_filenames(entry: dict[str, Any], source: str) -> list[str]:
+    files = entry.get("files")
+    if not isinstance(files, list) or not files:
+        raise CompletenessError(f"{source} has no files")
+    names: list[str] = []
+    for file in files:
+        name = file.get("filename") if isinstance(file, dict) else None
+        if not isinstance(name, str) or not name or Path(name).name != name:
+            raise CompletenessError(f"{source} has unsafe filename {name!r}")
+        names.append(name)
+    return names
+
+
+def required_from_backend_packs(version: str, entries: list[dict[str, Any]]) -> set[str]:
+    names: set[str] = set()
+    for entry in entries:
+        source = str(entry.get("id") or "backend-pack")
+        provider, target = qualification_manifest.artifact_cell(entry)
+        names.add(f"openasr-{version}-qualification-{provider}-{target}.json")
+        names.update(_payload_filenames(entry, source))
+    return names
+
+
+def required_assets(
+    version: str,
+    matrix: list[dict[str, Any]],
+    pack_entries: list[dict[str, Any]],
+) -> set[str]:
+    names = required_cli_archives(version, matrix)
+    names.update(backend_pack_names(matrix))
+    names.update(required_from_backend_packs(version, pack_entries))
+    names.update(
+        {
+            "backend-plugin-hints.json",
+            "catalog.backends.candidate.json",
+            f"openasr-{version}-build-provenance.bundle.json",
+            "SHA256SUMS",
+        }
+    )
+    return names
+
+
+def load_pack_entries(pack_dir: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for path in sorted(pack_dir.glob("backend-pack-*.json")):
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise CompletenessError(f"{path.name} must contain a JSON object")
+        entries.append(value)
+    return entries
+
+
+def compare_assets(
+    *,
+    version: str,
+    actual: set[str],
+    matrix: list[dict[str, Any]],
+    pack_entries: list[dict[str, Any]],
+) -> tuple[list[str], list[str], str | None]:
+    required = required_assets(version, matrix, pack_entries)
+    optional = optional_experimental_archives(version, matrix)
+    lock_asset = f"openasr-{version}{LOCK_ASSET_SUFFIX}"
+    lock = lock_asset if lock_asset in actual else None
+    missing = sorted(required - actual)
+    extra = sorted(actual - required - optional - ({lock_asset} if lock else set()))
+    return missing, extra, lock
+
+
+def _emit_lines(values: list[str]) -> None:
+    for value in values:
+        sys.stdout.write(f"{value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    packs = sub.add_parser("pack-names")
+    packs.add_argument("--matrix", type=Path, default=MATRIX_PATH)
+
+    compare = sub.add_parser("compare")
+    compare.add_argument("--version", required=True)
+    compare.add_argument("--matrix", type=Path, default=MATRIX_PATH)
+    compare.add_argument("--pack-dir", type=Path, required=True)
+    compare.add_argument("--actual-file", type=Path, required=True)
+
+    args = parser.parse_args()
+    try:
+        if args.command == "pack-names":
+            _emit_lines(backend_pack_names(load_matrix(args.matrix)))
+            return 0
+
+        matrix = load_matrix(args.matrix)
+        pack_entries = load_pack_entries(args.pack_dir)
+        actual = {
+            line
+            for line in args.actual_file.read_text(encoding="utf-8").splitlines()
+            if line
+        }
+        missing, extra, lock = compare_assets(
+            version=args.version,
+            actual=actual,
+            matrix=matrix,
+            pack_entries=pack_entries,
+        )
+        required = sorted(required_assets(args.version, matrix, pack_entries))
+        optional = sorted(optional_experimental_archives(args.version, matrix))
+        sys.stdout.write("== required ==\n")
+        _emit_lines(required)
+        sys.stdout.write("== optional experimental ==\n")
+        _emit_lines(optional)
+        sys.stdout.write("== actual ==\n")
+        _emit_lines(sorted(actual))
+        if lock:
+            sys.stderr.write(
+                f"release still has qualification mutation lock {lock}\n"
+            )
+        if missing:
+            sys.stderr.write("release is missing expected asset(s):\n")
+            sys.stderr.write("\n".join(missing) + "\n")
+        if extra:
+            sys.stderr.write("release contains unexpected asset(s):\n")
+            sys.stderr.write("\n".join(extra) + "\n")
+        if lock or missing or extra:
+            return 1
+        sys.stdout.write(f"release has all {len(required)} expected assets.\n")
+        return 0
+    except CompletenessError as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/release-manifest/release_completeness_test.py
+++ b/tooling/release-manifest/release_completeness_test.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import qualification_manifest
+import release_completeness as completeness
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = completeness.load_matrix()
+WORKFLOW = (ROOT / ".github" / "workflows" / "release-binaries.yml").read_text(
+    encoding="utf-8"
+)
+
+
+def _pack(*, vendor: str, targets: list[str], files: list[str], ident: str) -> dict:
+    return {
+        "id": ident,
+        "vendor": vendor,
+        "targets": targets,
+        "files": [{"filename": name, "sha256": "a" * 64, "size": 1} for name in files],
+    }
+
+
+class ReleaseCompletenessTests(unittest.TestCase):
+    def test_required_cli_archives_match_non_experimental_non_plugin_matrix_rows(self) -> None:
+        names = completeness.required_cli_archives("0.1.37", MATRIX)
+        self.assertIn("openasr-0.1.37-linux-x86_64.tar.gz", names)
+        self.assertIn("openasr-0.1.37-windows-x86_64-neutral.zip", names)
+        self.assertIn("openasr-0.1.37-linux-x86_64-vulkan.tar.gz", names)
+        self.assertIn("openasr-0.1.37-xcframework.zip", names)
+        self.assertIn("openasr-0.1.37-xcframework.zip.sha256", names)
+        self.assertNotIn("openasr-0.1.37-linux-x86_64-musl.tar.gz", names)
+        self.assertNotIn("openasr-0.1.37-windows-arm64.zip", names)
+        self.assertNotIn("openasr-0.1.37-windows-x86_64-vulkan-generic-plugin.dll", names)
+
+    def test_optional_experimental_archives_cover_musl_and_windows_arm64(self) -> None:
+        names = completeness.optional_experimental_archives("0.1.37", MATRIX)
+        self.assertEqual(
+            names,
+            {
+                "openasr-0.1.37-linux-x86_64-musl.tar.gz",
+                "openasr-0.1.37-linux-arm64-musl.tar.gz",
+                "openasr-0.1.37-windows-arm64.zip",
+            },
+        )
+
+    def test_qualification_names_use_artifact_cell_including_vulkan_generic(self) -> None:
+        entries = [
+            _pack(
+                vendor="cuda",
+                targets=["sm_75"],
+                files=["openasr-0.1.37-windows-x86_64-cuda-sm_75-plugin.dll"],
+                ident="cuda-sm-75",
+            ),
+            _pack(
+                vendor="vulkan",
+                targets=[],
+                files=["openasr-0.1.37-windows-x86_64-vulkan-generic-plugin.dll"],
+                ident="vulkan-generic",
+            ),
+        ]
+        names = completeness.required_from_backend_packs("0.1.37", entries)
+        self.assertEqual(qualification_manifest.artifact_cell(entries[1]), ("vulkan", "generic"))
+        self.assertIn("openasr-0.1.37-qualification-cuda-sm_75.json", names)
+        self.assertIn("openasr-0.1.37-qualification-vulkan-generic.json", names)
+        self.assertNotIn("openasr-0.1.37-qualification-vulkan-windows-x86_64.json", names)
+
+    def test_compare_allows_successful_experimental_archives_and_rejects_unknown_extras(self) -> None:
+        entries = [
+            _pack(
+                vendor="vulkan",
+                targets=[],
+                files=["plugin.dll", "vendor.zip"],
+                ident="vulkan-generic",
+            )
+        ]
+        required = completeness.required_assets("0.1.37", MATRIX, entries)
+        actual = set(required)
+        actual.add("openasr-0.1.37-windows-arm64.zip")
+        missing, extra, lock = completeness.compare_assets(
+            version="0.1.37",
+            actual=actual,
+            matrix=MATRIX,
+            pack_entries=entries,
+        )
+        self.assertEqual(missing, [])
+        self.assertEqual(extra, [])
+        self.assertIsNone(lock)
+
+        actual.add("unexpected.bin")
+        missing, extra, lock = completeness.compare_assets(
+            version="0.1.37",
+            actual=actual,
+            matrix=MATRIX,
+            pack_entries=entries,
+        )
+        self.assertEqual(extra, ["unexpected.bin"])
+
+    def test_compare_rejects_qualification_mutation_lock(self) -> None:
+        entries = [
+            _pack(
+                vendor="vulkan",
+                targets=[],
+                files=["plugin.dll"],
+                ident="vulkan-generic",
+            )
+        ]
+        required = completeness.required_assets("0.1.37", MATRIX, entries)
+        actual = set(required)
+        actual.add("openasr-0.1.37-qualification-mutation.lock")
+        missing, extra, lock = completeness.compare_assets(
+            version="0.1.37",
+            actual=actual,
+            matrix=MATRIX,
+            pack_entries=entries,
+        )
+        self.assertEqual(lock, "openasr-0.1.37-qualification-mutation.lock")
+        self.assertEqual(extra, [])
+        self.assertEqual(missing, [])
+
+    def test_pack_names_cli_emits_the_21_required_backend_entries(self) -> None:
+        names = completeness.backend_pack_names(MATRIX)
+        self.assertEqual(len(names), 21)
+        self.assertIn("backend-pack-vulkan-generic.json", names)
+        self.assertEqual(len([name for name in names if name.startswith("backend-pack-cuda-")]), 6)
+        self.assertEqual(len([name for name in names if name.startswith("backend-pack-hip-")]), 14)
+
+    def test_compare_cli_accepts_a_complete_actual_list(self) -> None:
+        entries = [
+            _pack(
+                vendor="cuda",
+                targets=["sm_75"],
+                files=["cuda.dll"],
+                ident="cuda-sm-75",
+            ),
+            _pack(
+                vendor="vulkan",
+                targets=[],
+                files=["vulkan.dll"],
+                ident="vulkan-generic",
+            ),
+        ]
+        required = completeness.required_assets("0.1.37", MATRIX, entries)
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "backend-pack-cuda-sm_75.json").write_text(
+                json.dumps(entries[0]), encoding="utf-8"
+            )
+            (root / "backend-pack-vulkan-generic.json").write_text(
+                json.dumps(entries[1]), encoding="utf-8"
+            )
+            actual = root / "actual.txt"
+            actual.write_text("\n".join(sorted(required)) + "\n", encoding="utf-8")
+            missing, extra, lock = completeness.compare_assets(
+                version="0.1.37",
+                actual=required,
+                matrix=MATRIX,
+                pack_entries=completeness.load_pack_entries(root),
+            )
+            self.assertEqual((missing, extra, lock), ([], [], None))
+
+
+class CompletenessWorkflowContractTests(unittest.TestCase):
+    def test_completeness_job_can_see_drafts_and_uses_shared_expected_set(self) -> None:
+        job = WORKFLOW.split("\n  verify-completeness:\n", 1)[1]
+        header = job.split("\n    steps:", 1)[0]
+        self.assertIn("contents: write", header)
+        self.assertIn("tooling/release-manifest/release_completeness.py", job)
+        self.assertNotIn("qualification-vulkan-windows-x86_64", job)
+        self.assertNotIn("is not an exact CUDA/HIP target entry", job)
+
+    def test_workflow_does_not_expect_the_retired_vulkan_windows_qualification_name(self) -> None:
+        self.assertNotIn("qualification-vulkan-windows-x86_64", WORKFLOW)
+        self.assertNotIn("vulkan-windows-x86_64.json", WORKFLOW)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/release-manifest/windows_backend_release_contract_test.py
+++ b/tooling/release-manifest/windows_backend_release_contract_test.py
@@ -122,15 +122,18 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
             "--require-single-target",
             "--out dist/catalog.backends.candidate.json",
             "--out dist/backend-plugin-hints.json",
-            'names.append(f"backend-pack-cuda-sm_{row[\'cuda_gpu_target\']}.json")',
-            'names.append(f"backend-pack-hip-{row[\'hip_gpu_target\']}.json")',
-            'names.append("backend-pack-vulkan-generic.json")',
-            'echo "backend-plugin-hints.json"',
-            'echo "catalog.backends.candidate.json"',
             "staging/catalog.backends.candidate.json",
         )
         for fragment in required:
             self.assertIn(fragment, self.workflow)
+        completeness = (ROOT / "tooling" / "release-manifest" / "release_completeness.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('f"backend-pack-cuda-sm_{row[\'cuda_gpu_target\']}.json"', completeness)
+        self.assertIn('f"backend-pack-hip-{row[\'hip_gpu_target\']}.json"', completeness)
+        self.assertIn('"backend-pack-vulkan-generic.json"', completeness)
+        self.assertIn('"backend-plugin-hints.json"', completeness)
+        self.assertIn('"catalog.backends.candidate.json"', completeness)
 
     def test_plugin_vendor_and_signing_steps_cover_all_gpu_providers(self) -> None:
         self.assertIn(
@@ -289,7 +292,11 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
         self.assertIn("refusing to overwrite assets on a public release", self.workflow)
         self.assertIn("release tag and checked-out source commit differ", self.workflow)
         self.assertIn("formal release assets may be uploaded only to an existing draft", self.workflow)
-        self.assertIn("contains unexpected asset(s)", self.workflow)
+        completeness = (ROOT / "tooling" / "release-manifest" / "release_completeness.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("contains unexpected asset(s)", completeness)
+        self.assertIn("tooling/release-manifest/release_completeness.py", self.workflow)
         self.assertIn("staging/*.sha256", self.workflow)
     def test_qualification_manifests_bind_the_successful_attestation_bundle(self) -> None:
         checksums = self.workflow.split("\n  checksums:\n", 1)[1].split(
@@ -404,10 +411,10 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
             ),
             2,
         )
-        self.assertIn(
-            'lock_asset="openasr-${version}-qualification-mutation.lock"',
-            self.workflow,
+        completeness = (ROOT / "tooling" / "release-manifest" / "release_completeness.py").read_text(
+            encoding="utf-8"
         )
+        self.assertIn('LOCK_ASSET_SUFFIX = "-qualification-mutation.lock"', completeness)
         self.assertIn("stopped being a draft before asset upload", self.workflow)
 
     def test_qualification_release_lock_is_exclusive_and_nonce_owned(self) -> None:


### PR DESCRIPTION
## Summary

The v0.1.37 `Release core` matrix and upload succeeded. Completeness then failed with `release not found` because the job inherited `contents: read` and GitHub draft releases are invisible to that token.

The inline expected list would also have failed after that: it still named Vulkan qualification `openasr-*-qualification-vulkan-windows-x86_64.json` (retired sidecar) instead of `...-vulkan-generic.json`, treated Vulkan backend packs as CUDA/HIP-only, and rejected successful experimental musl/windows-arm64 archives.

## Why

Draft completeness must see the draft, and the expected set must be the same names the checksums job actually compiles.

## Changes

- Give `verify-completeness` `contents: write` so `gh release view/download` can see the draft.
- Move the expected/optional asset set into `tooling/release-manifest/release_completeness.py`, using `qualification_manifest.artifact_cell` for qualification filenames.
- Treat experimental matrix rows as optional extras.

The v0.1.37 tag stays at `bdc6d095` (attestation source-digest). This PR does not rebuild or retag. Local compare against the live draft reports 82 required assets present.

## Tests run

- [x] `python3 -m unittest discover -s tooling/release-manifest -p 'release_completeness_test.py'`
- [x] `python3 -m unittest discover -s tooling/release-manifest -p 'windows_backend_release_contract_test.py'` (2 pre-existing errors: worktree has no ggml submodule)
- [x] Live `release_completeness.py compare --version 0.1.37` against the current draft: 82 expected assets, 0 missing, experimental extras allowed

Workflow/Python-only change. Rust sources untouched.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- AI usage disclosure: YES