### PR TITLE
fix(catalog): summarize incompatible backend ABI diagnostics

### DIFF
--- a/crates/openasr-core/src/registry.rs
+++ b/crates/openasr-core/src/registry.rs
@@ -1838,13 +1838,15 @@ pub fn parse_model_catalog(contents: &str, source: &str) -> Result<ModelCatalog,
 /// can gate what a client is allowed to show/download/stage, so "hide" (not
 /// "show with a guessed value") is the only safe degrade.
 ///
-/// Returns one human-readable note per dropped entry for the caller to log;
+/// Returns human-readable notes for the caller to log. ABI schema mismatches
+/// are counted in one summary per load, rather than one line per historical pack;
 /// never panics. Deliberately does NOT touch `languages` -- a plain
 /// `Vec<String>`, any code (including one this build has no curated label
 /// for) is always tolerated and displayed as-is, no filtering needed. See
 /// `docs/CATALOG_COMPATIBILITY.md`.
 fn filter_forward_compatible_catalog(catalog: &mut ModelCatalog) -> Vec<String> {
     let mut notes = Vec::new();
+    let mut incompatible_abi_counts = BTreeMap::<u32, usize>::new();
     catalog.models.retain(|model| {
         if model.kind == CatalogModelKind::Unknown {
             notes.push(format!(
@@ -1887,12 +1889,7 @@ fn filter_forward_compatible_catalog(catalog: &mut ModelCatalog) -> Vec<String> 
             return false;
         }
         if backend.host_abi.schema_version != BACKEND_HOST_ABI_SCHEMA_VERSION {
-            notes.push(format!(
-                "catalog: hiding backend '{}': unsupported host ABI schema {} (this build supports {})",
-                backend.id,
-                backend.host_abi.schema_version,
-                BACKEND_HOST_ABI_SCHEMA_VERSION
-            ));
+            *incompatible_abi_counts.entry(backend.host_abi.schema_version).or_default() += 1;
             return false;
         }
         if backend
@@ -1908,6 +1905,17 @@ fn filter_forward_compatible_catalog(catalog: &mut ModelCatalog) -> Vec<String> 
         }
         true
     });
+    if !incompatible_abi_counts.is_empty() {
+        let count: usize = incompatible_abi_counts.values().sum();
+        let schemas = incompatible_abi_counts
+            .iter()
+            .map(|(schema, count)| format!("{schema}: {count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        notes.push(format!(
+            "catalog: hiding {count} backend packs with unsupported host ABI schemas ({schemas}); this build supports {BACKEND_HOST_ABI_SCHEMA_VERSION}"
+        ));
+    }
     notes
 }
 

--- a/crates/openasr-core/src/registry/tests/catalog.rs
+++ b/crates/openasr-core/src/registry/tests/catalog.rs
@@ -536,6 +536,58 @@ fn catalog_parser_hides_unrecognized_model_kind_via_full_parse_pipeline() {
 }
 
 #[test]
+fn catalog_abi_filter_summarizes_repeated_mismatches_per_load() {
+    let contents = catalog_json_with_backends(&valid_hip_backend_json());
+    let original: ModelCatalog = serde_json::from_str(&contents).unwrap();
+    let mut fixture = original.clone();
+    for index in 0..700 {
+        let mut backend = original.backends[0].clone();
+        backend.id = format!("old-backend-{index}");
+        backend.host_abi.schema_version = 2;
+        fixture.backends.push(backend);
+    }
+    for _ in 0..2 {
+        let mut catalog = fixture.clone();
+        let notes = super::filter_forward_compatible_catalog(&mut catalog);
+        assert_eq!(catalog.backends.len(), 1);
+        assert_eq!(catalog.backends[0].id, "hip-radeon");
+        assert_eq!(notes.len(), 1, "one summary per load, not per backend");
+        assert!(notes[0].contains("700 backend packs"), "{notes:?}");
+        assert!(notes[0].contains("2: 700"), "{notes:?}");
+        assert!(notes[0].contains(&format!("supports {BACKEND_HOST_ABI_SCHEMA_VERSION}")));
+        super::validate_model_catalog(&catalog, "fixture").unwrap();
+    }
+    let parsed = parse_model_catalog(&serde_json::to_string(&fixture).unwrap(), "fixture").unwrap();
+    assert_eq!(parsed.backends.len(), 1);
+}
+
+#[test]
+fn catalog_abi_summary_keeps_other_compatibility_diagnostics() {
+    let contents = catalog_json_with_backends(&valid_hip_backend_json());
+    let mut catalog: ModelCatalog = serde_json::from_str(&contents).unwrap();
+    for schema in [2, BACKEND_HOST_ABI_SCHEMA_VERSION + 1] {
+        let mut backend = catalog.backends[0].clone();
+        backend.id = format!("other-schema-{schema}");
+        backend.host_abi.schema_version = schema;
+        catalog.backends.push(backend);
+    }
+    let mut unknown = catalog.backends[0].clone();
+    unknown.id = "future-vendor".to_string();
+    unknown.vendor = CatalogBackendVendor::Unknown;
+    catalog.backends.push(unknown);
+    let notes = super::filter_forward_compatible_catalog(&mut catalog);
+    assert_eq!(catalog.backends.len(), 1);
+    assert_eq!(notes.len(), 2);
+    assert!(notes.iter().any(|note| note.contains("future-vendor")));
+    let summary = notes
+        .iter()
+        .find(|note| note.contains("2 backend packs"))
+        .unwrap();
+    assert!(summary.contains("2: 1"));
+    assert!(summary.contains(&format!("{}: 1", BACKEND_HOST_ABI_SCHEMA_VERSION + 1)));
+}
+
+#[test]
 fn catalog_parser_hides_backend_with_unrecognized_vendor_via_full_parse_pipeline() {
     let backends = format!(
         "{},\n{}",

--- a/docs/CATALOG_COMPATIBILITY.md
+++ b/docs/CATALOG_COMPATIBILITY.md
@@ -64,6 +64,12 @@ the signing keys, and the epoch/signature verification math are untouched.
   two; `kind` similarly determines dispatch (market listing vs. capability
   pack vs. translation model), so an unrecognized value must not silently
   masquerade as `asr-model`.
+- **Unsupported backend host ABI schemas.** Packs whose host ABI schema differs
+  from the supported version remain hidden. Each parse emits one summary with
+  the total hidden pack count, counts by schema version, and the supported
+  version. Historical releases therefore do not produce a separate log line
+  for every pack. Other compatibility diagnostics and all validation failures
+  remain unchanged; this is per-load reporting, not process-global suppression.
 - **Unknown JSON object keys.** Neither `ModelCatalog` nor `CatalogModel`
   declare `#[serde(deny_unknown_fields)]`, so a future field this build
   doesn't know about is already ignored by serde's default behavior. (The


### PR DESCRIPTION
## Summary

Summarize unsupported backend host ABI schemas once per catalog load instead of logging every historical backend pack separately.

## Why

A catalog containing hundreds of packs for older host ABIs produces hundreds of equivalent compatibility messages each time it is parsed. The useful information is the number hidden, the affected schema versions, and the schema this build supports.

## Changes

- Aggregate ABI mismatch counts by schema into one deterministic diagnostic per load.
- Preserve compatibility filtering, other diagnostics, signature verification and validation failures.
- Add regressions for 700 incompatible packs, repeated loads, and mixed diagnostics.
- Document the per-load reporting contract.

## Tests run

- [x] 116 catalog tests, including signature, cache, epoch and compatibility cases.
- [x] New 700-pack regression failed before the fix and passed after it.
- [x] Sensitive-content scan of the source commit.
- [x] `cargo fmt --check`.
- [x] `cargo clippy --all-targets -- -D warnings`.
- [x] `cargo nextest run --workspace`: 5128 passed, 220 skipped.
- [x] `cargo test --workspace --doc`.
- [x] `cargo deny check`: advisories, bans, licenses and sources passed.

## Scope / non-goals

No catalog content, activation, release pin, ABI or runtime behavior changes. No process-global diagnostic suppression or performance claims. Model-family onboarding does not apply.

## Docs updated

- [x] `docs/CATALOG_COMPATIBILITY.md` reflects the changed diagnostic behavior.
- [x] No docs overclaim current capabilities.

## Artifact confirmation

- [x] No model weights, large binaries, generated artifacts, secrets, or private audio.
- [x] No vendored runtime sources or unverified model download metadata.

## Requirements

- [x] Repository-owner implementation and submission authorization applies to this change.
- AI usage disclosure: YES
