### PR TITLE
fix(release): retry GitHub draft asset downloads

### DIFF
--- a/scripts/sync-windows-backend-cdn.sh
+++ b/scripts/sync-windows-backend-cdn.sh
@@ -62,9 +62,11 @@ echo "==> downloading all signed release bytes (qualification remains separate)"
 python3 - "$workdir" "${backend_entries[@]}" <<'PY'
 import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
 
 root = Path(sys.argv[1])
 downloaded: set[str] = set()
@@ -76,20 +78,7 @@ for entry_path in sys.argv[2:]:
             raise SystemExit(f"unsafe backend release filename: {name!r}")
         dest = root / name
         if name not in downloaded:
-            subprocess.run(
-                [
-                    "gh",
-                    "release",
-                    "download",
-                    f"v{entry['version']}",
-                    "-p",
-                    name,
-                    "-D",
-                    str(root),
-                    "--clobber",
-                ],
-                check=True,
-            )
+            gh_release.download_asset(f"v{entry['version']}", name, root)
             downloaded.add(name)
         digest = hashlib.sha256()
         size = 0

--- a/scripts/verify-release-completeness.sh
+++ b/scripts/verify-release-completeness.sh
@@ -29,10 +29,18 @@ cleanup() { rm -rf -- "$pack_names" "$pack_dir" "$actual_file"; }
 trap cleanup EXIT
 
 python3 tooling/release-manifest/release_completeness.py pack-names > "$pack_names"
-while IFS= read -r pack_name; do
-  [ -n "$pack_name" ] || continue
-  gh release download "$tag" --repo "$repository" -p "$pack_name" -D "$pack_dir"
-done < "$pack_names"
+python3 - "$tag" "$repository" "$pack_names" "$pack_dir" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
+
+tag, repository, pack_names, pack_dir = sys.argv[1:5]
+for pack_name in Path(pack_names).read_text(encoding="utf-8").splitlines():
+    if pack_name:
+        gh_release.download_asset(tag, pack_name, Path(pack_dir), repository=repository)
+PY
 gh release view "$tag" --repo "$repository" --json assets \
   --jq '.assets[].name' | sort > "$actual_file"
 python3 tooling/release-manifest/release_completeness.py compare \

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -89,7 +89,7 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         )[0]
         self.assertIn("contents: write", family_caller)
         self.assertIn("contents: write", deploy_caller)
-        self.assertIn("gh release download", completeness)
+        self.assertIn("gh_release.download_asset", completeness)
         self.assertIn("gh release view", completeness)
     def test_reusable_release_declares_every_referenced_input(self) -> None:
         binaries = (ROOT / ".github/workflows/release-binaries.yml").read_text(

--- a/tooling/release-manifest/gh_release.py
+++ b/tooling/release-manifest/gh_release.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Retry GitHub Release downloads. Large draft assets often fail with EOF."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+
+def download_asset(
+    tag: str,
+    name: str,
+    dest_dir: Path,
+    *,
+    repository: str | None = None,
+    attempts: int = 6,
+) -> None:
+    if Path(name).name != name:
+        raise ValueError(f"unsafe release asset name: {name!r}")
+    command = [
+        "gh",
+        "release",
+        "download",
+        tag,
+        "-p",
+        name,
+        "-D",
+        str(dest_dir),
+        "--clobber",
+    ]
+    if repository:
+        command.extend(["--repo", repository])
+    last_error: subprocess.CalledProcessError | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            subprocess.run(command, check=True)
+            return
+        except subprocess.CalledProcessError as error:
+            last_error = error
+            if attempt == attempts:
+                break
+            time.sleep(min(2 ** attempt, 16))
+    assert last_error is not None
+    raise last_error

--- a/tooling/release-manifest/gh_release_test.py
+++ b/tooling/release-manifest/gh_release_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import gh_release
+
+
+class GhReleaseDownloadTests(unittest.TestCase):
+    def test_retries_transient_failures_then_succeeds(self) -> None:
+        dest = Path("/tmp")
+        with mock.patch("gh_release.subprocess.run") as run, mock.patch(
+            "gh_release.time.sleep"
+        ) as sleep:
+            run.side_effect = [
+                subprocess.CalledProcessError(1, ["gh"]),
+                subprocess.CalledProcessError(1, ["gh"]),
+                None,
+            ]
+            gh_release.download_asset("v0.1.37", "backend-pack-vulkan-generic.json", dest)
+            self.assertEqual(run.call_count, 3)
+            self.assertEqual(sleep.call_count, 2)
+
+    def test_refuses_unsafe_asset_names(self) -> None:
+        with self.assertRaises(ValueError):
+            gh_release.download_asset("v0.1.37", "../escape.dll", Path("/tmp"))


### PR DESCRIPTION
## Summary

`scripts/sync-windows-backend-cdn.sh v0.1.37` failed twice on `gh release download` with `unexpected EOF` while fetching plugin DLLs from the draft.

## Why

Large GitHub draft assets are flaky over a single download. The inert publication path must retry rather than abort after one truncated transfer.

## Changes

- Add `tooling/release-manifest/gh_release.py` with bounded retries.
- Use it from CDN sync and completeness verification.

## Tests run

- [x] `python3 -m unittest discover -s tooling/release-manifest -p 'gh_release_test.py'`

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- AI usage disclosure: YES