### PR TITLE
fix(server): keep served model identity independent of residency

### DIFF
--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -712,11 +712,10 @@ pub(super) async fn serve(
             ),
             ffmpeg_bin,
             ffmpeg_bin_explicit,
-            // Bind the verified launch pack as served identity immediately.
-            // Boot reactivation still attests residency from durable V2; idle
-            // unload must not clear this slot. `requested()` would hide the
-            // identity until first-compute attestation and empty `/v1/models`.
-            model_pack_path: model_source.model_pack_path.into(),
+            // Launch path is served identity; current() waits for attestation.
+            model_pack_path: openasr_server::ActiveRuntimeSlot::requested(
+                model_source.model_pack_path,
+            ),
         },
         launch_options,
     )

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -712,9 +712,11 @@ pub(super) async fn serve(
             ),
             ffmpeg_bin,
             ffmpeg_bin_explicit,
-            model_pack_path: openasr_server::ActiveRuntimeSlot::requested(
-                model_source.model_pack_path,
-            ),
+            // Bind the verified launch pack as served identity immediately.
+            // Boot reactivation still attests residency from durable V2; idle
+            // unload must not clear this slot. `requested()` would hide the
+            // identity until first-compute attestation and empty `/v1/models`.
+            model_pack_path: model_source.model_pack_path.into(),
         },
         launch_options,
     )

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1547,10 +1547,14 @@ impl ActiveRuntimeSlot {
     }
 
     pub(crate) fn served_snapshot(&self) -> Option<ActiveRuntimeSnapshot> {
-        if let Some(snapshot) = self.current_snapshot() {
-            return Some(snapshot);
-        }
         let state = self.lock_read();
+        if let Some(binding) = state.active.as_ref() {
+            return Some(ActiveRuntimeSnapshot {
+                generation: state.generation,
+                path: binding.path.clone(),
+                residency_key: binding.residency_key(),
+            });
+        }
         state
             .requested_path
             .as_ref()
@@ -2744,12 +2748,8 @@ async fn models(
             .map(|card| served_model_item(card.id, None))
             .collect(),
         BackendKind::Native => {
-            // Served identity, not residency: a bound verified pack is listed
-            // even if idle-unload evicted weights or boot attestation has not
-            // finished. No bound pack is a normal fresh-install state -- empty
-            // list, not an error (the transcription path is the fail-closed
-            // boundary for "no model"). Identity is re-verified from the pack
-            // on every read; never from a config string.
+            // Empty list is the no-pack state, not an error. Re-verify the
+            // served pack on every read so listing cannot follow a config string.
             match runtime.model_pack_path.served_pack_path() {
                 None => Vec::new(),
                 Some(model_pack_path) => {

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1496,7 +1496,11 @@ impl From<Option<PathBuf>> for ActiveRuntimeSlot {
 
 impl ActiveRuntimeSlot {
     /// Constructs the daemon's startup state from durable requested intent.
-    /// The path is not returned by [`Self::current`] until reactivation passes.
+    ///
+    /// [`Self::current`] stays empty until reactivation attests the live
+    /// runtime. [`Self::served_pack_path`] still returns this path: served
+    /// identity is the verified pack this process will run, not whether
+    /// weights are resident. Idle unload must not clear it.
     pub fn requested(path: Option<PathBuf>) -> Self {
         Self {
             inner: Arc::new(RwLock::new(ActiveRuntimeSlotState {
@@ -1526,6 +1530,13 @@ impl ActiveRuntimeSlot {
         self.current_snapshot().map(|snapshot| snapshot.path)
     }
 
+    /// Pack this process is serving. Prefers the attested live binding, then
+    /// the launch/durable requested path. Distinct from residency: idle unload
+    /// clears warm markers, not this path. Empty only when no pack is bound.
+    pub fn served_pack_path(&self) -> Option<PathBuf> {
+        self.served_snapshot().map(|snapshot| snapshot.path)
+    }
+
     pub(crate) fn current_snapshot(&self) -> Option<ActiveRuntimeSnapshot> {
         let state = self.lock_read();
         state.active.as_ref().map(|binding| ActiveRuntimeSnapshot {
@@ -1535,13 +1546,30 @@ impl ActiveRuntimeSlot {
         })
     }
 
+    pub(crate) fn served_snapshot(&self) -> Option<ActiveRuntimeSnapshot> {
+        if let Some(snapshot) = self.current_snapshot() {
+            return Some(snapshot);
+        }
+        let state = self.lock_read();
+        state
+            .requested_path
+            .as_ref()
+            .map(|path| ActiveRuntimeSnapshot {
+                generation: state.generation,
+                path: path.clone(),
+                residency_key: idle_activity::NativeRuntimeResidencyKey::legacy_path(path),
+            })
+    }
+
     fn snapshot_is_current(&self, snapshot: &ActiveRuntimeSnapshot) -> bool {
         let state = self.lock_read();
-        state.generation == snapshot.generation
-            && state
-                .active
-                .as_ref()
-                .is_some_and(|binding| binding.path == snapshot.path)
+        if state.generation != snapshot.generation {
+            return false;
+        }
+        if let Some(binding) = state.active.as_ref() {
+            return binding.path == snapshot.path;
+        }
+        state.requested_path.as_ref() == Some(&snapshot.path)
     }
 
     pub fn requested_path(&self) -> Option<PathBuf> {
@@ -1821,7 +1849,7 @@ impl ServerRuntime {
         match self.backend {
             BackendKind::Mock => Ok(()),
             BackendKind::Native => {
-                let Some(model_pack_path) = self.model_pack_path.current() else {
+                let Some(model_pack_path) = self.model_pack_path.served_pack_path() else {
                     return Ok(());
                 };
                 let _ = validate_native_runtime_pack(&model_pack_path)?;
@@ -1832,11 +1860,12 @@ impl ServerRuntime {
 
     /// Whether a native model pack is currently bound (surfaced by `/health` so
     /// clients can distinguish "daemon not reachable" from "daemon ready, no
-    /// model installed" without racing a separate models-list call).
+    /// model installed" without racing a separate models-list call). Bound
+    /// means this process has a served identity, not that weights are resident.
     fn has_model_bound(&self) -> bool {
         match self.backend {
             BackendKind::Mock => true,
-            BackendKind::Native => self.model_pack_path.is_some(),
+            BackendKind::Native => self.model_pack_path.served_pack_path().is_some(),
         }
     }
 
@@ -1955,13 +1984,12 @@ impl ServerRuntime {
     fn model_is_resident(&self) -> bool {
         match self.backend {
             BackendKind::Mock => true,
-            BackendKind::Native => {
-                self.model_pack_path
-                    .current_snapshot()
-                    .is_some_and(|snapshot| {
-                        idle_activity::native_model_is_resident(snapshot.residency_key())
-                    })
-            }
+            BackendKind::Native => self
+                .model_pack_path
+                .served_snapshot()
+                .is_some_and(|snapshot| {
+                    idle_activity::native_model_is_resident(snapshot.residency_key())
+                }),
         }
     }
 }
@@ -2716,10 +2744,13 @@ async fn models(
             .map(|card| served_model_item(card.id, None))
             .collect(),
         BackendKind::Native => {
-            // No model bound is a normal fresh-install state, not an error:
-            // report an empty model list rather than fail-closed here (the
-            // transcription path is the fail-closed boundary for "no model").
-            match runtime.model_pack_path.current() {
+            // Served identity, not residency: a bound verified pack is listed
+            // even if idle-unload evicted weights or boot attestation has not
+            // finished. No bound pack is a normal fresh-install state -- empty
+            // list, not an error (the transcription path is the fail-closed
+            // boundary for "no model"). Identity is re-verified from the pack
+            // on every read; never from a config string.
+            match runtime.model_pack_path.served_pack_path() {
                 None => Vec::new(),
                 Some(model_pack_path) => {
                     let adapter = validate_native_runtime_pack(&model_pack_path)
@@ -2781,7 +2812,7 @@ async fn capabilities(
     let transcription = if runtime.backend == BackendKind::Native {
         runtime
             .model_pack_path
-            .current()
+            .served_pack_path()
             .as_deref()
             .map(native_runtime_transcription_capabilities_for_path)
             .unwrap_or_else(|| TranscriptionBackendCapabilities::for_backend_kind(runtime.backend))
@@ -2818,7 +2849,7 @@ pub(crate) fn realtime_capabilities_for_runtime(
     let mut capabilities = if runtime.backend == BackendKind::Native {
         runtime
             .model_pack_path
-            .current()
+            .served_pack_path()
             .as_deref()
             .map(cached_native_realtime_capabilities_for_path)
             .unwrap_or_else(|| RealtimeBackendCapabilities::for_backend_kind(runtime.backend))

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -1345,7 +1345,7 @@ async fn warm_up_native_pack(
                 let _activation_barrier = runtime
                     .begin_native_activation()
                     .map_err(|error| error.to_string())?;
-                let Some(active_model) = runtime.model_pack_path.current_snapshot() else {
+                let Some(active_model) = runtime.model_pack_path.served_snapshot() else {
                     // Fresh install / no model installed yet: nothing to warm.
                     // The daemon still serves `/health`; a later activation
                     // binds and probes a verified pack transactionally.
@@ -1536,7 +1536,7 @@ impl RealtimeBackendWorkerKey {
         Self {
             backend: runtime.backend.to_string(),
             ffmpeg_bin: runtime.ffmpeg_bin.clone(),
-            model_pack_path: runtime.model_pack_path.current(),
+            model_pack_path: runtime.model_pack_path.served_pack_path(),
         }
     }
 }

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -469,7 +469,7 @@ fn realtime_phrase_bias_rejection_message(
     capability: openasr_core::api::backend::BackendFeatureCapability,
 ) -> String {
     if runtime.backend == openasr_core::BackendKind::Native
-        && let Some(path) = runtime.model_pack_path.current()
+        && let Some(path) = runtime.model_pack_path.served_pack_path()
         && let Some(adapter) = native_runtime_model_adapter_for_path(&path)
     {
         return format!(
@@ -1203,7 +1203,7 @@ impl WsSession {
         partial_results: bool,
         word_timestamps: bool,
     ) -> Result<(), ()> {
-        let Some(active_model) = self.runtime.model_pack_path.current_snapshot() else {
+        let Some(active_model) = self.runtime.model_pack_path.served_snapshot() else {
             self.emit_error(
                 RealtimeErrorCode::StartupConfigError,
                 "Native realtime streaming requires an explicit local runtime pack path.",

--- a/crates/openasr-server/src/routes/models_api.rs
+++ b/crates/openasr-server/src/routes/models_api.rs
@@ -35,7 +35,7 @@ pub(crate) async fn default_model(
     let mut response = default_model_response(
         &home,
         distribution.catalog_source(),
-        runtime.model_pack_path.current().as_deref(),
+        runtime.model_pack_path.served_pack_path().as_deref(),
     )?;
     response.idle_switch_pending = runtime
         .native_execution
@@ -63,7 +63,7 @@ pub(crate) async fn set_default_model(
         let body = default_model_response_with_idle_switch(
             &home,
             distribution.catalog_source(),
-            runtime.model_pack_path.current().as_deref(),
+            runtime.model_pack_path.served_pack_path().as_deref(),
             Some(pack.pull),
         )?;
         return Ok((StatusCode::ACCEPTED, Json(body)).into_response());
@@ -84,7 +84,7 @@ pub(crate) async fn set_default_model(
     Ok(Json(default_model_response_with_idle_switch(
         &home,
         distribution.catalog_source(),
-        runtime.model_pack_path.current().as_deref(),
+        runtime.model_pack_path.served_pack_path().as_deref(),
         None,
     )?)
     .into_response())
@@ -102,7 +102,7 @@ pub(crate) async fn cancel_idle_switch(
     Ok(Json(default_model_response_with_idle_switch(
         &home,
         distribution.catalog_source(),
-        runtime.model_pack_path.current().as_deref(),
+        runtime.model_pack_path.served_pack_path().as_deref(),
         None,
     )?))
 }

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -2498,7 +2498,7 @@ pub(crate) async fn transcribe_with_runtime(
         }
         BackendKind::Native => {
             tokio::task::spawn_blocking(move || {
-                let active_model = runtime.model_pack_path.current_snapshot().ok_or_else(|| {
+                let active_model = runtime.model_pack_path.served_snapshot().ok_or_else(|| {
                     ApiError::Backend(openasr_core::BackendError::NativeModelPackPathRejected {
                         reason: format!(
                             "Model '{}' is not installed. No models are installed on this server yet -- install one first (openasr pull {}, or via the model market).",

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -2868,19 +2868,31 @@ async fn issue_376_get_json(app: axum::Router, uri: &str) -> (StatusCode, serde_
 }
 
 fn issue_376_realtime_handshake_accepts(runtime: &ServerRuntime, model_id: &str) {
-    let path = runtime
+    let snapshot = runtime
         .model_pack_path
-        .served_pack_path()
+        .served_snapshot()
         .expect("served pack for realtime handshake");
-    let adapter = validate_native_runtime_pack(&path).expect("verify served pack");
+    let adapter = validate_native_runtime_pack(snapshot.path()).expect("verify served pack");
     validate_native_request_model(&adapter, model_id)
         .expect("session.start identity must match the served pack");
+    let key = native_model_session_key(&adapter).expect("native session key");
+    let admitted = runtime
+        .acquire_native_execution_for_snapshot(
+            &snapshot,
+            &key,
+            None,
+            NativeAdmissionKind::Realtime,
+            None,
+        )
+        .expect("session.start admission must accept the served snapshot");
+    drop(admitted);
 }
 
 #[tokio::test]
 async fn issue_376_requested_launch_pack_lists_verified_identity_before_attestation() {
     let temp = tempfile::tempdir().unwrap();
     let pack = write_valid_installed_pack_for_test(temp.path(), "moonshine-tiny", "q8_0", "q8");
+    persist_default_pack(temp.path(), &pack, QuantPreference::pinned(&pack.quant)).unwrap();
     let runtime = ServerRuntime {
         backend: BackendKind::Native,
         native_execution: NativeExecutionSupervisor::default(),
@@ -2906,6 +2918,14 @@ async fn issue_376_requested_launch_pack_lists_verified_identity_before_attestat
     assert_eq!(status, StatusCode::OK);
     assert_eq!(models["data"].as_array().unwrap().len(), 1);
     assert_eq!(models["data"][0]["id"], "moonshine-tiny");
+
+    let (status, default) = issue_376_get_json(app.clone(), "/v1/models/default").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(default["default_model"], "moonshine-tiny");
+    assert_eq!(
+        default["activation"], "committed",
+        "served launch path must count as the bound default before attestation"
+    );
 
     let (status, health) = issue_376_get_json(app.clone(), "/health").await;
     assert_eq!(status, StatusCode::OK);
@@ -2996,6 +3016,54 @@ async fn issue_376_idle_unload_keeps_served_identity_on_models_default_and_realt
     assert_eq!(status, StatusCode::OK);
     assert_eq!(capabilities_after, capabilities_before);
     issue_376_realtime_handshake_accepts(&runtime, "moonshine-tiny");
+}
+
+#[test]
+fn issue_376_session_start_and_transcription_admit_from_served_snapshot() {
+    let start = include_str!("realtime/ws_session.rs")
+        .split("pub(crate) async fn start_native_streaming_session")
+        .nth(1)
+        .expect("start_native_streaming_session")
+        .split("\n    pub(crate)")
+        .next()
+        .expect("start_native_streaming_session body");
+    assert!(
+        start.contains("served_snapshot()"),
+        "session.start must admit the served pack, not only the attested live pointer: {start}"
+    );
+    assert!(
+        !start.contains("current_snapshot()"),
+        "session.start must not fall back to current_snapshot: {start}"
+    );
+
+    let native_arm = include_str!("routes/transcription.rs")
+        .split("pub(crate) async fn transcribe_with_runtime")
+        .nth(1)
+        .expect("transcribe_with_runtime")
+        .split("BackendKind::Native =>")
+        .nth(1)
+        .expect("native transcription arm");
+    assert!(
+        native_arm.contains("served_snapshot()"),
+        "native transcription must admit the served pack: {native_arm}"
+    );
+
+    let served = include_str!("lib.rs")
+        .split("pub(crate) fn served_snapshot")
+        .nth(1)
+        .expect("served_snapshot")
+        .split("fn snapshot_is_current")
+        .next()
+        .expect("served_snapshot body");
+    assert_eq!(
+        served.matches("lock_read()").count(),
+        1,
+        "served_snapshot must observe active and requested under one lock: {served}"
+    );
+    assert!(
+        !served.contains("current_snapshot()"),
+        "served_snapshot must not re-enter current_snapshot across a second lock: {served}"
+    );
 }
 
 #[test]

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -2817,6 +2817,11 @@ async fn boot_reactivation_attests_v2_before_publishing_active_runtime() {
         runtime.model_pack_path.requested_path().as_deref(),
         Some(pack_path.as_path())
     );
+    assert_eq!(
+        runtime.model_pack_path.served_pack_path().as_deref(),
+        Some(pack_path.as_path()),
+        "served identity must be available from launch intent before attestation"
+    );
 
     let reactivation = realtime::spawn_boot_native_warmup(runtime.clone(), home.clone());
     tokio::time::timeout(std::time::Duration::from_secs(30), reactivation)
@@ -2843,6 +2848,174 @@ async fn boot_reactivation_attests_v2_before_publishing_active_runtime() {
             .runtime_receipts()
             .reconcile_live_leases_quiescent(services.memory_broker()),
         openasr_core::runtime_receipts::LeaseReceiptShadow::Matched
+    );
+}
+
+async fn issue_376_get_json(app: axum::Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    use axum::body::{Body, to_bytes};
+    use tower::ServiceExt;
+
+    let response = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).expect("json response"),
+    )
+}
+
+fn issue_376_realtime_handshake_accepts(runtime: &ServerRuntime, model_id: &str) {
+    let path = runtime
+        .model_pack_path
+        .served_pack_path()
+        .expect("served pack for realtime handshake");
+    let adapter = validate_native_runtime_pack(&path).expect("verify served pack");
+    validate_native_request_model(&adapter, model_id)
+        .expect("session.start identity must match the served pack");
+}
+
+#[tokio::test]
+async fn issue_376_requested_launch_pack_lists_verified_identity_before_attestation() {
+    let temp = tempfile::tempdir().unwrap();
+    let pack = write_valid_installed_pack_for_test(temp.path(), "moonshine-tiny", "q8_0", "q8");
+    let runtime = ServerRuntime {
+        backend: BackendKind::Native,
+        native_execution: NativeExecutionSupervisor::default(),
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: ActiveRuntimeSlot::requested(Some(pack.path.clone())),
+    };
+    assert!(
+        runtime.model_pack_path.current().is_none(),
+        "attestation must not have published the live pointer yet"
+    );
+
+    let app = app_with_runtime_and_distribution(
+        runtime.clone(),
+        DistributionRuntime {
+            openasr_home: Some(temp.path().to_path_buf()),
+            catalog_url: None,
+            catalog_local_override: None,
+        },
+    );
+
+    let (status, models) = issue_376_get_json(app.clone(), "/v1/models").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models["data"].as_array().unwrap().len(), 1);
+    assert_eq!(models["data"][0]["id"], "moonshine-tiny");
+
+    let (status, health) = issue_376_get_json(app.clone(), "/health").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(health["model_installed"], true);
+    assert_eq!(
+        health["model_resident"], false,
+        "launch identity must not be conflated with residency"
+    );
+
+    let (status, capabilities) = issue_376_get_json(app, "/v1/capabilities").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(capabilities["object"], "capabilities");
+    assert!(
+        capabilities["transcription"].is_object(),
+        "capabilities must be derived from the served pack: {capabilities}"
+    );
+
+    issue_376_realtime_handshake_accepts(&runtime, "moonshine-tiny");
+}
+
+#[tokio::test]
+async fn issue_376_idle_unload_keeps_served_identity_on_models_default_and_realtime_handshake() {
+    let _generation_lock = idle_activity::native_unload_generation_test_lock().await;
+    let temp = tempfile::tempdir().unwrap();
+    let pack = write_valid_installed_pack_for_test(temp.path(), "moonshine-tiny", "q8_0", "q8");
+    persist_default_pack(temp.path(), &pack, QuantPreference::pinned(&pack.quant)).unwrap();
+    let runtime = ServerRuntime {
+        backend: BackendKind::Native,
+        native_execution: NativeExecutionSupervisor::default(),
+        ffmpeg_bin: None,
+        ffmpeg_bin_explicit: false,
+        model_pack_path: Some(pack.path.clone()).into(),
+    };
+    let snapshot = runtime
+        .model_pack_path
+        .served_snapshot()
+        .expect("bound pack");
+    idle_activity::mark_native_model_warm(snapshot.residency_key());
+    assert!(runtime.model_is_resident());
+
+    let app = app_with_runtime_and_distribution(
+        runtime.clone(),
+        DistributionRuntime {
+            openasr_home: Some(temp.path().to_path_buf()),
+            catalog_url: None,
+            catalog_local_override: None,
+        },
+    );
+
+    let (status, models_before) = issue_376_get_json(app.clone(), "/v1/models").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models_before["data"][0]["id"], "moonshine-tiny");
+    let (status, default_before) = issue_376_get_json(app.clone(), "/v1/models/default").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(default_before["default_model"], "moonshine-tiny");
+    assert_eq!(default_before["activation"], "committed");
+    let (status, capabilities_before) = issue_376_get_json(app.clone(), "/v1/capabilities").await;
+    assert_eq!(status, StatusCode::OK);
+    issue_376_realtime_handshake_accepts(&runtime, "moonshine-tiny");
+
+    idle_activity::bump_native_unload_generation();
+    runtime
+        .native_execution
+        .execution_services()
+        .unload_idle_native_model_runtime_caches();
+    assert!(
+        !runtime.model_is_resident(),
+        "idle unload must evict residency"
+    );
+    assert_eq!(
+        runtime.model_pack_path.served_pack_path().as_deref(),
+        Some(pack.path.as_path()),
+        "idle unload must not clear served identity"
+    );
+
+    let (status, models_after) = issue_376_get_json(app.clone(), "/v1/models").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models_after, models_before);
+    let (status, default_after) = issue_376_get_json(app.clone(), "/v1/models/default").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(default_after["default_model"], "moonshine-tiny");
+    assert_eq!(default_after["activation"], "committed");
+    let (status, health) = issue_376_get_json(app.clone(), "/health").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(health["model_installed"], true);
+    assert_eq!(health["model_resident"], false);
+    let (status, capabilities_after) = issue_376_get_json(app, "/v1/capabilities").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(capabilities_after, capabilities_before);
+    issue_376_realtime_handshake_accepts(&runtime, "moonshine-tiny");
+}
+
+#[test]
+fn idle_unload_reaper_does_not_clear_served_identity() {
+    let source = include_str!("idle_activity.rs");
+    let spawn = source
+        .split("pub(crate) fn spawn_idle_unload_reaper")
+        .nth(1)
+        .expect("spawn_idle_unload_reaper")
+        .split("#[cfg(test)]")
+        .next()
+        .expect("reaper body");
+    assert!(
+        spawn.contains("unload_idle_native_model_runtime_caches")
+            && spawn.contains("bump_native_unload_generation"),
+        "reaper must evict residency, not served identity: {spawn}"
+    );
+    assert!(
+        !spawn.contains("clear_active") && !spawn.contains("clear_active_native_model"),
+        "idle unload must not clear served identity: {spawn}"
     );
 }
 


### PR DESCRIPTION
## Summary

`GET /v1/models` on native serve now reports the verified pack this process is serving, even before first-compute attestation and after idle unload. The Native contract stays 0 or 1 id; no bound pack still returns an empty list.

## Why

`openasr serve --model <id>` only stored launch intent in `ActiveRuntimeSlot::requested()`. `/v1/models` and the other served-identity surfaces read `current()`, which stays empty until V2 reactivation attests a live runtime. Idle unload evicts weights; it was never supposed to change identity. Those two facts were conflated, so 0.1.38 listed `{"data":[]}` while transcription still worked.

## Changes

- Add `served_pack_path` / `served_snapshot` as the shared served-identity read. Identity is re-verified from the pack on each listing, not taken from a config string.
- Wire `/v1/models`, `/v1/models/default`, `/v1/capabilities`, `/health.model_installed`, realtime `session.start`, and native transcription through that read.
- Bind `openasr serve --model` as served identity at launch. Boot warmup still attests residency. Idle unload still only evicts warm markers.
- Regression tests named `issue_376_*` cover launch-before-attest and idle-unload consistency across models, default, and the realtime identity handshake.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-server`
- [x] `cargo test -p openasr-server --doc`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo deny check`

## Manual smoke checks

Isolated `OPENASR_HOME` (copied `xasr-zh-en` pack, no hardlink, no real `~/.openasr`): `openasr serve --model xasr-zh-en` then immediate `GET /v1/models` returned `xasr-zh-en` with `/health.model_installed=true` and `model_resident=false`.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

## Docs updated

- [ ] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not persist `--model` into durable V2 default-selection. Does not change idle-unload thresholds or catalog public projection.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES

Closes #376