### PR TITLE
fix(core): correct moonshine contracts and unify timeline task control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Core API: `refine_existing_transcription_timeline` and
+  `align_plain_transcript_to_audio` now require a `RequestExecutionContext`
+  argument for progress and cooperative task control. Callers without an
+  external controller must pass an explicit uncancellable context.
+
 - Breaking API cleanup: removed the id-less `GET /v1/audio/transcriptions/progress`
   compatibility route and its aggregate native-progress API. Clients must use
   `GET /v1/audio/transcriptions/{id}/progress`. Removed the hidden, unsupported
@@ -161,6 +166,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Breaking:** Voice ID: the minimum accepted speech for one enrollment sample (`MIN_SAMPLE_SPEECH_SECONDS`) is raised from 5.0s to 10.0s, to sit above recognition's own naming floor (8.0s) with a margin -- an enrollment that only just cleared the old floor could already fail the very next recognition attempt, since real speech is consistently thinner evidence than an enrollment prompt's read-aloud passage for the same nominal seconds. A sample between 5 and 10 seconds of detected speech that previously enrolled now fails quality assessment with the same "too short" error, pointing the user at a longer re-record.
 
 ### Fixed
+
+- Moonshine: conv-stem GroupNorm now normalizes over both time and channels,
+  matching the reference model instead of normalizing each frame separately.
+  Runtime metadata validation also uses the architecture registry's identities,
+  accepting the canonical identity emitted by the local pack writer.
+- Server: precise-timeline requests with `transcription_id` now share file
+  queueing, ownership, pause/resume/cancel, and disconnect cleanup. SSE file
+  requests with an id also join the shared FIFO instead of returning busy.
 
 - Long-form: duplicate and isolated fragments at long-audio slice seams
   are fixed; slice windows and non-seam cue timings are unchanged.

--- a/crates/openasr-cli/src/native_segment_cli.rs
+++ b/crates/openasr-cli/src/native_segment_cli.rs
@@ -1712,6 +1712,9 @@ pub(super) fn align_plain_transcript_command(
         execution_target,
         options.language.as_deref(),
         options.keep_word_timestamps,
+        &openasr_core::RequestExecutionContext::uncancellable(
+            "standalone alignment CLI has no external request controller",
+        ),
     )
     .map_err(|error| consent::CliExit::new(consent::ExitCode::RuntimeFailed, error.to_string()))?;
     write_rendered_formats(

--- a/crates/openasr-cli/tests/rt_378_align.rs
+++ b/crates/openasr-cli/tests/rt_378_align.rs
@@ -299,6 +299,7 @@ fn rt_378_kanji_only_japanese_tagged_en_or_auto_fails_closed() {
         ExecutionTarget::Cpu,
         Some("ja"),
         true,
+        &openasr_core::RequestExecutionContext::uncancellable("test has no external controller"),
     )
     .expect_err("pure kanji tagged ja must fail closed");
     assert!(
@@ -327,6 +328,7 @@ fn assert_external_manuscript_fails_closed(manuscript: &str, case: &str) {
         ExecutionTarget::Cpu,
         Some("en"),
         true,
+        &openasr_core::RequestExecutionContext::uncancellable("test has no external controller"),
     ) {
         Ok(transcription) => {
             let words: Vec<&str> = transcription

--- a/crates/openasr-core/src/api/backend/native_transcribe.rs
+++ b/crates/openasr-core/src/api/backend/native_transcribe.rs
@@ -1656,6 +1656,8 @@ fn resolve_prepared_audio_samples(
 /// timestamps and the dual-view projection change. Missing Forced Aligner pack
 /// fails closed with [`BackendError::WordTimestampAlignmentPackMissing`] (no
 /// silent download).
+/// The explicit request context supplies progress identity and cooperative
+/// pause/cancel control, including the already-precise fast path.
 pub fn refine_existing_transcription_timeline(
     transcription: Transcription,
     prepared_audio_16khz_mono: &[f32],
@@ -1663,7 +1665,13 @@ pub fn refine_existing_transcription_timeline(
     execution_target: crate::ExecutionTarget,
     language_hint: Option<&str>,
     keep_word_timestamps: bool,
+    execution_context: &crate::RequestExecutionContext,
 ) -> Result<Transcription, BackendError> {
+    if execution_context.control.wait_at_slice_boundary()
+        == super::transcription_control::SliceBoundaryControl::Canceled
+    {
+        return Err(BackendError::TranscriptionCanceled);
+    }
     if prepared_audio_16khz_mono.is_empty() {
         return Err(BackendError::WordTimestampAlignmentFailed {
             reason: "audio is empty; cannot refine timeline without PCM samples".into(),
@@ -1698,15 +1706,9 @@ pub fn refine_existing_transcription_timeline(
     let pcm = PcmBuffer::from_vec(prepared_audio_16khz_mono.to_vec());
     let request_intent = ExecutionIntent::from(execution_target);
     let backend_class = progress_backend_class(&request_intent);
-    // Post-hoc FA is an independent operation: its own progress id is not
-    // available here (caller may install one later). Report through a detached
-    // reporter unless the caller shares an id via thread-local in a follow-up;
-    // for now install under no-id (no publish) unless we invent an id. Server
-    // post-hoc path should pass progress once it has a request id -- keep the
-    // align loop progress-capable via optional reporter below.
-    let _progress_handle = ProgressRegistryHandle::new(None);
+    let _progress_handle = ProgressRegistryHandle::new(execution_context.request_id.clone());
     let progress = ProgressReporter::install(
-        None,
+        execution_context.request_id.clone(),
         ProgressPlan::post_hoc_align(audio_duration_s, backend_class),
     );
     // Align is a separate heavyweight phase; drop idle primary ASR caches so
@@ -1718,9 +1720,7 @@ pub fn refine_existing_transcription_timeline(
         language_hint,
         execution_services,
         &request_intent,
-        &crate::RequestExecutionContext::uncancellable(
-            "post-hoc timeline refinement has no external request control",
-        ),
+        execution_context,
         Some(&progress),
         crate::subtitle::ForcedAlignmentFailurePolicy::FailClosed,
     )?;
@@ -1759,6 +1759,7 @@ pub fn align_plain_transcript_to_audio(
     execution_target: crate::ExecutionTarget,
     language_hint: Option<&str>,
     keep_word_timestamps: bool,
+    execution_context: &crate::RequestExecutionContext,
 ) -> Result<Transcription, BackendError> {
     if prepared_audio_16khz_mono.is_empty() {
         return Err(BackendError::WordTimestampAlignmentFailed {
@@ -1809,6 +1810,7 @@ pub fn align_plain_transcript_to_audio(
         execution_target,
         Some(language.as_str()),
         true,
+        execution_context,
     )?;
     if keep_word_timestamps {
         Ok(refined)
@@ -1942,7 +1944,9 @@ pub(crate) fn refine_transcription_word_timestamps_with_forced_aligner_policy(
             let mut completed_align_duration_s = 0.0f64;
             let mut boundary_log_probs = Vec::new();
             for (index, segment) in refined.segments.iter_mut().enumerate() {
-                if execution_context.is_canceled() {
+                if execution_context.control.wait_at_slice_boundary()
+                    == super::transcription_control::SliceBoundaryControl::Canceled
+                {
                     return Err(BackendError::TranscriptionCanceled);
                 }
                 if segment.text.trim().is_empty() {

--- a/crates/openasr-core/src/models/moonshine/encoder_graph.rs
+++ b/crates/openasr-core/src/models/moonshine/encoder_graph.rs
@@ -464,7 +464,7 @@ impl MoonshineEncoderGraphRuntime {
 
         // HF conv stem order (modeling_moonshine.MoonshineEncoder.forward):
         //   x = tanh(conv1(x)); x = groupnorm(x); x = gelu(conv2(x)); x = gelu(conv3(x))
-        // GroupNorm(num_groups=1) is applied right after conv1, over the 288 channels.
+        // GroupNorm(num_groups=1) reduces both time and channels per waveform.
 
         // conv1 (no bias) -> tanh. Output [conv1_len, d_model] (ne0=time, ne1=channels).
         let conv1_len = conv_out_len(n_samples, CONV1_KERNEL, CONV1_STRIDE)?;
@@ -479,36 +479,14 @@ impl MoonshineEncoderGraphRuntime {
             .map_err(build_err("conv1"))?;
         state = graph.tanh(state).map_err(build_err("conv1_tanh"))?;
 
-        // GroupNorm(1) over channels per time-step: transpose to channel-major [d_model, time],
-        // ggml_norm over ne0(channels), affine, then transpose back to [time, d_model] for conv2.
-        let mut chan = graph
-            .permute(state, 1, 0, 2, 3)
-            .map_err(build_err("ggml_permute(gn_channel_major)"))?;
-        chan = graph
-            .cont(chan)
-            .map_err(build_err("ggml_cont(gn_channel_major)"))?;
-        chan = graph
-            .reshape_2d(chan, d_model, conv1_len)
-            .map_err(build_err("ggml_reshape_2d(gn_channel_major)"))?;
-        chan = graph
-            .norm(chan, MOONSHINE_GROUP_NORM_EPSILON)
-            .map_err(build_err("ggml_norm(groupnorm)"))?;
-        chan = graph
-            .mul(chan, self.arena.graph_tensor(self.groupnorm_weight))
-            .map_err(build_err("ggml_mul(groupnorm_w)"))?;
-        chan = graph
-            .add(chan, self.arena.graph_tensor(self.groupnorm_bias))
-            .map_err(build_err("ggml_add(groupnorm_b)"))?;
-        // transpose back to [time, d_model] for conv2 data layout.
-        state = graph
-            .permute(chan, 1, 0, 2, 3)
-            .map_err(build_err("ggml_permute(gn_time_major)"))?;
-        state = graph
-            .cont(state)
-            .map_err(build_err("ggml_cont(gn_time_major)"))?;
-        state = graph
-            .reshape_2d(state, conv1_len, d_model)
-            .map_err(build_err("ggml_reshape_2d(gn_time_major)"))?;
+        state = conv_stem_group_norm(
+            &graph,
+            state,
+            self.arena.graph_tensor(self.groupnorm_weight),
+            self.arena.graph_tensor(self.groupnorm_bias),
+            conv1_len,
+            d_model,
+        )?;
 
         // conv2 + bias -> gelu (exact erf).
         state = graph
@@ -1010,4 +988,151 @@ fn upload_layer(
 
 fn build_err(step: &'static str) -> impl Fn(GgmlCpuGraphError) -> MoonshineEncoderError {
     move |source| MoonshineEncoderError::GraphBuildFailed { step, source }
+}
+
+fn conv_stem_group_norm<'a>(
+    graph: &GgmlCpuGraphBuilder<'a>,
+    input: GgmlCpuTensor<'a>,
+    weight: GgmlCpuTensor<'a>,
+    bias: GgmlCpuTensor<'a>,
+    frames: usize,
+    channels: usize,
+) -> Result<GgmlCpuTensor<'a>, MoonshineEncoderError> {
+    // ggml's GroupNorm channel axis is ne2. The conv output already stores
+    // contiguous [time, channel] values, so this view needs no transpose/copy.
+    let input = graph
+        .reshape_3d(input, frames, 1, channels)
+        .map_err(build_err("gn_shape"))?;
+    let output = graph
+        .group_norm(input, 1, MOONSHINE_GROUP_NORM_EPSILON)
+        .map_err(build_err("gn_norm"))?;
+    let output = graph
+        .reshape_2d(output, frames, channels)
+        .map_err(build_err("gn_output_shape"))?;
+    let weight = graph
+        .reshape_2d(weight, 1, channels)
+        .map_err(build_err("gn_weight_shape"))?;
+    let bias = graph
+        .reshape_2d(bias, 1, channels)
+        .map_err(build_err("gn_bias_shape"))?;
+    let output = graph.mul(output, weight).map_err(build_err("gn_weight"))?;
+    graph.add(output, bias).map_err(build_err("gn_bias"))
+}
+
+#[cfg(test)]
+mod normalization_tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires offline PyTorch stem dump; set OPENASR_MOONSHINE_STEM_REFERENCE and OPENASR_MOONSHINE_STEM_BACKEND=cpu|metal"]
+    fn moonshine_conv_stem_real_reference() {
+        #[derive(serde::Deserialize)]
+        struct Reference {
+            frames: usize,
+            channels: usize,
+            input: Vec<f32>,
+            weight: Vec<f32>,
+            bias: Vec<f32>,
+            expected: Vec<f32>,
+        }
+        let reference: Reference = serde_json::from_slice(
+            &std::fs::read(
+                std::env::var("OPENASR_MOONSHINE_STEM_REFERENCE").expect("reference path"),
+            )
+            .expect("reference JSON"),
+        )
+        .expect("valid reference");
+        let backend = match std::env::var("OPENASR_MOONSHINE_STEM_BACKEND").as_deref() {
+            Ok("cpu") => crate::ggml_runtime::GgmlCpuGraphBackend::Cpu,
+            #[cfg(target_os = "macos")]
+            Ok("metal") => crate::ggml_runtime::GgmlCpuGraphBackend::Metal,
+            _ => panic!("explicit supported reference backend required"),
+        };
+        assert_eq!(reference.input.len(), reference.frames * reference.channels);
+        assert_eq!(reference.expected.len(), reference.input.len());
+        assert_eq!(reference.weight.len(), reference.channels);
+        assert_eq!(reference.bias.len(), reference.channels);
+        let mut runner = GgmlCpuGraphRunner::new(GgmlCpuGraphConfig {
+            backend,
+            ..GgmlCpuGraphConfig::conservative_default()
+        })
+        .unwrap();
+        let mut graph = runner.start_graph();
+        let input = graph
+            .new_tensor_2d_f32(reference.frames, reference.channels, "input")
+            .unwrap();
+        let weight = graph
+            .new_tensor_1d_f32(reference.channels, "weight")
+            .unwrap();
+        let bias = graph.new_tensor_1d_f32(reference.channels, "bias").unwrap();
+        for tensor in [input, weight, bias] {
+            graph.set_input(tensor).unwrap();
+        }
+        let output = conv_stem_group_norm(
+            &graph,
+            input,
+            weight,
+            bias,
+            reference.frames,
+            reference.channels,
+        )
+        .unwrap();
+        graph.set_output(output).unwrap();
+        graph
+            .set_f32_slice(input, &reference.input, "input")
+            .unwrap();
+        graph
+            .set_f32_slice(weight, &reference.weight, "weight")
+            .unwrap();
+        graph.set_f32_slice(bias, &reference.bias, "bias").unwrap();
+        let actual = graph
+            .compute_output_f32(output, reference.expected.len())
+            .unwrap();
+        for (index, (actual, expected)) in actual.iter().zip(reference.expected).enumerate() {
+            assert!(
+                (actual - expected).abs() <= 2.0e-4 + expected.abs() * 1.0e-5,
+                "{backend:?} index {index}: {actual} != {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn moonshine_conv_stem_group_norm_matches_channel_time_reference() {
+        let mut runner =
+            GgmlCpuGraphRunner::new(GgmlCpuGraphConfig::conservative_default()).unwrap();
+        let mut graph = runner.start_graph();
+        let input = graph.new_tensor_2d_f32(3, 2, "input").unwrap();
+        let weight = graph.new_tensor_1d_f32(2, "weight").unwrap();
+        let bias = graph.new_tensor_1d_f32(2, "bias").unwrap();
+        for tensor in [input, weight, bias] {
+            graph.set_input(tensor).unwrap();
+        }
+        let output = conv_stem_group_norm(&graph, input, weight, bias, 3, 2).unwrap();
+        graph.set_output(output).unwrap();
+        let values = [1.0_f32, 2.0, 4.0, 10.0, 20.0, 40.0];
+        let weights = [2.0_f32, 0.5];
+        let biases = [-1.0_f32, 3.0];
+        graph.set_f32_slice(input, &values, "input").unwrap();
+        graph.set_f32_slice(weight, &weights, "weight").unwrap();
+        graph.set_f32_slice(bias, &biases, "bias").unwrap();
+        let actual = graph.compute_output_f32(output, values.len()).unwrap();
+        // GroupNorm(1) reduces channels AND time for each waveform, then
+        // applies one affine pair per channel (PyTorch [batch, channel, time]).
+        let mean = values.iter().map(|&x| f64::from(x)).sum::<f64>() / values.len() as f64;
+        let variance = values
+            .iter()
+            .map(|&x| (f64::from(x) - mean).powi(2))
+            .sum::<f64>()
+            / values.len() as f64;
+        for (index, (&value, actual)) in values.iter().zip(actual).enumerate() {
+            let channel = index / 3;
+            let expected = (f64::from(value) - mean) / (variance + 1.0e-5).sqrt()
+                * f64::from(weights[channel])
+                + f64::from(biases[channel]);
+            assert!(
+                (f64::from(actual) - expected).abs() < 1.0e-5,
+                "index {index}: actual {actual}, expected {expected}"
+            );
+        }
+    }
 }

--- a/crates/openasr-core/src/models/moonshine/runtime_contract.rs
+++ b/crates/openasr-core/src/models/moonshine/runtime_contract.rs
@@ -10,7 +10,6 @@ use crate::{GgufTensorIndex, GgufTensorMetadata};
 use super::tokenizer::MoonshineTokenizer;
 
 pub(crate) const GENERAL_ARCHITECTURE_KEY: &str = "general.architecture";
-pub(crate) const MOONSHINE_ARCHITECTURE_VALUE: &str = "moonshine-encoder-decoder";
 
 pub(crate) const MOONSHINE_VOCAB_SIZE_KEY: &str = "moonshine.vocab_size";
 pub(crate) const MOONSHINE_D_MODEL_KEY: &str = "moonshine.d_model";
@@ -71,9 +70,16 @@ pub(crate) fn parse_moonshine_execution_metadata<M: ScalarMetadataView>(
 ) -> Result<MoonshineExecutionMetadata, MoonshineRuntimeContractError> {
     let architecture = required_string_scalar(metadata, GENERAL_ARCHITECTURE_KEY)
         .map_err(map_metadata_contract_error)?;
-    if architecture != MOONSHINE_ARCHITECTURE_VALUE {
+    let descriptor = crate::arch::OpenAsrArchitectureRegistry::with_builtins()
+        .find_by_model_architecture(crate::arch::MOONSHINE_GGML_ARCHITECTURE_ID)
+        .expect("Moonshine must be registered");
+    if !descriptor
+        .identity
+        .runtime_architecture_aliases
+        .contains(&architecture)
+    {
         return Err(MoonshineRuntimeContractError::UnexpectedArchitecture {
-            expected: MOONSHINE_ARCHITECTURE_VALUE,
+            expected: crate::arch::MOONSHINE_GGML_ARCHITECTURE_ID,
             found: architecture.to_string(),
         });
     }
@@ -532,7 +538,7 @@ mod tests {
 
     fn valid_metadata() -> BTreeMap<String, String> {
         scalar_metadata(&[
-            (GENERAL_ARCHITECTURE_KEY, MOONSHINE_ARCHITECTURE_VALUE),
+            (GENERAL_ARCHITECTURE_KEY, "moonshine"),
             (MOONSHINE_VOCAB_SIZE_KEY, "4"),
             (MOONSHINE_D_MODEL_KEY, "16"),
             (MOONSHINE_ENCODER_LAYERS_KEY, "1"),
@@ -552,6 +558,21 @@ mod tests {
 
     fn execution_metadata() -> MoonshineExecutionMetadata {
         parse_moonshine_execution_metadata(&valid_metadata()).expect("metadata must parse")
+    }
+
+    #[test]
+    fn accepts_registered_architecture_aliases_and_rejects_foreign_families() {
+        for architecture in ["moonshine", crate::arch::MOONSHINE_GGML_ARCHITECTURE_ID] {
+            let mut metadata = valid_metadata();
+            metadata.insert(GENERAL_ARCHITECTURE_KEY.into(), architecture.into());
+            parse_moonshine_execution_metadata(&metadata).expect("registered Moonshine identity");
+        }
+        let mut metadata = valid_metadata();
+        metadata.insert(GENERAL_ARCHITECTURE_KEY.into(), "whisper".into());
+        assert!(matches!(
+            parse_moonshine_execution_metadata(&metadata),
+            Err(MoonshineRuntimeContractError::UnexpectedArchitecture { .. })
+        ));
     }
 
     fn tokenizer_gguf_metadata(model: &str, tokens: &[&str]) -> GgufMetadata {

--- a/crates/openasr-core/src/subtitle/refine.rs
+++ b/crates/openasr-core/src/subtitle/refine.rs
@@ -71,6 +71,26 @@ mod tests {
     }
 
     #[test]
+    fn refine_existing_honors_cancel_before_reliable_fast_path() {
+        let services = NativeExecutionServices::for_local_process().unwrap();
+        let control = std::sync::Arc::new(crate::TranscriptionControl::new());
+        control.request_pause();
+        control.request_cancel();
+        let context = crate::RequestExecutionContext::new(Some("refine-cancel".into()), control);
+        let error = refine_existing_transcription_timeline(
+            reliable_two_speaker_transcription(),
+            &[0.0; 48_000],
+            &services,
+            ExecutionTarget::Cpu,
+            Some("en"),
+            true,
+            &context,
+        )
+        .unwrap_err();
+        assert!(matches!(error, crate::BackendError::TranscriptionCanceled));
+    }
+
+    #[test]
     fn refine_existing_noop_when_native_reliable_preserves_speakers_and_fills_cues() {
         let services = NativeExecutionServices::for_local_process()
             .expect("native execution services for test");
@@ -82,6 +102,7 @@ mod tests {
             ExecutionTarget::Cpu,
             Some("en"),
             true,
+            &crate::RequestExecutionContext::uncancellable("test has no external controller"),
         )
         .expect("native-reliable refine should no-op without the aligner pack");
         assert_eq!(
@@ -128,6 +149,9 @@ mod tests {
                     ExecutionTarget::Cpu,
                     Some("en"),
                     true,
+                    &crate::RequestExecutionContext::uncancellable(
+                        "test has no external controller",
+                    ),
                 )
                 .expect_err("missing forced-aligner pack must fail closed")
             },
@@ -157,6 +181,7 @@ mod tests {
             ExecutionTarget::Cpu,
             Some("en"),
             true,
+            &crate::RequestExecutionContext::uncancellable("test has no external controller"),
         )
         .expect_err("empty transcript must fail closed");
         assert!(
@@ -180,6 +205,7 @@ mod tests {
             ExecutionTarget::Cpu,
             Some("en"),
             true,
+            &crate::RequestExecutionContext::uncancellable("test has no external controller"),
         )
         .expect_err("punctuation-only transcript must fail closed");
         assert!(
@@ -203,6 +229,7 @@ mod tests {
             ExecutionTarget::Cpu,
             Some("ja"),
             true,
+            &crate::RequestExecutionContext::uncancellable("test has no external controller"),
         )
         .expect_err("japanese must fail closed");
         assert!(
@@ -216,6 +243,7 @@ mod tests {
             ExecutionTarget::Cpu,
             Some("en"),
             true,
+            &crate::RequestExecutionContext::uncancellable("test has no external controller"),
         )
         .expect_err("hiragana must fail closed even when tagged english");
         assert!(
@@ -246,6 +274,9 @@ mod tests {
                     ExecutionTarget::Cpu,
                     Some("en"),
                     true,
+                    &crate::RequestExecutionContext::uncancellable(
+                        "test has no external controller",
+                    ),
                 )
                 .expect_err("missing forced-aligner pack must fail closed")
             },
@@ -301,6 +332,7 @@ mod tests {
                     ExecutionTarget::Cpu,
                     Some("en"),
                     true,
+                    &crate::RequestExecutionContext::uncancellable("test has no external controller"),
                 )
                 .expect("jfk forced alignment")
             },

--- a/crates/openasr-server/src/lib.rs
+++ b/crates/openasr-server/src/lib.rs
@@ -1856,6 +1856,24 @@ impl ServerRuntime {
         Ok(AdmittedNativeExecution { permit, activity })
     }
 
+    /// Auxiliary compute does not depend on the active ASR snapshot, but must
+    /// retain native occupancy and serialize entry against model activation.
+    pub(crate) fn acquire_native_auxiliary_execution(
+        &self,
+        identity: &str,
+        admitted_file_id: Option<&str>,
+    ) -> Result<AdmittedNativeExecution, ApiError> {
+        let _activation_gate = self.begin_native_activation()?;
+        let activity = NativeActivityGuard::enter();
+        let permit = self.try_acquire_native_execution(
+            identity,
+            None,
+            NativeAdmissionKind::File,
+            admitted_file_id,
+        )?;
+        Ok(AdmittedNativeExecution { permit, activity })
+    }
+
     fn try_acquire_native_execution(
         &self,
         verified_model_identity: &str,

--- a/crates/openasr-server/src/realtime/mod.rs
+++ b/crates/openasr-server/src/realtime/mod.rs
@@ -50,11 +50,11 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 use super::{
-    ApiError, DistributionContext, PENDING_IDLE_SWITCH_MESSAGE, SERVER_BUSY_MESSAGE, ServerAuth,
-    ServerRuntime, apply_remote_compute_client_request_policy, file_slot_occupied,
-    is_remote_compute_client_request, native_hardware_target_from_execution_target,
-    parse_transcription_multipart, realtime_capabilities_for_runtime_and_distribution,
-    record_file_transcription_history, transcribe_parsed_file, transcribe_with_runtime,
+    ApiError, DistributionContext, ServerAuth, ServerRuntime,
+    apply_remote_compute_client_request_policy, is_remote_compute_client_request,
+    native_hardware_target_from_execution_target, parse_transcription_multipart,
+    realtime_capabilities_for_runtime_and_distribution, record_file_transcription_history,
+    transcribe_parsed_file, transcribe_with_runtime,
 };
 
 mod native_worker;
@@ -211,12 +211,6 @@ pub(crate) async fn stream_transcription(
         ));
     }
     let record_history = !remote_compute_client;
-    if !runtime.native_execution.remote_policy().admits_new_tasks() {
-        return Err(ApiError::Conflict(PENDING_IDLE_SWITCH_MESSAGE.to_string()));
-    }
-    if file_slot_occupied(&runtime, None) {
-        return Err(ApiError::Busy(SERVER_BUSY_MESSAGE.to_string()));
-    }
     let model_id = parsed.request.model_id.clone();
     let stream_started_at = Instant::now();
     // One-shot file jobs finish before SSE starts. Any error is already

--- a/crates/openasr-server/src/routes/transcription.rs
+++ b/crates/openasr-server/src/routes/transcription.rs
@@ -222,7 +222,28 @@ pub(crate) async fn precise_timeline(
     let ffmpeg_bin = runtime.ffmpeg_bin.clone();
     let ffmpeg_bin_explicit = runtime.ffmpeg_bin_explicit;
     let response_format = parsed.response_format;
-    let refined = tokio::task::spawn_blocking(move || {
+    let (execution_context, mut control_cleanup) = admit_file_request(
+        &runtime,
+        &distribution,
+        &auth,
+        &headers,
+        parsed.transcription_id.as_deref(),
+    )
+    .await?;
+    // Acquire before spawning: disconnect may drop the HTTP future before the
+    // blocking worker starts. The worker must retain visible native occupancy.
+    let admission = runtime.acquire_native_auxiliary_execution(
+        "precise-timeline",
+        execution_context.request_id.as_deref(),
+    )?;
+    let worker_context = execution_context.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let _admission = admission;
+        if worker_context.is_canceled() {
+            return Err(ApiError::Backend(
+                openasr_core::BackendError::TranscriptionCanceled,
+            ));
+        }
         let prepared = prepare_audio_input(
             &parsed.audio_path,
             &AudioPreparationOptions::new(backend)
@@ -252,8 +273,6 @@ pub(crate) async fn precise_timeline(
                 "Uploaded audio decoded to zero samples; cannot refine timeline".into(),
             ));
         }
-        // Keep the activity guard so idle unload does not race the aligner.
-        let _activity_guard = NativeActivityGuard::enter();
         // Keep the upload temp path alive across prepare + load.
         let _audio_keepalive = parsed.audio_temp;
         match parsed.transcript {
@@ -265,6 +284,7 @@ pub(crate) async fn precise_timeline(
                     parsed.execution_target.unwrap_or_default(),
                     parsed.language_hint.as_deref(),
                     parsed.keep_word_timestamps,
+                    &worker_context,
                 )
                 .map_err(ApiError::Backend)
             }
@@ -275,12 +295,22 @@ pub(crate) async fn precise_timeline(
                 parsed.execution_target.unwrap_or_default(),
                 parsed.language_hint.as_deref(),
                 parsed.keep_word_timestamps,
+                &worker_context,
             )
             .map_err(ApiError::Backend),
         }
     })
     .await
-    .map_err(ApiError::BackendJoin)??;
+    .map_err(ApiError::BackendJoin)?;
+    if let Some(cleanup) = control_cleanup.as_mut() {
+        cleanup.disarm();
+    }
+    if execution_context.is_canceled() {
+        return Err(ApiError::Backend(
+            openasr_core::BackendError::TranscriptionCanceled,
+        ));
+    }
+    let refined = result?;
     let rendered = render_transcription(&refined, response_format).map_err(ApiError::Serialize)?;
     let content_type = match response_format {
         ResponseFormat::Json | ResponseFormat::VerboseJson => mime::APPLICATION_JSON.as_ref(),
@@ -296,6 +326,7 @@ pub(crate) async fn precise_timeline(
 
 #[derive(Debug)]
 struct PreciseTimelineUpload {
+    transcription_id: Option<String>,
     audio_path: PathBuf,
     /// Keeps the uploaded temp file alive until prepare/load finish.
     audio_temp: tempfile::TempPath,
@@ -354,6 +385,7 @@ async fn parse_precise_timeline_multipart(
     let mut execution_target: Option<ExecutionTarget> = None;
     let mut response_format = ResponseFormat::VerboseJson;
     let mut return_speaker_embeddings = false;
+    let mut transcription_id = None;
 
     while let Some(field) = multipart.next_field().await.map_err(ApiError::Multipart)? {
         let name = field.name().unwrap_or_default().to_string();
@@ -368,6 +400,11 @@ async fn parse_precise_timeline_multipart(
             }
             "transcript_json" => {
                 transcript_json = Some(field.text().await.map_err(ApiError::Multipart)?);
+            }
+            "transcription_id" => {
+                let value = field.text().await.map_err(ApiError::Multipart)?;
+                let trimmed = value.trim();
+                transcription_id = (!trimmed.is_empty()).then(|| trimmed.to_string());
             }
             "transcript" => {
                 transcript_plain = Some(field.text().await.map_err(ApiError::Multipart)?);
@@ -409,6 +446,7 @@ async fn parse_precise_timeline_multipart(
     let audio_path = audio_temp.to_path_buf();
 
     Ok(PreciseTimelineUpload {
+        transcription_id,
         audio_path,
         audio_temp,
         transcript,
@@ -1025,6 +1063,50 @@ pub(crate) struct FileTranscriptionOutcome {
     pub request_receipt: Option<openasr_core::NativeExecutionReceiptCollector>,
 }
 
+/// Shared ownership, FIFO admission and disconnect cleanup for file compute.
+async fn admit_file_request(
+    runtime: &ServerRuntime,
+    distribution: &DistributionContext,
+    auth: &ServerAuth,
+    headers: &HeaderMap,
+    id: Option<&str>,
+) -> Result<
+    (
+        openasr_core::RequestExecutionContext,
+        Option<ActiveTranscriptionCleanup>,
+    ),
+    ApiError,
+> {
+    let Some(id) = id else {
+        if !runtime.native_execution.remote_policy().admits_new_tasks() {
+            return Err(ApiError::Conflict(PENDING_IDLE_SWITCH_MESSAGE.to_string()));
+        }
+        if file_slot_occupied(runtime, None) {
+            return Err(ApiError::Busy(SERVER_BUSY_MESSAGE.to_string()));
+        }
+        return Ok((
+            openasr_core::RequestExecutionContext::uncancellable(
+                "client did not register a transcription id",
+            ),
+            None,
+        ));
+    };
+    let owner = auth.pairing_device_id_for_headers(headers);
+    let control = register_active_transcription(distribution, id, owner.as_deref())?;
+    let cleanup = ActiveTranscriptionCleanup::new(
+        Some(runtime.clone()),
+        distribution.clone(),
+        runtime.native_execution.remote_policy().clone(),
+        id.to_string(),
+        Arc::clone(&control),
+    );
+    wait_for_file_admission(runtime, id, &control).await?;
+    Ok((
+        openasr_core::RequestExecutionContext::new(Some(id.to_string()), control),
+        Some(cleanup),
+    ))
+}
+
 /// Shared file-job admission, cancel control, decode, and finish_file Drop
 /// guard. JSON and `?stream=true` both go through this so stream cannot skip
 /// the FIFO, owner registry, or abort cleanup.
@@ -1039,25 +1121,18 @@ pub(crate) async fn transcribe_parsed_file(
 ) -> Result<FileTranscriptionOutcome, ApiError> {
     let history_request = parsed.request.clone();
     let _uploaded_file = parsed._uploaded_file;
-    let control = if let Some(id) = parsed.transcription_id.clone() {
-        let owner = auth.pairing_device_id_for_headers(&headers);
-        let control = register_active_transcription(&distribution, &id, owner.as_deref())?;
-        Some((id, control))
-    } else {
-        None
-    };
-    let mut control_cleanup = control.as_ref().map(|(id, control)| {
-        ActiveTranscriptionCleanup::new(
-            Some(runtime.clone()),
-            distribution.clone(),
-            runtime.native_execution.remote_policy().clone(),
-            id.clone(),
-            Arc::clone(control),
-        )
-    });
     let run_started = Instant::now();
-    if let Some((id, control)) = &control {
-        if let Err(error) = wait_for_file_admission(&runtime, id, control).await {
+    let (mut execution_context, mut control_cleanup) = match admit_file_request(
+        &runtime,
+        &distribution,
+        &auth,
+        &headers,
+        parsed.transcription_id.as_deref(),
+    )
+    .await
+    {
+        Ok(admitted) => admitted,
+        Err(error) => {
             if matches!(
                 error,
                 ApiError::Backend(openasr_core::BackendError::TranscriptionCanceled)
@@ -1074,18 +1149,6 @@ pub(crate) async fn transcribe_parsed_file(
             }
             return Err(error);
         }
-    } else if !runtime.native_execution.remote_policy().admits_new_tasks() {
-        return Err(ApiError::Conflict(PENDING_IDLE_SWITCH_MESSAGE.to_string()));
-    } else if file_slot_occupied(&runtime, None) {
-        return Err(ApiError::Busy(SERVER_BUSY_MESSAGE.to_string()));
-    }
-    let mut execution_context = match &control {
-        Some((id, control)) => {
-            openasr_core::RequestExecutionContext::new(Some(id.clone()), Arc::clone(control))
-        }
-        None => openasr_core::RequestExecutionContext::uncancellable(
-            "client never registered a transcription id for this request, so it has no cancel source",
-        ),
     };
     if let Some(request_attempt_id) = request_attempt_id {
         execution_context = execution_context.with_request_attempt_id(request_attempt_id);

--- a/crates/openasr-server/src/ssot_redteam_tests.rs
+++ b/crates/openasr-server/src/ssot_redteam_tests.rs
@@ -847,7 +847,7 @@ async fn ssot_13_pending_idle_switch_rejects_stream_file_jobs() {
 /// SSOT 10: a busy server must queue cancelable file jobs. `?stream=true`
 /// must not jump the FIFO.
 ///
-/// If correct: queued (or 429 without starting a second native slot).
+/// If correct: queued and cancellable without starting a second native slot.
 /// Otherwise Y: 200 while the native slot is still held.
 #[tokio::test]
 async fn ssot_10_stream_file_jobs_do_not_bypass_fifo() {
@@ -860,32 +860,234 @@ async fn ssot_10_stream_file_jobs_do_not_bypass_fifo() {
         .try_acquire("hold-native-slot")
         .unwrap();
     let app = policy_app(runtime.clone(), home);
-    let response = post_transcription(
-        app,
+    let streamed = tokio::spawn(post_transcription(
+        app.clone(),
         "/v1/audio/transcriptions?stream=true",
         Some("stream-queued"),
-    )
-    .await;
-    assert_ne!(
-        response.status(),
-        StatusCode::OK,
-        "stream=true must not run while the native slot is occupied: {:?}",
-        response.status()
-    );
-    assert!(
-        runtime
+    ));
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while !runtime
             .native_execution
             .remote_policy()
             .is_file_queued("stream-queued")
-            || response.status() == StatusCode::TOO_MANY_REQUESTS
-            || response.status() == StatusCode::CONFLICT,
-        "busy stream file job must enter the FIFO or fail closed busy, got {}",
-        response.status()
+        {
+            assert!(
+                !streamed.is_finished(),
+                "stream job rejected instead of queued"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("stream job enters FIFO");
+    let cancel = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/audio/transcriptions/stream-queued/cancel")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(cancel.status(), StatusCode::ACCEPTED);
+    let response = tokio::time::timeout(std::time::Duration::from_secs(2), streamed)
+        .await
+        .expect("queued cancellation completes")
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    assert!(
+        !runtime
+            .native_execution
+            .remote_policy()
+            .is_file_queued("stream-queued")
     );
 }
 
-/// SSOT 22: a client must be able to cancel a file job. The SSE stream path
-/// currently uses an uncancellable execution context.
+async fn post_timeline(app: axum::Router, id: Option<&str>) -> axum::http::Response<Body> {
+    let (content_type, body) = sample_multipart(id, false);
+    let body = String::from_utf8(body).unwrap().replace(
+        "--openasr-redteam-boundary--",
+        "--openasr-redteam-boundary\r\nContent-Disposition: form-data; name=\"transcript\"\r\n\r\nhello world\r\n--openasr-redteam-boundary--",
+    );
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/v1/audio/precise-timeline")
+            .header(header::CONTENT_TYPE, content_type)
+            .body(Body::from(body))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn precise_timeline_running_worker_honors_pause_resume_and_cancel() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = ServerRuntime::default();
+    let app = policy_app(runtime.clone(), temp.path().join("home"));
+    for action in ["resume", "cancel"] {
+        let permit = runtime
+            .native_execution
+            .try_acquire("held-native-slot")
+            .unwrap();
+        let boundary = "timeline-control-boundary";
+        let mut body = format!("--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"jfk.wav\"\r\nContent-Type: audio/wav\r\n\r\n").into_bytes();
+        body.extend_from_slice(include_bytes!("../../../fixtures/jfk.wav"));
+        let transcript = r#"{"text":"hello","timeline_quality":"native_reliable","segments":[{"start":0,"end":1,"text":"hello","words":[{"word":"hello","start":0,"end":1}]}]}"#;
+        body.extend_from_slice(format!("\r\n--{boundary}\r\nContent-Disposition: form-data; name=\"transcript_json\"\r\n\r\n{transcript}\r\n--{boundary}\r\nContent-Disposition: form-data; name=\"transcription_id\"\r\n\r\ntimeline-running\r\n--{boundary}--\r\n").as_bytes());
+        let task = tokio::spawn(
+            app.clone().oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/audio/precise-timeline")
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(body))
+                    .unwrap(),
+            ),
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !runtime
+                .native_execution
+                .remote_policy()
+                .is_file_queued("timeline-running")
+            {
+                assert!(!task.is_finished(), "timeline failed before queueing");
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        let pause = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/audio/transcriptions/timeline-running/pause")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(pause.status(), StatusCode::ACCEPTED);
+        drop(permit);
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while runtime
+                .native_execution
+                .remote_policy()
+                .file_running()
+                .as_deref()
+                != Some("timeline-running")
+                || !runtime.native_execution.has_active_sessions()
+            {
+                assert!(!task.is_finished(), "paused worker finished unexpectedly");
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(!task.is_finished());
+        let control = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!(
+                        "/v1/audio/transcriptions/timeline-running/{action}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(control.status(), StatusCode::ACCEPTED);
+        let response = tokio::time::timeout(std::time::Duration::from_secs(3), task)
+            .await
+            .expect("controlled worker exits")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            if action == "resume" {
+                StatusCode::OK
+            } else {
+                StatusCode::CONFLICT
+            }
+        );
+        assert!(!runtime.native_execution.has_active_sessions());
+        assert!(
+            runtime
+                .native_execution
+                .remote_policy()
+                .file_running()
+                .is_none()
+        );
+    }
+}
+
+#[tokio::test]
+async fn precise_timeline_uses_shared_fifo_and_cancel_cleanup() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime = ServerRuntime::default();
+    let _permit = runtime
+        .native_execution
+        .try_acquire("held-native-slot")
+        .unwrap();
+    let app = policy_app(runtime.clone(), temp.path().join("home"));
+    assert_eq!(
+        post_timeline(app.clone(), None).await.status(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+    for disconnect in [false, true] {
+        let task = tokio::spawn(post_timeline(app.clone(), Some("timeline-queued")));
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !runtime
+                .native_execution
+                .remote_policy()
+                .is_file_queued("timeline-queued")
+            {
+                assert!(!task.is_finished(), "timeline rejected instead of queued");
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timeline enters shared FIFO");
+        if disconnect {
+            task.abort();
+            assert!(task.await.unwrap_err().is_cancelled());
+        } else {
+            let cancel = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/v1/audio/transcriptions/timeline-queued/cancel")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(cancel.status(), StatusCode::ACCEPTED);
+            let response = tokio::time::timeout(std::time::Duration::from_secs(2), task)
+                .await
+                .expect("timeline cancellation completes")
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::CONFLICT);
+        }
+        assert!(
+            !runtime
+                .native_execution
+                .remote_policy()
+                .is_file_queued("timeline-queued")
+        );
+    }
+}
+
+/// SSOT 22: a client must be able to cancel a file job.
 ///
 /// If correct: cancel returns 202 and the stream fails closed canceled.
 /// Otherwise Y: cancel 404 / stream completes with status ok.

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -162,8 +162,9 @@ local equivalent (`temperature`, `include[]`, `chunking_strategy`,
 form field) is rejected with an actionable 400: SSE streaming is the
 OpenASR realtime protocol behind the `?stream=true` query parameter, not
 OpenAI `transcript.text.*` events. When that query-parameter stream is used
-for a file job, a busy server returns HTTP 429 instead of joining the
-cancelable JSON file FIFO; see [Known Limitations](KNOWN_LIMITATIONS.md).
+for a file job, supplying `transcription_id` enables the same cancelable FIFO
+as JSON file jobs; without an id, a busy server returns HTTP 429. Computation
+finishes before SSE headers are sent; see [Known Limitations](KNOWN_LIMITATIONS.md).
 
 ### Incomplete transcripts
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -78,7 +78,10 @@ do not run inference.
 Yes. `openasr align audio.wav --transcript script.txt -f srt` force-aligns a
 plain-text manuscript onto the audio with the Qwen3-ForcedAligner pack (no ASR).
 The HTTP equivalent is `POST /v1/audio/precise-timeline` with `file` +
-`transcript`. Japanese and Korean fail closed by language tag (`ja`/`ko`)
+`transcript`. Add `transcription_id` to opt into the shared file FIFO and
+`/v1/audio/transcriptions/{id}/{progress,pause,resume,cancel}` controls.
+Pause applies at alignment segment boundaries, not within a running native
+operation. Japanese and Korean fail closed by language tag (`ja`/`ko`)
 or by kana/hangul script. Pure-kanji Japanese cannot be identified as
 Japanese: tagged `ja` it is 400; tagged `en` it follows the CJK character
 tokenizer. A missing pack, empty normalized text, a prompt past decoder

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -121,8 +121,7 @@ for the code map and [Roadmap](ROADMAP.md) for development priorities.
   fail, the request still succeeds: the native approximate timeline is kept,
   `timeline_quality` stays `native_approximate`, and
   `timeline_degraded_reason` names the cause. CLI prints a warning and
-  exits 0; HTTP `json` / `verbose_json` include the field. Desktop does
-  not yet read the reason. Explicit `aligned` only
+  exits 0; HTTP `json` / `verbose_json` include the field. Explicit `aligned` only
   refines words; the automatic Voice ID path additionally consumes those
   words to assign each text run to the canonical speaker timeline.
 - External manuscript alignment (`openasr align` / `POST /v1/audio/precise-timeline`
@@ -149,9 +148,11 @@ for the code map and [Roadmap](ROADMAP.md) for development priorities.
   otherwise matching script) were not in the calibration set. A theoretically
   sharp but token-wrong timestamp head can also miss. This compute endpoint
   never downloads the pack; paired device tokens may call it (it is a
-  compute route, not operator-only). This route is not yet on the file
-  FIFO / pause / cancel surface used by `/v1/audio/transcriptions`; a request
-  that has entered alignment cannot be cancelled that way. The plain-transcript
+  compute route, not operator-only). With a `transcription_id`, this route
+  shares the file FIFO and the `/v1/audio/transcriptions/{id}` progress,
+  pause, resume, and cancel endpoints. Pause takes effect at segment boundaries;
+  cancellation is cooperative, not an immediate interruption of every native
+  operation. Requests without an id fail busy rather than queue. The plain-transcript
   path still aligns the whole recording as one Forced Aligner item: it does
   not auto-split. Inputs that would exceed decoder context or the 400 s grid
   fail closed instead of being chunked. Kanji-only Japanese with no kana, when
@@ -280,12 +281,12 @@ for the code map and [Roadmap](ROADMAP.md) for development priorities.
   are retained. See
   [Graph cancellation contract](design/graph-cancellation.md).
   Pause still only blocks at slice boundaries and never arms graph cancellation.
-- `POST /v1/audio/transcriptions?stream=true` shares owner checks, cancel
-  control, and `finish_file` cleanup with JSON file jobs, but a busy server
-  rejects the stream with HTTP 429 instead of enqueueing it on the cancelable
-  file FIFO. JSON `POST /v1/audio/transcriptions` still queues. Desktop remote
-  file transcription uses the JSON endpoint. A later change can emit a queued
-  SSE event and then stream the result.
+- `POST /v1/audio/transcriptions?stream=true` shares the file FIFO, owner
+  checks, cancellation, and cleanup with JSON file jobs. A `transcription_id`
+  is required for queueing; requests without one return HTTP 429 when busy.
+  File computation completes before SSE headers are sent, so admission and
+  compute failures retain their HTTP status. There is no queued SSE event;
+  use the request's progress endpoint while waiting.
 
 ## Related docs
 

--- a/skills/openasr/references/http-api.md
+++ b/skills/openasr/references/http-api.md
@@ -55,8 +55,11 @@ pack that is being served.
 - `POST /v1/audio/precise-timeline` -- OpenASR-native forced alignment
   (multipart form). Does not run ASR. Accepts source `file` plus exactly one
   of `transcript` (plain text) or `transcript_json` (timed verbose/json body).
-  Optional: `language`, `word_timestamps` (default true), `execution_target`,
+  Optional: `transcription_id`, `language`, `word_timestamps` (default true), `execution_target`,
   `response_format` (`verbose_json` default; `json`/`text`/`srt`/`vtt`/`markdown`).
+  With `transcription_id`, uses the shared file FIFO and transcription
+  progress/pause/resume/cancel endpoints. Pause applies at segment boundaries;
+  cancellation is cooperative. Without an id, busy requests fail with 429.
   SRT/VTT reuse the shared subtitle exporter. Missing Forced Aligner pack,
   unsupported language (tag `ja`/`jp`/`ko`/`kr` or hiragana/katakana/hangul
   in the text), empty normalized text, audio past the timestamp grid, a
@@ -72,7 +75,7 @@ pack that is being served.
   it explicitly).
 - `POST /v1/audio/transcriptions/{id}/pause|resume|cancel` -- OpenASR
   extension: control an in-flight request that supplied a `transcription_id`
-  form field.
+  form field, including precise-timeline requests.
 - `GET /v1/devices` -- OpenASR extension (0.1.13+): read-only enumeration of
   this daemon's own ggml compute devices (`{"object":"devices",
   "default_execution_target","devices":[{"id","name","meta","kind","target",

--- a/tooling/moonshine-reference-dumper/dump_stem.py
+++ b/tooling/moonshine-reference-dumper/dump_stem.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Dump the official Moonshine conv-stem normalization for an offline checkpoint.
+
+Requires torch, transformers and soundfile. Outputs model-derived tensors: keep
+the JSON outside version control. The ignored moonshine_conv_stem_real_reference
+test consumes it via OPENASR_MOONSHINE_STEM_REFERENCE (CPU or Metal).
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+import soundfile
+import torch
+import transformers
+from transformers import MoonshineForConditionalGeneration
+
+
+def sha256(path):
+    with path.open("rb") as source:
+        return hashlib.file_digest(source, "sha256").hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--audio", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    audio, rate = soundfile.read(args.audio, dtype="float32")
+    if rate != 16000 or audio.ndim != 1:
+        parser.error("audio must be 16 kHz mono")
+    torch.set_num_threads(1)
+    model = MoonshineForConditionalGeneration.from_pretrained(
+        args.checkpoint, local_files_only=True
+    ).eval()
+    encoder = model.model.encoder
+    with torch.inference_mode():
+        state = torch.tanh(encoder.conv1(torch.from_numpy(audio)[None, None]))
+        expected = encoder.groupnorm(state)
+    result = {
+        "torch": torch.__version__,
+        "transformers": transformers.__version__,
+        "checkpoint_sha256": sha256(args.checkpoint / "model.safetensors"),
+        "audio_sha256": sha256(args.audio),
+        "frames": state.shape[2],
+        "channels": state.shape[1],
+        "input": state.flatten().tolist(),
+        "weight": encoder.groupnorm.weight.tolist(),
+        "bias": encoder.groupnorm.bias.tolist(),
+        "expected": expected.flatten().tolist(),
+    }
+    args.output.write_text(json.dumps(result), encoding="utf-8")
+    print(f"wrote {result['channels']} channels x {result['frames']} frames")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Correct Moonshine conv-stem GroupNorm to reduce time and channels, and validate pack identities through the existing architecture registry.
- Share file FIFO admission, ownership and disconnect cleanup with precise-timeline requests; propagate request contexts for progress and cooperative pause/cancel.
- Route SSE file jobs through the same admission path instead of rejecting controllable jobs before queueing.
- Replace stale limitations with the implemented contract.

## Why

The old normalization diverged from the reference model. Local Moonshine conversion also failed production verification because writer and reader used different registered architecture identities. Precise alignment bypassed file-task control, while SSE had a duplicate busy check.

## Tests run

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` — 5,130 passed, 221 skipped; followed by the family gate after the identity correction.
- [x] `cargo test --workspace --doc`
- [x] `cargo xtask family conformance --profile-id moonshine` — 4,225 core tests passed, 205 skipped; Python 282 passed; generated inventory/catalog and GPU placement checks passed.
- Production-seam normalization regression reproduced the old failure. Real PyTorch intermediate tensors match CPU and Metal.
- Official Moonshine Tiny checkpoint imported as fp16; JFK CLI output matches the reference transcript exactly. A catalog-verified q8 pack produced the same transcript through a real loopback HTTP server with explicit `metal:apple-m1` selection.
- Tests cover timeline busy admission, queued cancellation/disconnect, running worker pause/resume/cancel, and SSE FIFO cancellation.

## Scope / non-goals

Core-only; no release, catalog publication or version change. CUDA/Windows hardware qualification and desktop timeline control buttons are not covered. Pause remains cooperative at segment boundaries. The public refine/align Rust APIs now require an explicit `RequestExecutionContext`; this is a source-breaking change documented in the changelog. No new dependency or permissive verification fallback.

## Artifact confirmation

- [x] No model weights, large binaries, private audio, secrets or generated artifacts are committed.
- [x] Documentation does not claim untested hardware qualification.

## Requirements

AI usage disclosure: YES
