### PR TITLE
fix(longform): stitch wordless CJK overlap at slice seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Long-form: duplicate and isolated fragments at long-audio slice seams
+  are fixed; slice windows and non-seam cue timings are unchanged.
 - Core: invalid GGUF/ggml type ids — out of range or retired slots whose
   block size is zero — are rejected before any ggml type-trait query. An
   unknown tensor type can no longer be treated as quantized or used to

--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -762,10 +762,11 @@ fn transcribe_mock_formats_match_core_renderers() {
 // fixtures (ffmpeg concat, no new audio content). Pinned against
 // `OPENASR_GGML_BACKEND=cpu` (Metal currently OOMs this family's 7B decoder
 // on a 16GB unified-memory Mac, see the T5 report); the auto energy-VAD
-// slicer picked 3 chunks here, whose seams show as the two small stray-token
-// artifacts in the golden ("我 我" and an extra "中") -- both present in the
-// real committed pack's output, not smoothed over.
-const FIRERED_LLM_GOLDEN_LONGFORM_EN_ZH_TEXT: &str = "and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗中 周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country";
+// slicer picked 3 chunks here. The extra "中" is a model token. The first-seam
+// "我 我" is consumed by the shared assembler; the join space remains
+// (`周末的时候我 通常会`). Bytes come from feeding the three origin slice
+// texts through TranscriptAssembler (pending pack re-measure).
+const FIRERED_LLM_GOLDEN_LONGFORM_EN_ZH_TEXT: &str = "and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗中 周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country";
 
 #[test]
 #[ignore = "requires the private ~8.9GB dev-only firered2-llm-q8_0.oasr pack; runs the real \
@@ -819,15 +820,17 @@ fn firered_llm_golden_diff_longform_cli_transcribe_matches_reference_decode() {
 // this family's ~8B combined weights on a 16GB unified-memory Mac is
 // unverified, see this module's e2e report).
 // The longform assembler joins retained, trimmed segment texts with one space.
-// The spaces inside this `concat!` are therefore golden bytes. The same
-// family's single-utterance EN->ZH golden
+// The spaces inside this `concat!` are therefore golden bytes, taken from
+// feeding the three origin slice texts through TranscriptAssembler. The
+// first-seam "我 我" is consumed; the join space remains (`我 通常会`).
+// The same family's single-utterance EN->ZH golden
 // (`mimo_asr::executor::tests::golden_diff_end_to_end_transcribe_en_zh_mixed_wav`)
 // also asserts the EN->ZH space.
 const GOLDEN_MIMO_LONGFORM_EN_ZH_TEXT: &str = concat!(
     "And so, my fellow Americans, ask not what your country can do for you. ",
     "Ask what you can do for your country. ",
     "今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，",
-    "听说那里的麻婆豆腐特别正宗。周末的时候，我 我通常会读书或者看一部电影放松一下。",
+    "听说那里的麻婆豆腐特别正宗。周末的时候，我 通常会读书或者看一部电影放松一下。",
     "And so, my fellow Americans, ask not what your country can do for you, ",
     "ask what you can do for your country.",
     "今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，",
@@ -889,20 +892,19 @@ fn mimo_asr_golden_diff_longform_cli_transcribe_matches_reference_decode() {
 // `encoder_attention_span_caps_every_builtin_architecture_on_the_production_path`
 // in `native_transcribe.rs`), so this 69s input forces the auto energy-VAD
 // slicer to split -- confirmed 3 chunks via `--format verbose_json`'s
-// `longform.chunk_count`. Pinned against `OPENASR_GGML_BACKEND=cpu`. The two
-// chunk seams show up as the golden's two textual artifacts: a duplicated "我"
-// at the first seam (VAD overlap re-transcribing the boundary word) and a
-// missing space between "COUNTRY" and "今天" / "ANDSO" run together at chunk
-// boundaries where the assembler's join lands between two tokens with no SPM
-// space marker between them -- both present in the real committed pack's
-// output, not smoothed over.
+// `longform.chunk_count`. Pinned against `OPENASR_GGML_BACKEND=cpu`. The
+// missing space between "COUNTRY" and "今天" / "ANDSO" is a tokenizer join.
+// The first-seam "我 我" is consumed by the shared assembler; the join
+// space remains (`周末的时候我 通常会`). Bytes come from feeding the
+// three origin slice texts through TranscriptAssembler
+// (pending pack re-measure).
 fn firered_aed_dev_pack_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp/firered-out/firered-aed-l-fp16.oasr")
 }
 
 const GOLDEN_FIRERED_AED_LONGFORM_EN_ZH_TEXT: &str = concat!(
     "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO ",
-    "FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 我通常会读书或者看一部电影放松一下 ",
+    "FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 通常会读书或者看一部电影放松一下 ",
     "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO ",
     "FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗 周末的时候我通常会读书或者看一部电影放松一下 ",
     "ANDSO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR ",
@@ -1021,6 +1023,80 @@ fn moss_transcribe_diarize_golden_diff_longform_cli_transcribe_matches_reference
         output.trim_end(),
         GOLDEN_MOSS_TRANSCRIBE_DIARIZE_LONGFORM_EN_ZH_TEXT,
         "unexpected longform CLI transcript"
+    );
+}
+
+// qwen3-asr-0.6b longform seam: the shared assembler used to keep the
+// energy-slicer overlap re-read on wordless CJK segments (0.1.40 reproduced
+// "周末的时候，我。" / "的时候，" at 25.5s). This pins the user-facing CLI
+// path once a published qwen3 pack is available.
+#[test]
+#[ignore = "requires qwen3-asr-0.6b:q4 in OPENASR_QWEN3_HOME or OPENASR_QWEN3_ASR_PACK; \
+            runs the real longform CLI path on fixtures/longform_en_zh.wav"]
+fn qwen3_asr_longform_cli_seam_does_not_duplicate_overlap_text() {
+    let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures/longform_en_zh.wav")
+        .canonicalize()
+        .expect("longform_en_zh.wav fixture must exist");
+
+    let mut command = if let Ok(home) = std::env::var("OPENASR_QWEN3_HOME") {
+        let mut command = openasr_with_home(Path::new(&home));
+        command.env("OPENASR_OFFLINE", "1").args([
+            "transcribe",
+            &input.display().to_string(),
+            "-m",
+            "qwen3-asr-0.6b:q4",
+            "--offline",
+            "--format",
+            "text",
+        ]);
+        command
+    } else {
+        let pack_path =
+            match external_test_fixture_path("OPENASR_QWEN3_ASR_PACK", "Qwen3-ASR 0.6B .oasr pack")
+            {
+                Ok(path) => path,
+                Err(skip) => {
+                    eprintln!("skipping: {skip}");
+                    return;
+                }
+            };
+        let mut command = openasr();
+        command.env("OPENASR_OFFLINE", "1").args([
+            "transcribe",
+            &input.display().to_string(),
+            "--model-pack",
+            &pack_path.display().to_string(),
+            "--offline",
+            "--format",
+            "text",
+        ]);
+        command
+    };
+
+    let assert = command.assert().success();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    let text = output.trim_end();
+    eprintln!("qwen3-asr longform CLI transcript: {text:?}");
+    assert_eq!(
+        text.matches("听说那里的麻婆豆腐特别正宗").count(),
+        2,
+        "each Chinese block keeps 听说…正宗 once, got {text:?}"
+    );
+    assert!(
+        !text.split_whitespace().any(|cue| cue == "吃饭。")
+            && !text.contains("\n吃饭。\n")
+            && !text.contains("吃饭。吃饭"),
+        "isolated 吃饭。 seam fragment must not survive, got {text:?}"
+    );
+    assert_eq!(
+        text.matches("周末的时候").count(),
+        2,
+        "weekend sentence must appear once per Chinese block, got {text:?}"
+    );
+    assert!(
+        text.contains("我通常会"),
+        "stitched sentence must keep both halves, got {text:?}"
     );
 }
 

--- a/crates/openasr-core/src/longform/assembler.rs
+++ b/crates/openasr-core/src/longform/assembler.rs
@@ -128,17 +128,35 @@ impl TranscriptAssembler {
         }
         let time_domain = transcript.time_domain;
         let slice = transcript.slice.clone();
+        // Text stitch is a cross-slice seam repair for wordless seq2seq
+        // families. Same-slice adjacent cues (Whisper word timestamps, cue
+        // splitter output) stay distinct even when their texts share a tail.
+        let mut cross_slice_seam = true;
         for mut segment in transcript.segments {
             segment.text = segment.text.trim().to_string();
             if segment.text.is_empty() {
                 continue;
             }
             let mut mapped = self.map_segment_time(&segment, &slice, time_domain);
+            // Cross-slice stitch first. DecodeInvariant families (qwen/moss/
+            // firered/mimo) force interpolated words for cue splitting; those
+            // words make a midpoint trim eat the textual re-read prefix and
+            // would skip stitch if we required `words.is_empty()`. Same-slice
+            // adjacent cues still skip stitch via `cross_slice_seam`.
+            if cross_slice_seam && self.try_stitch_seam_overlap(&mut mapped) {
+                self.stats.duplicate_merge_count += 1;
+                if mapped.text.trim().is_empty() {
+                    continue;
+                }
+                self.segments.push(mapped);
+                self.speaker_scope_by_segment.push(speaker_scope);
+                cross_slice_seam = false;
+                continue;
+            }
             // Time-domain overlap trim: drop any leading words / whole segments
             // whose audio lies in the region a prior slice already committed.
-            // This is text-agnostic, so it catches weak-model hallucinations of
-            // the re-read overlap (e.g. "belief" mis-decoded as "If,") that the
-            // text-equality dedup below cannot see.
+            // Skip when stitch already consumed the re-read; interpolated
+            // seq2seq words would otherwise delete the matching prefix.
             if let Some(boundary) = trim_boundary
                 && trim_committed_overlap(&mut mapped, boundary)
             {
@@ -149,6 +167,7 @@ impl TranscriptAssembler {
                 self.stats.duplicate_merge_count += 1;
                 continue;
             }
+            cross_slice_seam = false;
             // Distinct segments are kept distinct: the post-ASR cue
             // re-segmentation pass owns subtitle granularity, so the assembler
             // no longer coalesces adjacent same-speaker segments into paragraph
@@ -283,11 +302,117 @@ impl TranscriptAssembler {
         if previous_words == current_words {
             return true;
         }
+        if current_words.len() >= self.merge_policy.redundant_min_words
+            && contains_window(&previous_words, &current_words)
+        {
+            return true;
+        }
+        // Fuzzy LCW drop stays ASCII-only. Per-character CJK units make the
+        // longform_en_zh fixture (repeated Mandarin blocks plus a new tail)
+        // look like an 80% re-read and would delete the continuation.
+        if !mostly_ascii_units(&previous_words) || !mostly_ascii_units(&current_words) {
+            return false;
+        }
         let overlap = longest_common_window_len(&previous_words, &current_words);
         let min_len = previous_words.len().min(current_words.len());
         min_len >= self.merge_policy.redundant_min_words
             && overlap as f32 / min_len as f32 >= self.merge_policy.redundant_overlap_ratio
     }
+
+    /// Stitch a wordless cross-slice re-read by a tail-anchored suffix/prefix
+    /// match. Seq2seq families such as Qwen emit one segment spanning the
+    /// whole slice and no word timestamps, so the time-domain trim above cannot
+    /// see the 0.5–2s energy overlap.
+    ///
+    /// Thresholds: n ≥ 2 when the windows time-overlap, n ≥ 3 on a mere
+    /// abutment. A one-unit match is allowed only for a single non-numeral
+    /// CJK char that is not a doubled sentence-initial (「谢谢」), and only
+    /// when the segment time-overlap covers that char's estimated duration
+    /// -- so 「我 我」 / 「吃饭」+「饭，」 still stitch, while 「八」/「谢」
+    /// and English head-words do not. Matches are always a suffix of
+    /// `previous`; an interior window is never searched.
+    ///
+    /// The stitch rewrites text only. `previous.end` is left alone so a
+    /// later slice cannot swallow the earlier segment's boundary.
+    fn try_stitch_seam_overlap(&mut self, current: &mut Segment) -> bool {
+        let Some(previous) = self.segments.last_mut() else {
+            return false;
+        };
+        let time_overlap = previous.end - current.start;
+        let time_overlaps = time_overlap > 1.0e-3;
+        let gap_seconds = current.start - previous.end;
+        if !time_overlaps && gap_seconds > self.merge_policy.max_gap_seconds {
+            return false;
+        }
+        let min_units = if time_overlaps { 2 } else { 3 };
+        apply_suffix_prefix_stitch(previous, current, min_units, time_overlap)
+    }
+}
+
+fn speakers_conflict(previous: &Segment, current: &Segment) -> bool {
+    match (&previous.speaker, &current.speaker) {
+        (Some(left), Some(right)) => left != right,
+        _ => false,
+    }
+}
+
+/// Rewrite seam text when a tail-anchored suffix/prefix overlap exists.
+/// Returns `true` when `current` was trimmed (caller drops it if empty).
+/// Never extends `previous.end`.
+fn apply_suffix_prefix_stitch(
+    previous: &mut Segment,
+    current: &mut Segment,
+    min_units: usize,
+    time_overlap_seconds: f32,
+) -> bool {
+    let Some(overlap) = suffix_prefix_overlap(
+        &previous.text,
+        &current.text,
+        min_units,
+        time_overlap_seconds,
+    ) else {
+        return false;
+    };
+    let consume_end = extend_consumed_current_end(&current.text, overlap.curr_end);
+    let prev_prefix = char_prefix(&previous.text, overlap.prev_start);
+    let consumed = current
+        .text
+        .chars()
+        .take(consume_end)
+        .skip(overlap.curr_start)
+        .collect::<String>();
+    let consumed = consumed.trim();
+    let remainder = char_suffix(&current.text, consume_end).trim().to_string();
+    let previous_words = split_words_at_char(&previous.text, &previous.words, overlap.prev_start);
+    let current_words = split_words_at_char(&current.text, &current.words, consume_end);
+    let leftover_words = current_words
+        .as_ref()
+        .map(|(_, leftover)| leftover.clone())
+        .unwrap_or_default();
+    if speakers_conflict(previous, current) {
+        current.text = remainder;
+        current.words = leftover_words;
+        return true;
+    }
+    if let Some((keep_prefix, _)) = previous_words {
+        previous.words = keep_prefix;
+    }
+    let mut completed = format!("{prev_prefix}{consumed}");
+    // A period sitting on `previous` after the overlap is a truncated-slice
+    // hallucination when current continues with content (no punct right after
+    // the overlap). Keep it only when the remainder is empty or current
+    // already carried immediately-following seam punct.
+    let strip_truncated_period = consume_end == overlap.curr_end && !remainder.is_empty();
+    if !strip_truncated_period {
+        let trailing = previous_trailing_punct(&previous.text, overlap.prev_end);
+        if !trailing.is_empty() && !completed.ends_with(&trailing) {
+            completed.push_str(&trailing);
+        }
+    }
+    previous.text = completed;
+    current.text = remainder;
+    current.words = leftover_words;
+    true
 }
 
 fn map_word_time_to_original(
@@ -339,9 +464,11 @@ fn trim_committed_overlap(segment: &mut Segment, boundary: f32) -> bool {
         return true;
     }
     if segment.words.is_empty() {
-        // No word anchors: fall back to the segment midpoint.
-        let midpoint = 0.5 * (segment.start + segment.end);
-        return midpoint < boundary;
+        // A wordless slice-spanning segment's midpoint almost never sits inside
+        // the 0.5–2s overlap, so a midpoint rule would keep the whole re-read.
+        // Leave the text for suffix-prefix stitch instead of dropping or keeping
+        // the segment as a unit.
+        return false;
     }
     let first_keep = segment
         .words
@@ -406,16 +533,262 @@ fn leading_word_char_offset(
     Some(idx)
 }
 
+/// Split `words` at the first token whose aligned start is `>= char_index`.
+/// `None` when the greedy word/text walk does not align (leave words alone).
+fn split_words_at_char(
+    text: &str,
+    words: &[WordTimestamp],
+    char_index: usize,
+) -> Option<(Vec<WordTimestamp>, Vec<WordTimestamp>)> {
+    if words.is_empty() {
+        return Some((Vec::new(), Vec::new()));
+    }
+    let chars: Vec<char> = text.chars().collect();
+    let mut split_at = words.len();
+    for index in 0..=words.len() {
+        let offset = leading_word_char_offset(&chars, words, index)?;
+        if offset >= char_index {
+            split_at = index;
+            break;
+        }
+    }
+    Some((words[..split_at].to_vec(), words[split_at..].to_vec()))
+}
+
+/// Word list for [`TranscriptAssembler::try_drop_redundant_segment`].
+/// ASCII keeps the historical fold (`don't` → `dont`, `twenty-one` →
+/// `twentyone`, `café` → `caf`). CJK has no ASCII letters, so it falls
+/// through to one unit per non-punctuation character.
 fn normalize_words(text: &str) -> Vec<String> {
     text.split_whitespace()
-        .map(|word| {
-            word.chars()
+        .flat_map(|word| {
+            let ascii: String = word
+                .chars()
                 .filter(|ch| ch.is_ascii_alphanumeric())
                 .collect::<String>()
-                .to_ascii_lowercase()
+                .to_ascii_lowercase();
+            if !ascii.is_empty() {
+                return vec![ascii];
+            }
+            word.chars()
+                .filter(|ch| !is_seam_punctuation(*ch))
+                .map(|ch| ch.to_string())
+                .collect::<Vec<_>>()
         })
         .filter(|word| !word.is_empty())
         .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OverlapUnit {
+    token: String,
+    start: usize,
+    end: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SuffixPrefixOverlap {
+    prev_start: usize,
+    prev_end: usize,
+    curr_start: usize,
+    curr_end: usize,
+}
+
+fn is_seam_punctuation(ch: char) -> bool {
+    matches!(
+        ch,
+        ',' | '.' | '!' | '?' | ';' | ':' | '，' | '。' | '！' | '？' | '；' | '：' | '、'
+    )
+}
+
+fn is_ascii_word_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '\'' || ch == '-'
+}
+
+fn is_cjk_numeral(ch: char) -> bool {
+    matches!(
+        ch,
+        '零' | '一'
+            | '二'
+            | '三'
+            | '四'
+            | '五'
+            | '六'
+            | '七'
+            | '八'
+            | '九'
+            | '十'
+            | '百'
+            | '千'
+            | '万'
+    )
+}
+
+fn is_numeric_unit(token: &str) -> bool {
+    !token.is_empty()
+        && token
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || is_cjk_numeral(ch))
+}
+
+fn is_single_cjk_char(token: &str) -> bool {
+    let mut chars = token.chars();
+    match (chars.next(), chars.next()) {
+        (Some(ch), None) => !ch.is_ascii() && !ch.is_ascii_whitespace(),
+        _ => false,
+    }
+}
+
+fn overlap_units(text: &str) -> Vec<OverlapUnit> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut units = Vec::new();
+    let mut index = 0usize;
+    while index < chars.len() {
+        let ch = chars[index];
+        if ch.is_whitespace() || is_seam_punctuation(ch) {
+            index += 1;
+            continue;
+        }
+        if is_ascii_word_char(ch) {
+            let start = index;
+            let mut token = String::new();
+            while index < chars.len() && is_ascii_word_char(chars[index]) {
+                token.push(chars[index].to_ascii_lowercase());
+                index += 1;
+            }
+            units.push(OverlapUnit {
+                token,
+                start,
+                end: index,
+            });
+            continue;
+        }
+        units.push(OverlapUnit {
+            token: ch.to_string(),
+            start: index,
+            end: index + 1,
+        });
+        index += 1;
+    }
+    units
+}
+
+fn char_prefix(text: &str, char_count: usize) -> String {
+    text.chars().take(char_count).collect()
+}
+
+fn char_suffix(text: &str, char_skip: usize) -> String {
+    text.chars().skip(char_skip).collect()
+}
+
+const CJK_CHAR_SECONDS: f32 = 0.18;
+
+/// Longest *suffix* of `previous` that is a prefix of `current`. Interior
+/// matches are not considered: a re-read can only replay the previous tail.
+fn suffix_prefix_overlap(
+    previous: &str,
+    current: &str,
+    min_units: usize,
+    time_overlap_seconds: f32,
+) -> Option<SuffixPrefixOverlap> {
+    let previous_units = overlap_units(previous);
+    let current_units = overlap_units(current);
+    if previous_units.is_empty() || current_units.is_empty() {
+        return None;
+    }
+    let max_n = previous_units.len().min(current_units.len());
+    if max_n == 0 {
+        return None;
+    }
+    for n in (1..=max_n).rev() {
+        let previous_suffix = &previous_units[previous_units.len() - n..];
+        let current_prefix = &current_units[..n];
+        if !previous_suffix
+            .iter()
+            .zip(current_prefix)
+            .all(|(left, right)| left.token == right.token)
+        {
+            continue;
+        }
+        if !accept_overlap_n(
+            n,
+            min_units,
+            previous_suffix,
+            &current_units,
+            time_overlap_seconds,
+        ) {
+            continue;
+        }
+        return Some(SuffixPrefixOverlap {
+            prev_start: previous_suffix[0].start,
+            prev_end: previous_suffix[n - 1].end,
+            curr_start: current_prefix[0].start,
+            curr_end: current_prefix[n - 1].end,
+        });
+    }
+    None
+}
+
+fn accept_overlap_n(
+    n: usize,
+    min_units: usize,
+    overlap: &[OverlapUnit],
+    current_units: &[OverlapUnit],
+    time_overlap_seconds: f32,
+) -> bool {
+    if overlap.iter().all(|unit| is_numeric_unit(&unit.token)) {
+        return false;
+    }
+    if n >= min_units {
+        return true;
+    }
+    // Single-char CJK re-read (「我 我」, 「吃饭」/「饭，」): require the
+    // windows to actually overlap by at least that char's spoken duration.
+    // A doubled sentence-initial (「谢谢」) is a new phrase, not a re-read.
+    n == 1
+        && time_overlap_seconds > 1.0e-3
+        && time_overlap_seconds + 1.0e-3 >= CJK_CHAR_SECONDS
+        && overlap.len() == 1
+        && is_single_cjk_char(&overlap[0].token)
+        && !(current_units.len() >= 2 && current_units[0].token == current_units[1].token)
+}
+
+fn extend_consumed_current_end(current: &str, overlap_end: usize) -> usize {
+    let chars: Vec<char> = current.chars().collect();
+    if overlap_end >= chars.len() {
+        return chars.len();
+    }
+    let mut end = overlap_end;
+    while end < chars.len() && chars[end].is_whitespace() {
+        end += 1;
+    }
+    while end < chars.len() && is_seam_punctuation(chars[end]) {
+        end += 1;
+    }
+    end
+}
+
+/// Punctuation that already sat on `previous` after the overlap units.
+fn previous_trailing_punct(previous: &str, prev_end: usize) -> String {
+    let chars: Vec<char> = previous.chars().collect();
+    let mut index = prev_end;
+    while index < chars.len() && chars[index].is_whitespace() {
+        index += 1;
+    }
+    let mut trailing = String::new();
+    while index < chars.len() && is_seam_punctuation(chars[index]) {
+        trailing.push(chars[index]);
+        index += 1;
+    }
+    trailing
+}
+
+fn mostly_ascii_units(words: &[String]) -> bool {
+    if words.is_empty() {
+        return false;
+    }
+    let ascii = words.iter().filter(|word| word.is_ascii()).count();
+    ascii * 2 >= words.len()
 }
 
 fn contains_window(haystack: &[String], needle: &[String]) -> bool {
@@ -427,23 +800,29 @@ fn contains_window(haystack: &[String], needle: &[String]) -> bool {
         .any(|window| window == needle)
 }
 
+/// Longest common *contiguous* window. DP is O(n·m) / O(min(n, m)) space.
 fn longest_common_window_len(left: &[String], right: &[String]) -> usize {
     if left.is_empty() || right.is_empty() {
         return 0;
     }
-    let mut longest = 0usize;
-    for start in 0..left.len() {
-        for end in (start + 1)..=left.len() {
-            let candidate = &left[start..end];
-            if candidate.len() <= longest {
-                continue;
-            }
-            if contains_window(right, candidate) {
-                longest = candidate.len();
+    let (short, long) = if left.len() <= right.len() {
+        (left, right)
+    } else {
+        (right, left)
+    };
+    let mut prev = vec![0usize; short.len() + 1];
+    let mut best = 0usize;
+    for long_token in long {
+        let mut curr = vec![0usize; short.len() + 1];
+        for (index, short_token) in short.iter().enumerate() {
+            if short_token == long_token {
+                curr[index + 1] = prev[index] + 1;
+                best = best.max(curr[index + 1]);
             }
         }
+        prev = curr;
     }
-    longest
+    best
 }
 
 #[cfg(test)]
@@ -703,6 +1082,46 @@ mod tests {
         }
     }
 
+    /// DecodeInvariant interpolation: Han+trailing punct (「我。」) and ASCII
+    /// runs with attached punct, linearly spaced — same grouping as
+    /// `seq2seq_word_timestamps_from_generated_tokens`.
+    fn interpolated_words(text: &str, start: f32, end: f32) -> Vec<WordTimestamp> {
+        let mut tokens = Vec::new();
+        let mut current = String::new();
+        for ch in text.chars() {
+            if ch.is_whitespace() {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+                continue;
+            }
+            let starts_han = !ch.is_ascii() && !is_seam_punctuation(ch);
+            let last_is_han = current
+                .chars()
+                .next_back()
+                .is_some_and(|last| !last.is_ascii() && !is_seam_punctuation(last));
+            if (starts_han && !current.is_empty()) || (ch.is_ascii_alphanumeric() && last_is_han) {
+                tokens.push(std::mem::take(&mut current));
+            }
+            current.push(ch);
+        }
+        if !current.is_empty() {
+            tokens.push(current);
+        }
+        if tokens.is_empty() {
+            return Vec::new();
+        }
+        let step = (end - start).max(1.0e-3) / tokens.len() as f32;
+        tokens
+            .iter()
+            .enumerate()
+            .map(|(index, token)| {
+                let word_start = start + step * index as f32;
+                word(token, word_start, word_start + step)
+            })
+            .collect()
+    }
+
     #[test]
     fn assembler_time_trims_hallucinated_leading_overlap_word() {
         // Field defect shape: a forced cut at 1.0s widens the overlap so the next
@@ -957,5 +1376,582 @@ mod tests {
         assert!(transcription.segments[0].end <= 1.0);
         assert!(transcription.segments[1].start >= 12.0);
         assert!(transcription.segments[1].end <= 13.0);
+    }
+
+    fn energy_slice(index: usize, start: usize, end: usize) -> AudioSlice {
+        AudioSlice {
+            index,
+            kind: AudioSliceKind::Energy,
+            start_sample: start,
+            end_sample: end,
+            content_start_sample: start,
+            content_end_sample: end,
+        }
+    }
+
+    fn assemble_three_wordless(slices: [&str; 3]) -> String {
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        let bounds = [
+            (0, 16_000 * 25 + 8_000),
+            (16_000 * 25, 16_000 * 50 + 8_000),
+            (16_000 * 50, 16_000 * 69 + 9_600),
+        ];
+        for (index, (text, (start, end))) in slices.iter().zip(bounds).enumerate() {
+            assembler.push_slice_result(SliceTranscript {
+                slice: energy_slice(index, start, end),
+                text: (*text).to_string(),
+                segments: Vec::new(),
+                time_domain: SegmentTimeDomain::RelativeToSliceContent,
+            });
+        }
+        assembler.into_transcription().text
+    }
+
+    fn assemble_wordless_overlap(previous: &str, current: &str) -> Transcription {
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(0, 0, 16_000 * 25 + 8_000),
+            text: previous.to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(1, 16_000 * 25, 16_000 * 50 + 8_000),
+            text: current.to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        assembler.into_transcription()
+    }
+
+    #[test]
+    fn assembler_stitches_qwen_e2e_abutting_wordless_slice_segments() {
+        let previous = "And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country. 今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭。听说那里的麻婆豆腐特别正宗。周末的时候，我。";
+        let current = "的时候，我通常会读书或者看一部电影，放松一下。今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭。听说那里的麻婆豆腐特别正宗。吃饭。听说那里的麻婆豆腐特别正宗。周末的时候，我通常会读书或者看一部电影，放松一下。And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.";
+        let (transcription, stats) = {
+            let mut assembler =
+                TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+            assembler.push_slice_result(SliceTranscript {
+                slice: energy_slice(0, 0, 16_000 * 25 + 8_000),
+                text: previous.to_string(),
+                segments: Vec::new(),
+                time_domain: SegmentTimeDomain::RelativeToSliceContent,
+            });
+            assembler.push_slice_result(SliceTranscript {
+                slice: energy_slice(1, 16_000 * 25, 16_000 * 69 + 9_600),
+                text: current.to_string(),
+                segments: Vec::new(),
+                time_domain: SegmentTimeDomain::RelativeToSliceContent,
+            });
+            assembler.into_parts()
+        };
+        assert!(
+            stats.duplicate_merge_count >= 1,
+            "abutting 的时候我 (n=4) must stitch, got {stats:?} text={:?}",
+            transcription.text
+        );
+        assert!(
+            transcription.segments[0].text.ends_with("周末的时候，我"),
+            "previous must keep its own window text, got {:#?}",
+            transcription.segments[0]
+        );
+        assert!(
+            !transcription.segments[0].text.contains("通常会"),
+            "current body must not move onto previous, got {:#?}",
+            transcription.segments[0]
+        );
+        assert!(
+            transcription.segments[1].text.starts_with("通常会"),
+            "remainder must start after the overlap units, got {:#?}",
+            transcription.segments[1]
+        );
+        assert!(
+            !transcription.segments[1].text.starts_with("的时候"),
+            "re-read prefix must not survive on the later slice, got {:#?}",
+            transcription.segments
+        );
+        assert!(
+            (transcription.segments[0].end - 25.5).abs() < 1e-3,
+            "previous.end must stay on the first slice window, got {:#?}",
+            transcription.segments
+        );
+        assert!(
+            (transcription.segments[1].start - 25.0).abs() < 1e-3,
+            "remainder must keep the later slice window, got {:#?}",
+            transcription.segments
+        );
+    }
+
+    #[test]
+    fn assembler_stitches_decode_invariant_worded_qwen_slice_seam() {
+        // Production CLI path: DecodeInvariant words are forced on for cue
+        // splitting, so qwen emits one slice-spanning segment with interpolated
+        // timestamps. Midpoint trim would eat "的时候" and skip stitch.
+        let previous = "And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country. 今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭。听说那里的麻婆豆腐特别正宗。周末的时候，我。";
+        let current = "的时候，我通常会读书或者看一部电影，放松一下。今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭。听说那里的麻婆豆腐特别正宗。吃饭。听说那里的麻婆豆腐特别正宗。周末的时候，我通常会读书或者看一部电影，放松一下。And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.";
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(0, 0, 16_000 * 25 + 8_000),
+            text: previous.to_string(),
+            segments: vec![absolute_segment(
+                previous,
+                0.0,
+                25.5,
+                interpolated_words(previous, 0.0, 25.5),
+            )],
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(1, 16_000 * 25, 16_000 * 69 + 9_600),
+            text: current.to_string(),
+            segments: vec![absolute_segment(
+                current,
+                0.0,
+                44.1,
+                interpolated_words(current, 0.0, 44.1),
+            )],
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        let (transcription, stats) = assembler.into_parts();
+        assert!(
+            stats.duplicate_merge_count >= 1,
+            "worded DecodeInvariant seam must stitch, got {stats:?} text={:?}",
+            transcription.text
+        );
+        assert!(
+            transcription.segments[0].text.ends_with("周末的时候，我"),
+            "previous must keep its own window text, got {:#?}",
+            transcription.segments[0]
+        );
+        assert!(
+            !transcription.segments[0].text.contains("通常会"),
+            "current body must not move onto previous, got {:#?}",
+            transcription.segments[0]
+        );
+        assert!(
+            transcription.segments.len() >= 2,
+            "remainder must stay after the overlap units, got {:#?}",
+            transcription.segments
+        );
+        assert!(
+            transcription.segments[1].text.starts_with("通常会"),
+            "remainder must start after the overlap units, got {:#?}",
+            transcription.segments[1]
+        );
+        assert!(
+            (transcription.segments[0].end - 25.5).abs() < 1e-3,
+            "previous.end must stay on the first slice window, got {:#?}",
+            transcription.segments
+        );
+        assert!(
+            (transcription.segments[1].start - 25.0).abs() < 1e-3,
+            "remainder must keep the later slice window, got {:#?}",
+            transcription.segments
+        );
+    }
+
+    #[test]
+    fn assembler_stitches_wordless_cjk_overlap_re_read() {
+        // Field defect from qwen3-asr-0.6b on fixtures/longform_en_zh.wav: the
+        // energy cut at 25.5s re-reads ~0.5s of audio, the model emits one
+        // wordless segment per slice, and the overlap decoded as "的时候，"
+        // after a truncated "周末的时候，我。".
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(0, 0, 16_000 * 25 + 8_000),
+            text: "周末的时候，我。".to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(1, 16_000 * 25, 16_000 * 50 + 8_000),
+            text: "的时候，我通常会读书或者看一部电影，放松一下。".to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        let (transcription, stats) = assembler.into_parts();
+        assert_eq!(
+            transcription.text.replace(' ', ""),
+            "周末的时候，我通常会读书或者看一部电影，放松一下。"
+        );
+        assert_eq!(transcription.segments[0].text, "周末的时候，我");
+        assert!(
+            transcription.segments[1].text.starts_with("通常会"),
+            "remainder must start after the overlap units, got {:#?}",
+            transcription.segments
+        );
+        assert!(
+            !transcription
+                .segments
+                .iter()
+                .any(|segment| segment.text.contains("的时候，") && segment.start + 1.0e-3 >= 25.0),
+            "re-read prefix must not survive on the later slice, got {:#?}",
+            transcription.segments
+        );
+        assert!(
+            (transcription.segments[0].end - 25.5).abs() < 1e-3,
+            "stitch must not swallow previous.end, got {:#?}",
+            transcription.segments
+        );
+        assert!(
+            stats.duplicate_merge_count >= 1,
+            "overlap re-read must count as a seam stitch, got {stats:?}"
+        );
+    }
+
+    #[test]
+    fn assembler_strips_truncated_period_when_remainder_continues() {
+        // Qwen seam: the model plants `。` at the slice cut. Current continues
+        // with content after the overlap, so that period is not real.
+        let previous = "周末的时候，我。";
+        let current = "的时候，我通常会读书或者看一部电影，放松一下。";
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(0, 0, 16_000 * 25 + 8_000),
+            text: previous.to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(1, 16_000 * 25, 16_000 * 50 + 8_000),
+            text: current.to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        let transcription = assembler.into_transcription();
+        assert!(
+            transcription.segments[0].text.ends_with('我'),
+            "truncated period must be stripped, got {:#?}",
+            transcription.segments[0]
+        );
+        assert!(
+            !transcription.segments[0].text.ends_with('。'),
+            "previous must not keep the fake period, got {:#?}",
+            transcription.segments[0]
+        );
+        assert!(
+            (transcription.segments[0].end - 25.5).abs() < 1e-3,
+            "stripping the period must not move previous.end, got {:#?}",
+            transcription.segments
+        );
+    }
+
+    #[test]
+    fn assembler_does_not_move_current_sentence_body_onto_previous() {
+        // Text may cross the slice window; timestamps must stay with the
+        // audio that produced them. Consumed = overlap units + following
+        // punct only.
+        let previous = "周末的时候，我。";
+        let current = "的时候，我通常会读书或者看一部电影，放松一下。今天天气非常好，";
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(0, 0, 16_000 * 25 + 8_000),
+            text: previous.to_string(),
+            segments: vec![absolute_segment(previous, 0.0, 25.5, Vec::new())],
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(1, 16_000 * 25, 16_000 * 50 + 8_000),
+            text: current.to_string(),
+            segments: vec![absolute_segment(current, 0.0, 25.5, Vec::new())],
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        let transcription = assembler.into_transcription();
+        assert_eq!(transcription.segments[0].text, "周末的时候，我");
+        assert!(
+            !transcription.segments[0].text.contains("通常会"),
+            "previous must not absorb speech after the slice boundary, got {:#?}",
+            transcription.segments[0]
+        );
+        assert!(
+            transcription.segments[1]
+                .text
+                .contains("通常会读书或者看一部电影，放松一下。"),
+            "sentence body must stay on the later slice, got {:#?}",
+            transcription.segments[1]
+        );
+        assert!(
+            (transcription.segments[0].end - 25.5).abs() < 1e-3,
+            "previous.end must stay 25.5, got {:#?}",
+            transcription.segments
+        );
+        assert!(
+            (transcription.segments[1].start - 25.0).abs() < 1e-3,
+            "remainder must keep the later slice start, got {:#?}",
+            transcription.segments
+        );
+    }
+
+    #[test]
+    fn assembler_joins_origin_longform_golden_slice_texts() {
+        let mimo = assemble_three_wordless([
+            "And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country. 今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，听说那里的麻婆豆腐特别正宗。周末的时候，我",
+            "我通常会读书或者看一部电影放松一下。And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，听说那里的麻婆豆腐特别正宗。",
+            "周末的时候，我通常会读书或者看一部电影放松一下。And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country.",
+        ]);
+        let firered_aed = assemble_three_wordless([
+            "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我",
+            "我通常会读书或者看一部电影放松一下 AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗",
+            "周末的时候我通常会读书或者看一部电影放松一下 ANDSO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY",
+        ]);
+        let firered_llm = assemble_three_wordless([
+            "and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我",
+            "我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗中",
+            "周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country",
+        ]);
+        assert_eq!(
+            mimo,
+            "And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country. 今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，听说那里的麻婆豆腐特别正宗。周末的时候，我 通常会读书或者看一部电影放松一下。And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，听说那里的麻婆豆腐特别正宗。 周末的时候，我通常会读书或者看一部电影放松一下。And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country."
+        );
+        assert_eq!(
+            firered_aed,
+            "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 通常会读书或者看一部电影放松一下 AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗 周末的时候我通常会读书或者看一部电影放松一下 ANDSO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY"
+        );
+        assert_eq!(
+            firered_llm,
+            "and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗中 周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country"
+        );
+    }
+
+    #[test]
+    fn assembler_stitches_single_cjk_char_when_windows_time_overlap() {
+        // firered / mimo goldens on the same fixture: "...我" + "我通常会..."
+        let transcription =
+            assemble_wordless_overlap("周末的时候，我", "我通常会读书或者看一部电影放松一下。");
+        assert_eq!(
+            transcription.text.replace(' ', ""),
+            "周末的时候，我通常会读书或者看一部电影放松一下。"
+        );
+    }
+
+    #[test]
+    fn assembler_keeps_short_abutting_repetition_without_time_overlap() {
+        // Two-unit prefix shared by abutting complete slices must not stitch.
+        // Exact duplicates still drop via text-equality; this pair differs.
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(0, 0, 16_000),
+            text: "今天好".to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(1, 16_000, 32_000),
+            text: "今天坏".to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        let transcription = assembler.into_transcription();
+        assert_eq!(transcription.segments.len(), 2);
+        assert_eq!(transcription.text, "今天好 今天坏");
+    }
+
+    #[test]
+    fn assembler_drops_leading_orphan_contained_in_previous_suffix() {
+        // 50.5s qwen shape: next slice re-reads a tail-anchored prefix
+        // "吃饭。听说…正宗。" (15 units ≥ 2), then continues.
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(0, 0, 16_000 * 50 + 8_000),
+            text: "晚上我们还计划去一家新开的川菜馆吃饭。听说那里的麻婆豆腐特别正宗。".to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(1, 16_000 * 50, 16_000 * 69),
+            text: "吃饭。听说那里的麻婆豆腐特别正宗。周末的时候，我通常会读书或者看一部电影，放松一下。".to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        let (transcription, stats) = assembler.into_parts();
+        assert!(
+            !transcription.text.contains("吃饭。吃饭")
+                && transcription
+                    .text
+                    .matches("听说那里的麻婆豆腐特别正宗")
+                    .count()
+                    == 1,
+            "leading 吃饭。 plus the re-read sentence must be dropped, got {:?}",
+            transcription.text
+        );
+        assert!(
+            transcription
+                .text
+                .contains("周末的时候，我通常会读书或者看一部电影，放松一下。"),
+            "continuation after the re-read must stay, got {:?}",
+            transcription.text
+        );
+        assert!(
+            !transcription
+                .segments
+                .iter()
+                .any(|segment| segment.text.trim() == "吃饭。"),
+            "isolated 吃饭。 cue must not survive, got {:#?}",
+            transcription.segments
+        );
+        assert!(
+            stats.duplicate_merge_count >= 1,
+            "leading re-read trim must count, got {stats:?}"
+        );
+    }
+
+    #[test]
+    fn assembler_stitches_partial_suffix_char_re_read() {
+        // moss shape at the same seam: "...吃饭" + "饭，听说..."
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(0, 0, 16_000 * 50 + 8_000),
+            text: "晚上我们还计划去一家新开的川菜馆吃饭".to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(1, 16_000 * 50, 16_000 * 69),
+            text: "饭，听说那里的麻婆豆腐特别正宗。".to_string(),
+            segments: Vec::new(),
+            time_domain: SegmentTimeDomain::RelativeToSliceContent,
+        });
+        let transcription = assembler.into_transcription();
+        assert_eq!(
+            transcription.text.replace(' ', ""),
+            "晚上我们还计划去一家新开的川菜馆吃饭，听说那里的麻婆豆腐特别正宗。"
+        );
+    }
+
+    #[test]
+    fn assembler_keeps_wo_when_new_sentence_starts_with_wo() {
+        let transcription = assemble_wordless_overlap(
+            "今天天气非常好，我打算和朋友们一起去公园散步。",
+            "我觉得晚上会下雨。",
+        );
+        assert!(
+            transcription.text.contains("我觉得晚上会下雨"),
+            "new-sentence 我 must stay, got {:?}",
+            transcription.text
+        );
+        assert!(!transcription.text.contains("散步。觉得"));
+    }
+
+    #[test]
+    fn assembler_keeps_jintian_when_it_is_not_the_previous_tail() {
+        let transcription = assemble_wordless_overlap("我们今天去公园散步。", "今天晚上吃什么？");
+        assert!(
+            transcription.text.contains("今天晚上吃什么"),
+            "new-sentence 今天 must stay, got {:?}",
+            transcription.text
+        );
+    }
+
+    #[test]
+    fn assembler_keeps_english_head_word_that_is_not_the_previous_tail() {
+        let transcription = assemble_wordless_overlap(
+            "and so my fellow americans ask not what your country can do for you",
+            "and then we all went home",
+        );
+        assert!(
+            transcription.text.contains("and then we all went home"),
+            "English head-word must stay, got {:?}",
+            transcription.text
+        );
+        assert!(!transcription.text.contains("for you then"));
+    }
+
+    #[test]
+    fn assembler_does_not_glue_digit_strings_at_a_shared_numeral() {
+        let transcription = assemble_wordless_overlap("电话是一三八", "八零零一二三四");
+        assert_eq!(transcription.segments.len(), 2);
+        assert_eq!(transcription.text, "电话是一三八 八零零一二三四");
+    }
+
+    #[test]
+    fn assembler_does_not_eat_reduplicated_thanks() {
+        let transcription = assemble_wordless_overlap("非常感谢", "谢谢大家");
+        assert_eq!(transcription.segments.len(), 2);
+        assert_eq!(transcription.text, "非常感谢 谢谢大家");
+    }
+
+    #[test]
+    fn assembler_keeps_worded_adjacent_segments_in_the_same_slice() {
+        let mut assembler =
+            TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default());
+        assembler.push_slice_result(SliceTranscript {
+            slice: energy_slice(0, 0, 16_000 * 6),
+            text: "that is how it ended in the end in the end we all agreed".to_string(),
+            segments: vec![
+                absolute_segment(
+                    "that is how it ended in the end",
+                    0.0,
+                    3.0,
+                    vec![
+                        word("that", 0.0, 0.3),
+                        word("is", 0.3, 0.5),
+                        word("how", 0.5, 0.8),
+                        word("it", 0.8, 1.0),
+                        word("ended", 1.0, 1.5),
+                        word("in", 1.6, 1.8),
+                        word("the", 1.8, 2.1),
+                        word("end", 2.1, 3.0),
+                    ],
+                ),
+                absolute_segment(
+                    "in the end we all agreed",
+                    3.0,
+                    6.0,
+                    vec![
+                        word("in", 3.0, 3.2),
+                        word("the", 3.2, 3.4),
+                        word("end", 3.4, 3.8),
+                        word("we", 3.8, 4.1),
+                        word("all", 4.1, 4.5),
+                        word("agreed", 4.5, 6.0),
+                    ],
+                ),
+            ],
+            time_domain: SegmentTimeDomain::AbsoluteOriginal,
+        });
+        let transcription = assembler.into_transcription();
+        assert_eq!(transcription.segments.len(), 2);
+        assert_eq!(
+            transcription.segments[0].text,
+            "that is how it ended in the end"
+        );
+        assert_eq!(transcription.segments[1].text, "in the end we all agreed");
+        assert_eq!(transcription.segments[0].words.len(), 8);
+        assert_eq!(transcription.segments[1].words.len(), 6);
+    }
+
+    #[test]
+    fn normalize_words_keeps_ascii_fold_and_splits_cjk() {
+        assert_eq!(normalize_words("don't"), vec!["dont".to_string()]);
+        assert_eq!(normalize_words("twenty-one"), vec!["twentyone".to_string()]);
+        assert_eq!(normalize_words("café"), vec!["caf".to_string()]);
+        assert_eq!(
+            normalize_words("今天好"),
+            vec!["今".to_string(), "天".to_string(), "好".to_string()]
+        );
+    }
+
+    #[test]
+    fn longest_common_window_is_quadratic_for_200_units() {
+        let left: Vec<String> = (0..200).map(|index| format!("t{index}")).collect();
+        let mut right = left.clone();
+        right.rotate_left(40);
+        let started = std::time::Instant::now();
+        let overlap = longest_common_window_len(&left, &right);
+        let elapsed = started.elapsed();
+        assert_eq!(overlap, 160);
+        assert!(
+            elapsed.as_millis() < 200,
+            "LCW of 200 units must stay well under 200ms, took {elapsed:?}"
+        );
     }
 }

--- a/crates/openasr-core/src/longform/slicing.rs
+++ b/crates/openasr-core/src/longform/slicing.rs
@@ -4760,4 +4760,31 @@ mod tests {
             plan.stats.provenance
         );
     }
+
+    #[test]
+    fn longform_en_zh_fixture_energy_slices_overlap_at_seams() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../fixtures/longform_en_zh.wav");
+        let samples = crate::api::audio_io::load_wav_16khz_mono_f32_v0(
+            path,
+            "longform seam fixture",
+            "longform_en_zh.wav",
+        )
+        .expect("load fixtures/longform_en_zh.wav");
+        let options = LongFormOptions {
+            mode: LongFormMode::Energy,
+            ..LongFormOptions::default()
+        };
+        let plan = plan_longform_slices(&samples, 16_000, &options, None).unwrap();
+        assert!(
+            plan.slices.len() >= 2,
+            "69s fixture must slice under the 30s energy window, got {plan:#?}"
+        );
+        for pair in plan.slices.windows(2) {
+            assert!(
+                pair[1].content_start_sample < pair[0].content_end_sample,
+                "consecutive energy slices must re-read the cut: {pair:#?}"
+            );
+        }
+    }
 }

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -234,6 +234,12 @@ sequencing, see [Roadmap](ROADMAP.md) (Implemented-baseline section).
   ignored -- use a multilingual Whisper pack when you need to force or read back the
   language. (Wiring Qwen's text-prompt language conditioning is tracked, but needs a
   real-pack parity check against the reference inference before it can be claimed.)
+  Qwen3-ASR 0.6B q4 on `fixtures/en_zh_mixed.wav` (5s English + ~8s Mandarin)
+  currently drops the English lead-in and truncates the Mandarin tail; the same
+  clip is a single 0--13s decode (not VAD/leading-silence clipping), and the
+  family rejects `--language`. Treat this as a model code-switch limit of that
+  pack -- use Whisper, MiMo-ASR, or moss-transcribe-diarize when the English
+  half must be kept. fp16 / 1.7B were not re-measured on this host.
   Dolphin is specify-only: it does not auto-detect, so an explicit `--language`
   selects one of its 14 recognition codes (`zh` plus 13 Chinese regional-dialect
   codes such as `zh-sichuan`, `zh-shanghai`, `zh-hebei`) via a decode-prompt


### PR DESCRIPTION
## Summary

Long-form transcription duplicated or orphaned CJK fragments at slice seams (e.g. `周末的时候，我。` / `的时候，` / `我通常会…` for Qwen3-ASR q4; a lone `饭，` cue for moss-transcribe-diarize on the 70s `en_zh_mixed` loop). The assembler's seam dedupe never fired for wordless CJK segments.

- Stitch the suffix/prefix overlap between the last segment of a slice and the first segment of the next slice for wordless CJK output. Consume only the overlapping units plus immediately following punctuation, so `previous` text can never include speech that lies after the slice boundary; `previous.end` and the remainder slice window are left untouched so forced alignment keeps its original windows.
- Drop a previous-side period that the model planted at the truncated cut when `current` continues the sentence.
- Guardrails against over-eating: tail-anchored overlap search only; `n >= 3` general, `n >= 2` for overlaps, pure digits rejected, single-CJK-char stitches only under ≥0.18s time overlap and not for reduplication (「我 我」, 「谢谢」). Cross-slice wordless segments only; worded adjacent segments in one slice are never merged.
- Longest-common-window is now O(n·m) DP; `normalize_words` keeps ASCII case-folding and splits CJK per char.
- Golden constants for mimo / firered-aed / firered-llm regenerated from real assembler output on the original slice texts; moss golden unchanged (no seam artefact in that shape).
- `docs/KNOWN_LIMITATIONS.md`: record that Qwen3-ASR 0.6B q4 drops the English lead-in on mixed EN/ZH clips (model code-switch limit, not a core bug — surfaced during the same diagnosis).

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- `cargo nextest run -p openasr-core longform` → 137 passed
- `cargo nextest run -p openasr-cli -E 'test(/longform/)' --run-ignored all` → 11 passed (pack-gated tests skip cleanly)
- Isolated-HOME e2e on qwen3-asr-0.6b q4 and moss-transcribe-diarize q4 (Metal): duplicate/orphan cues gone.
- Timestamp regression gate vs 0.1.40 baseline: moss 21/21 cues identical; qwen identical on all cues except the two seam cues whose text changed (display end/start move with the cue packer's CPS layout — no timing information lost). Slice windows identical (`0–25.5 / 25.5–69.6`).
- Three independent review rounds; rounds 1–2 caught over-eating and a forced-alignment window regression, both removed before this PR.

## Follow-ups (separate issues)

- CJK segment join inserts an ASCII space between Han sentences (pre-existing, more visible at seams).
- Remainder first-word timing stays anchored at its original slice position, leaving a 2–3s gap after the seam cue.
- Re-run the three fp16 CPU ignored goldens on a host with the packs.

AI usage disclosure: YES

Made with [Cursor](https://cursor.com)