### PR TITLE
docs(contributing): remove the DCO sign-off requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,10 @@ updated alongside behavior; no forbidden artifacts. Commit and PR titles follow
 `ggml`, ...). Use **ASCII punctuation** in titles and code: `-` not the em-dash,
 `->` not the arrow glyph, `...` not the ellipsis glyph. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, the full `<type>` list, the
-PR checklist, and the DCO sign-off.
+PR checklist, and contribution licensing.
+
+DCO sign-off trailers are not required. Do not request them from contributors
+or treat their absence as a review or merge blocker.
 
 ## AI usage policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,17 +155,10 @@ it fully, be able to explain any line without AI help, and own its maintenance.
 write PR descriptions, issue reports, and reviewer responses yourself — not with AI.
 The full policy and the rules for AI coding agents live in [AGENTS.md](AGENTS.md).
 
-## Developer Certificate of Origin (sign-off)
+## Contribution license
 
 OpenASR uses **inbound = outbound**: contributions are accepted under the same
-[Apache-2.0](LICENSE) license that covers the project. We require a
-[Developer Certificate of Origin](https://developercertificate.org/) sign-off on
-each commit — it certifies you wrote the patch or otherwise have the right to submit
-it under that license. Add it with `git commit -s`, which appends:
-
-```text
-Signed-off-by: Your Name <you@example.com>
-```
+[Apache-2.0](LICENSE) license that covers the project. No DCO sign-off is required.
 
 ## PR checklist
 
@@ -178,5 +171,4 @@ Before opening a PR:
 - `cargo clippy --all-targets -- -D warnings` passes;
 - relevant tests pass;
 - no forbidden artifacts were committed;
-- meaningful AI use is disclosed (see [AGENTS.md](AGENTS.md));
-- commits are signed off (`git commit -s`).
+- meaningful AI use is disclosed (see [AGENTS.md](AGENTS.md)).


### PR DESCRIPTION
Remove the mandatory DCO trailer and checklist requirement from CONTRIBUTING.md. Update AGENTS.md so missing DCO trailers cannot become review or merge blockers. Preserve Apache-2.0 contribution licensing and existing review, testing, and approval rules.

Validation: git diff --check; targeted search of contribution guidance and workflow configuration.

AI usage disclosure: YES