### PR TITLE
fix(runtime): restore Voice ID NES admission and moss scheduler teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Core: `--diarize` / Voice ID now installs the native execution broker
+  before Stream-VAD and ReDimNet admission. 0.1.37 failed closed with
+  `could not load the vendored FireRed Stream-VAD` because those weights
+  started requiring the process-wide broker after GPU ownership work, but
+  NES was only installed around speaker-turn computation.
 - Core: a DedicatedDevice quarantine from a terminal device failure can
   recover when a later candidate presents a healthy heap snapshot (new
   backend generation after the poisoned handle was leaked). Ledger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   `could not load the vendored FireRed Stream-VAD` because those weights
   started requiring the process-wide broker after GPU ownership work, but
   NES was only installed around speaker-turn computation.
+- Core: tearing down a scheduler-backed persistent graph (MOSS decode on
+  macOS, and any `start_graph` then persistent-session handoff) no longer
+  use-after-frees inside `ggml_backend_sched_reset`. Reset detaches the
+  scheduler-owned split graph instead of a caller cgraph that may already
+  have been parked, and the idle runner context is reset before it is
+  freed. 0.1.37 exited 139 after a successful moss-transcribe-diarize
+  CPU/Metal run.
 - Core: a DedicatedDevice quarantine from a terminal device failure can
   recover when a later candidate presents a healthy heap snapshot (new
   backend generation after the poisoned handle was leaked). Ledger

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -2319,6 +2319,15 @@ fn run_native_transcription_impl(
     }
 
     let audio_duration_seconds = prepared_audio.len() as f32 / 16_000.0;
+    // Stream-VAD, ReDimNet, and the segmenter admit through SystemMemoryOwner,
+    // which requires the process-wide broker. Install NES before materialize,
+    // not only around compute_speaker_attribution: 0.1.37 --diarize failed
+    // closed with VadUnavailable because admission ran with no broker.
+    let _voice_id_memory_context = (speaker_plan != SpeakerPlan::Off).then(|| {
+        crate::models::native_execution_services::install_native_execution_services(
+            execution_services.as_ref(),
+        )
+    });
     let speaker_runtime = if speaker_plan == SpeakerPlan::Off {
         None
     } else {
@@ -2361,15 +2370,6 @@ fn run_native_transcription_impl(
     // be attributed onto whichever transcription path runs below.
     let voice_id_audio = voice_id_audio_view(&prepared_audio, speaker_plan);
     let speaker_turns = if let Some(diarizer) = external_diarizer.as_ref() {
-        // External diarization runs outside the ASR candidate attempt, but its
-        // invocation-local scratch still belongs to this process-wide broker.
-        // Install only the service context for this phase: the scratch owner
-        // below creates and drops its own reservation, while persistent
-        // segmenter/embedder owners keep their independent candidate leases.
-        let _memory_context =
-            crate::models::native_execution_services::install_native_execution_services(
-                execution_services.as_ref(),
-            );
         let hint = match request.diarize_speakers {
             Some(speakers) => crate::diarize::contract::DiarizeHint::NumSpeakers(speakers),
             None => crate::diarize::contract::DiarizeHint::Auto,
@@ -5080,6 +5080,32 @@ mod tests {
         assert!(
             installed.load(std::sync::atomic::Ordering::SeqCst),
             "run_auxiliary_stage_with_policy must install CandidateActivationQuoteSource before the attempt"
+        );
+    }
+
+    #[test]
+    fn voice_id_installs_nes_before_vad_materialize() {
+        let source = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("src/api/backend/native_transcribe.rs"),
+        )
+        .expect("read native_transcribe.rs");
+        let impl_body = source
+            .split("fn run_native_transcription_impl(")
+            .nth(1)
+            .expect("run_native_transcription_impl")
+            .split("\nfn ")
+            .next()
+            .expect("impl body");
+        let install = impl_body
+            .find("install_native_execution_services")
+            .expect("Voice ID must install NES");
+        let materialize = impl_body
+            .find(".materialize(")
+            .expect("external diarizer materialize");
+        assert!(
+            install < materialize,
+            "Stream-VAD admission requires NES before ExternalDiarizer::materialize, got install@{install} materialize@{materialize}"
         );
     }
 

--- a/crates/openasr-core/src/diarize/external.rs
+++ b/crates/openasr-core/src/diarize/external.rs
@@ -364,8 +364,6 @@ fn bytes_for_count(count: usize, element_bytes: usize) -> u64 {
 pub enum ExternalDiarizationError {
     #[error(transparent)]
     Segmenter(#[from] SegmentError),
-    #[error("external Voice ID could not load the vendored FireRed Stream-VAD")]
-    VadUnavailable,
     #[error("external Voice ID FireRed VAD failed: {0}")]
     Vad(String),
     #[error("external Voice ID ReDim embedding failed: {0}")]
@@ -414,8 +412,7 @@ impl PreparedExternalDiarizer {
             Arc::clone(&execution_services),
             execution_intent.clone(),
         )
-        .map_err(|error| ExternalDiarizationError::Vad(error.to_string()))?
-        .ok_or(ExternalDiarizationError::VadUnavailable)?;
+        .map_err(|error| ExternalDiarizationError::Vad(error.to_string()))?;
         let segmenter = PolicyResolvedSegmenterRuntime::load_prepared(
             execution_services,
             execution_intent,

--- a/crates/openasr-core/src/diarize/vad/firered_stream/provider.rs
+++ b/crates/openasr-core/src/diarize/vad/firered_stream/provider.rs
@@ -205,10 +205,10 @@ impl PolicyResolvedFireRedStreamVadProvider {
     pub(crate) fn for_intent(
         execution_services: Arc<NativeExecutionServices>,
         intent: ExecutionIntent,
-    ) -> Result<Option<Self>, FireRedStreamVadError> {
-        let Some(model) = super::shared_model() else {
-            return Ok(None);
-        };
+    ) -> Result<Self, FireRedStreamVadError> {
+        let model = super::shared_model().ok_or_else(|| FireRedStreamVadError::ExecutionPolicy {
+            reason: "Stream-VAD admission failed; vendored weights require an installed native execution broker".to_string(),
+        })?;
         let model_for_builder = model.clone();
         let inventory = enumerate_compute_devices_from_ggml(&crate::ggml_available_devices());
         let plan = execution_services
@@ -259,10 +259,10 @@ impl PolicyResolvedFireRedStreamVadProvider {
             activation_quote,
         )
         .map_err(map_policy_error)?;
-        Ok(Some(Self {
+        Ok(Self {
             runtime: Mutex::new(runtime),
             invocation_scratch_peak_bytes,
-        }))
+        })
     }
 
     pub(crate) const fn invocation_scratch_peak_bytes(&self) -> u64 {
@@ -469,12 +469,14 @@ mod tests {
             NativeExecutionServices::for_local_process()
                 .expect("construct native execution services"),
         );
+        let _nes = crate::models::native_execution_services::install_native_execution_services(
+            services.as_ref(),
+        );
         let provider = PolicyResolvedFireRedStreamVadProvider::for_intent(
-            services,
+            Arc::clone(&services),
             ExecutionIntent::AcceleratedOnly,
         )
-        .expect("resolve explicit accelerated Stream-VAD")
-        .expect("embedded Stream-VAD model");
+        .expect("resolve explicit accelerated Stream-VAD");
         let placement = crate::GgmlExecutionTelemetryCollector::new();
         let _placement_guard = placement.install();
         let actual = provider

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -3402,6 +3402,15 @@ impl GgmlCpuGraphRunner {
     }
 
     fn park_idle_runner_graph_context(&mut self) {
+        // Same contract as `start_graph`: detach scheduler bindings while the
+        // idle cgraph and its tensors are still alive, then drop the context.
+        // Persistent sessions allocate a replacement metadata arena immediately
+        // after this park; leaving `allocated_graph` aimed at the freed context
+        // makes the later session Drop's `ggml_backend_sched_reset` UAF.
+        if let Some(scheduler) = self.scheduler.as_ref() {
+            unsafe { ffi::ggml_backend_sched_reset(scheduler.raw.as_ptr()) };
+            scheduler.memory_owner.active_graph_address.set(None);
+        }
         self.context = None;
     }
 
@@ -17180,6 +17189,106 @@ mod tests {
                 .expect("rebound first graph should compute"),
             vec![16.0, 36.0]
         );
+    }
+
+    #[test]
+    fn persistent_graph_session_drops_builder_before_context() {
+        let source = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/ggml_runtime/cpu_graph.rs"),
+        )
+        .expect("read cpu_graph.rs");
+        let struct_body = source
+            .split("pub(crate) struct GgmlPersistentGraphSession {")
+            .nth(1)
+            .expect("session struct")
+            .split('}')
+            .next()
+            .expect("struct body");
+        let builder = struct_body
+            .find("builder: GgmlCpuGraphBuilder")
+            .expect("builder");
+        let context = struct_body
+            .find("_context: GgmlContextGuard")
+            .expect("context");
+        let scheduler = struct_body
+            .find("_scheduler: Option<GgmlBackendSchedulerGuard>")
+            .expect("scheduler");
+        assert!(
+            builder < context && context < scheduler,
+            "builder must drop before the context/scheduler it aliases, got builder@{builder} context@{context} scheduler@{scheduler}"
+        );
+
+        let park = source
+            .split("fn park_idle_runner_graph_context(")
+            .nth(1)
+            .expect("park_idle_runner_graph_context")
+            .split("\n    fn ")
+            .next()
+            .expect("park body");
+        let reset = park
+            .find("ggml_backend_sched_reset")
+            .expect("park must reset the scheduler");
+        let drop_context = park
+            .find("self.context = None")
+            .expect("park drops context");
+        assert!(
+            reset < drop_context,
+            "idle runner context must be detached from the scheduler before it is freed, got reset@{reset} drop@{drop_context}"
+        );
+    }
+
+    fn scheduler_start_graph_then_persistent_session_drop(config: GgmlCpuGraphConfig) {
+        let mut runner =
+            GgmlCpuGraphRunner::new(config).expect("scheduler runner should initialize");
+        {
+            let output = runner
+                .compute_add_f32(&[1.0, 2.0], &[3.0, 4.0])
+                .expect("one-shot start_graph compute");
+            assert_eq!(output, vec![4.0, 6.0]);
+        }
+        let mut session = runner
+            .start_persistent_graph_session(1024 * 1024)
+            .expect("persistent session after start_graph");
+        let graph = session.builder();
+        let input = graph
+            .new_tensor_1d_f32(2, "persistent_input")
+            .expect("input");
+        graph.set_input(input).expect("input flag");
+        let output = graph.mul(input, input).expect("square");
+        graph.set_output(output).expect("output flag");
+        graph
+            .prepare_outputs_for_upload(&[output])
+            .expect("prepare persistent graph");
+        graph
+            .set_f32_slice(input, &[2.0, 3.0], "persistent_input")
+            .expect("upload");
+        assert_eq!(
+            graph
+                .compute_output_f32(output, 2)
+                .expect("persistent compute"),
+            vec![4.0, 9.0]
+        );
+        drop(session);
+        drop(runner);
+    }
+
+    #[test]
+    fn scheduler_start_graph_then_persistent_session_drop_does_not_segfault() {
+        let mut config = GgmlCpuGraphConfig::conservative_default();
+        config.use_scheduler = true;
+        scheduler_start_graph_then_persistent_session_drop(config);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn metal_scheduler_start_graph_then_persistent_session_drop_does_not_segfault() {
+        let mut config = GgmlCpuGraphConfig::conservative_default();
+        config.backend = GgmlCpuGraphBackend::Metal;
+        config.use_scheduler = true;
+        if GgmlCpuGraphRunner::new(config).is_err() {
+            return;
+        }
+        scheduler_start_graph_then_persistent_session_drop(config);
     }
 
     #[test]

--- a/crates/openasr-core/src/models/qwen/logits_head.rs
+++ b/crates/openasr-core/src/models/qwen/logits_head.rs
@@ -807,11 +807,13 @@ struct Qwen3AsrLlmLogitsHeadGraphExecutor {
     d_model: usize,
     vocab_size: usize,
     rms_norm_epsilon: f32,
-    runner: GgmlCpuGraphRunner,
+    // `reuse` holds raw graph/scheduler pointers into `runner` and `arena`,
+    // so it MUST drop first. Rust drops fields in declaration order.
+    reuse: Option<QwenReusableLogitsGraph>,
     arena: GgmlStaticTensorArena,
     output_norm_weight: GgmlStaticTensor,
     output_weight: GgmlStaticTensor,
-    reuse: Option<QwenReusableLogitsGraph>,
+    runner: GgmlCpuGraphRunner,
 }
 
 impl fmt::Debug for Qwen3AsrLlmLogitsHeadGraphExecutor {
@@ -880,11 +882,11 @@ impl Qwen3AsrLlmLogitsHeadGraphExecutor {
             d_model,
             vocab_size,
             rms_norm_epsilon,
-            runner,
+            reuse: None,
             arena,
             output_norm_weight: norm,
             output_weight: weight,
-            reuse: None,
+            runner,
         })
     }
 
@@ -1153,6 +1155,31 @@ mod tests {
     use crate::testing::{TinyGgufFixtureSpec, write_tiny_gguf_runtime_source};
 
     use super::*;
+
+    #[test]
+    fn logits_executor_drops_reusable_session_before_runner() {
+        let source = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/models/qwen/logits_head.rs"),
+        )
+        .expect("read logits_head.rs");
+        let struct_body = source
+            .split("struct Qwen3AsrLlmLogitsHeadGraphExecutor {")
+            .nth(1)
+            .expect("executor struct")
+            .split('}')
+            .next()
+            .expect("struct body");
+        let reuse = struct_body
+            .find("reuse: Option<QwenReusableLogitsGraph>")
+            .expect("reuse field");
+        let runner = struct_body
+            .find("runner: GgmlCpuGraphRunner")
+            .expect("runner field");
+        assert!(
+            reuse < runner,
+            "logits persistent session must drop before the runner it aliases, got reuse@{reuse} runner@{runner}"
+        );
+    }
 
     #[test]
     fn tied_embedding_and_logits_share_one_mmap_payload_range() {


### PR DESCRIPTION
## Summary

Two 0.1.37 family-gate regressions: `--diarize` failed closed because Stream-VAD admitted without NES, and `moss-transcribe-diarize` SIGSEGV'd after a successful decode while dropping a scheduler-backed persistent graph.

## Why

GPU ownership made vendored FireRed Stream-VAD require the process-wide broker, but native transcribe only installed NES around speaker-turn computation. Separately, `ggml_backend_sched_reset` detached the caller's source cgraph after that context had already been parked, which is the moss macOS exit 139.

## Changes

- Install NES before Voice ID Stream-VAD / ReDimNet materialize; stop swallowing `VadUnavailable`.
- Pin ggml so scheduler reset detaches the live split graph, not a possibly-parked caller cgraph.
- Reset the idle runner context's scheduler bindings before freeing it.
- Drop the Qwen logits reusable session before its runner.

## Tests run

- [x] `cargo fmt --all`
- [x] `cargo test -p openasr-core --lib persistent_graph_session_drops_builder_before_context`
- [x] `cargo test -p openasr-core --lib persistent_session_drop` (CPU + Metal scheduler handoff)
- [x] `cargo test -p openasr-core --lib logits_executor_drops_reusable_session_before_runner`
- [x] `cargo test -p openasr-core --lib sibling_persistent_graphs_rebind_the_shared_scheduler_before_reuse`
- [x] `cargo test -p openasr-core --lib persistent_graph_session_reuses_built_graph_on_scheduler_path`
- [x] `cargo test -p openasr-core --lib voice_id_installs_nes_before_vad_materialize`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

Isolated `OPENASR_HOME`, `OPENASR_GGML_BACKEND=cpu`, release CLI:

- `openasr transcribe -m moss-transcribe-diarize:q4 --offline fixtures/jfk.wav` EXIT 0 (was 139 after postprocess)
- `openasr transcribe -m whisper-tiny:q4 --diarize --offline fixtures/jfk.wav` EXIT 0 (was Voice ID Stream-VAD load failure)

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

## Docs updated

- [x] CHANGELOG
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not retag v0.1.37. Shipping the binary fix is a later 0.1.38 Release core after this merges.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES