### PR TITLE
feat(pull): skip re-download when installed pack hash matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Core: `openasr pull` skips the network fetch when the installed
+  content-addressed object already matches the catalog SHA-256, then
+  re-verifies the pack contract and refreshes the install record. A catalog
+  filename alone is not identity; an unsealed object whose bytes do not hash
+  to the catalog digest is fetched again. `KNOWN_LIMITATIONS` no longer
+  claims that pull always re-downloads.
 - Core: `--diarize` / Voice ID now installs the native execution broker
   before Stream-VAD and ReDimNet admission. 0.1.37 failed closed with
   `could not load the vendored FireRed Stream-VAD` because those weights

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -2440,6 +2440,144 @@ fn installed_matches_rejects_a_size_mismatch_on_the_stat_alone() {
     assert!(!installed_matches(&target, &paths).unwrap());
 }
 
+/// Re-pulling a pack whose installed object matches the catalog SHA-256 must
+/// skip the download, re-run the pack verifier, and refresh the install
+/// record. The empty FakeClient panics if the download path is entered.
+#[test]
+fn pull_skips_download_when_installed_pack_hash_matches() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let mut client = FakeClient::with_responses(vec![ResponseSpec {
+        status: 200,
+        body: bytes.clone(),
+    }]);
+    let mut first_events = Vec::new();
+    let first = pull_model_pack_with_client(
+        &resolved,
+        temp.path(),
+        &mut client,
+        PullOptions::default(),
+        |event| first_events.push(event),
+    )
+    .unwrap();
+    assert!(
+        first_events
+            .iter()
+            .any(|event| matches!(event, PullProgress::Installed { .. }))
+    );
+    assert!(!client.ranges().is_empty());
+
+    let mut client = FakeClient::default();
+    let mut second_events = Vec::new();
+    let second = pull_model_pack_with_client(
+        &resolved,
+        temp.path(),
+        &mut client,
+        PullOptions::default(),
+        |event| second_events.push(event),
+    )
+    .unwrap();
+
+    assert!(
+        client.ranges().is_empty(),
+        "matching digest must not open a download"
+    );
+    assert!(
+        second_events
+            .iter()
+            .any(|event| matches!(event, PullProgress::UsingInstalled { .. }))
+    );
+    assert!(!second_events.iter().any(|event| matches!(
+        event,
+        PullProgress::DownloadStarted { .. } | PullProgress::Downloading { .. }
+    )));
+    assert_eq!(second.sha256, first.sha256);
+    assert_eq!(second.path, first.path);
+    assert!(
+        paths_for(temp.path(), &resolved)
+            .installed_meta_path
+            .exists()
+    );
+}
+
+/// A file sitting at the catalog filename is not identity. Skip only when
+/// the content-addressed object matches the catalog digest.
+#[test]
+fn pull_downloads_when_only_catalog_filename_is_present() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let decoy = temp
+        .path()
+        .join("models")
+        .join(&resolved.model_id)
+        .join(&resolved.quant)
+        .join(&resolved.filename);
+    fs::create_dir_all(decoy.parent().unwrap()).unwrap();
+    fs::write(&decoy, b"not-the-catalog-pack").unwrap();
+
+    let mut client = FakeClient::with_responses(vec![ResponseSpec {
+        status: 200,
+        body: bytes.clone(),
+    }]);
+    let mut events = Vec::new();
+    let installed = pull_model_pack_with_client(
+        &resolved,
+        temp.path(),
+        &mut client,
+        PullOptions::default(),
+        |event| events.push(event),
+    )
+    .unwrap();
+
+    assert!(!client.ranges().is_empty());
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, PullProgress::DownloadStarted { .. }))
+    );
+    assert_eq!(fs::read(&installed.path).unwrap(), bytes);
+    assert_eq!(fs::read(&decoy).unwrap(), b"not-the-catalog-pack");
+}
+
+/// Unsealed bytes at the catalog object path that do not hash to the catalog
+/// digest must not skip the download. Filename and path are not identity.
+#[test]
+fn pull_does_not_skip_download_when_unsealed_object_hash_mismatches() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let target = PullTarget::from_resolved(&resolved).unwrap();
+    let paths = pull_paths(temp.path(), &target).unwrap();
+    let mut decoy = bytes.clone();
+    *decoy.last_mut().unwrap() ^= 0xff;
+    assert_ne!(sha256_hex(&decoy), resolved.sha256);
+    seed_final_object(&paths, &decoy, false);
+
+    let mut client = FakeClient::with_responses(vec![ResponseSpec {
+        status: 200,
+        body: bytes.clone(),
+    }]);
+    let result = pull_model_pack_with_client(
+        &resolved,
+        temp.path(),
+        &mut client,
+        PullOptions::default(),
+        |_| {},
+    );
+
+    assert!(
+        !client.ranges().is_empty(),
+        "hash mismatch must re-enter the download path"
+    );
+    // The content store refuses to replace a digest object whose on-disk
+    // bytes do not match the digest in its path. Fail closed rather than
+    // treating the corrupt object as installed.
+    assert!(result.is_err());
+    assert_eq!(fs::read(&paths.final_path).unwrap(), decoy);
+}
+
 /// `config.json`'s `models_dir` field must be the single thing that decides
 /// where a pack lands and where `list_installed_packs` looks for it -- a
 /// redirected home must land the pack entirely outside `<home>/models` and

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -198,9 +198,6 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   (`--model-pack` / an installed `--model`). There is no per-request lazy model
   loading or an `openasr ps`-style multi-model runner yet -- restart `serve` to
   switch models.
-- `openasr pull` always fetches and re-installs; it has no incremental update
-  (no revision/digest diff, `up to date` check, or `--force`). Re-pulling a model
-  re-downloads it.
 - Source-language control is per-model and capability-gated (see
   `openasr show <pack>` / `/v1/capabilities`). Multilingual Whisper auto-detects an
   unset language and accepts an explicit `--language`; Cohere and the English-only

--- a/docs/MODEL_CATALOG_ARCHITECTURE.md
+++ b/docs/MODEL_CATALOG_ARCHITECTURE.md
@@ -167,7 +167,11 @@ non-interactive / `--offline`);
 fail-closed: HTTPS-only catalog pack URLs, size/sha256 checks, GGUF preflight,
 runtime-source validation, and a same-directory atomic rename are required before
 a pack counts as installed, and untrusted catalog pack filenames must be
-relative basename-only `.oasr` targets.
+relative basename-only `.oasr` targets. Re-pulling an already-installed pack
+skips the download when the content-addressed object matches the catalog
+SHA-256, then re-runs the pack verifier and refreshes the install record. A
+catalog filename alone is not identity; an unsealed object whose bytes do not
+hash to the catalog digest is fetched again rather than trusted.
 
 For the local file Voice ID pipeline, ReDimNet2-B6 is required for the default
 capability probe on both `speaker_source` values. An explicit WeSpeaker ResNet


### PR DESCRIPTION
## Summary

Re-pulling a catalog pack skips the network fetch when the installed content-addressed object already matches the catalog SHA-256. The pack verifier still runs, and the install record is refreshed. A catalog filename alone is not identity.

## Why

`docs/KNOWN_LIMITATIONS.md` still claimed that `openasr pull` always fetches and re-installs. The shared pull engine already skipped a matching installed object (`installed_matches` in `crates/openasr-core/src/pull.rs`); this PR pins that contract with tests and removes the stale limitation.

Refs #292.

## Changes

- Tests through `pull_model_pack_with_client`: matching digest skips download (`UsingInstalled`, empty FakeClient); a file at the catalog filename still downloads; an unsealed object whose bytes do not hash to the catalog digest re-enters the download path and fail-closes rather than replacing the corrupt digest object.
- `docs/KNOWN_LIMITATIONS.md`: drop the "always fetches and re-installs" bullet.
- `docs/MODEL_CATALOG_ARCHITECTURE.md` and `CHANGELOG.md`: document the skip-on-digest-match contract.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-core -- pull_skips_download_when_installed_pack_hash_matches pull_downloads_when_only_catalog_filename_is_present pull_does_not_skip_download_when_unsealed_object_hash_mismatches installed_matches`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

None. Coverage is the FakeClient pull tests above.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not add `--force`. Does not re-hash a sealed content-addressed object on every re-pull (the seal plus path digest remain the identity check; `openasr model-pack verify` is the corruption path). Does not change backend-plugin pull.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES