### PR TITLE
fix(docker): enable pairing and TLS in the default image command (#381)

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -37,19 +37,21 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ github.sha }},ignore-error=true
 
       - name: Start container
-        # Mock smoke: the image default CMD is the fail-closed native server,
-        # which exits without an installed pack, so pass explicit mock args.
+        # Mock smoke: the image default CMD is the native server, which cannot
+        # transcribe without an installed pack, so pass explicit mock args plus
+        # the same TLS + pairing flags the image default now uses.
         # No --rm: keep the container around so `docker logs` works on failure.
         run: |
           docker run -d --name openasr-docker-smoke -p 18080:8080 \
             -e OPENASR_DOCKER_SMOKE_PAIRING_ADMIN_TOKEN \
             openasr:ci serve --addr 0.0.0.0:8080 --backend mock \
+            --tls-self-signed \
             --pairing-admin-token-env OPENASR_DOCKER_SMOKE_PAIRING_ADMIN_TOKEN
 
       - name: Wait for server
         run: |
           for _ in {1..30}; do
-            if curl -fsS http://127.0.0.1:18080/health; then
+            if curl -kfsS https://127.0.0.1:18080/health; then
               exit 0
             fi
             sleep 1
@@ -61,11 +63,11 @@ jobs:
 
       - name: Smoke endpoints
         run: |
-          curl -fsS http://127.0.0.1:18080/health
-          curl -fsS \
+          curl -kfsS https://127.0.0.1:18080/health
+          curl -kfsS \
             -H "Authorization: Bearer ${OPENASR_DOCKER_SMOKE_PAIRING_ADMIN_TOKEN}" \
-            http://127.0.0.1:18080/v1/models
-          curl -fsS http://127.0.0.1:18080/v1/audio/transcriptions \
+            https://127.0.0.1:18080/v1/models
+          curl -kfsS https://127.0.0.1:18080/v1/audio/transcriptions \
             -H "Authorization: Bearer ${OPENASR_DOCKER_SMOKE_PAIRING_ADMIN_TOKEN}" \
             -F "file=@fixtures/jfk.wav" \
             -F "model=whisper-small" \

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -36,11 +36,41 @@ jobs:
           cache-from: type=gha,scope=${{ github.sha }}
           cache-to: type=gha,mode=max,scope=${{ github.sha }},ignore-error=true
 
-      - name: Start container
-        # Mock smoke: the image default CMD is the native server, which cannot
-        # transcribe without an installed pack, so pass explicit mock args plus
-        # the same TLS + pairing flags the image default now uses.
+      - name: Start container with image default command
+        # Pins the published CMD (pairing token file + TLS). A regression to
+        # `serve --addr 0.0.0.0:8080` with no pairing would fail this step.
         # No --rm: keep the container around so `docker logs` works on failure.
+        run: |
+          docker run -d --name openasr-docker-default -p 18080:8080 openasr:ci
+
+      - name: Wait for default-command server
+        run: |
+          for _ in {1..30}; do
+            if curl -kfsS https://127.0.0.1:18080/health; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker inspect openasr-docker-default --format 'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}' || true
+          docker logs openasr-docker-default
+          exit 1
+
+      - name: Assert default command enables pairing
+        run: |
+          docker logs openasr-docker-default 2>&1 | grep -F 'pairing admin token:'
+          docker exec openasr-docker-default test -s /data/pairing-admin-token
+          code="$(curl -kso /dev/null -w '%{http_code}' https://127.0.0.1:18080/v1/health)"
+          test "${code}" = 401
+
+      - name: Stop default-command container
+        if: always()
+        run: docker rm -f openasr-docker-default || true
+
+      - name: Start mock API container
+        # Transcription smoke needs --backend mock (no pack in the image).
+        # Pairing/TLS flags match the image default; the previous step is what
+        # actually exercises Dockerfile CMD.
         run: |
           docker run -d --name openasr-docker-smoke -p 18080:8080 \
             -e OPENASR_DOCKER_SMOKE_PAIRING_ADMIN_TOKEN \
@@ -80,6 +110,8 @@ jobs:
       - name: Check Docker Compose config
         run: docker compose -f compose.yaml config
 
-      - name: Cleanup container
+      - name: Cleanup containers
         if: always()
-        run: docker rm -f openasr-docker-smoke || true
+        run: |
+          docker rm -f openasr-docker-smoke || true
+          docker rm -f openasr-docker-default || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Docker: images 0.1.37-0.1.40 exit immediately on `docker run` because the
+  default command binds `0.0.0.0` without device pairing (required since
+  0.1.37). The default command now enables pairing (generating a token into
+  `$OPENASR_HOME/pairing-admin-token` when `OPENASR_PAIRING_ADMIN_TOKEN` is
+  unset) and `--tls-self-signed`. `OPENASR_ALLOW_INSECURE_NON_LOOPBACK` is no
+  longer set in the image; it remains an explicit TLS opt-in for a trusted
+  reverse proxy, and still does not disable pairing.
 - Windows: `openasr.exe` no longer imports `mfplat.dll` / `mfreadwrite.dll` at
   load time. Since 0.1.37 the HE-AAC path made every start fail with
   `STATUS_DLL_NOT_FOUND` (exit `0xC0000135`, no message) on Windows N/KN

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,9 @@ Source-build image (what `docker-smoke.yml` exercises; good for local tree chang
 
 ```bash
 docker build -t openasr:local .
-docker run --rm -d --name openasr-docker-smoke -p 18080:8080 openasr:local serve --addr 0.0.0.0:8080 --backend mock
-curl -fsS http://127.0.0.1:18080/health
+docker run --rm -d --name openasr-docker-smoke -p 18080:8080 openasr:local
+curl -kfsS https://127.0.0.1:18080/health
+docker logs openasr-docker-smoke
 docker rm -f openasr-docker-smoke
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,7 @@ dependencies = [
  "axum",
  "clap",
  "cpal",
+ "getrandom 0.3.4",
  "hound",
  "indicatif",
  "libc",

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,15 @@ COPY --from=builder /app/target/release/openasr /usr/local/bin/openasr
 COPY --from=builder /app/model-registry ./model-registry
 
 ENV OPENASR_HOME=/data
-# Binding 0.0.0.0 inside the container is the standard Docker pattern (exposure is
-# controlled by the operator's port-publish / orchestration). The server is
-# fail-closed against non-loopback plaintext by default; this image opts in
-# explicitly. Front it with TLS (or a TLS-terminating proxy) for untrusted networks.
-ENV OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1
+# Default command binds 0.0.0.0 with HTTPS (self-signed) and device pairing.
+# On first start, if OPENASR_PAIRING_ADMIN_TOKEN is unset, `serve` generates a
+# random token, writes it owner-only to /data/pairing-admin-token, and prints
+# it to stdout. Behind a TLS-terminating reverse proxy you may drop
+# --tls-self-signed and set OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1; that env
+# only waives TLS, never pairing.
 
 EXPOSE 8080
 
 USER openasr
 ENTRYPOINT ["openasr"]
-CMD ["serve", "--addr", "0.0.0.0:8080"]
+CMD ["serve", "--addr", "0.0.0.0:8080", "--tls-self-signed", "--pairing-admin-token-file", "/data/pairing-admin-token"]

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -70,12 +70,10 @@ COPY scripts/docker-cuda-entrypoint.sh /usr/local/bin/docker-cuda-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-cuda-entrypoint.sh
 
 ENV OPENASR_HOME=/data
-# See the CPU Dockerfile for why this opt-in is safe: binding 0.0.0.0 inside
-# the container is the standard Docker exposure pattern (the operator
-# controls exposure via port-publish/orchestration); the server stays
-# fail-closed against non-loopback plaintext unless this is set. Front it
-# with TLS (or a TLS-terminating proxy) for untrusted networks.
-ENV OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1
+# Default command binds 0.0.0.0 with HTTPS (self-signed) and device pairing.
+# See the CPU Dockerfile. OPENASR_ALLOW_INSECURE_NON_LOOPBACK is not set here;
+# it remains an explicit TLS opt-in for a trusted reverse proxy and never
+# waives pairing.
 
 # NVIDIA Container Toolkit contract: request GPU capability + full visibility
 # by default (overridable by the operator via `--gpus`/`NVIDIA_VISIBLE_DEVICES`).
@@ -93,4 +91,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
     CMD /usr/local/bin/docker-cuda-entrypoint.sh --gpu-check-only || exit 1
 
 ENTRYPOINT ["/usr/local/bin/docker-cuda-entrypoint.sh"]
-CMD ["serve", "--addr", "0.0.0.0:8080"]
+CMD ["serve", "--addr", "0.0.0.0:8080", "--tls-self-signed", "--pairing-admin-token-file", "/data/pairing-admin-token"]

--- a/Dockerfile.cuda.release
+++ b/Dockerfile.cuda.release
@@ -75,12 +75,10 @@ COPY scripts/docker-cuda-entrypoint.sh /usr/local/bin/docker-cuda-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-cuda-entrypoint.sh
 
 ENV OPENASR_HOME=/data
-# See the CPU Dockerfile for why this opt-in is safe: binding 0.0.0.0 inside
-# the container is the standard Docker exposure pattern (the operator
-# controls exposure via port-publish/orchestration); the server stays
-# fail-closed against non-loopback plaintext unless this is set. Front it
-# with TLS (or a TLS-terminating proxy) for untrusted networks.
-ENV OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1
+# Default command binds 0.0.0.0 with HTTPS (self-signed) and device pairing.
+# See the CPU Dockerfile. OPENASR_ALLOW_INSECURE_NON_LOOPBACK is not set here;
+# it remains an explicit TLS opt-in for a trusted reverse proxy and never
+# waives pairing.
 
 # NVIDIA Container Toolkit contract: request GPU capability + full visibility
 # by default (overridable by the operator via `--gpus`/`NVIDIA_VISIBLE_DEVICES`).
@@ -98,4 +96,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
     CMD /usr/local/bin/docker-cuda-entrypoint.sh --gpu-check-only || exit 1
 
 ENTRYPOINT ["/usr/local/bin/docker-cuda-entrypoint.sh"]
-CMD ["serve", "--addr", "0.0.0.0:8080"]
+CMD ["serve", "--addr", "0.0.0.0:8080", "--tls-self-signed", "--pairing-admin-token-file", "/data/pairing-admin-token"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -63,14 +63,15 @@ COPY --from=fetch /out/openasr /usr/local/bin/openasr
 COPY --from=fetch /out/model-registry ./model-registry
 
 ENV OPENASR_HOME=/data
-# Binding 0.0.0.0 inside the container is the standard Docker pattern (exposure is
-# controlled by the operator's port-publish / orchestration). The server is
-# fail-closed against non-loopback plaintext by default; this image opts in
-# explicitly. Front it with TLS (or a TLS-terminating proxy) for untrusted networks.
-ENV OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1
+# Default command binds 0.0.0.0 with HTTPS (self-signed) and device pairing.
+# On first start, if OPENASR_PAIRING_ADMIN_TOKEN is unset, `serve` generates a
+# random token, writes it owner-only to /data/pairing-admin-token, and prints
+# it to stdout. Behind a TLS-terminating reverse proxy you may drop
+# --tls-self-signed and set OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1; that env
+# only waives TLS, never pairing.
 
 EXPOSE 8080
 
 USER openasr
 ENTRYPOINT ["openasr"]
-CMD ["serve", "--addr", "0.0.0.0:8080"]
+CMD ["serve", "--addr", "0.0.0.0:8080", "--tls-self-signed", "--pairing-admin-token-file", "/data/pairing-admin-token"]

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ self-signed certificate) when talking to the container directly.
 
 **Token.** On first start, if `OPENASR_PAIRING_ADMIN_TOKEN` is unset, the server
 generates a random token, writes it owner-only to `/data/pairing-admin-token`,
-and prints `pairing admin token: … (saved at /data/…)` to stdout. Supply
+and prints `pairing admin token: … (saved at /data/…)` to stdout on that first
+generate. Later starts reuse the file and do not reprint the secret. Supply
 your own with `-e OPENASR_PAIRING_ADMIN_TOKEN=…`. Reuse a volume at `/data` so
 the generated token and pairing registry survive restarts.
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,44 @@ never auto-downloads a pack — install one first:
 docker pull quintinshaw/openasr:latest
 docker run --rm -d --name openasr \
   -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:latest
+docker logs openasr
+# pairing admin token: <token> (saved at /data/pairing-admin-token)
 docker exec openasr openasr pull whisper-small --yes
 
 # NVIDIA GPU (requires NVIDIA Container Toolkit; sm_75 / Turing+)
 docker pull quintinshaw/openasr:cuda-latest
 docker run --rm -d --name openasr-cuda --gpus all \
   -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:cuda-latest
+```
+
+The default command listens on `0.0.0.0:8080` with HTTPS (`--tls-self-signed`)
+and device pairing. Unauthenticated `/v1/*` calls return 401 until a client is
+paired; `GET /health` stays a liveness probe. Use `curl -k` (or pin the
+self-signed certificate) when talking to the container directly.
+
+**Token.** On first start, if `OPENASR_PAIRING_ADMIN_TOKEN` is unset, the server
+generates a random token, writes it owner-only to `/data/pairing-admin-token`,
+and prints `pairing admin token: … (saved at /data/…)` to stdout. Supply
+your own with `-e OPENASR_PAIRING_ADMIN_TOKEN=…`. Reuse a volume at `/data` so
+the generated token and pairing registry survive restarts.
+
+**Pair a client.** In the desktop app, add this server as a remote and approve
+with the admin token. Over the API: `POST /v1/pairing/requests` with a device
+name, then `POST /v1/pairing/requests/{id}/approve` with
+`Authorization: Bearer <token>`. Transcription then uses the issued device
+credential, not the admin token.
+
+**Behind a TLS-terminating reverse proxy.** Override the command to drop
+`--tls-self-signed` and set `OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1`. That env
+only waives TLS, and only on a trusted boundary; device pairing stays
+mandatory. Do not set it on an untrusted network.
+
+```bash
+docker run --rm -d --name openasr \
+  -p 8080:8080 -v openasr-data:/data \
+  -e OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1 \
+  quintinshaw/openasr:latest \
+  serve --addr 0.0.0.0:8080 --pairing-admin-token-file /data/pairing-admin-token
 ```
 
 | Tag | Platforms | Notes |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,7 +115,7 @@ docker run --rm -d --name openasr-cuda --gpus all \
 
 默认命令在 `0.0.0.0:8080` 上启用 HTTPS（`--tls-self-signed`）和设备配对。配对完成前，未认证的 `/v1/*` 请求返回 401；`GET /health` 仍是存活探针。直连容器请用 `curl -k`，或钉住自签证书。
 
-**Token。** 首次启动时，若未设置 `OPENASR_PAIRING_ADMIN_TOKEN`，服务会生成随机 token，以仅 owner 可读写的权限写入 `/data/pairing-admin-token`，并在 stdout 打印 `pairing admin token: … (saved at /data/…)`，方便 `docker logs` 查看。自带 token 用 `-e OPENASR_PAIRING_ADMIN_TOKEN=…`。把卷挂在 `/data`，生成的 token 和配对登记才能跨重启保留。
+**Token。** 首次启动时，若未设置 `OPENASR_PAIRING_ADMIN_TOKEN`，服务会生成随机 token，以仅 owner 可读写的权限写入 `/data/pairing-admin-token`，并在首次生成时于 stdout 打印 `pairing admin token: … (saved at /data/…)`。之后启动复用该文件，不再打印明文。自带 token 用 `-e OPENASR_PAIRING_ADMIN_TOKEN=…`。把卷挂在 `/data`，生成的 token 和配对登记才能跨重启保留。
 
 **客户端配对。** 桌面端把该服务加为远程，用管理员 token 批准。走 API：`POST /v1/pairing/requests` 提交设备名，再 `POST /v1/pairing/requests/{id}/approve`，请求头 `Authorization: Bearer <token>`。之后转写用签发的设备凭证，不要继续用管理员 token。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,12 +103,30 @@ model-registry 元数据;模型权重在运行时拉取到挂载在 `/data` 的�
 docker pull quintinshaw/openasr:latest
 docker run --rm -d --name openasr \
   -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:latest
+docker logs openasr
+# pairing admin token: <token> (saved at /data/pairing-admin-token)
 docker exec openasr openasr pull whisper-small --yes
 
 # NVIDIA GPU(需要 NVIDIA Container Toolkit; sm_75 / Turing 及以上)
 docker pull quintinshaw/openasr:cuda-latest
 docker run --rm -d --name openasr-cuda --gpus all \
   -p 8080:8080 -v openasr-data:/data quintinshaw/openasr:cuda-latest
+```
+
+默认命令在 `0.0.0.0:8080` 上启用 HTTPS（`--tls-self-signed`）和设备配对。配对完成前，未认证的 `/v1/*` 请求返回 401；`GET /health` 仍是存活探针。直连容器请用 `curl -k`，或钉住自签证书。
+
+**Token。** 首次启动时，若未设置 `OPENASR_PAIRING_ADMIN_TOKEN`，服务会生成随机 token，以仅 owner 可读写的权限写入 `/data/pairing-admin-token`，并在 stdout 打印 `pairing admin token: … (saved at /data/…)`，方便 `docker logs` 查看。自带 token 用 `-e OPENASR_PAIRING_ADMIN_TOKEN=…`。把卷挂在 `/data`，生成的 token 和配对登记才能跨重启保留。
+
+**客户端配对。** 桌面端把该服务加为远程，用管理员 token 批准。走 API：`POST /v1/pairing/requests` 提交设备名，再 `POST /v1/pairing/requests/{id}/approve`，请求头 `Authorization: Bearer <token>`。之后转写用签发的设备凭证，不要继续用管理员 token。
+
+**接在会终止 TLS 的反代后面。** 覆盖命令、去掉 `--tls-self-signed`，并设置 `OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1`。这个环境变量只豁免 TLS，且只该用在可信边界；设备配对仍然强制。不要在不可信网络上设置它。
+
+```bash
+docker run --rm -d --name openasr \
+  -p 8080:8080 -v openasr-data:/data \
+  -e OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1 \
+  quintinshaw/openasr:latest \
+  serve --addr 0.0.0.0:8080 --pairing-admin-token-file /data/pairing-admin-token
 ```
 
 | 标签 | 平台 | 说明 |

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,15 @@ services:
       OPENASR_HOME: /data
     volumes:
       - openasr-data:/data
-    command: ["serve", "--addr", "0.0.0.0:8080"]
+    command:
+      [
+        "serve",
+        "--addr",
+        "0.0.0.0:8080",
+        "--tls-self-signed",
+        "--pairing-admin-token-file",
+        "/data/pairing-admin-token",
+      ]
 
   # NVIDIA GPU variant (Dockerfile.cuda). Requires the NVIDIA Container
   # Toolkit on the host (https://github.com/NVIDIA/nvidia-container-toolkit)
@@ -36,7 +44,15 @@ services:
       OPENASR_HOME: /data
     volumes:
       - openasr-cuda-data:/data
-    command: ["serve", "--addr", "0.0.0.0:8080"]
+    command:
+      [
+        "serve",
+        "--addr",
+        "0.0.0.0:8080",
+        "--tls-self-signed",
+        "--pairing-admin-token-file",
+        "/data/pairing-admin-token",
+      ]
     deploy:
       resources:
         reservations:

--- a/crates/openasr-cli/Cargo.toml
+++ b/crates/openasr-cli/Cargo.toml
@@ -30,6 +30,7 @@ legacy-windows-static-sidecar = ["openasr-core/legacy-windows-static-sidecar"]
 anyhow.workspace = true
 clap.workspace = true
 cpal.workspace = true
+getrandom.workspace = true
 indicatif.workspace = true
 openasr-core.workspace = true
 openasr-server.workspace = true

--- a/crates/openasr-cli/src/cli_args.rs
+++ b/crates/openasr-cli/src/cli_args.rs
@@ -706,6 +706,11 @@ pub(crate) enum Command {
         /// Environment variable containing the pairing administrator token for remote device approval.
         #[arg(long)]
         pairing_admin_token_env: Option<String>,
+        /// Owner-only file holding the pairing administrator token. Created
+        /// with a random token if missing. When this flag is set, a non-empty
+        /// `$OPENASR_PAIRING_ADMIN_TOKEN` is used instead of the file.
+        #[arg(long, value_name = "PATH")]
+        pairing_admin_token_file: Option<PathBuf>,
         /// Model id from the registry.
         #[arg(long, env = "OPENASR_MODEL")]
         model: Option<String>,

--- a/crates/openasr-cli/src/main.rs
+++ b/crates/openasr-cli/src/main.rs
@@ -618,6 +618,7 @@ async fn run() -> Result<()> {
             tls_self_signed,
             tls_sans,
             pairing_admin_token_env,
+            pairing_admin_token_file,
             model,
             backend,
             ffmpeg_bin,
@@ -640,6 +641,7 @@ async fn run() -> Result<()> {
                     tls_self_signed,
                     tls_sans,
                     pairing_admin_token_env,
+                    pairing_admin_token_file,
                 },
                 parent_shutdown,
             )

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -750,11 +750,15 @@ fn load_active_api_key_hashes() -> Result<Vec<String>> {
     Ok(store.active_token_hashes())
 }
 
+const PAIRING_ADMIN_TOKEN_ENV: &str = "OPENASR_PAIRING_ADMIN_TOKEN";
+const PAIRING_ADMIN_TOKEN_RANDOM_BYTES: usize = 32;
+
 #[derive(Debug, Clone, Default)]
 pub(super) struct ServeSecurityOptions {
     pub tls_self_signed: bool,
     pub tls_sans: Vec<String>,
     pub pairing_admin_token_env: Option<String>,
+    pub pairing_admin_token_file: Option<PathBuf>,
 }
 
 fn serve_launch_options(
@@ -770,22 +774,8 @@ fn serve_launch_options(
     } else {
         openasr_server::ServerTlsConfig::Disabled
     };
-    let auth = match security
-        .pairing_admin_token_env
-        .as_deref()
-        .map(str::trim)
-        .filter(|name| !name.is_empty())
-    {
-        Some(env_name) => {
-            let token = env::var(env_name).with_context(|| {
-                format!("Could not read pairing administrator token from ${env_name}")
-            })?;
-            let token = token.trim();
-            if token.is_empty() {
-                bail!("Pairing administrator token in ${env_name} must not be empty.");
-            }
-            openasr_server::ServerAuth::pairing(token)
-        }
+    let auth = match resolve_pairing_admin_token(&security)? {
+        Some(token) => openasr_server::ServerAuth::pairing(token),
         // Local API keys (`openasr apikey create`) are a loopback-only escape
         // hatch: they let a trusted-but-explicit caller (a coding agent, a
         // script) require a bearer credential even from 127.0.0.1, where the
@@ -802,6 +792,109 @@ fn serve_launch_options(
         tls,
         ..Default::default()
     })
+}
+
+fn resolve_pairing_admin_token(security: &ServeSecurityOptions) -> Result<Option<String>> {
+    if let Some(env_name) = security
+        .pairing_admin_token_env
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    {
+        match env::var(env_name) {
+            Ok(token) => {
+                let token = token.trim();
+                if token.is_empty() {
+                    bail!("Pairing administrator token in ${env_name} must not be empty.");
+                }
+                return Ok(Some(token.to_string()));
+            }
+            Err(_) if security.pairing_admin_token_file.is_some() => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Could not read pairing administrator token from ${env_name}")
+                });
+            }
+        }
+    }
+
+    if security.pairing_admin_token_file.is_some()
+        && let Ok(token) = env::var(PAIRING_ADMIN_TOKEN_ENV)
+    {
+        let token = token.trim();
+        if token.is_empty() {
+            bail!("Pairing administrator token in ${PAIRING_ADMIN_TOKEN_ENV} must not be empty.");
+        }
+        return Ok(Some(token.to_string()));
+    }
+
+    if let Some(path) = security.pairing_admin_token_file.as_deref() {
+        let token = load_or_create_pairing_admin_token(path)?;
+        println!("pairing admin token: {token} (saved at {})", path.display());
+        return Ok(Some(token));
+    }
+
+    Ok(None)
+}
+
+fn load_or_create_pairing_admin_token(path: &Path) -> Result<String> {
+    match fs::read_to_string(path) {
+        Ok(contents) => {
+            let token = contents.trim();
+            if token.is_empty() {
+                bail!(
+                    "Pairing administrator token file {} is empty. Replace it with a non-empty token or delete it so OpenASR can generate one.",
+                    path.display()
+                );
+            }
+            Ok(token.to_string())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let token = generate_pairing_admin_token()?;
+            if let Some(parent) = path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "Could not create directory for pairing administrator token {}",
+                        parent.display()
+                    )
+                })?;
+            }
+            openasr_core::write_owner_only_file_atomically(path, token.as_bytes()).with_context(
+                || {
+                    format!(
+                        "Could not write pairing administrator token to {}",
+                        path.display()
+                    )
+                },
+            )?;
+            Ok(token)
+        }
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "Could not read pairing administrator token from {}",
+                path.display()
+            )
+        }),
+    }
+}
+
+fn generate_pairing_admin_token() -> Result<String> {
+    let mut bytes = [0u8; PAIRING_ADMIN_TOKEN_RANDOM_BYTES];
+    getrandom::fill(&mut bytes).context("Could not generate a pairing administrator token")?;
+    Ok(pairing_admin_token_hex(&bytes))
+}
+
+fn pairing_admin_token_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
 }
 
 fn default_tls_subject_alt_names(addr: SocketAddr, configured: &[String]) -> Vec<String> {
@@ -2528,6 +2621,128 @@ mod tests {
             StatusCode::OK,
             "non-loopback must not honor a loopback-only API key"
         );
+    }
+
+    #[test]
+    fn pairing_admin_token_file_generates_owner_only_nonempty_token() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pairing-admin-token");
+        let token = load_or_create_pairing_admin_token(&path).expect("generate token");
+        assert!(!token.is_empty(), "generated token must be non-empty");
+        assert_eq!(
+            fs::read_to_string(&path).unwrap().trim(),
+            token,
+            "generated token must be persisted as written"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "generated token file must be owner-only");
+        }
+    }
+
+    #[test]
+    fn pairing_admin_token_file_reuses_existing_contents() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pairing-admin-token");
+        fs::write(&path, "already-set-token\n").unwrap();
+        let first = load_or_create_pairing_admin_token(&path).expect("load token");
+        assert_eq!(first, "already-set-token");
+        let second = load_or_create_pairing_admin_token(&path).expect("reuse token");
+        assert_eq!(second, first);
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            b"already-set-token\n",
+            "an existing token file must not be rewritten"
+        );
+    }
+
+    #[test]
+    fn pairing_admin_token_file_rejects_empty_contents() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pairing-admin-token");
+        fs::write(&path, "  \n").unwrap();
+        let error = load_or_create_pairing_admin_token(&path)
+            .expect_err("empty token file must fail")
+            .to_string();
+        assert!(error.contains("is empty"), "{error}");
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "  \n",
+            "a rejected empty token file must be left untouched"
+        );
+    }
+
+    #[test]
+    fn non_loopback_pairing_token_file_and_tls_pass_listen_security() {
+        with_env_lock(|| {
+            let _escape = EnvVarRestore::remove("OPENASR_ALLOW_INSECURE_NON_LOOPBACK");
+            let _supplied = EnvVarRestore::remove(PAIRING_ADMIN_TOKEN_ENV);
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join("pairing-admin-token");
+            let addr = "0.0.0.0:8080".parse().unwrap();
+            let launch_options = serve_launch_options(
+                addr,
+                ServeSecurityOptions {
+                    tls_self_signed: true,
+                    pairing_admin_token_file: Some(path),
+                    ..Default::default()
+                },
+                Vec::new(),
+            )
+            .expect("serve launch options");
+            openasr_server::validate_listen_security(addr, &launch_options)
+                .expect("pairing + TLS must allow a non-loopback bind");
+        });
+    }
+
+    #[test]
+    fn non_loopback_without_pairing_token_still_fails_closed() {
+        with_env_lock(|| {
+            let _escape = EnvVarRestore::remove("OPENASR_ALLOW_INSECURE_NON_LOOPBACK");
+            let addr = "0.0.0.0:8080".parse().unwrap();
+            let launch_options = serve_launch_options(
+                addr,
+                ServeSecurityOptions {
+                    tls_self_signed: true,
+                    ..Default::default()
+                },
+                Vec::new(),
+            )
+            .expect("serve launch options");
+            let error = openasr_server::validate_listen_security(addr, &launch_options)
+                .expect_err("non-loopback without pairing must fail closed")
+                .to_string();
+            assert!(error.contains("requires device authentication"), "{error}");
+        });
+    }
+
+    #[test]
+    fn pairing_admin_token_env_overrides_token_file() {
+        with_env_lock(|| {
+            let _escape = EnvVarRestore::remove("OPENASR_ALLOW_INSECURE_NON_LOOPBACK");
+            let _supplied = EnvVarRestore::set(PAIRING_ADMIN_TOKEN_ENV, "operator-supplied-token");
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join("pairing-admin-token");
+            let addr = "0.0.0.0:8080".parse().unwrap();
+            let launch_options = serve_launch_options(
+                addr,
+                ServeSecurityOptions {
+                    tls_self_signed: true,
+                    pairing_admin_token_file: Some(path.clone()),
+                    ..Default::default()
+                },
+                Vec::new(),
+            )
+            .expect("serve launch options");
+            assert!(
+                !path.exists(),
+                "a supplied OPENASR_PAIRING_ADMIN_TOKEN must not create the token file"
+            );
+            openasr_server::validate_listen_security(addr, &launch_options)
+                .expect("env-supplied pairing token + TLS must allow a non-loopback bind");
+        });
     }
 
     fn align_options<'a>(

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -829,28 +829,66 @@ fn resolve_pairing_admin_token(security: &ServeSecurityOptions) -> Result<Option
     }
 
     if let Some(path) = security.pairing_admin_token_file.as_deref() {
-        let token = load_or_create_pairing_admin_token(path)?;
-        println!("pairing admin token: {token} (saved at {})", path.display());
-        return Ok(Some(token));
+        let loaded = load_or_create_pairing_admin_token(path)?;
+        println!(
+            "{}",
+            pairing_admin_token_file_announcement(loaded.created, &loaded.token, path)
+        );
+        return Ok(Some(loaded.token));
     }
 
     Ok(None)
 }
 
-fn load_or_create_pairing_admin_token(path: &Path) -> Result<String> {
+#[derive(Debug)]
+struct PairingAdminTokenFile {
+    token: String,
+    created: bool,
+}
+
+fn pairing_admin_token_file_announcement(created: bool, token: &str, path: &Path) -> String {
+    if created {
+        format!("pairing admin token: {token} (saved at {})", path.display())
+    } else {
+        format!("using pairing admin token file {}", path.display())
+    }
+}
+
+fn empty_pairing_admin_token_file_error(path: &Path) -> anyhow::Error {
+    anyhow!(
+        "Pairing administrator token file {} is empty. Replace it with a non-empty token or delete it so OpenASR can generate one.",
+        path.display()
+    )
+}
+
+fn read_nonempty_pairing_admin_token(path: &Path) -> Result<String> {
+    let contents = fs::read_to_string(path).with_context(|| {
+        format!(
+            "Could not read pairing administrator token from {}",
+            path.display()
+        )
+    })?;
+    let token = contents.trim();
+    if token.is_empty() {
+        return Err(empty_pairing_admin_token_file_error(path));
+    }
+    Ok(token.to_string())
+}
+
+fn load_or_create_pairing_admin_token(path: &Path) -> Result<PairingAdminTokenFile> {
     match fs::read_to_string(path) {
         Ok(contents) => {
             let token = contents.trim();
             if token.is_empty() {
-                bail!(
-                    "Pairing administrator token file {} is empty. Replace it with a non-empty token or delete it so OpenASR can generate one.",
-                    path.display()
-                );
+                return Err(empty_pairing_admin_token_file_error(path));
             }
-            Ok(token.to_string())
+            Ok(PairingAdminTokenFile {
+                token: token.to_string(),
+                created: false,
+            })
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            let token = generate_pairing_admin_token()?;
+            let generated = generate_pairing_admin_token()?;
             if let Some(parent) = path
                 .parent()
                 .filter(|parent| !parent.as_os_str().is_empty())
@@ -862,15 +900,19 @@ fn load_or_create_pairing_admin_token(path: &Path) -> Result<String> {
                     )
                 })?;
             }
-            openasr_core::write_owner_only_file_atomically(path, token.as_bytes()).with_context(
-                || {
+            openasr_core::write_owner_only_file_atomically(path, generated.as_bytes())
+                .with_context(|| {
                     format!(
                         "Could not write pairing administrator token to {}",
                         path.display()
                     )
-                },
-            )?;
-            Ok(token)
+                })?;
+            // Re-read so a racing writer on a shared volume is what we serve.
+            let persisted = read_nonempty_pairing_admin_token(path)?;
+            Ok(PairingAdminTokenFile {
+                created: persisted == generated,
+                token: persisted,
+            })
         }
         Err(error) => Err(error).with_context(|| {
             format!(
@@ -2627,11 +2669,15 @@ mod tests {
     fn pairing_admin_token_file_generates_owner_only_nonempty_token() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("pairing-admin-token");
-        let token = load_or_create_pairing_admin_token(&path).expect("generate token");
-        assert!(!token.is_empty(), "generated token must be non-empty");
+        let loaded = load_or_create_pairing_admin_token(&path).expect("generate token");
+        assert!(loaded.created, "missing file must count as a create");
+        assert!(
+            !loaded.token.is_empty(),
+            "generated token must be non-empty"
+        );
         assert_eq!(
             fs::read_to_string(&path).unwrap().trim(),
-            token,
+            loaded.token,
             "generated token must be persisted as written"
         );
         #[cfg(unix)]
@@ -2648,9 +2694,11 @@ mod tests {
         let path = temp.path().join("pairing-admin-token");
         fs::write(&path, "already-set-token\n").unwrap();
         let first = load_or_create_pairing_admin_token(&path).expect("load token");
-        assert_eq!(first, "already-set-token");
+        assert!(!first.created, "existing file must not count as a create");
+        assert_eq!(first.token, "already-set-token");
         let second = load_or_create_pairing_admin_token(&path).expect("reuse token");
-        assert_eq!(second, first);
+        assert!(!second.created);
+        assert_eq!(second.token, first.token);
         assert_eq!(
             fs::read(&path).unwrap(),
             b"already-set-token\n",
@@ -2675,15 +2723,31 @@ mod tests {
     }
 
     #[test]
-    fn non_loopback_pairing_token_file_and_tls_pass_listen_security() {
-        with_env_lock(|| {
+    fn pairing_admin_token_file_announcement_omits_secret_on_reuse() {
+        let path = Path::new("/data/pairing-admin-token");
+        let created = pairing_admin_token_file_announcement(true, "secret-token", path);
+        assert!(created.contains("secret-token"), "{created}");
+        assert!(
+            created.contains("saved at /data/pairing-admin-token"),
+            "{created}"
+        );
+        let reused = pairing_admin_token_file_announcement(false, "secret-token", path);
+        assert!(
+            !reused.contains("secret-token"),
+            "reuse must not reprint the token: {reused}"
+        );
+        assert!(reused.contains("/data/pairing-admin-token"), "{reused}");
+    }
+
+    #[tokio::test]
+    async fn non_loopback_pairing_token_file_and_tls_enable_pairing_auth() {
+        let launch_options = with_env_lock(|| {
             let _escape = EnvVarRestore::remove("OPENASR_ALLOW_INSECURE_NON_LOOPBACK");
             let _supplied = EnvVarRestore::remove(PAIRING_ADMIN_TOKEN_ENV);
             let temp = tempfile::tempdir().unwrap();
             let path = temp.path().join("pairing-admin-token");
-            let addr = "0.0.0.0:8080".parse().unwrap();
-            let launch_options = serve_launch_options(
-                addr,
+            serve_launch_options(
+                "0.0.0.0:8080".parse().unwrap(),
                 ServeSecurityOptions {
                     tls_self_signed: true,
                     pairing_admin_token_file: Some(path),
@@ -2691,43 +2755,60 @@ mod tests {
                 },
                 Vec::new(),
             )
-            .expect("serve launch options");
-            openasr_server::validate_listen_security(addr, &launch_options)
-                .expect("pairing + TLS must allow a non-loopback bind");
+            .expect("serve launch options")
         });
+        match &launch_options.tls {
+            openasr_server::ServerTlsConfig::SelfSigned { .. } => {}
+            openasr_server::ServerTlsConfig::Disabled => panic!("expected self-signed TLS"),
+        }
+        let app = openasr_server::app_with_runtime_and_distribution_and_launch_options(
+            openasr_server::ServerRuntime::default(),
+            openasr_server::DistributionRuntime::default(),
+            launch_options,
+        );
+        assert_eq!(
+            models_status(app, None).await,
+            StatusCode::UNAUTHORIZED,
+            "generated pairing token must gate non-loopback API access"
+        );
     }
 
-    #[test]
-    fn non_loopback_without_pairing_token_still_fails_closed() {
-        with_env_lock(|| {
-            let _escape = EnvVarRestore::remove("OPENASR_ALLOW_INSECURE_NON_LOOPBACK");
-            let addr = "0.0.0.0:8080".parse().unwrap();
-            let launch_options = serve_launch_options(
-                addr,
-                ServeSecurityOptions {
-                    tls_self_signed: true,
-                    ..Default::default()
-                },
-                Vec::new(),
-            )
-            .expect("serve launch options");
-            let error = openasr_server::validate_listen_security(addr, &launch_options)
-                .expect_err("non-loopback without pairing must fail closed")
-                .to_string();
-            assert!(error.contains("requires device authentication"), "{error}");
-        });
+    #[tokio::test]
+    async fn non_loopback_without_pairing_token_leaves_auth_disabled() {
+        let launch_options = serve_launch_options(
+            "0.0.0.0:8080".parse().unwrap(),
+            ServeSecurityOptions {
+                tls_self_signed: true,
+                ..Default::default()
+            },
+            Vec::new(),
+        )
+        .expect("serve launch options");
+        match &launch_options.tls {
+            openasr_server::ServerTlsConfig::SelfSigned { .. } => {}
+            openasr_server::ServerTlsConfig::Disabled => panic!("expected self-signed TLS"),
+        }
+        let app = openasr_server::app_with_runtime_and_distribution_and_launch_options(
+            openasr_server::ServerRuntime::default(),
+            openasr_server::DistributionRuntime::default(),
+            launch_options,
+        );
+        assert_eq!(
+            models_status(app, None).await,
+            StatusCode::OK,
+            "without a pairing token, launch options must not enable auth"
+        );
     }
 
-    #[test]
-    fn pairing_admin_token_env_overrides_token_file() {
-        with_env_lock(|| {
+    #[tokio::test]
+    async fn pairing_admin_token_env_overrides_token_file() {
+        let launch_options = with_env_lock(|| {
             let _escape = EnvVarRestore::remove("OPENASR_ALLOW_INSECURE_NON_LOOPBACK");
             let _supplied = EnvVarRestore::set(PAIRING_ADMIN_TOKEN_ENV, "operator-supplied-token");
             let temp = tempfile::tempdir().unwrap();
             let path = temp.path().join("pairing-admin-token");
-            let addr = "0.0.0.0:8080".parse().unwrap();
             let launch_options = serve_launch_options(
-                addr,
+                "0.0.0.0:8080".parse().unwrap(),
                 ServeSecurityOptions {
                     tls_self_signed: true,
                     pairing_admin_token_file: Some(path.clone()),
@@ -2740,9 +2821,21 @@ mod tests {
                 !path.exists(),
                 "a supplied OPENASR_PAIRING_ADMIN_TOKEN must not create the token file"
             );
-            openasr_server::validate_listen_security(addr, &launch_options)
-                .expect("env-supplied pairing token + TLS must allow a non-loopback bind");
+            launch_options
         });
+        let app = openasr_server::app_with_runtime_and_distribution_and_launch_options(
+            openasr_server::ServerRuntime::default(),
+            openasr_server::DistributionRuntime::default(),
+            launch_options,
+        );
+        assert_eq!(
+            models_status(app.clone(), None).await,
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            models_status(app, Some("operator-supplied-token")).await,
+            StatusCode::OK
+        );
     }
 
     fn align_options<'a>(

--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -363,7 +363,8 @@ fn serve_help_documents_local_default_and_remote_security() {
         ))
         .stdout(predicate::str::contains("HTTPS/WSS"))
         .stdout(predicate::str::contains("--tls-self-signed"))
-        .stdout(predicate::str::contains("--pairing-admin-token-env"));
+        .stdout(predicate::str::contains("--pairing-admin-token-env"))
+        .stdout(predicate::str::contains("--pairing-admin-token-file"));
 }
 
 #[test]

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -830,7 +830,7 @@ impl Listener for TlsListener {
 /// requires device authentication, then TLS (unless the caller has explicitly
 /// set `OPENASR_ALLOW_INSECURE_NON_LOOPBACK`). The TLS escape never waives
 /// pairing.
-pub fn validate_listen_security(
+fn validate_listen_security(
     addr: SocketAddr,
     launch_options: &ServerLaunchOptions,
 ) -> anyhow::Result<()> {

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -826,7 +826,11 @@ impl Listener for TlsListener {
     }
 }
 
-fn validate_listen_security(
+/// Fail-closed bind policy for `serve`: loopback is unrestricted, non-loopback
+/// requires device authentication, then TLS (unless the caller has explicitly
+/// set `OPENASR_ALLOW_INSECURE_NON_LOOPBACK`). The TLS escape never waives
+/// pairing.
+pub fn validate_listen_security(
     addr: SocketAddr,
     launch_options: &ServerLaunchOptions,
 ) -> anyhow::Result<()> {

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -55,6 +55,32 @@ fn non_loopback_tls_escape_still_requires_authentication() {
     );
 }
 
+#[test]
+fn non_loopback_pairing_with_tls_is_allowed() {
+    let options = ServerLaunchOptions {
+        auth: ServerAuth::pairing("admin-token"),
+        tls: ServerTlsConfig::self_signed(["localhost"]),
+        ..Default::default()
+    };
+    validate_listen_security_with_escape("0.0.0.0:8080".parse().unwrap(), &options, false)
+        .expect("pairing + TLS must allow a non-loopback bind");
+}
+
+#[test]
+fn non_loopback_without_auth_fails_closed_even_with_tls_and_insecure_escape() {
+    let options = ServerLaunchOptions {
+        auth: ServerAuth::disabled(),
+        tls: ServerTlsConfig::self_signed(["localhost"]),
+        ..Default::default()
+    };
+    let err = validate_listen_security_with_escape("0.0.0.0:8080".parse().unwrap(), &options, true)
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("requires device authentication"),
+        "unexpected error: {err:?}"
+    );
+}
+
 fn header_map_with_bearer(token: &str) -> axum::http::HeaderMap {
     let mut headers = axum::http::HeaderMap::new();
     headers.insert(

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -208,8 +208,9 @@ Container Toolkit and refuse to start if no GPU is visible.
 
 The default command binds `0.0.0.0:8080` with HTTPS (`--tls-self-signed`) and
 device pairing. `docker logs` prints `pairing admin token: … (saved at
-/data/pairing-admin-token)` on first start (or reuse that file across volume
-restarts). Supply your own with `-e OPENASR_PAIRING_ADMIN_TOKEN=…`. Pair from
+/data/pairing-admin-token)` when the token file is first created; later starts
+reuse that file without reprinting the secret. Supply your own with
+`-e OPENASR_PAIRING_ADMIN_TOKEN=…`. Pair from
 the desktop app, or `POST /v1/pairing/requests` then approve with
 `Authorization: Bearer <token>`. Unauthenticated `/v1/*` calls return 401;
 `GET /health` is the liveness probe. Talk to the container with `curl -k`

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -204,8 +204,20 @@ model-registry metadata only — mount a volume at `/data`, then
 server never auto-pulls. They do not ship `perf/` bench-suite fixtures or
 baselines, so `openasr bench-suite` inside the container will fail looking for
 those files; run benchmarks from a git checkout. CUDA tags require the NVIDIA
-Container Toolkit and refuse to start if no GPU is visible. Longer guide:
-[openasr.org/docs/docker](https://openasr.org/docs/docker/).
+Container Toolkit and refuse to start if no GPU is visible.
+
+The default command binds `0.0.0.0:8080` with HTTPS (`--tls-self-signed`) and
+device pairing. `docker logs` prints `pairing admin token: … (saved at
+/data/pairing-admin-token)` on first start (or reuse that file across volume
+restarts). Supply your own with `-e OPENASR_PAIRING_ADMIN_TOKEN=…`. Pair from
+the desktop app, or `POST /v1/pairing/requests` then approve with
+`Authorization: Bearer <token>`. Unauthenticated `/v1/*` calls return 401;
+`GET /health` is the liveness probe. Talk to the container with `curl -k`
+(self-signed). Behind a TLS-terminating reverse proxy, drop `--tls-self-signed`
+from the command and set `OPENASR_ALLOW_INSECURE_NON_LOOPBACK=1` — that env
+only waives TLS, never pairing, and only belongs on a trusted boundary.
+
+Longer guide: [openasr.org/docs/docker](https://openasr.org/docs/docker/).
 
 ## Is ffmpeg required?
 


### PR DESCRIPTION
Fixes #381.

## Summary
Since 0.1.37 the official image exits immediately and restart-loops: `CMD serve --addr 0.0.0.0:8080` binds a non-loopback address, which now requires device pairing, and `OPENASR_ALLOW_INSECURE_NON_LOOPBACK` only waives TLS, never pairing. The image had neither.

| | 0.1.37–0.1.40 | now |
|---|---|---|
| `CMD` | `serve --addr 0.0.0.0:8080` | `+ --tls-self-signed --pairing-admin-token-file /data/pairing-admin-token` |
| `OPENASR_ALLOW_INSECURE_NON_LOOPBACK` | baked into the image (`=1`) | removed; explicit opt-in only, behind a TLS-terminating proxy |
| device pairing | off → bind refused, container exits | on by default; first start generates a random token, writes it `0600` to `/data/pairing-admin-token`, prints it once; `OPENASR_PAIRING_ADMIN_TOKEN` overrides |
| transport | plaintext HTTP (never actually started) | HTTPS, self-signed |
| `validate_listen_security_with_escape` | pairing required first; TLS escape does not relax auth | unchanged |

- CLI: new `--pairing-admin-token-file <path>`; missing → generate, existing → reuse (path only, no secret in logs), empty → error; a non-empty `$OPENASR_PAIRING_ADMIN_TOKEN` wins and the file is not written. Written token is read back before use.
- Dockerfile, Dockerfile.release, Dockerfile.cuda, Dockerfile.cuda.release, compose.yaml updated.
- README (en/zh-CN), docs/FAQ.md, CONTRIBUTING.md local smoke, CHANGELOG Unreleased/Fixed.
- `.github/workflows/docker-smoke.yml` now starts the image with its **default CMD** (no override), asserts HTTPS `/health`, the `pairing admin token:` log line, `/v1/health` → 401, then runs the mock transcription.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-cli -p openasr-server` (762 passed)
- [x] New tests: token file create/0600/reuse/empty-error; non-loopback + token + TLS passes; non-loopback without token still refused even with TLS + escape
- [ ] `docker-smoke.yml` on this PR (local Docker daemon was not running; the workflow is the reproduction of #381)

AI usage disclosure: YES

Made with [Cursor](https://cursor.com)