### PR TITLE
fix(release): fetch draft assets via GitHub API curl

### DIFF
--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -82,7 +82,8 @@ jobs:
           [ -f "$activation_catalog" ] || { echo "committed public catalog is missing" >&2; exit 1; }
           version="${{ inputs.release_tag }}"; version="${version#v}"
           mkdir -p staging/release
-          gh release download "${{ inputs.release_tag }}" -p 'backend-pack-*.json' -D staging/release
+          python3 tooling/release-manifest/gh_release.py download-packs \
+            "${{ inputs.release_tag }}" staging/release
           mapfile -t entries < <(find staging/release -name 'backend-pack-*.json' -type f | sort)
           [ "${#entries[@]}" -eq 21 ] || {
             echo "expected 21 exact release backend entries, found ${#entries[@]}" >&2; exit 1;
@@ -166,8 +167,10 @@ jobs:
           done
           [ "${#receipts[@]}" -ge 4 ] && [ "${#traces[@]}" -ge 2 ]
 
-          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-            -p 'backend-pack-*.json' -p SHA256SUMS -D "$workdir/release"
+          python3 tooling/release-manifest/gh_release.py download-packs \
+            "$RELEASE_TAG" "$workdir/release" --repo "$GITHUB_REPOSITORY"
+          python3 tooling/release-manifest/gh_release.py download \
+            "$RELEASE_TAG" "$workdir/release" SHA256SUMS --repo "$GITHUB_REPOSITORY"
           mapfile -t entries < <(find "$workdir/release" -type f -name 'backend-pack-*.json' -print | sort)
           [ "${#entries[@]}" -eq 21 ]
           python3 - "$hardware_raw" > "$workdir/subject-names.txt" <<'PY'
@@ -180,10 +183,15 @@ jobs:
               names.add(name)
           print("\n".join(sorted(names)))
           PY
-          while IFS= read -r name; do
-            [ -n "$name" ] && gh release download "$RELEASE_TAG" \
-              --repo "$GITHUB_REPOSITORY" -p "$name" -D "$workdir/release" --clobber
-          done < "$workdir/subject-names.txt"
+          python3 - "$RELEASE_TAG" "$GITHUB_REPOSITORY" "$workdir/release" "$workdir/subject-names.txt" <<'PY'
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, "tooling/release-manifest")
+          import gh_release
+          tag, repository, dest, names_file = sys.argv[1:5]
+          names = [line.strip() for line in Path(names_file).read_text(encoding="utf-8").splitlines() if line.strip()]
+          gh_release.download_assets(tag, names, Path(dest), repository=repository)
+          PY
           entry_args=(); for path in "${entries[@]}"; do entry_args+=(--entry "$path"); done
           subject_args=(); while IFS= read -r name; do [ -n "$name" ] && subject_args+=(--release-subject "$workdir/release/$name"); done < "$workdir/subject-names.txt"
           release_signer="${GITHUB_REPOSITORY}/.github/workflows/release-binaries.yml"

--- a/.github/workflows/family-regression.yml
+++ b/.github/workflows/family-regression.yml
@@ -67,7 +67,8 @@ jobs:
           version="${RELEASE_TAG#v}"
           mkdir -p staging/candidate
           asset="openasr-${version}-linux-x86_64.tar.gz"
-          gh release download "$RELEASE_TAG" -p "$asset" -p SHA256SUMS -D staging/candidate
+          python3 tooling/release-manifest/gh_release.py download \
+            "$RELEASE_TAG" staging/candidate "$asset" SHA256SUMS
           python3 tooling/release-manifest/release_asset_verifier.py \
             --asset "staging/candidate/$asset" --checksums staging/candidate/SHA256SUMS
           git fetch --no-tags origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
@@ -112,8 +113,8 @@ jobs:
           asset="openasr-${version}-${ASSET_SUFFIX}.tar.gz"
           workdir="${RUNNER_TEMP}/published-cli"
           mkdir -p "${workdir}"
-          if gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" \
-              --dir "${workdir}" --pattern "${asset}" --pattern SHA256SUMS; then
+          if python3 tooling/release-manifest/gh_release.py download \
+              "${tag}" "${workdir}" "${asset}" SHA256SUMS --repo "${GITHUB_REPOSITORY}"; then
             python3 tooling/release-manifest/release_asset_verifier.py \
               --asset "${workdir}/${asset}" --checksums "${workdir}/SHA256SUMS" || exit 1
             gh attestation verify "${workdir}/${asset}" \
@@ -194,8 +195,8 @@ jobs:
           asset="openasr-${version}-${ASSET_SUFFIX}.tar.gz"
           workdir="${RUNNER_TEMP}/published-cli"
           mkdir -p "${workdir}"
-          if gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" \
-              --dir "${workdir}" --pattern "${asset}" --pattern SHA256SUMS; then
+          if python3 tooling/release-manifest/gh_release.py download \
+              "${tag}" "${workdir}" "${asset}" SHA256SUMS --repo "${GITHUB_REPOSITORY}"; then
             python3 tooling/release-manifest/release_asset_verifier.py \
               --asset "${workdir}/${asset}" --checksums "${workdir}/SHA256SUMS" || exit 1
             gh attestation verify "${workdir}/${asset}" \

--- a/.github/workflows/publish-core-channels.yml
+++ b/.github/workflows/publish-core-channels.yml
@@ -79,9 +79,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-metadata
-          gh release download "$TAG" \
-            --pattern 'backend-pack-*.json' \
-            --dir release-metadata
+          python3 tooling/release-manifest/gh_release.py download-packs \
+            "$TAG" release-metadata
       - name: Require the finalizer's live distribution invariants
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/qualify-windows-backend.yml
+++ b/.github/workflows/qualify-windows-backend.yml
@@ -114,12 +114,13 @@ jobs:
           }
           $releaseDir = Join-Path $env:RUNNER_TEMP "openasr-release-inputs"
           New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
