### PR TITLE
fix(core): harden transcription readiness and timestamp provenance

### DIFF
--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -350,6 +350,11 @@ pub(super) fn resolve_model_source_for_backend(
         });
     }
 
+    // Installed binaries may run outside a checkout with no catalog override.
+    // Keep signed quant aliases available offline, just as show/language
+    // metadata does. This fallback performs no network request.
+    let catalog = Some(native_catalog_or_embedded(catalog, &home)?);
+
     // Native: an explicit --model-pack is the advanced escape hatch; otherwise
     // resolve an installed pack by model id. This path NEVER pulls -- the CLI
     // transcribe/live handlers run the consent-pull before reaching here, while
@@ -384,6 +389,17 @@ pub(super) fn resolve_model_source_for_backend(
         model_id,
         model_pack_path: Some(model_pack_root),
     })
+}
+
+fn native_catalog_or_embedded(
+    catalog: Option<openasr_core::ModelCatalog>,
+    home: &Path,
+) -> Result<openasr_core::ModelCatalog> {
+    match catalog {
+        Some(catalog) => Ok(catalog),
+        None => openasr_core::load_embedded_signed_catalog(home)
+            .context("Could not load the embedded signed model catalog"),
+    }
 }
 
 /// With no explicit reference, resolving the persisted default against installed
@@ -1767,6 +1783,17 @@ mod tests {
     use std::ffi::{OsStr, OsString};
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use tower::ServiceExt;
+
+    #[test]
+    fn installed_binary_resolves_quant_aliases_without_a_checkout_catalog() {
+        let home = tempfile::tempdir().unwrap();
+        let catalog = native_catalog_or_embedded(None, home.path()).unwrap();
+        let cards = runtime_registry(Some(&catalog)).unwrap();
+        for reference in ["xasr-zh-en:q8", "xasr-zh-en:q8_0"] {
+            let resolved = resolve_runtime_model_ref(&cards, Some(&catalog), reference).unwrap();
+            assert_eq!(resolved.runtime_model_id, "xasr-zh-en:q8_0");
+        }
+    }
 
     fn test_native_execution_services() -> Arc<NativeExecutionServices> {
         Arc::new(

--- a/crates/openasr-cli/tests/cli.rs
+++ b/crates/openasr-cli/tests/cli.rs
@@ -763,10 +763,10 @@ fn transcribe_mock_formats_match_core_renderers() {
 // `OPENASR_GGML_BACKEND=cpu` (Metal currently OOMs this family's 7B decoder
 // on a 16GB unified-memory Mac, see the T5 report); the auto energy-VAD
 // slicer picked 3 chunks here. The extra "中" is a model token. The first-seam
-// "我 我" is consumed by the shared assembler; the join space remains
-// (`周末的时候我 通常会`). Bytes come from feeding the three origin slice
+// "我 我" is consumed by the shared assembler without an inserted CJK space.
+// Bytes come from feeding the three origin slice
 // texts through TranscriptAssembler (pending pack re-measure).
-const FIRERED_LLM_GOLDEN_LONGFORM_EN_ZH_TEXT: &str = "and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗中 周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country";
+const FIRERED_LLM_GOLDEN_LONGFORM_EN_ZH_TEXT: &str = "and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗中周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country";
 
 #[test]
 #[ignore = "requires the private ~8.9GB dev-only firered2-llm-q8_0.oasr pack; runs the real \
@@ -774,13 +774,8 @@ const FIRERED_LLM_GOLDEN_LONGFORM_EN_ZH_TEXT: &str = "and so my fellow americans
             (~30 minutes wall clock at this family's current CPU-decode RTF -- see the T5 report)"]
 fn firered_llm_golden_diff_longform_cli_transcribe_matches_reference_decode() {
     let pack_path =
-        match external_test_fixture_path("OPENASR_FIRERED_LLM_PACK", "FireRed2 LLM .oasr pack") {
-            Ok(path) => path,
-            Err(skip) => {
-                eprintln!("skipping: {skip}");
-                return;
-            }
-        };
+        external_test_fixture_path("OPENASR_FIRERED_LLM_PACK", "FireRed2 LLM .oasr pack")
+            .expect("explicitly requested longform golden requires its exact model fixture");
     let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../fixtures/longform_en_zh.wav")
         .canonicalize()
@@ -819,10 +814,9 @@ fn firered_llm_golden_diff_longform_cli_transcribe_matches_reference_decode() {
 // content). Pinned against `OPENASR_GGML_BACKEND=cpu` (Metal memory fit for
 // this family's ~8B combined weights on a 16GB unified-memory Mac is
 // unverified, see this module's e2e report).
-// The longform assembler joins retained, trimmed segment texts with one space.
-// The spaces inside this `concat!` are therefore golden bytes, taken from
-// feeding the three origin slice texts through TranscriptAssembler. The
-// first-seam "我 我" is consumed; the join space remains (`我 通常会`).
+// The longform assembler joins retained texts at script-aware boundaries.
+// Expected bytes are projected from the three origin slice texts; exact-pack
+// re-measure remains required. The first-seam "我 我" is consumed without space.
 // The same family's single-utterance EN->ZH golden
 // (`mimo_asr::executor::tests::golden_diff_end_to_end_transcribe_en_zh_mixed_wav`)
 // also asserts the EN->ZH space.
@@ -830,11 +824,11 @@ const GOLDEN_MIMO_LONGFORM_EN_ZH_TEXT: &str = concat!(
     "And so, my fellow Americans, ask not what your country can do for you. ",
     "Ask what you can do for your country. ",
     "今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，",
-    "听说那里的麻婆豆腐特别正宗。周末的时候，我 通常会读书或者看一部电影放松一下。",
+    "听说那里的麻婆豆腐特别正宗。周末的时候，我通常会读书或者看一部电影放松一下。",
     "And so, my fellow Americans, ask not what your country can do for you, ",
     "ask what you can do for your country.",
     "今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，",
-    "听说那里的麻婆豆腐特别正宗。 ",
+    "听说那里的麻婆豆腐特别正宗。",
     "周末的时候，我通常会读书或者看一部电影放松一下。",
     "And so, my fellow Americans, ask not what your country can do for you. ",
     "Ask what you can do for your country.",
@@ -846,14 +840,8 @@ const GOLDEN_MIMO_LONGFORM_EN_ZH_TEXT: &str = concat!(
             (~38 minutes wall clock at this family's current CPU-decode RTF -- 3 chunk \
             decodes, see this test's doc comment)"]
 fn mimo_asr_golden_diff_longform_cli_transcribe_matches_reference_decode() {
-    let pack_path = match external_test_fixture_path("OPENASR_MIMO_ASR_PACK", "MiMo ASR .oasr pack")
-    {
-        Ok(path) => path,
-        Err(skip) => {
-            eprintln!("skipping: {skip}");
-            return;
-        }
-    };
+    let pack_path = external_test_fixture_path("OPENASR_MIMO_ASR_PACK", "MiMo ASR .oasr pack")
+        .expect("explicitly requested longform golden requires its exact model fixture");
     let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../fixtures/longform_en_zh.wav")
         .canonicalize()
@@ -894,8 +882,8 @@ fn mimo_asr_golden_diff_longform_cli_transcribe_matches_reference_decode() {
 // slicer to split -- confirmed 3 chunks via `--format verbose_json`'s
 // `longform.chunk_count`. Pinned against `OPENASR_GGML_BACKEND=cpu`. The
 // missing space between "COUNTRY" and "今天" / "ANDSO" is a tokenizer join.
-// The first-seam "我 我" is consumed by the shared assembler; the join
-// space remains (`周末的时候我 通常会`). Bytes come from feeding the
+// The first-seam "我 我" is consumed without an inserted CJK join space.
+// Bytes come from feeding the
 // three origin slice texts through TranscriptAssembler
 // (pending pack re-measure).
 fn firered_aed_dev_pack_path() -> PathBuf {
@@ -904,9 +892,9 @@ fn firered_aed_dev_pack_path() -> PathBuf {
 
 const GOLDEN_FIRERED_AED_LONGFORM_EN_ZH_TEXT: &str = concat!(
     "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO ",
-    "FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 通常会读书或者看一部电影放松一下 ",
+    "FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我通常会读书或者看一部电影放松一下 ",
     "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO ",
-    "FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗 周末的时候我通常会读书或者看一部电影放松一下 ",
+    "FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我通常会读书或者看一部电影放松一下 ",
     "ANDSO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR ",
     "YOUR COUNTRY",
 );
@@ -916,10 +904,11 @@ const GOLDEN_FIRERED_AED_LONGFORM_EN_ZH_TEXT: &str = concat!(
             longform-chunked CLI transcribe path on a ~69s fixture, OPENASR_GGML_BACKEND=cpu"]
 fn firered_aed_golden_diff_longform_cli_transcribe_matches_reference_decode() {
     let pack_path = firered_aed_dev_pack_path();
-    if !pack_path.exists() {
-        eprintln!("skipping: {} not present", pack_path.display());
-        return;
-    }
+    assert!(
+        pack_path.is_file(),
+        "explicitly requested longform golden requires {}",
+        pack_path.display()
+    );
     let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../fixtures/longform_en_zh.wav")
         .canonicalize()

--- a/crates/openasr-client/src/local_trust.rs
+++ b/crates/openasr-client/src/local_trust.rs
@@ -106,11 +106,10 @@ impl ManagedDaemonEndpoint {
 
 /// An opened-once proof of user-selected local media.
 ///
-/// The proof owns the file handle that was validated. Callers clone that
-/// handle for streaming; they never reopen the path. Replacing the directory
-/// entry after selection therefore cannot change the bytes an authorized
-/// request reads. The canonical path is retained only for native playback
-/// scope and display-name projection, never as later read authority.
+/// The proof owns the validated file handle. Independent readers must use
+/// [`Self::open_fresh`], which checks the reopened handle against this proof;
+/// the canonical path alone is never read authority. Cloned handles retain
+/// the opened generation but share a read cursor.
 #[derive(Debug)]
 pub struct SelectedMedia {
     file: File,
@@ -156,9 +155,31 @@ impl SelectedMedia {
         })
     }
 
+    /// Clone the held handle, sharing its read cursor. Use [`Self::open_fresh`]
+    /// for independent uploads or retries.
     pub fn try_clone_file(&self) -> Result<File, LocalTrustError> {
         self.ensure_identity()?;
         self.file.try_clone().map_err(LocalTrustError::CloneMedia)
+    }
+
+    /// Open an independent reader at offset zero, rejecting changed media or
+    /// a replaced path. Identity is checked on the opened handle, not the path.
+    pub fn open_fresh(&self) -> Result<File, LocalTrustError> {
+        self.ensure_identity()?;
+        let file = open_without_following_final_link(&self.canonical_path)
+            .map_err(LocalTrustError::OpenMedia)?;
+        let metadata = file
+            .metadata()
+            .map_err(LocalTrustError::InspectOpenedMedia)?;
+        if !is_plain_regular_file(&metadata) {
+            return Err(LocalTrustError::MediaIsNotRegularFile);
+        }
+        let identity = StrongFileIdentity::of_file(&file, &metadata)
+            .ok_or(LocalTrustError::UnsupportedMediaIdentity)?;
+        if identity != self.identity {
+            return Err(LocalTrustError::MediaIdentityChanged);
+        }
+        Ok(file)
     }
 
     pub fn canonical_path(&self) -> &Path {
@@ -240,7 +261,9 @@ fn open_without_following_final_link(path: &Path) -> std::io::Result<File> {
 
     OpenOptions::new()
         .read(true)
-        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        // Do not block if a path is raced into a FIFO; regular files ignore
+        // O_NONBLOCK and the opened metadata rejects special files below.
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
         .open(path)
 }
 
@@ -320,6 +343,10 @@ mod tests {
         assert_eq!(bytes, b"selected-generation");
         assert_eq!(selected.display_name(), "selected.wav");
         assert_eq!(selected.len(), b"selected-generation".len() as u64);
+        assert!(matches!(
+            selected.open_fresh(),
+            Err(LocalTrustError::MediaIdentityChanged)
+        ));
     }
 
     #[test]
@@ -332,6 +359,31 @@ mod tests {
     }
 
     #[test]
+    fn fresh_media_readers_have_independent_offsets_after_a_full_upload() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("selected.wav");
+        std::fs::write(&path, b"selected-generation").unwrap();
+        let selected = SelectedMedia::open(&path).unwrap();
+        let mut uploaded = Vec::new();
+        selected
+            .try_clone_file()
+            .unwrap()
+            .read_to_end(&mut uploaded)
+            .unwrap();
+        let mut first = selected.open_fresh().unwrap();
+        let mut second = selected.open_fresh().unwrap();
+        let mut prefix = [0; 3];
+        first.read_exact(&mut prefix).unwrap();
+        assert_eq!(&prefix, b"sel");
+        let mut replay = Vec::new();
+        second.read_to_end(&mut replay).unwrap();
+        assert_eq!(replay, uploaded);
+        let mut remainder = Vec::new();
+        first.read_to_end(&mut remainder).unwrap();
+        assert_eq!(remainder, b"ected-generation");
+    }
+
+    #[test]
     fn selected_media_rejects_in_place_mutation_before_cloning() {
         let directory = tempdir().unwrap();
         let path = directory.path().join("selected.wav");
@@ -341,6 +393,45 @@ mod tests {
         assert!(matches!(
             selected.try_clone_file(),
             Err(LocalTrustError::MediaIdentityChanged)
+        ));
+        assert!(matches!(
+            selected.open_fresh(),
+            Err(LocalTrustError::MediaIdentityChanged)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fresh_media_reader_rejects_symlink_to_the_original_generation() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("selected.wav");
+        let original = directory.path().join("original.wav");
+        std::fs::write(&path, b"audio").unwrap();
+        let selected = SelectedMedia::open(&path).unwrap();
+        std::fs::rename(&path, &original).unwrap();
+        std::os::unix::fs::symlink(&original, &path).unwrap();
+        assert!(matches!(
+            selected.open_fresh(),
+            Err(LocalTrustError::OpenMedia(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fresh_media_reader_rejects_fifo_replacement_without_waiting_for_a_writer() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("selected.wav");
+        std::fs::write(&path, b"audio").unwrap();
+        let selected = SelectedMedia::open(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        let fifo = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        // SAFETY: fifo is a valid, NUL-terminated path in the owned tempdir.
+        assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o600) }, 0);
+        assert!(matches!(
+            selected.open_fresh(),
+            Err(LocalTrustError::MediaIsNotRegularFile)
         ));
     }
 

--- a/crates/openasr-core/src/api/backend/native.rs
+++ b/crates/openasr-core/src/api/backend/native.rs
@@ -273,8 +273,7 @@ impl NativeRuntimeModelAdapter {
     /// descriptor is the sole source of this capability fact.
     pub fn requires_forced_aligner_for_voice_id(&self) -> bool {
         !self.descriptor.speaker_segmentation.is_in_decoder()
-            && self.descriptor.word_timestamp_source
-                == crate::arch::WordTimestampSource::ForcedAligner
+            && self.descriptor.word_timestamp_source != crate::arch::WordTimestampSource::Native
     }
 }
 

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1002,6 +1002,7 @@ struct NativeTranscriptionOutcome {
     transcription: Transcription,
     prepared_audio: PcmBuffer,
     emits_punctuation: Option<bool>,
+    word_timestamp_source: crate::arch::WordTimestampSource,
     speaker_finalization: SpeakerFinalizationContext,
     /// Resolved progress weights (actual backend + segmenter after prepare).
     progress_backend: ProgressBackendClass,
@@ -1264,6 +1265,7 @@ fn run_native_transcription_fallible_with_input(
         transcription,
         prepared_audio,
         emits_punctuation,
+        word_timestamp_source,
         speaker_finalization,
         progress_backend: backend_class,
         progress_segmenter: segmenter_kind,
@@ -1313,8 +1315,11 @@ fn run_native_transcription_fallible_with_input(
         execution_context.as_ref(),
         &progress,
     )?;
-    let native_validation =
-        crate::subtitle::validate_word_anchors(&transcription, audio_duration_s);
+    let native_validation = crate::subtitle::validate_native_word_anchors(
+        &transcription,
+        audio_duration_s,
+        word_timestamp_source,
+    );
     let voice_id_needs_align = speaker_finalization
         .requires_word_alignment(&transcription, native_validation.is_reliable());
     let align_decision = crate::subtitle::decide_forced_alignment(
@@ -1554,7 +1559,7 @@ fn optional_punctuation_failure_disables_stage(
 /// stage's documented "finalize-only, per segment" contract -- see
 /// `crate::punctuation`'s module docs) and rebuilds the top-level `text` field
 /// from the punctuated segments the same way the longform assembler does
-/// (trim, drop empties, join with a space), so the punctuated text and
+/// (trim, drop empties, join at script-aware boundaries), so the punctuated text and
 /// segments stay consistent. A segment whose classifier call fails keeps its
 /// original (unpunctuated) text -- fail-closed per segment rather than
 /// aborting the whole transcript.
@@ -1568,13 +1573,12 @@ fn punctuate_transcription_segments(
             segment.text = punctuated;
         }
     }
-    transcription.text = transcription
-        .segments
-        .iter()
-        .map(|segment| segment.text.trim())
-        .filter(|text| !text.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
+    transcription.text = crate::transcript_text::join_segment_texts(
+        transcription
+            .segments
+            .iter()
+            .map(|segment| segment.text.as_str()),
+    );
     transcription
 }
 
@@ -1604,13 +1608,12 @@ fn punctuate_transcription_segments_with_actor(
         }
         progress.report_units((index as u64).saturating_add(1), total.max(1));
     }
-    transcription.text = transcription
-        .segments
-        .iter()
-        .map(|segment| segment.text.trim())
-        .filter(|text| !text.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
+    transcription.text = crate::transcript_text::join_segment_texts(
+        transcription
+            .segments
+            .iter()
+            .map(|segment| segment.text.as_str()),
+    );
     Ok(transcription)
 }
 
@@ -2665,6 +2668,19 @@ fn run_native_transcription_impl(
     let strip_forced_word_timestamps =
         (external_speakers || force_word_timestamps_for_segmentation) && !request.word_timestamps;
     request_options.word_timestamps_forced_for_diarization = strip_forced_word_timestamps;
+    // Decode-sensitive families preserve their ordinary decode when words
+    // are forced only for speaker attribution. Their batch lane also produces
+    // post-hoc estimates; batch eligibility is not proof of cross-attention
+    // anchors even if a particular request ultimately executes serially.
+    let word_timestamp_source = if (strip_forced_word_timestamps
+        || request_options.serve_batch.enabled())
+        && selected_family.word_timestamps
+            == crate::arch::OpenAsrWordTimestampStrategy::DecodeSensitive
+    {
+        crate::arch::WordTimestampSource::NativeApproximate
+    } else {
+        selected_family.word_timestamp_source
+    };
     // OADP Phase 0: the request-level adapter path rides the execution options
     // down to the family executor (env stays the server-side fallback).
     request_options.adapter_path = request.adapter_path.clone();
@@ -2838,6 +2854,7 @@ fn run_native_transcription_impl(
                 },
                 prepared_audio,
                 emits_punctuation,
+                word_timestamp_source,
                 speaker_finalization: SpeakerFinalizationContext::new(
                     speaker_turns,
                     voice_id_embedder,
@@ -2853,7 +2870,10 @@ fn run_native_transcription_impl(
         }
         if has_processed_audio || plan.slices.len() > 1 {
             let mut assembler =
-                TranscriptAssembler::new(plan.timeline.clone(), SegmentMergePolicy::default());
+                TranscriptAssembler::new(plan.timeline.clone(), SegmentMergePolicy::default())
+                    .with_approximate_word_timestamps(
+                        word_timestamp_source.has_synthetic_word_spans(),
+                    );
             let mut rolling_prompt = request_options.prompt.clone().unwrap_or_default();
             let mut rolling_prompt_token_ids: Vec<u32> = Vec::new();
             let carry_prompt_mode =
@@ -3185,6 +3205,7 @@ fn run_native_transcription_impl(
                     transcription,
                     prepared_audio,
                     emits_punctuation,
+                    word_timestamp_source,
                     speaker_finalization: SpeakerFinalizationContext::new(
                         speaker_turns,
                         voice_id_embedder,
@@ -3209,6 +3230,7 @@ fn run_native_transcription_impl(
                 transcription,
                 prepared_audio,
                 emits_punctuation,
+                word_timestamp_source,
                 speaker_finalization: SpeakerFinalizationContext::new(
                     speaker_turns,
                     voice_id_embedder,
@@ -3295,6 +3317,7 @@ fn run_native_transcription_impl(
         transcription,
         prepared_audio,
         emits_punctuation,
+        word_timestamp_source,
         speaker_finalization: SpeakerFinalizationContext::new(
             speaker_turns,
             voice_id_embedder,
@@ -4872,13 +4895,12 @@ fn normalize_transcription_segments(
 
     transcription.segments = normalized;
     if trimmed_text.is_empty() {
-        transcription.text = transcription
-            .segments
-            .iter()
-            .map(|segment| segment.text.trim())
-            .filter(|text| !text.is_empty())
-            .collect::<Vec<_>>()
-            .join(" ");
+        transcription.text = crate::transcript_text::join_segment_texts(
+            transcription
+                .segments
+                .iter()
+                .map(|segment| segment.text.as_str()),
+        );
     } else {
         transcription.text = trimmed_text;
     }

--- a/crates/openasr-core/src/api/streaming.rs
+++ b/crates/openasr-core/src/api/streaming.rs
@@ -560,38 +560,7 @@ fn realtime_word_to_timestamp(word: &RealtimeTranscriptWord) -> crate::WordTimes
 /// space-free text, so segments already ending or starting with a CJK
 /// character are concatenated without an inserted ASCII space; otherwise a
 /// single space separates them.
-fn join_segment_texts<'a>(texts: impl Iterator<Item = &'a str>) -> String {
-    let mut out = String::new();
-    for text in texts {
-        let text = text.trim();
-        if text.is_empty() {
-            continue;
-        }
-        if !out.is_empty() {
-            let prev = out.chars().last();
-            let next = text.chars().next();
-            if !boundary_is_cjk(prev) && !boundary_is_cjk(next) {
-                out.push(' ');
-            }
-        }
-        out.push_str(text);
-    }
-    out
-}
-
-fn boundary_is_cjk(ch: Option<char>) -> bool {
-    matches!(ch, Some(ch) if is_cjk(ch))
-}
-
-fn is_cjk(ch: char) -> bool {
-    matches!(ch as u32,
-        0x3400..=0x4DBF   // CJK Ext A
-        | 0x4E00..=0x9FFF // CJK Unified
-        | 0xF900..=0xFAFF // CJK Compatibility Ideographs
-        | 0x3000..=0x303F // CJK symbols/punctuation
-        | 0xFF00..=0xFFEF // Fullwidth forms
-    )
-}
+use crate::transcript_text::join_segment_texts;
 
 #[cfg(test)]
 #[path = "streaming_tests.rs"]

--- a/crates/openasr-core/src/api/streaming_tests.rs
+++ b/crates/openasr-core/src/api/streaming_tests.rs
@@ -405,9 +405,9 @@ fn irregular_chunk_feed_keeps_frame_sequence_and_matches_whole_feed() {
 
 #[test]
 fn cjk_segments_join_without_inserted_space() {
-    let joined = super::join_segment_texts(["你好", "世界"].into_iter());
+    let joined = super::join_segment_texts(["你好", "世界"]);
     assert_eq!(joined, "你好世界");
-    let latin = super::join_segment_texts(["hello", "world"].into_iter());
+    let latin = super::join_segment_texts(["hello", "world"]);
     assert_eq!(latin, "hello world");
 }
 

--- a/crates/openasr-core/src/arch/mod.rs
+++ b/crates/openasr-core/src/arch/mod.rs
@@ -459,7 +459,18 @@ impl SpeakerSegmentationSource {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WordTimestampSource {
     Native,
+    /// Native decoder emission instants, not measured spoken-word spans.
+    /// Retain them as approximate anchors; precise timelines need alignment.
+    NativeEmission,
+    /// Decode-token positions interpolated across the audio, not acoustic spans.
+    NativeApproximate,
     ForcedAligner,
+}
+
+impl WordTimestampSource {
+    pub(crate) fn has_synthetic_word_spans(self) -> bool {
+        matches!(self, Self::NativeApproximate | Self::ForcedAligner)
+    }
 }
 
 /// How one recording is cut up for this architecture before decode -- the
@@ -968,6 +979,23 @@ pub(crate) fn builtin_adapter_descriptor(model_architecture: &str) -> GgmlFamily
         .find_by_model_architecture(model_architecture)
         .unwrap_or_else(|| panic!("builtin architecture '{model_architecture}' must be registered"))
         .ggml_family_adapter_descriptor()
+}
+
+/// Current runtime support for acoustic word spans, keyed by signed catalog
+/// family. This is a dependency-planning hint, not an execution or alignment
+/// proof: individual results still require validation. Catalog `native` also
+/// covers emission points and interpolated estimates in older catalogs.
+pub fn native_word_anchor_support() -> BTreeMap<String, bool> {
+    OpenAsrArchitectureRegistry::with_builtins()
+        .descriptors()
+        .iter()
+        .map(|descriptor| {
+            (
+                descriptor.identity.catalog_family_id.to_string(),
+                descriptor.execution_contract.word_timestamp_source == WordTimestampSource::Native,
+            )
+        })
+        .collect()
 }
 
 /// Whether a builtin family's decoder ever predicts a punctuation token (see
@@ -1678,7 +1706,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
             streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
-            word_timestamp_source: WordTimestampSource::Native,
+            word_timestamp_source: WordTimestampSource::NativeApproximate,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
             invocation_span: OpenAsrInvocationSpan::Elastic,
             emits_punctuation: Some(true),
@@ -1869,7 +1897,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
             streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
-            word_timestamp_source: WordTimestampSource::Native,
+            word_timestamp_source: WordTimestampSource::NativeApproximate,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
             invocation_span: OpenAsrInvocationSpan::Elastic,
             emits_punctuation: Some(true),
@@ -2247,7 +2275,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
             streaming_partial_granularity: StreamingPartialGranularity::FrameSyncAppend,
             speaker_segmentation: SpeakerSegmentationSource::External,
-            word_timestamp_source: WordTimestampSource::Native,
+            word_timestamp_source: WordTimestampSource::NativeEmission,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
             invocation_span: OpenAsrInvocationSpan::Elastic,
             emits_punctuation: Some(true),
@@ -2348,7 +2376,7 @@ const BUILTIN_ARCHITECTURE_DESCRIPTORS: &[OpenAsrArchitectureDescriptor] = &[
             word_timestamps: OpenAsrWordTimestampStrategy::DecodeInvariant,
             streaming_partial_granularity: StreamingPartialGranularity::RevisableSnapshot,
             speaker_segmentation: SpeakerSegmentationSource::External,
-            word_timestamp_source: WordTimestampSource::Native,
+            word_timestamp_source: WordTimestampSource::NativeApproximate,
             longform_slice_shape: OpenAsrLongformSliceShape::SharedWindow,
             invocation_span: OpenAsrInvocationSpan::Elastic,
             emits_punctuation: Some(true),
@@ -3260,6 +3288,24 @@ mod tests {
     }
 
     #[test]
+    fn native_word_anchor_support_distinguishes_spans_from_estimates() {
+        let support = native_word_anchor_support();
+        for family in [
+            "qwen",
+            "cohere",
+            "moonshine",
+            "xasr-zipformer",
+            "firered-aed",
+        ] {
+            assert_eq!(support.get(family), Some(&false), "{family}");
+        }
+        for family in ["whisper", "parakeet", "parakeet-tdt", "wav2vec2"] {
+            assert_eq!(support.get(family), Some(&true), "{family}");
+        }
+        assert!(!support.contains_key("unknown-family"));
+    }
+
+    #[test]
     fn builtin_architectures_validate_inventory_invariants() {
         OpenAsrArchitectureRegistry::with_builtins()
             .validate_references()
@@ -3626,6 +3672,16 @@ mod tests {
             let expected_word_source =
                 if forced_aligner_word_timestamps.contains(model_architecture) {
                     WordTimestampSource::ForcedAligner
+                } else if model_architecture == XASR_ZIPFORMER_GGML_ARCHITECTURE_ID {
+                    WordTimestampSource::NativeEmission
+                } else if [
+                    COHERE_TRANSCRIBE_GGML_ARCHITECTURE_ID,
+                    QWEN3_ASR_GGML_ARCHITECTURE_ID,
+                    MOONSHINE_GGML_ARCHITECTURE_ID,
+                ]
+                .contains(&model_architecture)
+                {
+                    WordTimestampSource::NativeApproximate
                 } else {
                     WordTimestampSource::Native
                 };

--- a/crates/openasr-core/src/lib.rs
+++ b/crates/openasr-core/src/lib.rs
@@ -15,6 +15,7 @@ mod file_identity;
 mod http;
 mod pe_image_identity;
 mod qualification_manifest_security;
+mod transcript_text;
 mod transport;
 #[cfg(test)]
 mod windows_cmake_cache;
@@ -49,7 +50,7 @@ pub use arch::{
     WHISPER_AUDIO_FRONTEND_ID, WHISPER_DECODE_POLICY_ID, WHISPER_GGML_ADAPTER_ID,
     WHISPER_GGML_ARCHITECTURE_ID, WHISPER_TOKENIZER_ID, XASR_ZIPFORMER_AUDIO_FRONTEND_ID,
     XASR_ZIPFORMER_DECODE_POLICY_ID, XASR_ZIPFORMER_GGML_ADAPTER_ID,
-    XASR_ZIPFORMER_GGML_ARCHITECTURE_ID, XASR_ZIPFORMER_TOKENIZER_ID,
+    XASR_ZIPFORMER_GGML_ARCHITECTURE_ID, XASR_ZIPFORMER_TOKENIZER_ID, native_word_anchor_support,
 };
 pub use backend_distribution::{
     ACTIVATED_BACKEND_SCHEMA_VERSION, ActivatedBackendPack, BACKEND_HOST_ABI_SCHEMA_VERSION,

--- a/crates/openasr-core/src/longform/assembler.rs
+++ b/crates/openasr-core/src/longform/assembler.rs
@@ -58,6 +58,7 @@ pub struct TranscriptAssembler {
     /// a redundant re-read (or a weak-model hallucination of partial audio) and
     /// is trimmed by time before it can survive into the transcript.
     committed_end_original: Option<f32>,
+    approximate_word_timestamps: bool,
 }
 
 impl TranscriptAssembler {
@@ -69,7 +70,15 @@ impl TranscriptAssembler {
             speaker_scope_by_segment: Vec::new(),
             stats: LongFormAssembleStats::default(),
             committed_end_original: None,
+            approximate_word_timestamps: false,
         }
+    }
+
+    /// Only decoders without native word alignment may regenerate estimates
+    /// after stitching. Acoustic/native anchors retain their original times.
+    pub(crate) fn with_approximate_word_timestamps(mut self, approximate: bool) -> Self {
+        self.approximate_word_timestamps = approximate;
+        self
     }
 
     pub fn push_slice_result(&mut self, transcript: SliceTranscript) {
@@ -193,13 +202,9 @@ impl TranscriptAssembler {
     pub(crate) fn into_parts_with_speaker_scopes(
         self,
     ) -> (Transcription, LongFormAssembleStats, Vec<Option<usize>>) {
-        let text = self
-            .segments
-            .iter()
-            .map(|segment| segment.text.trim())
-            .filter(|value| !value.is_empty())
-            .collect::<Vec<_>>()
-            .join(" ");
+        let text = crate::transcript_text::join_segment_texts(
+            self.segments.iter().map(|segment| segment.text.as_str()),
+        );
         let transcription = Transcription {
             truncated_decodes: Vec::new(),
             unnamed_speakers: Vec::new(),
@@ -345,7 +350,31 @@ impl TranscriptAssembler {
             return false;
         }
         let min_units = if time_overlaps { 2 } else { 3 };
-        apply_suffix_prefix_stitch(previous, current, min_units, time_overlap)
+        let stitched = apply_suffix_prefix_stitch(previous, current, min_units, time_overlap);
+        if stitched && self.approximate_word_timestamps {
+            // A prior seam may already have advanced these estimates beyond
+            // the original audio window. Preserve that committed boundary
+            // when this same segment is stitched to yet another slice.
+            let previous_start = previous
+                .words
+                .first()
+                .map_or(previous.start, |word| word.start.max(previous.start))
+                .min(previous.end);
+            previous.words = crate::subtitle::cues::interpolate_word_timestamps(
+                &previous.text,
+                previous_start,
+                previous.end,
+            );
+            // Keep both original segment windows for subsequent alignment.
+            // Only the approximate remainder starts after committed speech.
+            let remainder_start = current.start.max(previous.end).min(current.end);
+            current.words = crate::subtitle::cues::interpolate_word_timestamps(
+                &current.text,
+                remainder_start,
+                current.end,
+            );
+        }
+        stitched
     }
 }
 
@@ -490,12 +519,11 @@ fn trim_committed_overlap(segment: &mut Segment, boundary: f32) -> bool {
             .to_string(),
         // Words did not align to the text (unexpected): rebuild from the kept
         // word tokens rather than mis-slice the string.
-        None => segment.words[first_keep..]
-            .iter()
-            .map(|word| word.word.trim())
-            .filter(|word| !word.is_empty())
-            .collect::<Vec<_>>()
-            .join(" "),
+        None => crate::transcript_text::join_segment_texts(
+            segment.words[first_keep..]
+                .iter()
+                .map(|word| word.word.as_str()),
+        ),
     };
     segment.words.drain(0..first_keep);
     if let Some(first) = segment.words.first() {
@@ -1485,6 +1513,76 @@ mod tests {
     }
 
     #[test]
+    fn stitched_estimates_fill_the_original_windows_without_retiming_native_words() {
+        let previous = "周末的时候，我。";
+        let current = "的时候，我通常会读书。";
+        for approximate in [false, true] {
+            let mut assembler =
+                TranscriptAssembler::new(TimelineMap::identity(), SegmentMergePolicy::default())
+                    .with_approximate_word_timestamps(approximate);
+            assembler.push_slice_result(SliceTranscript {
+                slice: energy_slice(0, 0, 16_000 * 25 + 8_000),
+                text: previous.into(),
+                segments: vec![absolute_segment(
+                    previous,
+                    0.0,
+                    25.5,
+                    interpolated_words(previous, 0.0, 25.5),
+                )],
+                time_domain: SegmentTimeDomain::RelativeToSliceContent,
+            });
+            let original_words = interpolated_words(current, 0.0, 20.0);
+            assembler.push_slice_result(SliceTranscript {
+                slice: energy_slice(1, 16_000 * 25, 16_000 * 45),
+                text: current.into(),
+                segments: vec![absolute_segment(current, 0.0, 20.0, original_words.clone())],
+                time_domain: SegmentTimeDomain::RelativeToSliceContent,
+            });
+            let out = assembler.into_transcription();
+            assert_eq!(out.segments.len(), 2);
+            let left = &out.segments[0];
+            let right = &out.segments[1];
+            assert_eq!(left.end, 25.5);
+            assert_eq!(right.start, 25.0);
+            assert_eq!(right.end, 45.0);
+            assert_eq!(right.text, "通常会读书。");
+            if approximate {
+                assert_eq!(left.words.last().unwrap().end, left.end);
+                assert_eq!(right.words.first().unwrap().start, left.end);
+                assert_eq!(right.words.last().unwrap().end, right.end);
+                assert_eq!(
+                    left.words
+                        .iter()
+                        .map(|word| word.word.as_str())
+                        .collect::<String>(),
+                    left.text
+                );
+                assert!(right.words.iter().all(|word| word.confidence.is_none()));
+                // A later stitch must not rewind a start already repaired at
+                // the preceding seam, even when the original windows overlap.
+                let mut next = absolute_segment("会读书。然后散步。", 44.5, 60.0, Vec::new());
+                let mut resumed = TranscriptAssembler::new(
+                    TimelineMap::identity(),
+                    SegmentMergePolicy::default(),
+                )
+                .with_approximate_word_timestamps(true);
+                resumed.segments = out.segments.clone();
+                assert!(resumed.try_stitch_seam_overlap(&mut next));
+                assert_eq!(resumed.segments[1].words[0].start, 25.5);
+            } else {
+                let native_first = original_words
+                    .iter()
+                    .find(|word| word.word == "通")
+                    .unwrap();
+                assert_eq!(
+                    right.words.first().unwrap().start,
+                    25.0 + native_first.start
+                );
+            }
+        }
+    }
+
+    #[test]
     fn assembler_stitches_decode_invariant_worded_qwen_slice_seam() {
         // Production CLI path: DecodeInvariant words are forced on for cue
         // splitting, so qwen emits one slice-spanning segment with interpolated
@@ -1707,15 +1805,15 @@ mod tests {
         ]);
         assert_eq!(
             mimo,
-            "And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country. 今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，听说那里的麻婆豆腐特别正宗。周末的时候，我 通常会读书或者看一部电影放松一下。And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，听说那里的麻婆豆腐特别正宗。 周末的时候，我通常会读书或者看一部电影放松一下。And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country."
+            "And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country. 今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，听说那里的麻婆豆腐特别正宗。周末的时候，我通常会读书或者看一部电影放松一下。And so, my fellow Americans, ask not what your country can do for you, ask what you can do for your country.今天天气非常好，我打算和朋友们一起去公园散步。晚上我们还计划去一家新开的川菜馆吃饭，听说那里的麻婆豆腐特别正宗。周末的时候，我通常会读书或者看一部电影放松一下。And so, my fellow Americans, ask not what your country can do for you. Ask what you can do for your country."
         );
         assert_eq!(
             firered_aed,
-            "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 通常会读书或者看一部电影放松一下 AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗 周末的时候我通常会读书或者看一部电影放松一下 ANDSO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY"
+            "AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我通常会读书或者看一部电影放松一下 AND SO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我通常会读书或者看一部电影放松一下 ANDSO MY FELLOW AMERICANS ASK NOT WHAT YOUR COUNTRY CAN DO FOR YOU ASK WHAT YOU CAN DO FOR YOUR COUNTRY"
         );
         assert_eq!(
             firered_llm,
-            "and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我 通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗中 周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country"
+            "and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country 今天天气非常好我打算和朋友们一起去公园散步晚上我们还计划去一家新开的川菜馆吃饭听说那里的麻婆豆腐特别正宗中周末的时候我通常会读书或者看一部电影放松一下 and so my fellow americans ask not what your country can do for you ask what you can do for your country"
         );
     }
 
@@ -1725,7 +1823,7 @@ mod tests {
         let transcription =
             assemble_wordless_overlap("周末的时候，我", "我通常会读书或者看一部电影放松一下。");
         assert_eq!(
-            transcription.text.replace(' ', ""),
+            transcription.text,
             "周末的时候，我通常会读书或者看一部电影放松一下。"
         );
     }
@@ -1750,7 +1848,7 @@ mod tests {
         });
         let transcription = assembler.into_transcription();
         assert_eq!(transcription.segments.len(), 2);
-        assert_eq!(transcription.text, "今天好 今天坏");
+        assert_eq!(transcription.text, "今天好今天坏");
     }
 
     #[test]
@@ -1869,14 +1967,14 @@ mod tests {
     fn assembler_does_not_glue_digit_strings_at_a_shared_numeral() {
         let transcription = assemble_wordless_overlap("电话是一三八", "八零零一二三四");
         assert_eq!(transcription.segments.len(), 2);
-        assert_eq!(transcription.text, "电话是一三八 八零零一二三四");
+        assert_eq!(transcription.text, "电话是一三八八零零一二三四");
     }
 
     #[test]
     fn assembler_does_not_eat_reduplicated_thanks() {
         let transcription = assemble_wordless_overlap("非常感谢", "谢谢大家");
         assert_eq!(transcription.segments.len(), 2);
-        assert_eq!(transcription.text, "非常感谢 谢谢大家");
+        assert_eq!(transcription.text, "非常感谢谢谢大家");
     }
 
     #[test]

--- a/crates/openasr-core/src/models/cohere/decoder_graph.rs
+++ b/crates/openasr-core/src/models/cohere/decoder_graph.rs
@@ -258,12 +258,9 @@ pub(crate) fn run_cohere_decoder_graph_short_form_with_runtime(
                 &decode_text_token_ids,
             )?
         } else {
-            let text = segments
-                .iter()
-                .map(|segment| segment.text.trim())
-                .filter(|text| !text.is_empty())
-                .collect::<Vec<_>>()
-                .join(" ");
+            let text = crate::transcript_text::join_segment_texts(
+                segments.iter().map(|segment| segment.text.as_str()),
+            );
             Transcription {
                 truncated_decodes: Vec::new(),
                 unnamed_speakers: Vec::new(),

--- a/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
+++ b/crates/openasr-core/src/models/moss_transcribe_diarize/speaker_segments.rs
@@ -448,12 +448,9 @@ pub(crate) fn normalize_moss_td_decode(
             segment.speaker_label = None;
         }
     }
-    let text = segments
-        .iter()
-        .map(|segment| segment.text.trim())
-        .filter(|segment_text| !segment_text.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
+    let text = crate::transcript_text::join_segment_texts(
+        segments.iter().map(|segment| segment.text.as_str()),
+    );
     MossTdNormalizedDecode {
         segments,
         text,

--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -308,6 +308,10 @@ pub struct CatalogModel {
     /// Where this ASR family obtains usable word anchors. This mirrors the
     /// architecture descriptor so clients can install a forced-aligner pack
     /// before starting external speaker attribution instead of failing late.
+    /// Older signed catalogs label emission points and interpolated estimates
+    /// as `Native`; local dependency planning must also consult
+    /// [`crate::native_word_anchor_support`]. A catalog flag is not proof that
+    /// an individual result has reliable acoustic word spans.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub word_timestamp_source: Option<CatalogWordTimestampSource>,
     // Whether the model's transcripts include punctuation -- an architecture/

--- a/crates/openasr-core/src/registry/tests/catalog.rs
+++ b/crates/openasr-core/src/registry/tests/catalog.rs
@@ -1804,7 +1804,11 @@ fn embedded_catalog_speaker_capabilities_match_architecture_registry() {
             architecture
         );
         let expected_word_source = match descriptor.execution_contract.word_timestamp_source {
-            crate::arch::WordTimestampSource::Native => CatalogWordTimestampSource::Native,
+            crate::arch::WordTimestampSource::Native
+            | crate::arch::WordTimestampSource::NativeApproximate
+            | crate::arch::WordTimestampSource::NativeEmission => {
+                CatalogWordTimestampSource::Native
+            }
             crate::arch::WordTimestampSource::ForcedAligner => {
                 CatalogWordTimestampSource::ForcedAligner
             }

--- a/crates/openasr-core/src/subtitle/anchors.rs
+++ b/crates/openasr-core/src/subtitle/anchors.rs
@@ -53,6 +53,10 @@ pub enum WordAnchorQuality {
 /// One concrete reason a word-anchor stream failed validation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum WordAnchorIssue {
+    /// The decoder supplied emission points, not spoken-word intervals.
+    NativeEmissionPoints,
+    /// This decoder has no native word alignment; its word spans are estimates.
+    ApproximateNativeWords,
     /// A timed speech segment carried no `words[]`.
     MissingWordsOnSpeech {
         segment_index: usize,
@@ -95,6 +99,33 @@ pub enum WordAnchorIssue {
     InsufficientTextCoverage { segment_index: usize, coverage: f32 },
     /// A large span of speech had no word anchors between consecutive words.
     LargeWordlessGap { segment_index: usize, gap_s: f32 },
+}
+
+/// Validate native timestamps using the decoder's timing contract as well as
+/// the numeric anchors. Monotonic emission points cannot prove word spans.
+pub(crate) fn validate_native_word_anchors(
+    transcription: &Transcription,
+    audio_duration_s: f32,
+    source: crate::arch::WordTimestampSource,
+) -> WordAnchorValidation {
+    let mut validation = validate_word_anchors(transcription, audio_duration_s);
+    if transcription.segments.iter().any(is_speech_segment) {
+        let issue = match source {
+            crate::arch::WordTimestampSource::Native => None,
+            crate::arch::WordTimestampSource::NativeEmission => {
+                Some(WordAnchorIssue::NativeEmissionPoints)
+            }
+            crate::arch::WordTimestampSource::ForcedAligner
+            | crate::arch::WordTimestampSource::NativeApproximate => {
+                Some(WordAnchorIssue::ApproximateNativeWords)
+            }
+        };
+        if let Some(issue) = issue {
+            validation.quality = WordAnchorQuality::Unreliable;
+            validation.issues.push(issue);
+        }
+    }
+    validation
 }
 
 /// Validate word anchors on a finished transcription against the audio length.
@@ -316,6 +347,71 @@ mod tests {
             segments,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn emission_points_do_not_certify_a_precise_native_timeline() {
+        use crate::arch::WordTimestampSource;
+        use crate::subtitle::{TimelinePrecisionPolicy, decide_forced_alignment};
+
+        let t = transcription(vec![segment(
+            "你好世界",
+            vec![word("你好", 0.5, 0.54), word("世界", 0.8, 0.84)],
+        )]);
+        assert!(validate_word_anchors(&t, 1.0).is_reliable());
+        let validation = validate_native_word_anchors(&t, 1.0, WordTimestampSource::NativeEmission);
+        assert!(!validation.is_reliable());
+        assert!(
+            validation
+                .issues
+                .contains(&WordAnchorIssue::NativeEmissionPoints)
+        );
+        assert!(
+            decide_forced_alignment(
+                TimelinePrecisionPolicy::Always,
+                false,
+                false,
+                false,
+                &validation
+            )
+            .need_align
+        );
+        assert!(
+            decide_forced_alignment(
+                TimelinePrecisionPolicy::Auto,
+                false,
+                false,
+                true,
+                &validation
+            )
+            .need_align
+        );
+        assert!(
+            !decide_forced_alignment(
+                TimelinePrecisionPolicy::Off,
+                false,
+                false,
+                true,
+                &validation
+            )
+            .need_align
+        );
+        assert!(validate_native_word_anchors(&t, 1.0, WordTimestampSource::Native).is_reliable());
+        let approximate = validate_native_word_anchors(&t, 1.0, WordTimestampSource::ForcedAligner);
+        assert!(!approximate.is_reliable());
+        assert!(
+            approximate
+                .issues
+                .contains(&WordAnchorIssue::ApproximateNativeWords)
+        );
+        assert!(
+            validate_native_word_anchors(
+                &Transcription::default(),
+                1.0,
+                WordTimestampSource::NativeEmission
+            )
+            .is_reliable()
+        );
     }
 
     #[test]

--- a/crates/openasr-core/src/subtitle/cues.rs
+++ b/crates/openasr-core/src/subtitle/cues.rs
@@ -226,7 +226,7 @@ fn build_tokens(segment: &Segment, chars: &[char]) -> (Vec<CueToken>, bool) {
             .collect();
         return (tokens, true);
     }
-    (synthesize_tokens(segment, chars), false)
+    (synthesize_tokens(chars, segment.start, segment.end), false)
 }
 
 /// Synthesise word-sized tokens when real `words[]` are missing or cannot be
@@ -241,13 +241,13 @@ fn build_tokens(segment: &Segment, chars: &[char]) -> (Vec<CueToken>, bool) {
 ///
 /// Times are interpolated proportionally across
 /// `[segment.start, segment.end]` by character position.
-fn synthesize_tokens(segment: &Segment, chars: &[char]) -> Vec<CueToken> {
+fn synthesize_tokens(chars: &[char], start: f32, end: f32) -> Vec<CueToken> {
     let total = chars.len();
     if total == 0 {
         return Vec::new();
     }
-    let span_start = segment.start;
-    let span = (segment.end - segment.start).max(0.0);
+    let span_start = start;
+    let span = (end - start).max(0.0);
     let at = |char_index: usize| span_start + span * (char_index as f32 / total as f32);
     let mut tokens = Vec::new();
     let mut index = 0usize;
@@ -283,6 +283,25 @@ fn synthesize_tokens(segment: &Segment, chars: &[char]) -> Vec<CueToken> {
         });
     }
     tokens
+}
+
+/// Rebuild approximate word anchors after a manuscript seam edit. These are
+/// presentation estimates, never acoustic evidence or forced-aligned words.
+pub(crate) fn interpolate_word_timestamps(
+    text: &str,
+    start: f32,
+    end: f32,
+) -> Vec<crate::WordTimestamp> {
+    let chars: Vec<char> = text.chars().collect();
+    synthesize_tokens(&chars, start, end)
+        .into_iter()
+        .map(|token| crate::WordTimestamp {
+            word: chars[token.char_start..token.char_end].iter().collect(),
+            start: token.start,
+            end: token.end,
+            confidence: None,
+        })
+        .collect()
 }
 
 fn is_cjk_or_fullwidth_punct(ch: char) -> bool {

--- a/crates/openasr-core/src/subtitle/mod.rs
+++ b/crates/openasr-core/src/subtitle/mod.rs
@@ -17,6 +17,7 @@ mod mismatch;
 mod reading;
 mod refine;
 mod timeline;
+pub(crate) use anchors::validate_native_word_anchors;
 
 pub use anchors::{
     WordAnchorIssue, WordAnchorQuality, WordAnchorValidation, validate_word_anchors,

--- a/crates/openasr-core/src/subtitle/reading.rs
+++ b/crates/openasr-core/src/subtitle/reading.rs
@@ -18,6 +18,7 @@
 //!   segmented at natural boundaries)
 
 use crate::api::backend::{Segment, WordTimestamp};
+use crate::transcript_text::needs_ascii_space_join;
 
 /// Soft ceiling on merged paragraph duration (seconds). Tunable V1 constant.
 pub const MAX_PARAGRAPH_SECONDS: f32 = 45.0;
@@ -123,39 +124,6 @@ fn merge_into(target: &mut Segment, next: Segment) {
         target.speaker_snapshot_label = next.speaker_snapshot_label;
     }
     append_words(&mut target.words, next.words);
-}
-
-fn needs_ascii_space_join(left: &str, right: &str) -> bool {
-    let Some(prev) = left.chars().next_back() else {
-        return false;
-    };
-    let Some(next) = right.chars().next() else {
-        return false;
-    };
-    if prev.is_whitespace() || next.is_whitespace() {
-        return false;
-    }
-    // CJK / fullwidth runs concatenate without a Latin word space.
-    if is_cjk_or_fullwidth(prev) || is_cjk_or_fullwidth(next) {
-        return false;
-    }
-    true
-}
-
-fn is_cjk_or_fullwidth(ch: char) -> bool {
-    matches!(
-        u32::from(ch),
-        0x1100..=0x115F
-            | 0x2E80..=0x2EFF
-            | 0x3000..=0x303F
-            | 0x3040..=0x30FF
-            | 0x3400..=0x4DBF
-            | 0x4E00..=0x9FFF
-            | 0xAC00..=0xD7A3
-            | 0xF900..=0xFAFF
-            | 0xFF00..=0xFF60
-            | 0x20000..=0x3134F
-    )
 }
 
 fn append_words(target: &mut Vec<WordTimestamp>, next: Vec<WordTimestamp>) {

--- a/crates/openasr-core/src/transcript_text.rs
+++ b/crates/openasr-core/src/transcript_text.rs
@@ -1,0 +1,68 @@
+//! Shared text projection for already segmented transcripts.
+
+/// Trim segment boundaries and join non-empty pieces without introducing
+/// spaces into CJK/fullwidth runs. Interior manuscript text is untouched.
+pub(crate) fn join_segment_texts<'a>(texts: impl IntoIterator<Item = &'a str>) -> String {
+    let mut out = String::new();
+    for text in texts {
+        let text = text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        if needs_ascii_space_join(&out, text) {
+            out.push(' ');
+        }
+        out.push_str(text);
+    }
+    out
+}
+
+pub(crate) fn needs_ascii_space_join(left: &str, right: &str) -> bool {
+    let (Some(prev), Some(next)) = (left.chars().next_back(), right.chars().next()) else {
+        return false;
+    };
+    !prev.is_whitespace()
+        && !next.is_whitespace()
+        && !is_cjk_or_fullwidth(prev)
+        && !is_cjk_or_fullwidth(next)
+}
+
+fn is_cjk_or_fullwidth(ch: char) -> bool {
+    matches!(
+        u32::from(ch),
+        0x2E80..=0x2EFF
+            | 0x3000..=0x303F
+            | 0x3040..=0x30FF
+            | 0x3400..=0x4DBF
+            | 0x4E00..=0x9FFF
+            | 0xF900..=0xFAFF
+            | 0xFF00..=0xFFEF
+            | 0x20000..=0x3134F
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::join_segment_texts;
+
+    #[test]
+    fn joins_segment_boundaries_without_rewriting_interior_text() {
+        for (pieces, expected) in [
+            (
+                vec![" 我 ", "通常会", "读书。", "", "然后散步。"],
+                "我通常会读书。然后散步。",
+            ),
+            (
+                vec![" hello ", "", " world. ", "Next sentence."],
+                "hello world. Next sentence.",
+            ),
+            (vec!["今日は", "晴れです。"], "今日は晴れです。"),
+            (vec!["안녕하세요", "세계"], "안녕하세요 세계"),
+            (vec!["𠀀", "世界"], "𠀀世界"),
+            (vec!["使用 OpenASR", "软件"], "使用 OpenASR软件"),
+            (vec!["inside  spaces", "stay"], "inside  spaces stay"),
+        ] {
+            assert_eq!(join_segment_texts(pieces), expected);
+        }
+    }
+}

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1365,6 +1365,18 @@ pub struct ActiveRuntimeSlot {
     /// surfaces this as `status != "ok"` so a swallowed log is not the only
     /// signal (`openasr serve --model` with no durable V2 used to do that).
     launch_attestation_failed: Arc<AtomicBool>,
+    pending_boot_attestations: Arc<AtomicU64>,
+}
+
+/// Covers the entire boot task, including queued work and pack verification,
+/// before the inner native warmup lease exists. It is deliberately separate
+/// from the activation busy gate so boot cannot block its own transaction.
+pub(crate) struct BootAttestationGuard(Arc<AtomicU64>);
+
+impl Drop for BootAttestationGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 #[doc(hidden)]
@@ -1514,6 +1526,7 @@ impl From<Option<PathBuf>> for ActiveRuntimeSlot {
             activation_probe_failpoint: Arc::new(RwLock::new(None)),
             activation_failpoint: Arc::new(RwLock::new(None)),
             launch_attestation_failed: Arc::new(AtomicBool::new(false)),
+            pending_boot_attestations: Arc::new(AtomicU64::new(0)),
         }
     }
 }
@@ -1536,11 +1549,22 @@ impl ActiveRuntimeSlot {
             activation_probe_failpoint: Arc::new(RwLock::new(None)),
             activation_failpoint: Arc::new(RwLock::new(None)),
             launch_attestation_failed: Arc::new(AtomicBool::new(false)),
+            pending_boot_attestations: Arc::new(AtomicU64::new(0)),
         }
     }
 
     pub(crate) fn mark_launch_attestation_failed(&self) {
         self.launch_attestation_failed.store(true, Ordering::SeqCst);
+    }
+
+    pub(crate) fn begin_boot_attestation(&self) -> BootAttestationGuard {
+        self.pending_boot_attestations
+            .fetch_add(1, Ordering::SeqCst);
+        BootAttestationGuard(Arc::clone(&self.pending_boot_attestations))
+    }
+
+    pub(crate) fn boot_attestation_pending(&self) -> bool {
+        self.pending_boot_attestations.load(Ordering::SeqCst) != 0
     }
 
     pub(crate) fn launch_attestation_failed(&self) -> bool {
@@ -1815,6 +1839,11 @@ impl ServerRuntime {
                 ));
             }
         };
+        if self.model_pack_path.boot_attestation_pending() {
+            return Err(ApiError::Conflict(
+                "The server is still preparing its startup model; retry the request.".to_string(),
+            ));
+        }
         if !self.model_pack_path.snapshot_is_current(snapshot) {
             return Err(ApiError::Conflict(
                 "The active model changed while the native session was being prepared; retry the request."

--- a/crates/openasr-server/src/realtime/native_worker.rs
+++ b/crates/openasr-server/src/realtime/native_worker.rs
@@ -1118,19 +1118,24 @@ impl Drop for NativeWarmupLease {
     }
 }
 
-pub(crate) async fn wait_while_native_warmup_in_flight() {
+pub(crate) async fn wait_while_native_warmup_in_flight(runtime: &ServerRuntime) {
     let started = Instant::now();
     let notify = native_warmup_notify();
-    while native_warmup_in_flight() && started.elapsed() < Duration::from_secs(60) {
+    while (runtime.model_pack_path.boot_attestation_pending() || native_warmup_in_flight())
+        && started.elapsed() < Duration::from_secs(60)
+    {
         let _ = tokio::time::timeout(Duration::from_millis(50), notify.notified()).await;
     }
 }
 
 /// Blocking counterpart for `spawn_blocking` transcription: same 60s cap, no
-/// tokio runtime. Call immediately before `acquire_native_execution`.
-pub(crate) fn wait_while_native_warmup_in_flight_blocking() {
+/// tokio runtime. Call before reading the active model snapshot: successful
+/// boot attestation publishes a new generation even for the same pack.
+pub(crate) fn wait_while_native_warmup_in_flight_blocking(runtime: &ServerRuntime) {
     let started = Instant::now();
-    while native_warmup_in_flight() && started.elapsed() < Duration::from_secs(60) {
+    while (runtime.model_pack_path.boot_attestation_pending() || native_warmup_in_flight())
+        && started.elapsed() < Duration::from_secs(60)
+    {
         std::thread::sleep(Duration::from_millis(50));
     }
 }
@@ -1139,11 +1144,13 @@ pub(crate) fn spawn_boot_native_warmup(
     runtime: ServerRuntime,
     home: PathBuf,
 ) -> tokio::task::JoinHandle<()> {
+    let boot_attestation = runtime.model_pack_path.begin_boot_attestation();
     // Reactivation walks the same verify -> resolve -> reserve -> materialize
     // -> attest -> reconcile transaction as set-default. Durable V2 is used
     // when it still names the launch pack; a `--model` launch without V2
     // attests that pack directly instead of logging and staying unattested.
     tokio::task::spawn_blocking(move || {
+        let _boot_attestation = boot_attestation;
         let Some(requested_path) = runtime.model_pack_path.requested_path() else {
             return;
         };

--- a/crates/openasr-server/src/realtime/tests.rs
+++ b/crates/openasr-server/src/realtime/tests.rs
@@ -2848,7 +2848,9 @@ async fn boot_warmup_does_not_consume_the_user_session_slot() {
 #[tokio::test]
 async fn wait_while_native_warmup_in_flight_unblocks_when_lease_drops() {
     let lease = try_begin_native_warmup().expect("warmup lease must be free");
-    let waiter = tokio::spawn(wait_while_native_warmup_in_flight());
+    let waiter = tokio::spawn(async {
+        wait_while_native_warmup_in_flight(&ServerRuntime::default()).await;
+    });
     tokio::time::sleep(Duration::from_millis(20)).await;
     assert!(
         !waiter.is_finished(),
@@ -2859,6 +2861,45 @@ async fn wait_while_native_warmup_in_flight_unblocks_when_lease_drops() {
         .await
         .expect("waiter must unblock when the warmup lease drops")
         .expect("waiter must not panic");
+}
+
+#[tokio::test]
+async fn boot_attestation_wait_covers_preparation_before_the_inner_warmup_lease() {
+    let runtime = ServerRuntime::default();
+    let boot = runtime.model_pack_path.begin_boot_attestation();
+    assert!(!native_warmup_in_flight());
+    let async_runtime = runtime.clone();
+    let async_waiter = tokio::spawn(async move {
+        wait_while_native_warmup_in_flight(&async_runtime).await;
+        async_runtime.model_pack_path.current_snapshot()
+    });
+    let blocking_runtime = runtime.clone();
+    let blocking_waiter = tokio::task::spawn_blocking(move || {
+        wait_while_native_warmup_in_flight_blocking(&blocking_runtime);
+        blocking_runtime.model_pack_path.current_snapshot()
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(!async_waiter.is_finished());
+    assert!(!blocking_waiter.is_finished());
+    runtime
+        .model_pack_path
+        .set_legacy_binding(Some(PathBuf::from("attested-boot-fixture.oasr")));
+    let published = runtime.model_pack_path.current_snapshot();
+    drop(boot);
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), async_waiter)
+            .await
+            .unwrap()
+            .unwrap(),
+        published
+    );
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), blocking_waiter)
+            .await
+            .unwrap()
+            .unwrap(),
+        published
+    );
 }
 
 #[tokio::test]

--- a/crates/openasr-server/src/realtime/ws_session.rs
+++ b/crates/openasr-server/src/realtime/ws_session.rs
@@ -1225,6 +1225,9 @@ impl WsSession {
         partial_results: bool,
         word_timestamps: bool,
     ) -> Result<(), ()> {
+        // Boot attestation changes the active publication generation; capture
+        // the served snapshot only after that transition, just like file ASR.
+        super::wait_while_native_warmup_in_flight(&self.runtime).await;
         let served = match self.runtime.resolve_served_native_pack() {
             Ok(Some(served)) => served,
             Ok(None) => {
@@ -1291,7 +1294,6 @@ impl WsSession {
                     return Err(());
                 }
             };
-        super::wait_while_native_warmup_in_flight().await;
         let admitted_execution = match self.runtime.acquire_native_execution_for_snapshot(
             &active_model,
             &model_session_key,

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -2836,6 +2836,12 @@ pub(crate) async fn transcribe_with_runtime(
         }
         BackendKind::Native => {
             tokio::task::spawn_blocking(move || {
+                // Boot attestation publishes a new generation of this same
+                // model. Wait before taking the snapshot, otherwise the first
+                // request rejects its own pre-warmup snapshot as stale.
+                let warmup_wait_started = Instant::now();
+                crate::realtime::wait_while_native_warmup_in_flight_blocking(&runtime);
+                let warmup_wait_duration = warmup_wait_started.elapsed();
                 let served = runtime.resolve_served_native_pack()?.ok_or_else(|| {
                     ApiError::Backend(openasr_core::BackendError::NativeModelPackPathRejected {
                         reason: format!(
@@ -2885,7 +2891,6 @@ pub(crate) async fn transcribe_with_runtime(
                         .map_err(ApiError::Backend)?;
                 let model_session_key = native_model_session_key(&adapter)?;
                 let admission_wait_started = Instant::now();
-                crate::realtime::wait_while_native_warmup_in_flight_blocking();
                 let admitted_execution = runtime
                     .acquire_native_execution_for_snapshot(
                         &active_model,
@@ -2894,7 +2899,7 @@ pub(crate) async fn transcribe_with_runtime(
                         NativeAdmissionKind::File,
                         execution_context.request_id.as_deref(),
                     );
-                let admission_wait_duration = admission_wait_started.elapsed();
+                let admission_wait_duration = warmup_wait_duration + admission_wait_started.elapsed();
                 openasr_core::stage_timing::log_stage(
                     "http_transcription",
                     "admission_wait",

--- a/crates/openasr-server/src/tests.rs
+++ b/crates/openasr-server/src/tests.rs
@@ -3063,6 +3063,22 @@ fn stale_active_runtime_snapshot_cannot_start_after_republication() {
         .current_snapshot()
         .expect("initial active runtime snapshot");
 
+    // A caller whose bounded startup wait expired must not bypass boot
+    // attestation, even if no inner warmup lease exists yet.
+    let boot = runtime.model_pack_path.begin_boot_attestation();
+    assert!(matches!(
+        runtime.acquire_native_execution_for_snapshot(
+            &snapshot,
+            "pending-boot",
+            None,
+            NativeAdmissionKind::Realtime,
+            None,
+        ),
+        Err(ApiError::Conflict(_))
+    ));
+    assert!(!runtime.native_execution.has_active_sessions());
+    drop(boot);
+
     // Re-publishing even the same path is a new generation: the underlying
     // bytes may have been reinstalled in place, so path equality cannot be an
     // admission authority and must not create an ABA hole.
@@ -3370,6 +3386,18 @@ fn issue_376_session_start_and_transcription_admit_from_served_snapshot() {
     assert!(
         native_arm.contains("resolve_served_native_pack()"),
         "native transcription must admit the currently resolvable served pack: {native_arm}"
+    );
+    assert!(
+        native_arm
+            .find("wait_while_native_warmup_in_flight_blocking")
+            .unwrap()
+            < native_arm.find("resolve_served_native_pack()").unwrap(),
+        "file requests must wait for boot publication before capturing a snapshot"
+    );
+    assert!(
+        start.find("wait_while_native_warmup_in_flight").unwrap()
+            < start.find("resolve_served_native_pack()").unwrap(),
+        "streaming requests must wait for boot publication before capturing a snapshot"
     );
 
     let served = include_str!("lib.rs")


### PR DESCRIPTION
## Summary

Fix media-reader reuse, installed-model resolution, transcript assembly, timestamp provenance, and first-request native server admission.

## Why

Repeated reads could share an exhausted file offset. Installed quant aliases could fail offline lookup. Longform joins could insert unwanted CJK spaces or regenerate committed approximate boundaries. Emission/interpolated timestamps could be mistaken for acoustic word spans. The first native request could capture a model generation before boot attestation completed.

## Changes

- Reopen selected media with identity checks for independent readers.
- Resolve installed quant aliases using the embedded catalog.
- Share script-aware transcript joining and preserve approximate seam boundaries.
- Distinguish emission points, estimated spans, and acoustic spans; expose a core-owned capability projection without changing signed catalog bytes.
- Await boot attestation before file/realtime snapshot capture, retaining generation admission checks.
- Add regressions and make explicitly selected model goldens fail when required fixtures are absent.

## Tests run

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (5113 passed, 220 skipped)
- [ ] `cargo test --workspace --doc` (pending PR CI)
- [ ] `cargo deny check` (pending PR CI)

## Manual smoke checks

Real local X-ASR English/Chinese Auto subtitle exports used forced alignment. Real Qwen longform output retained approximate provenance and contiguous estimated seams. Real HTTPS/WSS checks covered transcription, cancellation, re-admission, device ownership, reconnect grace, revocation, and timeline refinement.

## Scope / non-goals

No new model family, catalog activation, GPU qualification, or performance claim. Exact private Q8/FP16 golden fixtures and physical NVIDIA/older-macOS qualification are not available. Previously saved timestamp classifications are not migrated.

## Artifact confirmation

- [x] No model weights, binaries, secrets, private audio, or unverified download metadata committed.
- [x] No vendored runtime sources added.

## Requirements

- [ ] I have read and agree with the contributing guidelines and AI usage policy.
- [ ] I understand every line of this change and own its maintenance.
- AI usage disclosure: YES
