### PR TITLE
ci(release): grant draft readers write and re-verify on finalize

### DIFF
--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -61,7 +61,9 @@ concurrency:
 permissions:
   actions: read
   attestations: read
-  contents: read
+  # PublishedInert deploy runs against a GitHub *draft* release. Drafts are
+  # invisible to contents:read, so this workflow needs write to see them.
+  contents: write
 
 jobs:
   gate-activation:

--- a/.github/workflows/family-regression.yml
+++ b/.github/workflows/family-regression.yml
@@ -38,7 +38,9 @@ concurrency:
 
 permissions:
   attestations: read
-  contents: read
+  # Pre-publication runs download a GitHub *draft* release. Drafts are
+  # invisible to contents:read, so this workflow needs write to see them.
+  contents: write
   packages: read
 
 defaults:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1708,26 +1708,7 @@ jobs:
       - name: Assert the release has every expected matrix asset
         # Draft GitHub Releases are invisible to contents:read. This job only
         # reads the draft, but it still needs contents:write to see it.
-        # Qualification filenames come from qualification_manifest.artifact_cell
-        # so Vulkan stays generic, not a retired windows-x86_64 sidecar name.
         run: |
           set -euo pipefail
-          tag="${RELEASE_TAG}"
-          [ -n "$tag" ] || { echo "release tag is empty" >&2; exit 1; }
-          version="${OPENASR_VERSION}"
-          pack_names="$(mktemp)"
-          python3 tooling/release-manifest/release_completeness.py pack-names \
-            > "$pack_names"
-          pack_dir="$(mktemp -d)"
-          while IFS= read -r pack_name; do
-            [ -n "$pack_name" ] || continue
-            gh release download "$tag" --repo "${{ github.repository }}" \
-              -p "$pack_name" -D "$pack_dir"
-          done < "$pack_names"
-          actual_file="$(mktemp)"
-          gh release view "$tag" --repo "${{ github.repository }}" --json assets \
-            --jq '.assets[].name' | sort > "$actual_file"
-          python3 tooling/release-manifest/release_completeness.py compare \
-            --version "$version" \
-            --pack-dir "$pack_dir" \
-            --actual-file "$actual_file"
+          [ -n "${RELEASE_TAG}" ] || { echo "release tag is empty" >&2; exit 1; }
+          scripts/verify-release-completeness.sh "${RELEASE_TAG}" "${{ github.repository }}"

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -10,8 +10,9 @@ name: Release core
 #      the pin; they never override it.
 #   2. If no GitHub Release exists yet: create the empty draft, then call
 #      release-binaries.yml with `formal_release: true`.
-#   3. If the matching release is still a draft: run the pre-publication
-#      family gate and deploy the committed PublishedInert catalog.
+#   3. If the matching release is still a draft: re-verify completeness,
+#      run the pre-publication family gate, and deploy the committed
+#      PublishedInert catalog.
 #
 # The GitHub Release stays a draft until `scripts/finalize-core-release.sh`
 # runs locally after the signed catalog + CDN plane is live. Agents do not
@@ -227,14 +228,28 @@ jobs:
     # ship an unsigned Windows release binary" gate.
     secrets: inherit
 
+  verify-draft-completeness:
+    name: Verify draft release completeness
+    needs: [resolve]
+    if: needs.resolve.outputs.should_finalize == 'true' && success()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Assert the draft still has the complete attested subject set
+        run: scripts/verify-release-completeness.sh "${{ needs.resolve.outputs.tag }}" "${{ github.repository }}"
+
   prepublication-family:
     name: Pre-publication family correctness gate
-    needs: [resolve]
+    needs: [resolve, verify-draft-completeness]
     if: needs.resolve.outputs.should_finalize == 'true' && success()
     permissions:
       actions: read
       attestations: read
-      contents: read
+      contents: write
       packages: read
     uses: ./.github/workflows/family-regression.yml
     with:
@@ -249,7 +264,7 @@ jobs:
     permissions:
       actions: read
       attestations: read
-      contents: read
+      contents: write
     uses: ./.github/workflows/deploy-catalog.yml
     with:
       orchestrator_run_id: ${{ github.run_id }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -142,9 +142,11 @@ bytes without exposing an unqualified provider to users.
    the epoch, and signs the full/public catalogs. It consumes no hardware or
    token-correctness receipt. Review, commit, and push the five catalog/epoch
    files.
-4. Dispatch `Release core` again. Its reusable pre-publication family contract
-   verifies the immutable draft CLI and runs the real-pack CPU family gate. The
-   orchestrator then calls the sole deployment entrypoint,
+4. Dispatch `Release core` again. It re-verifies the draft's complete attested
+   subject set (the same completeness gate as the original matrix, so a later
+   CI-only fix can still see the draft), then runs the reusable pre-publication
+   family contract against the immutable draft CLI and the real-pack CPU family
+   gate. The orchestrator then calls the sole deployment entrypoint,
    `.github/workflows/deploy-catalog.yml`, with
    `activation_transition: published-inert`. The deploy job checks the signed
    catalog, CDN payloads, and released-binary compatibility before writing it.

--- a/scripts/verify-release-completeness.sh
+++ b/scripts/verify-release-completeness.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Verify a GitHub Release (draft or public) has the required subject set.
+# Draft releases are invisible to contents:read tokens; callers must supply
+# a token that can see the release.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+[ "$#" -ge 1 ] && [ "$#" -le 2 ] || {
+  echo "usage: $(basename "$0") vX.Y.Z [owner/repo]" >&2
+  exit 1
+}
+tag="$1"
+[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "tag must be vX.Y.Z" >&2
+  exit 1
+}
+version="${tag#v}"
+repository="${2:-${GITHUB_REPOSITORY:-QuintinShaw/openasr}}"
+command -v gh >/dev/null 2>&1 || { echo "gh is required" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
+
+pack_names="$(mktemp)"
+pack_dir="$(mktemp -d)"
+actual_file="$(mktemp)"
+cleanup() { rm -rf -- "$pack_names" "$pack_dir" "$actual_file"; }
+trap cleanup EXIT
+
+python3 tooling/release-manifest/release_completeness.py pack-names > "$pack_names"
+while IFS= read -r pack_name; do
+  [ -n "$pack_name" ] || continue
+  gh release download "$tag" --repo "$repository" -p "$pack_name" -D "$pack_dir"
+done < "$pack_names"
+gh release view "$tag" --repo "$repository" --json assets \
+  --jq '.assets[].name' | sort > "$actual_file"
+python3 tooling/release-manifest/release_completeness.py compare \
+  --version "$version" \
+  --pack-dir "$pack_dir" \
+  --actual-file "$actual_file"

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -17,31 +17,80 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
 
     def test_release_caller_grants_every_permission_requested_by_reusable_jobs(self) -> None:
         release = (ROOT / ".github/workflows/release-core.yml").read_text(encoding="utf-8")
+        permission_rank = {"read": 1, "write": 2}
+        cases = (
+            (
+                "binaries",
+                "\n  binaries:\n",
+                "\n  verify-draft-completeness:\n",
+                ROOT / ".github/workflows/release-binaries.yml",
+            ),
+            (
+                "prepublication-family",
+                "\n  prepublication-family:\n",
+                "\n  deploy-catalog:\n",
+                ROOT / ".github/workflows/family-regression.yml",
+            ),
+            (
+                "deploy-catalog",
+                "\n  deploy-catalog:\n",
+                "\n  finalize-notes:\n",
+                ROOT / ".github/workflows/deploy-catalog.yml",
+            ),
+        )
+        for name, start, end, path in cases:
+            caller = release.split(start, maxsplit=1)[1].split(end, maxsplit=1)[0]
+            called = path.read_text(encoding="utf-8")
+            caller_permissions = dict(
+                re.findall(r"(?m)^      ([a-z-]+): (read|write)$", caller)
+            )
+            requested_permissions = re.findall(
+                r"(?m)^(?:  |      )([a-z-]+): (read|write)$", called
+            )
+            for scope, requested in requested_permissions:
+                granted = caller_permissions.get(scope)
+                self.assertIsNotNone(
+                    granted,
+                    f"{name} caller does not grant requested {scope}: {requested}",
+                )
+                self.assertGreaterEqual(
+                    permission_rank[granted],
+                    permission_rank[requested],
+                    f"{name} caller grants {scope}: {granted}, below {requested}",
+                )
+
+    def test_draft_release_readers_request_contents_write(self) -> None:
+        release = (ROOT / ".github/workflows/release-core.yml").read_text(encoding="utf-8")
+        family = (ROOT / ".github/workflows/family-regression.yml").read_text(
+            encoding="utf-8"
+        )
+        deploy = (ROOT / ".github/workflows/deploy-catalog.yml").read_text(
+            encoding="utf-8"
+        )
         binaries = (ROOT / ".github/workflows/release-binaries.yml").read_text(
             encoding="utf-8"
         )
-        caller = release.split("\n  binaries:\n", maxsplit=1)[1].split(
-            "\n  prepublication-family:\n", maxsplit=1
+        completeness = (ROOT / "scripts/verify-release-completeness.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("scripts/verify-release-completeness.sh", release)
+        self.assertIn("scripts/verify-release-completeness.sh", binaries)
+        self.assertIn("verify-draft-completeness:", release)
+        self.assertIn("needs: [resolve, verify-draft-completeness]", release)
+        completeness_job = binaries.split("\n  verify-completeness:\n", 1)[1]
+        self.assertIn("contents: write", completeness_job.split("\n    steps:", 1)[0])
+        self.assertIn("contents: write", family.split("jobs:", 1)[0])
+        self.assertIn("contents: write", deploy.split("jobs:", 1)[0])
+        family_caller = release.split("\n  prepublication-family:\n", 1)[1].split(
+            "\n  deploy-catalog:\n", 1
         )[0]
-        caller_permissions = dict(
-            re.findall(r"(?m)^      ([a-z-]+): (read|write)$", caller)
-        )
-        requested_permissions = re.findall(
-            r"(?m)^(?:  |      )([a-z-]+): (read|write)$", binaries
-        )
-        permission_rank = {"read": 1, "write": 2}
-
-        for scope, requested in requested_permissions:
-            granted = caller_permissions.get(scope)
-            self.assertIsNotNone(
-                granted,
-                f"release-core reusable caller does not grant requested {scope}: {requested}",
-            )
-            self.assertGreaterEqual(
-                permission_rank[granted],
-                permission_rank[requested],
-                f"release-core reusable caller grants {scope}: {granted}, below {requested}",
-            )
+        deploy_caller = release.split("\n  deploy-catalog:\n", 1)[1].split(
+            "\n  finalize-notes:\n", 1
+        )[0]
+        self.assertIn("contents: write", family_caller)
+        self.assertIn("contents: write", deploy_caller)
+        self.assertIn("gh release download", completeness)
+        self.assertIn("gh release view", completeness)
     def test_reusable_release_declares_every_referenced_input(self) -> None:
         binaries = (ROOT / ".github/workflows/release-binaries.yml").read_text(
             encoding="utf-8"
@@ -94,6 +143,8 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn("release ${tag} is a draft", release)
         self.assertIn("uses: ./.github/workflows/family-regression.yml", release)
         self.assertIn("uses: ./.github/workflows/deploy-catalog.yml", release)
+        self.assertIn("verify-draft-completeness:", release)
+        self.assertIn("scripts/verify-release-completeness.sh", release)
         self.assertNotIn("correctness_sources_artifact", release)
         self.assertNotIn("correctness_matrix_artifact", release)
         self.assertIn("orchestrator_run_id: ${{ github.run_id }}", release)

--- a/tooling/release-manifest/release_completeness_test.py
+++ b/tooling/release-manifest/release_completeness_test.py
@@ -169,7 +169,7 @@ class CompletenessWorkflowContractTests(unittest.TestCase):
         job = WORKFLOW.split("\n  verify-completeness:\n", 1)[1]
         header = job.split("\n    steps:", 1)[0]
         self.assertIn("contents: write", header)
-        self.assertIn("tooling/release-manifest/release_completeness.py", job)
+        self.assertIn("scripts/verify-release-completeness.sh", job)
         self.assertNotIn("qualification-vulkan-windows-x86_64", job)
         self.assertNotIn("is not an exact CUDA/HIP target entry", job)
 

--- a/tooling/release-manifest/windows_backend_release_contract_test.py
+++ b/tooling/release-manifest/windows_backend_release_contract_test.py
@@ -135,6 +135,10 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
         self.assertIn('"backend-plugin-hints.json"', completeness)
         self.assertIn('"catalog.backends.candidate.json"', completeness)
 
+    def test_plugin_rows_skip_cli_smoke(self) -> None:
+        self.assertIn("crate=\"openasr-core\"", self.workflow)
+        self.assertGreaterEqual(self.workflow.count("matrix.distribution != 'plugin'"), 2)
+
     def test_plugin_vendor_and_signing_steps_cover_all_gpu_providers(self) -> None:
         self.assertIn(
             "matrix.distribution == 'plugin'", self.workflow
@@ -296,7 +300,7 @@ class WindowsBackendReleaseContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("contains unexpected asset(s)", completeness)
-        self.assertIn("tooling/release-manifest/release_completeness.py", self.workflow)
+        self.assertIn("scripts/verify-release-completeness.sh", self.workflow)
         self.assertIn("staging/*.sha256", self.workflow)
     def test_qualification_manifests_bind_the_successful_attestation_bundle(self) -> None:
         checksums = self.workflow.split("\n  checksums:\n", 1)[1].split(


### PR DESCRIPTION
## Summary

The v0.1.37 matrix uploaded a complete draft, but completeness failed because `contents:read` cannot see GitHub drafts. The same token restriction would have failed the second `Release core` dispatch: family regression and catalog deploy also download that draft.

## Why

Every job that reads a draft release must have `contents:write`. Completeness must also run on the finalize path so a later CI-only fix can still gate the existing draft without rebuilding.

## Changes

- Extract `scripts/verify-release-completeness.sh`.
- Re-run completeness on the finalize dispatch before the family gate.
- Grant `contents:write` to family-regression, deploy-catalog, and their `Release core` callers.
- Contract-test plugin CLI smoke skips and draft-reader write grants.

Does not rebuild or retag v0.1.37. Live completeness against the current draft reports 82 required assets.

## Tests run

- [x] `python3 -m unittest discover -s tooling/release-manifest -p 'release_completeness_test.py'`
- [x] `python3 -m unittest discover -s tooling/release-manifest -p 'core_release_finalization_contract_test.py'`
- [x] `python3 -m unittest discover -s tooling/release-manifest -p 'windows_backend_release_contract_test.py'` (2 pre-existing ggml submodule errors in this worktree)
- [x] `scripts/verify-release-completeness.sh v0.1.37`

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- AI usage disclosure: YES