### PR TITLE
fix(release): dispatch channels after token publication

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -355,3 +355,28 @@ jobs:
           shared-key: release-core-finalize-ubuntu-latest
       - name: Publish the draft after catalog and notes succeed
         run: scripts/finalize-core-release.sh "${{ needs.resolve.outputs.tag }}"
+
+  dispatch-channels:
+    name: Dispatch ${{ matrix.workflow }}
+    needs: [resolve, publish-release]
+    if: needs.resolve.outputs.should_finalize == 'true' && success()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        workflow: [publish-core-channels.yml, sync-release-to-cnb.yml]
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      WORKFLOW: ${{ matrix.workflow }}
+    steps:
+      # GITHUB_TOKEN publication does not emit a new release-triggered run.
+      # Explicit dispatch preserves each channel's published-release gates and
+      # lets failed dispatches retry without repeating a successful sibling.
+      - name: Start the published-release channel workflow
+        run: gh workflow run "$WORKFLOW" --repo "$GITHUB_REPOSITORY" --ref "$DEFAULT_BRANCH" -f "tag=$RELEASE_TAG"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -200,7 +200,11 @@ Key policy: a dedicated B2 application key restricted to the release bucket
 and the `core/` prefix with `listFiles` / `readFiles` / `writeFiles` only
 (no `deleteFiles`), separate from the desktop installer key.
 
-Publishing the release triggers two independent GitHub Actions workflows:
+After publishing with `GITHUB_TOKEN`, the orchestrator explicitly dispatches two
+independent GitHub Actions workflows. A token-created release does not trigger
+new `release: published` workflow runs; those listeners remain available for
+maintainer-created releases. Dispatch jobs run only after `publish-release`
+succeeds, and a failed dispatch can be retried without repeating its sibling:
 
 - `publish-core-channels.yml` moves Docker/Homebrew only after the canonical
   catalog/CDN plane is complete.

--- a/scripts/finalize-core-release.sh
+++ b/scripts/finalize-core-release.sh
@@ -482,4 +482,4 @@ gh release edit "$tag" --repo "$repository" --draft=false --latest
 scripts/qualification-release-lock.sh release "$tag" "$lock_token"
 lock_acquired=false
 echo "RELEASE-PUBLISHED-INERT ${tag}"
-echo "China asset mirror: .github/workflows/sync-release-to-cnb.yml on release published"
+echo "China asset mirror: the orchestrator dispatches .github/workflows/sync-release-to-cnb.yml after publication"

--- a/tooling/release-manifest/core_release_finalization_contract_test.py
+++ b/tooling/release-manifest/core_release_finalization_contract_test.py
@@ -340,6 +340,26 @@ class CoreReleaseFinalizationContractTests(unittest.TestCase):
         self.assertNotIn("needs.resolve.outputs.tag", brew_checkout)
         self.assertIn("ref: ${{ needs.resolve.outputs.tag }}", channels)
 
+    def test_token_publication_explicitly_dispatches_channels_after_publish(self) -> None:
+        release = (ROOT / ".github/workflows/release-core.yml").read_text(encoding="utf-8")
+        dispatch = release.split("\n  dispatch-channels:\n", 1)[1]
+        self.assertIn("needs: [resolve, publish-release]", dispatch)
+        self.assertIn("if: needs.resolve.outputs.should_finalize == 'true' && success()", dispatch)
+        self.assertIn("actions: write", dispatch)
+        self.assertIn("contents: read", dispatch)
+        self.assertNotIn("contents: write", dispatch)
+        self.assertNotIn("secrets.", dispatch)
+        self.assertIn("fail-fast: false", dispatch)
+        self.assertIn("workflow: [publish-core-channels.yml, sync-release-to-cnb.yml]", dispatch)
+        self.assertIn("RELEASE_TAG: ${{ needs.resolve.outputs.tag }}", dispatch)
+        self.assertIn("DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}", dispatch)
+        self.assertIn("WORKFLOW: ${{ matrix.workflow }}", dispatch)
+        self.assertIn(
+            'gh workflow run "$WORKFLOW" --repo "$GITHUB_REPOSITORY" '
+            '--ref "$DEFAULT_BRANCH" -f "tag=$RELEASE_TAG"',
+            dispatch,
+        )
+
     def test_china_asset_mirror_runs_on_github_after_publish_not_on_the_finalizer_host(self) -> None:
         cnb = (ROOT / ".github/workflows/sync-release-to-cnb.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary

Explicitly dispatch the existing Docker/Homebrew and CNB workflows after the core release is published successfully.

## Why

Releases published with `GITHUB_TOKEN` do not trigger new `release: published` workflow runs. The release orchestrator uses that token, so downstream distribution otherwise depends on manual repair dispatches.

## Changes

- Add two independent dispatch matrix jobs gated on successful publication.
- Pass the resolved release tag to the existing workflows on the default branch; retain their published-release and distribution checks.
- Scope the dispatch token to Actions write and contents read, without release credentials.
- Keep failed dispatches independently retryable and document the token-event boundary.

## Tests run

- `actionlint .github/workflows/release-core.yml`
- `python3 -m unittest discover -s tooling/release-manifest -p '*_test.py'` (218 passed)
- Finalization contract tests rerun after the log wording update (14 passed).
- `python3 tooling/check_public_source_hygiene.py`
- `git diff --check`

## Scope / non-goals

No runtime changes, release tag changes, new channel implementation, GPU activation, or Environment approval changes. Existing release-event listeners remain available for maintainer-created releases.

## Artifact confirmation

- [x] No weights, binaries, secrets, private audio, or vendored runtime sources were added.
- [x] No model download metadata changed.

## Requirements

- [x] Contributing and repository policies reviewed.
- [ ] The maintainer owns the change and its ongoing maintenance.
- AI usage disclosure: YES
