### PR TITLE
ci(release): sync backend CDN bytes and publish from actions

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -9,13 +9,17 @@ name: Release core
 #      and, for a new draft, peel to this commit. Dispatch inputs confirm
 #      the pin; they never override it.
 #   2. If no GitHub Release exists yet: create the empty draft, then call
-#      release-binaries.yml with `formal_release: true`.
+#      release-binaries.yml with `formal_release: true`, then
+#      `sync-backend-cdn` (core-release Environment approval + B2 secrets).
 #   3. If the matching release is still a draft: re-verify completeness,
-#      run the pre-publication family gate, and deploy the committed
-#      PublishedInert catalog.
+#      run the pre-publication family gate, deploy the committed
+#      PublishedInert catalog, rewrite Install & Verify, then
+#      `publish-release` (same Environment approval) runs
+#      `scripts/finalize-core-release.sh`.
 #
-# The GitHub Release stays a draft until `scripts/finalize-core-release.sh`
-# runs locally after the signed catalog + CDN plane is live. Agents do not
+# The GitHub Release stays a draft until `publish-release` succeeds. The
+# only remaining local maintainer step is signing and pushing the catalog
+# with `scripts/prepare-windows-backend-catalog-release.sh`. Agents do not
 # dispatch this workflow. See RELEASING.md.
 
 on:
@@ -228,6 +232,28 @@ jobs:
     # ship an unsigned Windows release binary" gate.
     secrets: inherit
 
+  sync-backend-cdn:
+    name: Sync Windows backend bytes to CDN
+    needs: [resolve, release, binaries]
+    if: needs.resolve.outputs.should_build == 'true' && success()
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    environment: core-release
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      B2_S3_ENDPOINT: ${{ secrets.B2_S3_ENDPOINT }}
+      B2_APPLICATION_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
+      B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/free-disk-space
+        with:
+          tool-cache: true
+      - name: Sync signed backend packs to B2
+        run: scripts/sync-windows-backend-cdn.sh "${{ needs.resolve.outputs.tag }}" --allow-ci
+
   verify-draft-completeness:
     name: Verify draft release completeness
     needs: [resolve]
@@ -295,3 +321,35 @@ jobs:
           python3 scripts/splice-install-verify.py current-body.md install-verify.md > new-body.md
 
           gh release edit "$tag" --notes-file new-body.md
+
+  publish-release:
+    name: Publish draft as latest
+    needs: [resolve, finalize-notes, deploy-catalog]
+    if: needs.resolve.outputs.should_finalize == 'true' && success()
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    environment: core-release
+    permissions:
+      actions: read
+      attestations: read
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      OPENASR_DEPLOY_CATALOG_RUN_ID: ${{ github.run_id }}
+      OPENASR_GGML_NATIVE: "0"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/free-disk-space
+        with:
+          tool-cache: true
+      - name: Install Linux audio build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: ./.github/actions/rust-cache
+        with:
+          shared-key: release-core-finalize-ubuntu-latest
+      - name: Publish the draft after catalog and notes succeed
+        run: scripts/finalize-core-release.sh "${{ needs.resolve.outputs.tag }}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,12 +73,14 @@ bump, or CI's `--locked` builds fail:
    - If no GitHub Release exists yet, the workflow creates the **draft**, then
      calls `release-binaries.yml` with `formal_release: true` (Linux
      x86_64/arm64, macOS x86_64/arm64, Windows, plus Vulkan/CUDA/HIP
-     variants). There is no bootstrap macOS/Linux rebuild and no `push: tags`
-     matrix racing the orchestrator. Completeness fails the run if a required
-     archive is missing.
+     variants), then waits for `core-release` Environment approval and syncs
+     the Windows GPU backend packs to B2. There is no bootstrap macOS/Linux
+     rebuild and no `push: tags` matrix racing the orchestrator. Completeness
+     fails the run if a required archive is missing.
    - If the matching release is still a draft, a second dispatch runs the
-     pre-publication family gate and deploys the committed PublishedInert
-     catalog (see below).
+     pre-publication family gate, deploys the committed PublishedInert
+     catalog, and waits for `core-release` Environment approval to publish
+     the draft (see below).
    - A published (non-draft) release is a no-op.
 
 ### Release notes structure
@@ -99,12 +101,14 @@ No pre-release channels: the core releases plain `X.Y.Z` versions only.
 ## Manual runs
 
 `Release core` is `workflow_dispatch` only. The first dispatch (no GitHub
-Release yet) creates the draft and builds the matrix. After the generated
+Release yet) creates the draft, builds the matrix, and syncs backend CDN
+bytes after `core-release` Environment approval. After the generated
 PublishedInert catalog has been reviewed, signed, committed, and pushed,
 dispatch it again with the same `version` to run the pre-publication family
-gate and catalog deployment for that draft. Failed build or aggregation jobs
-are recovered only with GitHub's **Re-run failed jobs** on the original
-release run, which preserves its exact tag/source/artifact lineage.
+gate, catalog deployment, and `publish-release` (same Environment approval)
+for that draft. Failed build or aggregation jobs are recovered only with
+GitHub's **Re-run failed jobs** on the original release run, which preserves
+its exact tag/source/artifact lineage.
 
 `workflow_dispatch` on `Release binaries` (`.github/workflows/release-binaries.yml`)
 is diagnostic-only: `only_target` is mandatory and the run may publish only an
@@ -127,35 +131,64 @@ bytes without exposing an unqualified provider to users.
 
 ### Publish the inert release bytes
 
-1. Let `Release core` create the draft and let its single formal
-   `release-binaries.yml` call build and checksum the complete release matrix,
-   sign the applicable Windows binaries, and attest the full subject set. Do not
-   use the diagnostic one-target dispatch to assemble or mutate a release.
-2. Run `scripts/sync-windows-backend-cdn.sh vX.Y.Z` locally with the B2 release
-   credentials. It verifies and copies every file declared by the 1 Vulkan, 6
-   CUDA, and 14 HIP release entries to
-   `https://dl.openasr.org/core/vX.Y.Z/`. GitHub is the provenance mirror, not a
-   runtime download fallback.
-3. Run `scripts/prepare-windows-backend-catalog-release.sh vX.Y.Z` locally with
-   the production catalog signing seed. It verifies all 21 exact entries and
-   their already-live CDN bytes, merges every entry as `PublishedInert`, bumps
-   the epoch, and signs the full/public catalogs. It consumes no hardware or
-   token-correctness receipt. Review, commit, and push the five catalog/epoch
-   files.
-4. Dispatch `Release core` again. It re-verifies the draft's complete attested
-   subject set (the same completeness gate as the original matrix, so a later
-   CI-only fix can still see the draft), then runs the reusable pre-publication
-   family contract against the immutable draft CLI and the real-pack CPU family
-   gate. The orchestrator then calls the sole deployment entrypoint,
-   `.github/workflows/deploy-catalog.yml`, with
+The only remaining local maintainer step is catalog signing. Everything else
+runs in Actions after Environment approval.
+
+1. Dispatch `Release core`. Stage 1 creates the draft and lets its single
+   formal `release-binaries.yml` call build and checksum the complete release
+   matrix, sign the applicable Windows binaries, and attest the full subject
+   set. Do not use the diagnostic one-target dispatch to assemble or mutate a
+   release.
+2. Approve the `sync-backend-cdn` job in the Actions UI. It runs under the
+   `core-release` GitHub Environment (required reviewers) and executes
+   `scripts/sync-windows-backend-cdn.sh vX.Y.Z --allow-ci`. The job verifies
+   and copies every file declared by the 1 Vulkan, 6 CUDA, and 14 HIP release
+   entries to `https://dl.openasr.org/core/vX.Y.Z/`. Uploads are idempotent
+   and never overwrite a different object at the same key. GitHub is the
+   provenance mirror, not a runtime download fallback.
+3. Run `scripts/prepare-windows-backend-catalog-release.sh vX.Y.Z` locally
+   with the production catalog signing seed. It verifies all 21 exact entries
+   and their already-live CDN bytes, merges every entry as `PublishedInert`,
+   bumps the epoch, and signs the full/public catalogs. It consumes no
+   hardware or token-correctness receipt. Review, commit, and push the five
+   catalog/epoch files. This is the only local release step that still needs
+   the signing seed.
+4. Dispatch `Release core` again. Stage 2 re-verifies the draft's complete
+   attested subject set (the same completeness gate as the original matrix, so
+   a later CI-only fix can still see the draft), then runs the reusable
+   pre-publication family contract against the immutable draft CLI and the
+   real-pack CPU family gate. The orchestrator then calls the sole deployment
+   entrypoint, `.github/workflows/deploy-catalog.yml`, with
    `activation_transition: published-inert`. The deploy job checks the signed
    catalog, CDN payloads, and released-binary compatibility before writing it.
-5. Record the successful orchestrator run id as
-   `OPENASR_DEPLOY_CATALOG_RUN_ID`, wait until the no-credential catalog/CDN
-   checks see the committed bytes, and run
-   `scripts/finalize-core-release.sh vX.Y.Z`. The finalizer binds the exact tag,
-   source commit, deploy run, catalog SHA, signature SHA, release subjects, and
-   live CDN bytes before removing the GitHub draft flag.
+   `finalize-notes` then rewrites Install & Verify from the real asset list.
+5. Approve the `publish-release` job in the Actions UI (same `core-release`
+   Environment). It runs `scripts/finalize-core-release.sh` with
+   `OPENASR_DEPLOY_CATALOG_RUN_ID` set to this orchestrator run. The
+   reusable deploy workflow shares that run id, so the finalizer looks up
+   the "Deploy PublishedInert candidate catalog" job on this run, binds the
+   exact tag, source commit, catalog SHA, signature SHA, release subjects,
+   and live CDN bytes (retrying the no-credential catalog/CDN plane for up
+   to 10 minutes), then removes the GitHub draft flag.
+
+Any failure leaves the GitHub release as a draft.
+
+### GitHub Environment `core-release`
+
+Create this Environment on `QuintinShaw/openasr` before the first
+Actions-driven publish. Required reviewers must be enabled so the B2 write
+key and the undraft step are not available until a human approves the job
+in the Actions UI.
+
+Environment secrets (not repository secrets):
+
+- `B2_S3_ENDPOINT`
+- `B2_APPLICATION_KEY_ID`
+- `B2_APPLICATION_KEY`
+
+Key policy: a dedicated B2 application key restricted to the release bucket
+and the `core/` prefix with `listFiles` / `readFiles` / `writeFiles` only
+(no `deleteFiles`), separate from the desktop installer key.
 
 Publishing the release triggers two independent GitHub Actions workflows:
 
@@ -167,9 +200,6 @@ Publishing the release triggers two independent GitHub Actions workflows:
   `finalize-core-release.sh` must not pull the matrix onto a maintainer
   laptop for this. Missing `CNB_TOKEN` skips; a token present with a failed
   upload fails that workflow only and does not roll back GitHub.
-
-Any failure in the pre-publication sequence leaves the GitHub release as a
-draft.
 
 ### Qualify and activate one exact backend after publication
 

--- a/scripts/finalize-core-release.sh
+++ b/scripts/finalize-core-release.sh
@@ -2,6 +2,11 @@
 # Publish a draft core release only after its signed public catalog exposes the
 # new Windows GPU provider bytes as PublishedInert. Real-hardware qualification
 # happens after publication and can only activate a later signed catalog epoch.
+#
+# The primary caller is release-core.yml's `publish-release` job, which sets
+# OPENASR_DEPLOY_CATALOG_RUN_ID to the orchestrator github.run_id (the
+# reusable deploy-catalog.yml job lives in that same run). A local run still
+# works after stage 2 finishes; pass the completed orchestrator run id.
 
 set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -163,11 +168,46 @@ python3 tooling/release-manifest/backend_hardware_evidence.py \
 
 # The reusable deploy workflow is the only catalog publication path. Initial
 # release publication accepts only its already-verified PublishedInert epoch.
+# deploy-catalog.yml records GITHUB_RUN_ID == orchestrator_run_id, so the
+# caller run id is the binding id. When this script runs as a later job in
+# that same Actions run, the overall conclusion is still empty; require the
+# "Deploy PublishedInert candidate catalog" job itself to have succeeded.
 deploy_run_id="${OPENASR_DEPLOY_CATALOG_RUN_ID:-}"
 [ -n "$deploy_run_id" ] || fail "set OPENASR_DEPLOY_CATALOG_RUN_ID to the successful reusable catalog-deploy run"
-deploy_conclusion="$(gh run view "$deploy_run_id" --repo "$repository" --json conclusion --jq .conclusion)"
-[ "$deploy_conclusion" = "success" ] \
-  || fail "catalog deploy run $deploy_run_id did not succeed (conclusion=$deploy_conclusion)"
+deploy_preflight="$workdir/deploy-run-preflight.json"
+gh run view "$deploy_run_id" --repo "$repository" \
+  --json conclusion,status,event,workflowName,jobs > "$deploy_preflight" \
+  || fail "cannot inspect catalog deploy run $deploy_run_id"
+python3 - "$deploy_preflight" "$deploy_run_id" <<'PY' \
+  || fail "catalog deploy run $deploy_run_id did not succeed"
+import json, os, sys
+
+value = json.load(open(sys.argv[1], encoding="utf-8"))
+run_id = sys.argv[2]
+if value.get("workflowName") != "Release core":
+    raise SystemExit("deploy binding came from another workflow")
+if value.get("event") != "workflow_dispatch":
+    raise SystemExit("release finalization run was not an explicit dispatch")
+jobs = value.get("jobs")
+if not isinstance(jobs, list) or not any(
+    isinstance(job, dict)
+    and "Deploy PublishedInert candidate catalog" in str(job.get("name", ""))
+    and job.get("conclusion") == "success"
+    for job in jobs
+):
+    raise SystemExit("run has no successful PublishedInert catalog deploy job")
+conclusion = value.get("conclusion")
+status = value.get("status")
+same_run = os.environ.get("GITHUB_ACTIONS") == "true" and os.environ.get("GITHUB_RUN_ID") == run_id
+if conclusion == "success":
+    pass
+elif same_run and status in {"in_progress", "queued", "waiting", "pending", "requested"}:
+    pass
+else:
+    raise SystemExit(
+        f"catalog deploy run did not succeed (conclusion={conclusion} status={status})"
+    )
+PY
 
 # Re-read the annotated remote tag while holding the qualification mutation
 # lock. Its peeled commit must still equal the release identity checked before
@@ -313,16 +353,16 @@ done < "$workdir/qualification-subjects.txt"
 
 deploy_metadata="$workdir/deploy-run.json"
 gh run view "$deploy_run_id" --repo "$repository" \
-  --json workflowName,conclusion,headSha,event,jobs,url > "$deploy_metadata" \
+  --json workflowName,conclusion,status,headSha,event,jobs,url > "$deploy_metadata" \
   || fail "cannot inspect catalog deploy run $deploy_run_id"
-python3 - "$deploy_metadata" "$current_commit" <<'PY' \
+python3 - "$deploy_metadata" "$current_commit" "$deploy_run_id" <<'PY' \
   || fail "catalog deploy run is not bound to this committed PublishedInert catalog"
-import json, sys
+import json, os, sys
 value = json.load(open(sys.argv[1], encoding="utf-8"))
 if value.get("workflowName") != "Release core":
     raise SystemExit("deploy binding came from another workflow")
-if value.get("conclusion") != "success" or value.get("event") != "workflow_dispatch":
-    raise SystemExit("release finalization run did not complete successfully by explicit dispatch")
+if value.get("event") != "workflow_dispatch":
+    raise SystemExit("release finalization run was not an explicit dispatch")
 if value.get("headSha") != sys.argv[2]:
     raise SystemExit("release finalization run used another catalog commit")
 jobs = value.get("jobs")
@@ -333,6 +373,17 @@ if not isinstance(jobs, list) or not any(
     for job in jobs
 ):
     raise SystemExit("run has no successful PublishedInert catalog deploy job")
+conclusion = value.get("conclusion")
+status = value.get("status")
+same_run = os.environ.get("GITHUB_ACTIONS") == "true" and os.environ.get("GITHUB_RUN_ID") == sys.argv[3]
+if conclusion == "success":
+    pass
+elif same_run and status in {"in_progress", "queued", "waiting", "pending", "requested"}:
+    pass
+else:
+    raise SystemExit(
+        f"catalog deploy run did not succeed (conclusion={conclusion} status={status})"
+    )
 PY
 
 deploy_binding_dir="$workdir/deploy-binding"
@@ -377,26 +428,52 @@ PY
 python3 tooling/publish-model/scripts/check_catalog_consistency.py \
   || fail "committed catalog/signature pair does not verify under production trust roots"
 
-cache_bust="$(date +%s)"
-curl -fsSL "https://catalog.openasr.org/v1/catalog.json?release=${tag}-${cache_bust}" \
-  -o "$workdir/catalog.json"
-curl -fsSL "https://catalog.openasr.org/v1/catalog.signature.json?release=${tag}-${cache_bust}" \
-  -o "$workdir/catalog.signature.json"
-OPENASR_HOME="$workdir/home" \
-OPENASR_CATALOG_FILE="$workdir/catalog.json" \
-OPENASR_CATALOG_IDENTITY="https://catalog.openasr.org/v1/catalog.json" \
-  cargo run --quiet -p openasr-cli -- doctor >/dev/null
-python3 tooling/release-manifest/backend_catalog.py verify-catalog \
-  --catalog "$workdir/catalog.json" "${all_backend_entry_args[@]}"
-python3 tooling/release-manifest/backend_hardware_evidence.py \
-  "${all_backend_entry_args[@]}" \
-  --catalog "$workdir/catalog.json" --version "$version" >/dev/null
-python3 tooling/release-manifest/backend_catalog.py verify-cdn \
-  --catalog "$workdir/catalog.json" --version "$version"
-cmp -s model-registry/catalog.public.json "$workdir/catalog.json" \
-  || fail "live catalog bytes differ from the deploy run's committed catalog"
-cmp -s model-registry/catalog.public.signature.json "$workdir/catalog.signature.json" \
-  || fail "live catalog signature differs from the deploy run's committed signature"
+# Live catalog/CDN can lag the deploy job. Retry the no-credential plane for
+# up to 10 minutes so a just-written catalog is not a spurious publish failure.
+verify_live_catalog_cdn() {
+  local attempt="$1"
+  local cache_bust
+  cache_bust="$(date +%s)-${attempt}"
+  curl -fsSL "https://catalog.openasr.org/v1/catalog.json?release=${tag}-${cache_bust}" \
+    -o "$workdir/catalog.json" || return 1
+  curl -fsSL "https://catalog.openasr.org/v1/catalog.signature.json?release=${tag}-${cache_bust}" \
+    -o "$workdir/catalog.signature.json" || return 1
+  OPENASR_HOME="$workdir/home-${attempt}" \
+  OPENASR_CATALOG_FILE="$workdir/catalog.json" \
+  OPENASR_CATALOG_IDENTITY="https://catalog.openasr.org/v1/catalog.json" \
+    cargo run --quiet -p openasr-cli -- doctor >/dev/null || return 1
+  python3 tooling/release-manifest/backend_catalog.py verify-catalog \
+    --catalog "$workdir/catalog.json" "${all_backend_entry_args[@]}" || return 1
+  python3 tooling/release-manifest/backend_hardware_evidence.py \
+    "${all_backend_entry_args[@]}" \
+    --catalog "$workdir/catalog.json" --version "$version" >/dev/null || return 1
+  python3 tooling/release-manifest/backend_catalog.py verify-cdn \
+    --catalog "$workdir/catalog.json" --version "$version" || return 1
+  if ! cmp -s model-registry/catalog.public.json "$workdir/catalog.json"; then
+    echo "live catalog bytes differ from the deploy run's committed catalog" >&2
+    return 1
+  fi
+  if ! cmp -s model-registry/catalog.public.signature.json "$workdir/catalog.signature.json"; then
+    echo "live catalog signature differs from the deploy run's committed signature" >&2
+    return 1
+  fi
+  return 0
+}
+
+cdn_ok=false
+for attempt in $(seq 1 20); do
+  if verify_live_catalog_cdn "$attempt"; then
+    cdn_ok=true
+    break
+  fi
+  if [ "$attempt" -eq 20 ]; then
+    break
+  fi
+  echo "live catalog/CDN not yet consistent (attempt ${attempt}/20); retrying in 30s" >&2
+  sleep 30
+done
+[ "$cdn_ok" = "true" ] \
+  || fail "live catalog bytes differ from the deploy run's committed catalog after 10 minutes of retries"
 
 echo "==> signed catalog exposes ${tag} provider bytes as PublishedInert; publishing release"
 [ "$(gh release view "$tag" --repo "$repository" --json isDraft --jq .isDraft)" = "true" ] \

--- a/scripts/prepare-windows-backend-catalog-release.sh
+++ b/scripts/prepare-windows-backend-catalog-release.sh
@@ -4,8 +4,8 @@
 # This is deliberately LOCAL ONLY: it consumes the production catalog signing
 # seed, but it does not push, deploy, publish, or undraft anything.  A release
 # remains incomplete until the resulting catalog commit is reviewed, pushed,
-# deployed by deploy-catalog.yml, and finalize-core-release.sh verifies the
-# live bytes before publishing the draft.
+# deployed by deploy-catalog.yml, and release-core.yml's publish-release job
+# runs finalize-core-release.sh to verify the live bytes before undrafting.
 
 set -euo pipefail
 
@@ -178,5 +178,5 @@ echo "  published-inert/signed backend entries: ${#backend_entries[@]}"
 echo "  hardware-qualified exact entries: 0 (qualification is post-publication)"
 echo "  epoch: ${old_epoch} -> ${new_epoch}"
 echo "  next: review and commit model-registry/catalog{,.public}{,.signature}.json + catalog.epoch"
-echo "  then push the catalog commit, wait for deploy-catalog.yml (which rechecks CDN), and run:"
-echo "    scripts/finalize-core-release.sh ${tag}"
+echo "  then push the catalog commit and dispatch Release core again."
+echo "  Stage 2 deploys the catalog and publishes the draft after core-release approval."

--- a/scripts/sync-windows-backend-cdn.sh
+++ b/scripts/sync-windows-backend-cdn.sh
@@ -3,8 +3,10 @@
 # https://dl.openasr.org/core/vX.Y.Z/.
 #
 # The signed catalog's files[].url values point only at this prefix. GitHub
-# release mirrors are provenance, not a runtime download fallback. This step
-# is local: B2 write credentials never enter CI.
+# release mirrors are provenance, not a runtime download fallback. The
+# primary caller is release-core.yml's `sync-backend-cdn` job, which passes
+# --allow-ci and reads B2 write credentials from the core-release Environment.
+# A local run without CI still sources ~/.openasr/b2-release.env.
 
 set -euo pipefail
 
@@ -19,16 +21,28 @@ fail() {
 
 trap 'fail "aborted at line $LINENO"' ERR
 
-[ "$#" -eq 1 ] || fail "usage: $(basename "$0") vX.Y.Z"
-version="${1#v}"
+allow_ci=false
+tag_arg=""
+for arg in "$@"; do
+  case "$arg" in
+    --allow-ci) allow_ci=true ;;
+    -*) fail "unknown flag: ${arg}" ;;
+    *)
+      [ -z "$tag_arg" ] || fail "usage: $(basename "$0") vX.Y.Z [--allow-ci]"
+      tag_arg="$arg"
+      ;;
+  esac
+done
+[ -n "$tag_arg" ] || fail "usage: $(basename "$0") vX.Y.Z [--allow-ci]"
+version="${tag_arg#v}"
 [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "version must be X.Y.Z or vX.Y.Z"
 tag="v${version}"
 
 if [ "${CI:-}" = "true" ] || [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-  fail "refusing to use B2 write credentials in CI"
+  [ "$allow_ci" = "true" ] || fail "refusing to use B2 write credentials in CI without --allow-ci"
 fi
 [ -n "${B2_S3_ENDPOINT:-}" ] && [ -n "${B2_APPLICATION_KEY_ID:-}" ] && [ -n "${B2_APPLICATION_KEY:-}" ] \
-  || fail "source ~/.openasr/b2-release.env before running (B2_S3_ENDPOINT / B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY)"
+  || fail "source ~/.openasr/b2-release.env or set the core-release Environment secrets (B2_S3_ENDPOINT / B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY)"
 command -v gh >/dev/null 2>&1 || fail "gh is required"
 command -v python3 >/dev/null 2>&1 || fail "python3 is required"
 gh auth status >/dev/null 2>&1 || fail "gh is not authenticated"

--- a/tooling/release-manifest/README.md
+++ b/tooling/release-manifest/README.md
@@ -124,11 +124,15 @@ is not required. A revoked backend cannot be requalified or reactivated.
 Do not hand-edit provider entries or activation bindings.
 
 ```bash
-# Before publishing a core release: make every exact provider byte public but inert.
-scripts/sync-windows-backend-cdn.sh vX.Y.Z
+# After stage 1 of Release core (draft + binaries + approved CDN sync):
+# sign the PublishedInert catalog locally, then review / commit / push.
 scripts/prepare-windows-backend-catalog-release.sh vX.Y.Z
-OPENASR_DEPLOY_CATALOG_RUN_ID=<release-core-run-id> \
-  scripts/finalize-core-release.sh vX.Y.Z
+
+# CDN sync and undraft now run in release-core.yml after core-release
+# Environment approval. Local escape hatch (same scripts the jobs call):
+#   scripts/sync-windows-backend-cdn.sh vX.Y.Z
+#   OPENASR_DEPLOY_CATALOG_RUN_ID=<release-core-run-id> \
+#     scripts/finalize-core-release.sh vX.Y.Z
 
 # After exact-tag hardware qualification: prepare one reviewed activation epoch.
 scripts/activate-windows-backend-catalog-release.sh \
@@ -141,8 +145,10 @@ scripts/revoke-windows-backend-catalog-release.sh vX.Y.Z BACKEND_ID
 The CDN sync writes the immutable provider payloads to B2 but does not change a
 catalog or GitHub release. Catalog preparation writes only the five local
 catalog/epoch files; it does not commit, push, deploy, publish, or activate
-anything. The finalizer only publishes a draft whose already-deployed catalog
-exposes the release provider entries as PublishedInert.
+anything. `release-core.yml` runs the CDN sync and the finalizer after
+`core-release` Environment approval. The finalizer only publishes a draft
+whose already-deployed catalog exposes the release provider entries as
+PublishedInert.
 
 Real-hardware evidence must come from a tag-scoped dispatch of
 `.github/workflows/qualify-windows-backend.yml` with exact `release_tag`,

--- a/tooling/release-manifest/b2_sync.py
+++ b/tooling/release-manifest/b2_sync.py
@@ -18,23 +18,24 @@ The command uses the same environment variable names as
   B2_BUCKET             Default: openasr-releases
   B2_S3_REGION          Override if it cannot be inferred from B2_S3_ENDPOINT.
 
-Credential source: these write credentials live ONLY in
+Credential source: locally these write credentials live ONLY in
 `~/.openasr/b2-release.env` (chmod 600, outside the repo). `source` that file
 in the shell that runs this script, e.g. `source ~/.openasr/b2-release.env`
 immediately before the command. Do NOT export them from a long-lived shell
 profile (~/.zshrc, ~/.bashrc, ...): a release-bucket write key must not be
-inherited by every terminal process. They are also never CI secrets /
-repository variables / workflow literals for this script -- core's B2 sync is
-a local, human-run step (see README). Missing vars fail closed below with a
-message pointing at the `source` step.
+inherited by every terminal process. `release-core.yml`'s `sync-backend-cdn`
+job reads the same variable names from the `core-release` GitHub Environment
+(required reviewers; never repository-level secrets or workflow literals).
+Missing vars fail closed below with a message pointing at the local `source`
+step or that Environment.
 
 Immutability, same policy as the desktop publish script: before uploading a
 key, HEAD it. If an object already exists there with a DIFFERENT sha256, this
 aborts rather than silently overwriting a shipped release asset -- bump the
-version instead. Re-uploading byte-identical content is a no-op.
-
-This is deliberately not wired into GitHub Actions. It is invoked by the
-maintainer-controlled Windows backend CDN sync path after target approval.
+version instead. Re-uploading byte-identical content is a no-op. New uploads
+record `x-amz-meta-sha256`; later HEADs compare size plus that digest. Objects
+that predate the metadata fall back to size + ETag/MD5, or download-and-hash
+when the ETag is a multipart `hash-N` form.
 """
 from __future__ import annotations
 
@@ -58,6 +59,7 @@ ALGORITHM = "AWS4-HMAC-SHA256"
 SERVICE = "s3"
 DEFAULT_BUCKET = "openasr-releases"
 DEFAULT_DL_BASE_URL = "https://dl.openasr.org"
+SHA256_META_HEADER = "x-amz-meta-sha256"
 
 
 class B2SyncError(Exception):
@@ -158,13 +160,21 @@ class Transport:
     """Minimal HTTP transport seam so tests can inject a fake instead of
     making real network calls."""
 
-    def request(self, method: str, url: str, headers: dict[str, str], body: bytes) -> tuple[int, dict[str, str]]:
+    def request(
+        self, method: str, url: str, headers: dict[str, str], body: bytes
+    ) -> tuple[int, dict[str, str], bytes]:
         request = urllib.request.Request(url, data=body if method != "HEAD" else None, method=method, headers=headers)
         try:
             with urllib.request.urlopen(request) as response:  # noqa: S310 (fixed https B2 endpoint)
-                return response.status, dict(response.headers)
+                payload = b"" if method == "HEAD" else response.read()
+                return response.status, dict(response.headers), payload
         except urllib.error.HTTPError as error:
-            return error.code, dict(error.headers or {})
+            payload = b""
+            try:
+                payload = error.read()
+            except Exception:
+                payload = b""
+            return error.code, dict(error.headers or {}), payload
 
 
 @dataclass
@@ -183,17 +193,19 @@ class B2Credentials:
         secret_access_key = env.get("B2_APPLICATION_KEY")
         if not endpoint:
             raise B2SyncError(
-                "B2_S3_ENDPOINT is not set. These B2 write credentials are kept only in "
-                "~/.openasr/b2-release.env (not in any shell profile and not in CI); run "
-                "`source ~/.openasr/b2-release.env` in this shell and retry. The endpoint is "
+                "B2_S3_ENDPOINT is not set. Locally these B2 write credentials live only in "
+                "~/.openasr/b2-release.env (not in any shell profile); run "
+                "`source ~/.openasr/b2-release.env` in this shell and retry. In Actions they "
+                "come from the core-release Environment secrets. The endpoint is "
                 "the bucket's S3-compatible URL, e.g. https://s3.us-east-005.backblazeb2.com "
                 "(the region/cluster is not known until the bucket is created)."
             )
         if not access_key_id or not secret_access_key:
             raise B2SyncError(
                 "B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY must both be set to sync. They "
-                "live only in ~/.openasr/b2-release.env; run `source ~/.openasr/b2-release.env` "
-                "in this shell and retry (do not export them from ~/.zshrc or any login profile)."
+                "live only in ~/.openasr/b2-release.env locally; run `source ~/.openasr/b2-release.env` "
+                "in this shell and retry (do not export them from ~/.zshrc or any login profile). "
+                "In Actions they come from the core-release Environment secrets."
             )
         return cls(
             endpoint=endpoint,
@@ -248,21 +260,34 @@ class B2Client:
         on any other non-2xx status."""
         payload_hash = sha256_hex(b"")
         headers = self._signed_headers("HEAD", key, payload_hash, {})
-        status, response_headers = self.transport.request("HEAD", self._object_url(key), headers, b"")
+        status, response_headers, _body = self.transport.request("HEAD", self._object_url(key), headers, b"")
         if status == 404:
             return None
         if not 200 <= status < 300:
             raise B2SyncError(f"HEAD {key} failed with status {status}")
         return response_headers
 
+    def get_object(self, key: str) -> bytes:
+        """Download an existing object so a multipart ETag can be compared by SHA-256."""
+        payload_hash = sha256_hex(b"")
+        headers = self._signed_headers("GET", key, payload_hash, {})
+        status, _response_headers, body = self.transport.request("GET", self._object_url(key), headers, b"")
+        if not 200 <= status < 300:
+            raise B2SyncError(f"GET {key} failed with status {status}")
+        return body
+
     def put_object(self, key: str, data: bytes, content_type: str = "application/octet-stream") -> None:
         payload_hash = sha256_hex(data)
-        # content-type/content-length are part of the SIGNED headers here
-        # (passed as extra_headers into sign_request), matching
+        # content-type/content-length/user-metadata are part of the SIGNED
+        # headers here (passed as extra_headers into sign_request), matching
         # b2-s3-client.mjs's s3ObjectRequest -- not just attached afterward.
-        extra_headers = {"content-type": content_type, "content-length": str(len(data))}
+        extra_headers = {
+            "content-type": content_type,
+            "content-length": str(len(data)),
+            SHA256_META_HEADER: payload_hash,
+        }
         headers = self._signed_headers("PUT", key, payload_hash, extra_headers)
-        status, _ = self.transport.request("PUT", self._object_url(key), headers, data)
+        status, _response_headers, _body = self.transport.request("PUT", self._object_url(key), headers, data)
         if not 200 <= status < 300:
             raise B2SyncError(f"PUT {key} failed with status {status}")
 
@@ -274,15 +299,44 @@ def _normalize_etag(etag: str | None) -> str:
     return (etag or "").replace('"', "").lower()
 
 
-def decide_immutability_action(remote: dict[str, object] | None, local_size: int, local_md5_hex: str) -> str:
+def _header(headers: dict[str, str], *names: str) -> str | None:
+    lowered = {key.lower(): value for key, value in headers.items()}
+    for name in names:
+        value = lowered.get(name.lower())
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _is_multipart_etag(etag: str) -> bool:
+    return "-" in etag
+
+
+def decide_immutability_action(
+    remote: dict[str, object] | None,
+    local_size: int,
+    local_md5_hex: str,
+    local_sha256_hex: str | None = None,
+) -> str:
     """Mirrors release-publish.mjs's `decideImmutabilityAction`: "put" if
     nothing is there yet, "skip" if an identical object already is (same
-    size + ETag/md5 -- an idempotent re-run), or raises if a DIFFERENT
-    object already occupies the key (never silently overwrite a shipped
-    release asset; the caller must bump the version instead)."""
+    size + SHA-256 when metadata is present, otherwise size + ETag/md5 --
+    an idempotent re-run), or raises if a DIFFERENT object already occupies
+    the key (never silently overwrite a shipped release asset; the caller
+    must bump the version instead)."""
     if remote is None:
         return "put"
     remote_size = remote.get("size")
+    remote_sha256 = str(remote.get("sha256") or "").lower()
+    local_sha256 = (local_sha256_hex or "").lower()
+    if remote_sha256 and local_sha256:
+        if remote_size == local_size and remote_sha256 == local_sha256:
+            return "skip"
+        raise B2SyncError(
+            f"refusing to overwrite existing object with different content "
+            f"(remote size={remote_size} sha256={remote_sha256!r} vs local size={local_size} "
+            f"sha256={local_sha256!r}); bump the version instead of re-publishing under the same one"
+        )
     remote_etag = _normalize_etag(remote.get("etag"))  # type: ignore[arg-type]
     if remote_size == local_size and remote_etag == local_md5_hex.lower():
         return "skip"
@@ -310,13 +364,17 @@ def _sync_to_keys(
         head = client.head_object(key)
         remote = None
         if head is not None:
-            content_length = head.get("Content-Length") or head.get("content-length")
+            content_length = _header(head, "Content-Length")
             remote = {
                 "size": int(content_length) if content_length is not None else None,
-                "etag": head.get("ETag") or head.get("etag"),
+                "etag": _header(head, "ETag"),
+                "sha256": _header(head, SHA256_META_HEADER),
             }
+            etag = _normalize_etag(remote.get("etag"))  # type: ignore[arg-type]
+            if not remote["sha256"] and _is_multipart_etag(etag):
+                remote["sha256"] = sha256_hex(client.get_object(key))
         local_md5_hex = hashlib.md5(data).hexdigest()  # noqa: S324 (B2/S3 ETag comparison, not a security use)
-        action = decide_immutability_action(remote, len(data), local_md5_hex)
+        action = decide_immutability_action(remote, len(data), local_md5_hex, sha256_hex(data))
         if action == "put":
             client.put_object(key, data)
 

--- a/tooling/release-manifest/b2_sync_test.py
+++ b/tooling/release-manifest/b2_sync_test.py
@@ -8,6 +8,7 @@ from b2_sync import (
     B2Client,
     B2Credentials,
     B2SyncError,
+    SHA256_META_HEADER,
     amz_date_parts,
     build_canonical_request,
     canonical_uri,
@@ -222,6 +223,21 @@ class DecideImmutabilityActionTest(unittest.TestCase):
         with self.assertRaises(B2SyncError):
             decide_immutability_action(remote, 10, "abc123")
 
+    def test_skip_when_sha256_metadata_matches(self) -> None:
+        payload = b"same-bytes"
+        digest = hashlib.sha256(payload).hexdigest()
+        remote = {"size": len(payload), "etag": '"not-the-md5"', "sha256": digest}
+        self.assertEqual(
+            decide_immutability_action(remote, len(payload), "abc123", digest),
+            "skip",
+        )
+
+    def test_raises_when_sha256_metadata_differs(self) -> None:
+        remote = {"size": 10, "etag": '"ignored"', "sha256": "ab" * 32}
+        with self.assertRaises(B2SyncError) as ctx:
+            decide_immutability_action(remote, 10, "abc123", "cd" * 32)
+        self.assertIn("sha256", str(ctx.exception))
+
 
 class FakeTransport:
     """In-memory stand-in for b2_sync.Transport -- lets sync_files be tested
@@ -229,6 +245,8 @@ class FakeTransport:
 
     def __init__(self) -> None:
         self.objects: dict[str, bytes] = {}
+        self.meta: dict[str, dict[str, str]] = {}
+        self.etags: dict[str, str] = {}
         self.requests: list[tuple[str, str]] = []
 
     def request(self, method, url, headers, body):
@@ -237,15 +255,27 @@ class FakeTransport:
         key = url.split("/", 3)[-1]
         if method == "HEAD":
             if key not in self.objects:
-                return 404, {}
+                return 404, {}, b""
             data = self.objects[key]
-            return 200, {
+            response_headers = {
                 "Content-Length": str(len(data)),
-                "ETag": f'"{hashlib.md5(data).hexdigest()}"',
+                "ETag": self.etags.get(key, f'"{hashlib.md5(data).hexdigest()}"'),
             }
+            response_headers.update(self.meta.get(key, {}))
+            return 200, response_headers, b""
+        if method == "GET":
+            if key not in self.objects:
+                return 404, {}, b""
+            return 200, {"Content-Length": str(len(self.objects[key]))}, self.objects[key]
         if method == "PUT":
             self.objects[key] = body
-            return 200, {}
+            stored_meta = {}
+            for name, value in headers.items():
+                if name.lower() == SHA256_META_HEADER:
+                    stored_meta[SHA256_META_HEADER] = value
+            self.meta[key] = stored_meta
+            self.etags[key] = f'"{hashlib.md5(body).hexdigest()}"'
+            return 200, {}, b""
         raise AssertionError(f"unexpected method: {method}")
 
 
@@ -311,6 +341,41 @@ class SyncFilesTest(unittest.TestCase):
         client, _ = _fake_client()
         with self.assertRaises(B2SyncError):
             sync_files(client, "0.1.10", [self.dist_dir / "does-not-exist.zip"])
+
+    def test_put_records_sha256_user_metadata(self) -> None:
+        client, transport = _fake_client()
+        payload = b'{"schema_version":1}'
+        path = self._write("backend-pack-cuda-sm_86.json", payload)
+
+        sync_files(client, "0.1.10", [path])
+
+        key = "core/v0.1.10/backend-pack-cuda-sm_86.json"
+        self.assertEqual(transport.meta[key][SHA256_META_HEADER], hashlib.sha256(payload).hexdigest())
+
+    def test_skip_when_legacy_multipart_etag_matches_downloaded_sha256(self) -> None:
+        client, transport = _fake_client()
+        payload = b"multipart-identical-bytes"
+        path = self._write("backend-pack-cuda-sm_86.json", payload)
+        key = "core/v0.1.10/backend-pack-cuda-sm_86.json"
+        transport.objects[key] = payload
+        transport.etags[key] = '"abc123def456-3"'
+
+        urls = sync_files(client, "0.1.10", [path])
+
+        self.assertEqual(urls, ["https://dl.openasr.org/core/v0.1.10/backend-pack-cuda-sm_86.json"])
+        self.assertEqual(sum(1 for method, _ in transport.requests if method == "GET"), 1)
+        self.assertEqual(sum(1 for method, _ in transport.requests if method == "PUT"), 0)
+
+    def test_refuses_legacy_multipart_etag_when_downloaded_bytes_differ(self) -> None:
+        client, transport = _fake_client()
+        path = self._write("backend-pack-cuda-sm_86.json", b"local-bytes")
+        key = "core/v0.1.10/backend-pack-cuda-sm_86.json"
+        transport.objects[key] = b"remote-different-bytes"
+        transport.etags[key] = '"abc123def456-3"'
+
+        with self.assertRaises(B2SyncError):
+            sync_files(client, "0.1.10", [path])
+        self.assertEqual(sum(1 for method, _ in transport.requests if method == "PUT"), 0)
 
 
 if __name__ == "__main__":

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -22,7 +22,7 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
             (
                 "binaries",
                 "\n  binaries:\n",
-                "\n  verify-draft-completeness:\n",
+                "\n  sync-backend-cdn:\n",
                 ROOT / ".github/workflows/release-binaries.yml",
             ),
             (
@@ -179,6 +179,15 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn("orchestrator_run_id: ${{ github.run_id }}", release)
         self.assertIn("activation_transition: published-inert", release)
         self.assertIn("needs: [resolve, prepublication-family]", release)
+        self.assertIn("sync-backend-cdn:", release)
+        self.assertIn("environment: core-release", release)
+        self.assertIn("sync-windows-backend-cdn.sh", release)
+        self.assertIn("--allow-ci", release)
+        self.assertIn("needs: [resolve, release, binaries]", release)
+        self.assertIn("publish-release:", release)
+        self.assertIn("finalize-core-release.sh", release)
+        self.assertIn("OPENASR_DEPLOY_CATALOG_RUN_ID: ${{ github.run_id }}", release)
+        self.assertIn("needs: [resolve, finalize-notes, deploy-catalog]", release)
         self.assertIn("verify-assets", prepare)
         self.assertIn("gh_release.download_asset", prepare)
         self.assertIn("gh_release.download_url", prepare)
@@ -204,6 +213,8 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
             prepare.index('old_epoch="$(tr -d'),
         )
         self.assertIn("prepare-windows-backend-catalog-release.sh", sync)
+        self.assertIn("--allow-ci", sync)
+        self.assertIn("refusing to use B2 write credentials in CI without --allow-ci", sync)
         self.assertNotIn("backend-hardware-evidence-*.json", sync)
         self.assertNotIn("backend-hardware-audit-*.json", sync)
         self.assertNotIn("backend_hardware_evidence.py", sync)
@@ -248,6 +259,9 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertIn("OPENASR_DEPLOY_CATALOG_RUN_ID", finalize)
         self.assertIn("gh run view", finalize)
         self.assertIn('"Deploy PublishedInert candidate catalog"', finalize)
+        self.assertIn("GITHUB_RUN_ID", finalize)
+        self.assertIn("in_progress", finalize)
+        self.assertIn("retrying in 30s", finalize)
         self.assertIn('value.get("headSha") != sys.argv[2]', finalize)
         self.assertIn('deploy-catalog-binding-${deploy_run_id}', finalize)
         self.assertIn('"release_tag": tag', finalize)


### PR DESCRIPTION
## Summary

Move the two non-signing local release steps into `release-core.yml` so a maintainer's local work is only signing the catalog with the production seed.

- Stage 1 gains `sync-backend-cdn` (after `binaries`): verifies the 21 Windows GPU backend-pack files against the draft release entries and uploads them to B2 `core/vX.Y.Z/`. Runs under GitHub Environment `core-release` (required reviewers) with the B2 secrets scoped to that environment.
- Stage 2 gains `publish-release` (after `deploy-catalog` and `finalize-notes`): runs `finalize-core-release.sh` with `OPENASR_DEPLOY_CATALOG_RUN_ID=${{ github.run_id }}`, same environment, `contents: write` only on this job.
- `sync-windows-backend-cdn.sh` refuses to run under CI unless `--allow-ci` is passed; the local path is unchanged.
- `b2_sync.py` records `x-amz-meta-sha256` on upload and never overwrites: an existing object with matching size + SHA-256 is skipped, a mismatch fails the job before any PUT (falls back to size + ETag, or GET+hash for multipart ETags, for objects uploaded before this change).
- `finalize-core-release.sh` accepts the in-progress orchestrator run when `GITHUB_RUN_ID` matches and retries the no-credential catalog/CDN checks for up to 10 minutes to absorb CDN propagation.
- `RELEASING.md` and `tooling/release-manifest/README.md` describe the new sequence, the `core-release` Environment, the three secrets, and the restricted B2 key policy (`listFiles`/`readFiles`/`writeFiles`, `core/` prefix, no `deleteFiles`).

## Why

`RELEASING.md` kept B2 sync and the final publish local on the premise that CDN write credentials must not enter CI. Client integrity does not depend on that: clients trust only the locally signed catalog and its SHA-256s, and the desktop release already uploads to the same bucket from Actions. Keeping the signing seed local and gating the two CI jobs behind a reviewed Environment preserves the trust boundary while removing two error-prone manual steps.

## Tests run

- [x] `python3 -m unittest discover -s tooling/release-manifest -p '*_test.py'` (216 OK)
- [x] `python3 -m unittest discover -s tooling/publish-model/scripts -p '*_test.py'` (282 OK)
- [x] `bash -n` + `shellcheck` on both scripts
- [x] `actionlint .github/workflows/release-core.yml`
- [x] `CI=true scripts/sync-windows-backend-cdn.sh v0.0.0` refuses without `--allow-ci`

Not exercised for real: no workflow was dispatched. The current v0.1.39 release continues on the existing local path; this lands for the next release.

## Scope / non-goals

Does not move `prepare-windows-backend-catalog-release.sh` (signing seed stays local). Does not change `deploy-catalog.yml`, `release-binaries.yml`, CNB or channel workflows. Does not rotate the B2 key.

## Docs updated

- [x] `RELEASING.md`, `tooling/release-manifest/README.md`

## Artifact confirmation

- [x] No secrets, weights, binaries or private material committed.

## Requirements

- [x] I have read and agree with the contributing guidelines and the AI usage policy in AGENTS.md.
- [x] I understand every line of this change and can explain it without AI assistance, and I own its maintenance.
- AI usage disclosure: YES

Made with [Cursor](https://cursor.com)