### PR TITLE
docs: note stream file jobs reject busy with 429 not FIFO

### DIFF
--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -159,7 +159,9 @@ local equivalent (`temperature`, `include[]`, `chunking_strategy`,
 `known_speaker_*`) are accepted and ignored. SDK `stream=True` (the `stream`
 form field) is rejected with an actionable 400: SSE streaming is the
 OpenASR realtime protocol behind the `?stream=true` query parameter, not
-OpenAI `transcript.text.*` events.
+OpenAI `transcript.text.*` events. When that query-parameter stream is used
+for a file job, a busy server returns HTTP 429 instead of joining the
+cancelable JSON file FIFO; see [Known Limitations](KNOWN_LIMITATIONS.md).
 
 ### Incomplete transcripts
 

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -238,6 +238,12 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   are retained. See
   [Graph cancellation contract](design/graph-cancellation.md).
   Pause still only blocks at slice boundaries and never arms graph cancellation.
+- `POST /v1/audio/transcriptions?stream=true` shares owner checks, cancel
+  control, and `finish_file` cleanup with JSON file jobs, but a busy server
+  rejects the stream with HTTP 429 instead of enqueueing it on the cancelable
+  file FIFO. JSON `POST /v1/audio/transcriptions` still queues. Desktop remote
+  file transcription uses the JSON endpoint. A later change can emit a queued
+  SSE event and then stream the result.
 
 ## What works now
 


### PR DESCRIPTION
## Summary

Document that `POST /v1/audio/transcriptions?stream=true` returns HTTP 429 when the server is busy instead of joining the cancelable JSON file FIFO.

## Why

JSON file jobs still queue. The SSE query-parameter path shares owner, cancel, and finish_file cleanup, but does not enqueue. Desktop remote file transcription uses the JSON endpoint. Third-party API callers need this written down.

## Changes

- `docs/KNOWN_LIMITATIONS.md`
- `docs/AGENT_INTEGRATION.md` (pointer from the `?stream=true` note)

## Tests run

- [x] docs-only; no code change

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES

Refs QuintinShaw/openasr#338