### PR TITLE
ci(release): let sync-backend-cdn read the draft release

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -240,7 +240,9 @@ jobs:
     timeout-minutes: 180
     environment: core-release
     permissions:
-      contents: read
+      # Draft releases are invisible to a read-only token: `gh release view`
+      # returns 404 until publication, so the sync would fail-closed forever.
+      contents: write
     env:
       GH_TOKEN: ${{ github.token }}
       B2_S3_ENDPOINT: ${{ secrets.B2_S3_ENDPOINT }}


### PR DESCRIPTION
## Summary
- First real run of the #392 flow (v0.1.39, run 33754994018) failed in `sync-backend-cdn` with `GitHub release v0.1.39 does not exist`: a read-only `GITHUB_TOKEN` cannot see draft releases, so `gh release view` 404s until publication.
- Grant `contents: write` to the job, matching `verify-draft-completeness`. The script only downloads assets and never edits the release.

## Test plan
- [ ] Next core release: `sync-backend-cdn` passes preflight and uploads to B2 after Environment approval.
- v0.1.39 itself was synced with the local escape hatch `scripts/sync-windows-backend-cdn.sh`.

Made with [Cursor](https://cursor.com)