### PR TITLE
ci(release): run channel helpers from the default branch

### DIFF
--- a/.github/workflows/publish-core-channels.yml
+++ b/.github/workflows/publish-core-channels.yml
@@ -69,9 +69,15 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
+      # Helper scripts must come from the live default branch. A release:
+      # published event checks out the tag by default, so a later CI-only fix
+      # (for example gh_release.py writing progress to stderr) would otherwise
+      # be invisible and skip Docker/Homebrew. Release bytes still come from
+      # the published tag via download-packs, SHA256SUMS, and the live catalog.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.resolve.outputs.tag }}
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
       - name: Download release trust metadata
         env:
           GH_TOKEN: ${{ github.token }}
@@ -145,7 +151,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.resolve.outputs.tag }}
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
       - name: Check for tap credentials
         id: check
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -261,9 +261,15 @@ secret is not set, the job prints a `::notice::` and builds without pushing
 A red Docker job fails that leg of the workflow only and does not delete or
 roll back the already-published Release.
 
+The distribution gate and Homebrew formula updater check out helper scripts
+from the repository default branch, not the release tag, so a later CI-only
+fix still applies when repairing an already-public tag. Docker images still
+build from the tag's Dockerfiles and the published Linux tarballs.
+
 Manual dry-run / re-publish against an existing tag:
 
 ```bash
+gh workflow run publish-core-channels.yml -f tag=vX.Y.Z
 gh workflow run docker-release.yml \
   -f version=X.Y.Z -f tag=vX.Y.Z -f push=false -f mark_latest=false -f variants=all
 ```

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -312,6 +312,16 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn("verify-cdn", channels)
         self.assertIn("needs: [resolve, distribution-gate]", channels)
         self.assertIn("git push origin main", channels)
+        gate = channels.split("\n  distribution-gate:\n", 1)[1].split(
+            "\n  docker-images:\n", 1
+        )[0]
+        self.assertIn("github.event.repository.default_branch", gate)
+        self.assertNotIn("needs.resolve.outputs.tag", gate.split("Download release trust metadata", 1)[0])
+        brew = channels.split("\n  update-homebrew-tap:\n", 1)[1]
+        brew_checkout = brew.split("\n      - name: Check for tap credentials\n", 1)[0]
+        self.assertIn("github.event.repository.default_branch", brew_checkout)
+        self.assertNotIn("needs.resolve.outputs.tag", brew_checkout)
+        self.assertIn("ref: ${{ needs.resolve.outputs.tag }}", channels)
 
     def test_family_regression_reuses_published_assets_instead_of_racing_raw_tag(self) -> None:
         family = (ROOT / ".github/workflows/family-regression.yml").read_text(


### PR DESCRIPTION
## Summary

`publish-core-channels.yml` now checks out helper scripts from the default branch. Release bytes still come from the published tag.

## Why

v0.1.38 Docker/Homebrew never ran. The distribution gate checked out the tag, so `gh_release.py` still printed download progress on stdout and `gate-catalog-against-released-binary.sh` treated that line as the CLI path (exit 127). The stderr fix is already on `main`.

## Changes

- Distribution gate and Homebrew updater check out `github.event.repository.default_branch`.
- Docker images still build from the tag Dockerfiles and published Linux tarballs.
- Contract test covers the checkout split.

## Tests run

- [x] `python3 -m unittest tooling.release-manifest.core_release_finalization_contract_test`

## Manual smoke checks

Dispatch against public `v0.1.38` from this branch after push.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not retag or change the GitHub core release / catalog.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES