### PR TITLE
test(server): pin live SSE, pull job ids, and boot logs (#402)

### DIFF
--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -406,7 +406,7 @@ pub async fn serve_with_launch_options(
                 ),
             );
             println!("OpenASR server listening on http://{addr}");
-            spawn_ggml_backend_boot_log();
+            drop(spawn_ggml_backend_boot_log(ggml_backend_boot_probe));
             axum::serve(listener, app).await?;
         }
         ServerTlsConfig::SelfSigned { subject_alt_names } => {
@@ -446,7 +446,7 @@ pub async fn serve_with_launch_options(
                 "OpenASR server listening on https://{addr} (certificate sha256:{}, pairing code {})",
                 identity.certificate_sha256, identity.pairing_safety_code
             );
-            spawn_ggml_backend_boot_log();
+            drop(spawn_ggml_backend_boot_log(ggml_backend_boot_probe));
             axum::serve(TlsListener::new(listener, identity.acceptor), app).await?;
         }
     }
@@ -460,23 +460,30 @@ pub async fn serve_with_launch_options(
 /// is bound. Blocking the listen path on `ggml_cuda_init` / `LoadLibrary`
 /// made `--no-model` start pay GPU init; the banner and `/health` must not
 /// wait for that.
-fn spawn_ggml_backend_boot_log() {
-    tokio::task::spawn_blocking(|| {
+fn ggml_backend_boot_log_message(summary: &str) -> String {
+    format!("stage=ggml_backend {summary}")
+}
+
+fn ggml_backend_boot_probe() -> String {
+    let info = openasr_core::ggml_runtime_info();
+    openasr_core::ggml_runtime_boot_summary(&info)
+}
+
+fn spawn_ggml_backend_boot_log(
+    probe: impl FnOnce() -> String + Send + 'static,
+) -> tokio::task::JoinHandle<String> {
+    tokio::task::spawn_blocking(move || {
         let stage_started = Instant::now();
-        let info = openasr_core::ggml_runtime_info();
+        let summary = probe();
         openasr_core::stage_timing::log_stage(
             "server_boot",
             "ggml_backend",
             stage_started.elapsed(),
         );
-        openasr_core::stage_timing::log_event(
-            "server_boot",
-            format_args!(
-                "stage=ggml_backend {}",
-                openasr_core::ggml_runtime_boot_summary(&info)
-            ),
-        );
-    });
+        let message = ggml_backend_boot_log_message(&summary);
+        openasr_core::stage_timing::log_event("server_boot", format_args!("{message}"));
+        message
+    })
 }
 
 /// Validity window for a freshly generated self-signed TLS identity: long

--- a/crates/openasr-server/src/realtime/mod.rs
+++ b/crates/openasr-server/src/realtime/mod.rs
@@ -640,7 +640,7 @@ enum ClientMessage {
     SessionClose,
 }
 
-#[cfg(fuzzing)]
+#[cfg(any(test, fuzzing))]
 pub fn fuzz_parse_client_message(data: &[u8]) -> Result<(), serde_json::Error> {
     serde_json::from_slice::<ClientMessage>(data).map(|_| ())
 }

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -4,7 +4,7 @@
 
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Arc, Mutex, OnceLock,
         atomic::{AtomicBool, Ordering},
@@ -1235,7 +1235,7 @@ pub(crate) fn spawn_boot_native_warmup(
     })
 }
 
-fn log_default_reactivation_failed(home: &Path, requested_path: &Path, reason: &str) {
+fn log_default_reactivation_failed(home: &Path, requested_path: &Path, reason: &str) -> String {
     let mut reason = single_line_log_value(reason);
     for sensitive_path in [home, requested_path] {
         let rendered = sensitive_path.to_string_lossy();
@@ -1248,6 +1248,7 @@ fn log_default_reactivation_failed(home: &Path, requested_path: &Path, reason: &
         "server_boot",
         format_args!("stage=default_reactivation_failed reason={reason}"),
     );
+    reason
 }
 
 /// Attest a candidate pack without publishing it as the live default.
@@ -1775,5 +1776,48 @@ async fn run_realtime_backend_job(
             })
         }
         Err(error) => BackendResult::Error(error),
+    }
+}
+
+#[cfg(test)]
+mod reactivation_log_tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn default_reactivation_failure_log_redacts_paths_and_flattens_newlines() {
+        let home = Path::new("/tmp/openasr-home-secret");
+        let pack = Path::new("/tmp/openasr-home-secret/models/pack.oasr");
+        let rendered = log_default_reactivation_failed(
+            home,
+            pack,
+            "failed to activate /tmp/openasr-home-secret/models/pack.oasr:\nbad pack",
+        );
+        assert!(
+            !rendered.contains("openasr-home-secret"),
+            "home/pack paths must not leak into daemon logs: {rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted-path>"),
+            "redaction marker missing: {rendered}"
+        );
+        assert!(
+            !rendered.contains('\n'),
+            "log lines must stay single-line: {rendered}"
+        );
+        assert!(
+            rendered.contains("bad pack"),
+            "failure reason must remain after redaction: {rendered}"
+        );
+        assert!(rendered.len() <= 512, "log reason must stay bounded");
+    }
+
+    #[test]
+    fn default_reactivation_failure_log_truncates_long_reasons() {
+        let home = Path::new("/home/openasr");
+        let pack = Path::new("/models/pack.oasr");
+        let rendered = log_default_reactivation_failed(home, pack, &"x".repeat(1024));
+        assert_eq!(rendered.len(), 512);
+        assert!(rendered.chars().all(|c| c == 'x'));
     }
 }

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -2344,6 +2344,66 @@ fn session_start_keeps_unknown_envelope_fields_extensible() {
     );
 }
 
+#[test]
+fn fuzz_parse_client_message_rejects_invalid_json_and_accepts_session_close() {
+    assert!(fuzz_parse_client_message(b"not-json").is_err());
+    assert!(fuzz_parse_client_message(br#"{"type":"session.close"}"#).is_ok());
+}
+
+#[test]
+fn protocol_event_id_uses_zero_padded_proto_sequence() {
+    assert_eq!(protocol_event_id(1), "proto_000001");
+    assert_eq!(protocol_event_id(42), "proto_000042");
+}
+
+async fn rendered_sse_event(event: Event) -> String {
+    use axum::response::IntoResponse;
+    let (sender, receiver) = mpsc::channel::<Result<Event, Infallible>>(1);
+    sender.send(Ok(event)).await.unwrap();
+    drop(sender);
+    let response = Sse::new(ReceiverStream::new(receiver)).into_response();
+    let bytes = axum::body::to_bytes(response.into_body(), 16 * 1024)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn send_sse_emits_named_session_envelope() {
+    let (sender, mut receiver) = mpsc::channel(1);
+    let envelope = one_shot_controller("whisper-large-v3-turbo")
+        .session_created_event("2026-09-07T00:00:00.000Z");
+    let event_id = envelope.event_id.0.clone();
+    send_sse(&sender, envelope).await;
+    let event = tokio::time::timeout(std::time::Duration::from_millis(200), receiver.recv())
+        .await
+        .expect("send_sse must enqueue an SSE frame")
+        .expect("channel open")
+        .expect("event");
+    let body = rendered_sse_event(event).await;
+    assert!(body.contains("event: session.created"), "{body}");
+    assert!(body.contains(&format!("id: {event_id}")), "{body}");
+    assert!(body.contains("\"type\":\"session.created\""), "{body}");
+}
+
+#[tokio::test]
+async fn send_event_delivers_the_envelope_or_fails_closed() {
+    let envelope = one_shot_controller("whisper-large-v3-turbo")
+        .session_created_event("2026-09-07T00:00:00.000Z");
+    let (sender, mut receiver) = mpsc::channel(1);
+    assert_eq!(send_event(&sender, envelope.clone()).await, Ok(()));
+    let got = tokio::time::timeout(std::time::Duration::from_millis(200), receiver.recv())
+        .await
+        .expect("send_event must deliver without hanging")
+        .expect("envelope");
+    assert_eq!(got.event_type, "session.created");
+    assert_eq!(got.event_id, envelope.event_id);
+
+    let (closed_sender, closed_receiver) = mpsc::channel(1);
+    drop(closed_receiver);
+    assert_eq!(send_event(&closed_sender, envelope).await, Err(()));
+}
+
 #[tokio::test]
 async fn native_streaming_session_receives_binary_frames_without_file_fallback_worker() {
     let (event_sender, mut event_receiver) = mpsc::channel(8);

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -4451,6 +4451,129 @@ async fn pull_job_control_ack_sets_flag_without_terminal_state_flip() {
     distribution.clear_active_job("pull-control");
 }
 
+#[test]
+fn next_job_id_is_unique_pull_timestamp_sequence() {
+    let temp = tempfile::tempdir().unwrap();
+    let distribution = distribution_context_for_test(temp.path());
+    let first = distribution.next_job_id();
+    let second = distribution.next_job_id();
+    assert_ne!(first, second);
+    for job_id in [&first, &second] {
+        let mut parts = job_id.splitn(3, '-');
+        assert_eq!(parts.next(), Some("pull"), "{job_id}");
+        let timestamp = parts.next().expect(job_id);
+        let seq = parts.next().expect(job_id);
+        assert!(
+            !timestamp.is_empty() && timestamp.chars().all(|c| c.is_ascii_digit()),
+            "{job_id}"
+        );
+        assert!(
+            !seq.is_empty() && seq.chars().all(|c| c.is_ascii_digit()),
+            "{job_id}"
+        );
+    }
+    let first_seq: u64 = first.rsplit('-').next().unwrap().parse().unwrap();
+    let second_seq: u64 = second.rsplit('-').next().unwrap().parse().unwrap();
+    assert_eq!(second_seq, first_seq + 1);
+}
+
+#[test]
+fn notify_job_snapshot_publishes_to_existing_watchers() {
+    let temp = tempfile::tempdir().unwrap();
+    let distribution = distribution_context_for_test(temp.path());
+    let resolved = resolved_pull_fixture();
+    let snapshot = PullJobSnapshot::queued("pull-notify".to_string(), &resolved, None, false);
+    distribution.insert_job(snapshot).unwrap();
+    let receiver = distribution.subscribe_job("pull-notify").unwrap();
+
+    let mut next = distribution.snapshot("pull-notify").unwrap();
+    next.state = PullJobState::Downloading;
+    next.error = Some("bytes arriving".to_string());
+    distribution.notify_job_snapshot(&next);
+
+    let observed = receiver.borrow().clone();
+    assert_eq!(observed.state, PullJobState::Downloading);
+    assert_eq!(observed.error.as_deref(), Some("bytes arriving"));
+}
+
+#[test]
+fn cancel_job_reports_whether_an_active_worker_was_signaled() {
+    let temp = tempfile::tempdir().unwrap();
+    let distribution = distribution_context_for_test(temp.path());
+    assert!(
+        !distribution.cancel_job("missing-job"),
+        "unknown jobs must not report a successful cancel"
+    );
+
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+    let pause_flag = Arc::new(AtomicBool::new(false));
+    distribution.register_active_job("pull-live", cancel_flag.clone(), pause_flag.clone());
+    assert!(distribution.cancel_job("pull-live"));
+    assert!(cancel_flag.load(Ordering::SeqCst));
+    assert!(!pause_flag.load(Ordering::SeqCst));
+}
+
+#[test]
+fn model_activation_failpoint_labels_are_stable_and_distinct() {
+    let labeled = [
+        (
+            ModelActivationFailpoint::PackVerification,
+            "pack-verification",
+        ),
+        (
+            ModelActivationFailpoint::CandidateResolution,
+            "candidate-resolution",
+        ),
+        (
+            ModelActivationFailpoint::QuoteObservation,
+            "quote-observation",
+        ),
+        (
+            ModelActivationFailpoint::BrokerReservation,
+            "broker-reservation",
+        ),
+        (
+            ModelActivationFailpoint::NativeMaterialization,
+            "native-materialization",
+        ),
+        (
+            ModelActivationFailpoint::FirstComputeAttestation,
+            "first-compute-attestation",
+        ),
+        (ModelActivationFailpoint::Reconciliation, "reconciliation"),
+        (ModelActivationFailpoint::V2StagingWrite, "v2-staging-write"),
+        (ModelActivationFailpoint::V2StagingSync, "v2-staging-sync"),
+        (
+            ModelActivationFailpoint::AtomicBeforeReplace,
+            "atomic-before-replace",
+        ),
+        (
+            ModelActivationFailpoint::AtomicAfterReplace,
+            "atomic-after-replace",
+        ),
+        (
+            ModelActivationFailpoint::DurableCommitBeforeLivePublish,
+            "durable-commit-before-live-publish",
+        ),
+    ];
+    let mut seen = std::collections::HashSet::new();
+    for (failpoint, expected) in labeled {
+        let label = failpoint.label();
+        assert_eq!(label, expected);
+        assert!(seen.insert(label), "duplicate failpoint label {label}");
+    }
+}
+
+#[tokio::test]
+async fn spawn_ggml_backend_boot_log_joins_injected_probe_summary() {
+    let handle = spawn_ggml_backend_boot_log(|| "best_backend=Metal cpu_backend=CPU".to_string());
+    let message = handle.await.expect("boot log task");
+    assert_eq!(
+        message,
+        "stage=ggml_backend best_backend=Metal cpu_backend=CPU"
+    );
+}
+
 #[tokio::test]
 async fn transcription_control_endpoints_flip_pause_resume_cancel_flags() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/openasr-server/tests/api.rs
+++ b/crates/openasr-server/tests/api.rs
@@ -5807,10 +5807,13 @@ async fn stream_transcriptions_with_mock_backend_emits_protocol_events() {
     );
     let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
     let body = String::from_utf8_lossy(&bytes);
+    assert!(body.contains("event: session.created"), "{body}");
     assert!(body.contains("event: segment_start"));
     assert!(body.contains("event: final"));
     assert!(body.contains("event: segment_end"));
     assert!(body.contains("event: done"));
+    assert!(body.contains("id: proto_000001"), "{body}");
+    assert!(body.contains("id: proto_000002"), "{body}");
     assert!(body.contains("\"totalLatencyMs\":"));
 }
 


### PR DESCRIPTION
Closes #402.

## Summary
The mutation-testing survivors listed in #402 (SSE helpers, `next_job_id`, boot/reactivation logging) are not dead code: desktop consumes the pull-job SSE stream, `POST /v1/audio/transcriptions?stream=true` is a public endpoint, and the boot/reactivation log paths run in production. Nothing is removed. Instead each helper now has a direct test that asserts its observable effect, so a no-op mutant fails:

- `protocol_event_id` / `send_sse` / `sse_event`: exact `id: proto_000001` and `event: session.created` frames, also pinned end to end in `tests/api.rs`.
- `send_event` (WS): delivery on an open channel, `Err` on a dropped receiver.
- `next_job_id`: `pull-<unix-ms>-<seq>` shape and monotonic sequence; `notify_job_snapshot` and `cancel_job` observable through the watcher and cancel flag.
- `spawn_ggml_backend_boot_log` now takes an injectable probe and returns its `JoinHandle<String>`; production still detaches it after the listen banner, the test joins a fake probe and asserts the logged line. No GPU plugin is loaded in tests.
- `log_default_reactivation_failed` returns the redacted, single-line, 512-byte-bounded reason so the redaction contract is asserted.
- `fuzz_parse_client_message` is compiled under `cfg(any(test, fuzzing))` and gets a unit test.

No public API or wire change; no CHANGELOG entry since user-visible behaviour is unchanged.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-server -p openasr-cli` (781 passed)
- [x] `cargo test --workspace --doc`
- [x] Independent review: listen path still non-blocking, `JoinHandle` drop detaches (tokio `spawn_blocking` is not abortable)

AI usage disclosure: YES

Made with [Cursor](https://cursor.com)