### PR TITLE
fix(cli): drop ggml backend before exiting on parent loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   process-tap setup. The same failure is fail-closed in the IOProc: a panic
   or foreign exception stops capture with `capture_backend_failed` rather
   than taking down the process.
+- CLI: `openasr serve --parent-pid` now shuts down through the same path as
+  Ctrl-C / SIGTERM instead of calling `process::exit`. ggml Metal backends
+  drop before process teardown, so the daemon no longer aborts in
+  `ggml-metal-device.m` (`GGML_ASSERT` on residency sets) after the parent
+  process disappears.
 - Core: live capture no longer panics when a downsampled mic callback (for
   example 44.1 kHz stereo in 512-frame chunks) leaves the resampler read head
   past the current buffer. The leftover position continues in the next chunk

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -626,9 +626,7 @@ async fn run() -> Result<()> {
             max_native_sessions_per_model,
             parent_pid,
         } => {
-            if let Some(parent_pid) = parent_pid {
-                parent_watchdog::spawn(parent_pid);
-            }
+            let parent_shutdown = parent_pid.and_then(parent_watchdog::spawn);
             serve(
                 native_execution_services,
                 addr,
@@ -643,6 +641,7 @@ async fn run() -> Result<()> {
                     tls_sans,
                     pairing_admin_token_env,
                 },
+                parent_shutdown,
             )
             .await
         }

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -601,6 +601,7 @@ pub(super) async fn serve(
     no_model: bool,
     max_native_sessions_per_model: std::num::NonZeroUsize,
     security: ServeSecurityOptions,
+    parent_shutdown: Option<parent_watchdog::ParentShutdown>,
 ) -> Result<()> {
     let home = openasr_home()?;
     // Read the config document once: `config` and `idle_unload` (used below
@@ -705,24 +706,26 @@ pub(super) async fn serve(
     // `idle_unload` lives on `Preferences`, on the same document already
     // loaded above as `config_document` -- no second read needed.
     launch_options.idle_unload_after = config_document.preferences.idle_unload.idle_threshold();
-    openasr_server::serve_with_launch_options(
-        addr,
-        openasr_server::ServerRuntime {
-            backend,
-            native_execution: openasr_server::NativeExecutionSupervisor::with_execution_services(
-                max_native_sessions_per_model,
-                native_execution_services,
-            ),
-            ffmpeg_bin,
-            ffmpeg_bin_explicit,
-            // Launch path is served identity; current() waits for attestation.
-            model_pack_path: openasr_server::ActiveRuntimeSlot::requested(
-                model_source.model_pack_path,
-            ),
-        },
-        launch_options,
-    )
-    .await
+    tokio::select! {
+        result = openasr_server::serve_with_launch_options(
+            addr,
+            openasr_server::ServerRuntime {
+                backend,
+                native_execution: openasr_server::NativeExecutionSupervisor::with_execution_services(
+                    max_native_sessions_per_model,
+                    native_execution_services,
+                ),
+                ffmpeg_bin,
+                ffmpeg_bin_explicit,
+                // Launch path is served identity; current() waits for attestation.
+                model_pack_path: openasr_server::ActiveRuntimeSlot::requested(
+                    model_source.model_pack_path,
+                ),
+            },
+            launch_options,
+        ) => result,
+        _ = parent_watchdog::wait_for_shutdown(parent_shutdown) => Ok(()),
+    }
 }
 
 /// True when this `serve` process was launched by the desktop supervisor,

--- a/crates/openasr-cli/src/parent_watchdog.rs
+++ b/crates/openasr-cli/src/parent_watchdog.rs
@@ -1,4 +1,4 @@
-//! Kills this process when the process that spawned it (identified by
+//! Shuts this process down when the process that spawned it (identified by
 //! `openasr serve --parent-pid <pid>`) disappears without cleanly stopping
 //! this one first.
 //!
@@ -14,8 +14,11 @@
 //! fresh ephemeral port rather than noticing the leftover.
 //!
 //! `--parent-pid` closes that gap independent of *how* the supervisor dies:
-//! this process polls whether `parent_pid` is still alive and exits as soon
-//! as it is not, with no dependency on the supervisor sending any signal.
+//! this process polls whether `parent_pid` is still alive and joins the same
+//! graceful shutdown path as Ctrl-C / SIGTERM as soon as it is not, so ggml
+//! backends can drop before process teardown. Calling `process::exit` here
+//! skipped Rust `Drop` and aborted in ggml Metal atexit
+//! (`GGML_ASSERT([rsets->data count] == 0)`).
 
 use std::{thread, time::Duration};
 
@@ -24,14 +27,19 @@ use std::{thread, time::Duration};
 /// enough that it costs nothing meaningful over a daemon's lifetime.
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
-/// Spawns a background thread that exits this process shortly after
+/// Receiver fired when the watched parent disappears. The serve loop awaits
+/// this alongside Ctrl-C / SIGTERM so every exit path drops backends first.
+pub(crate) type ParentShutdown = tokio::sync::oneshot::Receiver<()>;
+
+/// Spawns a background thread that signals graceful shutdown shortly after
 /// `parent_pid` disappears. A no-op if `parent_pid` is 0 (never a valid pid,
 /// and clap's `Option<u32>` cannot itself reject it), so a malformed launch
 /// arg degrades to "watchdog disabled" rather than an instant self-kill.
-pub(crate) fn spawn(parent_pid: u32) {
+pub(crate) fn spawn(parent_pid: u32) -> Option<ParentShutdown> {
     if parent_pid == 0 {
-        return;
+        return None;
     }
+    let (tx, rx) = tokio::sync::oneshot::channel();
     let spawned = thread::Builder::new()
         .name("parent-death-watchdog".to_string())
         .spawn(move || {
@@ -40,7 +48,8 @@ pub(crate) fn spawn(parent_pid: u32) {
                     eprintln!(
                         "openasr serve: parent process {parent_pid} is gone; shutting down to avoid an orphaned daemon."
                     );
-                    std::process::exit(0);
+                    let _ = tx.send(());
+                    return;
                 }
                 thread::sleep(POLL_INTERVAL);
             }
@@ -50,7 +59,43 @@ pub(crate) fn spawn(parent_pid: u32) {
     // safety net rather than aborting a healthy startup.
     if let Err(error) = spawned {
         eprintln!("openasr serve: could not start parent-death watchdog: {error}");
+        return None;
     }
+    Some(rx)
+}
+
+/// Completes when the operator sends Ctrl-C / SIGTERM or the parent watchdog
+/// fires. Shared by `openasr serve` so parent-loss and interactive stop both
+/// return from the server future instead of `process::exit`.
+pub(crate) async fn wait_for_shutdown(parent_gone: Option<ParentShutdown>) {
+    let parent_lost = async {
+        match parent_gone {
+            Some(rx) => {
+                let _ = rx.await;
+            }
+            None => std::future::pending::<()>().await,
+        }
+    };
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {}
+        _ = unix_terminate() => {}
+        _ = parent_lost => {}
+    }
+}
+
+#[cfg(unix)]
+async fn unix_terminate() {
+    match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+        Ok(mut signal) => {
+            let _ = signal.recv().await;
+        }
+        Err(_) => std::future::pending::<()>().await,
+    }
+}
+
+#[cfg(not(unix))]
+async fn unix_terminate() {
+    std::future::pending::<()>().await
 }
 
 /// Unix liveness probe: `kill(pid, 0)` sends no signal, it only asks the
@@ -131,5 +176,20 @@ mod tests {
         let pid = child.id();
         child.wait().expect("wait for child");
         assert!(!parent_is_alive(pid));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn parent_loss_signals_shutdown_without_exiting() {
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn `true`");
+        let pid = child.id();
+        child.wait().expect("wait for child");
+        let rx = spawn(pid).expect("watchdog should start for a real pid");
+        tokio::time::timeout(Duration::from_secs(8), rx)
+            .await
+            .expect("watchdog should notice the dead parent")
+            .expect("watchdog oneshot should fire");
     }
 }


### PR DESCRIPTION
## Summary

`openasr serve --parent-pid` now joins the same graceful shutdown path as Ctrl-C / SIGTERM instead of calling `process::exit`, so ggml Metal backends drop before process teardown.

## Why

When Desktop 0.1.22 aborted on system-audio start, the sidecar logged `parent process N is gone` and then immediately:

```
ggml-metal-device.m:917: GGML_ASSERT([rsets->data count] == 0) failed
```

`crates/openasr-cli/src/parent_watchdog.rs` used `std::process::exit(0)`. That skips Rust `Drop`, so atexit-time Metal device teardown still saw residency sets held by a live backend. There was no existing serve graceful-shutdown hook in `openasr-server` (`axum::serve` is awaited without `with_graceful_shutdown`). This PR does not touch `openasr-server`; the CLI wraps that future and cancels it.

## Changes

- Parent-loss watchdog signals a oneshot instead of `process::exit`.
- `openasr serve` awaits that signal together with Ctrl-C and SIGTERM, then returns so `NativeExecutionServices` / ggml backends drop before the process exits.
- Unit test: a dead child pid fires the oneshot without exiting the test process.
- Manual: isolated `OPENASR_HOME`, `openasr serve --no-model --parent-pid <parent>`, kill parent after Metal init (`use residency sets = true`). Child exits in ~3s. Log has `parent process ... is gone` and no `GGML_ASSERT`.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-cli` (289 passed, 4 skipped)
- [x] `cargo test --workspace --doc`
- [ ] `cargo deny check`

## Manual smoke checks

- Isolated `OPENASR_HOME`; `openasr serve --addr 127.0.0.1:0 --backend native --no-model --parent-pid <sleep>`; kill parent after `ggml_metal_rsets_init`. Child exits; log has no `GGML_ASSERT`.

## Model-family changes (when applicable)

- [ ] I followed the root `AGENTS.md` model-family onboarding entry point and
      ran `cargo xtask family conformance --profile-id <profile-id>`.
- [ ] I stated `core-only`, `staged release candidate`, or `public-ready`; any
      staged/public-ready work completes Model Onboarding Step 5 without
      hand-editing generated catalog/registry truth.
- [ ] Real-weight quality/performance claims have artifact-backed evidence;
      otherwise they are explicitly listed as unverified.

## Docs updated

- [x] README or docs updated, if behavior or limitations changed.
- [x] No docs overclaim current capabilities.

## Scope / non-goals

- Does not change `openasr-server`. Cancelling the CLI-awaited `axum::serve` future is the shutdown signal.
- Does not fix the macOS system-audio `__rust_foreign_exception` abort (separate PR).

## Artifact confirmation

- [x] I did not commit model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] I did not add vendored runtime sources outside `crates/openasr-core/third_party/openasr-ggml`.
- [x] I did not add unverified model download URLs or fake SHA256 hashes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](../CONTRIBUTING.md) and the AI usage policy in [AGENTS.md](../AGENTS.md).
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES

Closes #390