### PR TITLE
test(core): make pull retry/backoff predicates testable without real sleeps (#401)

### DIFF
--- a/crates/openasr-core/src/pull.rs
+++ b/crates/openasr-core/src/pull.rs
@@ -371,7 +371,7 @@ struct PullPaths {
     lock_path: PathBuf,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 struct PullOptions {
     available_space_override: Option<u64>,
     low_speed_timeout: Duration,
@@ -392,6 +392,10 @@ struct PullOptions {
     /// instead of needing real multi-hundred-MB bodies. `None` in
     /// production, always -- the real segment size is the fixed constant.
     parallel_segment_bytes_override: Option<u64>,
+    /// Clock and sleeper for retry backoff and low-speed windows.
+    /// [`PullOptions::default`] is always the wall clock so a `cfg(test)`
+    /// slip cannot silently busy-poll production retries.
+    time: Arc<dyn PullTime>,
 }
 
 impl PullOptions {
@@ -405,8 +409,130 @@ impl PullOptions {
             segment_low_speed_absolute_floor_bytes: SEGMENT_LOW_SPEED_ABSOLUTE_FLOOR_BYTES,
             segment_low_speed_cooldown: SEGMENT_LOW_SPEED_COOLDOWN,
             parallel_segment_bytes_override: None,
+            time: Arc::new(WallClock),
         }
     }
+
+    /// Test constructor: same knobs as production, but backoff/sleep is a
+    /// no-op so retry loops finish without waiting on the wall clock.
+    #[cfg(test)]
+    fn for_tests() -> Self {
+        Self {
+            time: Arc::new(ImmediateClock),
+            ..Self::default()
+        }
+    }
+}
+
+/// Side effects the downloader needs for retry/backoff and low-speed windows.
+///
+/// No crate-level `Clock`/`Sleep` trait exists today (see the pull testability
+/// audit); this is the single injection point so production keeps the wall
+/// clock while tests can make backoff return immediately.
+trait PullTime: Send + Sync + std::fmt::Debug {
+    fn now(&self) -> Instant;
+    fn sleep(&self, duration: Duration);
+}
+
+#[derive(Debug)]
+struct WallClock;
+
+impl PullTime for WallClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+
+    fn sleep(&self, duration: Duration) {
+        if !duration.is_zero() {
+            std::thread::sleep(duration);
+        }
+    }
+}
+
+/// Test clock: `sleep` is a no-op so retry/backoff cannot burn real time.
+/// `now` still reads the wall clock, matching existing `Duration::ZERO`
+/// low-speed tests that judge a window on the first `observe` call.
+#[cfg(test)]
+#[derive(Debug)]
+struct ImmediateClock;
+
+#[cfg(test)]
+impl PullTime for ImmediateClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+
+    fn sleep(&self, _duration: Duration) {}
+}
+
+/// Test clock whose `sleep` advances `now` without waiting. Use when a
+/// test must cross a non-zero timeout/cooldown without `Duration::ZERO`.
+#[cfg(test)]
+#[derive(Debug)]
+struct VirtualClock {
+    origin: Instant,
+    offset_millis: AtomicUsize,
+}
+
+#[cfg(test)]
+impl VirtualClock {
+    fn new() -> Self {
+        Self {
+            origin: Instant::now(),
+            offset_millis: AtomicUsize::new(0),
+        }
+    }
+
+    fn advance(&self, duration: Duration) {
+        let millis = usize::try_from(duration.as_millis()).unwrap_or(usize::MAX);
+        self.offset_millis.fetch_add(millis, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+impl PullTime for VirtualClock {
+    fn now(&self) -> Instant {
+        self.origin + Duration::from_millis(self.offset_millis.load(Ordering::SeqCst) as u64)
+    }
+
+    fn sleep(&self, duration: Duration) {
+        self.advance(duration);
+    }
+}
+
+/// Test clock that records each `sleep` duration without waiting, so a
+/// retry test can assert the exact backoff sequence and kill a no-op
+/// `sleep_backoff` mutant.
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct RecordingClock {
+    sleeps: Mutex<Vec<Duration>>,
+}
+
+#[cfg(test)]
+impl RecordingClock {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn sleeps(&self) -> Vec<Duration> {
+        self.sleeps.lock().unwrap().clone()
+    }
+}
+
+#[cfg(test)]
+impl PullTime for RecordingClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+
+    fn sleep(&self, duration: Duration) {
+        self.sleeps.lock().unwrap().push(duration);
+    }
+}
+
+fn sleep_backoff(time: &dyn PullTime, attempt: usize) {
+    time.sleep(retry_backoff(attempt));
 }
 
 /// An HTTP byte-range request bound: open-ended (`bytes=start-`) when `end`
@@ -1597,7 +1723,7 @@ fn download_with_retries<C: DownloadClient>(
                     if attempt < DOWNLOAD_MAX_RETRIES && is_retryable_download_error(&error) =>
                 {
                     attempt += 1;
-                    std::thread::sleep(retry_backoff(attempt));
+                    sleep_backoff(&*options.time, attempt);
                     continue;
                 }
                 Err(error) => return Err(error),
@@ -1635,7 +1761,7 @@ fn download_with_retries<C: DownloadClient>(
             Ok(downloaded) => return Ok(downloaded),
             Err(error) if attempt < DOWNLOAD_MAX_RETRIES && is_retryable_download_error(&error) => {
                 attempt += 1;
-                std::thread::sleep(retry_backoff(attempt));
+                sleep_backoff(&*options.time, attempt);
             }
             Err(error) => return Err(error),
         }
@@ -1713,7 +1839,7 @@ fn download_response(
     let mut reader = response.reader;
     let mut buffer = vec![0_u8; DOWNLOAD_BUFFER_BYTES];
     let mut next_meta_write = bytes_done.saturating_add(METADATA_WRITE_INTERVAL_BYTES);
-    let mut low_speed = LowSpeedWindow::new();
+    let mut low_speed = LowSpeedWindow::new(options);
     loop {
         if should_cancel() {
             cleanup_partial(paths);
@@ -1751,13 +1877,7 @@ fn download_response(
             bytes_done,
             bytes_total: target.size_bytes,
         });
-        low_speed.observe(
-            &target.url,
-            target.size_bytes,
-            bytes_done,
-            read as u64,
-            options,
-        )?;
+        low_speed.observe(&target.url, target.size_bytes, bytes_done, read as u64)?;
         if bytes_done >= next_meta_write {
             write_partial_meta(
                 &paths.partial_meta_path,
@@ -2526,6 +2646,7 @@ enum SegmentEvent {
 /// condition -- it means "this connection is bad, get a new one" -- so it is
 /// handled by `run_segment_worker` requeuing the segment instead of by
 /// `fetch_segment_with_retries`'s same-connection retry loop.
+#[derive(Debug)]
 enum SegmentFetchOutcome {
     Done,
     /// Aborted mid-segment by cancel/pause; no event needed, the
@@ -2691,7 +2812,7 @@ fn fetch_segment_with_retries(
             Ok(outcome) => return Ok(outcome),
             Err(error) if attempt < SEGMENT_MAX_RETRIES && is_retryable_download_error(&error) => {
                 attempt += 1;
-                std::thread::sleep(retry_backoff(attempt));
+                sleep_backoff(&*options.time, attempt);
             }
             Err(error) => return Err(error),
         }
@@ -3441,47 +3562,54 @@ impl Read for StallGuardedReader {
 struct LowSpeedWindow {
     started_at: Instant,
     bytes_read: u64,
+    timeout: Duration,
+    min_bytes: u64,
+    time: Arc<dyn PullTime>,
 }
 
 impl LowSpeedWindow {
-    fn new() -> Self {
+    fn new(options: &PullOptions) -> Self {
         Self {
-            started_at: Instant::now(),
+            started_at: options.time.now(),
             bytes_read: 0,
+            timeout: options.low_speed_timeout,
+            min_bytes: options.low_speed_min_bytes,
+            time: options.time.clone(),
         }
     }
 
     /// Shared by the model-pack and backend-pack downloaders; only needs the
     /// URL (for the error message) and the expected total size, not a whole
-    /// `&PullTarget`.
+    /// `&PullTarget`. Thresholds and the clock are captured at construction
+    /// so `observe` cannot drift onto a different `options.time`.
     fn observe(
         &mut self,
         url: &str,
         size_bytes: u64,
         bytes_done: u64,
         bytes_read: u64,
-        options: &PullOptions,
     ) -> Result<(), PullError> {
-        if options.low_speed_min_bytes == 0 || bytes_done >= size_bytes {
+        if self.min_bytes == 0 || bytes_done >= size_bytes {
             return Ok(());
         }
         self.bytes_read = self.bytes_read.saturating_add(bytes_read);
-        let elapsed = self.started_at.elapsed();
-        if elapsed < options.low_speed_timeout {
+        let now = self.time.now();
+        let elapsed = now.saturating_duration_since(self.started_at);
+        if elapsed < self.timeout {
             return Ok(());
         }
-        if self.bytes_read < options.low_speed_min_bytes {
+        if self.bytes_read < self.min_bytes {
             return Err(PullError::Http {
                 url: url.to_string(),
                 message: format!(
                     "download stalled: received {} bytes in {:.1}s, below the {} byte minimum",
                     self.bytes_read,
                     elapsed.as_secs_f64(),
-                    options.low_speed_min_bytes
+                    self.min_bytes
                 ),
             });
         }
-        self.started_at = Instant::now();
+        self.started_at = now;
         self.bytes_read = 0;
         Ok(())
     }
@@ -3519,6 +3647,7 @@ struct SegmentLowSpeedWindow<'a> {
     relative_ratio: f64,
     absolute_floor_bytes: u64,
     cooldown: Duration,
+    time: Arc<dyn PullTime>,
     /// Set once this segment index has already been abandoned
     /// `SEGMENT_MAX_RETRIES` times: this attempt is its last chance, so
     /// evaluation is skipped entirely and it's simply allowed to finish
@@ -3534,7 +3663,7 @@ impl<'a> SegmentLowSpeedWindow<'a> {
         disabled: bool,
     ) -> Self {
         Self {
-            started_at: Instant::now(),
+            started_at: options.time.now(),
             bytes_read: 0,
             timeout: options.segment_low_speed_timeout,
             reference,
@@ -3542,6 +3671,7 @@ impl<'a> SegmentLowSpeedWindow<'a> {
             relative_ratio: options.segment_low_speed_relative_ratio,
             absolute_floor_bytes: options.segment_low_speed_absolute_floor_bytes,
             cooldown: options.segment_low_speed_cooldown,
+            time: options.time.clone(),
             disabled,
         }
     }
@@ -3566,11 +3696,12 @@ impl<'a> SegmentLowSpeedWindow<'a> {
             return false;
         }
         self.bytes_read = self.bytes_read.saturating_add(bytes_read);
-        if self.started_at.elapsed() < self.timeout {
+        let now = self.time.now();
+        if now.saturating_duration_since(self.started_at) < self.timeout {
             return false;
         }
         let window_bytes = self.bytes_read;
-        self.started_at = Instant::now();
+        self.started_at = now;
         self.bytes_read = 0;
         // Compare against the reference as it stood *before* this window is
         // folded in, so a slow window never gets to (even slightly) pull
@@ -3586,9 +3717,9 @@ impl<'a> SegmentLowSpeedWindow<'a> {
             return false;
         }
         let mut cooldown_slot = self.cooldown_slot.lock().unwrap();
-        let now = Instant::now();
+        let now = self.time.now();
         if let Some(last_trip) = *cooldown_slot
-            && now.duration_since(last_trip) < self.cooldown
+            && now.saturating_duration_since(last_trip) < self.cooldown
         {
             return false; // still cooling down from the last trip
         }
@@ -5383,9 +5514,19 @@ fn ensure_backend_content_object<C: DownloadClient>(
     home: &Path,
     progress: &mut impl FnMut(PullProgress),
     parallel: Option<&ParallelDownloadConfig>,
+    options: &PullOptions,
 ) -> Result<BackendContentObject, PullError> {
     let objects_root = home.join("backends").join("_objects");
-    ensure_backend_content_object_in(client, file, &objects_root, None, None, progress, parallel)
+    ensure_backend_content_object_in(
+        client,
+        file,
+        &objects_root,
+        None,
+        None,
+        progress,
+        parallel,
+        options,
+    )
 }
 
 fn ensure_backend_content_object_in<C: DownloadClient>(
@@ -5396,6 +5537,7 @@ fn ensure_backend_content_object_in<C: DownloadClient>(
     expected_unpacked_size_bytes: Option<u64>,
     progress: &mut impl FnMut(PullProgress),
     parallel: Option<&ParallelDownloadConfig>,
+    options: &PullOptions,
 ) -> Result<BackendContentObject, PullError> {
     fs::create_dir_all(objects_root).map_err(|source| PullError::Io {
         path: objects_root.to_path_buf(),
@@ -5427,9 +5569,10 @@ fn ensure_backend_content_object_in<C: DownloadClient>(
                 &source_path,
                 progress,
                 parallel,
+                options,
             )?;
         } else {
-            download_backend_file(client, file, &source_path, progress, parallel)?;
+            download_backend_file(client, file, &source_path, progress, parallel, options)?;
         }
     }
     preflight_backend_file(&source_path, backend_file_format(file.role)?)?;
@@ -5795,7 +5938,14 @@ pub fn install_backend_pack(
         factory: &factory,
     };
     let _store_lock = BackendStoreMutationLock::acquire(home)?;
-    install_backend_pack_with_client_locked(resolved, home, &mut client, progress, Some(&parallel))
+    install_backend_pack_with_client_locked(
+        resolved,
+        home,
+        &mut client,
+        progress,
+        Some(&parallel),
+        &PullOptions::default(),
+    )
 }
 
 /// Installs one resolved pack while the caller holds the backend-store
@@ -5816,7 +5966,14 @@ pub(crate) fn install_backend_pack_locked(
         connections: pull_connections_from_env(),
         factory: &factory,
     };
-    install_backend_pack_with_client_locked(resolved, home, &mut client, progress, Some(&parallel))
+    install_backend_pack_with_client_locked(
+        resolved,
+        home,
+        &mut client,
+        progress,
+        Some(&parallel),
+        &PullOptions::default(),
+    )
 }
 
 /// Install one already-resolved signed pack from a local file or folder,
@@ -5861,7 +6018,14 @@ pub fn install_backend_pack_from_local_path(
     }
     let mut client = LocalFileClient { files_by_url };
     let _store_lock = BackendStoreMutationLock::acquire(home)?;
-    install_backend_pack_with_client_locked(resolved, home, &mut client, progress, None)
+    install_backend_pack_with_client_locked(
+        resolved,
+        home,
+        &mut client,
+        progress,
+        None,
+        &PullOptions::default(),
+    )
 }
 
 fn index_local_backend_import_urls(
@@ -6110,11 +6274,13 @@ pub(crate) fn prepare_qualification_release_artifacts(
 
     let manifest = verified.manifest();
     let mut client = HttpDownloadClient::new()?;
+    let options = PullOptions::default();
     let binary_bundle = prepare_qualification_archive(
         &mut client,
         &manifest.artifacts.binary.bundle,
         &objects_root,
         &mut progress,
+        &options,
     )?;
     let plugin = manifest
         .artifacts
@@ -6128,6 +6294,7 @@ pub(crate) fn prepare_qualification_release_artifacts(
                 &locks_root,
                 Some(BackendFileFormat::NativeLibrary),
                 &mut progress,
+                &options,
             )
         })
         .transpose()?;
@@ -6136,7 +6303,13 @@ pub(crate) fn prepare_qualification_release_artifacts(
         .vendor
         .iter()
         .map(|artifact| {
-            prepare_qualification_archive(&mut client, artifact, &objects_root, &mut progress)
+            prepare_qualification_archive(
+                &mut client,
+                artifact,
+                &objects_root,
+                &mut progress,
+                &options,
+            )
         })
         .collect::<Result<Vec<_>, _>>()?;
     let attestation_bundle = prepare_qualification_direct_file(
@@ -6146,6 +6319,7 @@ pub(crate) fn prepare_qualification_release_artifacts(
         &locks_root,
         None,
         &mut progress,
+        &options,
     )?;
     Ok(PreparedQualificationArtifacts {
         artifact_root,
@@ -6196,6 +6370,7 @@ fn prepare_qualification_direct_file<C: DownloadClient>(
     locks_root: &Path,
     preflight: Option<BackendFileFormat>,
     progress: &mut impl FnMut(PullProgress),
+    options: &PullOptions,
 ) -> Result<PreparedQualificationFile, PullError> {
     let format_role = match artifact.format {
         QualificationArtifactFormat::NativeLibrary => CatalogBackendFileRole::Plugin,
@@ -6214,7 +6389,15 @@ fn prepare_qualification_direct_file<C: DownloadClient>(
     let lock_path = locks_root.join(format!("{}.lock", artifact.sha256));
     let _lock = BackendInstallLock::acquire(&lock_path)?;
     let path = digest_dir.join(&artifact.file_name);
-    download_backend_file_from_signed_urls(client, &file, &artifact.urls, &path, progress, None)?;
+    download_backend_file_from_signed_urls(
+        client,
+        &file,
+        &artifact.urls,
+        &path,
+        progress,
+        None,
+        options,
+    )?;
     reject_qualification_file_links(&path)?;
     if let Some(format) = preflight {
         preflight_backend_file(&path, format)?;
@@ -6231,6 +6414,7 @@ fn prepare_qualification_archive<C: DownloadClient>(
     artifact: &QualificationArtifact,
     objects_root: &Path,
     progress: &mut impl FnMut(PullProgress),
+    options: &PullOptions,
 ) -> Result<PreparedQualificationArchive, PullError> {
     let file = qualification_catalog_file(
         artifact,
@@ -6252,6 +6436,7 @@ fn prepare_qualification_archive<C: DownloadClient>(
         Some(expected_unpacked_size_bytes),
         progress,
         None,
+        options,
     )?;
     let object_dir = backend_content_object_dir_in(objects_root, &file);
     let source_path = object_dir.join("source").join(&artifact.file_name);
@@ -6323,6 +6508,7 @@ pub(crate) fn prepare_backend_runtime_objects_locked(
                     home,
                     &mut progress,
                     Some(&parallel),
+                    &PullOptions::default(),
                 )?;
                 let payload = backend_content_object_dir(home, file).join("payload");
                 for materialized in &object.files {
@@ -6400,7 +6586,14 @@ fn prepare_backend_runtime_objects_with_client<C: DownloadClient>(
         match file.role {
             CatalogBackendFileRole::Runtime | CatalogBackendFileRole::Archive => {
                 saw_runtime = true;
-                let object = ensure_backend_content_object(client, file, home, progress, None)?;
+                let object = ensure_backend_content_object(
+                    client,
+                    file,
+                    home,
+                    progress,
+                    None,
+                    &PullOptions::default(),
+                )?;
                 let payload = backend_content_object_dir(home, file).join("payload");
                 for materialized in &object.files {
                     let relative = Path::new(&materialized.relative_path);
@@ -6444,7 +6637,14 @@ fn install_backend_pack_with_client<C: DownloadClient>(
 ) -> Result<InstalledBackend, PullError> {
     ensure_backend_cli_version_for_install(resolved)?;
     let _store_lock = BackendStoreMutationLock::acquire(home)?;
-    install_backend_pack_with_client_locked(resolved, home, client, progress, None)
+    install_backend_pack_with_client_locked(
+        resolved,
+        home,
+        client,
+        progress,
+        None,
+        &PullOptions::for_tests(),
+    )
 }
 
 fn ensure_backend_cli_version_for_install(
@@ -6470,6 +6670,7 @@ fn install_backend_pack_with_client_locked<C: DownloadClient>(
     client: &mut C,
     mut progress: impl FnMut(PullProgress),
     parallel: Option<&ParallelDownloadConfig>,
+    options: &PullOptions,
 ) -> Result<InstalledBackend, PullError> {
     ensure_backend_cli_version_for_install(resolved)?;
     let vendor = backend_vendor_dirname(resolved.vendor)?;
@@ -6516,7 +6717,7 @@ fn install_backend_pack_with_client_locked<C: DownloadClient>(
         let materialized_files = match file.role {
             CatalogBackendFileRole::Plugin => {
                 let dest = staging_dir.join(&file.filename);
-                download_backend_file(client, file, &dest, &mut progress, parallel)?;
+                download_backend_file(client, file, &dest, &mut progress, parallel, options)?;
                 preflight_backend_file(&dest, backend_file_format(file.role)?)?;
                 vec![InstalledBackendMaterializedFile {
                     relative_path: file.filename.clone(),
@@ -6525,8 +6726,14 @@ fn install_backend_pack_with_client_locked<C: DownloadClient>(
                 }]
             }
             CatalogBackendFileRole::Runtime | CatalogBackendFileRole::Archive => {
-                let object =
-                    ensure_backend_content_object(client, file, home, &mut progress, parallel)?;
+                let object = ensure_backend_content_object(
+                    client,
+                    file,
+                    home,
+                    &mut progress,
+                    parallel,
+                    options,
+                )?;
                 materialize_backend_content_object(home, &staging_dir, file, &object)?
             }
             CatalogBackendFileRole::Unknown => {
@@ -6576,14 +6783,17 @@ fn is_transient_lock_error(error: &io::Error) -> bool {
     }
 }
 
-fn retry_transient_io<T>(mut op: impl FnMut() -> io::Result<T>) -> io::Result<T> {
+fn retry_transient_io<T>(
+    time: &dyn PullTime,
+    mut op: impl FnMut() -> io::Result<T>,
+) -> io::Result<T> {
     const DELAYS_MS: [u64; 6] = [200, 400, 800, 1600, 3200, 6400];
     let mut attempt = 0usize;
     loop {
         match op() {
             Ok(value) => return Ok(value),
             Err(error) if attempt < DELAYS_MS.len() && is_transient_lock_error(&error) => {
-                std::thread::sleep(Duration::from_millis(DELAYS_MS[attempt]));
+                time.sleep(Duration::from_millis(DELAYS_MS[attempt]));
                 attempt += 1;
             }
             Err(error) => return Err(error),
@@ -6591,18 +6801,18 @@ fn retry_transient_io<T>(mut op: impl FnMut() -> io::Result<T>) -> io::Result<T>
     }
 }
 
-fn copy_dir_all_retry(from: &Path, to: &Path) -> io::Result<()> {
-    retry_transient_io(|| fs::create_dir_all(to))?;
-    for entry in retry_transient_io(|| fs::read_dir(from))? {
+fn copy_dir_all_retry(time: &dyn PullTime, from: &Path, to: &Path) -> io::Result<()> {
+    retry_transient_io(time, || fs::create_dir_all(to))?;
+    for entry in retry_transient_io(time, || fs::read_dir(from))? {
         let entry = entry?;
         let source = entry.path();
         reject_symlink(&source).map_err(|error| io::Error::other(error.to_string()))?;
         let destination = to.join(entry.file_name());
-        let file_type = retry_transient_io(|| entry.file_type())?;
+        let file_type = retry_transient_io(time, || entry.file_type())?;
         if file_type.is_dir() {
-            copy_dir_all_retry(&source, &destination)?;
+            copy_dir_all_retry(time, &source, &destination)?;
         } else if file_type.is_file() {
-            retry_transient_io(|| {
+            retry_transient_io(time, || {
                 fs::copy(&source, &destination)?;
                 Ok(())
             })?;
@@ -6647,6 +6857,7 @@ fn promote_backend_directory(
         fingerprint,
         fs_rename,
         fs_remove_dir_all,
+        &WallClock,
     )
 }
 
@@ -6656,14 +6867,17 @@ fn promote_backend_directory_with(
     fingerprint: &str,
     rename: impl Fn(&Path, &Path) -> io::Result<()>,
     remove_dir_all: impl Fn(&Path) -> io::Result<()>,
+    time: &dyn PullTime,
 ) -> Result<(), PullError> {
     let final_parent = final_dir.parent().ok_or_else(|| PullError::InvalidTarget {
         field: "backend install path",
         reason: "final backend directory has no parent".to_string(),
     })?;
-    retry_transient_io(|| fs::create_dir_all(final_parent)).map_err(|source| PullError::Io {
-        path: final_parent.to_path_buf(),
-        source,
+    retry_transient_io(time, || fs::create_dir_all(final_parent)).map_err(|source| {
+        PullError::Io {
+            path: final_parent.to_path_buf(),
+            source,
+        }
     })?;
     let displaced = staging_dir
         .parent()
@@ -6671,22 +6885,24 @@ fn promote_backend_directory_with(
         .join(format!(".replaced-{fingerprint}-{}", unix_seconds_now()));
     let had_previous = final_dir.exists();
     if had_previous {
-        retry_transient_io(|| rename(final_dir, &displaced)).map_err(|source| PullError::Io {
-            path: final_dir.to_path_buf(),
-            source,
+        retry_transient_io(time, || rename(final_dir, &displaced)).map_err(|source| {
+            PullError::Io {
+                path: final_dir.to_path_buf(),
+                source,
+            }
         })?;
     }
-    match retry_transient_io(|| rename(staging_dir, final_dir)) {
+    match retry_transient_io(time, || rename(staging_dir, final_dir)) {
         Ok(()) => {}
         Err(source) if is_transient_lock_error(&source) => {
-            if let Err(copy_error) = copy_dir_all_retry(staging_dir, final_dir) {
-                let _ = retry_transient_io(|| remove_dir_all(final_dir));
+            if let Err(copy_error) = copy_dir_all_retry(time, staging_dir, final_dir) {
+                let _ = retry_transient_io(time, || remove_dir_all(final_dir));
                 if had_previous {
                     let _ = rename(&displaced, final_dir);
                 }
                 return Err(lock_exhausted_io(final_dir.to_path_buf(), copy_error));
             }
-            let _ = retry_transient_io(|| remove_dir_all(staging_dir));
+            let _ = retry_transient_io(time, || remove_dir_all(staging_dir));
         }
         Err(source) => {
             if had_previous {
@@ -6699,7 +6915,7 @@ fn promote_backend_directory_with(
         }
     }
     if had_previous {
-        let _ = retry_transient_io(|| remove_dir_all(&displaced));
+        let _ = retry_transient_io(time, || remove_dir_all(&displaced));
     }
     Ok(())
 }
@@ -7242,6 +7458,7 @@ fn download_backend_file_via_pull<C: DownloadClient>(
     dest: &Path,
     progress: &mut impl FnMut(PullProgress),
     parallel: Option<&ParallelDownloadConfig>,
+    options: &PullOptions,
 ) -> Result<(), PullError> {
     let target = PullTarget::for_backend_file(file)?;
     ensure_https_url(&target.url)?;
@@ -7250,7 +7467,7 @@ fn download_backend_file_via_pull<C: DownloadClient>(
         &target,
         &paths,
         client,
-        PullOptions::default(),
+        options.clone(),
         parallel,
         progress,
         &|| false,
@@ -7298,6 +7515,7 @@ fn download_backend_file_from_signed_urls<C: DownloadClient>(
     dest: &Path,
     progress: &mut impl FnMut(PullProgress),
     parallel: Option<&ParallelDownloadConfig>,
+    options: &PullOptions,
 ) -> Result<(), PullError> {
     let urls = expand_artifact_fetch_urls(urls);
     if urls.is_empty() {
@@ -7314,7 +7532,7 @@ fn download_backend_file_from_signed_urls<C: DownloadClient>(
         }
         let mut candidate = file.clone();
         candidate.url.clone_from(url);
-        match download_backend_file_once(client, &candidate, dest, progress, parallel) {
+        match download_backend_file_once(client, &candidate, dest, progress, parallel, options) {
             Ok(()) => return Ok(()),
             Err(error) if is_source_fallback_error(&error) => {
                 last_error = Some(error);
@@ -7343,6 +7561,7 @@ fn download_backend_file<C: DownloadClient>(
     dest: &Path,
     progress: &mut impl FnMut(PullProgress),
     parallel: Option<&ParallelDownloadConfig>,
+    options: &PullOptions,
 ) -> Result<(), PullError> {
     if backend_file_matches(dest, file) {
         return Ok(());
@@ -7358,6 +7577,7 @@ fn download_backend_file<C: DownloadClient>(
         dest,
         progress,
         parallel,
+        options,
     )
 }
 
@@ -7367,12 +7587,20 @@ fn download_backend_file_once<C: DownloadClient>(
     dest: &Path,
     progress: &mut impl FnMut(PullProgress),
     parallel: Option<&ParallelDownloadConfig>,
+    options: &PullOptions,
 ) -> Result<(), PullError> {
     if backend_file_matches(dest, file) {
         return Ok(());
     }
     if let Some(parallel) = parallel {
-        return download_backend_file_via_pull(client, file, dest, progress, Some(parallel));
+        return download_backend_file_via_pull(
+            client,
+            file,
+            dest,
+            progress,
+            Some(parallel),
+            options,
+        );
     }
     // The parent pack/object directory is already keyed by the full artifact
     // digest. Keep the leaf short enough for Windows MAX_PATH-era tools while
@@ -7408,11 +7636,12 @@ fn download_backend_file_once<C: DownloadClient>(
             &partial_meta,
             &mut expected_etag,
             progress,
+            options,
         ) {
             Ok(()) => return Ok(()),
             Err(error) if attempt < DOWNLOAD_MAX_RETRIES && is_retryable_download_error(&error) => {
                 attempt += 1;
-                std::thread::sleep(retry_backoff(attempt));
+                sleep_backoff(&*options.time, attempt);
             }
             Err(error) => return Err(error),
         }
@@ -7514,6 +7743,7 @@ fn download_backend_file_attempt<C: DownloadClient>(
     partial_meta: &Path,
     expected_etag: &mut Option<String>,
     progress: &mut impl FnMut(PullProgress),
+    options: &PullOptions,
 ) -> Result<(), PullError> {
     let (resume_from, persisted_etag) =
         prepare_backend_partial_for_resume(file, partial, partial_meta)?;
@@ -7594,8 +7824,7 @@ fn download_backend_file_attempt<C: DownloadClient>(
     let mut bytes_done = actual_resume;
     write_backend_partial_meta(partial_meta, file, expected_etag.clone(), bytes_done)?;
     let mut last_meta_bytes = bytes_done;
-    let mut low_speed = LowSpeedWindow::new();
-    let low_speed_options = PullOptions::default();
+    let mut low_speed = LowSpeedWindow::new(options);
     progress(PullProgress::DownloadStarted {
         bytes_total: file.size_bytes,
         resume_from: actual_resume,
@@ -7626,13 +7855,7 @@ fn download_backend_file_attempt<C: DownloadClient>(
             bytes_done,
             bytes_total: file.size_bytes,
         });
-        low_speed.observe(
-            &file.url,
-            file.size_bytes,
-            bytes_done,
-            read as u64,
-            &low_speed_options,
-        )?;
+        low_speed.observe(&file.url, file.size_bytes, bytes_done, read as u64)?;
     }
     out.sync_all().map_err(|source| PullError::Io {
         path: partial.to_path_buf(),

--- a/crates/openasr-core/src/pull_tests.rs
+++ b/crates/openasr-core/src/pull_tests.rs
@@ -9,7 +9,7 @@ use std::{
         Arc, Barrier, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use crate::{
@@ -248,6 +248,13 @@ struct RangeServerClient {
     etags: Arc<Vec<String>>,
     calls: Arc<AtomicUsize>,
     requests: Arc<Mutex<Vec<(u64, Option<u64>)>>>,
+    /// Per-range status queue consumed before a successful 206. Used to
+    /// inject a 503 (or other) on a specific segment without depending on
+    /// worker scheduling order.
+    fail_queue: Arc<Mutex<HashMap<(u64, Option<u64>), VecDeque<u16>>>>,
+    /// Hard ceiling so an infinite segment-retry mutant panics the test
+    /// instead of spinning until cargo-mutants times out.
+    call_ceiling: Arc<AtomicUsize>,
 }
 
 impl RangeServerClient {
@@ -258,7 +265,22 @@ impl RangeServerClient {
             etags: Arc::new(vec!["etag-a".to_string()]),
             calls: Arc::new(AtomicUsize::new(0)),
             requests: Arc::new(Mutex::new(Vec::new())),
+            fail_queue: Arc::new(Mutex::new(HashMap::new())),
+            call_ceiling: Arc::new(AtomicUsize::new(64)),
         }
+    }
+
+    fn fail_range(self, start: u64, end: Option<u64>, statuses: &[u16]) -> Self {
+        self.fail_queue
+            .lock()
+            .unwrap()
+            .insert((start, end), statuses.iter().copied().collect());
+        self
+    }
+
+    fn with_call_ceiling(self, ceiling: usize) -> Self {
+        self.call_ceiling.store(ceiling, Ordering::SeqCst);
+        self
     }
 
     fn without_range_support(self) -> Self {
@@ -287,10 +309,31 @@ impl DownloadClient for RangeServerClient {
         range: Option<ByteRange>,
     ) -> Result<DownloadResponse, PullError> {
         let call_index = self.calls.fetch_add(1, Ordering::SeqCst);
-        self.requests.lock().unwrap().push((
+        let ceiling = self.call_ceiling.load(Ordering::SeqCst);
+        assert!(
+            call_index < ceiling,
+            "RangeServerClient exceeded call ceiling {ceiling} (infinite retry?)"
+        );
+        let recorded = (
             range.map(|r| r.start).unwrap_or(0),
             range.and_then(|r| r.end),
-        ));
+        );
+        self.requests.lock().unwrap().push(recorded);
+        if let Some(status) = self
+            .fail_queue
+            .lock()
+            .unwrap()
+            .get_mut(&recorded)
+            .and_then(VecDeque::pop_front)
+        {
+            return Ok(DownloadResponse {
+                status,
+                content_length: Some(0),
+                content_range: None,
+                etag: Some("etag-a".to_string()),
+                reader: Box::new(Cursor::new(Vec::new())),
+            });
+        }
         let etag = self.etags[call_index.min(self.etags.len() - 1)].clone();
         let total = self.bytes.len() as u64;
         if !self.supports_range.load(Ordering::SeqCst) || range.is_none() {
@@ -329,7 +372,7 @@ fn small_segment_bytes(total: usize, segments: u64) -> u64 {
 fn parallel_test_options(segment_bytes: u64) -> PullOptions {
     PullOptions {
         parallel_segment_bytes_override: Some(segment_bytes),
-        ..PullOptions::default()
+        ..PullOptions::for_tests()
     }
 }
 
@@ -691,7 +734,7 @@ fn pull_installs_valid_pack_and_writes_record() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |event| events.push(event),
     )
     .unwrap();
@@ -901,7 +944,7 @@ fn capability_pack_stays_pullable_and_importable_by_digest() {
         &from_catalog,
         pull_home.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -939,7 +982,7 @@ fn pull_falls_back_to_next_source_after_sha_mismatch() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         &[DownloadSource::Hf, DownloadSource::HfMirror],
         None,
         None,
@@ -982,7 +1025,7 @@ fn china_chain_tries_modelscope_before_direct_hf() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         &[DownloadSource::ModelScope, DownloadSource::Hf],
         None,
         None,
@@ -1018,7 +1061,7 @@ fn pinned_source_does_not_fallback_after_sha_mismatch() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         &[DownloadSource::Hf],
         None,
         None,
@@ -1060,7 +1103,7 @@ fn pull_does_not_fallback_after_gguf_preflight_failure() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         &[DownloadSource::Hf, DownloadSource::HfMirror],
         None,
         None,
@@ -1112,7 +1155,7 @@ fn pull_does_not_fallback_after_runtime_validation_failure() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         &[DownloadSource::Hf, DownloadSource::HfMirror],
         None,
         None,
@@ -1152,7 +1195,7 @@ fn pull_falls_back_to_hf_mirror_after_weights_404() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         &[DownloadSource::Weights, DownloadSource::HfMirror],
         None,
         None,
@@ -1195,7 +1238,7 @@ fn pull_falls_back_to_next_source_after_403_forbidden() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         &[DownloadSource::Hf, DownloadSource::HfMirror],
         None,
         None,
@@ -1235,7 +1278,7 @@ fn pull_does_not_fallback_after_400_bad_request() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         &[DownloadSource::Hf, DownloadSource::HfMirror],
         None,
         None,
@@ -1272,7 +1315,7 @@ fn pull_does_not_fallback_after_401_unauthorized() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         &[DownloadSource::Hf, DownloadSource::HfMirror],
         None,
         None,
@@ -1308,7 +1351,7 @@ fn pull_cancel_cleans_partial_download() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |event| {
             if matches!(event, PullProgress::Downloading { .. }) {
                 cancel_on_progress.store(true, Ordering::SeqCst);
@@ -1342,7 +1385,7 @@ fn pull_pause_preserves_partial_download() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |event| {
             if matches!(event, PullProgress::Downloading { .. }) {
                 pause_on_progress.store(true, Ordering::SeqCst);
@@ -1364,7 +1407,7 @@ fn pull_pause_preserves_partial_download() {
         &resolved,
         temp.path(),
         &mut resume_client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -1392,7 +1435,7 @@ fn pull_cancel_pause_race_cancel_wins_and_cleans_partial_download() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |event| {
             if !matches!(event, PullProgress::Downloading { .. }) {
                 return;
@@ -1455,7 +1498,7 @@ fn pull_resumes_partial_when_server_returns_206() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -1494,7 +1537,7 @@ fn pull_keeps_partial_when_meta_url_came_from_another_download_source() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -1526,7 +1569,7 @@ fn pull_restarts_partial_when_server_returns_200() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -1556,7 +1599,7 @@ fn pull_restarts_partial_when_content_range_does_not_match_resume() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -1591,7 +1634,7 @@ fn pull_discards_partial_when_metadata_does_not_match_target() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -1615,7 +1658,7 @@ fn pull_rejects_sha_mismatch_and_removes_partial() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap_err();
@@ -1710,7 +1753,7 @@ fn download_response_rejects_fresh_content_length_mismatch_before_reading() {
         &paths,
         0,
         response,
-        &PullOptions::default(),
+        &PullOptions::for_tests(),
         &mut progress,
         &|| false,
         &|| false,
@@ -1751,7 +1794,7 @@ fn pull_retries_server_error_and_resumes_successfully() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -1771,7 +1814,7 @@ fn pull_retries_body_read_timeout_and_restarts_safely() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -1794,7 +1837,7 @@ fn pull_retries_low_speed_body_and_restarts_safely() {
         PullOptions {
             low_speed_timeout: Duration::ZERO,
             low_speed_min_bytes: 2,
-            ..PullOptions::default()
+            ..PullOptions::for_tests()
         },
         |_| {},
     )
@@ -1814,7 +1857,7 @@ fn pull_retries_low_speed_body_and_restarts_safely() {
 fn zero_window_options() -> PullOptions {
     PullOptions {
         segment_low_speed_timeout: Duration::ZERO,
-        ..PullOptions::default()
+        ..PullOptions::for_tests()
     }
 }
 
@@ -1997,7 +2040,7 @@ fn pull_rejects_non_https_url_before_downloading() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap_err();
@@ -2018,7 +2061,7 @@ fn pull_rejects_path_traversal_target_before_downloading() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap_err();
@@ -2051,7 +2094,7 @@ fn pull_rejects_symlinked_model_storage_dir_before_downloading() {
         &resolved,
         &home,
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap_err();
@@ -2079,7 +2122,7 @@ fn pull_rejects_symlinked_quant_storage_dir_before_downloading() {
         &resolved,
         &home,
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap_err();
@@ -2103,7 +2146,7 @@ fn pull_lock_blocks_second_writer() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap_err();
@@ -2177,7 +2220,7 @@ fn pull_rejects_corrupt_gguf_before_installing() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap_err();
@@ -2321,7 +2364,7 @@ fn pull_rejects_truncated_immutable_object_without_replacing_it() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap_err();
@@ -2457,7 +2500,7 @@ fn pull_skips_download_when_installed_pack_hash_matches() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |event| first_events.push(event),
     )
     .unwrap();
@@ -2474,7 +2517,7 @@ fn pull_skips_download_when_installed_pack_hash_matches() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |event| second_events.push(event),
     )
     .unwrap();
@@ -2526,7 +2569,7 @@ fn pull_downloads_when_only_catalog_filename_is_present() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |event| events.push(event),
     )
     .unwrap();
@@ -2563,7 +2606,7 @@ fn pull_does_not_skip_download_when_unsealed_object_hash_mismatches() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     );
 
@@ -2606,7 +2649,7 @@ fn config_models_dir_redirects_pull_and_list() {
         &resolved,
         home.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -2653,7 +2696,7 @@ fn pull_checks_available_space_before_download() {
         &mut client,
         PullOptions {
             available_space_override: Some(1),
-            ..PullOptions::default()
+            ..PullOptions::for_tests()
         },
         |_| {},
     )
@@ -2729,7 +2772,7 @@ fn remove_model_pack_deletes_installed_quant() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -2756,7 +2799,7 @@ fn remove_model_pack_deletes_empty_model_dir() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -2791,9 +2834,14 @@ fn remove_model_pack_keeps_model_dir_when_sibling_quant_remains() {
         status: 200,
         body: bytes.clone(),
     }]);
-    let first =
-        pull_model_pack_with_client(&resolved, home, &mut client, PullOptions::default(), |_| {})
-            .unwrap();
+    let first = pull_model_pack_with_client(
+        &resolved,
+        home,
+        &mut client,
+        PullOptions::for_tests(),
+        |_| {},
+    )
+    .unwrap();
 
     // A second quant of the same model, published as a ref against the very
     // same object. Deduplication makes this the interesting case: removing one
@@ -2855,7 +2903,7 @@ fn resolve_installed_pack_reference_matches_quant_aliases() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -2921,7 +2969,7 @@ fn remove_model_pack_deletes_installed_quant_by_canonical_quant_alias() {
         &resolved,
         temp.path(),
         &mut client,
-        PullOptions::default(),
+        PullOptions::for_tests(),
         |_| {},
     )
     .unwrap();
@@ -3198,6 +3246,7 @@ fn qualification_archive_uses_signed_url_fallback_and_exact_unpacked_identity() 
         &artifact,
         &temp.path().join("objects"),
         &mut |_| {},
+        &PullOptions::for_tests(),
     )
     .unwrap();
 
@@ -3240,16 +3289,28 @@ fn qualification_archive_repairs_a_content_object_missing_its_attested_source() 
         status: 200,
         body: archive.clone(),
     }]);
-    let prepared =
-        prepare_qualification_archive(&mut first, &artifact, &objects_root, &mut |_| {}).unwrap();
+    let prepared = prepare_qualification_archive(
+        &mut first,
+        &artifact,
+        &objects_root,
+        &mut |_| {},
+        &PullOptions::for_tests(),
+    )
+    .unwrap();
     fs::remove_file(&prepared.source.path).unwrap();
 
     let mut repair = FakeClient::with_responses(vec![ResponseSpec {
         status: 200,
         body: archive,
     }]);
-    let repaired =
-        prepare_qualification_archive(&mut repair, &artifact, &objects_root, &mut |_| {}).unwrap();
+    let repaired = prepare_qualification_archive(
+        &mut repair,
+        &artifact,
+        &objects_root,
+        &mut |_| {},
+        &PullOptions::for_tests(),
+    )
+    .unwrap();
     assert!(repaired.source.path.is_file());
     assert_eq!(repair.urls(), vec!["https://primary.example/vendor.zip"]);
 }
@@ -3285,6 +3346,7 @@ fn qualification_archive_rejects_a_signed_unpacked_size_that_does_not_match() {
             &artifact,
             &temp.path().join("objects"),
             &mut |_| {},
+            &PullOptions::for_tests(),
         ),
         Err(PullError::BackendFilePreflight { .. })
     ));
@@ -4347,6 +4409,7 @@ fn backend_pack_resume_survives_process_boundary_metadata_reload() {
             &partial_meta,
             &mut expected_etag,
             &mut |_| {},
+            &PullOptions::for_tests(),
         )
         .is_err()
     );
@@ -4362,7 +4425,15 @@ fn backend_pack_resume_survives_process_boundary_metadata_reload() {
         attempts: 1,
         ranges: Vec::new(),
     };
-    download_backend_file(&mut replacement, file, &dest, &mut |_| {}, None).unwrap();
+    download_backend_file(
+        &mut replacement,
+        file,
+        &dest,
+        &mut |_| {},
+        None,
+        &PullOptions::for_tests(),
+    )
+    .unwrap();
     assert_eq!(replacement.ranges(), vec![Some(700)]);
     assert_eq!(fs::read(dest).unwrap(), plugin);
     assert!(!partial.exists());
@@ -5874,7 +5945,7 @@ fn model_store_lifecycle_converts_and_reclaims_a_leaking_store() {
 #[test]
 fn retry_transient_io_succeeds_on_the_first_ok() {
     let mut calls = 0;
-    let value = retry_transient_io(|| {
+    let value = retry_transient_io(&ImmediateClock, || {
         calls += 1;
         Ok::<_, io::Error>(7)
     })
@@ -5886,7 +5957,7 @@ fn retry_transient_io_succeeds_on_the_first_ok() {
 #[test]
 fn retry_transient_io_does_not_retry_a_non_transient_error() {
     let mut calls = 0;
-    let error = retry_transient_io(|| {
+    let error = retry_transient_io(&ImmediateClock, || {
         calls += 1;
         Err::<(), _>(io::Error::from_raw_os_error(1))
     })
@@ -5899,7 +5970,7 @@ fn retry_transient_io_does_not_retry_a_non_transient_error() {
 #[test]
 fn retry_transient_io_gives_up_after_the_lock_budget() {
     let mut calls = 0;
-    let error = retry_transient_io(|| {
+    let error = retry_transient_io(&ImmediateClock, || {
         calls += 1;
         Err::<(), _>(io::Error::from_raw_os_error(32))
     })
@@ -5930,6 +6001,7 @@ fn promote_backend_directory_copies_when_rename_stays_locked() {
             fs::rename(from, to)
         },
         super::fs_remove_dir_all,
+        &ImmediateClock,
     )
     .expect("locked rename must still promote by copying the readable staging tree");
 
@@ -5960,6 +6032,7 @@ fn promote_backend_directory_clears_dest_when_copy_fallback_fails() {
             fs::rename(from, to)
         },
         super::fs_remove_dir_all,
+        &ImmediateClock,
     )
     .unwrap_err();
     let message = error.to_string();
@@ -5971,5 +6044,678 @@ fn promote_backend_directory_clears_dest_when_copy_fallback_fails() {
         fs::read(dest.join("prior.dll")).unwrap(),
         b"prior",
         "the previous install must be restored after a failed copy fallback"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Predicate matrix: decision functions tested directly so a mutated retry
+// / digest / fallback / verify predicate fails immediately instead of
+// hanging on real backoff or a real socket.
+// ---------------------------------------------------------------------------
+
+fn status_error(status: u16) -> PullError {
+    PullError::UnexpectedStatus {
+        url: "https://example.invalid/pack.oasr".to_string(),
+        status,
+    }
+}
+
+fn expected_download_backoff_sequence() -> Vec<Duration> {
+    (1..=DOWNLOAD_MAX_RETRIES).map(retry_backoff).collect()
+}
+
+#[test]
+fn retry_backoff_is_injected_and_does_not_sleep_under_the_test_clock() {
+    let clock = RecordingClock::new();
+    sleep_backoff(&clock, 1);
+    sleep_backoff(&clock, 5);
+    sleep_backoff(&clock, 8);
+    assert_eq!(
+        clock.sleeps(),
+        vec![retry_backoff(1), retry_backoff(5), retry_backoff(8),]
+    );
+    assert_eq!(retry_backoff(1), Duration::from_millis(500));
+    assert_eq!(retry_backoff(5), Duration::from_millis(5_000));
+    assert_eq!(retry_backoff(8), Duration::from_millis(5_000));
+}
+
+#[test]
+fn download_error_retry_and_source_fallback_matrix() {
+    struct Case {
+        name: &'static str,
+        error: PullError,
+        retry_same_source: bool,
+        fallback_to_next_source: bool,
+    }
+    let path = PathBuf::from("/tmp/openasr-predicate-matrix");
+    let cases = [
+        Case {
+            name: "http transport",
+            error: PullError::Http {
+                url: "https://example.invalid/pack.oasr".to_string(),
+                message: "reset".to_string(),
+            },
+            retry_same_source: true,
+            fallback_to_next_source: true,
+        },
+        Case {
+            name: "io",
+            error: PullError::Io {
+                path: path.clone(),
+                source: io::Error::other("disk"),
+            },
+            retry_same_source: true,
+            fallback_to_next_source: true,
+        },
+        Case {
+            name: "5xx",
+            error: status_error(503),
+            retry_same_source: true,
+            fallback_to_next_source: true,
+        },
+        Case {
+            name: "429",
+            error: status_error(429),
+            retry_same_source: false,
+            fallback_to_next_source: true,
+        },
+        Case {
+            name: "403",
+            error: status_error(403),
+            retry_same_source: false,
+            fallback_to_next_source: true,
+        },
+        Case {
+            name: "404",
+            error: status_error(404),
+            retry_same_source: false,
+            fallback_to_next_source: true,
+        },
+        Case {
+            name: "400",
+            error: status_error(400),
+            retry_same_source: false,
+            fallback_to_next_source: false,
+        },
+        Case {
+            name: "401",
+            error: status_error(401),
+            retry_same_source: false,
+            fallback_to_next_source: false,
+        },
+        Case {
+            name: "sha mismatch",
+            error: PullError::ShaMismatch {
+                path: path.clone(),
+                expected: "aa".repeat(32),
+                actual: "bb".repeat(32),
+            },
+            retry_same_source: false,
+            fallback_to_next_source: true,
+        },
+        Case {
+            name: "gguf preflight",
+            error: PullError::GgufPreflight {
+                path: path.clone(),
+                reason: "not a pack".to_string(),
+            },
+            retry_same_source: false,
+            fallback_to_next_source: false,
+        },
+        Case {
+            name: "runtime validation",
+            error: PullError::RuntimeValidation {
+                path,
+                reason: "family mismatch".to_string(),
+            },
+            retry_same_source: false,
+            fallback_to_next_source: false,
+        },
+    ];
+    for case in cases {
+        assert_eq!(
+            is_retryable_download_error(&case.error),
+            case.retry_same_source,
+            "{}: retry-same-source",
+            case.name
+        );
+        assert_eq!(
+            is_source_fallback_error(&case.error),
+            case.fallback_to_next_source,
+            "{}: fallback-to-next-source",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn same_source_retries_5xx_then_fails_closed_when_retries_are_exhausted() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let failures = (0..=DOWNLOAD_MAX_RETRIES)
+        .map(|_| ResponseSpec {
+            status: 503,
+            body: Vec::new(),
+        })
+        .collect();
+    let mut client = FakeClient::with_responses(failures);
+    let clock = Arc::new(RecordingClock::new());
+    let options = PullOptions {
+        time: clock.clone(),
+        ..PullOptions::for_tests()
+    };
+
+    let error = pull_model_pack_with_client(&resolved, temp.path(), &mut client, options, |_| {})
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        PullError::UnexpectedStatus { status: 503, .. }
+    ));
+    assert_eq!(client.urls().len(), DOWNLOAD_MAX_RETRIES + 1);
+    assert_eq!(clock.sleeps(), expected_download_backoff_sequence());
+    assert_no_partial_or_install(&paths_for(temp.path(), &resolved));
+}
+
+#[test]
+fn same_source_does_not_retry_a_client_4xx() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let mut client = FakeClient::with_responses(vec![
+        ResponseSpec {
+            status: 400,
+            body: b"bad request".to_vec(),
+        },
+        ResponseSpec {
+            status: 200,
+            body: bytes,
+        },
+    ]);
+
+    let error = pull_model_pack_with_client(
+        &resolved,
+        temp.path(),
+        &mut client,
+        PullOptions::for_tests(),
+        |_| {},
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        PullError::UnexpectedStatus { status: 400, .. }
+    ));
+    assert_eq!(client.urls().len(), 1, "400 must not retry the same source");
+    assert_no_partial_or_install(&paths_for(temp.path(), &resolved));
+}
+
+#[test]
+fn prepare_partial_for_resume_keeps_matching_bytes_and_discards_stale_or_orphan_state() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let target = PullTarget::from_resolved(&resolved).unwrap();
+    let paths = pull_paths(temp.path(), &target).unwrap();
+    fs::create_dir_all(&paths.dir).unwrap();
+
+    assert_eq!(prepare_partial_for_resume(&target, &paths).unwrap(), 0);
+
+    let split = bytes.len() / 2;
+    fs::write(&paths.partial_path, &bytes[..split]).unwrap();
+    write_partial_meta(
+        &paths.partial_meta_path,
+        &PartialMeta::for_target(&target, Some("etag-test".to_string()), split as u64),
+    )
+    .unwrap();
+    assert_eq!(
+        prepare_partial_for_resume(&target, &paths).unwrap(),
+        split as u64
+    );
+    assert!(paths.partial_path.exists());
+
+    let mut stale = target.clone();
+    stale.sha256 = "0".repeat(64);
+    write_partial_meta(
+        &paths.partial_meta_path,
+        &PartialMeta::for_target(&stale, Some("etag-test".to_string()), split as u64),
+    )
+    .unwrap();
+    assert_eq!(prepare_partial_for_resume(&target, &paths).unwrap(), 0);
+    assert!(!paths.partial_path.exists());
+    assert!(!paths.partial_meta_path.exists());
+
+    fs::write(&paths.partial_path, &bytes[..split]).unwrap();
+    assert_eq!(prepare_partial_for_resume(&target, &paths).unwrap(), 0);
+    assert!(
+        !paths.partial_path.exists(),
+        "a partial without metadata must be discarded, not resumed"
+    );
+}
+
+#[test]
+fn installed_digest_match_skips_download_mismatch_does_not() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let target = PullTarget::from_resolved(&resolved).unwrap();
+    let paths = pull_paths(temp.path(), &target).unwrap();
+    assert!(!installed_matches(&target, &paths).unwrap());
+
+    seed_final_object(&paths, &bytes, true);
+    assert!(installed_matches(&target, &paths).unwrap());
+
+    let mut other = target.clone();
+    other.sha256 = "ab".repeat(32);
+    other.size_bytes = bytes.len() as u64;
+    assert!(!installed_matches(&other, &paths).unwrap());
+}
+
+#[test]
+fn verify_partial_and_install_rejects_unverified_bytes_and_does_not_write_a_record() {
+    let garbage = b"this is not a GGUF-backed .oasr pack".to_vec();
+    let resolved = resolved_for(&garbage);
+    let temp = tempfile::tempdir().unwrap();
+    let (target, paths) = write_complete_partial(temp.path(), &resolved, &garbage);
+
+    let error = verify_partial_and_install(
+        &target,
+        &paths,
+        Some(DownloadedPartial {
+            bytes_done: garbage.len() as u64,
+            sha256: sha256_hex(&garbage),
+        }),
+        None,
+        &|| false,
+        |_| {},
+    )
+    .unwrap_err();
+
+    assert!(
+        matches!(
+            error,
+            PullError::GgufPreflight { .. } | PullError::RuntimeValidation { .. }
+        ),
+        "unverified bytes must fail closed: {error}"
+    );
+    assert!(!paths.final_path.exists());
+    assert!(!paths.installed_meta_path.exists());
+    assert!(
+        !paths.partial_path.exists(),
+        "a failed verify must not leave installable partial bytes"
+    );
+}
+
+#[test]
+fn signed_catalog_rejects_a_pack_digest_it_does_not_list() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let mut catalog = catalog_for_resolved(&resolved);
+    catalog.models.clear();
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("unknown.oasr");
+    fs::write(&source, bytes).unwrap();
+
+    let error = resolve_catalog_model_pack_from_path(&catalog, &source).unwrap_err();
+    assert!(
+        matches!(
+            error,
+            PullError::InvalidTarget {
+                field: "sha256",
+                ..
+            }
+        ),
+        "missing catalog entry must fail closed: {error}"
+    );
+    assert!(
+        list_installed_packs(temp.path()).unwrap().is_empty(),
+        "a digest absent from the signed catalog must not install"
+    );
+}
+
+#[test]
+fn digest_match_refresh_fails_closed_when_the_install_record_cannot_be_written() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let mut client = FakeClient::with_responses(vec![ResponseSpec {
+        status: 200,
+        body: bytes.clone(),
+    }]);
+    pull_model_pack_with_client(
+        &resolved,
+        temp.path(),
+        &mut client,
+        PullOptions::for_tests(),
+        |_| {},
+    )
+    .unwrap();
+
+    let paths = paths_for(temp.path(), &resolved);
+    fs::remove_file(&paths.installed_meta_path).unwrap();
+    fs::create_dir(&paths.installed_meta_path).unwrap();
+
+    let mut client = FakeClient::default();
+    let error = pull_model_pack_with_client(
+        &resolved,
+        temp.path(),
+        &mut client,
+        PullOptions::for_tests(),
+        |_| {},
+    )
+    .unwrap_err();
+
+    assert!(
+        client.urls().is_empty(),
+        "digest match must not re-enter the download path"
+    );
+    assert!(
+        matches!(error, PullError::Io { .. }),
+        "a record write failure must fail closed: {error}"
+    );
+}
+
+#[test]
+fn virtual_clock_trips_low_speed_without_waiting_and_releases_segment_cooldown() {
+    let clock = Arc::new(VirtualClock::new());
+    let options = PullOptions {
+        low_speed_timeout: Duration::from_secs(2),
+        low_speed_min_bytes: 64,
+        time: clock.clone(),
+        ..PullOptions::for_tests()
+    };
+    let mut window = LowSpeedWindow::new(&options);
+    assert!(
+        window
+            .observe("https://example.invalid/pack.oasr", 1_000, 8, 8)
+            .is_ok(),
+        "before the injected timeout the window must not trip"
+    );
+    clock.advance(Duration::from_secs(2));
+    let error = window
+        .observe("https://example.invalid/pack.oasr", 1_000, 16, 8)
+        .unwrap_err();
+    assert!(matches!(error, PullError::Http { .. }));
+
+    let reference = reference_with_history(&[10_000_000, 10_000_000, 10_000_000, 10_000_000]);
+    let cooldown_slot = Mutex::new(None);
+    let segment_options = PullOptions {
+        segment_low_speed_timeout: Duration::ZERO,
+        segment_low_speed_cooldown: Duration::from_secs(30),
+        time: clock.clone(),
+        ..PullOptions::for_tests()
+    };
+    let mut first = SegmentLowSpeedWindow::new(&segment_options, &reference, &cooldown_slot, false);
+    assert!(first.observe(1_000_000), "first outlier must trip");
+    let mut second =
+        SegmentLowSpeedWindow::new(&segment_options, &reference, &cooldown_slot, false);
+    assert!(
+        !second.observe(1_000_000),
+        "cooldown must suppress an immediate re-trip"
+    );
+    clock.advance(Duration::from_secs(30));
+    let mut third = SegmentLowSpeedWindow::new(&segment_options, &reference, &cooldown_slot, false);
+    assert!(
+        third.observe(1_000_000),
+        "after the injected cooldown the same outlier must trip again"
+    );
+}
+
+#[test]
+fn catalog_family_mismatch_is_a_terminal_fail_closed_error() {
+    let path = PathBuf::from("/tmp/openasr-family-mismatch.oasr");
+    let error = ensure_catalog_family_matches(Some("whisper"), Some("moonshine"), &path)
+        .expect_err("family mismatch must fail closed");
+    assert!(matches!(error, PullError::RuntimeValidation { .. }));
+    assert!(!is_retryable_download_error(&error));
+    assert!(!is_source_fallback_error(&error));
+    ensure_catalog_family_matches(Some("moonshine"), Some("moonshine"), &path).unwrap();
+    ensure_catalog_family_matches(None, Some("moonshine"), &path).unwrap();
+}
+
+fn count_requests_for(requests: &[(u64, Option<u64>)], start: u64, end: Option<u64>) -> usize {
+    requests
+        .iter()
+        .filter(|request| **request == (start, end))
+        .count()
+}
+
+#[test]
+fn segment_retry_recovers_from_one_5xx_without_retrying_siblings() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let total_segments = segment_count(bytes.len() as u64, segment_bytes);
+    assert!(total_segments >= 3, "fixture must have a non-probe sibling");
+    let (fail_start, fail_end) = segment_range(1, bytes.len() as u64, segment_bytes);
+
+    let server =
+        RangeServerClient::new(bytes.clone()).fail_range(fail_start, Some(fail_end), &[503]);
+    let (mut probe_client, factory) = parallel_probe_and_factory(&server);
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    pull_model_pack_with_client_parallel(
+        &resolved,
+        temp.path(),
+        &mut probe_client,
+        parallel_test_options(segment_bytes),
+        parallel,
+        |_| {},
+        || false,
+        || false,
+    )
+    .unwrap();
+
+    let requests = server.requests();
+    assert_eq!(
+        count_requests_for(&requests, fail_start, Some(fail_end)),
+        2,
+        "the 503 segment must be fetched twice (retry on the same attempt)"
+    );
+    for index in 0..total_segments {
+        if index == 1 {
+            continue;
+        }
+        let (start, end) = segment_range(index, bytes.len() as u64, segment_bytes);
+        assert_eq!(
+            count_requests_for(&requests, start, Some(end)),
+            1,
+            "sibling segment {index} must be fetched once"
+        );
+    }
+    assert_eq!(
+        server.call_count(),
+        total_segments + 1,
+        "one extra open is the recovered segment; the outer attempt must not restart"
+    );
+}
+
+#[test]
+fn segment_retry_fails_closed_when_the_segment_budget_is_exhausted() {
+    let bytes = tiny_pack_bytes();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let (start, end) = segment_range(1, bytes.len() as u64, segment_bytes);
+    let statuses = vec![503; SEGMENT_MAX_RETRIES + 8];
+    let mut server = RangeServerClient::new(bytes.clone())
+        .fail_range(start, Some(end), &statuses)
+        .with_call_ceiling(32);
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("segment.partial");
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .unwrap();
+    file.set_len(bytes.len() as u64).unwrap();
+    let (sender, _receiver) = std::sync::mpsc::channel();
+    let abort = AtomicBool::new(false);
+    let reference = SegmentThroughputReference::new();
+    let cooldown = Mutex::new(None);
+
+    let error = fetch_segment_with_retries(
+        &mut server,
+        &mut file,
+        &path,
+        "https://example.invalid/pack.oasr",
+        start,
+        end,
+        Some("etag-a"),
+        &abort,
+        &sender,
+        &PullOptions::for_tests(),
+        &reference,
+        &cooldown,
+        false,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        PullError::UnexpectedStatus { status: 503, .. }
+    ));
+    assert_eq!(
+        server.call_count(),
+        SEGMENT_MAX_RETRIES + 1,
+        "same-segment retries must stop at SEGMENT_MAX_RETRIES"
+    );
+}
+
+#[test]
+fn parallel_attempt_retries_then_fails_closed_and_clears_partial() {
+    let bytes = tiny_pack_bytes();
+    let resolved = resolved_for(&bytes);
+    let temp = tempfile::tempdir().unwrap();
+    let segment_bytes = small_segment_bytes(bytes.len(), 4);
+    let failures = (0..=DOWNLOAD_MAX_RETRIES)
+        .map(|_| ResponseSpec {
+            status: 503,
+            body: Vec::new(),
+        })
+        .collect();
+    let mut client = FakeClient::with_responses(failures);
+    let factory_client = client.clone();
+    let factory: Box<dyn Fn() -> Result<BoxedDownloadClient, PullError>> =
+        Box::new(move || Ok(Box::new(factory_client.clone()) as BoxedDownloadClient));
+    let parallel = ParallelDownloadConfig {
+        connections: 4,
+        factory: &*factory,
+    };
+
+    let error = pull_model_pack_with_client_parallel(
+        &resolved,
+        temp.path(),
+        &mut client,
+        parallel_test_options(segment_bytes),
+        parallel,
+        |_| {},
+        || false,
+        || false,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        PullError::UnexpectedStatus { status: 503, .. }
+    ));
+    assert_eq!(client.urls().len(), DOWNLOAD_MAX_RETRIES + 1);
+    assert_no_partial_or_install(&paths_for(temp.path(), &resolved));
+}
+
+fn signed_archive_fixture() -> (CatalogBackendFile, Vec<u8>, u64, Vec<String>) {
+    let payload = b"signed runtime";
+    let archive = backend_zip_bytes(&[("runtime.dll", payload)]);
+    let unpacked = payload.len() as u64;
+    let tree = materialized_tree_sha256(&[InstalledBackendMaterializedFile {
+        relative_path: "runtime.dll".to_string(),
+        sha256: sha256_hex(payload),
+        size_bytes: payload.len() as u64,
+    }]);
+    let urls = vec![
+        "https://primary.example/vendor.zip".to_string(),
+        "https://mirror.example/vendor.zip".to_string(),
+    ];
+    let file = CatalogBackendFile {
+        filename: "vendor.zip".to_string(),
+        url: urls[0].clone(),
+        mirrors: Vec::new(),
+        sha256: sha256_hex(&archive),
+        size_bytes: archive.len() as u64,
+        role: CatalogBackendFileRole::Archive,
+        extract_subdir: Some(String::new()),
+        extracted_tree_sha256: Some(tree),
+    };
+    (file, archive, unpacked, urls)
+}
+
+#[test]
+fn signed_url_chain_falls_back_after_404_and_installs_from_the_next_url() {
+    let (file, archive, unpacked, urls) = signed_archive_fixture();
+    let temp = tempfile::tempdir().unwrap();
+    let mut client = FakeClient::with_responses(vec![
+        ResponseSpec {
+            status: 404,
+            body: Vec::new(),
+        },
+        ResponseSpec {
+            status: 200,
+            body: archive,
+        },
+    ]);
+
+    ensure_backend_content_object_in(
+        &mut client,
+        &file,
+        &temp.path().join("objects"),
+        Some(&urls),
+        Some(unpacked),
+        &mut |_| {},
+        None,
+        &PullOptions::for_tests(),
+    )
+    .unwrap();
+
+    assert_eq!(client.urls(), urls);
+}
+
+#[test]
+fn signed_url_chain_does_not_fall_back_after_a_client_400() {
+    let (file, archive, unpacked, urls) = signed_archive_fixture();
+    let temp = tempfile::tempdir().unwrap();
+    let mut client = FakeClient::with_responses(vec![
+        ResponseSpec {
+            status: 400,
+            body: b"bad request".to_vec(),
+        },
+        ResponseSpec {
+            status: 200,
+            body: archive,
+        },
+    ]);
+
+    let error = ensure_backend_content_object_in(
+        &mut client,
+        &file,
+        &temp.path().join("objects"),
+        Some(&urls),
+        Some(unpacked),
+        &mut |_| {},
+        None,
+        &PullOptions::for_tests(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        PullError::UnexpectedStatus { status: 400, .. }
+    ));
+    assert_eq!(
+        client.urls(),
+        vec![urls[0].clone()],
+        "400 must fail closed on the first signed URL"
     );
 }


### PR DESCRIPTION
Closes #401.

## Summary
`pull.rs` retry / backoff / fallback predicates could not be mutation-tested: every survivor hit the 60s timeout because tests went through real `std::thread::sleep(retry_backoff(..))` and `Instant::elapsed()`.

- **`PullTime` clock injection**: `WallClock` in production, unconditionally (`PullOptions::default()` hard-codes it; no `cfg(test)` switch on any production path). Tests use `PullOptions::for_tests()` with `ImmediateClock`, `VirtualClock` (advance-only), or `RecordingClock` (captures every sleep). `retry_transient_io` and the backend download chain take the clock from the caller. `LowSpeedWindow` captures threshold + clock at construction so there is a single time source.
- **No trust-boundary change**: `PackVerifier`, signed-catalog digest, family check, and "unverified bytes never write an install record" are untouched; the existing `DownloadClient` abstraction is reused, no HTTP trait added.
- **Predicate matrix tests** (all < 1s, no network): 4xx/5xx/403/404/429/sha/gguf retry-vs-fallback, 5xx exhaustion fail-closed, 400 no-retry, resume keeps matching bytes / discards stale partials, digest match skips download, catalog family mismatch, backoff sequence pinned to `[500,1000,2000,4000,5000,5000]ms`, segment-level retry (recover after one 5xx without retrying siblings; fail closed at `SEGMENT_MAX_RETRIES`), parallel attempt exhaustion clears partial, multi-URL signed fallback (404 → next URL, 400 → stop).
- **Targeted `cargo-mutants`** on `sleep_backoff | fetch_segment_with_retries | is_source_fallback_error`: 26 caught / 0 missed / 0 timeout / 1 unviable (was 54 caught / 7 missed / 1 timeout over the wider decision-predicate set before the extra tests).

No public API or wire change; no user-visible behaviour change.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check --workspace`
- [x] `cargo nextest run -p openasr-core pull` (180 passed), `cargo nextest run -p openasr-cli` (302 passed)
- [x] Reverse mutations by reviewer: `sleep_backoff` no-op → 2 tests fail; segment retry guard → `false` → 2 tests fail
- [x] Two independent review rounds; final: no blocking / no suggestion

AI usage disclosure: YES

Made with [Cursor](https://cursor.com)