### PR TITLE
docs(docker): note bench-suite fixtures are not in the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   filename alone is not identity; an unsealed object whose bytes do not hash
   to the catalog digest is fetched again. `KNOWN_LIMITATIONS` no longer
   claims that pull always re-downloads.
+- Docs: published Docker images are runtime-only (binary + model-registry
+  metadata). They do not include `perf/` bench-suite fixtures or baselines;
+  run `openasr bench-suite` from a git checkout.
 - Core: `--diarize` / Voice ID now installs the native execution broker
   before Stream-VAD and ReDimNet admission. 0.1.37 failed closed with
   `could not load the vendored FireRed Stream-VAD` because those weights

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,8 @@ Published release images live on Docker Hub (`quintinshaw/openasr`,
 `quintinshaw/openasr:cuda-*`) and are assembled from GitHub Release assets by
 `.github/workflows/docker-release.yml` via `Dockerfile.release` /
 `Dockerfile.cuda.release`. See [RELEASING.md](RELEASING.md#docker-hub-images).
+Runtime images contain the binary and model-registry metadata only; they do
+not include `perf/` bench-suite fixtures or baselines.
 
 ## Formatting and linting
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ Drop-in compatible with OpenAI SDKs (`base_url="http://127.0.0.1:8080/v1"`) for 
 ### Docker
 
 Published images track each core release on
-[Docker Hub](https://hub.docker.com/r/quintinshaw/openasr) (binary +
+[Docker Hub](https://hub.docker.com/r/quintinshaw/openasr) (runtime binary +
 model-registry metadata only; pull models at runtime into a volume mounted at
-`/data`). The HTTP server never auto-downloads a pack — install one first:
+`/data`). They do not include `bench-suite` fixtures or committed baselines
+under `perf/`; run `openasr bench-suite` from a git checkout. The HTTP server
+never auto-downloads a pack — install one first:
 
 ```bash
 docker pull quintinshaw/openasr:latest

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,9 +94,10 @@ curl http://127.0.0.1:8080/v1/audio/transcriptions \
 ### Docker
 
 每个 core release 会同步发布到
-[Docker Hub](https://hub.docker.com/r/quintinshaw/openasr)(仅二进制 +
-model-registry 元数据;模型权重在运行时拉取到挂载在 `/data` 的卷)。HTTP 服务
-**不会**自动下载模型——先显式安装:
+[Docker Hub](https://hub.docker.com/r/quintinshaw/openasr)(仅运行时二进制 +
+model-registry 元数据;模型权重在运行时拉取到挂载在 `/data` 的卷)。镜像不含
+`perf/` 下的 bench-suite 夹具与基线，容器里直接跑 `openasr bench-suite`
+会找不到文件；基准请在 git 检出里跑。HTTP 服务 **不会**自动下载模型——先显式安装:
 
 ```bash
 docker pull quintinshaw/openasr:latest

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -25,7 +25,9 @@ contributors -- crate relationships, the audio-to-transcript pipeline, and the
 
 User-facing Docker install/run guide (tags, GPU, volumes, pull-before-serve):
 [openasr.org/docs/docker](https://openasr.org/docs/docker/). The short form lives
-in the root [README](../README.md#docker).
+in the root [README](../README.md#docker). Published images are runtime-only
+(binary + model-registry metadata); they do not include `perf/` bench-suite
+fixtures or baselines.
 
 ## Format contracts (`docs/format/`)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -199,8 +199,10 @@ amd64). The separate macOS/Windows desktop apps ship from
 Yes. `quintinshaw/openasr` on Docker Hub. Images contain the release binary and
 model-registry metadata only — mount a volume at `/data`, then
 `docker exec … openasr pull <model> --yes` before calling the HTTP API. The
-server never auto-pulls. CUDA tags require the NVIDIA Container Toolkit and
-refuse to start if no GPU is visible. Longer guide:
+server never auto-pulls. They do not ship `perf/` bench-suite fixtures or
+baselines, so `openasr bench-suite` inside the container will fail looking for
+those files; run benchmarks from a git checkout. CUDA tags require the NVIDIA
+Container Toolkit and refuse to start if no GPU is visible. Longer guide:
 [openasr.org/docs/docker](https://openasr.org/docs/docker/).
 
 ## Is ffmpeg required?

--- a/perf/PERFORMANCE.md
+++ b/perf/PERFORMANCE.md
@@ -28,7 +28,9 @@ The harness drives the **real** transcription call path (`transcribe_with_backen
 → `NativeBackend`), the same one `transcribe --benchmark` and `bench-suite` use — it measures
 the production runtime, not a re-implementation. Each entry runs in a fresh
 subprocess (`--run-single-entry`), so its peak RSS (a process high-water mark)
-is uncontaminated by earlier entries.
+is uncontaminated by earlier entries. Published Docker images are runtime-only
+and do not include these fixtures or baselines; run `bench-suite` from a git
+checkout.
 
 ## What is gated
 


### PR DESCRIPTION
## Summary

Document that published Docker images are runtime-only: they contain the binary and model-registry metadata, not `perf/` bench-suite fixtures or committed baselines. `openasr bench-suite` inside the container will fail looking for those files; run it from a git checkout.

## Why

Users hitting `openasr bench-suite` in the published image saw missing files and treated it as a broken environment. The image never copied `perf/`; this makes that boundary explicit in the in-repo Docker docs.

Refs #196.

## Changes

- README (en/zh), FAQ, CONTRIBUTING, docs index, and `perf/PERFORMANCE.md`: images are runtime-only and do not include bench-suite fixtures or baselines.
- CHANGELOG: matching user-facing note.

The longer website guide at openasr.org/docs/docker lives in the separate product repo and is not changed here.

## Tests run

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run --workspace`
- [ ] `cargo test --workspace --doc`
- [ ] `cargo deny check`

Docs-only change; no Rust compile.

## Manual smoke checks

None.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

Does not add fixtures to the image. Does not change Dockerfiles. Does not edit the product-website Docker page.

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES