### PR TITLE
fix(release): keep gh_release download progress off stdout

### DIFF
--- a/scripts/gate-catalog-against-released-binary.sh
+++ b/scripts/gate-catalog-against-released-binary.sh
@@ -92,8 +92,10 @@ resolve_binary() {
   local version="${tag#v}"
   local asset="openasr-${version}-linux-x86_64.tar.gz"
   mkdir -p "$asset_dir"
+  # Progress from gh_release.py must not land on stdout: this function's
+  # stdout is captured as the CLI path.
   if ! python3 tooling/release-manifest/gh_release.py download \
-        "$tag" "$asset_dir" "$asset" --repo "$repo"; then
+        "$tag" "$asset_dir" "$asset" --repo "$repo" >&2; then
     echo "::error::failed to download the ${tag} linux-x86_64 CLI release asset from ${repo}. Fail-closed: refusing to bless a catalog without exercising a real released binary against it." >&2
     exit 1
   fi

--- a/tooling/release-manifest/gh_release.py
+++ b/tooling/release-manifest/gh_release.py
@@ -124,7 +124,11 @@ def curl_download(
     command.append(url)
     last_error: BaseException | None = None
     for attempt in range(1, attempts + 1):
-        print(f"download {url} -> {dest.name} (attempt {attempt}/{attempts})", flush=True)
+        print(
+            f"download {url} -> {dest.name} (attempt {attempt}/{attempts})",
+            file=sys.stderr,
+            flush=True,
+        )
         dest.unlink(missing_ok=True)
         try:
             subprocess.run(command, check=True, timeout=timeout_seconds + 60)

--- a/tooling/release-manifest/gh_release_test.py
+++ b/tooling/release-manifest/gh_release_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
@@ -104,6 +105,28 @@ class GhReleaseDownloadTests(unittest.TestCase):
             self.assertIn("--http1.1", curl)
             self.assertNotIn("Authorization", " ".join(curl))
             self.assertEqual(dest.read_bytes(), b"payload")
+
+    def test_download_progress_goes_to_stderr_not_stdout(self) -> None:
+        view = json.dumps({"assets": [_asset("SHA256SUMS")]})
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "SHA256SUMS"
+
+            def run(command, check=True, timeout=None):
+                del check, timeout
+                dest.write_text("sums\n", encoding="utf-8")
+                return subprocess.CompletedProcess(command, 0)
+
+            with mock.patch.dict(os.environ, {"GH_TOKEN": "test-token"}, clear=False), mock.patch(
+                "gh_release.subprocess.check_output", return_value=view
+            ), mock.patch("gh_release.subprocess.run", side_effect=run), mock.patch(
+                "sys.stdout", new_callable=io.StringIO
+            ) as stdout, mock.patch(
+                "sys.stderr", new_callable=io.StringIO
+            ) as stderr:
+                gh_release.download_asset("v0.1.36", "SHA256SUMS", Path(tmp))
+            self.assertEqual(stdout.getvalue(), "")
+            self.assertIn("download ", stderr.getvalue())
+            self.assertIn("SHA256SUMS", stderr.getvalue())
 
     def test_download_assets_lists_the_release_once(self) -> None:
         view = json.dumps(


### PR DESCRIPTION
## Summary

Send \`gh_release.py\` download progress to stderr, and redirect the catalog-vs-released-binary gate's helper stdout, so command substitution cannot treat a progress line as the CLI path.

## Why

The v0.1.38 second Release core family gate was green (including diarize and moss). Catalog deploy then failed in \`gate-released-binary-compat\`: it captured \`download https://api.github.com/... -> openasr-0.1.36-linux-x86_64.tar.gz (attempt 1/6)\` as the binary path and \`doctor\` exited 127.

## Tests run

- [x] \`python3 -m unittest gh_release_test\` (from \`tooling/release-manifest\`)
- [ ] \`cargo clippy --all-targets -- -D warnings\`
- [ ] \`cargo nextest run --workspace\`

## Scope / non-goals

Does not change catalog bytes. After merge, re-dispatch Release core for v0.1.38 to deploy PublishedInert and continue finalize.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside \`crates/openasr-core/third_party/openasr-ggml\`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES