### PR TITLE
release: accept detached qualification signatures in draft completeness

### DIFF
--- a/tooling/release-manifest/release_completeness.py
+++ b/tooling/release-manifest/release_completeness.py
@@ -99,6 +99,21 @@ def required_from_backend_packs(version: str, entries: list[dict[str, Any]]) -> 
     return names
 
 
+def optional_qualification_signatures(version: str, entries: list[dict[str, Any]]) -> set[str]:
+    """Detached production signatures for the inert qualification manifests.
+
+    They are uploaded locally by sign-and-verify-qualification-manifests.sh
+    between the draft build and finalization, so a draft is complete without
+    them; finalize-core-release.sh separately requires the full set before
+    publication.
+    """
+    names: set[str] = set()
+    for entry in entries:
+        provider, target = qualification_manifest.artifact_cell(entry)
+        names.add(f"openasr-{version}-qualification-{provider}-{target}.signature.json")
+    return names
+
+
 def required_assets(
     version: str,
     matrix: list[dict[str, Any]],
@@ -137,6 +152,7 @@ def compare_assets(
 ) -> tuple[list[str], list[str], str | None]:
     required = required_assets(version, matrix, pack_entries)
     optional = optional_experimental_archives(version, matrix)
+    optional |= optional_qualification_signatures(version, pack_entries)
     lock_asset = f"openasr-{version}{LOCK_ASSET_SUFFIX}"
     lock = lock_asset if lock_asset in actual else None
     missing = sorted(required - actual)

--- a/tooling/release-manifest/release_completeness_test.py
+++ b/tooling/release-manifest/release_completeness_test.py
@@ -100,6 +100,37 @@ class ReleaseCompletenessTests(unittest.TestCase):
         )
         self.assertEqual(extra, ["unexpected.bin"])
 
+    def test_compare_accepts_detached_qualification_signatures_for_exact_cells_only(self) -> None:
+        entries = [
+            _pack(
+                vendor="cuda",
+                targets=["sm_75"],
+                files=["openasr-0.1.39-windows-x86_64-cuda-sm_75-plugin.dll"],
+                ident="cuda-sm-75",
+            )
+        ]
+        required = completeness.required_assets("0.1.39", MATRIX, entries)
+        self.assertNotIn("openasr-0.1.39-qualification-cuda-sm_75.signature.json", required)
+
+        actual = set(required)
+        actual.add("openasr-0.1.39-qualification-cuda-sm_75.signature.json")
+        missing, extra, lock = completeness.compare_assets(
+            version="0.1.39",
+            actual=actual,
+            matrix=MATRIX,
+            pack_entries=entries,
+        )
+        self.assertEqual((missing, extra, lock), ([], [], None))
+
+        actual.add("openasr-0.1.39-qualification-cuda-sm_120.signature.json")
+        _, extra, _ = completeness.compare_assets(
+            version="0.1.39",
+            actual=actual,
+            matrix=MATRIX,
+            pack_entries=entries,
+        )
+        self.assertEqual(extra, ["openasr-0.1.39-qualification-cuda-sm_120.signature.json"])
+
     def test_compare_rejects_qualification_mutation_lock(self) -> None:
         entries = [
             _pack(


### PR DESCRIPTION
## Summary
- Since #392, `verify-draft-completeness` and the CI finalize step run in the same stage-2 dispatch. Finalize requires all `openasr-<v>-qualification-<cell>.signature.json` assets, but `release_completeness.py` flagged exactly those files as unexpected extras, so stage 2 could never succeed (v0.1.39, run 33786498366).
- Treat per-cell detached signatures as optional assets in the completeness comparison. Signatures for cells without a backend pack are still rejected. Finalize keeps enforcing that the full set exists before publication.

## Test plan
- [x] `python3 -m unittest release_completeness_test core_release_finalization_contract_test` (new test covers accept + reject-unknown-cell)
- [ ] v0.1.39 stage-2 dispatch passes `verify-draft-completeness` and publishes after Environment approval

Made with [Cursor](https://cursor.com)