### PR TITLE
fix(core): reject invalid ggml type ids before type-trait queries (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Core: invalid GGUF/ggml type ids — out of range or retired slots whose
+  block size is zero — are rejected before any ggml type-trait query. An
+  unknown tensor type can no longer be treated as quantized or used to
+  compute a row size, both of which were undefined behaviour. (#400)
 - Docker: images 0.1.37-0.1.40 exit immediately on `docker run` because the
   default command binds `0.0.0.0` without device pairing (required since
   0.1.37). The default command now enables pairing (generating a token into

--- a/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
+++ b/crates/openasr-core/src/ggml_runtime/cpu_graph.rs
@@ -1826,6 +1826,10 @@ pub enum GgmlCpuGraphError {
     UnsupportedOperation { operation: GgmlCpuBinaryOp },
     #[error("ggml cpu graph input tensors are unsupported: {reason}")]
     UnsupportedInputs { reason: &'static str },
+    #[error(
+        "ggml type {ggml_type} is outside 0..GGML_TYPE_COUNT or is a retired slot (tensor: {tensor})"
+    )]
+    InvalidGgmlType { ggml_type: i64, tensor: String },
     #[error("ggml cpu graph tensor allocation failed for '{tensor}'")]
     TensorAllocationFailed { tensor: &'static str },
     #[error("ggml cpu graph construction failed at '{step}'")]
@@ -4356,10 +4360,14 @@ impl GgmlStaticTensorArena {
             });
         }
         let block_size =
-            usize::try_from(unsafe { ffi::ggml_blck_size(layout.type_) }).map_err(|_| {
-                GgmlCpuGraphError::UnsupportedInputs {
-                    reason: "loaded tensor block size exceeds usize boundary",
+            usize::try_from(ffi::ggml_blck_size_checked(layout.type_).map_err(|error| {
+                GgmlCpuGraphError::InvalidGgmlType {
+                    ggml_type: error.raw,
+                    tensor: tensor_name.to_string(),
                 }
+            })?)
+            .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+                reason: "loaded tensor block size exceeds usize boundary",
             })?;
         if block_size == 0 || !dims[0].is_multiple_of(block_size) {
             return Err(GgmlCpuGraphError::UnsupportedInputs {
@@ -9508,7 +9516,7 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
                 | ffi::GGML_TYPE_Q4_K
                 | ffi::GGML_TYPE_Q5_K
                 | ffi::GGML_TYPE_Q6_K
-        ) && unsafe { ffi::ggml_is_quantized(type_) };
+        ) && ffi::ggml_is_quantized_checked(type_) == Ok(true);
         if matches!(type_, ffi::GGML_TYPE_F16 | ffi::GGML_TYPE_F32) || supported_quant_type {
             return Ok(());
         }
@@ -9596,10 +9604,14 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
     }
 
     fn type_block_size(&self, type_: i32) -> Result<usize, GgmlCpuGraphError> {
-        let block_size = usize::try_from(unsafe { ffi::ggml_blck_size(type_) }).map_err(|_| {
-            GgmlCpuGraphError::UnsupportedInputs {
-                reason: "tensor block size exceeds usize boundary",
+        let block_size = usize::try_from(ffi::ggml_blck_size_checked(type_).map_err(|error| {
+            GgmlCpuGraphError::InvalidGgmlType {
+                ggml_type: error.raw,
+                tensor: String::from("(unknown)"),
             }
+        })?)
+        .map_err(|_| GgmlCpuGraphError::UnsupportedInputs {
+            reason: "tensor block size exceeds usize boundary",
         })?;
         if block_size == 0 {
             return Err(GgmlCpuGraphError::UnsupportedInputs {
@@ -9610,7 +9622,12 @@ impl<'a> GgmlCpuGraphBuilder<'a> {
     }
 
     fn element_size_bytes(&self, type_: i32) -> Result<usize, GgmlCpuGraphError> {
-        let size = unsafe { ffi::ggml_type_size(type_) };
+        let size = ffi::ggml_type_size_checked(type_).map_err(|error| {
+            GgmlCpuGraphError::InvalidGgmlType {
+                ggml_type: error.raw,
+                tensor: String::from("(unknown)"),
+            }
+        })?;
         if size == 0 {
             return Err(GgmlCpuGraphError::UnsupportedInputs {
                 reason: "tensor element byte width must be positive",
@@ -12693,7 +12710,10 @@ fn is_loaded_matmul_weight_candidate(layout: ffi::GgmlTensorLayoutPrefix) -> boo
 }
 
 fn ggml_type_name_lossy(type_: c_int) -> String {
-    unsafe { cstr_lossy(ffi::ggml_type_name(type_)) }
+    match ffi::ggml_type_name_checked(type_) {
+        Ok(ptr) => cstr_lossy(ptr),
+        Err(_) => format!("unknown-ggml-type-{type_}"),
+    }
 }
 
 unsafe fn write_tensor_data(

--- a/crates/openasr-core/src/ggml_runtime/ffi.rs
+++ b/crates/openasr-core/src/ggml_runtime/ffi.rs
@@ -379,6 +379,99 @@ pub(crate) const GGML_TYPE_Q4_K: c_int = 12;
 pub(crate) const GGML_TYPE_Q5_K: c_int = 13;
 pub(crate) const GGML_TYPE_Q6_K: c_int = 14;
 pub(crate) const GGML_TYPE_I32: c_int = 26;
+pub(crate) const GGML_TYPE_Q2_0: c_int = 42;
+
+/// Exclusive upper bound of `enum ggml_type` in vendored
+/// `third_party/openasr-ggml/include/ggml.h` (`GGML_TYPE_COUNT = 43`).
+/// ggml indexes `type_traits[type]` without a range check, so ids outside
+/// `0..GGML_TYPE_COUNT` are an out-of-bounds read. Retired slots inside that
+/// range (removed Q4_2/Q4_3, Q4_0_*, IQ4_NL_*) keep `blck_size == 0`;
+/// NDEBUG `ggml_row_size` would then divide by zero.
+///
+/// When bumping the vendored ggml pin: copy the new `GGML_TYPE_COUNT` from
+/// ggml.h, add any new live type constants, and re-run
+/// `checked_ggml_type_matches_vendored_count` plus the retired-slot tests
+/// (type ids 4 and 31).
+pub(crate) const GGML_TYPE_COUNT: c_int = 43;
+
+const _: () = assert!(GGML_TYPE_Q2_0 < GGML_TYPE_COUNT);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InvalidGgmlType {
+    pub raw: i64,
+}
+
+impl std::fmt::Display for InvalidGgmlType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ggml type {} is outside 0..{GGML_TYPE_COUNT} or is a retired slot",
+            self.raw
+        )
+    }
+}
+
+/// Reject a raw ggml type id before any further `type_traits` query.
+/// Retired in-range slots (`blck_size == 0`) fail the same way as OOB ids.
+pub(crate) fn checked_ggml_type(raw: u32) -> Result<c_int, InvalidGgmlType> {
+    checked_ggml_type_i64(i64::from(raw))
+}
+
+/// GGUF / host metadata store ggml types as `i32` (may be negative).
+pub(crate) fn checked_ggml_type_i32(raw: i32) -> Result<c_int, InvalidGgmlType> {
+    match u32::try_from(raw) {
+        Ok(raw) => checked_ggml_type(raw),
+        Err(_) => Err(InvalidGgmlType {
+            raw: i64::from(raw),
+        }),
+    }
+}
+
+fn checked_ggml_type_i64(raw: i64) -> Result<c_int, InvalidGgmlType> {
+    if raw < 0 || raw >= i64::from(GGML_TYPE_COUNT) {
+        return Err(InvalidGgmlType { raw });
+    }
+    let ty = raw as c_int;
+    // One FFI probe: retired ggml slots keep a type_traits entry with
+    // blck_size == 0. Calling ggml_row_size on those is integer-divide-by-zero
+    // under NDEBUG.
+    if unsafe { ggml_blck_size(ty) } <= 0 {
+        return Err(InvalidGgmlType { raw });
+    }
+    Ok(ty)
+}
+
+pub(crate) fn ggml_is_quantized_checked(raw: i32) -> Result<bool, InvalidGgmlType> {
+    let ty = checked_ggml_type_i32(raw)?;
+    Ok(unsafe { ggml_is_quantized(ty) })
+}
+
+pub(crate) fn ggml_blck_size_checked(raw: i32) -> Result<i64, InvalidGgmlType> {
+    let ty = checked_ggml_type_i32(raw)?;
+    Ok(unsafe { ggml_blck_size(ty) })
+}
+
+pub(crate) fn ggml_type_size_checked(raw: i32) -> Result<usize, InvalidGgmlType> {
+    let ty = checked_ggml_type_i32(raw)?;
+    Ok(unsafe { ggml_type_size(ty) })
+}
+
+pub(crate) fn ggml_row_size_checked(raw: i32, ne: i64) -> Result<usize, InvalidGgmlType> {
+    let ty = checked_ggml_type_i32(raw)?;
+    Ok(unsafe { ggml_row_size(ty, ne) })
+}
+
+pub(crate) fn ggml_get_type_traits_checked(
+    raw: i32,
+) -> Result<*const GgmlTypeTraits, InvalidGgmlType> {
+    let ty = checked_ggml_type_i32(raw)?;
+    Ok(unsafe { ggml_get_type_traits(ty) })
+}
+
+pub(crate) fn ggml_type_name_checked(raw: i32) -> Result<*const c_char, InvalidGgmlType> {
+    let ty = checked_ggml_type_i32(raw)?;
+    Ok(unsafe { ggml_type_name(ty) })
+}
 
 pub(crate) const GGML_LSTM_GATE_ORDER_IOFC: c_int = 0;
 pub(crate) const GGML_LSTM_GATE_ORDER_IFGO: c_int = 1;
@@ -1160,4 +1253,71 @@ unsafe extern "C" {
 
     #[cfg(target_os = "macos")]
     pub(crate) fn ggml_backend_metal_init() -> GgmlBackendRaw;
+}
+
+#[cfg(test)]
+mod ggml_type_tests {
+    use std::ffi::CStr;
+
+    use super::{
+        GGML_TYPE_COUNT, InvalidGgmlType, checked_ggml_type, checked_ggml_type_i32, ggml_type_name,
+    };
+
+    #[test]
+    fn checked_ggml_type_accepts_count_minus_one() {
+        assert_eq!(
+            checked_ggml_type((GGML_TYPE_COUNT - 1) as u32),
+            Ok(GGML_TYPE_COUNT - 1)
+        );
+        assert_eq!(
+            checked_ggml_type_i32(GGML_TYPE_COUNT - 1),
+            Ok(GGML_TYPE_COUNT - 1)
+        );
+    }
+
+    #[test]
+    fn checked_ggml_type_rejects_count_and_u32_max() {
+        assert_eq!(
+            checked_ggml_type(GGML_TYPE_COUNT as u32),
+            Err(InvalidGgmlType {
+                raw: i64::from(GGML_TYPE_COUNT)
+            })
+        );
+        assert_eq!(
+            checked_ggml_type(u32::MAX),
+            Err(InvalidGgmlType {
+                raw: i64::from(u32::MAX)
+            })
+        );
+        assert_eq!(
+            checked_ggml_type_i32(GGML_TYPE_COUNT),
+            Err(InvalidGgmlType {
+                raw: i64::from(GGML_TYPE_COUNT)
+            })
+        );
+        assert_eq!(checked_ggml_type_i32(-1), Err(InvalidGgmlType { raw: -1 }));
+    }
+
+    #[test]
+    fn checked_ggml_type_rejects_retired_slots() {
+        assert_eq!(checked_ggml_type_i32(4), Err(InvalidGgmlType { raw: 4 }));
+        assert_eq!(checked_ggml_type_i32(31), Err(InvalidGgmlType { raw: 31 }));
+        assert!(checked_ggml_type(4).is_err());
+        assert!(checked_ggml_type(31).is_err());
+    }
+
+    #[test]
+    fn checked_ggml_type_matches_vendored_count() {
+        let name_ptr = unsafe { ggml_type_name(GGML_TYPE_COUNT - 1) };
+        assert!(
+            !name_ptr.is_null(),
+            "ggml_type_name(COUNT-1) must name a live type"
+        );
+        let name = unsafe { CStr::from_ptr(name_ptr) }.to_string_lossy();
+        let upper = name.to_ascii_uppercase();
+        assert!(
+            !upper.contains("REMOVED") && !upper.contains("DEPRECATED"),
+            "ggml_type_name(COUNT-1) was {name:?}"
+        );
+    }
 }

--- a/crates/openasr-core/src/ggml_runtime/gguf_tensor_data.rs
+++ b/crates/openasr-core/src/ggml_runtime/gguf_tensor_data.rs
@@ -500,7 +500,15 @@ impl GgufTensorDataReader {
                 dim_index: 0,
                 dim_value: ne0,
             })?;
-        let block_size = unsafe { ffi::ggml_blck_size(payload.metadata.ggml_type) };
+        let ggml_type =
+            ffi::checked_ggml_type_i32(payload.metadata.ggml_type).map_err(|error| {
+                GgufTensorDataReadError::InvalidGgmlType {
+                    path: self.tensor_index.path().to_path_buf(),
+                    tensor_name: payload.metadata.name.clone(),
+                    ggml_type: error.raw,
+                }
+            })?;
+        let block_size = unsafe { ffi::ggml_blck_size(ggml_type) };
         if block_size <= 0 {
             return Err(
                 GgufTensorDataReadError::TensorTypeUnsupportedForWeightMaterialization {
@@ -527,7 +535,7 @@ impl GgufTensorDataReader {
                 actual_bytes: ne0,
             });
         }
-        let row_size = unsafe { ffi::ggml_row_size(payload.metadata.ggml_type, ne0_i64) };
+        let row_size = unsafe { ffi::ggml_row_size(ggml_type, ne0_i64) };
         let rows = payload
             .metadata
             .dims
@@ -563,7 +571,14 @@ impl GgufTensorDataReader {
             });
         }
 
-        let traits_ptr = unsafe { ffi::ggml_get_type_traits(payload.metadata.ggml_type) };
+        let traits_ptr = ffi::ggml_get_type_traits_checked(ggml_type).map_err(|_| {
+            GgufTensorDataReadError::TensorTypeUnsupportedForWeightMaterialization {
+                path: self.tensor_index.path().to_path_buf(),
+                tensor_name: payload.metadata.name.clone(),
+                ggml_type: payload.metadata.ggml_type,
+                type_name: payload.metadata.type_name.clone(),
+            }
+        })?;
         if traits_ptr.is_null() {
             return Err(
                 GgufTensorDataReadError::TensorTypeUnsupportedForWeightMaterialization {
@@ -624,7 +639,7 @@ impl GgufTensorDataReader {
         let (element_type, element_size_bytes) = match payload.metadata.ggml_type {
             GGML_TYPE_F32 => (GgufWeightTensorElementType::F32, 4_u64),
             GGML_TYPE_F16 => (GgufWeightTensorElementType::F16, 2_u64),
-            ggml_type if unsafe { ffi::ggml_is_quantized(ggml_type) } => {
+            ggml_type if ffi::ggml_is_quantized_checked(ggml_type) == Ok(true) => {
                 (GgufWeightTensorElementType::RawGgml { ggml_type }, 0_u64)
             }
             _ => {
@@ -765,7 +780,7 @@ pub struct GgufHostTensorPayload<'a> {
 /// tensor into per-row spans without re-opening the reader.
 pub(crate) fn ggml_row_size_bytes(ggml_type: i32, ne0: usize) -> Option<usize> {
     let ne0_i64 = i64::try_from(ne0).ok()?;
-    Some(unsafe { ffi::ggml_row_size(ggml_type, ne0_i64) })
+    ffi::ggml_row_size_checked(ggml_type, ne0_i64).ok()
 }
 
 /// Dequantize one typed/quantized ggml row -- `row_bytes` must be exactly
@@ -779,6 +794,11 @@ pub(crate) fn dequantize_ggml_row_to_f32(
     ne0: usize,
     out: &mut Vec<f32>,
 ) -> Result<(), GgufQuantizedRowDequantizeError> {
+    let ggml_type = ffi::checked_ggml_type_i32(ggml_type).map_err(|error| {
+        GgufQuantizedRowDequantizeError::InvalidGgmlType {
+            ggml_type: error.raw,
+        }
+    })?;
     let ne0_i64 =
         i64::try_from(ne0).map_err(|_| GgufQuantizedRowDequantizeError::Ne0Overflow { ne0 })?;
     let row_size = unsafe { ffi::ggml_row_size(ggml_type, ne0_i64) };
@@ -789,7 +809,8 @@ pub(crate) fn dequantize_ggml_row_to_f32(
             actual: row_bytes.len(),
         });
     }
-    let traits_ptr = unsafe { ffi::ggml_get_type_traits(ggml_type) };
+    let traits_ptr = ffi::ggml_get_type_traits_checked(ggml_type)
+        .map_err(|_| GgufQuantizedRowDequantizeError::UnsupportedType { ggml_type })?;
     if traits_ptr.is_null() {
         return Err(GgufQuantizedRowDequantizeError::UnsupportedType { ggml_type });
     }
@@ -825,6 +846,8 @@ pub(crate) enum GgufQuantizedRowDequantizeError {
     Ne0Overflow { ne0: usize },
     #[error("ggml_type {ggml_type} has no to_float trait for row dequantize")]
     UnsupportedType { ggml_type: i32 },
+    #[error("ggml type {ggml_type} is outside 0..GGML_TYPE_COUNT or is a retired slot")]
+    InvalidGgmlType { ggml_type: i64 },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1118,6 +1141,12 @@ pub enum GgufTensorDataReadError {
         ggml_type: i32,
         type_name: String,
     },
+    #[error("gguf tensor '{tensor_name}' in '{path}' has invalid ggml type {ggml_type}")]
+    InvalidGgmlType {
+        path: PathBuf,
+        tensor_name: String,
+        ggml_type: i64,
+    },
     #[error(
         "gguf tensor '{tensor_name}' in '{path}' uses quantized type without row traits for raw weight materialization: ggml_type={ggml_type} ({type_name})"
     )]
@@ -1291,6 +1320,13 @@ fn checked_row_major_ggml_tensor_bytes(
             tensor_name: tensor.name.clone(),
             rank: tensor.rank(),
             max_supported_rank: GGUF_MAX_WEIGHT_TENSOR_RANK,
+        }
+    })?;
+    let ggml_type = ffi::checked_ggml_type_i32(ggml_type).map_err(|error| {
+        GgufTensorDataReadError::InvalidGgmlType {
+            path: path.to_path_buf(),
+            tensor_name: tensor.name.clone(),
+            ggml_type: error.raw,
         }
     })?;
     let ne0_i64 =

--- a/crates/openasr-core/src/ggml_runtime/gguf_tensor_index.rs
+++ b/crates/openasr-core/src/ggml_runtime/gguf_tensor_index.rs
@@ -283,6 +283,12 @@ pub enum GgufTensorIndexReadError {
         tensor_name: String,
         ggml_type: i32,
     },
+    #[error("gguf tensor '{tensor_name}' in '{path}' has invalid ggml type {ggml_type}")]
+    InvalidGgmlType {
+        path: PathBuf,
+        tensor_name: String,
+        ggml_type: i64,
+    },
     #[error(
         "gguf tensor type name for tensor '{tensor_name}' in '{path}' is not valid utf-8: {source}"
     )]
@@ -463,7 +469,14 @@ pub(crate) fn read_gguf_tensor_index_from_context(
             dims.push(dim_value as u64);
         }
 
-        let ggml_type = unsafe { ffi::gguf_get_tensor_type(context.as_ptr(), tensor_index) };
+        let raw_ggml_type = unsafe { ffi::gguf_get_tensor_type(context.as_ptr(), tensor_index) };
+        let ggml_type = ffi::checked_ggml_type_i32(raw_ggml_type).map_err(|error| {
+            GgufTensorIndexReadError::InvalidGgmlType {
+                path: path.to_path_buf(),
+                tensor_name: name.clone(),
+                ggml_type: error.raw,
+            }
+        })?;
         let type_name_ptr = unsafe { ffi::ggml_type_name(ggml_type) };
         if type_name_ptr.is_null() {
             return Err(GgufTensorIndexReadError::NullTensorTypeName {

--- a/crates/openasr-core/src/ggml_runtime/gguf_write.rs
+++ b/crates/openasr-core/src/ggml_runtime/gguf_write.rs
@@ -233,8 +233,8 @@ pub(crate) enum GgufWriteError {
         expected: u64,
         actual: u64,
     },
-    #[error("gguf tensor '{name}' raw ggml type {ggml_type} has an invalid row size")]
-    TensorRawTypeInvalid { name: String, ggml_type: i32 },
+    #[error("gguf tensor '{name}' has invalid ggml type {ggml_type}")]
+    InvalidGgmlType { name: String, ggml_type: i64 },
     #[error("gguf streaming writer supports alignment 32, got {alignment}")]
     StreamingAlignmentUnsupported { alignment: u64 },
 }
@@ -483,11 +483,17 @@ fn stream_tensor_nbytes(tensor: &GgufStreamTensorSpec) -> Result<u64, GgufWriteE
             name: tensor.name.clone(),
             value: tensor.dims[0],
         })?;
-    let row_size = unsafe { ffi::ggml_row_size(tensor.ggml_type, ne0) };
-    if row_size == 0 {
-        return Err(GgufWriteError::TensorRawTypeInvalid {
+    let ggml_type = ffi::checked_ggml_type_i32(tensor.ggml_type).map_err(|error| {
+        GgufWriteError::InvalidGgmlType {
             name: tensor.name.clone(),
-            ggml_type: tensor.ggml_type,
+            ggml_type: error.raw,
+        }
+    })?;
+    let row_size = unsafe { ffi::ggml_row_size(ggml_type, ne0) };
+    if row_size == 0 {
+        return Err(GgufWriteError::InvalidGgmlType {
+            name: tensor.name.clone(),
+            ggml_type: i64::from(tensor.ggml_type),
         });
     }
     let rows = tensor

--- a/crates/openasr-core/src/ggml_runtime/mod.rs
+++ b/crates/openasr-core/src/ggml_runtime/mod.rs
@@ -111,8 +111,10 @@ pub use execution_telemetry::{
 pub(crate) use execution_telemetry::{
     current_execution_telemetry_collector, install_execution_telemetry_collector,
 };
+#[cfg(test)]
+pub(crate) use ffi::{GGML_TYPE_COUNT, GGML_TYPE_Q2_0, checked_ggml_type};
 pub(crate) use ffi::{
-    GGML_TYPE_F16, GGML_TYPE_F32, GGML_TYPE_Q4_K, GGML_TYPE_Q8_0, ggml_is_quantized,
+    GGML_TYPE_F16, GGML_TYPE_F32, GGML_TYPE_Q4_K, GGML_TYPE_Q8_0, ggml_is_quantized_checked,
 };
 pub(crate) use gguf_c_parser_sandbox::load_gguf_metadata_and_tensor_index_with_c_parser_sandbox;
 pub use gguf_c_parser_sandbox::{

--- a/crates/openasr-core/src/models/mimo_asr/rvq.rs
+++ b/crates/openasr-core/src/models/mimo_asr/rvq.rs
@@ -14,7 +14,8 @@
 use thiserror::Error;
 
 use crate::ggml_runtime::{
-    GGML_TYPE_F16, GGML_TYPE_F32, GgufTensorDataReadError, GgufTensorDataReader, ggml_is_quantized,
+    GGML_TYPE_F16, GGML_TYPE_F32, GgufTensorDataReadError, GgufTensorDataReader,
+    ggml_is_quantized_checked,
 };
 
 use super::runtime_contract::MimoAudiotokMetadata;
@@ -225,10 +226,12 @@ fn materialization_extra_bytes(ggml_type: i32, elements: u64) -> Result<u64, Str
                 .ok_or_else(|| "mimo-asr RVQ F16 transient quote overflowed".to_string())?,
         )
         .map_err(|_| "mimo-asr RVQ F16 transient quote exceeds u64".to_string()),
-        other if unsafe { ggml_is_quantized(other) } => Ok(0),
-        other => Err(format!(
-            "mimo-asr RVQ codebook ggml type {other} is unsupported for host materialization"
-        )),
+        other => match ggml_is_quantized_checked(other) {
+            Ok(true) => Ok(0),
+            Ok(false) | Err(_) => Err(format!(
+                "mimo-asr RVQ codebook ggml type {other} is unsupported for host materialization"
+            )),
+        },
     }
 }
 
@@ -450,6 +453,32 @@ mod tests {
         assert!(materialization_extra_bytes(999, 10).is_err());
         let too_many = (usize::MAX as u64 / 2).saturating_add(1);
         assert!(materialization_extra_bytes(GGML_TYPE_F16, too_many).is_err());
+    }
+
+    #[test]
+    fn materialization_peak_rejects_ggml_type_count_bounds() {
+        use crate::ggml_runtime::{
+            GGML_TYPE_COUNT, GGML_TYPE_Q2_0, checked_ggml_type, ggml_is_quantized_checked,
+        };
+        assert!(
+            materialization_extra_bytes(GGML_TYPE_COUNT, 10).is_err(),
+            "GGML_TYPE_COUNT itself is outside 0..COUNT"
+        );
+        assert_eq!(
+            materialization_extra_bytes(GGML_TYPE_Q2_0, 10),
+            Ok(0),
+            "Q2_0 is a quantized type with no host transient"
+        );
+        assert_eq!(
+            ggml_is_quantized_checked(GGML_TYPE_COUNT - 1),
+            Ok(true),
+            "COUNT-1 must remain a live quantized slot in the vendored table"
+        );
+        assert!(
+            checked_ggml_type(u32::MAX).is_err(),
+            "u32::MAX cannot be a ggml type id"
+        );
+        assert!(materialization_extra_bytes(-1, 10).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #400.

## Summary
`materialization_extra_bytes(999, _)` returned `Ok` on macOS because `ggml_is_quantized(999)` indexes ggml's `type_traits[]` without a range check: an out-of-bounds read whose value happened to be truthy. The same unchecked path existed everywhere a raw GGUF/host type id reached ggml.

- New crate-private wrappers in `ggml_runtime/ffi.rs`: `checked_ggml_type{,_i32,_i64}` plus `ggml_{is_quantized,blck_size,type_size,row_size,get_type_traits,type_name}_checked`. They reject ids outside `0..GGML_TYPE_COUNT` **and** retired slots (4/5, 31-33, 36-38) whose `blck_size == 0`, which would otherwise be an integer divide-by-zero inside `ggml_row_size` in release builds.
- Every call site that received an unvalidated type id now goes through them: `rvq.rs`, `gguf_tensor_data.rs`, `gguf_tensor_index.rs`, `gguf_write.rs`, `cpu_graph.rs`. Closed enums (`kv_element`, `GgufWriteTensorType`) are untouched.
- Each error enum gains an explicit `InvalidGgmlType` variant carrying the raw id (as `i64`, so `-1` is reported as `-1`) plus tensor name / file path where available, instead of masquerading as `NullTensorTypeName` or `QuantizedTensorMissingRowTraits`.
- `GGML_TYPE_COUNT = 43` is pinned to the vendored `ggml.h` by a const assert (`GGML_TYPE_Q2_0 < COUNT`) and an FFI test that `ggml_type_name(COUNT-1)` is a live, non-retired name; the constant's comment documents the upgrade check.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy -p openasr-core --all-targets -- -D warnings`
- [x] `cargo nextest run -p openasr-core ggml_runtime` (387 passed), `rvq` (9 passed, previously red test now green)
- [x] `cargo test -p openasr-core golden_diff`
- [x] New tests: COUNT / COUNT-1 / u32::MAX / -1 bounds; retired slots 4 and 31 rejected; vendored count check
- [x] Independent review confirmed all non-retired types (I8..F64, BF16, all quant blocks) have `blck_size >= 1`, so the retired-slot check cannot reject a legal type

AI usage disclosure: YES

Made with [Cursor](https://cursor.com)