-          gh release download $tag --repo $env:GITHUB_REPOSITORY `
-            --pattern "backend-pack-*.json" `
-            --pattern "catalog.backends.candidate.json" `
-            --pattern "SHA256SUMS" `
-            --pattern "openasr-$version-windows-x86_64-neutral.zip" `
-            --dir $releaseDir
+          & python tooling/release-manifest/gh_release.py download-packs $tag $releaseDir --repo $env:GITHUB_REPOSITORY
+          if ($LASTEXITCODE -ne 0) { throw "could not download backend-pack metadata" }
+          & python tooling/release-manifest/gh_release.py download $tag $releaseDir `
+            "catalog.backends.candidate.json" `
+            "SHA256SUMS" `
+            "openasr-$version-windows-x86_64-neutral.zip" `
+            --repo $env:GITHUB_REPOSITORY
           if ($LASTEXITCODE -ne 0) { throw "could not download exact release inputs" }
 
           $entries = @(Get-ChildItem -LiteralPath $releaseDir -Filter "backend-pack-*.json" -File)
@@ -137,7 +138,7 @@ jobs:
             throw "Vulkan release entry is not artifact-generic"
           }
           foreach ($file in $entry.files) {
-            gh release download $tag --repo $env:GITHUB_REPOSITORY --pattern $file.filename --dir $releaseDir
+            & python tooling/release-manifest/gh_release.py download $tag $releaseDir $file.filename --repo $env:GITHUB_REPOSITORY
             if ($LASTEXITCODE -ne 0) { throw "could not download $($file.filename)" }
           }
           $pluginRows = @($entry.files | Where-Object { $_.role -eq "plugin" })

--- a/scripts/activate-windows-backend-catalog-release.sh
+++ b/scripts/activate-windows-backend-catalog-release.sh
@@ -152,28 +152,31 @@ done
 [ "${#correctness_receipts[@]}" -ge 4 ] || fail "qualification runs contain no correctness receipt cell"
 [ "${#correctness_traces[@]}" -ge 2 ] || fail "qualification runs contain no correctness traces"
 
-gh release download "$tag" --repo "$repository" \
-  -p 'backend-pack-*.json' -p 'SHA256SUMS' \
-  -D "$workdir/release" --clobber
+python3 tooling/release-manifest/gh_release.py download-packs \
+  "$tag" "$workdir/release" --repo "$repository"
+python3 tooling/release-manifest/gh_release.py download \
+  "$tag" "$workdir/release" SHA256SUMS --repo "$repository"
 backend_entries=("$workdir"/release/backend-pack-*.json)
 [ "${#backend_entries[@]}" -eq 21 ] || fail "release does not contain exactly 21 backend entries"
 
-while IFS= read -r filename || [ -n "$filename" ]; do
-  [ -n "$filename" ] || continue
-  gh release download "$tag" --repo "$repository" \
-    -p "$filename" -D "$workdir/release" --clobber
-done < <(python3 - "$hardware_raw" <<'PY'
-import json, pathlib, sys
-raw = json.load(open(sys.argv[1], encoding="utf-8"))
-names = set()
+python3 - "$tag" "$repository" "$workdir/release" "$hardware_raw" <<'PY'
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
+
+tag, repository, dest = sys.argv[1], sys.argv[2], pathlib.Path(sys.argv[3])
+raw = json.load(open(sys.argv[4], encoding="utf-8"))
+names = []
 for subject in raw.get("attested_release_subjects", []):
     name = subject.get("filename") if isinstance(subject, dict) else None
     if not isinstance(name, str) or pathlib.Path(name).name != name:
         raise SystemExit("hardware audit has an unsafe release subject")
-    names.add(name)
-print("\n".join(sorted(names)))
+    names.append(name)
+gh_release.download_assets(tag, names, dest, repository=repository)
 PY
-)
 
 entry_args=()
 for entry in "${backend_entries[@]}"; do entry_args+=(--entry "$entry"); done

--- a/scripts/finalize-core-release.sh
+++ b/scripts/finalize-core-release.sh
@@ -74,13 +74,42 @@ scripts/qualification-release-lock.sh acquire "$tag" "$lock_token"
 lock_acquired=true
 [ "$(gh release view "$tag" --repo "$repository" --json isDraft --jq .isDraft)" = "true" ] \
   || fail "release ${tag} stopped being a draft while acquiring the finalization lock"
-gh release download "$tag" --repo "$repository" \
-  -p 'backend-pack-*.json' \
-  -p 'backend-plugin-hints.json' \
-  -p 'catalog.backends.candidate.json' \
-  -p 'openasr-*' \
-  -p 'SHA256SUMS' \
-  -D "$workdir" --clobber
+python3 - "$tag" "$repository" "$workdir" "$version" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
+import release_completeness
+
+tag, repository, dest, version = sys.argv[1], sys.argv[2], Path(sys.argv[3]), sys.argv[4]
+metadata = [
+    "SHA256SUMS",
+    "backend-plugin-hints.json",
+    "catalog.backends.candidate.json",
+    *release_completeness.backend_pack_names(release_completeness.load_matrix()),
+]
+gh_release.download_assets(tag, metadata, dest, repository=repository)
+subjects = []
+for line in (dest / "SHA256SUMS").read_text(encoding="utf-8").splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    asset_name = line.split(None, 1)[-1].lstrip("*")
+    if Path(asset_name).name != asset_name:
+        raise SystemExit(f"SHA256SUMS contains an unsafe release basename: {asset_name}")
+    subjects.append(asset_name)
+gh_release.download_assets(tag, subjects, dest, repository=repository)
+qualification = []
+for name in gh_release.list_asset_names(tag, repository):
+    if name.endswith(".lock"):
+        continue
+    if name.startswith(f"openasr-{version}-qualification-") or name == (
+        f"openasr-{version}-build-provenance.bundle.json"
+    ):
+        qualification.append(name)
+gh_release.download_assets(tag, qualification, dest, repository=repository)
+PY
 
 shopt -s nullglob
 backend_entries=("$workdir"/backend-pack-*.json)

--- a/scripts/gate-catalog-against-released-binary.sh
+++ b/scripts/gate-catalog-against-released-binary.sh
@@ -89,14 +89,11 @@ resolve_binary() {
   echo "==> latest stable CLI release: ${tag}" >&2
 
   local asset_dir="$work/release-asset"
+  local version="${tag#v}"
+  local asset="openasr-${version}-linux-x86_64.tar.gz"
   mkdir -p "$asset_dir"
-  # Pattern match (not a hardcoded filename) so this survives a version bump
-  # without edits. Anchored to the plain (non-CUDA/Vulkan/ROCm/musl) Linux
-  # x86_64 CPU build: the runner is native linux-x86_64, so this is the one
-  # build we can execute directly with no extra toolchain.
-  if ! gh release download "$tag" --repo "$repo" \
-        --pattern 'openasr-*-linux-x86_64.tar.gz' \
-        --dir "$asset_dir" --clobber; then
+  if ! python3 tooling/release-manifest/gh_release.py download \
+        "$tag" "$asset_dir" "$asset" --repo "$repo"; then
     echo "::error::failed to download the ${tag} linux-x86_64 CLI release asset from ${repo}. Fail-closed: refusing to bless a catalog without exercising a real released binary against it." >&2
     exit 1
   fi

--- a/scripts/prepare-windows-backend-catalog-release.sh
+++ b/scripts/prepare-windows-backend-catalog-release.sh
@@ -97,9 +97,11 @@ done
 echo "==> downloading signed plugin and vendor payloads from CDN"
 python3 - "$workdir" <<'PY'
 import json
-import subprocess
 import sys
 from pathlib import Path
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
 
 root = Path(sys.argv[1])
 downloaded = set()
@@ -113,24 +115,8 @@ for entry_path in sorted(root.glob("backend-pack-*.json")):
         if name in downloaded:
             continue
         url = f"https://dl.openasr.org/core/v{version}/{name}"
-        dest = root / name
         print(f"downloading {url}", flush=True)
-        subprocess.run(
-            [
-                "curl",
-                "-fsSL",
-                "--http1.1",
-                "--retry",
-                "5",
-                "--retry-all-errors",
-                "--connect-timeout",
-                "20",
-                "-o",
-                str(dest),
-                url,
-            ],
-            check=True,
-        )
+        gh_release.download_url(url, root / name)
         downloaded.add(name)
 PY
 

--- a/scripts/prepare-windows-backend-catalog-release.sh
+++ b/scripts/prepare-windows-backend-catalog-release.sh
@@ -119,6 +119,7 @@ for entry_path in sorted(root.glob("backend-pack-*.json")):
             [
                 "curl",
                 "-fsSL",
+                "--http1.1",
                 "--retry",
                 "5",
                 "--retry-all-errors",

--- a/scripts/prepare-windows-backend-catalog-release.sh
+++ b/scripts/prepare-windows-backend-catalog-release.sh
@@ -94,27 +94,42 @@ for entry in "${backend_entries[@]}"; do
   backend_entry_args+=(--entry "$entry")
 done
 
-echo "==> downloading signed plugin and vendor payloads"
+echo "==> downloading signed plugin and vendor payloads from CDN"
 python3 - "$workdir" <<'PY'
 import json
+import subprocess
 import sys
 from pathlib import Path
-
-sys.path.insert(0, "tooling/release-manifest")
-import gh_release
 
 root = Path(sys.argv[1])
 downloaded = set()
 for entry_path in sorted(root.glob("backend-pack-*.json")):
     entry = json.loads(entry_path.read_text(encoding="utf-8"))
+    version = entry["version"]
     for file in entry.get("files", []):
         name = file.get("filename")
         if not isinstance(name, str) or not name or Path(name).name != name:
             raise SystemExit(f"unsafe backend release filename: {name!r}")
         if name in downloaded:
             continue
-        print(f"downloading {name}", flush=True)
-        gh_release.download_asset(f"v{entry['version']}", name, root)
+        url = f"https://dl.openasr.org/core/v{version}/{name}"
+        dest = root / name
+        print(f"downloading {url}", flush=True)
+        subprocess.run(
+            [
+                "curl",
+                "-fsSL",
+                "--retry",
+                "5",
+                "--retry-all-errors",
+                "--connect-timeout",
+                "20",
+                "-o",
+                str(dest),
+                url,
+            ],
+            check=True,
+        )
         downloaded.add(name)
 PY
 

--- a/scripts/prepare-windows-backend-catalog-release.sh
+++ b/scripts/prepare-windows-backend-catalog-release.sh
@@ -63,9 +63,19 @@ for name in catalog.json catalog.signature.json catalog.public.json catalog.publ
 done
 
 echo "==> downloading backend entries for ${tag}"
-gh release download "$tag" \
-  -p 'backend-pack-*.json' \
-  -D "$workdir" --clobber
+python3 - "$tag" "$workdir" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
+import release_completeness
+
+tag, root = sys.argv[1], Path(sys.argv[2])
+for pack_name in release_completeness.backend_pack_names(release_completeness.load_matrix()):
+    print(f"downloading {pack_name}", flush=True)
+    gh_release.download_asset(tag, pack_name, root)
+PY
 
 shopt -s nullglob
 backend_entries=("$workdir"/backend-pack-*.json)
@@ -84,11 +94,14 @@ for entry in "${backend_entries[@]}"; do
   backend_entry_args+=(--entry "$entry")
 done
 
+echo "==> downloading signed plugin and vendor payloads"
 python3 - "$workdir" <<'PY'
 import json
-import subprocess
 import sys
 from pathlib import Path
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
 
 root = Path(sys.argv[1])
 downloaded = set()
@@ -100,10 +113,8 @@ for entry_path in sorted(root.glob("backend-pack-*.json")):
             raise SystemExit(f"unsafe backend release filename: {name!r}")
         if name in downloaded:
             continue
-        subprocess.run(
-            ["gh", "release", "download", f"v{entry['version']}", "-p", name, "-D", str(root), "--clobber"],
-            check=True,
-        )
+        print(f"downloading {name}", flush=True)
+        gh_release.download_asset(f"v{entry['version']}", name, root)
         downloaded.add(name)
 PY
 

--- a/scripts/qualification-release-lock.sh
+++ b/scripts/qualification-release-lock.sh
@@ -44,6 +44,8 @@ case "$action" in
     ;;
   release)
     [ -s "$token_file" ] || fail "ownership token is missing: $token_file"
+    # Tiny 64-hex ownership token. The local mutex contract test intercepts
+    # `gh release download`; this is not a payload-hang path.
     gh release download "$tag" --repo "$repository" -p "$asset_name" \
       -D "$temporary" --clobber >/dev/null
     cmp -s -- "$token_file" "$temporary/$asset_name" \

--- a/scripts/sign-and-verify-qualification-manifests.sh
+++ b/scripts/sign-and-verify-qualification-manifests.sh
@@ -84,11 +84,25 @@ lock_acquired=true
   || fail "${tag} stopped being a draft while acquiring the qualification lock"
 
 echo "==> downloading inert qualification assets for ${tag}"
-gh release download "$tag" --repo "$repository" \
-  -p "openasr-${version}-qualification-*.json" \
-  -p "openasr-${version}-build-provenance.bundle.json" \
-  -p "openasr-${version}-windows-x86_64-neutral.zip" \
-  -D "$workdir" --clobber
+python3 - "$tag" "$repository" "$workdir" "$version" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
+
+tag, repository, dest, version = sys.argv[1], sys.argv[2], Path(sys.argv[3]), sys.argv[4]
+names = [
+    f"openasr-{version}-windows-x86_64-neutral.zip",
+    f"openasr-{version}-build-provenance.bundle.json",
+]
+for name in gh_release.list_asset_names(tag, repository):
+    if name.endswith(".lock"):
+        continue
+    if name.startswith(f"openasr-{version}-qualification-") and name.endswith(".json"):
+        names.append(name)
+gh_release.download_assets(tag, names, dest, repository=repository)
+PY
 
 python3 - "$workdir" "$version" "$tag_commit" "$promote_cuda_targets" <<'PY'
 import json
@@ -202,11 +216,21 @@ if len(sources) != 1 or len(bundles) != 1:
 )
 PY
 
-while IFS= read -r asset_name || [ -n "$asset_name" ]; do
-  [ -n "$asset_name" ] || continue
-  [ -f "$workdir/$asset_name" ] || gh release download "$tag" --repo "$repository" \
-    -p "$asset_name" -D "$workdir" --clobber
-done < "$workdir/release-subjects.txt"
+python3 - "$tag" "$repository" "$workdir" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
+
+tag, repository, dest = sys.argv[1], sys.argv[2], Path(sys.argv[3])
+names = []
+for line in (dest / "release-subjects.txt").read_text(encoding="utf-8").splitlines():
+    name = line.strip()
+    if name and not (dest / name).is_file():
+        names.append(name)
+gh_release.download_assets(tag, names, dest, repository=repository)
+PY
 
 echo "==> verifying release bytes and Sigstore provenance before signing"
 python3 - "$workdir" <<'PY'
@@ -309,9 +333,23 @@ echo "==> uploading detached signatures to draft ${tag}"
 gh release upload "$tag" --repo "$repository" "${signature_paths[@]}" --clobber
 
 echo "==> re-downloading and verifying published manifest/signature pairs"
-gh release download "$tag" --repo "$repository" \
-  -p "openasr-${version}-qualification-*.json" \
-  -D "$verify_dir" --clobber
+python3 - "$tag" "$repository" "$verify_dir" "$version" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "tooling/release-manifest")
+import gh_release
+
+tag, repository, dest, version = sys.argv[1], sys.argv[2], Path(sys.argv[3]), sys.argv[4]
+names = [
+    name
+    for name in gh_release.list_asset_names(tag, repository)
+    if name.startswith(f"openasr-{version}-qualification-")
+    and name.endswith(".json")
+    and not name.endswith(".lock")
+]
+gh_release.download_assets(tag, names, dest, repository=repository)
+PY
 while IFS=$'\t' read -r manifest_name manifest_url signature_name; do
   [ -s "$verify_dir/$manifest_name" ] || fail "published manifest is missing: $manifest_name"
   [ -s "$verify_dir/$signature_name" ] || fail "published signature is missing: $signature_name"

--- a/scripts/sync-windows-backend-cdn.sh
+++ b/scripts/sync-windows-backend-cdn.sh
@@ -46,9 +46,7 @@ workdir="$(mktemp -d "${TMPDIR:-/tmp}/openasr-backend-cdn.XXXXXX")"
 trap 'rm -rf "$workdir"' EXIT
 
 echo "==> downloading backend entries for ${tag}"
-gh release download "$tag" \
-  -p 'backend-pack-*.json' \
-  -D "$workdir" --clobber
+python3 tooling/release-manifest/gh_release.py download-packs "$tag" "$workdir"
 
 shopt -s nullglob
 backend_entries=("$workdir"/backend-pack-*.json)

--- a/scripts/verify-release-completeness.sh
+++ b/scripts/verify-release-completeness.sh
@@ -22,25 +22,12 @@ repository="${2:-${GITHUB_REPOSITORY:-QuintinShaw/openasr}}"
 command -v gh >/dev/null 2>&1 || { echo "gh is required" >&2; exit 1; }
 command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
 
-pack_names="$(mktemp)"
 pack_dir="$(mktemp -d)"
 actual_file="$(mktemp)"
-cleanup() { rm -rf -- "$pack_names" "$pack_dir" "$actual_file"; }
+cleanup() { rm -rf -- "$pack_dir" "$actual_file"; }
 trap cleanup EXIT
 
-python3 tooling/release-manifest/release_completeness.py pack-names > "$pack_names"
-python3 - "$tag" "$repository" "$pack_names" "$pack_dir" <<'PY'
-import sys
-from pathlib import Path
-
-sys.path.insert(0, "tooling/release-manifest")
-import gh_release
-
-tag, repository, pack_names, pack_dir = sys.argv[1:5]
-for pack_name in Path(pack_names).read_text(encoding="utf-8").splitlines():
-    if pack_name:
-        gh_release.download_asset(tag, pack_name, Path(pack_dir), repository=repository)
-PY
+python3 tooling/release-manifest/gh_release.py download-packs "$tag" "$pack_dir" --repo "$repository"
 gh release view "$tag" --repo "$repository" --json assets \
   --jq '.assets[].name' | sort > "$actual_file"
 python3 tooling/release-manifest/release_completeness.py compare \

--- a/tooling/release-manifest/backend_catalog.py
+++ b/tooling/release-manifest/backend_catalog.py
@@ -643,6 +643,7 @@ def head_cdn_url(url: str) -> tuple[int, int | None]:
             "curl",
             "-sS",
             "-I",
+            "--http1.1",
             "--connect-timeout",
             "5",
             "--max-time",

--- a/tooling/release-manifest/backend_catalog_test.py
+++ b/tooling/release-manifest/backend_catalog_test.py
@@ -481,6 +481,7 @@ class BackendCatalogTest(unittest.TestCase):
             self.assertEqual(backend_catalog.head_cdn_url("https://example.invalid/file"), (200, 42))
 
         command = run.call_args.args[0]
+        self.assertIn("--http1.1", command)
         self.assertIn("--connect-timeout", command)
         self.assertIn("--max-time", command)
         self.assertIn("--retry", command)

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -89,8 +89,37 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         )[0]
         self.assertIn("contents: write", family_caller)
         self.assertIn("contents: write", deploy_caller)
-        self.assertIn("gh_release.download_asset", completeness)
+        self.assertIn("gh_release.py download-packs", completeness)
         self.assertIn("gh release view", completeness)
+
+    def test_release_readers_do_not_call_gh_release_download(self) -> None:
+        offenders: list[str] = []
+        roots = (
+            ROOT / "scripts",
+            ROOT / ".github" / "workflows",
+            ROOT / "tooling" / "release-manifest",
+        )
+        skip_names = {
+            "gh_release.py",
+            "gh_release_test.py",
+            "core_release_finalization_contract_test.py",
+            # 64-hex lock token; fake-gh mutex test intercepts this argv.
+            "qualification-release-lock.sh",
+        }
+        for root in roots:
+            for path in root.rglob("*"):
+                if not path.is_file() or path.name in skip_names:
+                    continue
+                if path.suffix not in {".sh", ".py", ".yml", ".yaml"}:
+                    continue
+                for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                    stripped = line.lstrip()
+                    if stripped.startswith("#") or stripped.startswith("//"):
+                        continue
+                    if "gh release download" in line:
+                        offenders.append(f"{path.relative_to(ROOT)}:{line_number}:{stripped}")
+        self.assertEqual(offenders, [])
+
     def test_reusable_release_declares_every_referenced_input(self) -> None:
         binaries = (ROOT / ".github/workflows/release-binaries.yml").read_text(
             encoding="utf-8"
@@ -152,6 +181,7 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn("needs: [resolve, prepublication-family]", release)
         self.assertIn("verify-assets", prepare)
         self.assertIn("gh_release.download_asset", prepare)
+        self.assertIn("gh_release.download_url", prepare)
         self.assertIn("publish_catalog.sh", prepare)
         self.assertIn("verify-catalog", prepare)
         self.assertIn("verify-cdn", prepare)
@@ -293,7 +323,9 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn("releases/latest", family)
         self.assertIn("refusing a duplicate local build", family)
         self.assertEqual(family.count("release_asset_verifier.py"), 3)
-        self.assertEqual(family.count("--pattern SHA256SUMS"), 2)
+        self.assertEqual(family.count("gh_release.py download"), 3)
+        self.assertGreaterEqual(family.count("SHA256SUMS"), 3)
+        self.assertNotIn("--pattern", family)
         self.assertEqual(family.count("gh attestation verify"), 3)
         self.assertEqual(family.count("--signer-workflow"), 3)
         self.assertIn("attestations: read", family)
@@ -343,10 +375,10 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
             "qualification may consume only already-public PublishedInert release bytes",
             qualify,
         )
-        self.assertIn("gh release download $tag", qualify)
+        self.assertIn("gh_release.py", qualify)
         self.assertLess(
             qualify.index("qualification may consume only already-public PublishedInert release bytes"),
-            qualify.index("gh release download $tag"),
+            qualify.index("gh_release.py"),
         )
         self.assertIn('"backend-pack-*.json"', qualify)
         self.assertIn('"catalog.backends.candidate.json"', qualify)
@@ -373,7 +405,7 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn("--json isDraft,isPrerelease,tagName,publishedAt", prepare)
         self.assertIn("already-public stable PublishedInert bytes", prepare)
         self.assertLess(prepare.index("already-public stable PublishedInert bytes"), prepare.index("gh run download"))
-        self.assertIn('gh release download "$tag" --repo "$repository"', prepare)
+        self.assertIn("gh_release.py download-packs", prepare)
         self.assertIn("qualification-signer-workflow", prepare)
         self.assertIn("must be independently qualified", gate)
 

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -151,6 +151,7 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn("activation_transition: published-inert", release)
         self.assertIn("needs: [resolve, prepublication-family]", release)
         self.assertIn("verify-assets", prepare)
+        self.assertIn("gh_release.download_asset", prepare)
         self.assertIn("publish_catalog.sh", prepare)
         self.assertIn("verify-catalog", prepare)
         self.assertIn("verify-cdn", prepare)

--- a/tooling/release-manifest/gh_release.py
+++ b/tooling/release-manifest/gh_release.py
@@ -15,6 +15,7 @@ def download_asset(
     *,
     repository: str | None = None,
     attempts: int = 6,
+    timeout_seconds: int = 600,
 ) -> None:
     if Path(name).name != name:
         raise ValueError(f"unsafe release asset name: {name!r}")
@@ -31,12 +32,13 @@ def download_asset(
     ]
     if repository:
         command.extend(["--repo", repository])
-    last_error: subprocess.CalledProcessError | None = None
+    last_error: BaseException | None = None
     for attempt in range(1, attempts + 1):
+        print(f"gh release download {tag} {name} (attempt {attempt}/{attempts})", flush=True)
         try:
-            subprocess.run(command, check=True)
+            subprocess.run(command, check=True, timeout=timeout_seconds)
             return
-        except subprocess.CalledProcessError as error:
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
             last_error = error
             if attempt == attempts:
                 break

--- a/tooling/release-manifest/gh_release.py
+++ b/tooling/release-manifest/gh_release.py
@@ -1,11 +1,161 @@
 #!/usr/bin/env python3
-"""Retry GitHub Release downloads. Large draft assets often fail with EOF."""
+"""Retry GitHub Release and CDN downloads with stall detection.
+
+``gh release download`` hangs or EOFs on draft assets, especially glob
+patterns against a large draft. Every release reader must go through this
+helper: resolve a named asset via the GitHub JSON API, then curl the
+octet-stream URL over HTTP/1.1 with a stall abort and retries.
+"""
 
 from __future__ import annotations
 
+import argparse
+import json
+import os
 import subprocess
+import sys
 import time
 from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ATTEMPTS = 6
+DEFAULT_TIMEOUT_SECONDS = 1800
+STALL_SECONDS = 30
+STALL_BYTES_PER_SEC = 1024
+USER_AGENT = "openasr-release-fetch"
+
+
+class DownloadError(RuntimeError):
+    pass
+
+
+def _safe_name(name: str) -> str:
+    if Path(name).name != name or not name or name in {".", ".."}:
+        raise ValueError(f"unsafe release asset name: {name!r}")
+    return name
+
+
+def _repo_args(repository: str | None) -> list[str]:
+    return ["--repo", repository] if repository else []
+
+
+def _auth_token() -> str:
+    for key in ("GH_TOKEN", "GITHUB_TOKEN"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+    completed = subprocess.run(
+        ["gh", "auth", "token"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    token = completed.stdout.strip()
+    if not token:
+        raise DownloadError("no GitHub token for release asset download")
+    return token
+
+
+def list_assets(tag: str, repository: str | None = None) -> list[dict[str, Any]]:
+    payload = json.loads(
+        subprocess.check_output(
+            ["gh", "release", "view", tag, "--json", "assets", *_repo_args(repository)],
+            text=True,
+        )
+    )
+    assets = payload.get("assets")
+    if not isinstance(assets, list):
+        raise DownloadError(f"release {tag} asset list is missing")
+    return [asset for asset in assets if isinstance(asset, dict)]
+
+
+def list_asset_names(tag: str, repository: str | None = None) -> list[str]:
+    names: list[str] = []
+    for asset in list_assets(tag, repository):
+        name = asset.get("name")
+        if isinstance(name, str) and Path(name).name == name and name not in {".", ".."}:
+            names.append(name)
+    return names
+
+
+def _asset_api_url(tag: str, name: str, repository: str | None) -> str:
+    name = _safe_name(name)
+    for asset in list_assets(tag, repository):
+        if asset.get("name") != name:
+            continue
+        api_url = asset.get("apiUrl")
+        if isinstance(api_url, str) and api_url.startswith("https://api.github.com/"):
+            return api_url
+        raise DownloadError(f"release {tag} asset {name} has no GitHub API URL")
+    raise DownloadError(f"release {tag} has no asset {name}")
+
+
+def curl_download(
+    url: str,
+    dest: Path,
+    *,
+    headers: list[tuple[str, str]] | None = None,
+    attempts: int = DEFAULT_ATTEMPTS,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> None:
+    if not url.startswith("https://"):
+        raise ValueError(f"refusing non-HTTPS download URL: {url!r}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        "curl",
+        "-fL",
+        "--http1.1",
+        "--connect-timeout",
+        "20",
+        "--max-time",
+        str(timeout_seconds),
+        "--speed-time",
+        str(STALL_SECONDS),
+        "--speed-limit",
+        str(STALL_BYTES_PER_SEC),
+        "-A",
+        USER_AGENT,
+        "-o",
+        str(dest),
+    ]
+    for key, value in headers or []:
+        command.extend(["-H", f"{key}: {value}"])
+    command.append(url)
+    last_error: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        print(f"download {url} -> {dest.name} (attempt {attempt}/{attempts})", flush=True)
+        dest.unlink(missing_ok=True)
+        try:
+            subprocess.run(command, check=True, timeout=timeout_seconds + 60)
+            if dest.is_file() and dest.stat().st_size > 0:
+                return
+            last_error = DownloadError(f"empty download: {url}")
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+            last_error = error
+        if attempt == attempts:
+            break
+        time.sleep(min(2**attempt, 16))
+    assert last_error is not None
+    raise last_error
+
+
+def download_url(
+    url: str,
+    dest: Path,
+    *,
+    attempts: int = DEFAULT_ATTEMPTS,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+) -> None:
+    curl_download(url, dest, attempts=attempts, timeout_seconds=timeout_seconds)
+
+
+def _github_headers(token: str) -> list[tuple[str, str]]:
+    return [
+        ("Authorization", f"Bearer {token}"),
+        ("Accept", "application/octet-stream"),
+        ("X-GitHub-Api-Version", "2022-11-28"),
+    ]
 
 
 def download_asset(
@@ -14,34 +164,93 @@ def download_asset(
     dest_dir: Path,
     *,
     repository: str | None = None,
-    attempts: int = 6,
-    timeout_seconds: int = 600,
+    attempts: int = DEFAULT_ATTEMPTS,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
 ) -> None:
-    if Path(name).name != name:
-        raise ValueError(f"unsafe release asset name: {name!r}")
-    command = [
-        "gh",
-        "release",
-        "download",
-        tag,
-        "-p",
-        name,
-        "-D",
-        str(dest_dir),
-        "--clobber",
-    ]
-    if repository:
-        command.extend(["--repo", repository])
-    last_error: BaseException | None = None
-    for attempt in range(1, attempts + 1):
-        print(f"gh release download {tag} {name} (attempt {attempt}/{attempts})", flush=True)
-        try:
-            subprocess.run(command, check=True, timeout=timeout_seconds)
-            return
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
-            last_error = error
-            if attempt == attempts:
-                break
-            time.sleep(min(2 ** attempt, 16))
-    assert last_error is not None
-    raise last_error
+    name = _safe_name(name)
+    dest = Path(dest_dir) / name
+    curl_download(
+        _asset_api_url(tag, name, repository),
+        dest,
+        headers=_github_headers(_auth_token()),
+        attempts=attempts,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def download_assets(
+    tag: str,
+    names: list[str],
+    dest_dir: Path,
+    *,
+    repository: str | None = None,
+) -> None:
+    catalog = {asset.get("name"): asset for asset in list_assets(tag, repository)}
+    token = _auth_token()
+    seen: set[str] = set()
+    for name in names:
+        name = _safe_name(name)
+        if name in seen:
+            continue
+        seen.add(name)
+        asset = catalog.get(name)
+        if not isinstance(asset, dict):
+            raise DownloadError(f"release {tag} has no asset {name}")
+        api_url = asset.get("apiUrl")
+        if not isinstance(api_url, str) or not api_url.startswith("https://api.github.com/"):
+            raise DownloadError(f"release {tag} asset {name} has no GitHub API URL")
+        curl_download(
+            api_url,
+            Path(dest_dir) / name,
+            headers=_github_headers(token),
+        )
+
+
+def _dispatch(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    download = subparsers.add_parser("download")
+    download.add_argument("tag")
+    download.add_argument("dest", type=Path)
+    download.add_argument("names", nargs="+")
+    download.add_argument("--repo")
+
+    url = subparsers.add_parser("download-url")
+    url.add_argument("url")
+    url.add_argument("dest", type=Path)
+
+    packs = subparsers.add_parser("download-packs")
+    packs.add_argument("tag")
+    packs.add_argument("dest", type=Path)
+    packs.add_argument("--repo")
+
+    args = parser.parse_args(argv)
+    if args.command == "download":
+        download_assets(args.tag, args.names, args.dest, repository=args.repo)
+        return
+    if args.command == "download-url":
+        download_url(args.url, args.dest)
+        return
+
+    import release_completeness
+
+    download_assets(
+        args.tag,
+        release_completeness.backend_pack_names(release_completeness.load_matrix()),
+        args.dest,
+        repository=args.repo,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        _dispatch(sys.argv[1:] if argv is None else argv)
+    except (DownloadError, ValueError, OSError, json.JSONDecodeError, subprocess.SubprocessError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tooling/release-manifest/gh_release_test.py
+++ b/tooling/release-manifest/gh_release_test.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -8,22 +11,148 @@ from unittest import mock
 import gh_release
 
 
+def _asset(name: str, api_url: str = "https://api.github.com/repos/o/r/releases/assets/1") -> dict[str, str]:
+    return {"name": name, "apiUrl": api_url, "id": "RA_not_numeric"}
+
+
 class GhReleaseDownloadTests(unittest.TestCase):
     def test_retries_transient_failures_then_succeeds(self) -> None:
-        dest = Path("/tmp")
-        with mock.patch("gh_release.subprocess.run") as run, mock.patch(
-            "gh_release.time.sleep"
-        ) as sleep:
-            run.side_effect = [
-                subprocess.CalledProcessError(1, ["gh"]),
-                subprocess.TimeoutExpired(["gh"], 600),
-                None,
-            ]
-            gh_release.download_asset("v0.1.37", "backend-pack-vulkan-generic.json", dest)
-            self.assertEqual(run.call_count, 3)
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = Path(tmp)
+            dest = dest_dir / "backend-pack-vulkan-generic.json"
+
+            def run(command, check=True, timeout=None, capture_output=False, text=False):
+                del check, timeout, capture_output, text
+                if command[:1] == ["curl"]:
+                    if run.calls == 0:
+                        run.calls += 1
+                        raise subprocess.CalledProcessError(22, command)
+                    if run.calls == 1:
+                        run.calls += 1
+                        raise subprocess.TimeoutExpired(command, 1800)
+                    dest.write_text("ok\n", encoding="utf-8")
+                    run.calls += 1
+                    return subprocess.CompletedProcess(command, 0)
+                raise AssertionError(command)
+
+            run.calls = 0
+            view = json.dumps({"assets": [_asset("backend-pack-vulkan-generic.json")]})
+            with mock.patch.dict(os.environ, {"GH_TOKEN": "test-token"}, clear=False), mock.patch(
+                "gh_release.subprocess.check_output", return_value=view
+            ), mock.patch("gh_release.subprocess.run", side_effect=run) as run_mock, mock.patch(
+                "gh_release.time.sleep"
+            ) as sleep:
+                gh_release.download_asset(
+                    "v0.1.37", "backend-pack-vulkan-generic.json", dest_dir
+                )
+            self.assertEqual(dest.read_text(encoding="utf-8"), "ok\n")
+            self.assertEqual(run_mock.call_count, 3)
             self.assertEqual(sleep.call_count, 2)
-            self.assertEqual(run.call_args.kwargs.get("timeout"), 600)
+            curl = run_mock.call_args.args[0]
+            self.assertIn("--http1.1", curl)
+            self.assertIn("--speed-time", curl)
+            self.assertIn("--speed-limit", curl)
+            self.assertIn("Bearer test-token", " ".join(curl))
+            self.assertIn("application/octet-stream", " ".join(curl))
+
+    def test_uses_api_url_not_node_id_or_browser_url(self) -> None:
+        view = json.dumps(
+            {
+                "assets": [
+                    {
+                        "name": "SHA256SUMS",
+                        "id": "RA_kwDOTLO0884gEJX_",
+                        "apiUrl": "https://api.github.com/repos/QuintinShaw/openasr/releases/assets/537957887",
+                        "url": "https://github.com/QuintinShaw/openasr/releases/download/untagged-draft/SHA256SUMS",
+                    }
+                ]
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "SHA256SUMS"
+
+            def run(command, check=True, timeout=None):
+                del check, timeout
+                self.assertEqual(command[-1], "https://api.github.com/repos/QuintinShaw/openasr/releases/assets/537957887")
+                dest.write_text("sums\n", encoding="utf-8")
+                return subprocess.CompletedProcess(command, 0)
+
+            with mock.patch.dict(os.environ, {"GH_TOKEN": "test-token"}, clear=False), mock.patch(
+                "gh_release.subprocess.check_output", return_value=view
+            ), mock.patch("gh_release.subprocess.run", side_effect=run):
+                gh_release.download_asset("v0.1.37", "SHA256SUMS", Path(tmp))
+            self.assertEqual(dest.read_text(encoding="utf-8"), "sums\n")
 
     def test_refuses_unsafe_asset_names(self) -> None:
         with self.assertRaises(ValueError):
             gh_release.download_asset("v0.1.37", "../escape.dll", Path("/tmp"))
+
+    def test_download_url_retries_and_requires_https(self) -> None:
+        with self.assertRaises(ValueError):
+            gh_release.download_url("http://dl.openasr.org/core/v0.1.37/x.zip", Path("/tmp/x.zip"))
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "payload.bin"
+
+            def run(command, check=True, timeout=None):
+                del check, timeout
+                dest.write_bytes(b"payload")
+                return subprocess.CompletedProcess(command, 0)
+
+            with mock.patch("gh_release.subprocess.run", side_effect=run) as run_mock:
+                gh_release.download_url("https://dl.openasr.org/core/v0.1.37/payload.bin", dest)
+            curl = run_mock.call_args.args[0]
+            self.assertIn("--http1.1", curl)
+            self.assertNotIn("Authorization", " ".join(curl))
+            self.assertEqual(dest.read_bytes(), b"payload")
+
+    def test_download_assets_lists_the_release_once(self) -> None:
+        view = json.dumps(
+            {
+                "assets": [
+                    _asset("SHA256SUMS", "https://api.github.com/repos/o/r/releases/assets/1"),
+                    _asset("hints.json", "https://api.github.com/repos/o/r/releases/assets/2"),
+                ]
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = Path(tmp)
+
+            def run(command, check=True, timeout=None):
+                del check, timeout
+                Path(command[command.index("-o") + 1]).write_text("ok\n", encoding="utf-8")
+                return subprocess.CompletedProcess(command, 0)
+
+            with mock.patch.dict(os.environ, {"GH_TOKEN": "test-token"}, clear=False), mock.patch(
+                "gh_release.subprocess.check_output", return_value=view
+            ) as view_mock, mock.patch("gh_release.subprocess.run", side_effect=run):
+                gh_release.download_assets(
+                    "v0.1.37", ["SHA256SUMS", "hints.json", "SHA256SUMS"], dest_dir
+                )
+            self.assertEqual(view_mock.call_count, 1)
+            self.assertEqual((dest_dir / "SHA256SUMS").read_text(encoding="utf-8"), "ok\n")
+            self.assertEqual((dest_dir / "hints.json").read_text(encoding="utf-8"), "ok\n")
+
+    def test_cli_download_many(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = Path(tmp)
+            with mock.patch.object(gh_release, "download_assets") as download_assets:
+                self.assertEqual(
+                    gh_release.main(
+                        [
+                            "download",
+                            "v0.1.37",
+                            str(dest_dir),
+                            "SHA256SUMS",
+                            "backend-plugin-hints.json",
+                            "--repo",
+                            "QuintinShaw/openasr",
+                        ]
+                    ),
+                    0,
+                )
+            download_assets.assert_called_once_with(
+                "v0.1.37",
+                ["SHA256SUMS", "backend-plugin-hints.json"],
+                dest_dir,
+                repository="QuintinShaw/openasr",
+            )

--- a/tooling/release-manifest/gh_release_test.py
+++ b/tooling/release-manifest/gh_release_test.py
@@ -16,12 +16,13 @@ class GhReleaseDownloadTests(unittest.TestCase):
         ) as sleep:
             run.side_effect = [
                 subprocess.CalledProcessError(1, ["gh"]),
-                subprocess.CalledProcessError(1, ["gh"]),
+                subprocess.TimeoutExpired(["gh"], 600),
                 None,
             ]
             gh_release.download_asset("v0.1.37", "backend-pack-vulkan-generic.json", dest)
             self.assertEqual(run.call_count, 3)
             self.assertEqual(sleep.call_count, 2)
+            self.assertEqual(run.call_args.kwargs.get("timeout"), 600)
 
     def test_refuses_unsafe_asset_names(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary

Stop using `gh release download` for draft and large release assets. Every remaining reader now goes through a shared helper that resolves a named asset via the GitHub JSON API and curls the octet-stream URL over HTTP/1.1 with stall detection and retries.

## Why

v0.1.37 already hit this class twice: glob `gh release download` hung for tens of minutes against the draft, and large GitHub/CDN transfers EOF or reset mid-file. The previous helper still called `gh release download`, so finalize, family-regression, and deploy-catalog would hit the same hang on the second Release core dispatch.

## Changes

- `tooling/release-manifest/gh_release.py` downloads via `apiUrl` + curl (`--http1.1`, stall abort, retries). CDN fetches share the same curl path.
- Named-only downloads: backend packs come from `release_completeness.backend_pack_names()`, SHA256SUMS subjects and qualification files from the asset list. No glob patterns.
- Callers updated: completeness, catalog prepare/sync/finalize/activate/sign, family-regression, deploy-catalog, qualify-windows-backend, publish-core-channels, gate-released-binary.
- Contract test fails if a new `gh release download` sneaks back into scripts or workflows (except the 64-hex qualification lock token).
- CDN HEAD probes also force HTTP/1.1.

## Tests run

- [x] `python3 -m unittest gh_release_test core_release_finalization_contract_test backend_catalog_test` (from `tooling/release-manifest`)
- [x] `python3 -m unittest windows_backend_release_contract_test.WindowsBackendReleaseContractTests.test_qualification_release_lock_is_exclusive_and_nonce_owned`
- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

Not a runtime behavior change. This unblocks the v0.1.37 catalog/finalize path.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not publish v0.1.37 or change catalog bytes. Qualification lock download stays on `gh release download` because the mutex contract test intercepts that argv for a 64-hex token.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES